### PR TITLE
[BugFix] fix paimon jni scanner

### DIFF
--- a/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonSplitScannerFactory.java
+++ b/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonSplitScannerFactory.java
@@ -17,24 +17,11 @@ package com.starrocks.paimon.reader;
 import com.starrocks.jni.connector.ScannerFactory;
 import com.starrocks.jni.connector.ScannerHelper;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-
 public class PaimonSplitScannerFactory implements ScannerFactory {
     static ClassLoader classLoader;
 
     static {
-        String basePath = System.getenv("STARROCKS_HOME");
-        List<File> preloadFiles = new ArrayList<>();
-        preloadFiles.add(new File(basePath + "/lib/jni-packages/starrocks-hadoop-ext.jar"));
-        File dir = new File(basePath + "/lib/paimon-reader-lib");
-        preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
-        dir = new File(basePath + "/lib/common-runtime-lib");
-        preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
-        classLoader = ScannerHelper.createChildFirstClassLoader(preloadFiles, "paimon scanner");
+        classLoader = ScannerHelper.createModuleClassLoader("paimon-reader-lib");
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:

Get error message like

```
(1064, "Failed to open the off-heap table scanner. java exception details: java.lang.LinkageError: loader constraint violation: when resolving method 'org.slf4j.ILoggerFactory org.slf4j.impl.StaticLoggerBinder.getLoggerFactory()' the class loader com.starrocks.utils.loader.ChildFirstClassLoader @53235a88 of the current class, org/slf4j/LoggerFactory, and the class loader 'app' for the method's defining class, org/slf4j/impl/StaticLoggerBinder, have different Class objects for the type org/slf4j/ILoggerFactory used in the signature (org.slf4j.LoggerFactory is in unnamed module of loader com.starrocks.utils.loader.ChildFirstClassLoader @53235a88, parent loader 'bootstrap'; org.slf4j.impl.StaticLoggerBinder is in unnamed module of loader 'app')
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:423)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:362)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:388)
	at org.apache.paimon.fs.FileIO.<clinit>(FileIO.java:64)
	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)
	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unsafe.java:1155)
	at java.base/jdk.internal.reflect.UnsafeFieldAccessorFactory.newFieldAccessor(UnsafeFieldAccessorFactory.java:42)
	at java.base/jdk.internal.reflect.ReflectionFactory.newFieldAccessor(ReflectionFactory.java:185)
	at java.base/java.lang.reflect.Field.acquireFieldAccessor(Field.java:1132)
	at java.base/java.lang.reflect.Field.getFieldAccessor(Field.java:1113)
	at java.base/java.lang.reflect.Field.getLong(Field.java:637)
	at java.base/java.io.ObjectStreamClass.getDeclaredSUID(ObjectStreamClass.java:1844)
	at java.base/java.io.ObjectStreamClass$2.run(ObjectStreamClass.java:527)
	at java.base/java.io.ObjectStreamClass$2.run(ObjectStreamClass.java:515)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
	at java.base/java.io.ObjectStreamClass.<init>(ObjectStreamClass.java:515)
	at java.base/java.io.ObjectStreamClass.lookup(ObjectStreamClass.java:409)
	at java.base/java.io.ObjectStreamClass.initNonProxy(ObjectStreamClass.java:710)
	at java.base/java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:2062)
	at java.base/java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1909)
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2235)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1744)
	at java.base/java.io.ObjectInputStream$FieldValues.<init>(ObjectInputStream.java:2617)
	at java.base/java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2468)
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2268)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1744)
	at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:514)
	at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:472)
	at org.apache.paimon.utils.InstantiationUtil.deserializeObject(InstantiationUtil.java:52)
	at org.apache.paimon.utils.InstantiationUtil.deserializeObject(InstantiationUtil.java:40)
	at com.starrocks.paimon.reader.PaimonScannerUtils.decodeStringToObject(PaimonScannerUtils.java:46)
	at com.starrocks.paimon.reader.PaimonSplitScanner.open(PaimonSplitScanner.java:113)
```

## What I'm doing:

I forgot to change paimon reader lib class loader in this pr: #60163

Fixes https://github.com/StarRocks/StarRocksTest/issues/9876

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
