### PR TITLE
[Feature] Add splitting and merging tablets info in the publish version rpc request for dynamic tablet splitting and merging

### DIFF
--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -39,6 +39,16 @@ message PublishVersionRequest {
     repeated TxnInfoPB txn_infos = 7;
     repeated int64 rebuild_pindex_tablet_ids = 8;
     optional bool enable_aggregate_publish = 9;
+    // Distribution key column physical names (column id)
+    repeated string distribution_columns = 10;
+    // This field is used for 2 cases to specify the splitting tablets info (not included in tablet_ids):
+    // 1. The split tablet transaction, in which the txn type in txn_infos is TXN_SPLIT_TABLET.
+    // 2. The nornal write transaction but need cross-commit during tablet splitting.
+    repeated SplittingTabletInfoPB splitting_tablet_infos = 11;
+    // This field is used for 2 cases to specify the merging tablets info (not included in tablet_ids):
+    // 1. The merge tablet transaction, in which the txn type in txn_infos is TXN_MERGE_TABLET.
+    // 2. The nornal write transaction but need cross-commit during tablet merging.
+    repeated MergingTabletInfoPB merging_tablet_infos = 12;
 }
 
 message PublishVersionResponse {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -252,5 +252,14 @@ message TxnInfoPB {
     optional bool force_publish = 5; // only used for compaction
     optional bool rebuild_pindex = 6;
     optional int64 gtid = 7 [default=0];
-};
+}
 
+message SplittingTabletInfoPB {
+    optional int64 old_tablet_id = 1;
+    repeated int64 new_tablet_ids = 2;
+}
+
+message MergingTabletInfoPB {
+    repeated int64 old_tablet_ids = 1;
+    optional int64 new_tablet_id = 2;
+}

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -107,6 +107,8 @@ enum TxnTypePB {
      TXN_NORMAL = 0;
      TXN_REPLICATION = 1;
      TXN_EMPTY = 2;
+     TXN_SPLIT_TABLET = 3;
+     TXN_MERGE_TABLET = 4;
 }
 
 enum ReplicationTxnStatePB {


### PR DESCRIPTION
## Why I'm doing:
This is a preliminary work for later PRs for tablet splitting and merging.
This PR is for 2 cases:
1. In the split or merge tablet transaction, the publish version rpc request need to carry the distributed columns and the splitting or merging tablets info to do tablet splitting or merging.
2. In the normal write transaction during tablet splitting or merging, the publish version rpc request need to carry the splitting or merging tablets info to do cross-commit (Write data to old tablets but apply to new tablets).

## What I'm doing:
Add splitting and merging tablets info in the publish version rpc request for dynamic tablet splitting and merging.

Fixes https://github.com/StarRocks/starrocks/issues/59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
