### PR TITLE
[Enhancement] Avoid selecting dead backend or compute node when picking up backend

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -350,7 +350,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
 
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         for (Tablet tablet : tablets) {
-            Long backendId = warehouseManager.getComputeNodeId(computeResource, (LakeTablet) tablet);
+            Long backendId = warehouseManager.getAliveComputeNodeId(computeResource, (LakeTablet) tablet);
             if (backendId == null) {
                 throw new AlterCancelException("no alive node");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/TabletView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/TabletView.java
@@ -49,7 +49,7 @@ public class TabletView {
             LakeTablet lakeTablet = (LakeTablet) tablet;
             // TODO(ComputeResource): support more better compute resource acquiring.
             Long computeNodeId = GlobalStateMgr.getCurrentState().getWarehouseMgr()
-                    .getComputeNodeId(DEFAULT_RESOURCE, lakeTablet);
+                    .getAliveComputeNodeId(DEFAULT_RESOURCE, lakeTablet);
             tvo.setPrimaryComputeNodeId(computeNodeId);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -641,7 +641,15 @@ public class StarOSAgent {
             throw new StarRocksException(InternalErrorCode.REPLICA_FEW_ERR,
                     "Failed to get primary backend. shard id: " + shardId);
         }
-        return backendIds.iterator().next();
+
+        Long backendId = backendIds
+                .stream()
+                .filter(id -> GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkBackendAlive(id) ||
+                        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkComputeNodeAlive(id))
+                .findFirst()
+                .get();
+
+        return backendId;
     }
 
     public long getPrimaryComputeNodeIdByShard(ShardInfo shardInfo) throws StarRocksException {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -641,15 +641,7 @@ public class StarOSAgent {
             throw new StarRocksException(InternalErrorCode.REPLICA_FEW_ERR,
                     "Failed to get primary backend. shard id: " + shardId);
         }
-
-        Long backendId = backendIds
-                .stream()
-                .filter(id -> GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkBackendAlive(id) ||
-                        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkComputeNodeAlive(id))
-                .findFirst()
-                .get();
-
-        return backendId;
+        return backendIds.iterator().next();
     }
 
     public long getPrimaryComputeNodeIdByShard(ShardInfo shardInfo) throws StarRocksException {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -133,7 +133,7 @@ public class LakeRestoreJob extends RestoreJob {
                 Long computeNodeId = GlobalStateMgr.getCurrentState().getWarehouseMgr()
                         .getAliveComputeNodeId(WarehouseManager.DEFAULT_RESOURCE, tablet);
                 Preconditions.checkArgument(computeNodeId != null,
-                        "No alive backend or compute node in {} warehouse", WarehouseManager.DEFAULT_RESOURCE);
+                        "No alive backend or compute node in %s warehouse", WarehouseManager.DEFAULT_RESOURCE);
                 LakeTableSnapshotInfo info = new LakeTableSnapshotInfo(db.getId(), idChain.getTblId(),
                         idChain.getPartId(), idChain.getIdxId(), idChain.getTabletId(),
                         computeNodeId, tbl.getSchemaHashByIndexId(index.getId()), -1);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -132,7 +132,8 @@ public class LakeRestoreJob extends RestoreJob {
                 tablet = (LakeTablet) index.getTablet(idChain.getTabletId());
                 Long computeNodeId = GlobalStateMgr.getCurrentState().getWarehouseMgr()
                         .getAliveComputeNodeId(WarehouseManager.DEFAULT_RESOURCE, tablet);
-
+                Preconditions.checkArgument(computeNodeId != null,
+                        "No alive backend or compute node in {} warehouse", WarehouseManager.DEFAULT_RESOURCE);
                 LakeTableSnapshotInfo info = new LakeTableSnapshotInfo(db.getId(), idChain.getTblId(),
                         idChain.getPartId(), idChain.getIdxId(), idChain.getTabletId(),
                         computeNodeId, tbl.getSchemaHashByIndexId(index.getId()), -1);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -131,7 +131,7 @@ public class LakeRestoreJob extends RestoreJob {
                 MaterializedIndex index = part.getDefaultPhysicalPartition().getIndex(idChain.getIdxId());
                 tablet = (LakeTablet) index.getTablet(idChain.getTabletId());
                 Long computeNodeId = GlobalStateMgr.getCurrentState().getWarehouseMgr()
-                        .getComputeNodeId(WarehouseManager.DEFAULT_RESOURCE, tablet);
+                        .getAliveComputeNodeId(WarehouseManager.DEFAULT_RESOURCE, tablet);
 
                 LakeTableSnapshotInfo info = new LakeTableSnapshotInfo(db.getId(), idChain.getTblId(),
                         idChain.getPartId(), idChain.getIdxId(), idChain.getTabletId(),

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -316,9 +316,8 @@ public class WarehouseManager implements Writable {
             throw ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE,
                     String.format("id: %d", computeResource.getWarehouseId()));
         }
-        List<Long> nodeIds = new ArrayList<>();
         try {
-            nodeIds = GlobalStateMgr.getCurrentState().getStarOSAgent()
+            List<Long> nodeIds = GlobalStateMgr.getCurrentState().getStarOSAgent()
                     .getAllNodeIdsByShard(tablet.getShardId(), computeResource.getWorkerGroupId());
             Long nodeId = nodeIds
                     .stream()

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -324,7 +324,7 @@ public class WarehouseManager implements Writable {
                     .stream()
                     .filter(id -> GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkBackendAlive(id))
                     .findFirst()
-                    .get();
+                    .orElse(null);
             return nodeId;
         } catch (StarRocksException e) {
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -310,6 +310,27 @@ public class WarehouseManager implements Writable {
         }
     }
 
+    public Long getAliveComputeNodeId(ComputeResource computeResource, LakeTablet tablet) {
+        // check warehouse exists
+        if (!warehouseExists(computeResource.getWarehouseId())) {
+            throw ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE,
+                    String.format("id: %d", computeResource.getWarehouseId()));
+        }
+        List<Long> nodeIds = new ArrayList<>();
+        try {
+            nodeIds = GlobalStateMgr.getCurrentState().getStarOSAgent()
+                    .getAllNodeIdsByShard(tablet.getShardId(), computeResource.getWorkerGroupId());
+            Long nodeId = nodeIds
+                    .stream()
+                    .filter(id -> GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkBackendAlive(id))
+                    .findFirst()
+                    .get();
+            return nodeId;
+        } catch (StarRocksException e) {
+            return null;
+        }
+    }
+
     public List<Long> getAllComputeNodeIdsAssignToTablet(ComputeResource computeResource, LakeTablet tablet) {
         // check warehouse exists
         if (!warehouseExists(computeResource.getWarehouseId())) {
@@ -330,7 +351,7 @@ public class WarehouseManager implements Writable {
             throw ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE,
                     String.format("id: %d", computeResource.getWarehouseId()));
         }
-        Long computeNodeId = getComputeNodeId(computeResource, tablet);
+        Long computeNodeId = getAliveComputeNodeId(computeResource, tablet);
         if (computeNodeId == null) {
             Warehouse warehouse = idToWh.get(computeResource.getWarehouseId());
             throw ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE,

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -322,7 +322,8 @@ public class WarehouseManager implements Writable {
                     .getAllNodeIdsByShard(tablet.getShardId(), computeResource.getWorkerGroupId());
             Long nodeId = nodeIds
                     .stream()
-                    .filter(id -> GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkBackendAlive(id))
+                    .filter(id -> GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkBackendAlive(id) ||
+                            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkComputeNodeAlive(id))
                     .findFirst()
                     .orElse(null);
             return nodeId;

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2426,9 +2426,13 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                         try {
                             // use default warehouse nodes
                             Long computeNodeId = warehouseManager.getAliveComputeNodeId(computeResource, cloudNativeTablet);
-                            Preconditions.checkArgument(computeNodeId != null,
-                                    "No alive compute node found for tablet. Check if any backend is down or not. tablet_id: %s",
-                                    tablet.getId());
+                            if (computeNodeId == null) {
+                                errorStatus.setError_msgs(Lists.newArrayList(
+                                        "No alive compute node found for tablet. Check if any backend is down or not. tablet_id: "
+                                                + tablet.getId()));
+                                result.setStatus(errorStatus);
+                                return result;
+                            }
                             TTabletLocation tabletLocation = new TTabletLocation(tablet.getId(),
                                     Collections.singletonList(computeNodeId));
                             tablets.add(tabletLocation);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2425,7 +2425,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                         LakeTablet cloudNativeTablet = (LakeTablet) tablet;
                         try {
                             // use default warehouse nodes
-                            long computeNodeId = warehouseManager.getAliveComputeNodeId(computeResource, cloudNativeTablet);
+                            Long computeNodeId = warehouseManager.getAliveComputeNodeId(computeResource, cloudNativeTablet);
+                            Preconditions.checkArgument(computeNodeId != null,
+                                    "No alive compute node found for tablet. Check if any backend is down or not. tablet_id: %s",
+                                    tablet.getId());
                             TTabletLocation tabletLocation = new TTabletLocation(tablet.getId(),
                                     Collections.singletonList(computeNodeId));
                             tablets.add(tabletLocation);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2425,7 +2425,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                         LakeTablet cloudNativeTablet = (LakeTablet) tablet;
                         try {
                             // use default warehouse nodes
-                            long computeNodeId = warehouseManager.getComputeNodeId(computeResource, cloudNativeTablet);
+                            long computeNodeId = warehouseManager.getAliveComputeNodeId(computeResource, cloudNativeTablet);
                             TTabletLocation tabletLocation = new TTabletLocation(tablet.getId(),
                                     Collections.singletonList(computeNodeId));
                             tablets.add(tabletLocation);

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -796,6 +796,11 @@ public class SystemInfoService implements GsonPostProcessable {
         return backend != null && backend.isAvailable();
     }
 
+    public boolean checkComputeNodeAlive(long cnId) {
+        ComputeNode cn = idToComputeNodeRef.get(cnId);
+        return cn != null && cn.isAvailable();
+    }
+
     public boolean checkNodeAvailable(ComputeNode node) {
         if (node != null) {
             if (node instanceof Backend) {

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -796,11 +796,6 @@ public class SystemInfoService implements GsonPostProcessable {
         return backend != null && backend.isAvailable();
     }
 
-    public boolean checkComputeNodeAlive(long cnId) {
-        ComputeNode cn = idToComputeNodeRef.get(cnId);
-        return cn != null && cn.isAvailable();
-    }
-
     public boolean checkNodeAvailable(ComputeNode node) {
         if (node != null) {
             if (node instanceof Backend) {

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -812,6 +812,11 @@ public class SystemInfoService implements GsonPostProcessable {
         return backend != null && backend.isAlive();
     }
 
+    public boolean checkComputeNodeAlive(long cnId) {
+        ComputeNode computeNode = idToComputeNodeRef.get(cnId);
+        return computeNode != null && computeNode.isAlive();
+    }
+
     public ComputeNode getComputeNodeWithHeartbeatPort(String host, int heartPort) {
         for (ComputeNode computeNode : idToComputeNodeRef.values()) {
             if (NetUtils.isSameIP(computeNode.getHost(), host) && computeNode.getHeartbeatPort() == heartPort) {

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
@@ -223,6 +223,13 @@ public class TablePartitionActionTest extends StarRocksHttpTestCase {
 
                 GlobalStateMgr.getCurrentState().getWarehouseMgr()
                         .getComputeNodeId((ComputeResource) any, (LakeTablet) any);
+
+                minTimes = 0;
+                result = testBackendId1;
+
+                GlobalStateMgr.getCurrentState().getWarehouseMgr()
+                        .getAliveComputeNodeId((ComputeResource) any, (LakeTablet) any);
+
                 minTimes = 0;
                 result = testBackendId1;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
@@ -255,6 +255,11 @@ public class PseudoClusterTest {
             }
 
             @Mock
+            public List<Long> getAllNodeIdsByShard(long shardId, long workerGroupId) {
+                return GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds(true);
+            }
+
+            @Mock
             public FilePathInfo allocateFilePath(String storageVolumeId, long dbId, long tableId) throws DdlException {
                 return pathInfo;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -75,6 +75,8 @@ public class WarehouseManagerTest {
                 () -> mgr.getAllComputeNodeIds(WarehouseComputeResource.of(1L)));
         ExceptionChecker.expectThrowsWithMsg(ErrorReportException.class, "Warehouse id: 1 not exist.",
                 () -> mgr.getComputeNodeId(WarehouseComputeResource.of(1L), null));
+        ExceptionChecker.expectThrowsWithMsg(ErrorReportException.class, "Warehouse id: 1 not exist.",
+                () -> mgr.getAliveComputeNodeId(WarehouseComputeResource.of(1L), null));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplCreatePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplCreatePartitionTest.java
@@ -1,0 +1,131 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.DropTableStmt;
+import com.starrocks.thrift.TCreatePartitionRequest;
+import com.starrocks.thrift.TCreatePartitionResult;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.apache.thrift.TException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class FrontendServiceImplCreatePartitionTest {
+    @Mocked
+    ExecuteEnv exeEnv;
+
+    private static ConnectContext connectContext;
+
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        Config.alter_scheduler_interval_millisecond = 100;
+        Config.dynamic_partition_enable = true;
+        Config.dynamic_partition_check_interval_seconds = 1;
+        Config.enable_strict_storage_medium_check = false;
+        Config.stream_load_max_txn_num_per_be = 5;
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                    .withTable("CREATE TABLE test_table (\n" +
+                                "    event_day DATE,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY date_trunc('day', event_day) (\n" +
+                                "START (\"2020-06-01\") END (\"2022-06-05\") EVERY (INTERVAL 1 day)\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\"\n" +
+                                ");");
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String dropSQL = "drop table if exists test.test_table";
+        try {
+            DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
+            GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
+        } catch (Exception ex) {
+
+        }
+    }
+
+    @Test
+    public void testCreatePartition() throws TException {
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return new TransactionState();
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public Long getAliveComputeNodeId(ComputeResource computeResource, LakeTablet tablet) {
+                return null;
+            }
+        };
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_table");
+        List<List<String>> partitionValues = Lists.newArrayList();
+        List<String> values = Lists.newArrayList();
+        values.add("1990-04-24");
+        partitionValues.add(values);
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TCreatePartitionRequest request = new TCreatePartitionRequest();
+        request.setDb_id(db.getId());
+        request.setTable_id(table.getId());
+        request.setPartition_values(partitionValues);
+        TCreatePartitionResult partition = impl.createPartition(request);
+
+        Assertions.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.RUNTIME_ERROR);
+
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplCreatePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplCreatePartitionTest.java
@@ -55,11 +55,7 @@ public class FrontendServiceImplCreatePartitionTest {
     @BeforeAll
     public static void beforeClass() throws Exception {
         FeConstants.runningUnitTest = true;
-        Config.alter_scheduler_interval_millisecond = 100;
-        Config.dynamic_partition_enable = true;
-        Config.dynamic_partition_check_interval_seconds = 1;
         Config.enable_strict_storage_medium_check = false;
-        Config.stream_load_max_txn_num_per_be = 5;
         UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplCreatePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplCreatePartitionTest.java
@@ -126,6 +126,7 @@ public class FrontendServiceImplCreatePartitionTest {
         TCreatePartitionResult partition = impl.createPartition(request);
 
         Assertions.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.RUNTIME_ERROR);
-        Assertions.assertTrue(partition.getStatus().getError_msgs().get(0).contains("Check if any backend is down or not"));
+        Assertions.assertTrue(partition.getStatus().getError_msgs().get(0)
+                .contains("No alive compute node found for tablet. " + "Check if any backend is down or not. tablet_id:"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedWarehouseManager.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedWarehouseManager.java
@@ -115,6 +115,11 @@ public class MockedWarehouseManager extends WarehouseManager {
     }
 
     @Override
+    public Long getAliveComputeNodeId(ComputeResource computeResource, LakeTablet tablet) {
+        return computeNodeId;
+    }
+
+    @Override
     public List<Long> getAllComputeNodeIdsAssignToTablet(ComputeResource computeResource, LakeTablet tablet) {
         return computeNodeIdSetAssignedToTablet;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedWarehouseManager.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedWarehouseManager.java
@@ -57,7 +57,9 @@ public class MockedWarehouseManager extends WarehouseManager {
         super(computeResourceProvider, new ArrayList<>());
         warehouseIdToComputeNodeIds.put(DEFAULT_WAREHOUSE_ID, List.of(1000L));
         computeNodeIdSetAssignedToTablet.addAll(Lists.newArrayList(1000L));
-        computeNodeSetAssignedToTablet.addAll(Sets.newHashSet(new ComputeNode(1000L, "127.0.0.1", 9030)));
+        ComputeNode computeNode = new ComputeNode(1000L, "127.0.0.1", 9030);
+        computeNode.setAlive(true);
+        computeNodeSetAssignedToTablet.addAll(Sets.newHashSet(computeNode));
     }
     @Override
     public Warehouse getWarehouse(String warehouseName) {

--- a/fe/fe-core/src/test/java/com/starrocks/warehouse/WarehouseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/warehouse/WarehouseTest.java
@@ -59,6 +59,11 @@ public class WarehouseTest {
             public Long getComputeNodeId(ComputeResource computeResource, LakeTablet tablet) {
                 return null;
             }
+
+            @Mock
+            public Long getAliveComputeNodeId(ComputeResource computeResource, LakeTablet tablet) {
+                return null;
+            }
         };
         try {
             warehouseManager.getComputeNodeAssignedToTablet(WarehouseManager.DEFAULT_RESOURCE, new LakeTablet(0));


### PR DESCRIPTION
## Why I'm doing:
as title

## What I'm doing:

 avoid picking dead backends or compute nodes by introducing a new getAliveComputeNodeId method 


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
