### PR TITLE
[BugFix] fix incorrect message shown from spill dir configuration

### DIFF
--- a/be/src/exec/spill/dir_manager.cpp
+++ b/be/src/exec/spill/dir_manager.cpp
@@ -26,7 +26,7 @@ namespace starrocks::spill {
 
 Status DirManager::init(const std::string& spill_dirs) {
     std::vector<starrocks::StorePath> spill_local_storage_paths;
-    RETURN_IF_ERROR(parse_conf_store_paths(spill_dirs, &spill_local_storage_paths));
+    RETURN_IF_ERROR(parse_conf_store_paths(spill_dirs, &spill_local_storage_paths, "config::spill_local_storage_dir"));
     if (spill_local_storage_paths.empty()) {
         return Status::InvalidArgument("cannot find spill_local_storage_dir");
     }

--- a/be/src/storage/options.cpp
+++ b/be/src/storage/options.cpp
@@ -142,7 +142,8 @@ Status parse_root_path(const string& root_path, StorePath* path) {
     return Status::OK();
 }
 
-Status parse_conf_store_paths(const string& config_path, std::vector<StorePath>* paths) {
+Status parse_conf_store_paths(const string& config_path, std::vector<StorePath>* paths,
+                              std::string_view configvar_name) {
     std::vector<string> path_vec = strings::Split(config_path, ";", strings::SkipWhitespace());
     for (auto& item : path_vec) {
         StorePath path;
@@ -154,8 +155,8 @@ Status parse_conf_store_paths(const string& config_path, std::vector<StorePath>*
         }
     }
     if (paths->empty() || (path_vec.size() != paths->size() && !config::ignore_broken_disk)) {
-        LOG(WARNING) << "fail to parse storage_root_path config. value=[" << config_path << "]";
-        return Status::InvalidArgument("Fail to parse storage_root_path");
+        LOG(WARNING) << "fail to parse " << configvar_name << " config. value=[" << config_path << "]";
+        return Status::InvalidArgument(fmt::format("Fail to parse {}", configvar_name));
     }
     return Status::OK();
 }

--- a/be/src/storage/options.h
+++ b/be/src/storage/options.h
@@ -57,7 +57,8 @@ struct StorePath {
 // parse a single root path of storage_root_path
 Status parse_root_path(const std::string& root_path, StorePath* path);
 
-Status parse_conf_store_paths(const std::string& config_path, std::vector<StorePath>* path);
+Status parse_conf_store_paths(const std::string& config_path, std::vector<StorePath>* path,
+                              std::string_view configvar_name = "config::storage_root_path");
 
 Status parse_conf_datacache_paths(const std::string& config_path, std::vector<std::string>* paths);
 

--- a/be/test/storage/options_test.cpp
+++ b/be/test/storage/options_test.cpp
@@ -102,4 +102,20 @@ TEST_F(OptionsTest, parse_root_path) {
     }
 }
 
+TEST_F(OptionsTest, parse_conf_store_paths) {
+    std::string root_path = "./relative_path_failed";
+    std::vector<StorePath> paths;
+    {
+        auto st = parse_conf_store_paths(root_path, &paths);
+        EXPECT_FALSE(st.ok()) << st;
+        EXPECT_TRUE(st.message().find("storage_root_path") != std::string_view::npos) << st.message();
+    }
+
+    {
+        auto st = parse_conf_store_paths(root_path, &paths, "my_defined_configvar_name");
+        EXPECT_FALSE(st.ok()) << st;
+        EXPECT_TRUE(st.message().find("my_defined_configvar_name") != std::string_view::npos) << st.message();
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
* report correct configuration name when parse_conf_store_paths other than storage_root_path

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
