### PR TITLE
[BugFix] Fix the error message when create python udf failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
@@ -72,7 +72,7 @@ public class CreateFunctionAnalyzer {
         } else if (CreateFunctionStmt.TYPE_STARROCKS_PYTHON.equalsIgnoreCase(langType)) {
             analyzePython(stmt);
         } else {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_OBJECT, "unknown lang type");
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "unknown lang type");
         }
         // build function
     }
@@ -579,11 +579,11 @@ public class CreateFunctionAnalyzer {
         String objectFile = stmt.getProperties().get(CreateFunctionStmt.FILE_KEY);
 
         if (isInline && !StringUtils.equals(objectFile, "inline")) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_OBJECT, "inline function file should be 'inline'");
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "inline function file should be 'inline'");
         }
 
         if (!inputType.equalsIgnoreCase("arrow") && !inputType.equalsIgnoreCase("scalar")) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_OBJECT, "unknown input type:", inputType);
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "unknown input type:" + inputType);
         }
 
         FunctionName functionName = stmt.getFunctionName();

--- a/test/sql/test_udf/R/test_python_udf
+++ b/test/sql/test_udf/R/test_python_udf
@@ -286,3 +286,36 @@ select add_one(2200000000);
 -- result:
 2200000001
 -- !result
+
+CREATE FUNCTION get_invalid_input(boolean) RETURNS
+string
+properties(
+    "symbol" = "echo",
+    "type" = "Python",
+    "file" = "inline",
+    "input" = "invalid"
+)
+AS
+$$
+def echo(x):
+    return type(x)
+$$;
+-- result:
+[REGEX].*unknown input type.*
+-- !result
+CREATE FUNCTION get_invalid_input(boolean) RETURNS
+string
+properties(
+    "symbol" = "echo",
+    "type" = "Python",
+    "file" = "invalid",
+    "input" = "scalar"
+)
+AS
+$$
+def echo(x):
+    return type(x)
+$$;
+-- result:
+[REGEX].*inline function file should be.*
+-- !result

--- a/test/sql/test_udf/T/test_python_udf
+++ b/test/sql/test_udf/T/test_python_udf
@@ -247,3 +247,31 @@ $$;
 
 select add_one(1);
 select add_one(2200000000);
+
+CREATE FUNCTION get_invalid_input(boolean) RETURNS
+string
+properties(
+    "symbol" = "echo",
+    "type" = "Python",
+    "file" = "inline",
+    "input" = "invalid"
+)
+AS
+$$
+def echo(x):
+    return type(x)
+$$;
+
+CREATE FUNCTION get_invalid_input(boolean) RETURNS
+string
+properties(
+    "symbol" = "echo",
+    "type" = "Python",
+    "file" = "invalid",
+    "input" = "scalar"
+)
+AS
+$$
+def echo(x):
+    return type(x)
+$$;


### PR DESCRIPTION
## Why I'm doing:

Similar as https://github.com/StarRocks/starrocks/pull/60020/files

```
CREATE FUNCTION get_invalid_input(boolean) RETURNS
string
properties(
    "symbol" = "echo",
    "type" = "Python",
    "file" = "invalid",
    "input" = "scalar"
)
AS
$$
def echo(x):
    return type(x)
$$;
-- result:
E: (1347, "Getting analyzing error. Detail message: '%s'.'%s' is not '%s'.")
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
