### PR TITLE
[BugFix]Fix memory leaks due to PolicyRefresher thread leaks.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/RangerAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/RangerAccessController.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Objects;
 import java.util.Set;
 
+import static com.starrocks.server.GlobalStateMgr.isCheckpointThread;
 import static java.util.Locale.ENGLISH;
 
 public abstract class RangerAccessController extends ExternalAccessController implements AccessTypeConverter {
@@ -45,7 +46,9 @@ public abstract class RangerAccessController extends ExternalAccessController im
     public RangerAccessController(String serviceType, String serviceName) {
         RangerPluginConfig rangerPluginContext = buildRangerPluginContext(serviceType, serviceName);
         rangerPlugin = new RangerBasePlugin(rangerPluginContext);
-        rangerPlugin.init(); // this will initialize policy engine and policy refresher
+        if (!isCheckpointThread()) {
+            rangerPlugin.init(); // this will initialize policy engine and policy refresher
+        }
         rangerPlugin.setResultProcessor(new RangerDefaultAuditHandler());
 
         LOG.info("Start Ranger plugin ({} - {}) success",

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -122,7 +122,6 @@ public class CatalogMgr {
                 String serviceName = properties.get("ranger.plugin.hive.service.name");
                 if (serviceName == null || serviceName.isEmpty()) {
                     if (accessControl.equals("ranger")) {
-                        Authorizer.getInstance().removeAccessControl(catalogName);
                         Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
                     } else if (accessControl.equals("allowall")) {
                         Authorizer.getInstance().setAccessControl(catalogName, new AllowAllAccessController());
@@ -130,7 +129,6 @@ public class CatalogMgr {
                         Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
                     }
                 } else {
-                    Authorizer.getInstance().removeAccessControl(catalogName);
                     Authorizer.getInstance().setAccessControl(catalogName, new RangerHiveAccessController(serviceName));
                 }
 
@@ -361,7 +359,6 @@ public class CatalogMgr {
             String accessControl = config.getOrDefault("catalog.access.control", Config.access_control);
             if (serviceName == null || serviceName.isEmpty()) {
                 if (accessControl.equals("ranger")) {
-                    Authorizer.getInstance().removeAccessControl(catalogName);
                     Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
                 } else if (accessControl.equals("allowall")) {
                     Authorizer.getInstance().setAccessControl(catalogName, new AllowAllAccessController());
@@ -369,7 +366,6 @@ public class CatalogMgr {
                     Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
                 }
             } else {
-                Authorizer.getInstance().removeAccessControl(catalogName);
                 Authorizer.getInstance().setAccessControl(catalogName, new RangerHiveAccessController(serviceName));
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -122,6 +122,7 @@ public class CatalogMgr {
                 String serviceName = properties.get("ranger.plugin.hive.service.name");
                 if (serviceName == null || serviceName.isEmpty()) {
                     if (accessControl.equals("ranger")) {
+                        Authorizer.getInstance().removeAccessControl(catalogName);
                         Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
                     } else if (accessControl.equals("allowall")) {
                         Authorizer.getInstance().setAccessControl(catalogName, new AllowAllAccessController());
@@ -129,6 +130,7 @@ public class CatalogMgr {
                         Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
                     }
                 } else {
+                    Authorizer.getInstance().removeAccessControl(catalogName);
                     Authorizer.getInstance().setAccessControl(catalogName, new RangerHiveAccessController(serviceName));
                 }
 
@@ -359,6 +361,7 @@ public class CatalogMgr {
             String accessControl = config.getOrDefault("catalog.access.control", Config.access_control);
             if (serviceName == null || serviceName.isEmpty()) {
                 if (accessControl.equals("ranger")) {
+                    Authorizer.getInstance().removeAccessControl(catalogName);
                     Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
                 } else if (accessControl.equals("allowall")) {
                     Authorizer.getInstance().setAccessControl(catalogName, new AllowAllAccessController());
@@ -366,6 +369,7 @@ public class CatalogMgr {
                     Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
                 }
             } else {
+                Authorizer.getInstance().removeAccessControl(catalogName);
                 Authorizer.getInstance().setAccessControl(catalogName, new RangerHiveAccessController(serviceName));
             }
 


### PR DESCRIPTION
## Why I'm doing:
<img width="1249" alt="Clipboard_Screenshot_1750939998" src="https://github.com/user-attachments/assets/e3c7bf11-d7cb-4729-bf4d-3e21d8036b81" />
<img width="837" alt="Clipboard_Screenshot_1750940796" src="https://github.com/user-attachments/assets/abcf09ab-93ab-4861-8a1d-74c30ffc8872" />


## What I'm doing:
1 After each checkpoint, execute GlobalStateMgr.destroyCheckpoint()
2 AccessControlProvider.catalogToAccessControl is reset, setAccessControl can never execute RangerPlugin.cleanup
3 So in the checkpoint thread, it is not allowed to execute rangerPlugin.init

Fixes #60354

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
