### PR TITLE
[Enhancement] Add increase value in tablet scheduler stat proc

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/SchedulerStatProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/SchedulerStatProcNode.java
@@ -41,21 +41,18 @@ import com.starrocks.server.GlobalStateMgr;
 
 public class SchedulerStatProcNode implements ProcNodeInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("Item").add("Value").build();
+            .add("Item").add("Value").add("Increase").build();
 
     private TabletSchedulerStat stat;
 
     public SchedulerStatProcNode() {
-        this.stat = GlobalStateMgr.getCurrentState().getTabletScheduler().getStat().getLastSnapshot();
+        this.stat = GlobalStateMgr.getCurrentState().getTabletScheduler().getStat();
     }
 
     @Override
     public ProcResult fetchResult() throws AnalysisException {
         BaseProcResult result = new BaseProcResult();
         result.setNames(TITLE_NAMES);
-        if (stat == null) {
-            return result;
-        }
         result.setRows(stat.getBrief());
         return result;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerStatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerStatTest.java
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.clone;
+
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.TimeUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class TabletSchedulerStatTest {
+
+    @Test
+    public void testGetBrief() {
+        TabletSchedulerStat stat = new TabletSchedulerStat();
+
+        // update
+        stat.counterCloneTask.incrementAndGet();
+        stat.counterCloneTaskSucceeded.incrementAndGet();
+        Assertions.assertEquals(1L, stat.counterCloneTask.get());
+        Assertions.assertEquals(1L, stat.counterCloneTaskSucceeded.get());
+        Assertions.assertEquals(0L, stat.counterCloneTaskFailed.get());
+        Assertions.assertNull(stat.getLastSnapshot());
+        long lastSnapShotTime = ((AtomicLong) Deencapsulation.getField(stat, "lastSnapshotTime")).get();
+        Assertions.assertEquals(-1L, lastSnapShotTime);
+
+        // snapshot
+        Deencapsulation.invoke(stat, "snapshot");
+        Assertions.assertNotNull(stat.getLastSnapshot());
+        lastSnapShotTime = ((AtomicLong) Deencapsulation.getField(stat, "lastSnapshotTime")).get();
+        Assertions.assertTrue(lastSnapShotTime > 0);
+
+        // update
+        stat.counterCloneTask.incrementAndGet();
+        stat.counterCloneTaskFailed.incrementAndGet();
+        Assertions.assertEquals(2L, stat.counterCloneTask.get());
+        Assertions.assertEquals(1L, stat.counterCloneTaskSucceeded.get());
+        Assertions.assertEquals(1L, stat.counterCloneTaskFailed.get());
+
+        // test getBrief
+        List<List<String>> infos = stat.getBrief();
+        Assertions.assertEquals(27, infos.size());
+        for (List<String> info : infos) {
+            if (info.get(0).equals("num of clone task")) {
+                Assertions.assertEquals("1", info.get(1));
+                Assertions.assertEquals("1", info.get(2));
+            } else if (info.get(0).equals("num of clone task succeeded")) {
+                Assertions.assertEquals("1", info.get(1));
+                Assertions.assertEquals("0", info.get(2));
+            } else if (info.get(0).equals("num of clone task failed")) {
+                Assertions.assertEquals("0", info.get(1));
+                Assertions.assertEquals("1", info.get(2));
+            } else if (info.get(0).equals("last snapshot time")) {
+                Assertions.assertEquals(TimeUtils.longToTimeString(lastSnapShotTime), info.get(1));
+                String increase = info.get(2);
+                Assertions.assertTrue(Long.parseLong(increase.substring(0, increase.length() - 1)) >= 0);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

```
mysql> show proc "/cluster_balance/sched_stat";
+---------------------------------------------------+-------+
| Item                                              | Value |
+---------------------------------------------------+-------+
| num of tablet check round                         | 20    |
| cost of tablet check(ms)                          | 24    |
| num of tablet checked in tablet checker           | 986   |
| num of unhealthy tablet checked in tablet checker | 133   |
| num of tablet being added to tablet scheduler     | 38    |
| num of tablet schedule round                      | 380   |
| cost of tablet schedule(ms)                       | 145   |
| num of tablet being scheduled                     | 2338  |
| num of tablet being scheduled succeeded           | 38    |
| num of tablet being scheduled failed              | 2300  |
| num of tablet being scheduled discard             | 0     |
| num of tablet priority upgraded                   | 0     |
| num of clone task                                 | 38    |
| num of clone task succeeded                       | 38    |
| num of clone task failed                          | 0     |
| num of clone task timeout                         | 0     |
| num of replica missing error                      | 2338  |
| num of replica version missing error              | 0     |
| num of replica unavailable error                  | 0     |
| num of replica location mismatch error            | 0     |
| num of replica redundant error                    | 0     |
| num of replica missing in cluster error           | 0     |
| num of balance scheduled                          | 0     |
| num of colocate replica mismatch                  | 0     |
| num of colocate replica redundant                 | 0     |
| num of colocate balancer running round            | 0     |
+---------------------------------------------------+-------+
26 rows in set (0.01 sec)
```

## What I'm doing:

```
mysql> show proc "/cluster_balance/sched_stat";
+---------------------------------------------------+---------------------+----------+
| Item                                              | Value               | Increase |
+---------------------------------------------------+---------------------+----------+
| num of tablet check round                         | 40                  | 0        |
| cost of tablet check(ms)                          | 54368               | 0        |
| num of tablet checked in tablet checker           | 2962                | 0        |
| num of unhealthy tablet checked in tablet checker | 1687                | 0        |
| num of tablet being added to tablet scheduler     | 1649                | 0        |
| num of tablet schedule round                      | 740                 | 10       |
| cost of tablet schedule(ms)                       | 787                 | 1        |
| num of tablet being scheduled                     | 6128                | 27       |
| num of tablet being scheduled succeeded           | 501                 | 19       |
| num of tablet being scheduled failed              | 4000                | 8        |
| num of tablet being scheduled discard             | 1627                | 0        |
| num of tablet priority upgraded                   | 0                   | 0        |
| num of clone task                                 | 252                 | 19       |
| num of clone task succeeded                       | 252                 | 19       |
| num of clone task failed                          | 0                   | 0        |
| num of clone task timeout                         | 0                   | 0        |
| num of replica missing error                      | 0                   | 27       |
| num of replica version missing error              | 1543                | 0        |
| num of replica unavailable error                  | 0                   | 0        |
| num of replica location mismatch error            | 0                   | 0        |
| num of replica redundant error                    | 0                   | 0        |
| num of replica missing in cluster error           | 0                   | 0        |
| num of balance scheduled                          | 0                   | 0        |
| num of colocate replica mismatch                  | 4000                | 0        |
| num of colocate replica redundant                 | 498                 | 0        |
| num of colocate balancer running round            | 150                 | 5        |
| last snapshot time                                | 2025-06-25 16:31:09 | 9s       |
+---------------------------------------------------+---------------------+----------+
27 rows in set (0.00 sec)
```

1. Add a new column `Increase` for incremental value since the last snapshot.
2. Add a new line item to show `last snapshot time` and `increase time` since the last snapshot.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
