### PR TITLE
[Doc] reformat the CREATE TABLE doc

### DIFF
--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -27,8 +27,6 @@ CREATE [EXTERNAL] [TEMPORARY] TABLE [IF NOT EXISTS] [database.]table_name
 [BROKER PROPERTIES ("key"="value", ...)]
 ```
 
-## Parameters
-
 :::tip
 
 - The table name, partition name, column name, and index name you create must follow the naming conventions in [System limits](../../System_limit.md).
@@ -36,19 +34,136 @@ CREATE [EXTERNAL] [TEMPORARY] TABLE [IF NOT EXISTS] [database.]table_name
 
 :::
 
-### column_definition
+## Keywords
 
-Syntax:
+### `EXTERNAL`
+
+:::caution the external keyword is deprecated
+We recommend that you use [external catalogs](../../../data_source/catalog/catalog_overview.md) to query data from Hive, Iceberg, Hudi, and JDBC data sources instead of using the `EXTERNAL` keyword.
+:::
+
+:::tip recommendation
+From v3.1 onwards, StarRocks supports creating Parquet-formatted tables in Iceberg catalogs, and you can insert data to these Parquet-formatted Iceberg tables by using INSERT INTO.
+
+From v3.2 onwards, StarRocks supports creating Parquet-formatted tables in Hive catalogs, and supports sinking data to these Parquet-formatted Hive tables by using INSERT INTO. From v3.3 onwards, StarRocks supports creating ORC- and Textfile-formatted tables in Hive catalogs, and supports sinking data to these ORC- and Textfile-formatted Hive tables by using INSERT INTO.
+:::
+
+If you would like to use the deprecated `EXTERNAL` keyword please expand **`EXTERNAL` keyword details**
+
+<details>
+
+<summary>`EXTERNAL` keyword details`</summary>
+
+To create an external table to query external data sources, specify `CREATE EXTERNAL TABLE` and set `ENGINE` to any of these values. You can refer to [External table](../../../data_source/External_table.md) for more information.
+
+- For MySQL external tables, specify the following properties:
+
+    ```plaintext
+    PROPERTIES (
+        "host" = "mysql_server_host",
+        "port" = "mysql_server_port",
+        "user" = "your_user_name",
+        "password" = "your_password",
+        "database" = "database_name",
+        "table" = "table_name"
+    )
+    ```
+
+    Note:
+
+    "table_name" in MySQL should indicate the real table name. In contrast, "table_name" in CREATE TABLE statement indicates the name of this mysql table on StarRocks. They can either be different or the same.
+
+    The aim of creating MySQL tables in StarRocks is to access MySQL database. StarRocks itself does not maintain or store any MySQL data.
+
+- For Elasticsearch external tables, specify the following properties:
+
+    ```plaintext
+    PROPERTIES (
+
+    "hosts" = "http://192.168.0.1:8200,http://192.168.0.2:8200",
+    "user" = "root",
+    "password" = "root",
+    "index" = "tindex",
+    "type" = "doc"
+    )
+    ```
+
+  - `hosts`: the URL that is used to connect your Elasticsearch cluster. You can specify one or more URLs.
+  - `user`: the account of the root user that is used to log in to your Elasticsearch cluster for which basic authentication is enabled.
+  - `password`: the password of the preceding root account.
+  - `index`: the index of the StarRocks table in your Elasticsearch cluster. The index name is the same as the StarRocks table name. You can set this parameter to the alias of the StarRocks table.
+  - `type`: the type of index. The default value is `doc`.
+
+- For Hive external tables, specify the following properties:
+
+    ```plaintext
+    PROPERTIES (
+
+        "database" = "hive_db_name",
+        "table" = "hive_table_name",
+        "hive.metastore.uris" = "thrift://xx.xx.xx.xx:9083"
+    )
+    ```
+
+    Here, database is the name of the corresponding database in Hive table. Table is the name of Hive table. `hive.metastore.uris` is the server address.
+
+- For JDBC external tables, specify the following properties:
+
+    ```plaintext
+    PROPERTIES (
+    "resource"="jdbc0",
+    "table"="dest_tbl"
+    )
+    ```
+
+    `resource` is the JDBC resource name and `table` is the destination table.
+
+- For Iceberg external tables, specify the following properties:
+
+   ```plaintext
+    PROPERTIES (
+    "resource" = "iceberg0", 
+    "database" = "iceberg", 
+    "table" = "iceberg_table"
+    )
+    ```
+
+    `resource` is the Iceberg resource name. `database` is the Iceberg database. `table` is the Iceberg table.
+
+- For Hudi external tables, specify the following properties:
+
+  ```plaintext
+    PROPERTIES (
+    "resource" = "hudi0", 
+    "database" = "hudi", 
+    "table" = "hudi_table" 
+    )
+    ```
+
+</details>
+
+### `TEMPORARY`
+
+Creates a temporary table. From v3.3.1, StarRocks supports creating temporary tables in the Default Catalog. For more information, see [Temporary Table](../../../table_design/StarRocks_table_design.md#temporary-table).
+
+:::note
+When creating a temporary table, you must set `ENGINE` to `olap`.
+:::
+
+
+## Column definition
 
 ```SQL
 col_name col_type [agg_type] [NULL | NOT NULL] [DEFAULT "default_value"] [AUTO_INCREMENT] [AS generation_expr]
 ```
 
-**col_name**: column name.
+### col_name
 
 Note that normally you cannot create a column whose name is initiated with `__op` or `__row` because these name formats are reserved for special purposes in StarRocks and creating such columns may result in undefined behavior. If you do need to create such column, set the FE dynamic parameter [`allow_system_reserved_names`](../../../administration/management/FE_configuration.md#allow_system_reserved_names) to `TRUE`.
 
-**col_type**: Column type. Specific column information, such as types and ranges:
+### col_type
+
+Specific column information, such as types and ranges:
 
 - TINYINT (1 byte): Ranges from -2^7 + 1 to 2^7 - 1.
 - SMALLINT (2 bytes): Ranges from -2^15 + 1 to 2^15 - 1.
@@ -73,18 +188,20 @@ Note that normally you cannot create a column whose name is initiated with `__op
 - HLL (1~16385 bytes): For HLL type, there's no need to specify length or default value. The length will be controlled within the system according to data aggregation. HLL column can only be queried or used by [hll_union_agg](../../sql-functions/aggregate-functions/hll_union_agg.md), [Hll_cardinality](../../sql-functions/scalar-functions/hll_cardinality.md), and [hll_hash](../../sql-functions/scalar-functions/hll_hash.md).
 - BITMAP: Bitmap type does not require specified length or default value. It represents a set of unsigned bigint numbers. The largest element could be up to 2^64 - 1.
 
-**agg_type**: aggregation type. If not specified, this column is key column.
-If specified, it is value column. The aggregation types supported are as follows:
+### agg_type
 
-- SUM, MAX, MIN, REPLACE
-- HLL_UNION (only for HLL type)
-- BITMAP_UNION(only for BITMAP)
-- REPLACE_IF_NOT_NULL: This means the imported data will only be replaced when it is of non-null value. If it is of null value, StarRocks will retain the original value.
+Aggregation type. If not specified, this column is a key column.
+If specified, it is a value column. The aggregation types supported are as follows:
 
-> NOTE
->
-> - When the column of aggregation type BITMAP_UNION is imported, its original data types must be TINYINT, SMALLINT, INT, and BIGINT.
-> - If NOT NULL is specified by REPLACE_IF_NOT_NULL column when the table was created, StarRocks will still convert the data to NULL without sending an error report to the user. With this, the user can import selected columns.
+- `SUM`, `MAX`, `MIN`, `REPLACE`
+- `HLL_UNION` (only for `HLL` type)
+- `BITMAP_UNION` (only for `BITMAP`)
+- `REPLACE_IF_NOT_NULL`: This means the imported data will only be replaced when it is of non-null value. If it is of null value, StarRocks will retain the original value.
+
+:::note
+- When the column of aggregation type BITMAP_UNION is imported, its original data types must be TINYINT, SMALLINT, INT, and BIGINT.
+- If NOT NULL is specified by REPLACE_IF_NOT_NULL column when the table was created, StarRocks will still convert the data to NULL without sending an error report to the user. With this, the user can import selected columns.
+:::
 
 This aggregation type applies ONLY to the Aggregate table whose key_desc type is AGGREGATE KEY. Since v3.1.9, `REPLACE_IF_NOT_NULL` newly supports the columns of the BITMAP type.
 
@@ -100,7 +217,7 @@ This aggregation type applies ONLY to the Aggregate table whose key_desc type is
 
 **AS generation_expr**: specifies the generated column and its expression. [The generated column](../generated_columns.md) can be used to precompute and store the results of expressions, which significantly accelerates queries with the same complex expressions. Since v3.1, StarRocks supports generated columns.
 
-### index_definition
+## Index definition
 
 ```SQL
 INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] COMMENT 'xxxxxx'
@@ -108,103 +225,13 @@ INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] COMMENT 'xxxxxx'
 
 For more information about parameter descriptions and usage notes, see [Bitmap indexing](../../../table_design/indexes/Bitmap_index.md#create-an-index).
 
-### ENGINE type
+## `ENGINE`
 
 Default value: `olap`. If this parameter is not specified, an OLAP table (StarRocks native table) is created by default.
 
-Optional value: `mysql`, `elasticsearch`, `hive`, `jdbc` (2.3 and later), `iceberg`, and `hudi` (2.2 and later). If you want to create an external table to query external data sources, specify `CREATE EXTERNAL TABLE` and set `ENGINE` to any of these values. You can refer to [External table](../../../data_source/External_table.md) for more information.
+Optional value: `mysql`, `elasticsearch`, `hive`, `jdbc`, `iceberg`, and `hudi`. 
 
-**We recommend that you use catalogs to query data from Hive, Iceberg, Hudi, and JDBC data sources. External tables are deprecated.**
-
-**From v3.1 onwards, StarRocks supports creating Parquet-formatted tables in Iceberg catalogs, and you can insert data to these Parquet-formatted Iceberg tables by using INSERT INTO.**
-
-**From v3.2 onwards, StarRocks supports creating Parquet-formatted tables in Hive catalogs, and supports sinking data to these Parquet-formatted Hive tables by using INSERT INTO. From v3.3 onwards, StarRocks supports creating ORC- and Textfile-formatted tables in Hive catalogs, and supports sinking data to these ORC- and Textfile-formatted Hive tables by using INSERT INTO**
-
-- For MySQL, specify the following properties:
-
-    ```plaintext
-    PROPERTIES (
-        "host" = "mysql_server_host",
-        "port" = "mysql_server_port",
-        "user" = "your_user_name",
-        "password" = "your_password",
-        "database" = "database_name",
-        "table" = "table_name"
-    )
-    ```
-
-    Note:
-
-    "table_name" in MySQL should indicate the real table name. In contrast, "table_name" in CREATE TABLE statement indicates the name of this mysql table on StarRocks. They can either be different or the same.
-
-    The aim of creating MySQL tables in StarRocks is to access MySQL database. StarRocks itself does not maintain or store any MySQL data.
-
-- For Elasticsearch, specify the following properties:
-
-    ```plaintext
-    PROPERTIES (
-
-    "hosts" = "http://192.168.0.1:8200,http://192.168.0.2:8200",
-    "user" = "root",
-    "password" = "root",
-    "index" = "tindex",
-    "type" = "doc"
-    )
-    ```
-
-  - `hosts`: the URL that is used to connect your Elasticsearch cluster. You can specify one or more URLs.
-  - `user`: the account of the root user that is used to log in to your Elasticsearch cluster for which basic authentication is enabled.
-  - `password`: the password of the preceding root account.
-  - `index`: the index of the StarRocks table in your Elasticsearch cluster. The index name is the same as the StarRocks table name. You can set this parameter to the alias of the StarRocks table.
-  - `type`: the type of index. The default value is `doc`.
-
-- For Hive, specify the following properties:
-
-    ```plaintext
-    PROPERTIES (
-
-        "database" = "hive_db_name",
-        "table" = "hive_table_name",
-        "hive.metastore.uris" = "thrift://xx.xx.xx.xx:9083"
-    )
-    ```
-
-    Here, database is the name of the corresponding database in Hive table. Table is the name of Hive table. `hive.metastore.uris` is the server address.
-
-- For JDBC, specify the following properties:
-
-    ```plaintext
-    PROPERTIES (
-    "resource"="jdbc0",
-    "table"="dest_tbl"
-    )
-    ```
-
-    `resource` is the JDBC resource name and `table` is the destination table.
-
-- For Iceberg, specify the following properties:
-
-   ```plaintext
-    PROPERTIES (
-    "resource" = "iceberg0", 
-    "database" = "iceberg", 
-    "table" = "iceberg_table"
-    )
-    ```
-
-    `resource` is the Iceberg resource name. `database` is the Iceberg database. `table` is the Iceberg table.
-
-- For Hudi, specify the following properties:
-
-  ```plaintext
-    PROPERTIES (
-    "resource" = "hudi0", 
-    "database" = "hudi", 
-    "table" = "hudi_table" 
-    )
-    ```
-
-### key_desc
+## Key
 
 Syntax:
 
@@ -216,29 +243,34 @@ Data is sequenced in specified key columns and has different attributes for diff
 
 - AGGREGATE KEY: Identical content in key columns will be aggregated into value columns according to the specified aggregation type. It usually applies to business scenarios such as financial statements and multi-dimensional analysis.
 - UNIQUE KEY/PRIMARY KEY: Identical content in key columns will be replaced in value columns according to the import sequence. It can be applied to make addition, deletion, modification and query on key columns.
-- DUPLICATE KEY: Identical content in key columns, which also exists in StarRocks at the same time. It can be used to store detailed data or data with no aggregation attributes. **DUPLICATE KEY is the default type. Data will be sequenced according to key columns.**
+- DUPLICATE KEY: Identical content in key columns, which also exists in StarRocks at the same time. It can be used to store detailed data or data with no aggregation attributes. 
 
-> **NOTE**
->
-> Value columns do not need to specify aggregation types when other key_type is used to create tables with the exception of AGGREGATE KEY.
+  :::note
+  DUPLICATE KEY is the default type. Data will be sequenced according to key columns.
+  :::
 
-### COMMENT
+:::note
+Value columns do not need to specify aggregation types when other key_type is used to create tables with the exception of AGGREGATE KEY.
+:::
+
+## COMMENT
 
 You can add a table comment when you create a table, optional. Note that COMMENT must be placed after `key_desc`. Otherwise, the table cannot be created.
 
 From v3.1 onwards, you can modify the table comment suing `ALTER TABLE <table_name> COMMENT = "new table comment"`.
 
-### partition_desc
 
-Partition description can be used in the following ways:
+## Partition
 
-#### Create partitions dynamically
+Partitions can be managed in the following ways:
+
+### Create partitions dynamically
 
 [Dynamic partitioning](../../../table_design/data_distribution/dynamic_partitioning.md) provides a time-to-live (TTL) management for partitions. StarRocks automatically creates new partitions in advance and removes expired partitions to ensure data freshness. To enable this feature, you can configure Dynamic partitioning related properties at table creation.
 
-#### Create partitions one by one
+### Create partitions one by one
 
-**Specify only the upper bound for a partition**
+#### Specify only the upper bound for a partition
 
 Syntax:
 
@@ -251,9 +283,9 @@ PARTITION BY RANGE ( <partitioning_column1> [, <partitioning_column2>, ... ] )
 )
 ```
 
-Note:
-
+:::note
 Please use specified key columns and specified value ranges for partitioning.
+:::
 
 - For the naming conventions of partitions, see [System limits](../../System_limit.md).
 - Before v3.3.0, columns for the range partitioning only support the following types: TINYINT, SMALLINT, INT, BIGINT, LARGEINT, DATE, and DATETIME. Since v3.3.0, three specific time functions can be used as columns for the range partitioning. For detailed usage, see [Data distribution](../../../table_design/data_distribution/Data_distribution.md#manually-create-partitions).
@@ -270,12 +302,12 @@ Please use specified key columns and specified value ranges for partitioning.
   )
   ```
 
-Please note:
-
+:::note
 - Partitions are often used for managing data related to time.
 - When data backtracking is needed, you may want to consider emptying the first partition for adding partitions later when necessary.
+:::
 
-**Specify both the lower and upper bounds for a partition**
+#### Specify both the lower and upper bounds for a partition
 
 Syntax:
 
@@ -289,11 +321,11 @@ PARTITION BY RANGE ( <partitioning_column1> [, <partitioning_column2>, ... ] )
 )
 ```
 
-Note:
-
+:::note
 - Fixed Range is more flexible than LESS THAN. You can customize the left and right partitions.
 - Fixed Range is the same as LESS THAN in the other aspects.
 - When only one column is specified as the partitioning column, you can set `MAXVALUE` as the upper bound for the partitioning column of the most recent partition.
+:::
 
   ```SQL
   PARTITION BY RANGE (pay_dt) (
@@ -303,7 +335,7 @@ Note:
   )
   ```
 
-#### Create multiple partitions in a batch
+### Create multiple partitions in a batch
 
 Syntax
 
@@ -332,7 +364,8 @@ You can specify the start and end values in `START()` and `END()` and the time u
 
 For more information, see [Data distribution](../../../table_design/data_distribution/Data_distribution.md).
 
-### distribution_desc
+
+## Distribution
 
 StarRocks supports hash bucketing and random bucketing. If you do not configure bucketing, StarRocks uses random bucketing and automatically sets the number of buckets by default.
 
@@ -381,23 +414,28 @@ StarRocks supports hash bucketing and random bucketing. If you do not configure 
   - Bucketing columns cannot be modified after they are specified.
   - Since StarRocks v2.5.7, you do not need to set the number of buckets when you create a table. StarRocks automatically sets the number of buckets. If you want to set this parameter, see [Set the number of buckets](../../../table_design/data_distribution/Data_distribution.md#set-the-number-of-buckets).
 
-### ORDER BY
+## Rollup index
+
+You can create rollups in bulk when you create a table.
+
+Syntax:
+
+```SQL
+ROLLUP (rollup_name (column_name1, column_name2, ...)
+[FROM from_index_name]
+[PROPERTIES ("key"="value", ...)],...)
+```
+
+## ORDER BY
 
 Since v3.0, Primary Key tables support defining sort keys using `ORDER BY`. Since v3.3, Duplicate Key tables, Aggregate tables, and Unique Key tables support defining sort keys using `ORDER BY`.
 
 For more descriptions of sort keys, see [Sort keys and prefix indexes](../../../table_design/indexes/Prefix_index_sort_key.md).
 
-### TEMPORARY
 
-Creates a temporary table. From v3.3.1, StarRocks supports creating temporary tables in the Default Catalog. For more information, see [Temporary Table](../../../table_design/StarRocks_table_design.md#temporary-table).
+## PROPERTIES
 
-:::note
-When creating a temporary table, you must set `ENGINE` to `olap`.
-:::
-
-### PROPERTIES
-
-#### Specify initial storage medium, automatic storage cooldown time, replica number
+### Storage and replicas
 
 If the engine type is `OLAP`, you can specify initial storage medium (`storage_medium`), automatic storage cooldown time (`storage_cooldown_time`) or time interval (`storage_cooldown_ttl`), and replica number (`replication_num`) when you create a table.
 
@@ -441,7 +479,7 @@ PROPERTIES (
 
   - `storage_cooldown_time`: the automatic storage cooldown time (**absolute time**) when the table is cooled down from SSD to HDD. The specified time needs to be later than the current time. Format: "yyyy-MM-dd HH:mm:ss". When you need to configure different properties for specified partitions, you can execute [ALTER TABLE ... ADD PARTITION or ALTER TABLE ... MODIFY PARTITION](ALTER_TABLE.md).
 
-**Usages**
+**Usage**
 
 - The comparison between the parameters related to automatic storage cooldown is as follows:
   - `storage_cooldown_ttl`: A table property that specifies the time interval of automatic storage cooldown for partitions in the table. The system automatically cools down a partition at the time `the value of this parameter plus the upper time bound of the partition`. So automatic storage cooldown is performed at the partition granularity, which is more flexible.
@@ -470,9 +508,9 @@ PROPERTIES (
 )
 ```
 
-#### Add bloom filter index for a column
+### Bloom filter indexes
 
-If the Engine type is olap, you can specify a column to adopt bloom filter indexes.
+If the Engine type is `olap`, you can specify a column to adopt bloom filter indexes.
 
 The following limits apply when you use bloom filter index:
 
@@ -488,7 +526,7 @@ PROPERTIES (
 )
 ```
 
-#### Use Colocate Join
+### Colocate Join
 
 If you want to use Colocate Join attributes, specify it in `properties`.
 
@@ -498,7 +536,7 @@ PROPERTIES (
 )
 ```
 
-#### Configure dynamic partitions
+### Dynamic partitions
 
 If you want to use dynamic partition attributes, please specify it in properties.
 
@@ -524,7 +562,7 @@ PROPERTIES (
 | dynamic_partition.prefix    | No       | The prefix added to the names of dynamic partitions. Default value: `p`. |
 | dynamic_partition.buckets   | No       | The number of buckets per dynamic partition. The default value is the same as the number of buckets determined by the reserved word `BUCKETS` or automatically set by StarRocks. |
 
-#### Specify the bucket size (`bucket_size`) for tables configured with random bucketing
+### Bucket size with random bucketing
 
 Since v3.2, for tables configured with random bucketing, you can specify the bucket size by using the `bucket_size` parameter in `PROPERTIES` at table creation to enable the on-demand and dynamic increase of the number of buckets. Unit: B.
 
@@ -534,7 +572,7 @@ PROPERTIES (
 )
 ```
 
-#### Set data compression algorithm
+### Data compression algorithm
 
 You can specify a data compression algorithm for a table by adding property `compression` when you create a table.
 
@@ -563,7 +601,7 @@ PROPERTIES ("compression" = "zstd(3)")
 
 For more information about how to choose a suitable data compression algorithm, see [Data compression](../../../table_design/data_compression.md).
 
-#### Set write quorum for data loading
+### Write quorum for data loading
 
 If your StarRocks cluster has multiple data replicas, you can set different write quorum for tables, that is, how many replicas are required to return loading success before StarRocks can determine the loading task is successful. You can specify write quorum by adding the property `write_quorum` when you create a table. This property is supported from v2.5.
 
@@ -573,12 +611,12 @@ The valid values of `write_quorum` are:
 - `ONE`: When **one** of the data replicas returns loading success, StarRocks returns loading task success. Otherwise, StarRocks returns loading task failed.
 - `ALL`: When **all** of the data replicas return loading success, StarRocks returns loading task success. Otherwise, StarRocks returns loading task failed.
 
-> **CAUTION**
->
-> - Setting a low write quorum for loading increases the risk of data inaccessibility and even loss. For example, you load data into a table with one write quorum in a StarRocks cluster of two replicas, and the data was successfully loaded into only one replica. Despite that StarRocks determines the loading task succeeded, there is only one surviving replica of the data. If the server which stores the tablets of loaded data goes down, the data in these tablets becomes inaccessible. And if the disk of the server is damaged, the data is lost.
-> - StarRocks returns the loading task status only after all data replicas have returned the status. StarRocks will not return the loading task status when there are replicas whose loading status is unknown. In a replica, loading timeout is also considered as loading failed.
+:::caution
+- Setting a low write quorum for loading increases the risk of data inaccessibility and even loss. For example, you load data into a table with one write quorum in a StarRocks cluster of two replicas, and the data was successfully loaded into only one replica. Despite that StarRocks determines the loading task succeeded, there is only one surviving replica of the data. If the server which stores the tablets of loaded data goes down, the data in these tablets becomes inaccessible. And if the disk of the server is damaged, the data is lost.
+- StarRocks returns the loading task status only after all data replicas have returned the status. StarRocks will not return the loading task status when there are replicas whose loading status is unknown. In a replica, loading timeout is also considered as loading failed.
+:::
 
-#### Specify data writing and replication mode among replicas
+### Replica data writing and replication mode
 
 If your StarRocks cluster has multiple data replicas, you can specify the `replicated_storage` parameter in `PROPERTIES` to configure the data writing and replication mode among replicas.
 
@@ -592,19 +630,7 @@ In most cases, using the default value gains better data writing performance. If
     SET ("replicated_storage" = "false");
 ```
 
-#### Create rollup in bulk
-
-You can create rollup in bulk when you create a table.
-
-Syntax:
-
-```SQL
-ROLLUP (rollup_name (column_name1, column_name2, ...)
-[FROM from_index_name]
-[PROPERTIES ("key"="value", ...)],...)
-```
-
-#### Define Unique Key constraints and Foreign Key constraints for View Delta Join query rewrite
+### Delta Join unique and foreign key constraints
 
 To enable query rewrite in the View Delta Join scenario, you must define the Unique Key constraints `unique_constraints` and Foreign Key constraints `foreign_key_constraints` for the table to be joined in the Delta Join. See [Asynchronous materialized view - Rewrite queries in View Delta Join scenario](../../../using_starrocks/async_mv/use_cases/query_rewrite_with_materialized_views.md#query-delta-join-rewrite) for further information.
 
@@ -626,15 +652,15 @@ PROPERTIES (
 - `parent_table_name`: the name of the table to join.
 - `parent_column`: the column to be joined. They must be the Primary Keys or Unique Keys of the corresponding tables.
 
-> **CAUTION**
->
-> - `unique_constraints` and `foreign_key_constraints` are only used for query rewrite. Foreign Key constraints checks are not guaranteed when data is loaded into the table. You must ensure the data loaded into the table meets the constraints.
-> - The primary keys of a Primary Key table or the unique keys of a Unique Key table are, by default, the corresponding `unique_constraints`. You do not need to set it manually.
-> - The `child_column` in a table's `foreign_key_constraints` must be referenced to a `unique_key` in another table's `unique_constraints`.
-> - The number of `child_column` and `parent_column` must agree.
-> - The data types of the `child_column` and the corresponding `parent_column` must match.
+:::caution
+- `unique_constraints` and `foreign_key_constraints` are only used for query rewrite. Foreign Key constraints checks are not guaranteed when data is loaded into the table. You must ensure the data loaded into the table meets the constraints.
+- The primary keys of a Primary Key table or the unique keys of a Unique Key table are, by default, the corresponding `unique_constraints`. You do not need to set it manually.
+- The `child_column` in a table's `foreign_key_constraints` must be referenced to a `unique_key` in another table's `unique_constraints`.
+- The number of `child_column` and `parent_column` must agree.
+- The data types of the `child_column` and the corresponding `parent_column` must match.
+:::
 
-#### Create cloud-native tables for StarRocks Shared-data cluster
+### Cloud-native tables for shared-data clusters
 
 To use your StarRocks Shared-data cluster, you must create cloud-native tables with the following properties:
 
@@ -653,36 +679,37 @@ PROPERTIES (
   - When this property is set to `true`, the data to be loaded is simultaneously written into the object storage and the local disk (as the cache for query acceleration).
   - When this property is set to `false`, the data is loaded only into the object storage.
 
-  > **NOTE**
-  >
-  > To enable the local disk cache, you must specify the directory of the disk in the BE configuration item `storage_root_path`.
+  :::note
+  To enable the local disk cache, you must specify the directory of the disk in the BE configuration item `storage_root_path`.
+  :::
 
 - `datacache.partition_duration`: The validity duration of the hot data. When the local disk cache is enabled, all data is loaded into the cache. When the cache is full, StarRocks deletes the less recently used data from the cache. When a query needs to scan the deleted data, StarRocks checks if the data is within the duration of validity. If the data is within the duration, StarRocks loads the data into the cache again. If the data is not within the duration, StarRocks does not load it into the cache. This property is a string value that can be specified with the following units: `YEAR`, `MONTH`, `DAY`, and `HOUR`, for example, `7 DAY` and `12 HOUR`. If it is not specified, all data is cached as the hot data.
 
-  > **NOTE**
-  >
-  > This property is available only when `datacache.enable` is set to `true`.
+  :::note
+  This property is available only when `datacache.enable` is set to `true`.
+  :::
 
-#### Set fast schema evolution
+### Fast schema evolution
 
 `fast_schema_evolution`: Whether to enable fast schema evolution for the table. Valid values are `TRUE` or `FALSE` (default). Enabling fast schema evolution can increase the speed of schema changes and reduce resource usage when columns are added or dropped. Currently, this property can only be enabled at table creation, and it cannot be modified using [ALTER TABLE](ALTER_TABLE.md) after table creation.
 
-  > **NOTE**
-  >
-  > - Fast schema evolution is supported for shared-nothing clusters since v3.2.0.
-  > - Fast schema evolution is supported for shared-data clusters since v3.3 and is enabled by default. You do not need to specify this property when creating cloud-native tables in shared-data clusters. The FE dynamic parameter `enable_fast_schema_evolution` (Default: true) controls this behavior.
 
-#### Forbid Base Compaction
+  :::note
+  - Fast schema evolution is supported for shared-nothing clusters since v3.2.0.
+  - Fast schema evolution is supported for shared-data clusters since v3.3 and is enabled by default. You do not need to specify this property when creating cloud-native tables in shared-data clusters. The FE dynamic parameter `enable_fast_schema_evolution` (Default: true) controls this behavior.
+  :::
+
+### Forbid Base Compaction
 
 `base_compaction_forbidden_time_ranges`: The time range within which Base Compaction is forbidden for the table. When this property is set, the system performs Base Compaction on eligible tablets only outside the specified time range. This property is supported from v3.2.13.
 
-> **NOTE**
->
-> Make sure that the number of data loading to the table does not exceed 500 during the period when Base Compaction is forbidden.
+:::note
+Make sure that the number of data loading to the table does not exceed 500 during the period when Base Compaction is forbidden.
+:::
 
 The value of `base_compaction_forbidden_time_ranges` follows the [Quartz cron syntax](https://productresources.collibra.com/docs/collibra/latest/Content/Cron/co_quartz-cron-syntax.htm), and only supports these fields: `<minute> <hour> <day-of-the-month> <month> <day-of-the-week>`, where `<minute>` must be `*`.
 
-```Plain
+```SQL
 crontab_param_value ::= [ "" | crontab ]
 
 crontab ::= * <hour> <day-of-the-month> <month> <day-of-the-week>
@@ -712,7 +739,7 @@ Example:
 'base_compaction_forbidden_time_ranges' = '* 8-20 * * 2-6'
 ```
 
-#### Specify Common Partition Expression TTL
+### Specify Common Partition Expression TTL
 
 From v3.5.0 onwards, StarRocks native tables support Common Partition Expression TTL.
 
@@ -735,7 +762,7 @@ To disable this feature, you can use the ALTER TABLE statement to set this prope
 ALTER TABLE tbl SET('partition_retention_condition' = '');
 ```
 
-#### Configure flat json config (only support on shared-nothing clusters now)
+### Configure flat json config (only support on shared-nothing clusters now)
 
 If you want to use flat json attributes, please specify it in properties. See [ Flat JSON ](../../../using_starrocks/Flat_json.md) for further information
 
@@ -748,19 +775,18 @@ PROPERTIES (
 )
 ```
 
-**`PROPERTIES`**
+**Parameters**
 
 | Parameter                   | Required | Description                                                                                                                                                                                                                                                       |
 | --------------------------- |----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `flat_json.enable`    | No       | Whether to enable the Flat JSON feature. After this feature is enabled, newly loaded JSON data will be automatically flattened, improving JSON query performance.                                                                                                 |
 | `flat_json.null.factor` | No      | The proportion of NULL values in the column to extract for Flat JSON. A column will not be extracted if its proportion of NULL value is higher than this threshold. This parameter takes effect only when `flat_json.enable` is set to true.  Default value: 0.3. |
 | `flat_json.sparsity.factor`     | No      | The proportion of columns with the same name for Flat JSON. Extraction is not performed if the proportion of columns with the same name is lower than this value. This parameter takes effect only when `flat_json.enable` is set to true. Default value: 0.9.    |
-| `flat_json.column.max`       | No      | The maximum number of sub-fields that can be extracted by Flat JSON. This parameter takes effect only when `flat_json.enable` is set to true.  Default value: 100.                                                                                                |
-
+| `flat_json.column.max`       | No      | The maximum number of sub-fields that can be extracted by Flat JSON. This parameter takes effect only when `flat_json.enable` is set to true.  Default value: 100. |
 
 ## Examples
 
-### Create an Aggregate table that uses Hash bucketing and columnar storage
+### Aggregate table with Hash bucketing and columnar storage
 
 ```SQL
 CREATE TABLE example_db.table_hash
@@ -777,7 +803,7 @@ DISTRIBUTED BY HASH(k1)
 PROPERTIES ("storage_type"="column");
 ```
 
-### Create an Aggregate table and set the storage medium and cooldown time
+### Aggregate table with storage medium and cooldown time set
 
 ```SQL
 CREATE TABLE example_db.table_hash
@@ -797,7 +823,7 @@ PROPERTIES(
 );
 ```
 
-### Create a Duplicate Key table that uses Range partition, Hash bucketing, and column-based storage, and set the storage medium and cooldown time
+### Duplicate Key table with Range partition, Hash bucketing, column-based storage, storage medium, and cooldown time
 
 LESS THAN
 
@@ -861,7 +887,7 @@ PROPERTIES(
 );
 ```
 
-### Create a MySQL external table
+### MySQL external table
 
 ```SQL
 CREATE EXTERNAL TABLE example_db.table_mysql
@@ -884,7 +910,7 @@ PROPERTIES
 )
 ```
 
-### Create a table that contains HLL columns
+### Table with HLL columns
 
 ```SQL
 CREATE TABLE example_db.example_table
@@ -900,7 +926,7 @@ DISTRIBUTED BY HASH(k1)
 PROPERTIES ("storage_type"="column");
 ```
 
-### Create a table containing BITMAP_UNION aggregation type
+### Table using BITMAP_UNION aggregation type
 
 The original data type of `v1` and `v2` columns must be TINYINT, SMALLINT, or INT.
 
@@ -918,7 +944,7 @@ DISTRIBUTED BY HASH(k1)
 PROPERTIES ("storage_type"="column");
 ```
 
-### Create two tables that support Colocate Join
+### Tables that support Colocate Join
 
 ```SQL
 CREATE TABLE `t1` 
@@ -948,7 +974,7 @@ PROPERTIES
 );
 ```
 
-### Create a table with bitmap index
+### Table with bitmap index
 
 ```SQL
 CREATE TABLE example_db.table_hash
@@ -966,7 +992,7 @@ DISTRIBUTED BY HASH(k1)
 PROPERTIES ("storage_type"="column");
 ```
 
-### Create a dynamic partition table
+### Dynamic partition table
 
 The dynamic partitioning function must be enabled ("dynamic_partition.enable" = "true") in FE configuration. For more information, see [Configure dynamic partitions](#configure-dynamic-partitions).
 
@@ -1008,7 +1034,7 @@ PROPERTIES(
 );
 ```
 
-### Create a table where multiple partitions are created in a batch, and an integer type column is specified as partitioning column
+### Table with multiple partitions created in a batch, and an integer column as a partitioning column
 
   In the following example, the partitioning column `datekey` is of the INT type. All the partitions are created by only one simple partition clause  `START ("1") END ("5") EVERY (1)`. The range of all the partitions starts from `1` and ends at `5`, with a partition granularity of `1`:
   > **NOTE**
@@ -1031,7 +1057,7 @@ PROPERTIES(
   PROPERTIES ("replication_num" = "3");
   ```
 
-### Create a Hive external table
+### Hive external table
 
 Before you create a Hive external table, you must have created a Hive resource and database. For more information, see [External table](../../../data_source/External_table.md#deprecated-hive-external-table).
 
@@ -1051,7 +1077,7 @@ PROPERTIES
 );
 ```
 
-### Create a Primary Key table and specify the sort key
+### Primary Key table with specific sort key
 
 Suppose that you need to analyze user behavior in real time from dimensions such as users' address and last active time. When you create a table, you can define the `user_id` column as the primary key and define the combination of the `address` and `last_active` columns as the sort key.
 
@@ -1078,7 +1104,7 @@ PROPERTIES(
 );
 ```
 
-### Create a partitioned temporary table
+### Partitioned temporary table
 
 ```SQL
 CREATE TEMPORARY TABLE example_db.temp_table
@@ -1100,7 +1126,11 @@ PARTITION BY RANGE (k1)
 DISTRIBUTED BY HASH(k2);
 ```
 
-### Create a table that support flat json (only support on shared-nothing clusters now)
+### Table supporting flat JSON
+
+:::note
+Flat JSON is only support on shared-nothing clusters now.
+:::
 
 ```SQL
 CREATE TABLE example_db.example_table

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -52,7 +52,7 @@ If you would like to use the deprecated `EXTERNAL` keyword please expand **`EXTE
 
 <details>
 
-<summary>`EXTERNAL` keyword details`</summary>
+<summary>`EXTERNAL` keyword details</summary>
 
 To create an external table to query external data sources, specify `CREATE EXTERNAL TABLE` and set `ENGINE` to any of these values. You can refer to [External table](../../../data_source/External_table.md) for more information.
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -24,7 +24,6 @@ CREATE [EXTERNAL] [TEMPORARY] TABLE [IF NOT EXISTS] [database.]table_name
 [rollup_index]
 [ORDER BY (column_name1,...)]
 [PROPERTIES ("key"="value", ...)]
-[BROKER PROPERTIES ("key"="value", ...)]
 ```
 
 :::tip

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -38,17 +38,22 @@ CREATE [EXTERNAL] [TEMPORARY] TABLE [IF NOT EXISTS] [database.]table_name
 
 ### `EXTERNAL`
 
-:::caution the external keyword is deprecated
-We recommend that you use [external catalogs](../../../data_source/catalog/catalog_overview.md) to query data from Hive, Iceberg, Hudi, and JDBC data sources instead of using the `EXTERNAL` keyword.
+:::caution
+The `EXTERNAL` keyword is deprecated.
+
+We recommend that you use [external catalogs](../../../data_source/catalog/catalog_overview.md) to query data from Hive, Iceberg, Hudi, and JDBC data sources instead of using the `EXTERNAL` keyword to create external tables.
+
 :::
 
-:::tip recommendation
-From v3.1 onwards, StarRocks supports creating Parquet-formatted tables in Iceberg catalogs, and you can insert data to these Parquet-formatted Iceberg tables by using INSERT INTO.
+:::tip 
+**Recommendation**
+
+From v3.1 onwards, StarRocks supports creating Parquet-formatted tables in Iceberg catalogs, and supports sinking data to these Parquet-formatted Iceberg tables by using INSERT INTO.
 
 From v3.2 onwards, StarRocks supports creating Parquet-formatted tables in Hive catalogs, and supports sinking data to these Parquet-formatted Hive tables by using INSERT INTO. From v3.3 onwards, StarRocks supports creating ORC- and Textfile-formatted tables in Hive catalogs, and supports sinking data to these ORC- and Textfile-formatted Hive tables by using INSERT INTO.
 :::
 
-If you would like to use the deprecated `EXTERNAL` keyword please expand **`EXTERNAL` keyword details**
+If you would like to use the deprecated `EXTERNAL` keyword, please expand **`EXTERNAL` keyword details**
 
 <details>
 
@@ -71,7 +76,7 @@ To create an external table to query external data sources, specify `CREATE EXTE
 
     Note:
 
-    "table_name" in MySQL should indicate the real table name. In contrast, "table_name" in CREATE TABLE statement indicates the name of this mysql table on StarRocks. They can either be different or the same.
+    "table_name" in MySQL should indicate the real table name. In contrast, "table_name" in CREATE TABLE statement indicates the name of this MySQL table on StarRocks. They can either be different or the same.
 
     The aim of creating MySQL tables in StarRocks is to access MySQL database. StarRocks itself does not maintain or store any MySQL data.
 
@@ -79,8 +84,7 @@ To create an external table to query external data sources, specify `CREATE EXTE
 
     ```plaintext
     PROPERTIES (
-
-    "hosts" = "http://192.168.0.1:8200,http://192.168.0.2:8200",
+    "hosts" = "http://192.168.xx.xx:8200,http://192.168.xx0.xx:8200",
     "user" = "root",
     "password" = "root",
     "index" = "tindex",
@@ -98,7 +102,6 @@ To create an external table to query external data sources, specify `CREATE EXTE
 
     ```plaintext
     PROPERTIES (
-
         "database" = "hive_db_name",
         "table" = "hive_table_name",
         "hive.metastore.uris" = "thrift://xx.xx.xx.xx:9083"
@@ -259,7 +262,6 @@ You can add a table comment when you create a table, optional. Note that COMMENT
 
 From v3.1 onwards, you can modify the table comment suing `ALTER TABLE <table_name> COMMENT = "new table comment"`.
 
-
 ## Partition
 
 Partitions can be managed in the following ways:
@@ -408,7 +410,6 @@ StarRocks supports hash bucketing and random bucketing. If you do not configure 
   If partition data cannot be evenly distributed into each bucket by using one bucketing column, you can choose multiple bucketing columns (at most three). For more information, see [Choose bucketing columns](../../../table_design/data_distribution/Data_distribution.md#hash-bucketing).
 
   **Precautions**:
-
   - **When you create a table, you must specify its bucketing columns**.
   - The values of bucketing columns cannot be updated.
   - Bucketing columns cannot be modified after they are specified.
@@ -441,7 +442,7 @@ If the engine type is `OLAP`, you can specify initial storage medium (`storage_m
 
 The scope where the properties take effect: If the table has only one partition, the properties belong to the table. If the table is divided into multiple partitions, the properties belong to each partition. And when you need to configure different properties for specified partitions, you can execute [ALTER TABLE ... ADD PARTITION or ALTER TABLE ... MODIFY PARTITION](ALTER_TABLE.md) after table creation.
 
-**Set initial storage medium and automatic storage cooldown time**
+#### Set initial storage medium and automatic storage cooldown time
 
 ```sql
 PROPERTIES (
@@ -450,6 +451,8 @@ PROPERTIES (
     | "storage_cooldown_time" = "yyyy-MM-dd HH:mm:ss" }
 )
 ```
+
+**Properties**
 
 - `storage_medium`: the initial storage medium, which can be set to `SSD` or `HDD`. Make sure that the type of storage medium you explicitly specified is consistent with the BE disk types for your StarRocks cluster specified in the BE static parameter `storage_root_path`.<br />
 
@@ -469,8 +472,6 @@ PROPERTIES (
 
 - `storage_cooldown_ttl` or `storage_cooldown_time`: the automatic storage cooldown time or time interval. Automatic storage cooldown refers to automatically migrate data from SSD to HDD. This feature is only effective when the initial storage medium is SSD.
 
-  **Parameter**
-
   - `storage_cooldown_ttl`: the **time interval** of automatic storage cooldown for the partitions in this table. If you need to retain the most recent partitions on SSD and automatically cool down older partitions to HDD after a certain time interval, you can use this parameter. The automatic storage cooldown time for each partition is calculated using the value of this parameter plus the upper time bound of the partition.
 
   The supported values are `<num> YEAR`, `<num> MONTH`, `<num> DAY`, and `<num> HOUR`. `<num>` is a non-negative integer. The default value is null, indicating that storage cooldown is not automatically performed.
@@ -479,7 +480,7 @@ PROPERTIES (
 
   - `storage_cooldown_time`: the automatic storage cooldown time (**absolute time**) when the table is cooled down from SSD to HDD. The specified time needs to be later than the current time. Format: "yyyy-MM-dd HH:mm:ss". When you need to configure different properties for specified partitions, you can execute [ALTER TABLE ... ADD PARTITION or ALTER TABLE ... MODIFY PARTITION](ALTER_TABLE.md).
 
-**Usage**
+##### Usage
 
 - The comparison between the parameters related to automatic storage cooldown is as follows:
   - `storage_cooldown_ttl`: A table property that specifies the time interval of automatic storage cooldown for partitions in the table. The system automatically cools down a partition at the time `the value of this parameter plus the upper time bound of the partition`. So automatic storage cooldown is performed at the partition granularity, which is more flexible.
@@ -491,14 +492,14 @@ PROPERTIES (
 - If you do not configure these parameters, automatic storage cooldown is not be automatically performed.
 - Execute `SHOW PARTITIONS FROM <table_name>` to view the automatic storage cooldown time for each partition.
 
-**Limit**
+##### Limits
 
 - Expression and List partitioning are not supported.
 - The partition column need to be of date type.
 - Multiple partition columns are not supported.
 - Primary Key tables are not supported.
 
-**Set the number of replicas for each tablet in partitions**
+#### Set the number of replicas for each tablet in partitions
 
 `replication_num`: number of replicas for each table in the partitions. Default number: `3`.
 
@@ -542,7 +543,6 @@ If you want to use dynamic partition attributes, please specify it in properties
 
 ```SQL
 PROPERTIES (
-
     "dynamic_partition.enable" = "true|false",
     "dynamic_partition.time_unit" = "DAY|WEEK|MONTH",
     "dynamic_partition.start" = "${integer_value}",
@@ -626,8 +626,8 @@ If your StarRocks cluster has multiple data replicas, you can specify the `repli
 In most cases, using the default value gains better data writing performance. If you want to change the data writing and replication mode among replicas, run the ALTER TABLE command. Example:
 
 ```sql
-    ALTER TABLE example_db.my_table
-    SET ("replicated_storage" = "false");
+ALTER TABLE example_db.my_table
+SET ("replicated_storage" = "false");
 ```
 
 ### Delta Join unique and foreign key constraints
@@ -692,7 +692,6 @@ PROPERTIES (
 ### Fast schema evolution
 
 `fast_schema_evolution`: Whether to enable fast schema evolution for the table. Valid values are `TRUE` or `FALSE` (default). Enabling fast schema evolution can increase the speed of schema changes and reduce resource usage when columns are added or dropped. Currently, this property can only be enabled at table creation, and it cannot be modified using [ALTER TABLE](ALTER_TABLE.md) after table creation.
-
 
   :::note
   - Fast schema evolution is supported for shared-nothing clusters since v3.2.0.
@@ -775,9 +774,9 @@ PROPERTIES (
 )
 ```
 
-**Parameters**
+**Properties**
 
-| Parameter                   | Required | Description                                                                                                                                                                                                                                                       |
+| Property                    | Required | Description                                                                                                                                                                                                                                                       |
 | --------------------------- |----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `flat_json.enable`    | No       | Whether to enable the Flat JSON feature. After this feature is enabled, newly loaded JSON data will be automatically flattened, improving JSON query performance.                                                                                                 |
 | `flat_json.null.factor` | No      | The proportion of NULL values in the column to extract for Flat JSON. A column will not be extracted if its proportion of NULL value is higher than this threshold. This parameter takes effect only when `flat_json.enable` is set to true.  Default value: 0.3. |

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -27,99 +27,41 @@ CREATE [EXTERNAL] [TEMPORARY] TABLE [IF NOT EXISTS] [database.]table_name
 [BROKER PROPERTIES ("key"="value", ...)]
 ```
 
-## パラメータ
-
 :::tip
 
-- 作成するテーブル名、パーティション名、列名、インデックス名は、[システム制限](../../System_limit.md)に従う必要があります。
-- データベース名、テーブル名、列名、またはパーティション名を指定する際、StarRocks では一部のリテラルが予約キーワードとして使用されます。これらのキーワードを SQL ステートメントで直接使用しないでください。SQL ステートメントでそのようなキーワードを使用する場合は、バッククォート (`) で囲んでください。これらの予約キーワードについては、[キーワード](../keywords.md)を参照してください。
+- 作成するテーブル名、パーティション名、列名、インデックス名は、[システム制限](../../System_limit.md)の命名規則に従う必要があります。
+- データベース名、テーブル名、列名、またはパーティション名を指定する際、StarRocks では一部のリテラルが予約キーワードとして使用されていることに注意してください。これらのキーワードを SQL ステートメントで直接使用しないでください。SQL ステートメントでそのようなキーワードを使用する場合は、バッククォート (`) で囲んでください。これらの予約キーワードについては、[キーワード](../keywords.md) を参照してください。
 
 :::
 
-### column_definition
+## キーワード
 
-構文:
+### `EXTERNAL`
 
-```SQL
-col_name col_type [agg_type] [NULL | NOT NULL] [DEFAULT "default_value"] [AUTO_INCREMENT] [AS generation_expr]
-```
+:::caution
+`EXTERNAL` キーワードは非推奨です。
 
-**col_name**: 列名。
+Hive、Iceberg、Hudi、JDBC データソースからデータをクエリするには、`EXTERNAL` キーワードを使用して外部テーブルを作成するのではなく、[external catalogs](../../../data_source/catalog/catalog_overview.md) を使用することをお勧めします。
 
-通常、`__op` または `__row` で始まる名前の列を作成することはできません。これらの名前形式は StarRocks で特別な目的のために予約されており、そのような列を作成すると未定義の動作が発生する可能性があります。そのような列を作成する必要がある場合は、FE 動的パラメータ [`allow_system_reserved_names`](../../../administration/management/FE_configuration.md#allow_system_reserved_names) を `TRUE` に設定してください。
+:::
 
-**col_type**: 列の型。具体的な列情報、型と範囲:
+:::tip 
+**推奨事項**
 
-- TINYINT (1 バイト): -2^7 + 1 から 2^7 - 1 まで。
-- SMALLINT (2 バイト): -2^15 + 1 から 2^15 - 1 まで。
-- INT (4 バイト): -2^31 + 1 から 2^31 - 1 まで。
-- BIGINT (8 バイト): -2^63 + 1 から 2^63 - 1 まで。
-- LARGEINT (16 バイト): -2^127 + 1 から 2^127 - 1 まで。
-- FLOAT (4 バイト): 科学的記数法をサポート。
-- DOUBLE (8 バイト): 科学的記数法をサポート。
-- DECIMAL[(precision, scale)] (16 バイト)
+v3.1 以降、StarRocks は Iceberg カタログで Parquet 形式のテーブルを作成し、INSERT INTO を使用してこれらの Parquet 形式の Iceberg テーブルにデータをシンクすることをサポートしています。
 
-  - デフォルト値: DECIMAL(10, 0)
-  - precision: 1 ~ 38
-  - scale: 0 ~ precision
-  - 整数部: precision - scale
+v3.2 以降、StarRocks は Hive カタログで Parquet 形式のテーブルを作成し、INSERT INTO を使用してこれらの Parquet 形式の Hive テーブルにデータをシンクすることをサポートしています。v3.3 以降、StarRocks は Hive カタログで ORC および Textfile 形式のテーブルを作成し、INSERT INTO を使用してこれらの ORC および Textfile 形式の Hive テーブルにデータをシンクすることをサポートしています。
+:::
 
-    科学的記数法はサポートされていません。
+非推奨の `EXTERNAL` キーワードを使用したい場合は、**`EXTERNAL` キーワードの詳細**を展開してください。
 
-- DATE (3 バイト): 0000-01-01 から 9999-12-31 まで。
-- DATETIME (8 バイト): 0000-01-01 00:00:00 から 9999-12-31 23:59:59 まで。
-- CHAR[(length)]: 固定長文字列。範囲: 1 ~ 255。デフォルト値: 1。
-- VARCHAR[(length)]: 可変長文字列。デフォルト値は 1。単位: バイト。StarRocks 2.1 より前のバージョンでは、`length` の値の範囲は 1–65533 です。[プレビュー] StarRocks 2.1 以降のバージョンでは、`length` の値の範囲は 1–1048576 です。
-- HLL (1~16385 バイト): HLL 型の場合、長さやデフォルト値を指定する必要はありません。長さはデータ集約に応じてシステム内で制御されます。HLL 列は、[hll_union_agg](../../sql-functions/aggregate-functions/hll_union_agg.md)、[Hll_cardinality](../../sql-functions/scalar-functions/hll_cardinality.md)、および [hll_hash](../../sql-functions/scalar-functions/hll_hash.md) でのみクエリまたは使用できます。
-- BITMAP: ビットマップ型は、指定された長さやデフォルト値を必要としません。これは符号なし bigint 数の集合を表します。最大要素は 2^64 - 1 まで可能です。
+<details>
 
-**agg_type**: 集約タイプ。指定されていない場合、この列はキー列です。指定されている場合、それは値列です。サポートされている集約タイプは次のとおりです:
+<summary>`EXTERNAL` キーワードの詳細</summary>
 
-- SUM, MAX, MIN, REPLACE
-- HLL_UNION (HLL 型のみ)
-- BITMAP_UNION (BITMAP のみ)
-- REPLACE_IF_NOT_NULL: インポートされたデータが非 null 値の場合にのみ置換されることを意味します。null 値の場合、StarRocks は元の値を保持します。
+外部データソースをクエリするための外部テーブルを作成するには、`CREATE EXTERNAL TABLE` を指定し、`ENGINE` を次のいずれかの値に設定します。詳細については、[External table](../../../data_source/External_table.md) を参照してください。
 
-> NOTE
->
-> - 集約タイプ BITMAP_UNION の列がインポートされる場合、その元のデータ型は TINYINT、SMALLINT、INT、および BIGINT でなければなりません。
-> - テーブル作成時に REPLACE_IF_NOT_NULL 列に NOT NULL が指定されている場合、StarRocks はデータを NULL に変換し、ユーザーにエラーレポートを送信しません。これにより、ユーザーは選択された列をインポートできます。
-
-この集約タイプは、キータイプが AGGREGATE KEY の集計テーブルにのみ適用されます。v3.1.9 以降、`REPLACE_IF_NOT_NULL` は BITMAP 型の列を新たにサポートします。
-
-**NULL | NOT NULL**: 列が `NULL` を許可するかどうか。デフォルトでは、重複キーテーブル、集計テーブル、またはユニークキーテーブルを使用するテーブル内のすべての列に対して `NULL` が指定されます。主キーテーブルを使用するテーブルでは、デフォルトで値列には `NULL` が指定され、キー列には `NOT NULL` が指定されます。生データに `NULL` 値が含まれている場合、`\N` で表現します。StarRocks はデータロード中に `\N` を `NULL` として扱います。
-
-**DEFAULT "default_value"**: 列のデフォルト値。StarRocks にデータをロードする際、列にマッピングされたソースフィールドが空の場合、StarRocks は自動的に列にデフォルト値を埋めます。デフォルト値は次のいずれかの方法で指定できます:
-
-- **DEFAULT current_timestamp**: 現在の時間をデフォルト値として使用します。詳細については、[current_timestamp()](../../sql-functions/date-time-functions/current_timestamp.md) を参照してください。
-- **DEFAULT `<default_value>`**: 列データ型の指定された値をデフォルト値として使用します。たとえば、列のデータ型が VARCHAR の場合、`DEFAULT "beijing"` のように、beijing という VARCHAR 文字列をデフォルト値として指定できます。デフォルト値は、次の型のいずれかであってはなりません: ARRAY、BITMAP、JSON、HLL、および BOOLEAN。
-- **DEFAULT (\<expr\>)**: 指定された関数によって返される結果をデフォルト値として使用します。サポートされているのは、[uuid()](../../sql-functions/utility-functions/uuid.md) および [uuid_numeric()](../../sql-functions/utility-functions/uuid_numeric.md) 式のみです。
-
-**AUTO_INCREMENT**: `AUTO_INCREMENT` 列を指定します。`AUTO_INCREMENT` 列のデータ型は BIGINT でなければなりません。自動インクリメント ID は 1 から始まり、1 ずつ増加します。`AUTO_INCREMENT` 列の詳細については、[AUTO_INCREMENT](auto_increment.md) を参照してください。v3.0 以降、StarRocks は `AUTO_INCREMENT` 列をサポートします。
-
-**AS generation_expr**: 生成列とその式を指定します。[生成列](../generated_columns.md) は、式の結果を事前に計算して保存するために使用でき、同じ複雑な式を持つクエリを大幅に高速化します。v3.1 以降、StarRocks は生成列をサポートします。
-
-### index_definition
-
-```SQL
-INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] COMMENT 'xxxxxx'
-```
-
-パラメータの説明と使用上の注意については、[ビットマップインデックス](../../../table_design/indexes/Bitmap_index.md#create-an-index)を参照してください。
-
-### ENGINE type
-
-デフォルト値: `olap`。このパラメータが指定されていない場合、デフォルトで OLAP テーブル (StarRocks 内部テーブル) が作成されます。
-
-オプション値: `mysql`, `elasticsearch`, `hive`, `jdbc` (2.3 以降), `iceberg`, および `hudi` (2.2 以降)。外部データソースをクエリするための外部テーブルを作成する場合は、`CREATE EXTERNAL TABLE` を指定し、`ENGINE` をこれらのいずれかの値に設定します。詳細については、[外部テーブル](../../../data_source/External_table.md)を参照してください。
-
-**Hive、Iceberg、Hudi、および JDBC データソースからデータをクエリするには、カタログを使用することをお勧めします。外部テーブルは非推奨です。**
-
-**v3.1 以降、StarRocks は Iceberg カタログで Parquet 形式のテーブルを作成することをサポートしており、INSERT INTO を使用してこれらの Parquet 形式の Iceberg テーブルにデータを挿入できます。**
-
-**v3.2 以降、StarRocks は Hive カタログで Parquet 形式のテーブルを作成することをサポートしており、INSERT INTO を使用してこれらの Parquet 形式の Hive テーブルにデータを挿入することをサポートしています。v3.3 以降、StarRocks は Hive カタログで ORC および Textfile 形式のテーブルを作成することをサポートしており、INSERT INTO を使用してこれらの ORC および Textfile 形式の Hive テーブルにデータを挿入することをサポートしています。**
-
-- MySQL の場合、次のプロパティを指定します:
+- MySQL 外部テーブルの場合、次のプロパティを指定します：
 
     ```plaintext
     PROPERTIES (
@@ -132,18 +74,17 @@ INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] COMMENT 'xxxxxx'
     )
     ```
 
-    注意:
+    注意：
 
     MySQL の "table_name" は実際のテーブル名を示す必要があります。対照的に、CREATE TABLE ステートメントの "table_name" は StarRocks 上のこの MySQL テーブルの名前を示します。これらは異なる場合も同じ場合もあります。
 
-    StarRocks で MySQL テーブルを作成する目的は、MySQL データベースにアクセスすることです。StarRocks 自体は MySQL データを維持または保存しません。
+    StarRocks で MySQL テーブルを作成する目的は、MySQL データベースにアクセスすることです。StarRocks 自体は MySQL データを保持または保存しません。
 
-- Elasticsearch の場合、次のプロパティを指定します:
+- Elasticsearch 外部テーブルの場合、次のプロパティを指定します：
 
     ```plaintext
     PROPERTIES (
-
-    "hosts" = "http://192.168.0.1:8200,http://192.168.0.2:8200",
+    "hosts" = "http://192.168.xx.xx:8200,http://192.168.xx0.xx:8200",
     "user" = "root",
     "password" = "root",
     "index" = "tindex",
@@ -152,16 +93,15 @@ INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] COMMENT 'xxxxxx'
     ```
 
   - `hosts`: Elasticsearch クラスタに接続するために使用される URL。1 つ以上の URL を指定できます。
-  - `user`: 基本認証が有効な Elasticsearch クラスタにログインするために使用されるルートユーザーのアカウント。
-  - `password`: 前述のルートアカウントのパスワード。
+  - `user`: 基本認証が有効な Elasticsearch クラスタにログインするために使用される root ユーザーのアカウント。
+  - `password`: 上記の root アカウントのパスワード。
   - `index`: Elasticsearch クラスタ内の StarRocks テーブルのインデックス。インデックス名は StarRocks テーブル名と同じです。このパラメータを StarRocks テーブルのエイリアスに設定できます。
   - `type`: インデックスタイプ。デフォルト値は `doc` です。
 
-- Hive の場合、次のプロパティを指定します:
+- Hive 外部テーブルの場合、次のプロパティを指定します：
 
     ```plaintext
     PROPERTIES (
-
         "database" = "hive_db_name",
         "table" = "hive_table_name",
         "hive.metastore.uris" = "thrift://xx.xx.xx.xx:9083"
@@ -170,7 +110,7 @@ INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] COMMENT 'xxxxxx'
 
     ここで、database は Hive テーブル内の対応するデータベースの名前です。table は Hive テーブルの名前です。`hive.metastore.uris` はサーバーアドレスです。
 
-- JDBC の場合、次のプロパティを指定します:
+- JDBC 外部テーブルの場合、次のプロパティを指定します：
 
     ```plaintext
     PROPERTIES (
@@ -179,9 +119,9 @@ INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] COMMENT 'xxxxxx'
     )
     ```
 
-    `resource` は JDBC リソース名であり、`table` は宛先テーブルです。
+    `resource` は JDBC リソース名で、`table` は対象テーブルです。
 
-- Iceberg の場合、次のプロパティを指定します:
+- Iceberg 外部テーブルの場合、次のプロパティを指定します：
 
    ```plaintext
     PROPERTIES (
@@ -193,7 +133,7 @@ INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] COMMENT 'xxxxxx'
 
     `resource` は Iceberg リソース名です。`database` は Iceberg データベースです。`table` は Iceberg テーブルです。
 
-- Hudi の場合、次のプロパティを指定します:
+- Hudi 外部テーブルの場合、次のプロパティを指定します：
 
   ```plaintext
     PROPERTIES (
@@ -203,7 +143,97 @@ INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] COMMENT 'xxxxxx'
     )
     ```
 
-### key_desc
+</details>
+
+### `TEMPORARY`
+
+一時テーブルを作成します。v3.3.1 から、StarRocks は Default Catalog での一時テーブルの作成をサポートしています。詳細については、[Temporary Table](../../../table_design/StarRocks_table_design.md#temporary-table) を参照してください。
+
+:::note
+一時テーブルを作成する際には、`ENGINE` を `olap` に設定する必要があります。
+:::
+
+## 列定義
+
+```SQL
+col_name col_type [agg_type] [NULL | NOT NULL] [DEFAULT "default_value"] [AUTO_INCREMENT] [AS generation_expr]
+```
+
+### col_name
+
+通常、`__op` または `__row` で始まる名前の列を作成することはできません。これらの名前形式は StarRocks で特別な目的のために予約されており、そのような列を作成すると未定義の動作が発生する可能性があります。そのような列を作成する必要がある場合は、FE 動的パラメータ [`allow_system_reserved_names`](../../../administration/management/FE_configuration.md#allow_system_reserved_names) を `TRUE` に設定してください。
+
+### col_type
+
+特定の列情報、タイプと範囲：
+
+- TINYINT (1 バイト): -2^7 + 1 から 2^7 - 1 までの範囲。
+- SMALLINT (2 バイト): -2^15 + 1 から 2^15 - 1 までの範囲。
+- INT (4 バイト): -2^31 + 1 から 2^31 - 1 までの範囲。
+- BIGINT (8 バイト): -2^63 + 1 から 2^63 - 1 までの範囲。
+- LARGEINT (16 バイト): -2^127 + 1 から 2^127 - 1 までの範囲。
+- FLOAT (4 バイト): 科学的記数法をサポート。
+- DOUBLE (8 バイト): 科学的記数法をサポート。
+- DECIMAL[(precision, scale)] (16 バイト)
+
+  - デフォルト値: DECIMAL(10, 0)
+  - precision: 1 ~ 38
+  - scale: 0 ~ precision
+  - 整数部分: precision - scale
+
+    科学的記数法はサポートされていません。
+
+- DATE (3 バイト): 0000-01-01 から 9999-12-31 までの範囲。
+- DATETIME (8 バイト): 0000-01-01 00:00:00 から 9999-12-31 23:59:59 までの範囲。
+- CHAR[(length)]: 固定長文字列。範囲: 1 ~ 255。デフォルト値: 1。
+- VARCHAR[(length)]: 可変長文字列。デフォルト値は 1。単位: バイト。StarRocks 2.1 より前のバージョンでは、`length` の値の範囲は 1–65533 です。[プレビュー] StarRocks 2.1 以降のバージョンでは、`length` の値の範囲は 1–1048576 です。
+- HLL (1~16385 バイト): HLL タイプの場合、長さやデフォルト値を指定する必要はありません。長さはデータ集約に応じてシステム内で制御されます。HLL 列は [hll_union_agg](../../sql-functions/aggregate-functions/hll_union_agg.md)、[Hll_cardinality](../../sql-functions/scalar-functions/hll_cardinality.md)、および [hll_hash](../../sql-functions/scalar-functions/hll_hash.md) によってのみクエリまたは使用できます。
+- BITMAP: ビットマップタイプは、指定された長さやデフォルト値を必要としません。これは符号なしの bigint 数の集合を表します。最大の要素は 2^64 - 1 までです。
+
+### agg_type
+
+集計タイプ。指定されていない場合、この列はキー列です。
+指定されている場合、それは値列です。サポートされている集計タイプは次のとおりです：
+
+- `SUM`, `MAX`, `MIN`, `REPLACE`
+- `HLL_UNION` ( `HLL` タイプのみ)
+- `BITMAP_UNION` ( `BITMAP` のみ)
+- `REPLACE_IF_NOT_NULL`: これは、インポートされたデータが非ヌル値の場合にのみ置き換えられることを意味します。ヌル値の場合、StarRocks は元の値を保持します。
+
+:::note
+- 集計タイプ BITMAP_UNION の列がインポートされるとき、その元のデータタイプは TINYINT、SMALLINT、INT、および BIGINT でなければなりません。
+- テーブル作成時に REPLACE_IF_NOT_NULL 列で NOT NULL が指定されている場合、StarRocks はデータを NULL に変換し、ユーザーにエラーレポートを送信しません。これにより、ユーザーは選択した列をインポートできます。
+:::
+
+この集計タイプは、key_desc タイプが AGGREGATE KEY の集計テーブルにのみ適用されます。v3.1.9 以降、`REPLACE_IF_NOT_NULL` は BITMAP タイプの列を新たにサポートします。
+
+**NULL | NOT NULL**: 列が `NULL` を許可するかどうか。デフォルトでは、重複キーテーブル、集計テーブル、またはユニークキーテーブルを使用するテーブルのすべての列に対して `NULL` が指定されます。主キーテーブルを使用するテーブルでは、デフォルトで値列には `NULL` が指定され、キー列には `NOT NULL` が指定されます。生データに `NULL` 値が含まれている場合、`\N` で表現してください。StarRocks はデータロード中に `\N` を `NULL` として扱います。
+
+**DEFAULT "default_value"**: 列のデフォルト値。StarRocks にデータをロードする際、列にマッピングされたソースフィールドが空の場合、StarRocks は自動的にデフォルト値を列に埋めます。次のいずれかの方法でデフォルト値を指定できます：
+
+- **DEFAULT current_timestamp**: 現在の時刻をデフォルト値として使用します。詳細については、[current_timestamp()](../../sql-functions/date-time-functions/current_timestamp.md) を参照してください。
+- **DEFAULT `<default_value>`**: 列のデータタイプの与えられた値をデフォルト値として使用します。たとえば、列のデータタイプが VARCHAR の場合、`DEFAULT "beijing"` のように、デフォルト値として beijing という VARCHAR 文字列を指定できます。デフォルト値は ARRAY、BITMAP、JSON、HLL、および BOOLEAN タイプにはできません。
+- **DEFAULT (\<expr\>)**: 与えられた関数の結果をデフォルト値として使用します。サポートされているのは [uuid()](../../sql-functions/utility-functions/uuid.md) および [uuid_numeric()](../../sql-functions/utility-functions/uuid_numeric.md) 式のみです。
+
+**AUTO_INCREMENT**: `AUTO_INCREMENT` 列を指定します。`AUTO_INCREMENT` 列のデータタイプは BIGINT でなければなりません。自動インクリメントされた ID は 1 から始まり、1 のステップで増加します。`AUTO_INCREMENT` 列の詳細については、[AUTO_INCREMENT](auto_increment.md) を参照してください。v3.0 以降、StarRocks は `AUTO_INCREMENT` 列をサポートしています。
+
+**AS generation_expr**: 生成列とその式を指定します。[生成列](../generated_columns.md) は、式の結果を事前に計算して保存するために使用でき、同じ複雑な式を持つクエリを大幅に高速化します。v3.1 以降、StarRocks は生成列をサポートしています。
+
+## インデックス定義
+
+```SQL
+INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] COMMENT 'xxxxxx'
+```
+
+パラメータの説明と使用上の注意については、[ビットマップインデックス](../../../table_design/indexes/Bitmap_index.md#create-an-index) を参照してください。
+
+## `ENGINE`
+
+デフォルト値: `olap`。このパラメータが指定されていない場合、デフォルトで OLAP テーブル (StarRocks 内部テーブル) が作成されます。
+
+オプションの値: `mysql`, `elasticsearch`, `hive`, `jdbc`, `iceberg`, および `hudi`。
+
+## キー
 
 構文:
 
@@ -211,33 +241,37 @@ INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] COMMENT 'xxxxxx'
 key_type(k1[,k2 ...])
 ```
 
-データは指定されたキー列で順序付けされ、異なるキータイプに対して異なる属性を持ちます:
+データは指定されたキー列で順序付けされ、異なるキータイプに対して異なる属性を持ちます：
 
-- AGGREGATE KEY: キー列内の同一の内容は、指定された集約タイプに従って値列に集約されます。通常、財務報告書や多次元分析などのビジネスシナリオに適用されます。
-- UNIQUE KEY/PRIMARY KEY: キー列内の同一の内容は、インポート順序に従って値列に置き換えられます。キー列に対する追加、削除、変更、クエリを行うために適用できます。
-- DUPLICATE KEY: StarRocks に同時に存在するキー列内の同一の内容。詳細データや集約属性のないデータを保存するために使用できます。**DUPLICATE KEY はデフォルトのタイプです。データはキー列に従って順序付けされます。**
+- AGGREGATE KEY: キー列の同一内容は、指定された集計タイプに従って値列に集約されます。通常、財務報告書や多次元分析などのビジネスシナリオに適用されます。
+- UNIQUE KEY/PRIMARY KEY: キー列の同一内容は、インポート順序に従って値列に置き換えられます。キー列の追加、削除、変更、クエリに適用できます。
+- DUPLICATE KEY: StarRocks に同時に存在するキー列の同一内容。詳細データや集計属性のないデータを保存するために使用できます。
 
-> **NOTE**
->
-> AGGREGATE KEY を除いて、他の key_type を使用してテーブルを作成する場合、値列は集約タイプを指定する必要はありません。
+  :::note
+  DUPLICATE KEY はデフォルトのタイプです。データはキー列に従って順序付けされます。
+  :::
 
-### COMMENT
+:::note
+AGGREGATE KEY を除く他の key_type を使用してテーブルを作成する場合、値列は集計タイプを指定する必要はありません。
+:::
 
-テーブルを作成する際にテーブルコメントを追加できます（オプション）。COMMENT は `key_desc` の後に配置されなければなりません。そうでない場合、テーブルは作成されません。
+## COMMENT
+
+テーブル作成時にテーブルコメントを追加できます（オプション）。COMMENT は `key_desc` の後に配置する必要があることに注意してください。そうしないと、テーブルは作成されません。
 
 v3.1 以降、`ALTER TABLE <table_name> COMMENT = "new table comment"` を使用してテーブルコメントを変更できます。
 
-### partition_desc
+## パーティション
 
-パーティションの説明は次の方法で使用できます:
+パーティションは次の方法で管理できます：
 
-#### パーティションを動的に作成する
+### パーティションを動的に作成する
 
-[動的パーティション化](../../../table_design/data_distribution/dynamic_partitioning.md) は、パーティションのタイムトゥリブ (TTL) 管理を提供します。StarRocks はデータの新鮮さを確保するために、事前に新しいパーティションを自動的に作成し、期限切れのパーティションを削除します。この機能を有効にするには、テーブル作成時に動的パーティション化関連のプロパティを設定します。
+[動的パーティション化](../../../table_design/data_distribution/dynamic_partitioning.md) は、パーティションの有効期限管理 (TTL) を提供します。StarRocks はデータの新鮮さを確保するために、事前に新しいパーティションを自動的に作成し、期限切れのパーティションを削除します。この機能を有効にするには、テーブル作成時に動的パーティション化関連のプロパティを設定します。
 
-#### パーティションを一つずつ作成する
+### パーティションを一つずつ作成する
 
-**パーティションの上限のみを指定する**
+#### パーティションの上限のみを指定する
 
 構文:
 
@@ -250,16 +284,16 @@ PARTITION BY RANGE ( <partitioning_column1> [, <partitioning_column2>, ... ] )
 )
 ```
 
-注意:
+:::note
+指定されたキー列と指定された値範囲を使用してパーティション化してください。
+:::
 
-指定されたキー列と指定された値の範囲を使用してパーティション化してください。
-
-- パーティションの命名規則については、[システム制限](../../System_limit.md)を参照してください。
-- v3.3.0 より前は、レンジパーティション化の列は TINYINT、SMALLINT、INT、BIGINT、LARGEINT、DATE、および DATETIME のみをサポートしていました。v3.3.0 以降、3 つの特定の時間関数をレンジパーティション化の列として使用できます。詳細な使用方法については、[データ分布](../../../table_design/data_distribution/Data_distribution.md#manually-create-partitions)を参照してください。
-- パーティションは左閉じ右開きです。最初のパーティションの左境界は最小値です。
-- NULL 値は最小値を含むパーティションにのみ保存されます。最小値を含むパーティションが削除されると、NULL 値をインポートできなくなります。
+- パーティションの命名規則については、[システム制限](../../System_limit.md) を参照してください。
+- v3.3.0 より前は、レンジパーティション化の列は TINYINT、SMALLINT、INT、BIGINT、LARGEINT、DATE、および DATETIME のみをサポートしています。v3.3.0 以降、3 つの特定の時間関数をレンジパーティション化の列として使用できます。詳細な使用法については、[データ分布](../../../table_design/data_distribution/Data_distribution.md#manually-create-partitions) を参照してください。
+- パーティションは左閉右開です。最初のパーティションの左境界は最小値です。
+- NULL 値は最小値を含むパーティションにのみ保存されます。最小値を含むパーティションが削除されると、NULL 値はインポートできなくなります。
 - パーティション列は単一列または複数列のいずれかです。パーティション値はデフォルトの最小値です。
-- パーティション列として 1 つの列のみを指定する場合、最新のパーティションのパーティション列の上限として `MAXVALUE` を設定できます。
+- パーティション列として 1 つの列のみが指定されている場合、最新のパーティションのパーティション列の上限として `MAXVALUE` を設定できます。
 
   ```SQL
   PARTITION BY RANGE (pay_dt) (
@@ -269,12 +303,12 @@ PARTITION BY RANGE ( <partitioning_column1> [, <partitioning_column2>, ... ] )
   )
   ```
 
-注意してください:
+:::note
+- パーティションは、時間に関連するデータを管理するためによく使用されます。
+- データのバックトラッキングが必要な場合、必要に応じてパーティションを追加するために最初のパーティションを空にすることを検討するかもしれません。
+:::
 
-- パーティションは時間に関連するデータを管理するためによく使用されます。
-- データのバックトラッキングが必要な場合、後でパーティションを追加するために最初のパーティションを空にすることを検討するかもしれません。
-
-**パーティションの下限と上限の両方を指定する**
+#### パーティションの下限と上限の両方を指定する
 
 構文:
 
@@ -288,11 +322,11 @@ PARTITION BY RANGE ( <partitioning_column1> [, <partitioning_column2>, ... ] )
 )
 ```
 
-注意:
-
-- 固定範囲は LESS THAN よりも柔軟です。左と右のパーティションをカスタマイズできます。
-- 固定範囲は他の側面では LESS THAN と同じです。
-- パーティション列として 1 つの列のみを指定する場合、最新のパーティションのパーティション列の上限として `MAXVALUE` を設定できます。
+:::note
+- 固定レンジは LESS THAN よりも柔軟です。左と右のパーティションをカスタマイズできます。
+- 固定レンジは他の側面では LESS THAN と同じです。
+- パーティション列として 1 つの列のみが指定されている場合、最新のパーティションのパーティション列の上限として `MAXVALUE` を設定できます。
+:::
 
   ```SQL
   PARTITION BY RANGE (pay_dt) (
@@ -302,7 +336,7 @@ PARTITION BY RANGE ( <partitioning_column1> [, <partitioning_column2>, ... ] )
   )
   ```
 
-#### バッチで複数のパーティションを作成する
+### 複数のパーティションを一括で作成する
 
 構文
 
@@ -324,34 +358,34 @@ PARTITION BY RANGE ( <partitioning_column1> [, <partitioning_column2>, ... ] )
 
 説明
 
-`START()` と `END()` で開始値と終了値を指定し、`EVERY()` で時間単位またはパーティショングラニュラリティを指定して、バッチで複数のパーティションを作成できます。
+`START()` と `END()` で開始値と終了値を指定し、`EVERY()` で時間単位またはパーティショングラニュラリティを指定して、一括で複数のパーティションを作成できます。
 
-- v3.3.0 より前は、レンジパーティション化の列は TINYINT、SMALLINT、INT、BIGINT、LARGEINT、DATE、および DATETIME のみをサポートしていました。v3.3.0 以降、3 つの特定の時間関数をレンジパーティション化の列として使用できます。詳細な使用方法については、[データ分布](../../../table_design/data_distribution/Data_distribution.md#manually-create-partitions)を参照してください。
-- パーティション列が日付型の場合、`INTERVAL` キーワードを使用して時間間隔を指定する必要があります。時間単位として、時間 (v3.0 以降)、日、週、月、または年を指定できます。パーティションの命名規則は動的パーティションと同じです。
+- v3.3.0 より前は、レンジパーティション化の列は TINYINT、SMALLINT、INT、BIGINT、LARGEINT、DATE、および DATETIME のみをサポートしています。v3.3.0 以降、3 つの特定の時間関数をレンジパーティション化の列として使用できます。詳細な使用法については、[データ分布](../../../table_design/data_distribution/Data_distribution.md#manually-create-partitions) を参照してください。
+- パーティション列が日付型の場合、`INTERVAL` キーワードを使用して時間間隔を指定する必要があります。時間単位として、時間 (v3.0 以降)、日、週、月、年を指定できます。パーティションの命名規則は動的パーティションと同じです。
 
-詳細については、[データ分布](../../../table_design/data_distribution/Data_distribution.md)を参照してください。
+詳細については、[データ分布](../../../table_design/data_distribution/Data_distribution.md) を参照してください。
 
-### distribution_desc
+## ディストリビューション
 
-StarRocks はハッシュバケット法とランダムバケット法をサポートしています。バケット法を設定しない場合、StarRocks はデフォルトでランダムバケット法を使用し、バケット数を自動的に設定します。
+StarRocks はハッシュバケット法とランダムバケット法をサポートしています。バケット法を設定しない場合、StarRocks はランダムバケット法を使用し、デフォルトでバケット数を自動的に設定します。
 
 - ランダムバケット法 (v3.1 以降)
 
-  パーティション内のデータに対して、StarRocks は特定の列値に基づかずにすべてのバケットにデータをランダムに分配します。StarRocks にバケット数を自動的に設定させたい場合、バケット設定を指定する必要はありません。バケット数を手動で指定する場合、構文は次のとおりです:
+  パーティション内のデータに対して、StarRocks は特定の列値に基づかずにデータをすべてのバケットにランダムに分散します。StarRocks にバケット数を自動的に設定させたい場合、バケット設定を指定する必要はありません。バケット数を手動で指定する場合、構文は次のとおりです：
 
   ```SQL
   DISTRIBUTED BY RANDOM BUCKETS <num>
   ```
   
-  ただし、ランダムバケット法によるクエリパフォーマンスは、大量のデータをクエリし、特定の列を条件列として頻繁に使用する場合には理想的ではない可能性があります。このシナリオでは、ハッシュバケット法を使用することをお勧めします。少数のバケットのみをスキャンして計算する必要があるため、クエリパフォーマンスが大幅に向上します。
+  ただし、ランダムバケット法によって提供されるクエリパフォーマンスは、大量のデータをクエリし、特定の列を条件列として頻繁に使用する場合には理想的でない可能性があります。このようなシナリオでは、ハッシュバケット法を使用することをお勧めします。スキャンおよび計算が必要なバケットの数が少ないため、クエリパフォーマンスが大幅に向上します。
 
   **注意事項**
   - ランダムバケット法は重複キーテーブルの作成にのみ使用できます。
   - ランダムにバケットされたテーブルには [Colocation Group](../../../using_starrocks/Colocate_join.md) を指定できません。
   - Spark Load を使用してランダムにバケットされたテーブルにデータをロードすることはできません。
-  - StarRocks v2.5.7 以降、テーブルを作成する際にバケット数を設定する必要はありません。StarRocks は自動的にバケット数を設定します。このパラメータを設定したい場合は、[バケット数の設定](../../../table_design/data_distribution/Data_distribution.md#set-the-number-of-buckets)を参照してください。
+  - StarRocks v2.5.7 以降、テーブル作成時にバケット数を設定する必要はありません。StarRocks は自動的にバケット数を設定します。このパラメータを設定したい場合は、[バケット数の設定](../../../table_design/data_distribution/Data_distribution.md#set-the-number-of-buckets) を参照してください。
 
-  詳細については、[ランダムバケット法](../../../table_design/data_distribution/Data_distribution.md#random-bucketing-since-v31)を参照してください。
+  詳細については、[ランダムバケット法](../../../table_design/data_distribution/Data_distribution.md#random-bucketing-since-v31) を参照してください。
 
 - ハッシュバケット法
 
@@ -368,41 +402,44 @@ StarRocks はハッシュバケット法とランダムバケット法をサポ�
 
   そのような列が存在しない場合、クエリの複雑さに応じてバケット列を決定できます。
 
-  - クエリが複雑な場合、バケット列として高いカーディナリティを持つ列を選択することをお勧めします。これにより、バケット間でデータが均等に分配され、クラスタリソースの利用が向上します。
-  - クエリが比較的単純な場合、クエリ条件として頻繁に使用される列をバケット列として選択することをお勧めします。これにより、クエリ効率が向上します。
+  - クエリが複雑な場合、バケット列として高いカーディナリティを持つ列を選択して、バケット間のデータ分布を均等にし、クラスタリソースの利用率を向上させることをお勧めします。
+  - クエリが比較的単純な場合、クエリ条件として頻繁に使用される列をバケット列として選択して、クエリ効率を向上させることをお勧めします。
 
-  バケット列を 1 つ使用してもパーティションデータが各バケットに均等に分配されない場合、複数のバケット列 (最大 3 つ) を選択できます。詳細については、[バケット列の選択](../../../table_design/data_distribution/Data_distribution.md#hash-bucketing)を参照してください。
+  1 つのバケット列を使用してもパーティションデータが各バケットに均等に分配されない場合、複数のバケット列 (最大 3 つ) を選択できます。詳細については、[バケット列の選択](../../../table_design/data_distribution/Data_distribution.md#hash-bucketing) を参照してください。
 
   **注意事項**:
-
   - **テーブルを作成する際、バケット列を指定する必要があります**。
   - バケット列の値は更新できません。
   - バケット列は指定後に変更できません。
-  - StarRocks v2.5.7 以降、テーブルを作成する際にバケット数を設定する必要はありません。StarRocks は自動的にバケット数を設定します。このパラメータを設定したい場合は、[バケット数の設定](../../../table_design/data_distribution/Data_distribution.md#set-the-number-of-buckets)を参照してください。
+  - StarRocks v2.5.7 以降、テーブル作成時にバケット数を設定する必要はありません。StarRocks は自動的にバケット数を設定します。このパラメータを設定したい場合は、[バケット数の設定](../../../table_design/data_distribution/Data_distribution.md#set-the-number-of-buckets) を参照してください。
 
-### ORDER BY
+## ロールアップインデックス
 
-v3.0 以降、主キーテーブルは `ORDER BY` を使用してソートキーを定義することをサポートします。v3.3 以降、重複キーテーブル、集計テーブル、およびユニークキーテーブルは `ORDER BY` を使用してソートキーを定義することをサポートします。
+テーブル作成時に一括でロールアップを作成できます。
 
-ソートキーの詳細については、[ソートキーとプレフィックスインデックス](../../../table_design/indexes/Prefix_index_sort_key.md)を参照してください。
+構文:
 
-### TEMPORARY
+```SQL
+ROLLUP (rollup_name (column_name1, column_name2, ...)
+[FROM from_index_name]
+[PROPERTIES ("key"="value", ...)],...)
+```
 
-一時テーブルを作成します。v3.3.1 以降、StarRocks は Default Catalog で一時テーブルを作成することをサポートします。詳細については、[一時テーブル](../../../table_design/StarRocks_table_design.md#temporary-table)を参照してください。
+## ORDER BY
 
-:::note
-一時テーブルを作成する際、`ENGINE` を `olap` に設定する必要があります。
-:::
+v3.0 以降、主キーテーブルは `ORDER BY` を使用してソートキーを定義することをサポートしています。v3.3 以降、重複キーテーブル、集計テーブル、およびユニークキーテーブルは `ORDER BY` を使用してソートキーを定義することをサポートしています。
 
-### PROPERTIES
+ソートキーの詳細については、[ソートキーとプレフィックスインデックス](../../../table_design/indexes/Prefix_index_sort_key.md) を参照してください。
 
-#### 初期記憶媒体、ストレージの自動クールダウン時間、レプリカ数を指定する
+## プロパティ
 
-エンジンタイプが `OLAP` の場合、テーブルを作成する際に初期記憶媒体 (`storage_medium`)、ストレージの自動クールダウン時間 (`storage_cooldown_time`) または時間間隔 (`storage_cooldown_ttl`)、およびレプリカ数 (`replication_num`) を指定できます。
+### ストレージとレプリカ
 
-プロパティが有効な範囲: テーブルにパーティションが 1 つしかない場合、プロパティはテーブルに属します。テーブルが複数のパーティションに分割されている場合、プロパティは各パーティションに属します。指定されたパーティションに異なるプロパティを設定する必要がある場合は、テーブル作成後に [ALTER TABLE ... ADD PARTITION または ALTER TABLE ... MODIFY PARTITION](ALTER_TABLE.md) を実行できます。
+エンジンタイプが `OLAP` の場合、テーブル作成時に初期記憶媒体 (`storage_medium`)、自動ストレージクールダウン時間 (`storage_cooldown_time`) または時間間隔 (`storage_cooldown_ttl`)、およびレプリカ数 (`replication_num`) を指定できます。
 
-**初期記憶媒体とストレージの自動クールダウン時間を設定する**
+プロパティが有効な範囲: テーブルにパーティションが 1 つしかない場合、プロパティはテーブルに属します。テーブルが複数のパーティションに分割されている場合、プロパティは各パーティションに属します。指定されたパーティションに異なるプロパティを設定する必要がある場合、テーブル作成後に [ALTER TABLE ... ADD PARTITION または ALTER TABLE ... MODIFY PARTITION](ALTER_TABLE.md) を実行できます。
+
+#### 初期記憶媒体と自動ストレージクールダウン時間の設定
 
 ```sql
 PROPERTIES (
@@ -412,56 +449,56 @@ PROPERTIES (
 )
 ```
 
-- `storage_medium`: 初期記憶媒体で、`SSD` または `HDD` に設定できます。明示的に指定した記憶媒体のタイプが、StarRocks クラスタの BE ディスクタイプに指定された BE 静的パラメータ `storage_root_path` と一致していることを確認してください。<br />
+**プロパティ**
 
-    FE 設定項目 `enable_strict_storage_medium_check` が `true` に設定されている場合、テーブル作成時にシステムは BE ディスクタイプを厳密にチェックします。CREATE TABLE で指定した記憶媒体が BE ディスクタイプと一致しない場合、エラー "Failed to find enough host in all backends with storage medium is SSD|HDD." が返され、テーブル作成が失敗します。`enable_strict_storage_medium_check` が `false` に設定されている場合、システムはこのエラーを無視し、強制的にテーブルを作成します。ただし、データがロードされた後、クラスタのディスクスペースが不均等に分配される可能性があります。<br />
+- `storage_medium`: 初期記憶媒体で、`SSD` または `HDD` に設定できます。明示的に指定した記憶媒体のタイプが、StarRocks クラスタの BE ディスクタイプに対して BE 静的パラメータ `storage_root_path` で指定されたものと一致していることを確認してください。<br />
+
+    FE 設定項目 `enable_strict_storage_medium_check` が `true` に設定されている場合、テーブル作成時にシステムは BE ディスクタイプを厳密にチェックします。CREATE TABLE で指定した記憶媒体が BE ディスクタイプと一致しない場合、エラー "Failed to find enough host in all backends with storage medium is SSD|HDD." が返され、テーブル作成が失敗します。`enable_strict_storage_medium_check` が `false` に設定されている場合、システムはこのエラーを無視し、強制的にテーブルを作成します。ただし、データがロードされた後、クラスタディスクスペースが不均一に分配される可能性があります。<br />
 
     v2.3.6、v2.4.2、v2.5.1、および v3.0 以降、`storage_medium` が明示的に指定されていない場合、システムは BE ディスクタイプに基づいて記憶媒体を自動的に推測します。<br />
 
-  - システムは次のシナリオでこのパラメータを SSD に自動設定します:
+  - システムは次のシナリオでこのパラメータを SSD に自動的に設定します：
 
-    - BEs によって報告されたディスクタイプ (`storage_root_path`) が SSD のみを含む場合。
-    - BEs によって報告されたディスクタイプ (`storage_root_path`) が SSD と HDD の両方を含む場合。v2.3.10、v2.4.5、v2.5.4、および v3.0 以降、BEs によって報告された `storage_root_path` が SSD と HDD の両方を含み、プロパティ `storage_cooldown_time` が指定されている場合、システムは `storage_medium` を SSD に設定します。
+    - BE によって報告されたディスクタイプ (`storage_root_path`) が SSD のみを含む場合。
+    - BE によって報告されたディスクタイプ (`storage_root_path`) が SSD と HDD の両方を含む場合。v2.3.10、v2.4.5、v2.5.4、および v3.0 以降、BE によって報告された `storage_root_path` が SSD と HDD の両方を含み、プロパティ `storage_cooldown_time` が指定されている場合、システムは `storage_medium` を SSD に設定します。
 
-  - システムは次のシナリオでこのパラメータを HDD に自動設定します:
+  - システムは次のシナリオでこのパラメータを HDD に自動的に設定します：
 
-    - BEs によって報告されたディスクタイプ (`storage_root_path`) が HDD のみを含む場合。
-    - 2.3.10、2.4.5、2.5.4、および 3.0 以降、BEs によって報告された `storage_root_path` が SSD と HDD の両方を含み、プロパティ `storage_cooldown_time` が指定されていない場合、システムは `storage_medium` を HDD に設定します。
+    - BE によって報告されたディスクタイプ (`storage_root_path`) が HDD のみを含む場合。
+    - v2.3.10、v2.4.5、v2.5.4、および v3.0 以降、BE によって報告された `storage_root_path` が SSD と HDD の両方を含み、プロパティ `storage_cooldown_time` が指定されていない場合、システムは `storage_medium` を HDD に設定します。
 
-- `storage_cooldown_ttl` または `storage_cooldown_time`: ストレージの自動クールダウン時間または時間間隔。ストレージの自動クールダウンとは、SSD から HDD へのデータの自動移行を指します。この機能は、初期記憶媒体が SSD の場合にのみ有効です。
+- `storage_cooldown_ttl` または `storage_cooldown_time`: 自動ストレージクールダウン時間または時間間隔。自動ストレージクールダウンとは、SSD から HDD へのデータの自動移行を指します。この機能は、初期記憶媒体が SSD の場合にのみ有効です。
 
-  **パラメータ**
+  - `storage_cooldown_ttl`: このテーブルのパーティションに対する自動ストレージクールダウンの**時間間隔**。最新のパーティションを SSD に保持し、一定の時間間隔後に古いパーティションを自動的に HDD にクールダウンする必要がある場合、このパラメータを使用できます。各パーティションの自動ストレージクールダウン時間は、このパラメータの値とパーティションの上限時間を使用して計算されます。
 
-  - `storage_cooldown_ttl`: このテーブルのパーティションに対するストレージの自動クールダウンの**時間間隔**。最新のパーティションを SSD に保持し、一定の時間間隔後に古いパーティションを HDD に自動的にクールダウンする必要がある場合、このパラメータを使用できます。各パーティションのストレージの自動クールダウン時間は、このパラメータの値とパーティションの上限時間を使用して計算されます。
+  サポートされている値は `<num> YEAR`、`<num> MONTH`、`<num> DAY`、および `<num> HOUR` です。`<num>` は非負整数です。デフォルト値は null で、自動ストレージクールダウンが自動的に実行されないことを示します。
 
-  サポートされている値は `<num> YEAR`、`<num> MONTH`、`<num> DAY`、および `<num> HOUR` です。`<num>` は非負整数です。デフォルト値は null で、ストレージのクールダウンが自動的に実行されないことを示します。
+  たとえば、テーブル作成時に `"storage_cooldown_ttl"="1 DAY"` と指定し、範囲が `[2023-08-01 00:00:00,2023-08-02 00:00:00)` のパーティション `p20230801` が存在する場合、このパーティションの自動ストレージクールダウン時間は `2023-08-03 00:00:00` であり、これは `2023-08-02 00:00:00 + 1 DAY` です。テーブル作成時に `"storage_cooldown_ttl"="0 DAY"` と指定した場合、このパーティションの自動ストレージクールダウン時間は `2023-08-02 00:00:00` です。
 
-  たとえば、テーブル作成時に `"storage_cooldown_ttl"="1 DAY"` と指定し、範囲が `[2023-08-01 00:00:00,2023-08-02 00:00:00)` のパーティション `p20230801` が存在する場合、このパーティションのストレージの自動クールダウン時間は `2023-08-03 00:00:00` であり、これは `2023-08-02 00:00:00 + 1 DAY` です。テーブル作成時に `"storage_cooldown_ttl"="0 DAY"` と指定した場合、このパーティションのストレージの自動クールダウン時間は `2023-08-02 00:00:00` です。
+  - `storage_cooldown_time`: テーブルが SSD から HDD にクールダウンされるときの自動ストレージクールダウン時間 (**絶対時間**)。指定された時間は現在の時間より後である必要があります。形式: "yyyy-MM-dd HH:mm:ss"。指定されたパーティションに異なるプロパティを設定する必要がある場合、テーブル作成後に [ALTER TABLE ... ADD PARTITION または ALTER TABLE ... MODIFY PARTITION](ALTER_TABLE.md) を実行できます。
 
-  - `storage_cooldown_time`: テーブルが SSD から HDD にクールダウンされるストレージの自動クールダウン時間 (**絶対時間**)。指定された時間は現在の時間よりも後である必要があります。形式: "yyyy-MM-dd HH:mm:ss"。指定されたパーティションに異なるプロパティを設定する必要がある場合、テーブル作成後に [ALTER TABLE ... ADD PARTITION または ALTER TABLE ... MODIFY PARTITION](ALTER_TABLE.md) を実行できます。
+##### 使用法
 
-**使用方法**
-
-- ストレージの自動クールダウンに関連するパラメータの比較は次のとおりです:
-  - `storage_cooldown_ttl`: テーブル内のパーティションに対するストレージの自動クールダウンの時間間隔を指定するテーブルプロパティ。このパラメータの値とパーティションの上限時間を加算した時点でパーティションが自動的にクールダウンされます。したがって、ストレージの自動クールダウンはパーティショングラニュラリティで実行され、より柔軟です。
-  - `storage_cooldown_time`: このテーブルに対するストレージの自動クールダウン時間 (**絶対時間**) を指定するテーブルプロパティです。また、テーブル作成後に指定されたパーティションに対して異なるプロパティを設定することもできます。
-  - `storage_cooldown_second`: クラスタ内のすべてのテーブルに対するストレージの自動クールダウン遅延を指定する静的 FE パラメータです。
+- 自動ストレージクールダウンに関連するパラメータの比較は次のとおりです：
+  - `storage_cooldown_ttl`: テーブルのプロパティで、このテーブルのパーティションに対する自動ストレージクールダウンの時間間隔を指定します。システムは、このパラメータの値とパーティションの上限時間を加算した時点でパーティションを自動的にクールダウンします。したがって、自動ストレージクールダウンはパーティショングラニュラリティで実行され、より柔軟です。
+  - `storage_cooldown_time`: テーブルのプロパティで、このテーブルの自動ストレージクールダウン時間 (**絶対時間**) を指定します。また、テーブル作成後に指定されたパーティションに異なるプロパティを設定できます。
+  - `storage_cooldown_second`: クラスタ内のすべてのテーブルに対する自動ストレージクールダウン遅延を指定する静的 FE パラメータ。
 
 - テーブルプロパティ `storage_cooldown_ttl` または `storage_cooldown_time` は、FE 静的パラメータ `storage_cooldown_second` よりも優先されます。
 - これらのパラメータを設定する際には、`"storage_medium = "SSD"` を指定する必要があります。
-- これらのパラメータを設定しない場合、ストレージの自動クールダウンは自動的に実行されません。
-- 各パーティションのストレージの自動クールダウン時間を表示するには、`SHOW PARTITIONS FROM <table_name>` を実行します。
+- これらのパラメータを設定しない場合、自動ストレージクールダウンは自動的に実行されません。
+- 各パーティションの自動ストレージクールダウン時間を確認するには、`SHOW PARTITIONS FROM <table_name>` を実行します。
 
-**制限**
+##### 制限
 
-- 式とリストパーティション化はサポートされていません。
+- 表現およびリストパーティション化はサポートされていません。
 - パーティション列は日付型である必要があります。
 - 複数のパーティション列はサポートされていません。
 - 主キーテーブルはサポートされていません。
 
-**各パーティション内のタブレットに対するレプリカ数を設定する**
+#### 各パーティション内のタブレットのレプリカ数を設定する
 
-`replication_num`: 各パーティション内のテーブルに対するレプリカ数。デフォルト数: `3`。
+`replication_num`: 各パーティション内のテーブルのレプリカ数。デフォルト数: `3`。
 
 ```sql
 PROPERTIES (
@@ -469,17 +506,17 @@ PROPERTIES (
 )
 ```
 
-#### 列にブルームフィルターインデックスを追加する
+### ブルームフィルターインデックス
 
-エンジンタイプが olap の場合、ブルームフィルターインデックスを採用する列を指定できます。
+エンジンタイプが `olap` の場合、ブルームフィルターインデックスを採用する列を指定できます。
 
-ブルームフィルターインデックスを使用する際の制限は次のとおりです:
+ブルームフィルターインデックスを使用する際の制限は次のとおりです：
 
 - 重複キーテーブルまたは主キーテーブルのすべての列に対してブルームフィルターインデックスを作成できます。集計テーブルまたはユニークキーテーブルの場合、キー列に対してのみブルームフィルターインデックスを作成できます。
 - TINYINT、FLOAT、DOUBLE、および DECIMAL 列はブルームフィルターインデックスの作成をサポートしていません。
-- ブルームフィルターインデックスは、`in` および `=` 演算子を含むクエリのパフォーマンスを向上させることができます。たとえば、`Select xxx from table where x in {}` や `Select xxx from table where column = xxx` などです。この列により多くの離散値があると、より正確なクエリが可能になります。
+- ブルームフィルターインデックスは、`in` および `=` 演算子を含むクエリのパフォーマンスを向上させることができます。たとえば、`Select xxx from table where x in {}` および `Select xxx from table where column = xxx` です。この列により多くの離散値があるほど、クエリはより正確になります。
 
-詳細については、[ブルームフィルターインデックス](../../../table_design/indexes/Bloomfilter_index.md)を参照してください。
+詳細については、[ブルームフィルターインデックス](../../../table_design/indexes/Bloomfilter_index.md) を参照してください。
 
 ```SQL
 PROPERTIES (
@@ -487,9 +524,9 @@ PROPERTIES (
 )
 ```
 
-#### Colocate Join を使用する
+### Colocate Join
 
-Colocate Join 属性を使用する場合、`properties` に指定してください。
+Colocate Join 属性を使用したい場合、`properties` で指定してください。
 
 ```SQL
 PROPERTIES (
@@ -497,13 +534,12 @@ PROPERTIES (
 )
 ```
 
-#### 動的パーティションを設定する
+### 動的パーティション
 
-動的パーティション属性を使用する場合、`properties` に指定してください。
+動的パーティション属性を使用したい場合、`properties` で指定してください。
 
 ```SQL
 PROPERTIES (
-
     "dynamic_partition.enable" = "true|false",
     "dynamic_partition.time_unit" = "DAY|WEEK|MONTH",
     "dynamic_partition.start" = "${integer_value}",
@@ -517,15 +553,15 @@ PROPERTIES (
 | パラメータ                   | 必須 | 説明                                                  |
 | --------------------------- | -------- | ------------------------------------------------------------ |
 | dynamic_partition.enable    | No       | 動的パーティション化を有効にするかどうか。 有効な値: `TRUE` および `FALSE`。 デフォルト値: `TRUE`。 |
-| dynamic_partition.time_unit | Yes      | 動的に作成されるパーティションの時間粒度。必須パラメータです。有効な値: `DAY`、`WEEK`、および `MONTH`。時間粒度は動的に作成されるパーティションのサフィックス形式を決定します。<br/>  - 値が `DAY` の場合、動的に作成されるパーティションのサフィックス形式は `yyyyMMdd` です。例として、パーティション名のサフィックスは `20200321` です。<br/>  - 値が `WEEK` の場合、動的に作成されるパーティションのサフィックス形式は `yyyy_ww` で、たとえば `2020_13` は 2020 年の第 13 週を表します。<br/>  - 値が `MONTH` の場合、動的に作成されるパーティションのサフィックス形式は `yyyyMM` で、たとえば `202003` です。 |
-| dynamic_partition.start     | No       | 動的パーティション化の開始オフセット。このパラメータの値は負の整数でなければなりません。このオフセットの前のパーティションは、`dynamic_partition.time_unit` によって決定される現在の日、週、または月に基づいて削除されます。デフォルト値は `Integer.MIN_VALUE`、つまり -2147483648 であり、履歴パーティションは削除されないことを意味します。 |
+| dynamic_partition.time_unit | Yes      | 動的に作成されるパーティションの時間粒度。必須パラメータです。 有効な値: `DAY`、`WEEK`、および `MONTH`。 時間粒度は動的に作成されるパーティションのサフィックス形式を決定します。<br/>  - 値が `DAY` の場合、動的に作成されるパーティションのサフィックス形式は `yyyyMMdd` です。 例: `20200321`。<br/>  - 値が `WEEK` の場合、動的に作成されるパーティションのサフィックス形式は `yyyy_ww` で、例えば `2020_13` は 2020 年の第 13 週を表します。<br/>  - 値が `MONTH` の場合、動的に作成されるパーティションのサフィックス形式は `yyyyMM` で、例えば `202003` です。 |
+| dynamic_partition.start     | No       | 動的パーティション化の開始オフセット。このパラメータの値は負の整数でなければなりません。このオフセットの前のパーティションは、`dynamic_partition.time_unit` によって決定される現在の日、週、または月に基づいて削除されます。デフォルト値は `Integer.MIN_VALUE`、すなわち -2147483648 で、これは履歴パーティションが削除されないことを意味します。 |
 | dynamic_partition.end       | Yes      | 動的パーティション化の終了オフセット。このパラメータの値は正の整数でなければなりません。現在の日、週、または月から終了オフセットまでのパーティションが事前に作成されます。 |
 | dynamic_partition.prefix    | No       | 動的パーティションの名前に追加されるプレフィックス。デフォルト値: `p`。 |
-| dynamic_partition.buckets   | No       | 動的パーティションごとのバケット数。デフォルト値は、予約語 `BUCKETS` によって決定されるバケット数と同じです。または、StarRocks によって自動的に設定されます。 |
+| dynamic_partition.buckets   | No       | 動的パーティションごとのバケット数。デフォルト値は、予約語 `BUCKETS` によって決定されるバケット数と同じか、StarRocks によって自動的に設定されます。 |
 
-#### ランダムバケット法で設定されたテーブルのバケットサイズ (`bucket_size`) を指定する
+### ランダムバケット法によるバケットサイズ
 
-v3.2 以降、ランダムバケット法で設定されたテーブルに対して、テーブル作成時に `PROPERTIES` 内で `bucket_size` パラメータを使用してバケットサイズを指定し、バケット数のオンデマンドおよび動的な増加を有効にできます。単位: B。
+v3.2 以降、ランダムバケット法が設定されたテーブルの場合、テーブル作成時に `PROPERTIES` の `bucket_size` パラメータを使用してバケットサイズを指定し、バケット数のオンデマンドおよび動的な増加を有効にできます。単位: B。
 
 ```sql
 PROPERTIES (
@@ -533,18 +569,18 @@ PROPERTIES (
 )
 ```
 
-#### データ圧縮アルゴリズムを設定する
+### データ圧縮アルゴリズム
 
-テーブルを作成する際に、プロパティ `compression` を追加してデータ圧縮アルゴリズムを指定できます。
+テーブル作成時にプロパティ `compression` を追加してデータ圧縮アルゴリズムを指定できます。
 
-`compression` の有効な値は次のとおりです:
+`compression` の有効な値は次のとおりです：
 
 - `LZ4`: LZ4 アルゴリズム。
 - `ZSTD`: Zstandard アルゴリズム。
 - `ZLIB`: zlib アルゴリズム。
 - `SNAPPY`: Snappy アルゴリズム。
 
-v3.3.2 以降、StarRocks はテーブル作成時に zstd 圧縮形式の圧縮レベルを指定することをサポートします。
+v3.3.2 以降、StarRocks はテーブル作成時に zstd 圧縮形式の圧縮レベルを指定することをサポートしています。
 
 構文:
 
@@ -552,7 +588,7 @@ v3.3.2 以降、StarRocks はテーブル作成時に zstd 圧縮形式の圧縮
 PROPERTIES ("compression" = "zstd(<compression_level>)")
 ```
 
-`compression_level`: ZSTD 圧縮形式の圧縮レベル。タイプ: 整数。範囲: [1,22]。デフォルト: `3` (推奨)。数値が大きいほど、圧縮率が高くなります。圧縮レベルが高いほど、圧縮および解凍にかかる時間が増えます。
+`compression_level`: ZSTD 圧縮形式の圧縮レベル。タイプ: 整数。範囲: [1,22]。デフォルト: `3` (推奨)。数値が大きいほど、圧縮率が高くなります。圧縮レベルが高いほど、圧縮および解凍にかかる時間が増加します。
 
 例:
 
@@ -560,52 +596,40 @@ PROPERTIES ("compression" = "zstd(<compression_level>)")
 PROPERTIES ("compression" = "zstd(3)")
 ```
 
-適切なデータ圧縮アルゴリズムの選択方法については、[データ圧縮](../../../table_design/data_compression.md)を参照してください。
+適切なデータ圧縮アルゴリズムを選択する方法については、[データ圧縮](../../../table_design/data_compression.md) を参照してください。
 
-#### データロードの書き込みクォーラムを設定する
+### データロードのための書き込みクォーラム
 
-StarRocks クラスタに複数のデータレプリカがある場合、テーブルごとに異なる書き込みクォーラムを設定できます。つまり、StarRocks がロードタスクを成功と判断する前に、いくつのレプリカがロード成功を返す必要があるかを設定できます。テーブル作成時にプロパティ `write_quorum` を追加して書き込みクォーラムを指定できます。このプロパティは v2.5 からサポートされています。
+StarRocks クラスタに複数のデータレプリカがある場合、テーブルに対して異なる書き込みクォーラムを設定できます。つまり、StarRocks がロードタスクを成功と判断する前に、ロード成功を返す必要があるレプリカの数を指定できます。このプロパティは v2.5 からサポートされています。
 
-`write_quorum` の有効な値は次のとおりです:
+`write_quorum` の有効な値は次のとおりです：
 
 - `MAJORITY`: デフォルト値。データレプリカの**過半数**がロード成功を返した場合、StarRocks はロードタスク成功を返します。それ以外の場合、StarRocks はロードタスク失敗を返します。
 - `ONE`: データレプリカの**1 つ**がロード成功を返した場合、StarRocks はロードタスク成功を返します。それ以外の場合、StarRocks はロードタスク失敗を返します。
 - `ALL`: データレプリカの**すべて**がロード成功を返した場合、StarRocks はロードタスク成功を返します。それ以外の場合、StarRocks はロードタスク失敗を返します。
 
-> **注意**
->
-> - ロードの書き込みクォーラムを低く設定すると、データのアクセス不能や損失のリスクが増加します。たとえば、StarRocks クラスタに 2 つのレプリカがあるテーブルに対して 1 つの書き込みクォーラムでデータをロードし、データが 1 つのレプリカにのみ正常にロードされた場合、StarRocks はロードタスクが成功したと判断しますが、データの生存レプリカは 1 つしかありません。ロードされたデータのタブレットを保存するサーバーがダウンした場合、これらのタブレット内のデータはアクセス不能になります。サーバーのディスクが損傷した場合、データは失われます。
-> - StarRocks は、すべてのデータレプリカがステータスを返した後にのみロードタスクのステータスを返します。ロードステータスが不明なレプリカがある場合、StarRocks はロードタスクのステータスを返しません。レプリカ内でロードタイムアウトもロード失敗と見なされます。
+:::caution
+- ロードのための低い書き込みクォーラムを設定すると、データのアクセス不能や損失のリスクが増加します。たとえば、StarRocks クラスタに 2 つのレプリカがあるテーブルに対して 1 つの書き込みクォーラムでデータをロードし、データが 1 つのレプリカにのみ正常にロードされた場合、StarRocks はロードタスク成功と判断しますが、データの生存レプリカは 1 つしかありません。ロードされたデータのタブレットを保存するサーバーがダウンした場合、これらのタブレットのデータはアクセス不能になります。サーバーのディスクが破損した場合、データは失われます。
+- StarRocks は、すべてのデータレプリカがステータスを返した後にのみロードタスクのステータスを返します。ロードステータスが不明なレプリカがある場合、StarRocks はロードタスクのステータスを返しません。レプリカ内でのロードタイムアウトもロード失敗と見なされます。
+:::
 
-#### レプリカ間のデータ書き込みおよびレプリケーションモードを指定する
+### レプリカデータの書き込みとレプリケーションモード
 
-StarRocks クラスタに複数のデータレプリカがある場合、`PROPERTIES` 内で `replicated_storage` パラメータを指定して、レプリカ間のデータ書き込みおよびレプリケーションモードを構成できます。
+StarRocks クラスタに複数のデータレプリカがある場合、`PROPERTIES` の `replicated_storage` パラメータを指定して、レプリカ間のデータ書き込みとレプリケーションモードを構成できます。
 
-- `true` (v3.0 以降のデフォルト) は「単一リーダーレプリケーション」を示し、データはプライマリレプリカにのみ書き込まれます。他のレプリカはプライマリレプリカからデータを同期します。このモードは、複数のレプリカへのデータ書き込みによる CPU コストを大幅に削減します。v2.5 からサポートされています。
-- `false` (v2.5 のデフォルト) は「リーダーレスレプリケーション」を示し、データはプライマリおよびセカンダリレプリカを区別せずに直接複数のレプリカに書き込まれます。CPU コストはレプリカの数に比例して増加します。
+- `true` (v3.0 以降のデフォルト) は「シングルリーダーレプリケーション」を示し、データはプライマリレプリカにのみ書き込まれます。他のレプリカはプライマリレプリカからデータを同期します。このモードは、複数のレプリカへのデータ書き込みによって引き起こされる CPU コストを大幅に削減します。v2.5 からサポートされています。
+- `false` (v2.5 のデフォルト) は「リーダーレスレプリケーション」を示し、データはプライマリおよびセカンダリレプリカを区別せずに複数のレプリカに直接書き込まれます。CPU コストはレプリカの数によって増加します。
 
-ほとんどの場合、デフォルト値を使用することでより良いデータ書き込みパフォーマンスが得られます。レプリカ間のデータ書き込みおよびレプリケーションモードを変更したい場合は、ALTER TABLE コマンドを実行します。例:
+ほとんどの場合、デフォルト値を使用することで、より良いデータ書き込みパフォーマンスが得られます。レプリカ間のデータ書き込みとレプリケーションモードを変更したい場合は、ALTER TABLE コマンドを実行します。例:
 
 ```sql
-    ALTER TABLE example_db.my_table
-    SET ("replicated_storage" = "false");
+ALTER TABLE example_db.my_table
+SET ("replicated_storage" = "false");
 ```
 
-#### バルクでロールアップを作成する
+### Delta Join のユニークキーおよび外部キー制約
 
-テーブルを作成する際にバルクでロールアップを作成できます。
-
-構文:
-
-```SQL
-ROLLUP (rollup_name (column_name1, column_name2, ...)
-[FROM from_index_name]
-[PROPERTIES ("key"="value", ...)],...)
-```
-
-#### View Delta Join クエリの書き換えのためにユニークキー制約と外部キー制約を定義する
-
-View Delta Join シナリオでクエリの書き換えを有効にするには、Delta Join で結合されるテーブルに対してユニークキー制約 `unique_constraints` と外部キー制約 `foreign_key_constraints` を定義する必要があります。詳細については、[非同期マテリアライズドビュー - View Delta Join シナリオでのクエリの書き換え](../../../using_starrocks/async_mv/use_cases/query_rewrite_with_materialized_views.md#query-delta-join-rewrite)を参照してください。
+View Delta Join シナリオでクエリの書き換えを有効にするには、Delta Join で結合されるテーブルに対してユニークキー制約 `unique_constraints` と外部キー制約 `foreign_key_constraints` を定義する必要があります。詳細については、[非同期マテリアライズドビュー - View Delta Join シナリオでのクエリの書き換え](../../../using_starrocks/async_mv/use_cases/query_rewrite_with_materialized_views.md#query-delta-join-rewrite) を参照してください。
 
 ```SQL
 PROPERTIES (
@@ -620,22 +644,22 @@ PROPERTIES (
 ```
 
 - `child_column`: テーブルの外部キー。複数の `child_column` を定義できます。
-- `catalog_name`: 結合されるテーブルが存在するカタログの名前。指定されていない場合、デフォルトのカタログが使用されます。
+- `catalog_name`: 結合されるテーブルが存在するカタログの名前。指定されていない場合、デフォルトカタログが使用されます。
 - `database_name`: 結合されるテーブルが存在するデータベースの名前。指定されていない場合、現在のデータベースが使用されます。
 - `parent_table_name`: 結合されるテーブルの名前。
 - `parent_column`: 結合される列。これらは対応するテーブルの主キーまたはユニークキーでなければなりません。
 
-> **注意**
->
-> - `unique_constraints` と `foreign_key_constraints` はクエリの書き換えにのみ使用されます。テーブルにデータがロードされる際に外部キー制約のチェックは保証されません。テーブルにロードされるデータが制約を満たしていることを確認する必要があります。
-> - 主キーテーブルの主キーまたはユニークキーテーブルのユニークキーは、デフォルトで対応する `unique_constraints` です。手動で設定する必要はありません。
-> - テーブルの `foreign_key_constraints` 内の `child_column` は、他のテーブルの `unique_constraints` 内の `unique_key` に参照される必要があります。
-> - `child_column` と `parent_column` の数は一致している必要があります。
-> - `child_column` と対応する `parent_column` のデータ型は一致している必要があります。
+:::caution
+- `unique_constraints` と `foreign_key_constraints` はクエリの書き換えにのみ使用されます。テーブルにデータがロードされるとき、外部キー制約のチェックは保証されません。テーブルにロードされるデータが制約を満たしていることを確認する必要があります。
+- 主キーテーブルの主キーまたはユニークキーテーブルのユニークキーは、デフォルトで対応する `unique_constraints` です。手動で設定する必要はありません。
+- テーブルの `foreign_key_constraints` 内の `child_column` は、別のテーブルの `unique_constraints` 内の `unique_key` に参照されなければなりません。
+- `child_column` と `parent_column` の数は一致している必要があります。
+- `child_column` と対応する `parent_column` のデータタイプは一致している必要があります。
+:::
 
-#### StarRocks 共有データクラスタ用のクラウドネイティブテーブルを作成する
+### 共有データクラスタ用のクラウドネイティブテーブル
 
-StarRocks 共有データクラスタを使用するには、次のプロパティを持つクラウドネイティブテーブルを作成する必要があります:
+StarRocks 共有データクラスタを使用するには、次のプロパティを持つクラウドネイティブテーブルを作成する必要があります：
 
 ```SQL
 PROPERTIES (
@@ -649,94 +673,94 @@ PROPERTIES (
 
 - `datacache.enable`: ローカルディスクキャッシュを有効にするかどうか。デフォルト: `true`。
 
-  - このプロパティが `true` に設定されている場合、ロードされるデータはオブジェクトストレージとローカルディスク（クエリアクセラレーションのキャッシュとして）に同時に書き込まれます。
+  - このプロパティが `true` に設定されている場合、ロードされるデータはオブジェクトストレージとローカルディスク (クエリアクセラレーションのキャッシュとして) に同時に書き込まれます。
   - このプロパティが `false` に設定されている場合、データはオブジェクトストレージにのみロードされます。
 
-  > **注意**
-  >
-  > ローカルディスクキャッシュを有効にするには、BE 設定項目 `storage_root_path` にディスクのディレクトリを指定する必要があります。
+  :::note
+  ローカルディスクキャッシュを有効にするには、BE 設定項目 `storage_root_path` にディスクのディレクトリを指定する必要があります。
+  :::
 
-- `datacache.partition_duration`: ホットデータの有効期間。ローカルディスクキャッシュが有効な場合、すべてのデータがキャッシュにロードされます。キャッシュがいっぱいになると、StarRocks はキャッシュから使用頻度の低いデータを削除します。クエリが削除されたデータをスキャンする必要がある場合、StarRocks はデータが有効期間内であるかどうかを確認します。データが有効期間内であれば、StarRocks はデータを再びキャッシュにロードします。データが有効期間内でない場合、StarRocks はデータをキャッシュにロードしません。このプロパティは、`YEAR`、`MONTH`、`DAY`、`HOUR` などの単位で指定できる文字列値です。例: `7 DAY`、`12 HOUR`。指定されていない場合、すべてのデータがホットデータとしてキャッシュされます。
+- `datacache.partition_duration`: ホットデータの有効期間。ローカルディスクキャッシュが有効な場合、すべてのデータがキャッシュにロードされます。キャッシュがいっぱいになると、StarRocks はキャッシュから使用頻度の低いデータを削除します。クエリが削除されたデータをスキャンする必要がある場合、StarRocks はデータが有効期間内にあるかどうかを確認します。データが有効期間内であれば、StarRocks はデータを再度キャッシュにロードします。データが有効期間内でない場合、StarRocks はそれをキャッシュにロードしません。このプロパティは、`YEAR`、`MONTH`、`DAY`、および `HOUR` の単位で指定できる文字列値です。例: `7 DAY`、`12 HOUR`。指定されていない場合、すべてのデータがホットデータとしてキャッシュされます。
 
-  > **注意**
-  >
-  > このプロパティは、`datacache.enable` が `true` に設定されている場合にのみ利用可能です。
+  :::note
+  このプロパティは、`datacache.enable` が `true` に設定されている場合にのみ利用可能です。
+  :::
 
-#### 高速スキーマ進化を設定する
+### 高速スキーマ進化
 
-`fast_schema_evolution`: テーブルの高速スキーマ進化を有効にするかどうか。 有効な値は `TRUE` または `FALSE` (デフォルト) です。高速スキーマ進化を有効にすると、スキーマ変更の速度が向上し、列の追加や削除時のリソース使用量が削減されます。現在、このプロパティはテーブル作成時にのみ有効にでき、テーブル作成後に [ALTER TABLE](ALTER_TABLE.md) を使用して変更することはできません。
+`fast_schema_evolution`: テーブルに対して高速スキーマ進化を有効にするかどうか。 有効な値は `TRUE` または `FALSE` (デフォルト) です。高速スキーマ進化を有効にすると、スキーマ変更の速度が向上し、列の追加や削除時のリソース使用量が削減されます。現在、このプロパティはテーブル作成時にのみ有効にでき、テーブル作成後に [ALTER TABLE](ALTER_TABLE.md) を使用して変更することはできません。
 
-  > **注意**
-  >
-  > - 高速スキーマ進化は v3.2.0 以降、共有なしクラスタでのみサポートされています。
-  > - 高速スキーマ進化は v3.3.0 以降、共有データクラスタでのみサポートされ、デフォルトで有効になっています。共有データクラスタでクラウドネイティブテーブルを作成する場合、このプロパティを指定する必要はありません。FE のダイナミックパラメータ `enable_fast_schema_evolution` (デフォルト: true) がこの動作を制御します。
+  :::note
+  - 高速スキーマ進化は、v3.2.0 以降の共有なしクラスタでサポートされています。
+  - 高速スキーマ進化は、v3.3 以降の共有データクラスタでサポートされており、デフォルトで有効になっています。共有データクラスタでクラウドネイティブテーブルを作成する際にこのプロパティを指定する必要はありません。FE 動的パラメータ `enable_fast_schema_evolution` (デフォルト: true) がこの動作を制御します。
+  :::
 
-#### ベースコンパクションを禁止する
+### ベースコンパクションの禁止
 
 `base_compaction_forbidden_time_ranges`: テーブルに対してベースコンパクションが禁止される時間範囲。このプロパティが設定されている場合、システムは指定された時間範囲外でのみ適格なタブレットに対してベースコンパクションを実行します。このプロパティは v3.2.13 からサポートされています。
 
-> **注意**
->
-> ベースコンパクションが禁止されている期間中にテーブルにロードされるデータの数が 500 を超えないようにしてください。
+:::note
+ベースコンパクションが禁止されている期間中にテーブルにロードされるデータの数が 500 を超えないようにしてください。
+:::
 
-`base_compaction_forbidden_time_ranges` の値は [Quartz cron 構文](https://productresources.collibra.com/docs/collibra/latest/Content/Cron/co_quartz-cron-syntax.htm) に従い、これらのフィールドのみをサポートします: `<minute> <hour> <day-of-the-month> <month> <day-of-the-week>`。ここで `<minute>` は `*` でなければなりません。
+`base_compaction_forbidden_time_ranges` の値は [Quartz cron 構文](https://productresources.collibra.com/docs/collibra/latest/Content/Cron/co_quartz-cron-syntax.htm) に従い、`<minute> <hour> <day-of-the-month> <month> <day-of-the-week>` のフィールドのみをサポートし、`<minute>` は `*` でなければなりません。
 
-```Plain
+```SQL
 crontab_param_value ::= [ "" | crontab ]
 
 crontab ::= * <hour> <day-of-the-month> <month> <day-of-the-week>
 ```
 
-- このプロパティが設定されていない場合、または `""` (空の文字列) に設定されている場合、ベースコンパクションはいつでも禁止されません。
+- このプロパティが設定されていないか、`""` (空の文字列) に設定されている場合、ベースコンパクションはいつでも禁止されません。
 - このプロパティが `* * * * *` に設定されている場合、ベースコンパクションは常に禁止されます。
 - その他の値は Quartz cron 構文に従います。
   - 独立した値はフィールドの単位時間を示します。たとえば、`<hour>` フィールドの `8` は 8:00-8:59 を意味します。
   - 値の範囲はフィールドの時間範囲を示します。たとえば、`<hour>` フィールドの `8-9` は 8:00-9:59 を意味します。
   - カンマで区切られた複数の値の範囲は、フィールドの複数の時間範囲を示します。
-  - `<day of the week>` の開始値は `1` で日曜日を表し、`7` は土曜日を表します。
+  - `<day of the week>` の開始値は `1` で日曜日を示し、`7` は土曜日を示します。
 
 例:
 
 ```SQL
--- 毎日 8:00 am から 9:00 pm までベースコンパクションを禁止します。
+-- 毎日午前 8 時から午後 9 時までベースコンパクションを禁止します。
 'base_compaction_forbidden_time_ranges' = '* 8-20 * * *'
 
--- 毎日 0:00 am から 5:00 am までと 9:00 pm から 11:00 pm までベースコンパクションを禁止します。
+-- 毎日午前 0 時から午前 5 時まで、および午後 9 時から午後 11 時までベースコンパクションを禁止します。
 'base_compaction_forbidden_time_ranges' = '* 0-4,21-22 * * *'
 
 -- 月曜日から金曜日までベースコンパクションを禁止します (つまり、土曜日と日曜日には許可されます)。
 'base_compaction_forbidden_time_ranges' = '* * * * 2-6'
 
--- 毎営業日 (つまり、月曜日から金曜日) の 8:00 am から 9:00 pm までベースコンパクションを禁止します。
+-- 平日の午前 8 時から午後 9 時までベースコンパクションを禁止します (つまり、月曜日から金曜日)。
 'base_compaction_forbidden_time_ranges' = '* 8-20 * * 2-6'
 ```
 
-#### 共通パーティション式 TTL の指定
+### 共通パーティション式 TTL の指定
 
-v3.5.0以降、StarRocksのネイティブ・テーブルは共通パーティション式のTTLをサポートしています。
+v3.5.0 以降、StarRocks 内部テーブルは共通パーティション式 TTL をサポートしています。
 
-`partition_retention_condition`： パーティションを動的に保持することを宣言する式。式の条件を満たさないパーティションは定期的に削除されます。
-- 式にはパーティション列と定数のみを含めることができます。パーティション以外のカラムはサポートされていません。
-- 共通パーティション式は、リスト・パーティションとレンジ・パーティションで適用方法が異なります：
-  - リストパーティションを持つテーブルの場合、StarRocks は Common Partition Expression によってフィルタリングされたパーティションの削除をサポートします。
-  - StarRocks では、FE のパーティション刈り込み機能を使用してのみ、パーティションをフィルターして削除できます。パーティションのプルーニングがサポートしない述語に対応するパーティションは、フィルタリングおよび削除できません。
+`partition_retention_condition`: 動的に保持されるパーティションを宣言する式。この式の条件を満たさないパーティションは定期的に削除されます。
+- 式にはパーティション列と定数のみを含めることができます。非パーティション列はサポートされていません。
+- 共通パーティション式は、リストパーティションとレンジパーティションに対して異なる方法で適用されます：
+  - リストパーティションを持つテーブルの場合、StarRocks は共通パーティション式でフィルタリングされたパーティションを削除することをサポートしています。
+  - レンジパーティションを持つテーブルの場合、StarRocks は FE のパーティションプルーニング機能を使用してパーティションをフィルタリングおよび削除することしかできません。パーティションプルーニングによってサポートされていない述語に対応するパーティションはフィルタリングおよび削除できません。
 
-例
+例:
 
 ```SQL
--- 過去3ヶ月のデータを保持する。dt`列はテーブルのパーティション列である。
+-- 過去 3 か月のデータを保持します。列 `dt` はテーブルのパーティション列です。
 "partition_retention_condition" = "dt >= CURRENT_DATE() - INTERVAL 3 MONTH"
 ```
 
-この機能を無効にするには、ALTER TABLEステートメントでこのプロパティを空文字列に設定します：
+この機能を無効にするには、ALTER TABLE ステートメントを使用してこのプロパティを空の文字列として設定します：
 
 ```SQL
 ALTER TABLE tbl SET('partition_retention_condition' = '');
 ```
 
-#### フラットjsonコンフィグを設定する（現在は共有なしクラスタでのみサポート）
+### フラット JSON 設定の構成 (現在は共有なしクラスタのみサポート)
 
-フラットjson属性を使いたい場合は、プロパティで指定してください。詳細は [Flat JSON](../../../using_starrocks/Flat_json.md) を参照。
+フラット JSON 属性を使用したい場合、`properties` で指定してください。詳細については、[Flat JSON](../../../using_starrocks/Flat_json.md) を参照してください。
 
 ```SQL
 PROPERTIES (
@@ -747,18 +771,18 @@ PROPERTIES (
 )
 ```
 
-**`PROPERTIES`**
+**プロパティ**
 
-| パラメータ                    | 必須     | 説明                                                                                                                                                                                                                                                       |
+| プロパティ                    | 必須 | 説明                                                                                                                                                                                                                                                       |
 | --------------------------- |----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `flat_json.enable`    | いいえ     | フラットJSON機能を有効にするかどうか。この機能を有効にすると、新しく読み込まれたJSONデータは自動的に平坦化され、JSONクエリのパフォーマンスが向上します。                                                                                                 |
-| `flat_json.null.factor` | いいえ    | フラットJSON用に抽出するカラムのNULL値の割合。NULL値の割合がこのしきい値より高いカラムは抽出されません。このパラメータは `flat_json.enable` が true に設定されている場合にのみ有効である。 デフォルト値: 0.3。 |
-| `flat_json.sparsity.factor`     | いいえ    | フラットJSONの同名のカラムの割合。同じ名前のカラムの割合がこの値より小さい場合は、抽出は行われません。このパラメータは `flat_json.enable` が true に設定されている場合のみ有効である。デフォルト値: 0.9。    |
-| `flat_json.column.max`       | いいえ    | フラットJSONで抽出できるサブフィールドの最大数。このパラメータは `flat_json.enable` が true に設定されている場合のみ有効である。 デフォルト値: 100。                                                                                               |
+| `flat_json.enable`    | No       | フラット JSON 機能を有効にするかどうか。この機能が有効になると、新しくロードされた JSON データが自動的にフラット化され、JSON クエリのパフォーマンスが向上します。                                                                                                 |
+| `flat_json.null.factor` | No      | フラット JSON のために抽出する列の NULL 値の割合。このしきい値を超える NULL 値の割合を持つ列は抽出されません。このパラメータは `flat_json.enable` が true に設定されている場合にのみ有効です。 デフォルト値: 0.3。 |
+| `flat_json.sparsity.factor`     | No      | フラット JSON のために同じ名前を持つ列の割合。この値より低い割合を持つ同じ名前の列は抽出されません。このパラメータは `flat_json.enable` が true に設定されている場合にのみ有効です。デフォルト値: 0.9。    |
+| `flat_json.column.max`       | No      | フラット JSON によって抽出できるサブフィールドの最大数。このパラメータは `flat_json.enable` が true に設定されている場合にのみ有効です。 デフォルト値: 100。 |
 
 ## 例
 
-### ハッシュバケット法と列指向（カラムナ）ストレージを使用する集計テーブルを作成する
+### ハッシュバケット法と列指向ストレージを使用した集計テーブル
 
 ```SQL
 CREATE TABLE example_db.table_hash
@@ -775,7 +799,7 @@ DISTRIBUTED BY HASH(k1)
 PROPERTIES ("storage_type"="column");
 ```
 
-### 集計テーブルを作成し、ストレージ媒体とクールダウン時間を設定する
+### ストレージ媒体とクールダウン時間が設定された集計テーブル
 
 ```SQL
 CREATE TABLE example_db.table_hash
@@ -795,7 +819,7 @@ PROPERTIES(
 );
 ```
 
-### レンジパーティション、ハッシュバケット法、列指向（カラムナ）ストレージを使用し、ストレージ媒体とクールダウン時間を設定した重複キーテーブルを作成する
+### レンジパーティション、ハッシュバケット法、列ベースストレージ、ストレージ媒体、およびクールダウン時間を持つ重複キーテーブル
 
 LESS THAN
 
@@ -825,7 +849,7 @@ PROPERTIES(
 
 注意:
 
-このステートメントは 3 つのデータパーティションを作成します:
+このステートメントは 3 つのデータパーティションを作成します：
 
 ```SQL
 ( {    MIN     },   {"2014-01-01"} )
@@ -835,7 +859,7 @@ PROPERTIES(
 
 これらの範囲外のデータはロードされません。
 
-固定範囲
+固定レンジ
 
 ```SQL
 CREATE TABLE table_range
@@ -859,7 +883,7 @@ PROPERTIES(
 );
 ```
 
-### MySQL 外部テーブルを作成する
+### MySQL 外部テーブル
 
 ```SQL
 CREATE EXTERNAL TABLE example_db.table_mysql
@@ -882,7 +906,7 @@ PROPERTIES
 )
 ```
 
-### HLL 列を含むテーブルを作成する
+### HLL 列を持つテーブル
 
 ```SQL
 CREATE TABLE example_db.example_table
@@ -898,9 +922,9 @@ DISTRIBUTED BY HASH(k1)
 PROPERTIES ("storage_type"="column");
 ```
 
-### BITMAP_UNION 集約タイプを含むテーブルを作成する
+### BITMAP_UNION 集計タイプを使用するテーブル
 
-`v1` および `v2` 列の元のデータ型は TINYINT、SMALLINT、または INT でなければなりません。
+`v1` および `v2` 列の元のデータタイプは TINYINT、SMALLINT、または INT でなければなりません。
 
 ```SQL
 CREATE TABLE example_db.example_table
@@ -916,7 +940,7 @@ DISTRIBUTED BY HASH(k1)
 PROPERTIES ("storage_type"="column");
 ```
 
-### Colocate Join をサポートする 2 つのテーブルを作成する
+### Colocate Join をサポートするテーブル
 
 ```SQL
 CREATE TABLE `t1` 
@@ -946,7 +970,7 @@ PROPERTIES
 );
 ```
 
-### ビットマップインデックスを持つテーブルを作成する
+### ビットマップインデックスを持つテーブル
 
 ```SQL
 CREATE TABLE example_db.table_hash
@@ -964,11 +988,11 @@ DISTRIBUTED BY HASH(k1)
 PROPERTIES ("storage_type"="column");
 ```
 
-### 動的パーティションテーブルを作成する
+### 動的パーティションテーブル
 
-動的パーティション化機能は FE 設定で有効にする必要があります ("dynamic_partition.enable" = "true")。詳細については、[動的パーティションの設定](#configure-dynamic-partitions)を参照してください。
+動的パーティション化機能は FE 設定で有効にする必要があります ("dynamic_partition.enable" = "true")。詳細については、[動的パーティションの設定](#configure-dynamic-partitions) を参照してください。
 
-この例では、次の 3 日間のパーティションを作成し、3 日前に作成されたパーティションを削除します。たとえば、今日が 2020-01-08 の場合、次の名前のパーティションが作成されます: p20200108、p20200109、p20200110、p20200111。それらの範囲は次のとおりです:
+この例では、次の 3 日間のパーティションを作成し、3 日前に作成されたパーティションを削除します。たとえば、今日が 2020-01-08 の場合、次の名前のパーティションが作成されます: p20200108、p20200109、p20200110、p20200111。それらの範囲は次のとおりです：
 
 ```plaintext
 [types: [DATE]; keys: [2020-01-08]; ‥types: [DATE]; keys: [2020-01-09]; )
@@ -1006,32 +1030,32 @@ PROPERTIES(
 );
 ```
 
-### バッチで複数のパーティションを作成し、整数型の列をパーティション列として指定するテーブルを作成する
+### 一括で複数のパーティションを作成し、整数列をパーティション列として使用するテーブル
 
-  次の例では、パーティション列 `datekey` は INT 型です。すべてのパーティションは、単一の簡単なパーティションクロース `START ("1") END ("5") EVERY (1)` によって作成されます。すべてのパーティションの範囲は `1` から始まり、`5` で終わり、パーティショングラニュラリティは `1` です:
-  > **注意**
-  >
-  > **START()** および **END()** 内のパーティション列の値は引用符で囲む必要がありますが、**EVERY()** 内のパーティショングラニュラリティは引用符で囲む必要はありません。
+次の例では、パーティション列 `datekey` は INT 型です。すべてのパーティションは、単純なパーティションクローズ `START ("1") END ("5") EVERY (1)` のみで作成されます。すべてのパーティションの範囲は `1` から始まり、`5` で終わり、パーティショングラニュラリティは `1` です：
+> **注意**
+>
+> **START()** および **END()** 内のパーティション列の値は引用符で囲む必要がありますが、**EVERY()** 内のパーティショングラニュラリティは引用符で囲む必要はありません。
 
-  ```SQL
-  CREATE TABLE site_access (
-      datekey INT,
-      site_id INT,
-      city_code SMALLINT,
-      user_name VARCHAR(32),
-      pv BIGINT DEFAULT '0'
-  )
-  ENGINE=olap
-  DUPLICATE KEY(datekey, site_id, city_code, user_name)
-  PARTITION BY RANGE (datekey) (START ("1") END ("5") EVERY (1)
-  )
-  DISTRIBUTED BY HASH(site_id)
-  PROPERTIES ("replication_num" = "3");
-  ```
+```SQL
+CREATE TABLE site_access (
+    datekey INT,
+    site_id INT,
+    city_code SMALLINT,
+    user_name VARCHAR(32),
+    pv BIGINT DEFAULT '0'
+)
+ENGINE=olap
+DUPLICATE KEY(datekey, site_id, city_code, user_name)
+PARTITION BY RANGE (datekey) (START ("1") END ("5") EVERY (1)
+)
+DISTRIBUTED BY HASH(site_id)
+PROPERTIES ("replication_num" = "3");
+```
 
-### Hive 外部テーブルを作成する
+### Hive 外部テーブル
 
-Hive 外部テーブルを作成する前に、Hive リソースとデータベースを作成している必要があります。詳細については、[外部テーブル](../../../data_source/External_table.md#deprecated-hive-external-table)を参照してください。
+Hive 外部テーブルを作成する前に、Hive リソースとデータベースを作成している必要があります。詳細については、[外部テーブル](../../../data_source/External_table.md#deprecated-hive-external-table) を参照してください。
 
 ```SQL
 CREATE EXTERNAL TABLE example_db.table_hive
@@ -1049,9 +1073,9 @@ PROPERTIES
 );
 ```
 
-### 主キーテーブルを作成し、ソートキーを指定する
+### 特定のソートキーを持つ主キーテーブル
 
-ユーザーの住所や最終アクティブ時間などの次元からユーザーの行動をリアルタイムで分析する必要があるとします。テーブルを作成する際に、`user_id` 列を主キーとして定義し、`address` 列と `last_active` 列の組み合わせをソートキーとして定義できます。
+ユーザーの住所や最終アクティブ時間などの次元からリアルタイムでユーザーの行動を分析する必要があるとします。テーブルを作成する際に、`user_id` 列を主キーとして定義し、`address` 列と `last_active` 列の組み合わせをソートキーとして定義できます。
 
 ```SQL
 create table users (
@@ -1076,7 +1100,7 @@ PROPERTIES(
 );
 ```
 
-### パーティション化された一時テーブルを作成する
+### パーティション化された一時テーブル
 
 ```SQL
 CREATE TEMPORARY TABLE example_db.temp_table
@@ -1098,7 +1122,32 @@ PARTITION BY RANGE (k1)
 DISTRIBUTED BY HASH(k2);
 ```
 
-## 参考文献
+### フラット JSON をサポートするテーブル
+
+:::note
+フラット JSON は現在、共有なしクラスタのみでサポートされています。
+:::
+
+```SQL
+CREATE TABLE example_db.example_table
+(
+    k1 DATE,
+    k2 INT,
+    v1 VARCHAR(2048),
+    v2 JSON
+)
+ENGINE=olap
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k2)
+PROPERTIES (
+    "flat_json.enable" = "true",
+    "flat_json.null.factor" = "0.5",
+    "flat_json.sparsity.factor" = "0.5",
+    "flat_json.column.max" = "50"
+);
+```
+
+## 参考資料
 
 - [SHOW CREATE TABLE](SHOW_CREATE_TABLE.md)
 - [SHOW TABLES](SHOW_TABLES.md)

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -24,7 +24,6 @@ CREATE [EXTERNAL] [TEMPORARY] TABLE [IF NOT EXISTS] [database.]table_name
 [rollup_index]
 [ORDER BY (column_name1,...)]
 [PROPERTIES ("key"="value", ...)]
-[BROKER PROPERTIES ("key"="value", ...)]
 ```
 
 :::tip

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -24,7 +24,6 @@ CREATE [EXTERNAL] [TEMPORARY] TABLE [IF NOT EXISTS] [database.]table_name
 [rollup_index]
 [ORDER BY (column_name1,...)]
 [PROPERTIES ("key"="value", ...)]
-[BROKER PROPERTIES ("key"="value", ...)]
 ```
 
 :::tip

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -4,21 +4,19 @@ displayed_sidebar: docs
 
 # CREATE TABLE
 
-## 功能
-
-该语句用于创建表。
+在 StarRocks 中创建一个新表。
 
 :::tip
-该操作需要有在对应数据库内的建表权限 (CREATE TABLE)。
+此操作需要对目标数据库具有 CREATE TABLE 权限。
 :::
 
 ## 语法
 
-```sql
-CREATE [TEMPORARY] [EXTERNAL] TABLE [IF NOT EXISTS] [database.]table_name
+```SQL
+CREATE [EXTERNAL] [TEMPORARY] TABLE [IF NOT EXISTS] [database.]table_name
 (column_definition1[, column_definition2, ...]
-[, index_definition1[, index_definition2, ...]])
-[ENGINE = [olap|mysql|elasticsearch|hive|iceberg|hudi|jdbc]]
+[, index_definition1[, index_definition12,]])
+[ENGINE = [olap|mysql|elasticsearch|hive|hudi|iceberg|jdbc]]
 [key_desc]
 [COMMENT "table comment"]
 [partition_desc]
@@ -29,143 +27,43 @@ CREATE [TEMPORARY] [EXTERNAL] TABLE [IF NOT EXISTS] [database.]table_name
 [BROKER PROPERTIES ("key"="value", ...)]
 ```
 
-## 参数说明
-
 :::tip
 
-- 关于建表时对于表名、列名、分区名、索引名的命名要求，参见[系统限制](../../System_limit.md)。
-
-- 在指定数据库名、表名和列名等变量时，如果使用了保留关键字，必须使用反引号 (`) 包裹，否则可能会产生报错。有关 StarRocks 的保留关键字列表，请参见[关键字](../keywords.md#保留关键字)。
+- 您创建的表名、分区名、列名和索引名必须遵循 [系统限制](../../System_limit.md) 中的命名约定。
+- 当您指定数据库名、表名、列名或分区名时，请注意，某些字面量在 StarRocks 中被用作保留关键字。不要在 SQL 语句中直接使用这些关键字。如果您想在 SQL 语句中使用这样的关键字，请将其用一对反引号（`）括起来。有关这些保留关键字，请参见 [关键字](../keywords.md)。
 
 :::
 
-### column_definition
+## 关键字
 
-语法：
+### `EXTERNAL`
 
-```sql
-col_name col_type [agg_type] [NULL | NOT NULL] [DEFAULT "default_value"] [AUTO_INCREMENT] [AS generation_expr]
-```
+:::caution
+`EXTERNAL` 关键字已弃用。
 
-说明：
+我们建议您使用 [external catalogs](../../../data_source/catalog/catalog_overview.md) 从 Hive、Iceberg、Hudi 和 JDBC 数据源查询数据，而不是使用 `EXTERNAL` 关键字创建外部表。
 
-**col_name**：列名称。
+:::
 
-注意，在一般情况下，不能直接创建以以 `__op` 或 `__row` 开头命名的列，因为此类列名被 StarRocks 保留用于特殊目的，创建这样的列可能导致未知行为。如需创建这样的列，必须将 FE 动态参数 [`allow_system_reserved_names`](../../../administration/management/FE_configuration.md#allow_system_reserved_names) 设置为 `TRUE`。
+:::tip 
+**推荐**
 
-**col_type**：列数据类型
+从 v3.1 开始，StarRocks 支持在 Iceberg catalogs 中创建 Parquet 格式的表，并支持使用 INSERT INTO 将数据写入这些 Parquet 格式的 Iceberg 表。
 
-支持的列类型以及取值范围等信息如下：
+从 v3.2 开始，StarRocks 支持在 Hive catalogs 中创建 Parquet 格式的表，并支持使用 INSERT INTO 将数据写入这些 Parquet 格式的 Hive 表。从 v3.3 开始，StarRocks 支持在 Hive catalogs 中创建 ORC 和 Textfile 格式的表，并支持使用 INSERT INTO 将数据写入这些 ORC 和 Textfile 格式的 Hive 表。
+:::
 
-- TINYINT（1字节）
-  范围：-2^7 + 1 ~ 2^7 - 1
+如果您想使用已弃用的 `EXTERNAL` 关键字，请展开 **`EXTERNAL` 关键字详情**
 
-- SMALLINT（2字节）
-  范围：-2^15 + 1 ~ 2^15 - 1
+<details>
 
-- INT（4字节）
-  范围：-2^31 + 1 ~ 2^31 - 1
+<summary>`EXTERNAL` 关键字详情</summary>
 
-- BIGINT（8字节）
-  范围：-2^63 + 1 ~ 2^63 - 1
+要创建一个外部表以查询外部数据源，请指定 `CREATE EXTERNAL TABLE` 并将 `ENGINE` 设置为以下任一值。您可以参考 [External table](../../../data_source/External_table.md) 了解更多信息。
 
-- LARGEINT（16字节）
-  范围：-2^127 + 1 ~ 2^127 - 1
+- 对于 MySQL 外部表，指定以下属性：
 
-- FLOAT（4字节）
-  支持科学计数法。
-
-- DOUBLE（8字节）
-  支持科学计数法。
-
-- DECIMAL[(precision, scale)] (16字节)
-  保证精度的小数类型。默认是 DECIMAL(10, 0)
-    precision: 1 ~ 38
-    scale: 0 ~ precision
-  其中整数部分为：precision - scale
-  不支持科学计数法。
-
-- DATE（3字节）
-  范围：0000-01-01 ~ 9999-12-31
-
-- DATETIME（8字节）
-  范围：0000-01-01 00:00:00 ~ 9999-12-31 23:59:59
-
-- CHAR[(length)]
-
-  定长字符串。长度范围：1 ~ 255。默认为 1。
-
-- VARCHAR[(length)]
-
-  变长字符串。单位：字节，默认取值为 `1`。
-  - StarRocks 2.1.0 之前的版本，`length` 的取值范围为 1~65533。
-  - 【公测中】自 StarRocks 2.1.0 版本开始，`length` 的取值范围为 1~1048576。
-
-- HLL (1~16385个字节)
-
-  HLL 列类型，不需要指定长度和默认值，长度根据数据的聚合程度系统内控制，并且 HLL 列只能通过配套的 [hll_union_agg](../../sql-functions/aggregate-functions/hll_union_agg.md)、[hll_cardinality](../../sql-functions/scalar-functions/hll_cardinality.md)、[hll_hash](../../sql-functions/scalar-functions/hll_hash.md)进行查询或使用。
-
-- BITMAP
-  BITMAP 列类型，不需要指定长度和默认值。表示整型的集合，元素个数最大支持到 2^64 - 1。
-
-- ARRAY
-  支持在一个数组中嵌套子数组，最多可嵌套 14 层。您必须使用尖括号（ < 和 > ）来声明 ARRAY 的元素类型，如 ARRAY < INT >。目前不支持将数组中的元素声明为 [Fast Decimal](../../data-types/numeric/DECIMAL.md) 类型。
-
-**agg_type**：聚合类型，如果不指定，则该列为 key 列。否则，该列为 value 列。
-
-```plain
-支持的聚合类型如下：
-
-- SUM、MAX、MIN、REPLACE
-
-- HLL_UNION（仅用于 HLL列，为 HLL 独有的聚合方式)。
-
-- BITMAP_UNION（仅用于 BITMAP 列，为 BITMAP 独有的聚合方式)。
-
-- REPLACE_IF_NOT_NULL：这个聚合类型的含义是当且仅当新导入数据是非 NULL 值时会发生替换行为。如果新导入的数据是 NULL，那么 StarRocks 仍然会保留原值。
-```
-
-注意：
-
-1. BITMAP_UNION 聚合类型列在导入时的原始数据类型必须是 `TINYINT, SMALLINT, INT, BIGINT`。
-2. 如果在建表时 `REPLACE_IF_NOT_NULL` 列指定了 NOT NULL，那么 StarRocks 仍然会将其转化 NULL，不会向用户报错。用户可以借助这个类型完成「部分列导入」的功能。
-  该类型只对聚合表有用 (`key_desc` 的 `type` 为 `AGGREGATE KEY`)。自 3.1.9 起，`REPLACE_IF_NOT_NULL` 新增支持 BITMAP 类型的列。
-
-**NULL | NOT NULL**：列数据是否允许为 `NULL`。其中明细表、聚合表和更新表中所有列都默认指定 `NULL`。主键表的指标列默认指定 `NULL`，维度列默认指定 `NOT NULL`。如源数据文件中存在 `NULL` 值，可以用 `\N` 来表示，导入时 StarRocks 会将其解析为 `NULL`。
-
-**DEFAULT "default_value"**：列数据的默认值。导入数据时，如果该列对应的源数据文件中的字段为空，则自动填充 `DEFAULT` 关键字中指定的默认值。支持以下三种指定方式：
-
-- **DEFAULT current_timestamp**：默认值为当前时间。参见 [current_timestamp()](../../sql-functions/date-time-functions/current_timestamp.md) 。
-- **DEFAULT `<默认值>`**：默认值为指定类型的值。例如，列类型为 VARCHAR，即可指定默认值为 `DEFAULT "beijing"`。当前不支持指定 ARRAY、BITMAP、JSON、HLL 和 BOOLEAN 类型为默认值。
-- **DEFAULT (`<表达式>`)**：默认值为指定函数返回的结果。目前仅支持 [uuid()](../../sql-functions/utility-functions/uuid.md) 和 [uuid_numeric()](../../sql-functions/utility-functions/uuid_numeric.md) 表达式。
-
-**AUTO_INCREMENT**：指定自增列。自增列的数据类型只支持 BIGINT，自增 ID 从 1 开始增加，自增步长为 1。有关自增列的详细说明，请参见 [AUTO_INCREMENT](auto_increment.md)。自 v3.0，StarRocks 支持该功能。
-
-**AS generation_expr**：指定生成列和其使用的表达式。[生成列](../generated_columns.md)用于预先计算并存储表达式的结果，可以加速包含复杂表达式的查询。自 v3.1，StarRocks 支持该功能。
-
-### index_definition
-
-创建 bitmap 索引的语法如下。有关参数说明和使用限制，请参见 [Bitmap 索引](../../../table_design/indexes/Bitmap_index.md#创建索引)。
-
-```sql
-INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] [COMMENT '']
-```
-
-### ENGINE 类型
-
-默认为 `olap`，表示创建的是 StarRocks 内部表。
-
-可选值：`mysql`、`elasticsearch`、`hive`、`jdbc` (2.3 及以后)、`iceberg`、`hudi`（2.2 及以后）。如果指定了可选值，则创建的是对应类型的外部表 (external table)，在建表时需要使用 CREATE EXTERNAL TABLE。更多信息，参见[外部表](../../../data_source/External_table.md)。
-
-**从 3.0 版本起，对于查询 Hive、Iceberg、Hudi 和 JDBC 数据源的场景，推荐使用 Catalog 直接查询，不再推荐外部表的方式。具体参见 [Hive catalog](../../../data_source/catalog/hive_catalog.md)、[Iceberg catalog](../../../data_source/catalog/iceberg/iceberg_catalog.md)、[Hudi catalog](../../../data_source/catalog/hudi_catalog.md) 和 [JDBC catalog](../../../data_source/catalog/jdbc_catalog.md)。**
-
-**从 3.1 版本起，支持直接在 Iceberg catalog 内创建表（当前仅支持 Parquet 格式的表），您可以通过 [INSERT INTO](../loading_unloading/INSERT.md) 把数据插入到 Iceberg 表中。参见 [创建 Iceberg 表](../../../data_source/catalog/iceberg/iceberg_catalog.md#创建-iceberg-表)。**
-
-**从 3.2 版本起，支持直接在 Hive Catalog 内创建 Parquet 格式的表，并支持通过 [INSERT INTO](../loading_unloading/INSERT.md) 把数据插入到 Parquet 格式的 Hive 表中。从 3.3 版本起，支持直接在 Hive Catalog 中创建 ORC 及 Textfile 格式的表，并支持通过 [INSERT INTO](../loading_unloading/INSERT.md) 把数据插入到 ORC 及 Textfile 格式的 Hive 表中。参见[创建 Hive 表](../../../data_source/catalog/hive_catalog.md#创建-hive-表)和[向 Hive 表中插入数据](../../../data_source/catalog/hive_catalog.md#向-hive-表中插入数据)。**
-
-1. 如果是 mysql，则需要在 properties 提供以下信息：
-
-    ```sql
+    ```plaintext
     PROPERTIES (
         "host" = "mysql_server_host",
         "port" = "mysql_server_port",
@@ -177,29 +75,32 @@ INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] [COMMENT '']
     ```
 
     注意：
-    "table" 条目中的 "table_name" 是 MySQL 中的真实表名。
-    而 CREATE TABLE 语句中的 table_name 是该 MySQL 表在 StarRocks 中的名字，可以不同。
 
-    在 StarRocks 创建 MySQL 表的目的是可以通过 StarRocks 访问 MySQL 数据库。
-    而 StarRocks 本身并不维护、存储任何 MySQL 数据。
+    MySQL 中的 "table_name" 应指示实际的表名。相反，CREATE TABLE 语句中的 "table_name" 指示此 MySQL 表在 StarRocks 中的名称。它们可以不同也可以相同。
 
-2. 如果是 elasticsearch，则需要在 properties 提供以下信息：
+    在 StarRocks 中创建 MySQL 表的目的是访问 MySQL 数据库。StarRocks 本身不维护或存储任何 MySQL 数据。
 
-    ```sql
+- 对于 Elasticsearch 外部表，指定以下属性：
+
+    ```plaintext
     PROPERTIES (
-        "hosts" = "http://192.168.0.1:8200,http://192.168.0.2:8200",
-        "user" = "root",
-        "password" = "root",
-        "index" = "tindex",
-        "type" = "doc"
+    "hosts" = "http://192.168.xx.xx:8200,http://192.168.xx0.xx:8200",
+    "user" = "root",
+    "password" = "root",
+    "index" = "tindex",
+    "type" = "doc"
     )
     ```
 
-    其中 `hosts` 为 Elasticsearch 集群连接地址，可指定一个或者多个，`user 和 password` 为开启 basic 认证的 Elasticsearch 集群的用户名/密码，`index` 是 StarRocks 中的表对应的 Elasticsearch 的 index 名字，可以是 alias，`type` 指定 index 的类型，默认是 `doc`。
+  - `hosts`: 用于连接您的 Elasticsearch 集群的 URL。您可以指定一个或多个 URL。
+  - `user`: 用于登录启用了基本身份验证的 Elasticsearch 集群的 root 用户的账户。
+  - `password`: 上述 root 账户的密码。
+  - `index`: StarRocks 表在您的 Elasticsearch 集群中的索引。索引名称与 StarRocks 表名称相同。您可以将此参数设置为 StarRocks 表的别名。
+  - `type`: 索引的类型。默认值为 `doc`。
 
-3. 如果是 hive，则需要在 properties 提供以下信息：
+- 对于 Hive 外部表，指定以下属性：
 
-    ```sql
+    ```plaintext
     PROPERTIES (
         "database" = "hive_db_name",
         "table" = "hive_table_name",
@@ -207,205 +108,239 @@ INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] [COMMENT '']
     )
     ```
 
-    其中 `database` 是 Hive 表对应的库名字，`table` 是 hive 表的名字，`hive.metastore.uris` 是 Hive metastore 服务地址。
+    这里，database 是 Hive 表中对应数据库的名称。table 是 Hive 表的名称。`hive.metastore.uris` 是服务器地址。
 
-4. 如果是 jdbc，则需要在 properties 提供以下信息：
+- 对于 JDBC 外部表，指定以下属性：
 
-    ```sql
+    ```plaintext
     PROPERTIES (
-        "resource"="jdbc0",
-        "table"="dest_tbl"
+    "resource"="jdbc0",
+    "table"="dest_tbl"
     )
     ```
 
-    其中 `resource` 是所使用 JDBC 资源的名称。`table` 是目标数据库表名。
+    `resource` 是 JDBC 资源名称，`table` 是目标表。
 
-5. 如果是 iceberg，则需要在 properties 提供以下信息：
+- 对于 Iceberg 外部表，指定以下属性：
 
-    ```sql
+   ```plaintext
     PROPERTIES (
-        "resource" = "iceberg0", 
-        "database" = "iceberg", 
-        "table" = "iceberg_table"
+    "resource" = "iceberg0", 
+    "database" = "iceberg", 
+    "table" = "iceberg_table"
     )
     ```
 
-    其中 `resource` 是引用的 Iceberg 资源的名称。`database` 是 Iceberg 表所属的数据库名称。`table` Iceberg 表名称。
-6. 如果是 hudi，则需要在 properties 提供以下信息：
+    `resource` 是 Iceberg 资源名称。`database` 是 Iceberg 数据库。`table` 是 Iceberg 表。
 
-    ```sql
+- 对于 Hudi 外部表，指定以下属性：
+
+  ```plaintext
     PROPERTIES (
-        "resource" = "hudi0", 
-        "database" = "hudi", 
-        "table" = "hudi_table" 
+    "resource" = "hudi0", 
+    "database" = "hudi", 
+    "table" = "hudi_table" 
     )
     ```
 
-    其中 `resource` 是 Hudi 资源的名称。`database` 是 Hudi 表所属的数据库名称。`table` Hudi 表名称。
+</details>
 
-### key_desc
+### `TEMPORARY`
+
+创建一个临时表。从 v3.3.1 开始，StarRocks 支持在 Default Catalog 中创建临时表。有关更多信息，请参见 [Temporary Table](../../../table_design/StarRocks_table_design.md#temporary-table)。
+
+:::note
+创建临时表时，必须将 `ENGINE` 设置为 `olap`。
+:::
+
+## column_definition
+
+```SQL
+col_name col_type [agg_type] [NULL | NOT NULL] [DEFAULT "default_value"] [AUTO_INCREMENT] [AS generation_expr]
+```
+
+### col_name
+
+请注意，通常您不能创建以 `__op` 或 `__row` 开头的列名，因为这些名称格式在 StarRocks 中保留用于特殊用途，创建此类列可能会导致未定义的行为。如果您确实需要创建此类列，请将 FE 动态参数 [`allow_system_reserved_names`](../../../administration/management/FE_configuration.md#allow_system_reserved_names) 设置为 `TRUE`。
+
+### col_type
+
+特定列信息，例如类型和范围：
+
+- TINYINT (1 字节)：范围从 -2^7 + 1 到 2^7 - 1。
+- SMALLINT (2 字节)：范围从 -2^15 + 1 到 2^15 - 1。
+- INT (4 字节)：范围从 -2^31 + 1 到 2^31 - 1。
+- BIGINT (8 字节)：范围从 -2^63 + 1 到 2^63 - 1。
+- LARGEINT (16 字节)：范围从 -2^127 + 1 到 2^127 - 1。
+- FLOAT (4 字节)：支持科学计数法。
+- DOUBLE (8 字节)：支持科学计数法。
+- DECIMAL[(precision, scale)] (16 字节)
+
+  - 默认值：DECIMAL(10, 0)
+  - precision: 1 ~ 38
+  - scale: 0 ~ precision
+  - 整数部分：precision - scale
+
+    不支持科学计数法。
+
+- DATE (3 字节)：范围从 0000-01-01 到 9999-12-31。
+- DATETIME (8 字节)：范围从 0000-01-01 00:00:00 到 9999-12-31 23:59:59。
+- CHAR[(length)]：固定长度字符串。范围：1 ~ 255。默认值：1。
+- VARCHAR[(length)]：可变长度字符串。默认值为 1。单位：字节。在 StarRocks 2.1 之前的版本中，`length` 的值范围为 1–65533。[预览] 在 StarRocks 2.1 及更高版本中，`length` 的值范围为 1–1048576。
+- HLL (1~16385 字节)：对于 HLL 类型，无需指定长度或默认值。长度将根据数据聚合在系统内控制。HLL 列只能通过 [hll_union_agg](../../sql-functions/aggregate-functions/hll_union_agg.md)、[Hll_cardinality](../../sql-functions/scalar-functions/hll_cardinality.md) 和 [hll_hash](../../sql-functions/scalar-functions/hll_hash.md) 查询或使用。
+- BITMAP：Bitmap 类型不需要指定长度或默认值。它表示一组无符号 bigint 数字。最大元素可以达到 2^64 - 1。
+
+### agg_type
+
+聚合类型。如果未指定，则此列为键列。
+如果指定，则为值列。支持的聚合类型如下：
+
+- `SUM`、`MAX`、`MIN`、`REPLACE`
+- `HLL_UNION`（仅适用于 `HLL` 类型）
+- `BITMAP_UNION`（仅适用于 `BITMAP`）
+- `REPLACE_IF_NOT_NULL`：这意味着只有在导入的数据为非空值时才会替换。如果为 null 值，StarRocks 将保留原始值。
+
+:::note
+- 当导入聚合类型为 BITMAP_UNION 的列时，其原始数据类型必须为 TINYINT、SMALLINT、INT 和 BIGINT。
+- 如果在创建表时为 REPLACE_IF_NOT_NULL 列指定了 NOT NULL，StarRocks 仍会将数据转换为 NULL 而不会向用户发送错误报告。这样，用户可以选择性地导入列。
+:::
+
+此聚合类型仅适用于键描述类型为 AGGREGATE KEY 的聚合表。自 v3.1.9 起，`REPLACE_IF_NOT_NULL` 新增支持 BITMAP 类型的列。
+
+**NULL | NOT NULL**：列是否允许为 `NULL`。默认情况下，表中使用明细表、聚合表或更新表的所有列都指定为 `NULL`。在使用主键表的表中，默认情况下，值列指定为 `NULL`，而键列指定为 `NOT NULL`。如果原始数据中包含 `NULL` 值，请使用 `\N` 表示。在数据导入期间，StarRocks 将 `\N` 视为 `NULL`。
+
+**DEFAULT "default_value"**：列的默认值。当您将数据导入 StarRocks 时，如果映射到该列的源字段为空，StarRocks 会自动在该列中填充默认值。您可以通过以下方式之一指定默认值：
+
+- **DEFAULT current_timestamp**：使用当前时间作为默认值。有关更多信息，请参见 [current_timestamp()](../../sql-functions/date-time-functions/current_timestamp.md)。
+- **DEFAULT `<default_value>`**：使用列数据类型的给定值作为默认值。例如，如果列的数据类型为 VARCHAR，您可以指定一个 VARCHAR 字符串，例如 beijing，作为默认值，如 `DEFAULT "beijing"` 所示。请注意，默认值不能是以下类型之一：ARRAY、BITMAP、JSON、HLL 和 BOOLEAN。
+- **DEFAULT (\<expr\>)**：使用给定函数返回的结果作为默认值。仅支持 [uuid()](../../sql-functions/utility-functions/uuid.md) 和 [uuid_numeric()](../../sql-functions/utility-functions/uuid_numeric.md) 表达式。
+
+**AUTO_INCREMENT**：指定一个 `AUTO_INCREMENT` 列。`AUTO_INCREMENT` 列的数据类型必须为 BIGINT。自增 ID 从 1 开始，步长为 1。有关 `AUTO_INCREMENT` 列的更多信息，请参见 [AUTO_INCREMENT](auto_increment.md)。自 v3.0 起，StarRocks 支持 `AUTO_INCREMENT` 列。
+
+**AS generation_expr**：指定生成列及其表达式。[生成列](../generated_columns.md) 可用于预计算和存储表达式的结果，这显著加速了具有相同复杂表达式的查询。自 v3.1 起，StarRocks 支持生成列。
+
+## index_definition
+
+```SQL
+INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] COMMENT 'xxxxxx'
+```
+
+有关参数描述和使用注意事项的更多信息，请参见 [Bitmap 索引](../../../table_design/indexes/Bitmap_index.md#create-an-index)。
+
+## `ENGINE`
+
+默认值：`olap`。如果未指定此参数，则默认创建 OLAP 表（StarRocks 内表）。
+
+可选值：`mysql`、`elasticsearch`、`hive`、`jdbc`、`iceberg` 和 `hudi`。
+
+## Key
+
+语法：
+
+```SQL
+key_type(k1[,k2 ...])
+```
+
+数据按指定的键列排序，并且不同的键类型具有不同的属性：
+
+- AGGREGATE KEY：键列中的相同内容将根据指定的聚合类型聚合到值列中。通常适用于财务报表和多维分析等业务场景。
+- UNIQUE KEY/PRIMARY KEY：键列中的相同内容将根据导入顺序在值列中替换。可以应用于对键列进行增、删、改、查。
+- DUPLICATE KEY：键列中的相同内容同时存在于 StarRocks 中。可用于存储明细数据或无聚合属性的数据。
+
+  :::note
+  DUPLICATE KEY 是默认类型。数据将根据键列排序。
+  :::
+
+:::note
+当使用其他 key_type 创建表时，值列不需要指定聚合类型，AGGREGATE KEY 除外。
+:::
+
+## COMMENT
+
+您可以在创建表时添加表注释，选填。请注意，COMMENT 必须放在 `key_desc` 之后。否则，无法创建表。
+
+从 v3.1 开始，您可以使用 `ALTER TABLE <table_name> COMMENT = "new table comment"` 修改表注释。
+
+## 分区
+
+可以通过以下方式管理分区：
+
+### 动态创建分区
+
+[动态分区](../../../table_design/data_distribution/dynamic_partitioning.md) 提供了分区的生存时间 (TTL) 管理。StarRocks 自动提前创建新分区并删除过期分区，以确保数据的新鲜度。要启用此功能，您可以在创建表时配置动态分区相关属性。
+
+### 逐个创建分区
+
+#### 仅为分区指定上限
 
 语法：
 
 ```sql
-`key_type(k1[,k2 ...])`
+PARTITION BY RANGE ( <partitioning_column1> [, <partitioning_column2>, ... ] )
+  PARTITION <partition1_name> VALUES LESS THAN ("<upper_bound_for_partitioning_column1>" [ , "<upper_bound_for_partitioning_column2>", ... ] )
+  [ ,
+  PARTITION <partition2_name> VALUES LESS THAN ("<upper_bound_for_partitioning_column1>" [ , "<upper_bound_for_partitioning_column2>", ... ] )
+  , ... ] 
+)
 ```
 
-> 说明
->
-数据按照指定的 key 列进行排序，且根据不同的 `key_type` 具有不同特性。
-`key_type` 支持以下类型：
+:::note
+请使用指定的键列和指定的值范围进行分区。
+:::
 
-- AGGREGATE KEY: key 列相同的记录，value 列按照指定的聚合类型进行聚合，适合报表、多维分析等业务场景。
-- UNIQUE KEY/PRIMARY KEY: key 列相同的记录，value 列按导入顺序进行覆盖，适合按 key 列进行增删改查的点查询 (point query) 业务。
-- DUPLICATE KEY: key 列相同的记录，同时存在于 StarRocks 中，适合存储明细数据或者数据无聚合特性的业务场景。
+- 有关分区命名约定，请参见 [系统限制](../../System_limit.md)。
+- 在 v3.3.0 之前，范围分区的列仅支持以下类型：TINYINT、SMALLINT、INT、BIGINT、LARGEINT、DATE 和 DATETIME。自 v3.3.0 起，三种特定时间函数可以用作范围分区的列。有关详细用法，请参见 [数据分布](../../../table_design/data_distribution/Data_distribution.md#manually-create-partitions)。
+- 分区是左闭右开的。第一个分区的左边界为最小值。
+- NULL 值仅存储在包含最小值的分区中。当删除包含最小值的分区时，无法再导入 NULL 值。
+- 分区列可以是单列或多列。分区值为默认最小值。
+- 当仅指定一个列作为分区列时，可以将 `MAXVALUE` 设置为最近分区的分区列的上限。
 
-默认为 DUPLICATE KEY，数据按 key 列做排序。
+  ```SQL
+  PARTITION BY RANGE (pay_dt) (
+    PARTITION p1 VALUES LESS THAN ("20210102"),
+    PARTITION p2 VALUES LESS THAN ("20210103"),
+    PARTITION p3 VALUES LESS THAN MAXVALUE
+  )
+  ```
 
-除 AGGREGATE KEY 外，其他 `key_type` 在建表时，`value` 列不需要指定聚合类型 (agg_type)。
+:::note
+- 分区通常用于管理与时间相关的数据。
+- 当需要数据回溯时，您可能需要考虑清空第一个分区，以便在必要时添加分区。
+:::
 
-### COMMENT
+#### 为分区指定上下限
 
-表的注释，可选。注意建表时 COMMENT 必须在 `key_desc` 之后，否则建表失败。
+语法：
 
-如果后续想修改表的注释，可以使用 `ALTER TABLE <table_name> COMMENT = "new table comment"`（3.1 版本开始支持）。
+```SQL
+PARTITION BY RANGE ( <partitioning_column1> [, <partitioning_column2>, ... ] )
+(
+    PARTITION <partition_name1> VALUES [( "<lower_bound_for_partitioning_column1>" [ , "<lower_bound_for_partitioning_column2>", ... ] ), ( "<upper_bound_for_partitioning_column1?" [ , "<upper_bound_for_partitioning_column2>", ... ] ) ) 
+    [,
+    PARTITION <partition_name2> VALUES [( "<lower_bound_for_partitioning_column1>" [ , "<lower_bound_for_partitioning_column2>", ... ] ), ( "<upper_bound_for_partitioning_column1>" [ , "<upper_bound_for_partitioning_column2>", ... ] ) ) 
+    , ...]
+)
+```
 
-### partition_desc
+:::note
+- 指定上下限的方式比 LESS THAN 更灵活。您可以自定义左右分区。
+- 指定上下限的方式在其他方面与 LESS THAN 相同。
+- 当仅指定一个列作为分区列时，可以将 `MAXVALUE` 设置为最近分区的分区列的上限。
+:::
 
-支持三种分区方式，[表达式分区](../../../table_design/data_distribution/expression_partitioning.md)（推荐）、[Range 分区](../../../table_design/data_distribution/Data_distribution.md#range-分区) 和 [List 分区](../../../table_design/data_distribution/list_partitioning.md)。
+  ```SQL
+  PARTITION BY RANGE (pay_dt) (
+    PARTITION p202101 VALUES [("20210101"), ("20210201")),
+    PARTITION p202102 VALUES [("20210201"), ("20210301")),
+    PARTITION p202103 VALUES [("20210301"), (MAXVALUE))
+  )
+  ```
 
-使用 Range 分区时，提供三种创建方式，其语法、说明和示例如下：
+### 批量创建多个分区
 
-- **动态创建分区**
+语法
 
-    [动态分区](../../../table_design/data_distribution/dynamic_partitioning.md)提供了分区生命周期管理（TTL）。StarRocks 会自动提前创建新的分区，并删除过期的分区，以确保数据时效性。要启用这个功能，您可以在创建表时配置与动态分区相关的属性。
-
-- **手动创建分区**
-
-  - 仅指定各个分区的上界
-
-    语法：
-
-    ```sql
-    PARTITION BY RANGE ( <partitioning_column1> [, <partitioning_column2>, ... ] )
-    PARTITION <partition1_name> VALUES LESS THAN ("<upper_bound_for_partitioning_column1>" [ , "<upper_bound_for_partitioning_column2>", ... ] )
-    [ ,
-    PARTITION <partition2_name> VALUES LESS THAN ("<upper_bound_for_partitioning_column1>" [ , "<upper_bound_for_partitioning_column2>", ... ] )
-    , ... ] 
-    )
-    ```
-
-    说明：
-
-    使用指定的 key 列和指定的数值范围进行分区。
-
-    - 分区名称的命名要求，参见[系统限制](../../System_limit.md)。
-    - 3.3.0 之前，仅支持以下类型的列作为 Range 分区列：`TINYINT, SMALLINT, INT, BIGINT, LARGEINT, DATE, DATETIME`。自 3.3.0 起，支持三个特定时间函数为 Range 分区列。具体使用方式，参见[数据分布](../../../table_design/data_distribution/Data_distribution.md#手动创建分区)。
-    - 分区为左闭右开区间，首个分区的左边界为最小值。
-    - NULL 值只会存放在包含 **最小值** 的分区中。当包含最小值的分区被删除后，NULL 值将无法导入。
-    - 可以指定一列或多列作为分区列。如果分区值缺省，则会默认填充最小值。
-    - 当只指定一个列作为分区列时，您可以设置最后一个分区的分区列的上界为 MAXVALUE。
-
-    注意：
-
-    1. 分区一般用于时间维度的数据管理。
-    2. 有数据回溯需求的，可以考虑首个分区为空分区，以便后续增加分区。
-
-    示例：
-
-    1. 分区列 `pay_dt` 为 DATE 类型，并且按天分区。
-
-        ```sql
-        PARTITION BY RANGE(pay_dt)
-        (
-            PARTITION p1 VALUES LESS THAN ("2021-01-02"),
-            PARTITION p2 VALUES LESS THAN ("2021-01-03"),
-            PARTITION p3 VALUES LESS THAN ("2021-01-04")
-        )
-        ```
-
-    2. 分区列 `pay_dt` 为 INT 类型，并且按天分区。
-
-        ```sql
-        PARTITION BY RANGE(pay_dt)
-        (
-            PARTITION p1 VALUES LESS THAN ("20210102"),
-            PARTITION p2 VALUES LESS THAN ("20210103"),
-            PARTITION p3 VALUES LESS THAN ("20210104")
-        )
-        ```
-
-    3. 分区列 `pay_dt` 为 INT 类型，并且按天分区，最后一个分区没有上界。
-
-        ```sql
-        PARTITION BY RANGE(pay_dt)
-        (
-            PARTITION p1 VALUES LESS THAN ("20210102"),
-            PARTITION p2 VALUES LESS THAN ("20210103"),
-            PARTITION p3 VALUES LESS THAN MAXVALUE
-        )
-        ```
-
-  - 指定各个分区的上界和下界
-
-    语法：
-
-    ```sql
-    PARTITION BY RANGE ( <partitioning_column1> [, <partitioning_column2>, ... ] )
-    (
-        PARTITION <partition_name1> VALUES [( "<lower_bound_for_partitioning_column1>" [ , "<lower_bound_for_partitioning_column2>", ... ] ), ( "<upper_bound_for_partitioning_column1>" [ , "<upper_bound_for_partitioning_column2>", ... ] ) ) 
-        [,
-        PARTITION <partition_name2> VALUES [( "<lower_bound_for_partitioning_column1>" [ , "<lower_bound_for_partitioning_column2>", ... ] ), ( "<upper_bound_for_partitioning_column1>" [ , "<upper_bound_for_partitioning_column2>", ... ] ) ) 
-        , ...]
-    )
-    ```
-
-    说明：
-
-    - 与仅指定分区下界相比，指定各个分区的上界和下界相对灵活，并且您可以自定义左右区间。
-    - 其他与 LESS THAN 保持同步。
-    - 当只指定一个列作为分区列时，您可以设置最后一个分区的分区列的上界为 MAXVALUE。
-
-    示例：
-
-    1. 分区列 `pay_dt` 为 DATE 类型，并且按月分区。
-
-        ```sql
-        PARTITION BY RANGE (pay_dt)
-        (
-            PARTITION p202101 VALUES [("2021-01-01"), ("2021-02-01")),
-            PARTITION p202102 VALUES [("2021-02-01"), ("2021-03-01")),
-            PARTITION p202103 VALUES [("2021-03-01"), ("2021-04-01"))
-        )
-        ```
-
-    2. 分区列 `pay_dt` 为 INT 类型，并且按月分区。
-
-        ```sql
-        PARTITION BY RANGE (pay_dt)
-        (
-            PARTITION p202101 VALUES [("20210101"), ("20210201")),
-            PARTITION p202102 VALUES [("20210201"), ("20210301")),
-            PARTITION p202103 VALUES [("20210301"), ("20210401"))
-        )
-        ```
-
-    3. 分区列 `pay_dt` 为 INT 类型，并且按月分区，最后一个分区没有上界。
-
-        ```sql
-        PARTITION BY RANGE (pay_dt)
-        (
-            PARTITION p202101 VALUES [("20210101"), ("20210201")),
-            PARTITION p202102 VALUES [("20210201"), ("20210301")),
-            PARTITION p202103 VALUES [("20210301"), (MAXVALUE))
-        )
-        ```
-
-- **批量创建分区**
-
-  语法：
-
-  - 如果分区列为时间类型
+- 如果分区列是日期类型。
 
     ```sql
     PARTITION BY RANGE (<partitioning_column>) (
@@ -413,7 +348,7 @@ INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] [COMMENT '']
     )
     ```
 
-    - 如果分区列为整数类型
+- 如果分区列是整数类型。
 
     ```sql
     PARTITION BY RANGE (<partitioning_column>) (
@@ -421,56 +356,36 @@ INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] [COMMENT '']
     )
     ```
 
-    说明：
-    用户可以通过给出一个 START 值、一个 END 值以及一个定义分区增量值的 EVERY 子句批量产生分区。
+描述
 
-    - 3.3.0 之前，仅支持以下类型的列作为 Range 分区列：`TINYINT, SMALLINT, INT, BIGINT, LARGEINT, DATE, DATETIME`。自 3.3.0 起，支持三个特定时间函数为 Range 分区列。具体使用方式，参见[数据分布](../../../table_design/data_distribution/Data_distribution.md#手动创建分区)。
-    - 当分区列为日期类型时，需要指定 `INTERVAL` 关键字来表示日期间隔。目前日期间隔支持 hour (v3.0）、day、week、month、year，分区的命名规则同动态分区一样。
-    - 当分区列为整数类型时，START 值、END 值仍需要用双引号包裹。
-    - 仅支持指定一列作为分区列。
+您可以在 `START()` 和 `END()` 中指定起始和结束值，并在 `EVERY()` 中指定时间单位或分区粒度，以批量创建多个分区。
 
-    更多信息，请参见[批量创建分区](../../../table_design/data_distribution/Data_distribution.md#range-分区)。
+- 在 v3.3.0 之前，范围分区的列仅支持以下类型：TINYINT、SMALLINT、INT、BIGINT、LARGEINT、DATE 和 DATETIME。自 v3.3.0 起，三种特定时间函数可以用作范围分区的列。有关详细用法，请参见 [数据分布](../../../table_design/data_distribution/Data_distribution.md#manually-create-partitions)。
+- 如果分区列是日期类型，则需要使用 `INTERVAL` 关键字指定时间间隔。您可以将时间单位指定为小时（自 v3.0 起）、天、周、月或年。分区的命名约定与动态分区相同。
 
-    示例：
+有关更多信息，请参见 [数据分布](../../../table_design/data_distribution/Data_distribution.md)。
 
-    1. 分区列 `pay_dt` 为 DATE 类型，并且按年分区。
+## 数据分布
 
-        ```sql
-        PARTITION BY RANGE (pay_dt) (
-            START ("2018-01-01") END ("2023-01-01") EVERY (INTERVAL 1 YEAR)
-        )
-        ```
+StarRocks 支持哈希分桶和随机分桶。如果您不配置分桶，StarRocks 默认使用随机分桶并自动设置桶的数量。
 
-    2. 分区列 `pay_dt` 为 INT 类型，并且按年分区。
+- 随机分桶（自 v3.1 起）
 
-        ```sql
-        PARTITION BY RANGE (pay_dt) (
-            START ("2018") END ("2023") EVERY (1)
-        )
-        ```
-
-### distribution_desc
-
-支持随机分桶（Random bucketing）和哈希分桶（Hash bucketing）。如果不指定分桶信息，则 StarRocks 默认使用随机分桶且自动设置分桶数量。
-
-- 随机分桶（自 v3.1）
-
-  对每个分区的数据，StarRocks 将数据随机地分布在所有分桶中，而不受到特定列值的影响。并且如果选择由系统设置分桶数量，则您无需设置分桶信息。如果选择手动指定分桶数量，则语法如下：
+  对于分区中的数据，StarRocks 将数据随机分布在所有桶中，而不是基于特定的列值。如果您希望 StarRocks 自动设置桶的数量，则无需指定任何分桶配置。如果您选择手动指定桶的数量，语法如下：
 
   ```SQL
   DISTRIBUTED BY RANDOM BUCKETS <num>
   ```
-
-  不过值得注意的是，如果查询海量数据且查询时经常使用一些列会作为条件列，随机分桶提供的查询性能可能不够理想。在该场景下建议您使用哈希分桶，当查询时经常使用这些列作为条件列时，只需要扫描和计算查询命中的少量分桶，则可以显著提高查询性能。
+  
+  但是，请注意，当您查询大量数据并频繁使用某些列作为条件列时，随机分桶提供的查询性能可能不理想。在这种情况下，建议使用哈希分桶。因为只需扫描和计算少量桶，从而显著提高查询性能。
 
   **注意事项**
+  - 您只能使用随机分桶创建明细表。
+  - 您不能为随机分桶的表指定 [Colocation Group](../../../using_starrocks/Colocate_join.md)。
+  - Spark Load 不能用于将数据导入随机分桶的表。
+  - 自 StarRocks v2.5.7 起，创建表时无需设置桶的数量。StarRocks 会自动设置桶的数量。如果您想设置此参数，请参见 [设置桶的数量](../../../table_design/data_distribution/Data_distribution.md#set-the-number-of-buckets)。
 
-  - 不支持主键表、更新表和聚合表。
-  - 不支持指定 [Colocation Group](../../../using_starrocks/Colocate_join.md)。
-  - 不支持 [Spark Load](../../../loading/SparkLoad.md)。
-  - 自 2.5.7 版本起，建表时**无需手动指定分桶数量**，StarRocks 自动设置分桶数量。如果您需要手动设置分桶数量，请参见[设置分桶数量](../../../table_design/data_distribution/Data_distribution.md#设置分桶数量)。
-
-  更多随机分桶的信息，请参见[随机分桶](../../../table_design/data_distribution/Data_distribution.md#随机分桶自-v31)。
+  有关更多信息，请参见 [随机分桶](../../../table_design/data_distribution/Data_distribution.md#random-bucketing-since-v31)。
 
 - 哈希分桶
 
@@ -480,45 +395,51 @@ INDEX index_name (col_name[, col_name, ...]) [USING BITMAP] [COMMENT '']
   DISTRIBUTED BY HASH (k1[,k2 ...]) [BUCKETS num]
   ```
 
-  对每个分区的数据，StarRocks 会根据分桶键和分桶数量进行哈希分桶。
+  分区中的数据可以根据分桶列的哈希值和桶的数量细分为多个桶。我们建议您选择满足以下两个要求的列作为分桶列。
 
-  对于分桶键的选择，如果列是高基数且经常作为查询条件，则优先选择其为分桶键，进行哈希分桶。
-  如果不存在同时满足两个条件的列，则需要根据查询进行判断。
-  - 如果查询比较复杂，则建议选择高基数的列为分桶键，保证数据在各个分桶中尽量均衡，提高集群资源利用率。
-  - 如果查询比较简单，则建议选择经常作为查询条件的列为分桶键，提高查询效率。
-  并且，如果数据倾斜情况严重，您还可以使用多个列作为数据的分桶键，但是建议不超过 3 个列。
-  更多选择分桶键的信息，请参见[选择分桶键](../../../table_design/data_distribution/Data_distribution.md#哈希分桶).
+  - 高基数列，例如 ID
+  - 经常在查询中用作过滤器的列
 
-  **注意事项**
+  如果不存在这样的列，您可以根据查询的复杂性确定分桶列。
 
-  - **建表时，必须指定分桶键**。
-  - 作为分桶键的列，该列的值不支持更新。
-  - 分桶键指定后不支持修改。
-  - 自 2.5.7 版本起，建表时**无需手动指定分桶数量**，StarRocks 自动设置分桶数量。如果您需要手动设置分桶数量，请参见[设置分桶数量](../../../table_design/data_distribution/Data_distribution.md#设置分桶数量)。
+  - 如果查询复杂，建议选择高基数列作为分桶列，以确保桶之间的数据分布均衡，提高集群资源利用率。
+  - 如果查询相对简单，建议选择经常用作查询条件的列作为分桶列，以提高查询效率。
 
-### ORDER BY
+  如果使用一个分桶列无法将分区数据均匀分布到每个桶中，您可以选择多个分桶列（最多三个）。有关更多信息，请参见 [选择分桶列](../../../table_design/data_distribution/Data_distribution.md#hash-bucketing)。
 
-自 3.0 版本起，主键表支持使用 `ORDER BY` 定义排序键，自 3.3 版本起，明细表、聚合表和更新表支持使用 `ORDER BY` 定义排序键。
+  **注意事项**：
+  - **创建表时，必须指定其分桶列**。
+  - 分桶列的值不能更新。
+  - 指定后，分桶列不能修改。
+  - 自 StarRocks v2.5.7 起，创建表时无需设置桶的数量。StarRocks 会自动设置桶的数量。如果您想设置此参数，请参见 [设置桶的数量](../../../table_design/data_distribution/Data_distribution.md#set-the-number-of-buckets)。
 
-排序键的更多说明，请参见[排序键和前缀索引](../../../table_design/indexes/Prefix_index_sort_key.md)。
+## Rollup 索引
 
-### TEMPORARY
+您可以在创建表时批量创建 rollup。
 
-创建临时表。从 v3.3.1 版本开始，StarRocks 支持在 Default Catalog 中创建临时表。更多信息，请参见 [临时表](../../../table_design/StarRocks_table_design.md#临时表)。
+语法：
 
-:::note
-创建临时表时，必须将 `ENGINE` 设置为 `olap`。
-:::
+```SQL
+ROLLUP (rollup_name (column_name1, column_name2, ...)
+[FROM from_index_name]
+[PROPERTIES ("key"="value", ...)],...)
+```
 
-### PROPERTIES
+## ORDER BY
 
-#### 设置数据的初始存储介质、自动降冷时间和副本数
+自 v3.0 起，主键表支持使用 `ORDER BY` 定义排序键。自 v3.3 起，明细表、聚合表和更新表支持使用 `ORDER BY` 定义排序键。
 
-如果 ENGINE 类型为 OLAP，可以在属性 `properties` 中设置该表数据的初始存储介质（storage_medium）、自动降冷时间（storage_cooldown_time）或者时间间隔（storage_cooldown_ttl）和副本数（replication_num）。
+有关排序键的更多描述，请参见 [排序键和前缀索引](../../../table_design/indexes/Prefix_index_sort_key.md)。
 
-属性生效范围：当表为单分区表时，以上属性为表的属性。当表划分成多个分区时，以上属性属于每一个分区。并且如果希望不同分区有不同属性，则建表后可以执行 [ALTER TABLE ... ADD PARTITION 或 ALTER TABLE ... MODIFY PARTITION](ALTER_TABLE.md)。
+## PROPERTIES
 
-**设置数据的初始存储介质、自动降冷时间**
+### 存储和副本
+
+如果引擎类型为 `OLAP`，您可以在创建表时指定初始存储介质（`storage_medium`）、自动存储降冷时间（`storage_cooldown_time`）或时间间隔（`storage_cooldown_ttl`）以及副本数量（`replication_num`）。
+
+属性生效的范围：如果表只有一个分区，则属性属于表。如果表分为多个分区，则属性属于每个分区。当您需要为指定分区配置不同的属性时，可以在创建表后执行 [ALTER TABLE ... ADD PARTITION 或 ALTER TABLE ... MODIFY PARTITION](ALTER_TABLE.md)。
+
+#### 设置初始存储介质和自动存储降冷时间
 
 ```sql
 PROPERTIES (
@@ -528,51 +449,56 @@ PROPERTIES (
 )
 ```
 
-- `storage_medium`：数据初始存储介质，取值为 `SSD` 或 `HDD`。显式指定该参数时，请确保该值与 BE 静态参数 `storage_root_path` 中指定的集群存储介质相匹配。
-  
-  当 FE 配置项 `enable_strict_storage_medium_check` 为 `true` 时，表示在建表时会严格校验 BE 上的存储介质。如果建表语句中的存储介质和 BE 的存储类型不一致，建表语句会报错 `Failed to find enough hosts with storage medium [SSD|HDD] at all backends...`。当 `enable_strict_storage_medium_check` 为 `false` 时，可以忽略该报错强行建表，但是后续可能会导致集群磁盘空间分布出现不均衡。
+**属性**
 
-  从 2.3.6，2.4.2，2.5.1，3.0 及以上版本开始，支持在未显式指定该参数的情况下，由系统自动推导存储介质。
+- `storage_medium`：初始存储介质，可以设置为 `SSD` 或 `HDD`。确保您明确指定的存储介质类型与 BE 静态参数 `storage_root_path` 为您的 StarRocks 集群指定的 BE 磁盘类型一致。<br />
 
-  - 在以下场景中，系统推导该参数为 SSD：
-    - BE 上报的存储路径 (`storage_root_path`) 都是 SSD。
-    - BE 上报的存储路径包含 SSD 和 HDD。并且从 2.3.10，2.4.5，2.5.4，3.0 及以上版本开始，如果 BE 上报的存储路径两者都有且 FE 配置文件中设置了 `storage_cooldown_second`。
-  - 在以下场景中，系统推导该参数为 HDD：
-    - BE 上报的存储路径都是 HDD。
-    - 从 2.3.10，2.4.5，2.5.4，3.0 及以上版本开始，如果 BE 上报的存储路径两者都有且 FE 配置文件中未设置 `storage_cooldown_second`。
+    如果 FE 配置项 `enable_strict_storage_medium_check` 设置为 `true`，系统在创建表时严格检查 BE 磁盘类型。如果您在 CREATE TABLE 中指定的存储介质与 BE 磁盘类型不一致，则返回错误 "Failed to find enough host in all backends with storage medium is SSD|HDD."，并且表创建失败。如果 `enable_strict_storage_medium_check` 设置为 `false`，系统会忽略此错误并强制创建表。但是，加载数据后，集群磁盘空间可能会分布不均。<br />
 
-- `storage_cooldown_ttl` 或 `storage_cooldown_time`：数据自动降冷的时间间隔或者时间点。数据自动降冷，即数据自动从 SSD 介质迁移到 HDD 介质。只在数据初始存储介质为 SSD 时生效。
+    从 v2.3.6、v2.4.2、v2.5.1 和 v3.0 起，如果未明确指定 `storage_medium`，系统会根据 BE 磁盘类型自动推断存储介质。<br />
 
-  **参数说明**
+  - 在以下场景中，系统会自动将此参数设置为 SSD：
 
-  - `storage_cooldown_ttl`：该表分区自动降冷**时间间隔**。如果您需要保留最近几个分区在 SSD，其它较早的分区经过一定时间间隔自动降冷至 HDD，则您可以使用该参数，各个分区的自动降冷时间点为该参数值 + 该分区的时间上界。
-  
-      取值为 `<num> YEAR`，`<num> MONTH`，`<num> DAY` 或 `<num> HOUR`。`<num>` 为非负整数。默认值为空，表示该表分区不进行自动降冷。
-  
-      例如建表时指定 `"storage_cooldown_ttl"="1 DAY"`，建表后存在分区 `p20230801` ，其范围为 `[2023-08-01 00:00:00,2023-08-02 00:00:00)`，则该分区的自动降冷时间点是 `2023-08-03 00:00:00`，即 `2023-08-02 00:00:00 + 1 DAY`。如果建表时指定 `"storage_cooldown_ttl"="0 DAY"`，则该分区自动降冷时间点是 `2023-08-02 00:00:00`。
+    - BEs 报告的磁盘类型（`storage_root_path`）仅包含 SSD。
+    - BEs 报告的磁盘类型（`storage_root_path`）同时包含 SSD 和 HDD。请注意，从 v2.3.10、v2.4.5、v2.5.4 和 v3.0 起，当 BEs 报告的 `storage_root_path` 同时包含 SSD 和 HDD 且属性 `storage_cooldown_time` 被指定时，系统会将 `storage_medium` 设置为 SSD。
 
-  - `storage_cooldown_time`：该表自动降冷**时间点**（绝对时间）。数据在该时间点之后数据从 SSD 自动降冷到 HDD，设置的时间必须大于当前时间。取值格式为："yyyy-MM-dd HH:mm:ss"。如果需要不同分区具有不同自动降冷时间点，则需要执行 [ALTER TABLE ... ADD PARTITION 或 ALTER TABLE ... MODIFY PARTITION](ALTER_TABLE.md) 手动指定。
+  - 在以下场景中，系统会自动将此参数设置为 HDD：
 
-  **使用说明**
+    - BEs 报告的磁盘类型（`storage_root_path`）仅包含 HDD。
+    - 从 2.3.10、2.4.5、2.5.4 和 3.0 起，当 BEs 报告的 `storage_root_path` 同时包含 SSD 和 HDD 且属性 `storage_cooldown_time` 未指定时，系统会将 `storage_medium` 设置为 HDD。
 
-  - 目前 StarRocks 提供如下数据自动降冷的相关参数，对比如下：
-    - `storage_cooldown_ttl`：表的属性，指定该表中分区自动降冷时间间隔，由系统自动降冷表中到达时间点（时间间隔+分区时间上界）的分区。并且表按照分区粒度自动降冷，更加灵活。
-    - `storage_cooldown_time`：表的属性，指定该表的自动降冷时间点（绝对时间）。建表后也可以为不同分区配置不同时间点。
-    - `storage_cooldown_second`：FE 静态参数，指定集群范围内所有表的自动降冷时延。
-  - 表属性 `storage_cooldown_ttl` 或 `storage_cooldown_time` 比 FE 静态参数 `storage_cooldown_second` 优先级高。
-  - 配置以上参数时，必须指定 `"storage_medium = "SSD"`。
-  - 不配置以上参数时，则不进行自动降冷。
-  - 执行 `SHOW PARTITIONS FROM <table_name>` 查看各个分区的自动降冷时间点。
+- `storage_cooldown_ttl` 或 `storage_cooldown_time`：自动存储降冷时间或时间间隔。自动存储降冷是指将数据从 SSD 自动迁移到 HDD。此功能仅在初始存储介质为 SSD 时有效。
 
-  **限制**
-  - 不支持表达式分区和 List 分区。
-  - 不支持分区列为非日期类型。
-  - 不支持多个分区列。
-  - 不支持主键表。
+  - `storage_cooldown_ttl`：此表中分区的自动存储降冷的**时间间隔**。如果您需要保留最近的分区在 SSD 上，并在一定时间间隔后自动将较旧的分区降冷到 HDD，可以使用此参数。每个分区的自动存储降冷时间是使用此参数的值加上分区的上限时间计算的。
 
-**设置分区 Tablet 副本数**
+  支持的值为 `<num> YEAR`、`<num> MONTH`、`<num> DAY` 和 `<num> HOUR`。`<num>` 是一个非负整数。默认值为 null，表示不自动执行存储降冷。
 
-`replication_num`：分区 Tablet 副本数。默认为 3。
+  例如，您在创建表时将值指定为 `"storage_cooldown_ttl"="1 DAY"`，并且存在范围为 `[2023-08-01 00:00:00,2023-08-02 00:00:00)` 的分区 `p20230801`。此分区的自动存储降冷时间为 `2023-08-03 00:00:00`，即 `2023-08-02 00:00:00 + 1 DAY`。如果您在创建表时将值指定为 `"storage_cooldown_ttl"="0 DAY"`，则此分区的自动存储降冷时间为 `2023-08-02 00:00:00`。
+
+  - `storage_cooldown_time`：表从 SSD 降冷到 HDD 的自动存储降冷时间（**绝对时间**）。指定的时间需要晚于当前时间。格式："yyyy-MM-dd HH:mm:ss"。当您需要为指定分区配置不同的属性时，可以执行 [ALTER TABLE ... ADD PARTITION 或 ALTER TABLE ... MODIFY PARTITION](ALTER_TABLE.md)。
+
+##### 用法
+
+- 自动存储降冷相关参数之间的比较如下：
+  - `storage_cooldown_ttl`：一个表属性，指定表中分区的自动存储降冷的时间间隔。系统会在 `此参数的值加上分区的上限时间` 时自动降冷分区。因此，自动存储降冷在分区粒度上执行，更加灵活。
+  - `storage_cooldown_time`：一个表属性，指定此表的自动存储降冷时间（**绝对时间**）。此外，您可以在创建表后为指定分区配置不同的属性。
+  - `storage_cooldown_second`：一个静态 FE 参数，指定集群内所有表的自动存储降冷延迟。
+
+- 表属性 `storage_cooldown_ttl` 或 `storage_cooldown_time` 优先于 FE 静态参数 `storage_cooldown_second`。
+- 配置这些参数时，需要指定 `"storage_medium = "SSD"`。
+- 如果您不配置这些参数，则不会自动执行自动存储降冷。
+- 执行 `SHOW PARTITIONS FROM <table_name>` 查看每个分区的自动存储降冷时间。
+
+##### 限制
+
+- 不支持表达式和 List 分区。
+- 分区列需要是日期类型。
+- 不支持多个分区列。
+- 不支持主键表。
+
+#### 设置分区中每个 tablet 的副本数量
+
+`replication_num`：分区中每个表的副本数量。默认数量：`3`。
 
 ```sql
 PROPERTIES (
@@ -580,39 +506,39 @@ PROPERTIES (
 )
 ```
 
-#### 创建表时为列添加 bloom filter 索引
+### Bloom filter 索引
 
-如果 Engine 类型为 olap, 可以指定某列使用 bloom filter 索引。bloom filter 索引使用时有如下限制：
+如果引擎类型为 `olap`，您可以指定一个列采用 Bloom filter 索引。
 
-- 主键表和明细表中所有列都可以创建 Bloom filter 索引；聚合表和更新表中，只有维度列（即 Key 列）支持创建 Bloom filter 索引。
-- 不支持为 TINYINT、FLOAT、DOUBLE 和 DECIMAL 类型的列创建 Bloom filter 索引。
-- Bloom filter 索引只能提高查询条件为 `in` 和 `=` 的查询效率，值越分散效果越好。
+使用 Bloom filter 索引时适用以下限制：
 
-更多信息，参见 [Bloom filter 索引](../../../table_design/indexes/Bloomfilter_index.md)。
+- 您可以为明细表或主键表的所有列创建 Bloom filter 索引。对于聚合表或更新表，您只能为键列创建 Bloom filter 索引。
+- TINYINT、FLOAT、DOUBLE 和 DECIMAL 列不支持创建 Bloom filter 索引。
+- Bloom filter 索引只能提高包含 `in` 和 `=` 运算符的查询性能，例如 `Select xxx from table where x in {}` 和 `Select xxx from table where column = xxx`。此列中更多离散值将导致更精确的查询。
 
-```sql
+有关更多信息，请参见 [Bloom filter 索引](../../../table_design/indexes/Bloomfilter_index.md)
+
+```SQL
 PROPERTIES (
-    "bloom_filter_columns" = "k1, k2, k3"
+    "bloom_filter_columns"="k1,k2,k3"
 )
 ```
 
-#### 添加属性支持 Colocate Join
+### Colocate Join
 
-如果希望使用 Colocate Join 特性，需要在 properties 中指定:
+如果您想使用 Colocate Join 属性，请在 `properties` 中指定。
 
-``` sql
+```SQL
 PROPERTIES (
-    "colocate_with" = "table1"
+    "colocate_with"="table1"
 )
 ```
 
-详细的 Colocate Join 使用方法及应用场景请参考 [Colocate Join](../../../using_starrocks/Colocate_join.md) 章节。
+### 动态分区
 
-#### 设置动态分区
+如果您想使用动态分区属性，请在 properties 中指定。
 
-如果希望使用动态分区特性，需要在 properties 中指定如下参数：
-
-``` sql
+```SQL
 PROPERTIES (
     "dynamic_partition.enable" = "true|false",
     "dynamic_partition.time_unit" = "DAY|WEEK|MONTH",
@@ -620,42 +546,41 @@ PROPERTIES (
     "dynamic_partition.end" = "${integer_value}",
     "dynamic_partition.prefix" = "${string_value}",
     "dynamic_partition.buckets" = "${integer_value}"
-)
 ```
 
-| 参数                          | 是否必填 | 说明                                                         |
-| ----------------------------- | -------- | ------------------------------------------------------------ |
-| `dynamic_partition.enable`    | 否       | 开启动态分区特性，取值为 `TRUE`（默认）或 `FALSE`。       |
-| `dynamic_partition.time_unit` | 是       | 动态分区的时间粒度，取值为 `DAY`、`WEEK` 或 `MONTH`。时间粒度会决定动态创建的分区名后缀格式。  <br />取值为 `DAY` 时，动态创建的分区名后缀格式为 yyyyMMdd，例如 `20200321`。<br />取值为 `WEEK` 时，动态创建的分区名后缀格式为 `yyyy_ww`，例如 `2020_13` 代表 2020 年第 13 周。<br />取值为 `MONTH` 时，动态创建的分区名后缀格式为 yyyyMM，例如 `202003`。 |
-| `dynamic_partition.start`：   | 否       | 保留的动态分区的起始偏移，取值范围为负整数。根据 `dynamic_partition.time_unit` 属性的不同，以当天（周/月）为基准，分区范围在此偏移之前的分区将会被删除。比如设置为`-3`，并且`dynamic_partition.time_unit`为`day`，则表示 3 天前的分区会被删掉。<br />如果不填写，则默认为 `Integer.MIN_VALUE`，即 `-2147483648`，表示不删除历史分区。 |
-| `dynamic_partition.end`       | 是       | 提前创建的分区数量，取值范围为正整数。根据 `dynamic_partition.time_unit` 属性的不同，以当天（周/月）为基准，提前创建对应范围的分区。 |
-| `dynamic_partition.prefix`    | 否       | 动态分区的前缀名，默认值为 `p`。                             |
-| dynamic_partition.buckets     | 否       | 动态分区的分桶数量。默认与 BUCKETS 保留字指定的分桶数量、或者 StarRocks 自动设置的分桶数量保持一致。 |
+**`PROPERTIES`**
 
-#### 设置随机分桶表中分桶大小 (`bucket_size`)
+| 参数                   | 必需 | 描述                                                  |
+| --------------------------- | -------- | ------------------------------------------------------------ |
+| dynamic_partition.enable    | 否       | 是否启用动态分区。有效值：`TRUE` 和 `FALSE`。默认值：`TRUE`。 |
+| dynamic_partition.time_unit | 是      | 动态创建分区的时间粒度。它是一个必需参数。有效值：`DAY`、`WEEK` 和 `MONTH`。时间粒度决定了动态创建分区的后缀格式。<br/>  - 如果值为 `DAY`，动态创建分区的后缀格式为 `yyyyMMdd`。示例分区名称后缀为 `20200321`。<br/>  - 如果值为 `WEEK`，动态创建分区的后缀格式为 `yyyy_ww`，例如 `2020_13` 表示 2020 年的第 13 周。<br/>  - 如果值为 `MONTH`，动态创建分区的后缀格式为 `yyyyMM`，例如 `202003`。 |
+| dynamic_partition.start     | 否       | 动态分区的起始偏移量。此参数的值必须为负整数。基于当前日、周或月（由 `dynamic_partition.time_unit` 确定），在此偏移量之前的分区将被删除。默认值为 `Integer.MIN_VALUE`，即 -2147483648，表示不会删除历史分区。 |
+| dynamic_partition.end       | 是      | 动态分区的结束偏移量。此参数的值必须为正整数。从当前日、周或月到结束偏移量的分区将提前创建。 |
+| dynamic_partition.prefix    | 否       | 添加到动态分区名称的前缀。默认值：`p`。 |
+| dynamic_partition.buckets   | 否       | 每个动态分区的桶数。默认值与保留字 `BUCKETS` 确定的桶数或 StarRocks 自动设置的桶数相同。 |
 
-自 3.2 版本起，对于随机分桶的表，您可以在建表时在 `PROPERTIES` 中设置 `bucket_size` 参数来指定分桶大小，启用按需动态增加分桶数量。单位为 B。
+### 随机分桶的桶大小
 
-``` sql
+自 v3.2 起，对于配置了随机分桶的表，您可以在创建表时使用 `PROPERTIES` 中的 `bucket_size` 参数指定桶大小，以实现按需和动态增加桶的数量。单位：B。
+
+```sql
 PROPERTIES (
     "bucket_size" = "1073741824"
 )
 ```
 
-#### 设置数据压缩算法
+### 数据压缩算法
 
-您可以在建表时通过增加属性 `compression` 为该表指定数据压缩算法。
+您可以通过在创建表时添加属性 `compression` 来指定表的数据压缩算法。
 
-`compression` 有效值包括：
+`compression` 的有效值为：
 
 - `LZ4`：LZ4 算法。
 - `ZSTD`：Zstandard 算法。
 - `ZLIB`：zlib 算法。
 - `SNAPPY`：Snappy 算法。
 
-如不指定数据压缩算法，StarRocks 默认使用 LZ4。
-
-自 v3.3.2 起，StarRocks 支持在建表时指定 ZSTD 压缩格式的压缩级别。
+从 v3.3.2 起，StarRocks 支持在创建表时为 zstd 压缩格式指定压缩级别。
 
 语法：
 
@@ -663,7 +588,7 @@ PROPERTIES (
 PROPERTIES ("compression" = "zstd(<compression_level>)")
 ```
 
-`compression_level`：ZSTD 压缩格式的压缩级别。类型：Integer。范围：[1,22]。默认值：`3`（推荐）。数字越大，压缩率越高。压缩级别越高，压缩和解压的耗时越大。
+`compression_level`：ZSTD 压缩格式的压缩级别。类型：整数。范围：[1,22]。默认：`3`（推荐）。数字越大，压缩比越高。压缩级别越高，压缩和解压缩所需的时间越多。
 
 示例：
 
@@ -671,50 +596,40 @@ PROPERTIES ("compression" = "zstd(<compression_level>)")
 PROPERTIES ("compression" = "zstd(3)")
 ```
 
-关于如何选择合适的数据压缩算法，请参阅[数据压缩](../../../table_design/data_compression.md)。
+有关如何选择合适的数据压缩算法的更多信息，请参见 [数据压缩](../../../table_design/data_compression.md)。
 
-#### 设置数据导入安全等级
+### 设置数据导入安全等级
 
-如果您的 StarRocks 集群有多数据副本，可以在建表时在 `PROPERTIES` 中设置 `write_quorum` 参数来指定数据导入安全等级，即设置需要多少数据副本导入成功后 StarRocks 可返回导入成功。该属性从 2.5 版本开始支持。
+如果您的 StarRocks 集群有多个数据副本，您可以为表设置不同的导入安全等级裁，即在 StarRocks 确定导入任务成功之前需要多少个副本返回导入成功。您可以在创建表时通过添加属性 `write_quorum` 指定导入安全等级。此属性自 v2.5 起支持。
 
-`write_quorum` 的取值及其对应描述如下：
+`write_quorum` 的有效值为：
 
-- `MAJORITY`：默认值。当**多数**数据副本导入成功时，StarRocks 返回导入成功，否则返回失败。
-- `ONE`：当**一个**数据副本导入成功时，StarRocks 返回导入成功，否则返回失败。
-- `ALL`：当**所有**数据副本导入成功时，StarRocks 返回导入成功，否则返回失败。
+- `MAJORITY`：默认值。当**大多数**数据副本返回导入成功时，StarRocks 返回导入任务成功。否则，StarRocks 返回导入任务失败。
+- `ONE`：当**一个**数据副本返回导入成功时，StarRocks 返回导入任务成功。否则，StarRocks 返回导入任务失败。
+- `ALL`：当**所有**数据副本返回导入成功时，StarRocks 返回导入任务成功。否则，StarRocks 返回导入任务失败。
 
-> **注意**
->
-> - 设置较低的导入数据安全等级会增加数据不可访问甚至丢失的风险。例如，在 StarRocks 集群有两个数据副本的情况下设置 `write_quorum` 为 `ONE`，如果某个 Tablet 实际只成功导入了一个副本，而此副本所在机器后续下线，则会导致该 Tablet 中的数据因为没有存活副本而无法访问。如果服务器磁盘受损，则会导致该 Tablet 中的数据丢失。
-> - 仅当所有数据副本返回导入状态后，StarRocks 才会返回导入任务状态。当有副本导入状态未知时，StarRocks 不会返回导入任务状态。导入超时的副本亦会被标记为失败。
+:::caution
+- 为导入设置较低的写入仲裁会增加数据不可访问甚至丢失的风险。例如，您在一个具有两个副本的 StarRocks 集群中将数据导入到一个写入仲裁为 ONE 的表中，并且数据仅成功导入到一个副本中。尽管 StarRocks 确定导入任务成功，但数据只有一个存活的副本。如果存储已加载数据的 tablets 的服务器宕机，这些 tablets 中的数据将无法访问。如果服务器的磁盘损坏，数据将丢失。
+- StarRocks 仅在所有数据副本返回状态后才返回导入任务状态。当有副本的导入状态未知时，StarRocks 不会返回导入任务状态。在一个副本中，导入超时也被视为导入失败。
+:::
 
-#### 指定数据在多副本间的写入和同步方式
+### 副本数据写入和复制模式
 
-如果您的 StarRocks 集群有多数据副本，可以在建表时在 `PROPERTIES` 中设置 `replicated_storage` 参数来指定数据在多副本间的写入和同步方式。
+如果您的 StarRocks 集群有多个数据副本，您可以在 `PROPERTIES` 中指定 `replicated_storage` 参数来配置副本之间的数据写入和复制模式。
 
-- 设置为 `true`（3.0 及后续版本的默认值）表示 single leader replication，即数据只写入到主副本 (primary replica)，由主副本同步数据到从副本 (secondary replica)。该模式能有效降低多副本写入带来的 CPU 成本。该模式从 2.5 版本开始支持。
-- 设置为 `false`（2.5 版本的默认值）表示 leaderless replication，即数据直接写入到多个副本，不区分主从副本。该模式 CPU 成本比较高。
+- `true`（v3.0 及更高版本中的默认值）表示“单领导者复制 (single leader replication)”，这意味着数据仅写入主副本 (primary replica)。其他副本从主副本同步数据。此模式显著降低了因数据写入多个副本而导致的 CPU 成本。自 v2.5 起支持。
+- `false`（v2.5 中的默认值）表示“无领导者复制 (leaderless replication)”，这意味着数据直接写入多个副本，而不区分主副本和次副本。CPU 成本乘以副本数量。
 
-默认配置在绝大部分场景下能获得更好的写入性能，如果要修改已有表的多副本写入和同步方式，可执行 ALTER TABLE 命令，举例：
+在大多数情况下，使用默认值可以获得更好的数据写入性能。如果您想更改副本之间的数据写入和复制模式，请运行 ALTER TABLE 命令。示例：
 
 ```sql
 ALTER TABLE example_db.my_table
-SET ("replicated_storage" = "true");
+SET ("replicated_storage" = "false");
 ```
 
-#### 建表时批量创建多个 Rollup
+### Delta Join 唯一键和外键约束
 
-语法：
-
-```sql
-ROLLUP (rollup_name (column_name1, column_name2, ...)
-[FROM from_index_name]
-[PROPERTIES ("key" = "value", ...)],...)
-```
-
-#### 为 View Delta Join 查询改写定义 Unique Key 和外键约束
-
-要在 View Delta Join 场景中启用查询重写，您必须为 Delta Join 中的表定义 Unique Key 约束 `unique_constraints` 和外键约束 `foreign_key_constraints`。详细信息，请参阅 [异步物化视图 - 基于 View Delta Join 场景改写查询](../../../using_starrocks/async_mv/use_cases/query_rewrite_with_materialized_views.md#view-delta-join-改写)。
+要在 View Delta Join 场景中启用查询改写，您必须为 Delta Join 中要连接的表定义唯一键约束 `unique_constraints` 和外键约束 `foreign_key_constraints`。有关更多信息，请参见 [异步物化视图 - 在 View Delta Join 场景中改写查询](../../../using_starrocks/async_mv/use_cases/query_rewrite_with_materialized_views.md#query-delta-join-rewrite)。
 
 ```SQL
 PROPERTIES (
@@ -728,23 +643,23 @@ PROPERTIES (
 )
 ```
 
-- `child_column`：当前表中的外键列。 您可以定义多个 `child_column`。
-- `catalog_name`：待 Join 表所在的数据目录名。未指定此参数时使用默认目录。
-- `database_name`：待 Join 表所在的数据库名。未指定此参数时使用当前数据库。
-- `parent_table_name`：待 Join 表名。
-- `parent_column`：待 Join 列名，必须为相应表的 Primary Key 或 Unique Key。
+- `child_column`：表的外键。您可以定义多个 `child_column`。
+- `catalog_name`：要连接的表所在的 catalog 名称。如果未指定此参数，则使用默认 catalog。
+- `database_name`：要连接的表所在的数据库名称。如果未指定此参数，则使用当前数据库。
+- `parent_table_name`：要连接的表的名称。
+- `parent_column`：要连接的列。它们必须是相应表的主键或唯一键。
 
-> **注意**
->
-> - `unique_constraints` 约束和 `foreign_key_constraints` 约束仅用于查询重写。导入数据时，不保证进行外键约束校验。您必须确保导入的数据满足约束条件。
-> - 主键表的 Primary Key 或更新表的 Unique Key 默认是其 `unique_constraints`，您无需手动设置。
-> - `foreign_key_constraints` 中的 `child_column` 必须对应另一个表的 `unique_constraints` 中的 `unique_key`。
-> - `child_column` 和 `parent_column` 的数量必须一致。
-> - `child_column` 和对应的 `parent_column` 的数据类型必须匹配。
+:::caution
+- `unique_constraints` 和 `foreign_key_constraints` 仅用于查询改写。在将数据加载到表中时，不保证外键约束检查。您必须确保加载到表中的数据符合约束。
+- 主键表的主键或唯一键表的唯一键默认是相应的 `unique_constraints`。您无需手动设置。
+- 表中 `foreign_key_constraints` 的 `child_column` 必须引用另一个表中 `unique_constraints` 的 `unique_key`。
+- `child_column` 和 `parent_column` 的数量必须一致。
+- `child_column` 和相应 `parent_column` 的数据类型必须匹配。
+:::
 
-#### 为 StarRocks 存算分离集群创建云原生表
+### 存算分离集群的云原生表
 
-为了[使用 StarRocks 存算分离集群](../../../deployment/shared_data/shared_data.mdx)，您需要通过以下 PROPERTIES 创建云原生表：
+要使用您的 StarRocks 存算分离集群，您必须创建具有以下属性的云原生表：
 
 ```SQL
 PROPERTIES (
@@ -754,100 +669,100 @@ PROPERTIES (
 )
 ```
 
-- `storage_volume`：建表使用的 Storage Volume 名称。该属性自 v3.1 版本起支持。如果未指定该属性，则使用默认 Storage Volume。示例：`"storage_volume" = "def_volume"`。
+- `storage_volume`：用于存储要创建的云原生表的存储卷名称。如果未指定此属性，则使用默认存储卷。此属性自 v3.1 起支持。
 
 - `datacache.enable`：是否启用本地磁盘缓存。默认值：`true`。
 
-  - 当该属性设置为 `true` 时，数据会同时导入对象存储（或 HDFS）和本地磁盘（作为查询加速的缓存）。
-  - 当该属性设置为 `false` 时，数据仅导入到对象存储中。
+  - 当此属性设置为 `true` 时，加载的数据同时写入对象存储和本地磁盘（作为查询加速的缓存）。
+  - 当此属性设置为 `false` 时，数据仅加载到对象存储中。
 
-  > **说明**
-  >
-  > 如需启用本地磁盘缓存，必须在 BE 配置项 `storage_root_path` 中指定磁盘目录。更多信息，请参见 [BE 配置项](../../../administration/management/BE_configuration.md)。
+  :::note
+  要启用本地磁盘缓存，您必须在 BE 配置项 `storage_root_path` 中指定磁盘目录。
+  :::
 
-- `datacache.partition_duration`：热数据的有效期。当启用本地磁盘缓存时，所有数据都会导入至本地磁盘缓存中。当缓存满时，StarRocks 会从缓存中删除最近较少使用（Less recently used）的数据。当有查询需要扫描已删除的数据时，StarRocks 会检查该数据是否在有效期内。如果数据在有效期内，StarRocks 会再次将数据导入至缓存中。如果数据不在有效期内，StarRocks 不会将其导入至缓存中。该属性为字符串，您可以使用以下单位指定：`YEAR`、`MONTH`、`DAY` 和 `HOUR`，例如，`7 DAY` 和 `12 HOUR`。如果不指定，StarRocks 将所有数据都作为热数据进行缓存。
+- `datacache.partition_duration`：热数据的有效期。当启用本地磁盘缓存时，所有数据都加载到缓存中。当缓存已满时，StarRocks 从缓存中删除最近未使用的数据。当查询需要扫描已删除的数据时，StarRocks 检查数据是否在有效期内。如果数据在有效期内，StarRocks 将数据重新加载到缓存中。如果数据不在有效期内，StarRocks 不会将其加载到缓存中。此属性是一个字符串值，可以使用以下单位指定：`YEAR`、`MONTH`、`DAY` 和 `HOUR`，例如 `7 DAY` 和 `12 HOUR`。如果未指定，则所有数据都作为热数据缓存。
 
-  > **说明**
-  >
-  > 仅当 `datacache.enable` 设置为 `true` 时，此属性可用。
+  :::note
+  此属性仅在 `datacache.enable` 设置为 `true` 时可用。
+  :::
 
-#### 设置 fast schema evolution
+### 快速模式架构演进
 
-`fast_schema_evolution`: 是否开启该表的 fast schema evolution，取值：`TRUE` 或 `FALSE`（默认）。开启后增删列时可以提高 schema change 速度并降低资源使用。目前仅支持在建表时开启该属性，建表后不支持通过 [ALTER TABLE](ALTER_TABLE.md) 修改该属性。
+`fast_schema_evolution`：是否为表启用快速模式架构演进。有效值为 `TRUE` 或 `FALSE`（默认）。启用快速模式架构演进可以在添加或删除列时提高架构更改的速度并减少资源使用。目前，此属性只能在创建表时启用，不能在创建表后使用 [ALTER TABLE](ALTER_TABLE.md) 修改。
 
-> **NOTE**
->
-> - 存算一体集群自 v3.2.0 起支持 fast schema evolution。
-> - 存算分离集群自 v3.3.0 起支持 fast schema evolution，默认启用。在存算分离集群中创建云原生表时无需指定此属性，由 FE 动态参数 `enable_fast_schema_evolution`（默认值：true）控制此行为。
+  :::note
+  - 自 v3.2.0 起，存算一体集群支持快速模式架构演进。
+  - 自 v3.3 起，存算分离集群支持快速模式架构演进，并默认启用。在存算分离集群中创建云原生表时，您无需指定此属性。FE 动态参数 `enable_fast_schema_evolution`（默认值：true）控制此行为。
+  :::
 
-#### 禁止 Base Compaction
+### 禁止 Base Compaction
 
-`base_compaction_forbidden_time_ranges`：禁止对表进行 Base Compaction 的时间范围。设置该属性后，系统将仅在指定时间范围之外对符合条件的 Tablet 执行 Base Compaction。该属性 v3.2.13 起支持。
+`base_compaction_forbidden_time_ranges`：表禁止 Base Compaction 的时间范围。设置此属性后，系统仅在指定时间范围之外对符合条件的 tablets 执行 Base Compaction。此属性自 v3.2.13 起支持。
 
-> **说明**
->
-> 请确保在禁止 Base Compaction 期间，对于该表的导入次数不超过 500 次。
+:::note
+确保在禁止 Base Compaction 的期间，表的数据加载次数不超过 500。
+:::
 
-`base_compaction_forbidden_time_ranges` 的值遵循 [Quartz cron 语法](https://productresources.collibra.com/docs/collibra/latest/Content/Cron/co_quartz-cron-syntax.htm)，且只支持以下字段： `<minute> <hour> <day-of-the-month> <month> <day-of-the-week>` ，其中 `<minute>` 必须为 `*`。
+`base_compaction_forbidden_time_ranges` 的值遵循 [Quartz cron 语法](https://productresources.collibra.com/docs/collibra/latest/Content/Cron/co_quartz-cron-syntax.htm)，仅支持以下字段：`<minute> <hour> <day-of-the-month> <month> <day-of-the-week>`，其中 `<minute>` 必须为 `*`。
 
-```Plain
+```SQL
 crontab_param_value ::= [ "" | crontab ]
 
 crontab ::= * <hour> <day-of-the-month> <month> <day-of-the-week>
 ```
 
-- 如果未设置此属性或设置为 `""`（空字符串），则在任何时候都不禁止 Base Compaction。
+- 当此属性未设置或设置为 `""`（空字符串）时，Base Compaction 在任何时间都不被禁止。
 - 当此属性设置为 `* * * * *` 时，Base Compaction 始终被禁止。
 - 其他值遵循 Quartz cron 语法。
-  - 独立数值表示字段的单位时间。例如，`<hour>` 字段中的 `8` 表示 8:00-8:59。
-  - 数值范围表示字段的时间范围。例如，`<hour>` 字段中的 `8-9` 表示 8:00-9:59。
-  - 用逗号分隔的多个数值范围表示字段的多个时间范围。
-  - `<day-of-the-week>` 的起始值为 `1` 表示周日，`7` 表示周六。
+  - 独立值表示字段的单位时间。例如，`8` 在 `<hour>` 字段中表示 8:00-8:59。
+  - 值范围表示字段的时间范围。例如，`8-9` 在 `<hour>` 字段中表示 8:00-9:59。
+  - 用逗号分隔的多个值范围表示字段的多个时间范围。
+  - `<day of the week>` 的起始值为 `1` 表示星期日，`7` 表示星期六。
 
 示例：
 
 ```SQL
--- 每天 8AM～9PM 禁止执行 Base Compaction。
+-- 每天从上午 8:00 到晚上 9:00 禁止 Base Compaction。
 'base_compaction_forbidden_time_ranges' = '* 8-20 * * *'
 
--- 每天 0-5，21-23 点禁止执行 Base Compaction。
+-- 每天从凌晨 0:00 到凌晨 5:00 和晚上 9:00 到晚上 11:00 禁止 Base Compaction。
 'base_compaction_forbidden_time_ranges' = '* 0-4,21-22 * * *'
 
--- 每周一到周五禁止执行 Base Compaction（也即是在每周六/周日的全天允许执行）。
+-- 从星期一到星期五禁止 Base Compaction（即在星期六和星期日允许）。
 'base_compaction_forbidden_time_ranges' = '* * * * 2-6'
 
--- 每个工作日（周一到周五）的 8AM～9PM 禁止执行 Base Compaction。
+-- 每个工作日（即星期一到星期五）从上午 8:00 到晚上 9:00 禁止 Base Compaction。
 'base_compaction_forbidden_time_ranges' = '* 8-20 * * 2-6'
 ```
 
-#### 指定通用分区表达式 TTL
+### 指定通用分区表达式 TTL
 
-从 v3.5.0 开始，StarRocks 内表支持通用分区表达式（Common Partition Expression）TTL。
+从 v3.5.0 起，StarRocks 内表支持通用分区表达式 TTL。
 
-`partition_retention_condition`：用于声明动态保留分区的表达式。不符合表达式中条件的分区将被定期删除。
+`partition_retention_condition`：声明要动态保留的分区的表达式。不符合表达式中条件的分区将定期删除。
 - 表达式只能包含分区列和常量。不支持非分区列。
-- 通用分区表达式处理 List 分区和 Range 分区的方式不同：
-  - 对于 List 分区表，StarRocks 支持通过通用分区表达式过滤删除分区。
-  - 对于 Range 分区表，StarRocks 只能基于 FE 的分区裁剪功能过滤删除分区。对于分区裁剪不支持的谓词，StarRocks 无法过滤删除对应的分区。
+- 通用分区表达式在 List 分区和 Range 分区中的应用不同：
+  - 对于具有 List 分区的表，StarRocks 支持删除通过通用分区表达式过滤的分区。
+  - 对于具有 Range 分区的表，StarRocks 只能使用 FE 的分区裁剪功能过滤和删除分区。分区对应于分区裁剪不支持的谓词无法被过滤和删除。
 
 示例：
 
 ```SQL
--- 保留最近三个月的数据。dt 列为分区列。
+-- 保留最近三个月的数据。列 `dt` 是表的分区列。
 "partition_retention_condition" = "dt >= CURRENT_DATE() - INTERVAL 3 MONTH"
 ```
 
-如需禁用此功能，可以使用 ALTER TABLE 语句将此属性设置为空字符串：
+要禁用此功能，您可以使用 ALTER TABLE 语句将此属性设置为空字符串：
 
 ```SQL
 ALTER TABLE tbl SET('partition_retention_condition' = '');
 ```
 
-#### 设置 Flat JSON (目前仅支持存算一体的集群)
+### 配置 Flat JSON 配置（目前仅支持存算一体集群）
 
-如果你希望使用 Flat JSON 属性，请在 PROPERTIES 中进行设置。更多信息请参考：[Flat JSON](../../../using_starrocks/Flat_json.md)
+如果您想使用 Flat JSON 属性，请在 properties 中指定。有关更多信息，请参见 [Flat JSON](../../../using_starrocks/Flat_json.md)。
 
-``` sql
+```SQL
 PROPERTIES (
     "flat_json.enable" = "true|false",
     "flat_json.null.factor" = "0-1",
@@ -856,20 +771,20 @@ PROPERTIES (
 )
 ```
 
-| 参数                          | 是否必填 | 说明                                                                                      |
-| ----------------------------- | -------- |-----------------------------------------------------------------------------------------|
-| `flat_json.enable`    | 否       | 是否开启 Flat JSON 特性。开启后新导入的 JSON 数据会自动打平，提升 JSON 数据查询性能。取值为 `FALSE`（默认）或 `TRUE`。          |
-| `flat_json.null.factor` | 否       | 控制 Flat JSON 时，提取列的 NULL 值占比阈值，高于该比例不对该列进行提取，默认为 0.3。该参数仅在 enable_json_flat 为 true 时生效。 |
-| `flat_json.sparsity.factor`   | 否       | 控制 Flat JSON 时，同名列的占比阈值，当同名列占比低于该值时不进行提取，默认为 0.9。该参数仅在 enable_json_flat 为 true 时生效。     |
-| `flat_json.column.max`       | 否       | 控制 Flat JSON 时，最多提取的子列数量。该参数仅在 enable_json_flat 为 true 时生效。默认值是 100                     |
+**属性**
+
+| 属性                    | 必需 | 描述                                                                                                                                                                                                                                                       |
+| --------------------------- |----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `flat_json.enable`    | 否       | 是否启用 Flat JSON 功能。启用此功能后，新加载的 JSON 数据将自动扁平化，提高 JSON 查询性能。                                                                                                 |
+| `flat_json.null.factor` | 否      | Flat JSON 提取的列中 NULL 值的比例。如果列中 NULL 值的比例高于此阈值，则不会提取该列。此参数仅在 `flat_json.enable` 设置为 true 时生效。默认值：0.3。 |
+| `flat_json.sparsity.factor`     | 否      | Flat JSON 中同名列的比例。如果同名列的比例低于此值，则不进行提取。此参数仅在 `flat_json.enable` 设置为 true 时生效。默认值：0.9。    |
+| `flat_json.column.max`       | 否      | Flat JSON 可以提取的子字段的最大数量。此参数仅在 `flat_json.enable` 设置为 true 时生效。默认值：100。 |
 
 ## 示例
 
-### 创建 Hash 分桶表并根据 key 列对数据进行聚合
+### 使用哈希分桶和列式存储的聚合表
 
-创建一个 olap 表，使用 Hash 分桶，使用列存，相同 key 的记录进行聚合。
-
-``` sql
+```SQL
 CREATE TABLE example_db.table_hash
 (
     k1 TINYINT,
@@ -877,42 +792,38 @@ CREATE TABLE example_db.table_hash
     v1 CHAR(10) REPLACE,
     v2 INT SUM
 )
-ENGINE = olap
+ENGINE=olap
 AGGREGATE KEY(k1, k2)
 COMMENT "my first starrocks table"
 DISTRIBUTED BY HASH(k1)
-PROPERTIES ("storage_type" = "column");
+PROPERTIES ("storage_type"="column");
 ```
 
-### 创建表并设置存储介质和数据自动降冷时间
+### 设置存储介质和降冷时间的聚合表
 
-创建一个 olap 表，使用 Hash 分桶，使用列存，相同 key 的记录进行覆盖，设置初始存储介质和冷却时间。
-
-``` sql
+```SQL
 CREATE TABLE example_db.table_hash
 (
     k1 BIGINT,
     k2 LARGEINT,
     v1 VARCHAR(2048) REPLACE,
-    v2 SMALLINT DEFAULT "10"
+    v2 SMALLINT SUM DEFAULT "10"
 )
-ENGINE = olap
+ENGINE=olap
 UNIQUE KEY(k1, k2)
 DISTRIBUTED BY HASH (k1, k2)
 PROPERTIES(
-    "storage_type" = "column",
+    "storage_type"="column",
     "storage_medium" = "SSD",
-    "storage_cooldown_time" = "2025-06-04 00:00:00"
+    "storage_cooldown_time" = "2015-06-04 00:00:00"
 );
 ```
 
-### 创建分区表
+### 使用 Range 分区、哈希分桶、列式存储、存储介质和降冷时间的明细表
 
-创建一个 olap 表，使用 Range 分区，使用 Hash 分桶，默认使用列存，相同 key 的记录同时存在，设置初始存储介质和冷却时间。
+LESS THAN
 
-使用 LESS THAN 方式按照范围划分分区：
-
-``` sql
+```SQL
 CREATE TABLE example_db.table_range
 (
     k1 DATE,
@@ -921,7 +832,7 @@ CREATE TABLE example_db.table_range
     v1 VARCHAR(2048),
     v2 DATETIME DEFAULT "2014-02-04 15:36:00"
 )
-ENGINE = olap
+ENGINE=olap
 DUPLICATE KEY(k1, k2, k3)
 PARTITION BY RANGE (k1)
 (
@@ -931,25 +842,26 @@ PARTITION BY RANGE (k1)
 )
 DISTRIBUTED BY HASH(k2)
 PROPERTIES(
-    "storage_medium" = "SSD",
-    "storage_cooldown_time" = "2025-06-04 00:00:00"
+    "storage_medium" = "SSD", 
+    "storage_cooldown_time" = "2015-06-04 00:00:00"
 );
 ```
 
-说明：
-这个语句会将数据划分成如下 3 个分区：
+注意：
 
-``` sql
+此语句将创建三个数据分区：
+
+```SQL
 ( {    MIN     },   {"2014-01-01"} )
 [ {"2014-01-01"},   {"2014-06-01"} )
 [ {"2014-06-01"},   {"2014-12-01"} )
 ```
 
-不在这些分区范围内的数据将视为非法数据被过滤。
+超出这些范围的数据将不会被加载。
 
-使用 Fixed Range 方式创建分区：
+固定范围
 
-``` sql
+```SQL
 CREATE TABLE table_range
 (
     k1 DATE,
@@ -958,7 +870,7 @@ CREATE TABLE table_range
     v1 VARCHAR(2048),
     v2 DATETIME DEFAULT "2014-02-04 15:36:00"
 )
-ENGINE = olap
+ENGINE=olap
 DUPLICATE KEY(k1, k2, k3)
 PARTITION BY RANGE (k1, k2, k3)
 (
@@ -971,9 +883,9 @@ PROPERTIES(
 );
 ```
 
-### 创建一个 MySQL 外表
+### MySQL 外部表
 
-``` sql
+```SQL
 CREATE EXTERNAL TABLE example_db.table_mysql
 (
     k1 DATE,
@@ -982,7 +894,7 @@ CREATE EXTERNAL TABLE example_db.table_mysql
     k4 VARCHAR(2048),
     k5 DATETIME
 )
-ENGINE = mysql
+ENGINE=mysql
 PROPERTIES
 (
     "host" = "127.0.0.1",
@@ -991,12 +903,12 @@ PROPERTIES
     "password" = "mysql_passwd",
     "database" = "mysql_db_test",
     "table" = "mysql_table_test"
-);
+)
 ```
 
-### 创建一张含有 HLL 列的表
+### 带有 HLL 列的表
 
-``` sql
+```SQL
 CREATE TABLE example_db.example_table
 (
     k1 TINYINT,
@@ -1004,17 +916,17 @@ CREATE TABLE example_db.example_table
     v1 HLL HLL_UNION,
     v2 HLL HLL_UNION
 )
-ENGINE = olap
+ENGINE=olap
 AGGREGATE KEY(k1, k2)
 DISTRIBUTED BY HASH(k1)
-PROPERTIES ("storage_type" = "column");
+PROPERTIES ("storage_type"="column");
 ```
 
-### 创建一张含有 `BITMAP_UNION` 聚合类型的表
+### 使用 BITMAP_UNION 聚合类型的表
 
-v1 和 v2 列的原始数据类型必须是 `TINYINT, SMALLINT, INT`。
+`v1` 和 `v2` 列的原始数据类型必须为 TINYINT、SMALLINT 或 INT。
 
-``` sql
+```SQL
 CREATE TABLE example_db.example_table
 (
     k1 TINYINT,
@@ -1022,41 +934,45 @@ CREATE TABLE example_db.example_table
     v1 BITMAP BITMAP_UNION,
     v2 BITMAP BITMAP_UNION
 )
-ENGINE = olap
+ENGINE=olap
 AGGREGATE KEY(k1, k2)
 DISTRIBUTED BY HASH(k1)
-PROPERTIES ("storage_type" = "column");
+PROPERTIES ("storage_type"="column");
 ```
 
-### 创建两张支持 Colocate Join 的表
+### 支持 Colocate Join 的表
 
-创建 t1 和 t2 两个表，两表可进行 Colocate Join。两表属性中的 `colocate_with` 属性的值需保持一致。
-
-``` sql
-CREATE TABLE `t1` (
-    `id` int(11) COMMENT "",
+```SQL
+CREATE TABLE `t1` 
+(
+     `id` int(11) COMMENT "",
     `value` varchar(8) COMMENT ""
-) ENGINE = OLAP
+) 
+ENGINE=OLAP
 DUPLICATE KEY(`id`)
 DISTRIBUTED BY HASH(`id`)
-PROPERTIES (
+PROPERTIES 
+(
     "colocate_with" = "t1"
 );
 
-CREATE TABLE `t2` (
+CREATE TABLE `t2` 
+(
     `id` int(11) COMMENT "",
     `value` varchar(8) COMMENT ""
-) ENGINE = OLAP
+) 
+ENGINE=OLAP
 DUPLICATE KEY(`id`)
 DISTRIBUTED BY HASH(`id`)
-PROPERTIES (
+PROPERTIES 
+(
     "colocate_with" = "t1"
 );
 ```
 
-### 创建一个带有 bitmap 索引的表
+### 带有 bitmap 索引的表
 
-``` sql
+```SQL
 CREATE TABLE example_db.table_hash
 (
     k1 TINYINT,
@@ -1065,27 +981,27 @@ CREATE TABLE example_db.table_hash
     v2 INT SUM,
     INDEX k1_idx (k1) USING BITMAP COMMENT 'xxxxxx'
 )
-ENGINE = olap
+ENGINE=olap
 AGGREGATE KEY(k1, k2)
 COMMENT "my first starrocks table"
 DISTRIBUTED BY HASH(k1)
-PROPERTIES ("storage_type" = "column");
+PROPERTIES ("storage_type"="column");
 ```
 
-### 创建动态分区表
+### 动态分区表
 
- 创建动态分区表需要在 FE 配置中开启 **动态分区** 功能（`"dynamic_partition.enable" = "true"`），参数可参见本文[设置动态分区](#设置动态分区)。
+动态分区功能必须在 FE 配置中启用（"dynamic_partition.enable" = "true"）。有关更多信息，请参见 [配置动态分区](#configure-dynamic-partitions)。
 
- 该表每天提前创建 3 天的分区，并删除 3 天前的分区。例如今天为 `2020-01-08`，则会创建分区名为 `p20200108`，`p20200109`，`p20200110`，`p20200111` 的分区. 分区范围分别为:
+此示例为接下来的三天创建分区，并删除三天前创建的分区。例如，如果今天是 2020-01-08，将创建以下名称的分区：p20200108、p20200109、p20200110 和 p20200111，其范围为：
 
-```plain text
+```plaintext
 [types: [DATE]; keys: [2020-01-08]; ‥types: [DATE]; keys: [2020-01-09]; )
 [types: [DATE]; keys: [2020-01-09]; ‥types: [DATE]; keys: [2020-01-10]; )
 [types: [DATE]; keys: [2020-01-10]; ‥types: [DATE]; keys: [2020-01-11]; )
 [types: [DATE]; keys: [2020-01-11]; ‥types: [DATE]; keys: [2020-01-12]; )
 ```
 
-```sql
+```SQL
 CREATE TABLE example_db.dynamic_partition
 (
     k1 DATE,
@@ -1094,7 +1010,7 @@ CREATE TABLE example_db.dynamic_partition
     v1 VARCHAR(2048),
     v2 DATETIME DEFAULT "2014-02-04 15:36:00"
 )
-ENGINE = olap
+ENGINE=olap
 DUPLICATE KEY(k1, k2, k3)
 PARTITION BY RANGE (k1)
 (
@@ -1105,23 +1021,50 @@ PARTITION BY RANGE (k1)
 DISTRIBUTED BY HASH(k2)
 PROPERTIES(
     "storage_medium" = "SSD",
+    "dynamic_partition.enable" = "true",
     "dynamic_partition.time_unit" = "DAY",
     "dynamic_partition.start" = "-3",
     "dynamic_partition.end" = "3",
-    "dynamic_partition.prefix" = "p"
+    "dynamic_partition.prefix" = "p",
+    "dynamic_partition.buckets" = "10"
 );
 ```
 
-### 创建一个 Hive 外部表
+### 使用整数列作为分区列，并批量创建多个分区的表
 
-``` SQL
+在以下示例中，分区列 `datekey` 的类型为 INT。所有分区仅通过一个简单的分区子句 `START ("1") END ("5") EVERY (1)` 创建。所有分区的范围从 `1` 开始，到 `5` 结束，分区粒度为 `1`：
+> **注意**
+>
+> **START()** 和 **END()** 中的分区列值需要用引号括起来，而 **EVERY()** 中的分区粒度不需要用引号括起来。
+
+```SQL
+CREATE TABLE site_access (
+    datekey INT,
+    site_id INT,
+    city_code SMALLINT,
+    user_name VARCHAR(32),
+    pv BIGINT DEFAULT '0'
+)
+ENGINE=olap
+DUPLICATE KEY(datekey, site_id, city_code, user_name)
+PARTITION BY RANGE (datekey) (START ("1") END ("5") EVERY (1)
+)
+DISTRIBUTED BY HASH(site_id)
+PROPERTIES ("replication_num" = "3");
+```
+
+### Hive 外部表
+
+在创建 Hive 外部表之前，您必须创建 Hive 资源和数据库。有关更多信息，请参见 [外部表](../../../data_source/External_table.md#deprecated-hive-external-table)。
+
+```SQL
 CREATE EXTERNAL TABLE example_db.table_hive
 (
     k1 TINYINT,
     k2 VARCHAR(50),
     v INT
 )
-ENGINE = hive
+ENGINE=hive
 PROPERTIES
 (
     "resource" = "hive0",
@@ -1130,9 +1073,9 @@ PROPERTIES
 );
 ```
 
-### 创建一张主键表并且指定排序键
+### 带有特定排序键的主键表
 
-假设需要按地域、最近活跃时间实时分析用户情况，则可以将表示用户 ID 的 `user_id` 列作为主键，表示地域的 `address` 列和表示最近活跃时间的 `last_active` 列作为排序键。建表语句如下：
+假设您需要从用户地址和最后活跃时间等维度实时分析用户行为。在创建表时，您可以将 `user_id` 列定义为主键，并将 `address` 和 `last_active` 列的组合定义为排序键。
 
 ```SQL
 create table users (
@@ -1157,17 +1100,41 @@ PROPERTIES(
 );
 ```
 
-### 创建一张带有 Flat JSON 的表 (目前仅支持存算一体的集群)
+### 分区临时表
 
-创建一张开启flat json的表，并对其中的参数进行配置。建表语句如下：
+```SQL
+CREATE TEMPORARY TABLE example_db.temp_table
+(
+    k1 DATE,
+    k2 INT,
+    k3 SMALLINT,
+    v1 VARCHAR(2048),
+    v2 DATETIME DEFAULT "2014-02-04 15:36:00"
+)
+ENGINE=olap
+DUPLICATE KEY(k1, k2, k3)
+PARTITION BY RANGE (k1)
+(
+    PARTITION p1 VALUES LESS THAN ("2014-01-01"),
+    PARTITION p2 VALUES LESS THAN ("2014-06-01"),
+    PARTITION p3 VALUES LESS THAN ("2014-12-01")
+)
+DISTRIBUTED BY HASH(k2);
+```
+
+### 支持 Flat JSON 的表
+
+:::note
+Flat JSON 目前仅支持存算一体集群。
+:::
 
 ```SQL
 CREATE TABLE example_db.example_table
 (
-  k1 DATE,
-  k2 INT,
-  v1 VARCHAR(2048),
-  v2 JSON
+    k1 DATE,
+    k2 INT,
+    v1 VARCHAR(2048),
+    v2 JSON
 )
 ENGINE=olap
 DUPLICATE KEY(k1, k2)
@@ -1180,7 +1147,7 @@ PROPERTIES (
 );
 ```
 
-## References
+## 参考
 
 - [SHOW CREATE TABLE](SHOW_CREATE_TABLE.md)
 - [SHOW TABLES](SHOW_TABLES.md)


### PR DESCRIPTION
Simplify headings

Notes:

I do not think that BROKER PROPERTIES belongs in the syntax block:

```SQL
[BROKER PROPERTIES ("key"="value", ...)]
```

I don't really know if there is enough information for a reader to understand about rollup indices from:

```plaintext
You can create rollups in bulk when you create a table.
```

I will add Japanese and Chinese translations after a review.

Here is a PDF:
[CREATE TABLE _ StarRocks.pdf](https://github.com/user-attachments/files/20908364/CREATE.TABLE._.StarRocks.pdf)


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3