### PR TITLE
[BugFix] Fix alter mv active bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -226,8 +226,7 @@ public class AlterJobMgr {
             List<BaseTableInfo> baseTableInfos =
                     Lists.newArrayList(MaterializedViewAnalyzer.getBaseTableInfos(mvQueryStatement, !isReplay));
             materializedView.setBaseTableInfos(baseTableInfos);
-            materializedView.onReload();
-            materializedView.setActive();
+            materializedView.fixRelationship();
         } else if (AlterMaterializedViewStatusClause.INACTIVE.equalsIgnoreCase(status)) {
             materializedView.setInactiveAndReason(reason);
             // clear running & pending task runs since the mv has been inactive

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -523,7 +523,6 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         try {
             if (AlterMaterializedViewStatusClause.ACTIVE.equalsIgnoreCase(status)) {
                 // check if the materialized view can be activated without rebuilding relationships.
-                materializedView.fixRelationship();
                 if (materializedView.isActive()) {
                     return null;
                 }

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1967,18 +1967,10 @@ class StarrocksSQLApiLib(object):
             res = self.retry_execute_sql(show_sql, True)
             if not res["status"]:
                 tools.assert_true(False, "show mv state error")
-            success_cnt = get_success_count(res["result"])
+            success_cnt = self.get_task_run_success_count(res["result"])
             if success_cnt >= check_count:
                 return True
             return False
-
-        # information_schema.task_runs result
-        def get_success_count(results):
-            cnt = 0
-            for _res in results:
-                if _res[0] in TASK_RUN_SUCCESS_STATES:
-                    cnt += 1
-            return cnt
 
         max_loop_count = 180
         is_all_ok = False
@@ -2001,10 +1993,18 @@ class StarrocksSQLApiLib(object):
                 count += 1
         tools.assert_equal(True, is_all_ok, "wait async materialized view finish error")
 
+    # information_schema.task_runs result
+    def get_task_run_success_count(self, results):
+        cnt = 0
+        for _res in results:
+            if _res[0] in TASK_RUN_SUCCESS_STATES:
+                cnt += 1
+        return cnt
+
     def wait_mv_refresh_count(self, db_name, mv_name, expect_count):
-        show_sql = """select count(*) from information_schema.materialized_views 
+        show_sql = """select state from information_schema.materialized_views 
             join information_schema.task_runs using(task_name)
-            where table_schema='{}' and table_name='{}' and (state = 'SUCCESS' or state = 'MERGED'  or state = 'SKIPPED')
+            where table_schema='{}' and table_name='{}';
         """.format(
             db_name, mv_name
         )
@@ -2014,8 +2014,7 @@ class StarrocksSQLApiLib(object):
         refresh_count = 0
         while cnt < 60:
             res = self.retry_execute_sql(show_sql, True)
-            print(res)
-            refresh_count = res["result"][0][0]
+            refresh_count = self.get_task_run_success_count(res["result"])
             if refresh_count >= expect_count:
                 return
             else:

--- a/test/sql/test_mv/R/test_mv_with_schema_change_column_rename
+++ b/test/sql/test_mv/R/test_mv_with_schema_change_column_rename
@@ -49,7 +49,7 @@ SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHE
 -- result:
 true	
 -- !result
-SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;
+SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1 ORDER BY k1;
 -- result:
 None	0	None	None	None	None
 2020-06-23	1	beijing	haidian	1	-128.0
@@ -64,7 +64,7 @@ function: print_hit_materialized_view("SELECT count(k2) as count_datetime, min(k
 -- result:
 False
 -- !result
-SELECT count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition;
+SELECT count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition ORDER BY count_datetime, min_char, max_varchar, sum_boolean, avg_tinyint;
 -- result:
 4	beijing	zhonglou	3	0.0
 -- !result
@@ -74,7 +74,7 @@ INSERT INTO duplicate_table_with_null_partition VALUES ("2020-06-24","2020-06-23
 [UC]REFRESH MATERIALIZED VIEW test_mv1 with sync mode;
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'test_mv1' and TABLE_SCHEMA='db_${uuid0}';
 -- result:
-false	reload failed: null
+false	base table schema changed for columns: k1
 -- !result
 alter table duplicate_table_with_null_partition rename column k11 to k1;
 -- result:
@@ -85,19 +85,19 @@ INSERT INTO duplicate_table_with_null_partition VALUES ("2020-06-24","2020-06-23
 [UC]REFRESH MATERIALIZED VIEW test_mv1 with sync mode;
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'test_mv1' and TABLE_SCHEMA='db_${uuid0}';
 -- result:
-false	reload failed: null
+true	
 -- !result
 function: print_hit_materialized_view("SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;", "test_mv1")
 -- result:
-False
+True
 -- !result
-SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;
+SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1 ORDER BY k1;
 -- result:
+None	0	None	None	None	None
+2020-06-23	1	beijing	haidian	1	-128.0
+2020-06-24	2	beijing	haidian	2	-128.0
 2020-07-23	2	shanghai	pudong1	1	0.5
 2020-08-23	1	xian	zhonglou	1	127.0
-None	0	None	None	None	None
-2020-06-24	2	beijing	haidian	2	-128.0
-2020-06-23	1	beijing	haidian	1	-128.0
 -- !result
 drop database db_${uuid0} force;
 -- result:

--- a/test/sql/test_mv/R/test_mv_with_schema_change_column_rename
+++ b/test/sql/test_mv/R/test_mv_with_schema_change_column_rename
@@ -1,0 +1,104 @@
+-- name: test_mv_with_schema_change_column_rename
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `duplicate_table_with_null_partition` (
+  `k1` date,
+  `k2` datetime,
+  `k3` char(20),
+  `k4` varchar(20),
+  `k5` boolean,
+  `k6` tinyint
+)
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
+PARTITION BY RANGE(`k1`)
+(
+  PARTITION `p202006` VALUES LESS THAN ("2020-07-01"),
+  PARTITION `p202007` VALUES LESS THAN ("2020-08-01"),
+  PARTITION `p202008` VALUES LESS THAN ("2020-09-01")
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3;
+-- result:
+-- !result
+INSERT INTO duplicate_table_with_null_partition VALUES
+  ("2020-06-23","2020-06-23 00:00:00","beijing","haidian",-1,-128),
+  ("2020-07-23","2020-07-23 00:00:00","shanghai","pudong",0,0),
+  ("2020-07-23","2020-07-24 00:00:00","shanghai1","pudong1",1,1),
+  ("2020-08-23","2020-08-23 00:00:00","xian","zhonglou",1,127),
+  (NULL,NULL,NULL,NULL,NULL,NULL);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY k1 
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH ASYNC 
+AS SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;
+-- result:
+-- !result
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+function: print_hit_materialized_view("SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'test_mv1' and TABLE_SCHEMA='db_${uuid0}';
+-- result:
+true	
+-- !result
+SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;
+-- result:
+None	0	None	None	None	None
+2020-06-23	1	beijing	haidian	1	-128.0
+2020-07-23	2	shanghai	pudong1	1	0.5
+2020-08-23	1	xian	zhonglou	1	127.0
+-- !result
+alter table duplicate_table_with_null_partition rename column k1 to k11;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 with sync mode;
+function: print_hit_materialized_view("SELECT count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition", "test_mv1")
+-- result:
+False
+-- !result
+SELECT count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition;
+-- result:
+4	beijing	zhonglou	3	0.0
+-- !result
+INSERT INTO duplicate_table_with_null_partition VALUES ("2020-06-24","2020-06-23 00:00:00","beijing","haidian",-1,-128);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 with sync mode;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'test_mv1' and TABLE_SCHEMA='db_${uuid0}';
+-- result:
+false	reload failed: null
+-- !result
+alter table duplicate_table_with_null_partition rename column k11 to k1;
+-- result:
+-- !result
+INSERT INTO duplicate_table_with_null_partition VALUES ("2020-06-24","2020-06-23 00:00:00","beijing","haidian",-1,-128);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 with sync mode;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'test_mv1' and TABLE_SCHEMA='db_${uuid0}';
+-- result:
+false	reload failed: null
+-- !result
+function: print_hit_materialized_view("SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;
+-- result:
+2020-07-23	2	shanghai	pudong1	1	0.5
+2020-08-23	1	xian	zhonglou	1	127.0
+None	0	None	None	None	None
+2020-06-24	2	beijing	haidian	2	-128.0
+2020-06-23	1	beijing	haidian	1	-128.0
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_mv/T/test_mv_with_schema_change_column_rename
+++ b/test/sql/test_mv/T/test_mv_with_schema_change_column_rename
@@ -1,0 +1,58 @@
+-- name: test_mv_with_schema_change_column_rename
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `duplicate_table_with_null_partition` (
+  `k1` date,
+  `k2` datetime,
+  `k3` char(20),
+  `k4` varchar(20),
+  `k5` boolean,
+  `k6` tinyint
+)
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
+PARTITION BY RANGE(`k1`)
+(
+  PARTITION `p202006` VALUES LESS THAN ("2020-07-01"),
+  PARTITION `p202007` VALUES LESS THAN ("2020-08-01"),
+  PARTITION `p202008` VALUES LESS THAN ("2020-09-01")
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3;
+
+INSERT INTO duplicate_table_with_null_partition VALUES
+  ("2020-06-23","2020-06-23 00:00:00","beijing","haidian",-1,-128),
+  ("2020-07-23","2020-07-23 00:00:00","shanghai","pudong",0,0),
+  ("2020-07-23","2020-07-24 00:00:00","shanghai1","pudong1",1,1),
+  ("2020-08-23","2020-08-23 00:00:00","xian","zhonglou",1,127),
+  (NULL,NULL,NULL,NULL,NULL,NULL);
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY k1 
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH ASYNC 
+AS SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;
+
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+function: print_hit_materialized_view("SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;", "test_mv1")
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'test_mv1' and TABLE_SCHEMA='db_${uuid0}';
+SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;
+
+alter table duplicate_table_with_null_partition rename column k1 to k11;
+[UC]REFRESH MATERIALIZED VIEW test_mv1 with sync mode;
+function: print_hit_materialized_view("SELECT count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition", "test_mv1")
+SELECT count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition;
+
+INSERT INTO duplicate_table_with_null_partition VALUES ("2020-06-24","2020-06-23 00:00:00","beijing","haidian",-1,-128);
+[UC]REFRESH MATERIALIZED VIEW test_mv1 with sync mode;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'test_mv1' and TABLE_SCHEMA='db_${uuid0}';
+
+alter table duplicate_table_with_null_partition rename column k11 to k1;
+
+INSERT INTO duplicate_table_with_null_partition VALUES ("2020-06-24","2020-06-23 00:00:00","beijing","haidian",-1,-128);
+[UC]REFRESH MATERIALIZED VIEW test_mv1 with sync mode;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'test_mv1' and TABLE_SCHEMA='db_${uuid0}';
+
+function: print_hit_materialized_view("SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;", "test_mv1")
+SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;
+
+drop database db_${uuid0} force;

--- a/test/sql/test_mv/T/test_mv_with_schema_change_column_rename
+++ b/test/sql/test_mv/T/test_mv_with_schema_change_column_rename
@@ -35,12 +35,12 @@ AS SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_v
 function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
 function: print_hit_materialized_view("SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;", "test_mv1")
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'test_mv1' and TABLE_SCHEMA='db_${uuid0}';
-SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;
+SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1 ORDER BY k1;
 
 alter table duplicate_table_with_null_partition rename column k1 to k11;
 [UC]REFRESH MATERIALIZED VIEW test_mv1 with sync mode;
 function: print_hit_materialized_view("SELECT count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition", "test_mv1")
-SELECT count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition;
+SELECT count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition ORDER BY count_datetime, min_char, max_varchar, sum_boolean, avg_tinyint;
 
 INSERT INTO duplicate_table_with_null_partition VALUES ("2020-06-24","2020-06-23 00:00:00","beijing","haidian",-1,-128);
 [UC]REFRESH MATERIALIZED VIEW test_mv1 with sync mode;
@@ -53,6 +53,6 @@ INSERT INTO duplicate_table_with_null_partition VALUES ("2020-06-24","2020-06-23
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'test_mv1' and TABLE_SCHEMA='db_${uuid0}';
 
 function: print_hit_materialized_view("SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;", "test_mv1")
-SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1;
+SELECT k1, count(k2) as count_datetime, min(k3) as min_char, max(k4) as max_varchar, sum(k5) as sum_boolean, avg(k6) as avg_tinyint FROM duplicate_table_with_null_partition GROUP BY k1 ORDER BY k1;
 
 drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/60188 will inactive related mvs if base table has  column renamed, but there are some corner cases that mv is still active.


The root cause is  below, `setActive` is called no matter `onReload` is ok or not:
```
   List<BaseTableInfo> baseTableInfos =
                    Lists.newArrayList(MaterializedViewAnalyzer.getBaseTableInfos(mvQueryStatement, !isReplay));
            materializedView.setBaseTableInfos(baseTableInfos);
            materializedView.onReload();
            materializedView.setActive(); <- no matter onReload is success or fail, mv will make active!
```
## What I'm doing:
1. Ensure mv is actived only if `onReload` is success.


Fixes https://github.com/StarRocks/StarRocksTest/pull/9880

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
