### PR TITLE
[BugFix] Reserve leading inline comments

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ReserveLeadingInlineCommentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ReserveLeadingInlineCommentTest.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.getStarRocksAssert;
+
+public class ReserveLeadingInlineCommentTest {
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
+        starRocksAssert = getStarRocksAssert();
+        starRocksAssert = new StarRocksAssert();
+        starRocksAssert.withDatabase("db").useDatabase("db");
+
+        String createTblStmtStr = "create table db.tb2(kk1 int, kk2 varchar(200)) "
+                + "DUPLICATE KEY(kk1) distributed by hash(kk1) buckets 3 properties('replication_num' = '1');";
+        starRocksAssert.withTable(createTblStmtStr);
+    }
+
+    @Test
+    public void test() {
+        String sqlFmt = "{COMMENT} select count(1) from db.tb2";
+        String[] comments = new String[] {
+                "/*abc*/",
+                "   /*abcdef */",
+                "/*\n\n\n\rabcdef\n\n\r*/",
+                "/* celostar_context: {extrainfo} */"
+        };
+        for (String comment : comments) {
+            String sql = sqlFmt.replace("{COMMENT}", comment);
+            ConnectContext connectContext = starRocksAssert.getCtx();
+            StatementBase stmt = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+            Analyzer.analyze(stmt, connectContext);
+            String newSql = AstToSQLBuilder.toSQLOrDefault(stmt, stmt.getOrigStmt().originStmt);
+            Assert.assertTrue(newSql.contains(comment.trim()));
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Leading inline comments is removed in audit log  since 3.4.2 exceptionally, it is unexpected. so we must reserve inline comments

For an example
![image](https://github.com/user-attachments/assets/632fc049-79f4-4be2-bc8f-c1514bdf0798)

in fe.audit.log
![image](https://github.com/user-attachments/assets/29e52f64-e00f-4999-bd16-8281c92bf9fd)
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
