### PR TITLE
[BugFix] Fix window output partition propery

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
@@ -287,17 +287,6 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
         }
     }
 
-    private GroupExpression addChildEnforcer(PhysicalPropertySet oldOutputProperty,
-                                             DistributionProperty newDistributionProperty,
-                                             double childCost, Group childGroup) {
-        PhysicalPropertySet newOutputProperty = new PhysicalPropertySet(newDistributionProperty);
-        GroupExpression enforcer = newDistributionProperty.appendEnforcers(childGroup);
-
-        enforcer.setOutputPropertySatisfyRequiredProperty(newOutputProperty, newOutputProperty);
-        updateChildCostWithEnforcer(enforcer, oldOutputProperty, newOutputProperty, childCost, childGroup);
-        return enforcer;
-    }
-
     private void updateChildCostWithEnforcer(GroupExpression enforcer,
                                              PhysicalPropertySet oldOutputProperty,
                                              PhysicalPropertySet newOutputProperty,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -521,7 +521,7 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
         List<Integer> partitionColumnRefSet = new ArrayList<>();
 
         node.getPartitionExpressions().forEach(e -> partitionColumnRefSet.addAll(
-                Arrays.stream(e.getUsedColumns().getColumnIds()).boxed().collect(Collectors.toList())));
+                Arrays.stream(e.getUsedColumns().getColumnIds()).boxed().toList()));
 
         SortProperty sortProperty = SortProperty.createProperty(node.getEnforceOrderBy());
 
@@ -530,7 +530,8 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
             distributionProperty = DistributionProperty.createProperty(DistributionSpec.createGatherDistributionSpec());
         } else {
             // Use child distribution
-            distributionProperty = childrenOutputProperties.get(0).getDistributionProperty();
+            distributionProperty = DistributionProperty.createProperty(DistributionSpec.createHashDistributionSpec(
+                    new HashDistributionDesc(partitionColumnRefSet, SHUFFLE_AGG)));
         }
         return new PhysicalPropertySet(distributionProperty, sortProperty,
                 childrenOutputProperties.get(0).getCteProperty());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -523,15 +523,14 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
         node.getPartitionExpressions().forEach(e -> partitionColumnRefSet.addAll(
                 Arrays.stream(e.getUsedColumns().getColumnIds()).boxed().toList()));
 
-        SortProperty sortProperty = SortProperty.createProperty(node.getEnforceOrderBy());
+        SortProperty sortProperty = SortProperty.createProperty(node.getEnforceOrderBy(), partitionColumnRefSet);
 
         DistributionProperty distributionProperty;
         if (partitionColumnRefSet.isEmpty()) {
             distributionProperty = DistributionProperty.createProperty(DistributionSpec.createGatherDistributionSpec());
         } else {
-            // Use child distribution
-            distributionProperty = DistributionProperty.createProperty(DistributionSpec.createHashDistributionSpec(
-                    new HashDistributionDesc(partitionColumnRefSet, SHUFFLE_AGG)));
+            // Use child's distribution
+            distributionProperty = childrenOutputProperties.get(0).getDistributionProperty();
         }
         return new PhysicalPropertySet(distributionProperty, sortProperty,
                 childrenOutputProperties.get(0).getCteProperty());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
@@ -277,8 +277,8 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
         List<Integer> partitionColumnRefSet = new ArrayList<>();
 
         node.getPartitionExpressions().forEach(e -> partitionColumnRefSet
-                .addAll(Arrays.stream(e.getUsedColumns().getColumnIds()).boxed().collect(Collectors.toList())));
-        SortProperty sortProperty = SortProperty.createProperty(node.getEnforceOrderBy());
+                .addAll(Arrays.stream(e.getUsedColumns().getColumnIds()).boxed().toList()));
+        SortProperty sortProperty = SortProperty.createProperty(node.getEnforceOrderBy(), partitionColumnRefSet);
 
         DistributionProperty distributionProperty;
         if (partitionColumnRefSet.isEmpty()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1672,4 +1672,33 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 + "  |  output: count(2: v2), group_concat(CAST(2: v2 AS VARCHAR), ',')\n"
                 + "  |  group by: 1: v1");
     }
+
+
+    @Test
+    public void testWindowsPartitionDerive1() throws Exception {
+        String sql = "SELECT *, LAG(t1d) OVER (PARTITION BY t1a, t1b ORDER BY t1c) "
+                + "FROM (SELECT t1a, t1b, t1c, t1d, ROW_NUMBER() OVER (PARTITION BY t1a, t1b, t1c ORDER BY t1d) "
+                + "      FROM test_all_type) x; ";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  4:SORT\n"
+                + "  |  order by: <slot 1> 1: t1a ASC, <slot 2> 2: t1b ASC, <slot 3> 3: t1c ASC\n"
+                + "  |  analytic partition by: 1: t1a, 2: t1b\n"
+                + "  |  offset: 0\n"
+                + "  |  \n"
+                + "  3:EXCHANGE");
+    }
+
+    @Test
+    public void testWindowsPartitionDerive2() throws Exception {
+        String sql = "SELECT *, ROW_NUMBER() OVER (PARTITION BY t1a, t1b, t1c) "
+                + "FROM (SELECT t1a, t1b, t1c, t1d, LAG(t1d) OVER (PARTITION BY t1a, t1b ORDER BY t1c) "
+                + "      FROM test_all_type) x; ";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  3:ANALYTIC\n"
+                + "  |  functions: [, row_number(), ]\n"
+                + "  |  partition by: 1: t1a, 2: t1b, 3: t1c\n"
+                + "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n"
+                + "  |  \n"
+                + "  2:ANALYTIC");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1673,23 +1673,23 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 + "  |  group by: 1: v1");
     }
 
-
     @Test
     public void testWindowsPartitionDerive1() throws Exception {
         String sql = "SELECT *, LAG(t1d) OVER (PARTITION BY t1a, t1b ORDER BY t1c) "
-                + "FROM (SELECT t1a, t1b, t1c, t1d, ROW_NUMBER() OVER (PARTITION BY t1a, t1b, t1c ORDER BY t1d) "
-                + "      FROM test_all_type) x; ";
+                + "FROM (SELECT t1a, t1b, t1c, t1d, ROW_NUMBER() OVER (PARTITION BY t1a, t1b, t1c ORDER BY t1d) rn "
+                + "      FROM test_all_type) x;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  4:SORT\n"
+        assertContains(plan, "  3:SORT\n"
                 + "  |  order by: <slot 1> 1: t1a ASC, <slot 2> 2: t1b ASC, <slot 3> 3: t1c ASC\n"
                 + "  |  analytic partition by: 1: t1a, 2: t1b\n"
                 + "  |  offset: 0\n"
                 + "  |  \n"
-                + "  3:EXCHANGE");
+                + "  2:ANALYTIC");
     }
 
     @Test
     public void testWindowsPartitionDerive2() throws Exception {
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);
         String sql = "SELECT *, ROW_NUMBER() OVER (PARTITION BY t1a, t1b, t1c) "
                 + "FROM (SELECT t1a, t1b, t1c, t1d, LAG(t1d) OVER (PARTITION BY t1a, t1b ORDER BY t1c) "
                 + "      FROM test_all_type) x; ";


### PR DESCRIPTION
## Why I'm doing:

For SQL:
```
 select *, LAG(lo_extendedprice) OVER (PARTITION BY lo_orderkey, lo_custkey ORDER BY lo_commitdate) AS bug_1 from (
    select lo_orderkey, lo_custkey, lo_commitdate, lo_extendedprice, ROW_NUMBER() OVER (PARTITION BY lo_orderkey, lo_custkey, lo_commitdate ORDER BY lo_extendedprice) rn from lf where lo_orderkey=20742 and lo_custkey = 27361) x
```

![image](https://github.com/user-attachments/assets/c1ba49cb-5f31-4163-a869-b0e69c36100e)


the Plan:
![image](https://github.com/user-attachments/assets/05b22e54-21f7-4802-869b-069d13ee90fb)

the first window required: `partition by: 2: lo_orderkey, 4: lo_custkey, 16: lo_commitdate`
the second window required: `partition by: 2: lo_orderkey, 4: lo_custkey`

Although the property of scan output is `lo_orderkey`, which can meet the requirements of the first and second window, but the first window will insert a local partition, it's will lost `lo_orderkey` output property, so we can't output child property directly



## What I'm doing:


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
