### PR TITLE
[BugFix] Fixed the issue where the cache sharing function does not work in some cases due to incorrect node information acquisition.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/CandidateWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/CandidateWorkerProvider.java
@@ -146,7 +146,7 @@ public class CandidateWorkerProvider extends DefaultWorkerProvider implements Wo
         ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
         ImmutableList<Long> backendIds = historicalNodeMgr.getHistoricalBackendIds(warehouse);
         for (long nodeId : backendIds) {
-            ComputeNode backend = systemInfoService.getBackend(nodeId);
+            ComputeNode backend = systemInfoService.getBackendOrComputeNode(nodeId);
             if (backend != null) {
                 builder.put(nodeId, backend);
             }
@@ -161,7 +161,7 @@ public class CandidateWorkerProvider extends DefaultWorkerProvider implements Wo
         ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
         ImmutableList<Long> computeNodeIds = historicalNodeMgr.getHistoricalComputeNodeIds(warehouse);
         for (long nodeId : computeNodeIds) {
-            ComputeNode computeNode = systemInfoService.getComputeNode(nodeId);
+            ComputeNode computeNode = systemInfoService.getBackendOrComputeNode(nodeId);
             if (computeNode != null) {
                 builder.put(nodeId, computeNode);
             }


### PR DESCRIPTION
## Why I'm doing:
In share-data mode, we trace the historical backend nodes as compute nodes. This is the same as the current warehouse management logic. However, when getting the compute node information by the node id, we only check the compute node map in system service. This may cause the node information is acquired failed and lead to the cache sharing function does not work.

## What I'm doing:
Getting the node information by checking both the backend map and compute node map in system service.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
