### PR TITLE
[BugFix] Revert use file info instead of file path in bundle data file reader (#60220)

### DIFF
--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -149,13 +149,15 @@ StatusOr<std::unique_ptr<RandomAccessFile>> FileSystem::new_random_access_file_w
         const RandomAccessFileOptions& opts, const FileInfo& file_info) {
     if (file_info.bundle_file_offset.has_value() && file_info.bundle_file_offset.value() >= 0) {
         // If the file is a shared file, we need to create a new random access file with the offset.
+        // Notice, we CAN'T pass file_info to new_random_access_file, because size in file_info is not the size of the
+        // total bundle file.
         ASSIGN_OR_RETURN(auto file, new_random_access_file(opts, file_info.path));
         auto bundle_file = std::make_unique<BundleSeekableInputStream>(
                 file->stream(), file_info.bundle_file_offset.value(), file_info.size.value());
         RETURN_IF_ERROR(bundle_file->init());
         return std::make_unique<RandomAccessFile>(std::move(bundle_file), file->filename(), file->is_cache_hit());
     } else {
-        return new_random_access_file(opts, file_info.path);
+        return new_random_access_file(opts, file_info);
     }
 }
 

--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -149,13 +149,13 @@ StatusOr<std::unique_ptr<RandomAccessFile>> FileSystem::new_random_access_file_w
         const RandomAccessFileOptions& opts, const FileInfo& file_info) {
     if (file_info.bundle_file_offset.has_value() && file_info.bundle_file_offset.value() >= 0) {
         // If the file is a shared file, we need to create a new random access file with the offset.
-        ASSIGN_OR_RETURN(auto file, new_random_access_file(opts, file_info));
+        ASSIGN_OR_RETURN(auto file, new_random_access_file(opts, file_info.path));
         auto bundle_file = std::make_unique<BundleSeekableInputStream>(
                 file->stream(), file_info.bundle_file_offset.value(), file_info.size.value());
         RETURN_IF_ERROR(bundle_file->init());
         return std::make_unique<RandomAccessFile>(std::move(bundle_file), file->filename(), file->is_cache_hit());
     } else {
-        return new_random_access_file(opts, file_info);
+        return new_random_access_file(opts, file_info.path);
     }
 }
 


### PR DESCRIPTION
This reverts commit b81d60db998d8f58a6c1aa59c003167c339b9860.

## Why I'm doing:
I revert this pr #60220, this is because when data files are shared, the size in FileInfo does not represent the total file size—only the size of the shared segment. If this value is passed to the underlying interface, it will incorrectly set an excessively small length for the file, leading to errors during queries:

```
can not read fully
```

## What I'm doing:
This pull request updates the `FileSystem::new_random_access_file_w` method in `fs.cpp` to improve how file paths are handled when creating random access files. Specifically, it ensures that the `file_info.path` is passed instead of the `file_info` object when calling `new_random_access_file`.

File handling improvements:

* [`be/src/fs/fs.cpp`](diffhunk://#diff-840450cc5c871fa40694d430c9267aa12e9dd421a59ba5c5a561eaa6f14c24b8L152-R158): Modified the `FileSystem::new_random_access_file_w` method to pass `file_info.path` instead of the entire `file_info` object when calling `new_random_access_file`. This change ensures that the correct file path is used, simplifying the method's behavior and aligning it with the expected input for `new_random_access_file`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
