### PR TITLE
[Enhancement] Disable change file_bundling property when lake table has rollup which partitionId is not physical partitionId

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -43,6 +43,7 @@ import com.starrocks.common.InvalidOlapTableStateException;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.StorageVolumeMgr;
@@ -57,7 +58,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -285,24 +285,6 @@ public class LakeTable extends OlapTable {
         }
     }
 
-    private Optional<Long> extractIdFromPath(String path) {
-        if (path == null) {
-            return Optional.empty();
-        }
-    
-        int lastSlashIndex = path.lastIndexOf('/');
-        if (lastSlashIndex == -1 || lastSlashIndex == path.length() - 1) {
-            return Optional.empty();
-        }
-    
-        String idPart = path.substring(lastSlashIndex + 1);
-        try {
-            return Optional.of(Long.parseLong(idPart));
-        } catch (NumberFormatException e) {
-            return Optional.empty();
-        }
-    }
-
     public boolean checkLakeRollupAllowFileBundling() {
         return getPartitions().stream()
             .flatMap(partition -> partition.getSubPartitions().stream())
@@ -326,7 +308,7 @@ public class LakeTable extends OlapTable {
                     return false;
                 }
                 return shardInfos.stream()
-                    .allMatch(shardInfo -> extractIdFromPath(shardInfo.getFilePath().getFullPath())
+                    .allMatch(shardInfo -> LakeTableHelper.extractIdFromPath(shardInfo.getFilePath().getFullPath())
                         .map(id -> id == physicalPartitionId)
                         .orElse(false));
             });

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -292,7 +292,6 @@ public class LakeTable extends OlapTable {
                 long physicalPartitionId = physicalPartition.getId();
                 List<Long> shardIds = physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL).stream()
                         .flatMap(index -> index.getTablets().stream())
-                        .filter(LakeTablet.class::isInstance)
                         .map(tablet -> ((LakeTablet) tablet).getShardId())
                         .collect(Collectors.toList());
             

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -278,4 +278,22 @@ public class LakeTableHelper {
         }
         return false;
     }
+
+    public static Optional<Long> extractIdFromPath(String path) {
+        if (path == null) {
+            return Optional.empty();
+        }
+    
+        int lastSlashIndex = path.lastIndexOf('/');
+        if (lastSlashIndex == -1 || lastSlashIndex == path.length() - 1) {
+            return Optional.empty();
+        }
+    
+        String idPart = path.substring(lastSlashIndex + 1);
+        try {
+            return Optional.of(Long.parseLong(idPart));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -887,6 +887,13 @@ public class StarOSAgent {
         return shardInfos.get(0);
     }
 
+    @NotNull
+    public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) throws StarClientException {
+        prepare();
+        List<ShardInfo> shardInfos = client.getShardInfo(serviceId, shardIds, workerGroupId);
+        return shardInfos;
+    }
+
     public static FilePathInfo allocatePartitionFilePathInfo(FilePathInfo tableFilePathInfo, long physicalPartitionId) {
         String allocPath = StarClient.allocateFilePath(tableFilePathInfo, Long.hashCode(physicalPartitionId));
         return tableFilePathInfo.toBuilder().setFullPath(String.format("%s/%d", allocPath, physicalPartitionId)).build();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -304,7 +304,7 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
                             "Property " + PropertyAnalyzer.PROPERTIES_FILE_BUNDLING +
                                     " cannot be updated now because this table contains LakeRollup created in old version."  + 
-                                    "You can rebuild the Rollup and retry");
+                                    " You can rebuild the Rollup and retry");
             }
 
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -54,6 +54,7 @@ import com.starrocks.common.util.DynamicPartitionUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.WriteQuorum;
+import com.starrocks.lake.LakeTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -298,6 +299,14 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                                     " cannot be updated now because this table contains mixed metadata types "  + 
                                     "(both split and aggregate). Please wait until old metadata versions are vacuumed");
             }
+
+            if (!((LakeTable) olapTable).checkLakeRollupAllowFileBundling()) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                            "Property " + PropertyAnalyzer.PROPERTIES_FILE_BUNDLING +
+                                    " cannot be updated now because this table contains LakeRollup created in old version."  + 
+                                    "You can rebuild the Rollup and retry");
+            }
+
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE)) {
             if (!properties.get(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE).equalsIgnoreCase("true") &&
                     !properties.get(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE).equalsIgnoreCase("false")) {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -53,6 +53,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -235,5 +236,18 @@ public class LakeTableHelperTest {
                 Assert.assertEquals(ordinal, column.getUniqueId());
             }
         }
+    }
+
+    @Test
+    public void testExtractIdFromPath() {
+        Optional<Long> result = LakeTableHelper.extractIdFromPath(null);
+        Assert.assertFalse(result.isPresent());
+
+        result = LakeTableHelper.extractIdFromPath("12345");
+        Assert.assertFalse(result.isPresent());
+
+        result = LakeTableHelper.extractIdFromPath("s3://bucket/path/12345");
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(12345L, result.get().longValue());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
The issue(https://github.com/StarRocks/starrocks/issues/60184) mistake the physical partitonId and logical partitionId when create LakeRollup and this issue will cause execution errors during the publish of tables with file_bundling enabled, leading to a series of problems such as query errors.
So when we upgrade from old version and try to enable file_bundling, we will check the partitionId in ShardInfo and if found mismatch partitionId, we will reject enable file_bundling.

## What I'm doing:
Disable change file_bundling property when lake table has rollup which partitionId is not physical partitionId

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
