### PR TITLE
[Enhancement] Plan advisor supports blacklist strategy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -875,6 +875,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_PLAN_ANALYZER = "enable_plan_analyzer";
 
     public static final String ENABLE_PLAN_ADVISOR = "enable_plan_advisor";
+    public static final String ENABLE_PLAN_ADVISOR_BLACKLIST = "enable_plan_advisor_blacklist";
 
     public static final String DISABLE_GENERATED_COLUMN_REWRITE = "disable_generated_column_rewrite";
 
@@ -1767,6 +1768,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_PLAN_ADVISOR)
     private boolean enablePlanAdvisor = true;
+
+    @VarAttr(name = ENABLE_PLAN_ADVISOR_BLACKLIST)
+    private boolean enablePlanAdvisorBlacklist = true;
+
 
     @VarAttr(name = COUNT_DISTINCT_IMPLEMENTATION)
     private String countDistinctImplementation = "default";
@@ -4833,6 +4838,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnablePlanAdvisor(boolean enablePlanAdvisor) {
         this.enablePlanAdvisor = enablePlanAdvisor;
+    }
+
+    public boolean isEnablePlanAdvisorBlacklist() {
+        return enablePlanAdvisorBlacklist;
+    }
+
+    public void setEnablePlanAdvisorBlacklist(boolean enablePlanAdvisorBlacklist) {
+        this.enablePlanAdvisorBlacklist = enablePlanAdvisorBlacklist;
     }
 
     public void setCountDistinctImplementation(String countDistinctImplementation) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanAdvisorExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanAdvisorExecutor.java
@@ -93,7 +93,7 @@ public class PlanAdvisorExecutor {
 
         @Override
         public ShowResultSet visitDelPlanAdvisorStatement(DelPlanAdvisorStmt stmt, ConnectContext context) {
-            PlanTuningAdvisor.getInstance().deleteTuningGuides(UUID.fromString(stmt.getAdvisorId()));
+            PlanTuningAdvisor.getInstance().deleteTuningGuides(UUID.fromString(stmt.getAdvisorId()), false);
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyTuningGuideRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyTuningGuideRule.java
@@ -68,7 +68,9 @@ public class ApplyTuningGuideRule implements TreeRewriteRule {
 
         // delete the useless tuning guides
         if (!tuningGuides.isUseful()) {
-            PlanTuningAdvisor.getInstance().deleteTuningGuides(tuningGuides.getOriginalQueryId());
+            boolean enablePlanAdvisorBlacklist = taskContext.getOptimizerContext().getSessionVariable()
+                    .isEnablePlanAdvisorBlacklist();
+            PlanTuningAdvisor.getInstance().deleteTuningGuides(tuningGuides.getOriginalQueryId(), enablePlanAdvisorBlacklist);
             return root;
         }
 

--- a/test/sql/test_feedback/R/test_agg_feedback
+++ b/test/sql/test_feedback/R/test_agg_feedback
@@ -114,12 +114,15 @@ insert into pre_agg_case select generate_series, generate_series, generate_serie
 -- !result
 analyze full table pre_agg_case with sync mode;
 -- result:
-[REGEX].*pre_agg_case	analyze	status	OK
+[REGEX].*
 -- !result
 set enable_plan_advisor=true;
 -- result:
 -- !result
 set enable_plan_analyzer=true;
+-- result:
+-- !result
+set enable_plan_advisor_blacklist=false;
 -- result:
 -- !result
 set enable_global_runtime_filter = false;
@@ -131,7 +134,7 @@ None
 -- !result
 alter plan advisor add select count(*) from pre_agg_case group by c3;
 -- result:
-[REGEX]Add query into plan advisor in FE
+[REGEX]Add query into plan advisor in FE*
 -- !result
 function: assert_explain_not_contains("select count(*) from pre_agg_case group by c3", "StreamingAggTuningGuide")
 -- result:
@@ -139,7 +142,7 @@ None
 -- !result
 truncate plan advisor;
 -- result:
-[REGEX]Clear all plan advisor in FE
+[REGEX]Clear all plan advisor in FE*
 -- !result
 CREATE TABLE __row_util_base (
   k1 bigint NULL
@@ -198,7 +201,7 @@ insert into t1 select idx, idx % (20480000 / 26), idx from __row_util;
 -- !result
 analyze full table t1 with sync mode;
 -- result:
-[REGEX].*t1	analyze	status	OK
+[REGEX].*
 -- !result
 select count(1) as cnt from t1 group by c1 order by cnt limit 10;
 -- result:
@@ -215,7 +218,7 @@ select count(1) as cnt from t1 group by c1 order by cnt limit 10;
 -- !result
 alter plan advisor add select count(1) as cnt from t1 group by c1 order by cnt limit 10;
 -- result:
-[REGEX]Add query into plan advisor in FE
+[REGEX]Add query into plan advisor in FE*
 -- !result
 function: assert_explain_contains("select count(1) as cnt from t1 group by c1 order by cnt limit 10", "StreamingAggTuningGuide")
 -- result:
@@ -233,4 +236,57 @@ select count(1) as cnt from t1 group by c1 order by cnt limit 10;
 26
 26
 26
+-- !result
+set enable_plan_advisor_blacklist = true;
+-- result:
+-- !result
+truncate plan advisor;
+-- result:
+[REGEX]Clear all plan advisor in FE*
+-- !result
+alter plan advisor add select count(1) as cnt from t1 group by c1 order by cnt limit 10;
+-- result:
+[REGEX]Add query into plan advisor in FE*
+-- !result
+function: assert_explain_contains("select count(1) as cnt from t1 group by c1 order by cnt limit 10", "StreamingAggTuningGuide")
+-- result:
+None
+-- !result
+select count(1) as cnt from t1 group by c1 order by cnt limit 10;
+-- result:
+9
+25
+26
+26
+26
+26
+26
+26
+26
+26
+-- !result
+function: assert_explain_not_contains("select count(1) as cnt from t1 group by c1 order by cnt limit 10", "StreamingAggTuningGuide")
+-- result:
+None
+-- !result
+select count(1) as cnt from t1 group by c1 order by cnt limit 10;
+-- result:
+9
+25
+26
+26
+26
+26
+26
+26
+26
+26
+-- !result
+function: assert_explain_not_contains("select count(1) as cnt from t1 group by c1 order by cnt limit 10", "StreamingAggTuningGuide")
+-- result:
+None
+-- !result
+truncate plan advisor;
+-- result:
+[REGEX]Clear all plan advisor in FE*
 -- !result

--- a/test/sql/test_feedback/R/test_external_table_join_feedback
+++ b/test/sql/test_feedback/R/test_external_table_join_feedback
@@ -28,6 +28,9 @@ insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate
 insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'f', generate_series, generate_series from TABLE(generate_series(11, 5050000));
 -- result:
 -- !result
+set enable_plan_advisor_blacklist=false;
+-- result:
+-- !result
 set enable_plan_advisor=true;
 -- result:
 -- !result
@@ -54,6 +57,9 @@ alter plan advisor add select count(*) from (select * from iceberg_catalog_${uui
 function: assert_explain_contains("select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t", "RightChildEstimationErrorTuningGuide")
 -- result:
 None
+-- !result
+set enable_plan_advisor_blacklist=true;
+-- result:
 -- !result
 truncate plan advisor;
 -- result:

--- a/test/sql/test_feedback/R/test_join_feedback
+++ b/test/sql/test_feedback/R/test_join_feedback
@@ -36,9 +36,12 @@ insert into c1_skew values(50001, 'f', 50001, 50001);
 -- !result
 analyze full table c1_skew with sync mode;
 -- result:
-[REGEX].*c1_skew	analyze	status	OK
+[REGEX].*
 -- !result
 set enable_global_runtime_filter = false;
+-- result:
+-- !result
+set enable_plan_advisor_blacklist=false;
 -- result:
 -- !result
 function: assert_explain_not_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
@@ -47,7 +50,7 @@ None
 -- !result
 alter plan advisor add select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t;
 -- result:
-[REGEX]Add query into plan advisor in FE.*
+[REGEX]Add query into plan advisor in FE*
 -- !result
 function: assert_explain_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
 -- result:
@@ -61,7 +64,10 @@ function: assert_trace_values_contains("select count(*) from (select * from c1_s
 -- result:
 None
 -- !result
+set enable_plan_advisor_blacklist=true;
+-- result:
+-- !result
 truncate plan advisor;
 -- result:
-[REGEX]Clear all plan advisor in FE.*
+[REGEX]Clear all plan advisor in FE*
 -- !result

--- a/test/sql/test_feedback/R/test_parameterized
+++ b/test/sql/test_feedback/R/test_parameterized
@@ -39,6 +39,9 @@ test_feedback.test_feedback_parameterized	analyze	status	OK
 set enable_global_runtime_filter = false;
 -- result:
 -- !result
+set enable_plan_advisor_blacklist=false;
+-- result:
+-- !result
 truncate plan advisor;
 -- result:
 [REGEX]Clear all plan advisor in FE.*
@@ -110,6 +113,9 @@ None
 function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 < 550) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
 -- result:
 None
+-- !result
+set enable_plan_advisor_blacklist=true;
+-- result:
 -- !result
 truncate plan advisor;
 -- result:

--- a/test/sql/test_feedback/T/test_agg_feedback
+++ b/test/sql/test_feedback/T/test_agg_feedback
@@ -51,6 +51,7 @@ insert into pre_agg_case select generate_series, generate_series, generate_serie
 analyze full table pre_agg_case with sync mode;
 set enable_plan_advisor=true;
 set enable_plan_analyzer=true;
+set enable_plan_advisor_blacklist=false;
 set enable_global_runtime_filter = false;
 function: assert_explain_not_contains("select count(*) from pre_agg_case group by c3", "StreamingAggTuningGuide")
 alter plan advisor add select count(*) from pre_agg_case group by c3;
@@ -110,3 +111,14 @@ select count(1) as cnt from t1 group by c1 order by cnt limit 10;
 alter plan advisor add select count(1) as cnt from t1 group by c1 order by cnt limit 10;
 function: assert_explain_contains("select count(1) as cnt from t1 group by c1 order by cnt limit 10", "StreamingAggTuningGuide")
 select count(1) as cnt from t1 group by c1 order by cnt limit 10;
+
+set enable_plan_advisor_blacklist = true;
+truncate plan advisor;
+alter plan advisor add select count(1) as cnt from t1 group by c1 order by cnt limit 10;
+function: assert_explain_contains("select count(1) as cnt from t1 group by c1 order by cnt limit 10", "StreamingAggTuningGuide")
+select count(1) as cnt from t1 group by c1 order by cnt limit 10;
+function: assert_explain_not_contains("select count(1) as cnt from t1 group by c1 order by cnt limit 10", "StreamingAggTuningGuide")
+select count(1) as cnt from t1 group by c1 order by cnt limit 10;
+function: assert_explain_not_contains("select count(1) as cnt from t1 group by c1 order by cnt limit 10", "StreamingAggTuningGuide")
+truncate plan advisor;
+

--- a/test/sql/test_feedback/T/test_external_table_join_feedback
+++ b/test/sql/test_feedback/T/test_external_table_join_feedback
@@ -15,6 +15,7 @@ insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate
 insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'd', generate_series, generate_series from TABLE(generate_series(7, 8));
 insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'e', generate_series, generate_series from TABLE(generate_series(9, 10));
 insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'f', generate_series, generate_series from TABLE(generate_series(11, 5050000));
+set enable_plan_advisor_blacklist=false;
 set enable_plan_advisor=true;
 set enable_plan_analyzer=true;
 use iceberg_catalog_${uuid0}.iceberg_db_${uuid0};
@@ -29,7 +30,7 @@ alter plan advisor add select count(*) from (select * from iceberg_catalog_${uui
 
 
 function: assert_explain_contains("select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t", "RightChildEstimationErrorTuningGuide")
-
+set enable_plan_advisor_blacklist=true;
 truncate plan advisor;
 drop table iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew;
 drop database iceberg_catalog_${uuid0}.iceberg_db_${uuid0};

--- a/test/sql/test_feedback/T/test_join_feedback
+++ b/test/sql/test_feedback/T/test_join_feedback
@@ -23,9 +23,11 @@ insert into c1_skew select generate_series, 'e', generate_series, generate_serie
 insert into c1_skew values(50001, 'f', 50001, 50001);
 analyze full table c1_skew with sync mode;
 set enable_global_runtime_filter = false;
+set enable_plan_advisor_blacklist=false;
 function: assert_explain_not_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
 alter plan advisor add select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t;
 function: assert_explain_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
 function: assert_trace_values_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
 function: assert_trace_values_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "CandidateTuningGuides")
+set enable_plan_advisor_blacklist=true;
 truncate plan advisor;

--- a/test/sql/test_feedback/T/test_parameterized
+++ b/test/sql/test_feedback/T/test_parameterized
@@ -23,7 +23,7 @@ insert into test_feedback_parameterized select "2000-01-03", generate_series, ge
 
 analyze table test_feedback_parameterized;
 set enable_global_runtime_filter = false;
-
+set enable_plan_advisor_blacklist=false;
 truncate plan advisor;
 
 -- test date_col = 2020-01-01
@@ -57,6 +57,7 @@ function: assert_explain_contains("select count(*) from (select * from test_feed
 -- test col2 is True after merge ranges. test col2 < 550
 function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 < 550) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
 
+set enable_plan_advisor_blacklist=true;
 truncate plan advisor;
 
 


### PR DESCRIPTION
## Why I'm doing:
Currently, if the plan recommended by query feedback is not as good as the original plan, we will discard the ineffective tuning guides and use the original plan for the next query. However, incorrect tuning plans may still be generated based on the exec stats for the next query. This will cause query performance to fluctuate repeatedly.


## What I'm doing:
Plan advisor supports blacklist strategy. Add the SQL pattern that has generated a wrong tuning guide to the blacklist. Once a bad plan is detected and recommended, permanently disable the plan advisor for the same SQL pattern. 
User can also perform `truncate plan advisor` to clean up all blacklist and tuning guide cache for recovery.

session variable:
`enable_plan_advisor_blacklist` default is true.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
