### PR TITLE
[BugFix] Clean the stale datacache data to free disk spaces immediately.  (backport #60228)

### DIFF
--- a/be/src/block_cache/datacache_utils.cpp
+++ b/be/src/block_cache/datacache_utils.cpp
@@ -141,11 +141,17 @@ Status DataCacheUtils::parse_conf_datacache_disk_spaces(const std::string& confi
     return Status::OK();
 }
 
-void DataCacheUtils::clean_residual_datacache(const std::string& disk_path) {
+void DataCacheUtils::clean_residual_datacache(const std::string& disk_path, bool ignore_persistent_cache) {
     if (!FileSystem::Default()->path_exists(disk_path).ok()) {
         // ignore none existed disk path
         return;
     }
+
+    // Skip cleaning it if the directory contains persistent cache data and ignore_persistent_cache is true.
+    if (ignore_persistent_cache && FileSystem::Default()->path_exists(disk_path + "/meta").ok()) {
+        return;
+    }
+
     auto st = FileSystem::Default()->iterate_dir2(disk_path, [&](DirEntry entry) {
         if (!entry.is_dir.value_or(false) && entry.name.find("blockfile_") == 0) {
             auto file = fmt::format("{}/{}", disk_path, entry.name);
@@ -156,6 +162,35 @@ void DataCacheUtils::clean_residual_datacache(const std::string& disk_path) {
         return true;
     });
     LOG_IF(WARNING, !st.ok()) << "fail to clean residual datacache data, reason: " << st.message();
+}
+
+void DataCacheUtils::clean_stale_datacache(const std::string& stale_data_path_conf,
+                                           std::vector<std::string> cur_cache_paths) {
+    std::vector<std::string> path_vec = strings::Split(stale_data_path_conf, ";", strings::SkipWhitespace());
+    for (auto& item : path_vec) {
+        StripWhiteSpace(&item);
+        item.erase(item.find_last_not_of('/') + 1);
+        std::filesystem::path stale_path(item);
+        if (!std::filesystem::exists(stale_path)) {
+            continue;
+        }
+
+        bool in_use = false;
+        for (auto& path : cur_cache_paths) {
+            std::filesystem::path cache_path(path);
+            if (!std::filesystem::exists(cache_path)) {
+                continue;
+            }
+            std::error_code ec;
+            if (std::filesystem::equivalent(stale_path, cache_path, ec)) {
+                in_use = true;
+                break;
+            }
+        }
+        if (!in_use) {
+            clean_residual_datacache(stale_path, true);
+        }
+    }
 }
 
 Status DataCacheUtils::change_disk_path(const std::string& old_disk_path, const std::string& new_disk_path) {

--- a/be/src/block_cache/datacache_utils.h
+++ b/be/src/block_cache/datacache_utils.h
@@ -36,7 +36,10 @@ public:
                                                    const std::string& config_disk_size, bool ignore_broken_disk,
                                                    std::vector<DirSpace>* disk_spaces);
 
-    static void clean_residual_datacache(const std::string& disk_path);
+    static void clean_residual_datacache(const std::string& disk_path, bool ignore_persistent_cache);
+
+    static void clean_stale_datacache(const std::string& stale_data_path_conf,
+                                      std::vector<std::string> cur_cache_paths);
 
     static Status change_disk_path(const std::string& old_disk_path, const std::string& new_disk_path);
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1266,17 +1266,16 @@ CONF_Bool(datacache_unified_instance_enable, "true");
 // * lru: the typical `Least Recently Used` eviction policy.
 // * slru: segment lru eviction policies, which can better reduce cache pollution problem.
 CONF_String(datacache_eviction_policy, "slru");
-// Only used to clean the old and stale datacache files.
-// Users usually do not need to configure it.
-CONF_String(datacache_stale_data_path, "");
-CONF_Alias(datacache_stale_data_path, datacache_disk_path);
 
 // The following configurations will be deprecated, and we use the `datacache` prefix instead.
 // But it is temporarily necessary to keep them for a period of time to be compatible with
 // the old configuration files.
 CONF_Bool(block_cache_enable, "false");
 CONF_Int64(block_cache_disk_size, "0");
-CONF_String(block_cache_disk_path, "${STARROCKS_HOME}/block_cache/");
+// The `block_cache_disk_path` and `datacache_disk_path` have been deprecated,
+// users should not configure it anymore.
+CONF_String(block_cache_disk_path, "");
+CONF_Alias(block_cache_disk_path, datacache_disk_path);
 CONF_String(block_cache_meta_path, "${STARROCKS_HOME}/block_cache/");
 CONF_Int64(block_cache_block_size, "262144");   // 256K
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1266,6 +1266,10 @@ CONF_Bool(datacache_unified_instance_enable, "true");
 // * lru: the typical `Least Recently Used` eviction policy.
 // * slru: segment lru eviction policies, which can better reduce cache pollution problem.
 CONF_String(datacache_eviction_policy, "slru");
+// Only used to clean the old and stale datacache files.
+// Users usually do not need to configure it.
+CONF_String(datacache_stale_data_path, "");
+CONF_Alias(datacache_stale_data_path, datacache_disk_path);
 
 // The following configurations will be deprecated, and we use the `datacache` prefix instead.
 // But it is temporarily necessary to keep them for a period of time to be compatible with

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -128,16 +128,16 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
             total_quota_bytes += disk_size;
         }
 
-        std::string stale_data_path = config::datacache_stale_data_path.empty() ? config::block_cache_disk_path
-                                                                                : config::datacache_stale_data_path;
         // Automatically clean the old stale datacache to free disk space.
-        if (!stale_data_path.empty()) {
+        if (!config::block_cache_disk_path.empty()) {
+            LOG(WARNING) << "The `datacache_disk_path` and `block_cache_disk_path` have been deprecated and will be "
+                         << "ignored, currently the cache data is located in `${storage_root_path}/datacache`.";
             std::vector<std::string> cur_cache_paths;
             cur_cache_paths.reserve(cache_options.disk_spaces.size());
             for (auto& space : cache_options.disk_spaces) {
                 cur_cache_paths.push_back(space.path);
             }
-            DataCacheUtils::clean_stale_datacache(stale_data_path, cur_cache_paths);
+            DataCacheUtils::clean_stale_datacache(config::block_cache_disk_path, cur_cache_paths);
         }
 
         if (cache_options.disk_spaces.empty() || total_quota_bytes != 0) {

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -128,6 +128,18 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
             total_quota_bytes += disk_size;
         }
 
+        std::string stale_data_path = config::datacache_stale_data_path.empty() ? config::block_cache_disk_path
+                                                                                : config::datacache_stale_data_path;
+        // Automatically clean the old stale datacache to free disk space.
+        if (!stale_data_path.empty()) {
+            std::vector<std::string> cur_cache_paths;
+            cur_cache_paths.reserve(cache_options.disk_spaces.size());
+            for (auto& space : cache_options.disk_spaces) {
+                cur_cache_paths.push_back(space.path);
+            }
+            DataCacheUtils::clean_stale_datacache(stale_data_path, cur_cache_paths);
+        }
+
         if (cache_options.disk_spaces.empty() || total_quota_bytes != 0) {
             config::datacache_auto_adjust_enable = false;
         }

--- a/be/test/block_cache/block_cache_test.cpp
+++ b/be/test/block_cache/block_cache_test.cpp
@@ -329,7 +329,7 @@ TEST_F(BlockCacheTest, clear_residual_blockfiles) {
     }
 
     cache->shutdown();
-    DataCacheUtils::clean_residual_datacache(cache_dir);
+    DataCacheUtils::clean_residual_datacache(cache_dir, true);
 
     {
         std::vector<std::string> files;


### PR DESCRIPTION
## Why I'm doing:
Now we have deprecated the `datacache_disk_path` configuration and use the `${storage_root_path}/datacache` as the datacache path.
However, if users configured their own datacache paths before, after upgrading to current version, the old datacache data still remains until users manually clean it.

## What I'm doing:
Automatically check and clean the stale datacache data to free the disk spaces immediately.

For safety, we only clean cache directories that meet the following conditions:
* Only clean the data files that prefix with `blockfile_` in the directory, does not remove the cache directory.
* If there is a `meta` directory in the cache directory, means it is a persistent cache directory and be generated by StarRocks 3.4 or later, we will ignore the cache directory.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

