### PR TITLE
[BugFix] Fix information_schema.task_runs schema scan bugs

### DIFF
--- a/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
@@ -273,6 +273,7 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                 Slice value(str->c_str(), str->length());
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
             }
+            break;
         }
         case 15: {
             // job_id
@@ -282,6 +283,7 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                 Slice value(str->c_str(), str->length());
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
             }
+            break;
         }
         case 16: {
             // process_time


### PR DESCRIPTION
## Why I'm doing:
1. Fix a bug introduced by https://github.com/StarRocks/starrocks/pull/60054, which make crash in ASAN mode
```
[1750817570.16][thread: 47344112494336] je_mallctl execute dontdump success
*** Aborted at 1750817570 (unix time) try "date -d @1750817570" if you are using GNU date ***
PC: @     0x2b0e3de16387 __GI_raise
*** SIGABRT (@0x3e8000056f5) received by PID 22261 (TID 0x2b0f2901e700) LWP(22621) from PID 22261; stack trace: ***
   @         0x1fa7cc47 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
   @     0x2b0e3bd3a20b __pthread_once_slow
   @         0x1fa7c454 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
   @     0x2b0e3bd43630 (/usr/lib64/libpthread-2.17.so+0xf62f)
   @     0x2b0e3de16387 __GI_raise
   @     0x2b0e3de17a78 __GI_abort
   @          0xf2b1d2e starrocks::failure_function()
   @         0x1fa7124a google::LogMessage::Fail()
   @         0x1fa72c84 google::LogMessageFatal::~LogMessageFatal()
   @          0xf37d26e starrocks::Chunk::check_or_die()
   @         0x15b8d117 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
   @         0x15b8cada starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
   @          0xf6e4108 starrocks::ExecNode::eval_conjuncts(std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const&, starrocks::Chunk*, std::shared_ptr<std::vector<unsigned char, starrocks::ColumnAllocator<unsigned char> > >*, bool)
   @         0x1281d0ff starrocks::pipeline::SchemaChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
   @         0x127e634e starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
   @         0x110d341a auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const
   @         0x110d9e13 void std::__invoke_impl<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>(std::__invoke_other, starrocks::pipeline::ScanOperator::_trigger_next_scan(starro@
   @         0x110d9a6a std::enable_if<is_invocable_r_v<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>, void>::type std::__invoke_r<void, starrocks::pipeline::ScanOperator::_tr@
   @         0x110d939d std::_Function_handler<void (starrocks::workgroup::YieldContext&), starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}>::_M_invoke(std::_Any_data const&, starrocks::workgroup::YieldContext&)
   @         0x11541a9b std::function<void (starrocks::workgroup::YieldContext&)>::operator()(starrocks::workgroup::YieldContext&) const
   @         0x11540623 starrocks::workgroup::ScanTask::run()
   @         0x1162be48 starrocks::workgroup::ScanExecutor::worker_thread()
   @         0x1162b484 starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}::operator()() const
   @         0x1162d6ba void std::__invoke_impl<void, starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}&)
   @         0x1162d36d std::enable_if<is_invocable_r_v<void, starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}&>(starrocks::workgroup::ScanExecutor::initialize(@
   @         0x1162d0b9 std::_Function_handler<void (), starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
   @          0xd700352 std::function<void ()>::operator()() const
   @          0xdf91106 starrocks::FunctionRunnable::run()
   @          0xdf8bf5c starrocks::ThreadPool::dispatch_thread()
   @          0xdfae458 void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
   @          0xdfacd6b std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>
```

## What I'm doing:
1. Add `break` for task_runs schema scan. 


Fixes https://github.com/StarRocks/StarRocksTest/issues/9875

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
