### PR TITLE
[Enhancement] remove useless dir create operations when load spill

### DIFF
--- a/be/src/storage/lake/load_spill_block_manager.cpp
+++ b/be/src/storage/lake/load_spill_block_manager.cpp
@@ -92,7 +92,6 @@ Status LoadSpillBlockManager::init() {
     std::vector<std::shared_ptr<spill::Dir>> remote_dirs;
     // Remote FS can also use data cache to speed up.
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_remote_spill_path));
-    RETURN_IF_ERROR(fs->create_dir_if_missing(_remote_spill_path));
     auto dir = std::make_shared<spill::RemoteDir>(_remote_spill_path, std::move(fs), nullptr, INT64_MAX);
     remote_dirs.emplace_back(dir);
     _remote_dir_manager = std::make_unique<spill::DirManager>(remote_dirs);

--- a/be/src/storage/lake/load_spill_block_manager.cpp
+++ b/be/src/storage/lake/load_spill_block_manager.cpp
@@ -92,6 +92,11 @@ Status LoadSpillBlockManager::init() {
     std::vector<std::shared_ptr<spill::Dir>> remote_dirs;
     // Remote FS can also use data cache to speed up.
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_remote_spill_path));
+    if (fs->type() != FileSystem::Type::STARLET) {
+        // in starlet fs, there is opt create_missing_parent and it will create the parent dir if not exists.
+        // but in other fs, we need to create the parent dir manually.
+        RETURN_IF_ERROR(fs->create_dir_if_missing(_remote_spill_path));
+    }
     auto dir = std::make_shared<spill::RemoteDir>(_remote_spill_path, std::move(fs), nullptr, INT64_MAX);
     remote_dirs.emplace_back(dir);
     _remote_dir_manager = std::make_unique<spill::DirManager>(remote_dirs);


### PR DESCRIPTION
## Why I'm doing:
in starlet fs, there is opt create_missing_parent and it will create the parent dir if not exists.
https://github.com/StarRocks/starrocks/blob/9c9f55fe34b94a960419e94f74eed07c4795db4e/be/src/fs/fs_starlet.cpp#L358
So we don't need to pre create load_spill dir when use starlet fs, because in some fs system like S3, it will lead to useless PUT operations.

## What I'm doing:
This pull request includes a change to the `LoadSpillBlockManager::init()` method in the `be/src/storage/lake/load_spill_block_manager.cpp` file. The change ensures compatibility with file systems other than `STARLET` by adding logic to manually create the parent directory if it does not exist.

File system compatibility:

* [`be/src/storage/lake/load_spill_block_manager.cpp`](diffhunk://#diff-3d5ac9393009053362a818f7b4a988b0053fa6b1079ab9294dfdc2904511010bR95-R99): Added a conditional check to verify the file system type and manually create the parent directory for non-`STARLET` file systems, as `STARLET` automatically handles this via an optional setting.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
