### PR TITLE
[Enhancement] adding -j syntax support to run-fe-ut.sh

### DIFF
--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -36,6 +36,7 @@ Usage: $0 <options>
      --dry-run                  dry-run unit tests
      --coverage                 run coverage statistic tasks
      --dumpcase [PATH]          run dump case and save to path
+     -j                         build parallel, default is 4
 
   Eg.
     $0                                            run all unit tests
@@ -44,6 +45,7 @@ Usage: $0 <options>
     $0 --dry-run                                  dry-run unit tests
     $0 --coverage                                 run coverage statistic tasks
     $0 --dumpcase /home/disk1/                    run dump case and save to path
+    $0 -j16 --test com.starrocks.utframe.Demo     run demo test with 16 parallel threads
   "
   exit 1
 }
@@ -51,7 +53,7 @@ Usage: $0 <options>
 # -l run only used for compatibility
 OPTS=$(getopt \
   -n $0 \
-  -o '' \
+  -o 'j:' \
   -l 'test:' \
   -l 'filter:' \
   -l 'dry-run' \
@@ -74,6 +76,7 @@ TEST_NAME=*
 FILTER_TEST=""
 COVERAGE=0
 DUMPCASE=0
+PARALLEL=${FE_UT_PARALLEL:-4}
 while true; do
     case "$1" in
         --coverage) COVERAGE=1 ; shift ;;
@@ -83,6 +86,7 @@ while true; do
         --dumpcase) DUMPCASE=1; shift ;;
         --dry-run) DRY_RUN=1 ; shift ;;
         --help) HELP=1 ; shift ;;
+        -j) PARALLEL=$2; shift 2 ;;
         --) shift ;  break ;;
         *) echo "Internal error" ; exit 1 ;;
     esac
@@ -100,10 +104,8 @@ echo "*********************************"
 cd ${STARROCKS_HOME}/fe/
 mkdir -p build/compile
 
-if [ -z "${FE_UT_PARALLEL}" ]; then
-    # the default fe unit test parallel is 1
-    export FE_UT_PARALLEL=4
-fi
+# Set FE_UT_PARALLEL if -j parameter is provided
+export FE_UT_PARALLEL=$PARALLEL
 echo "Unit test parallel is: $FE_UT_PARALLEL"
 
 if [ -d "./mocked" ]; then
@@ -143,6 +145,6 @@ else
         fi
 
         # set trimStackTrace to false to show full stack when debugging specified class or case
-        ${MVN_CMD} test -DfailIfNoTests=false -DtrimStackTrace=false -D test="$TEST_NAME"
+        ${MVN_CMD} test -DfailIfNoTests=false -DtrimStackTrace=false -D test="$TEST_NAME" -T $PARALLEL
     fi
 fi

--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -36,7 +36,7 @@ Usage: $0 <options>
      --dry-run                  dry-run unit tests
      --coverage                 run coverage statistic tasks
      --dumpcase [PATH]          run dump case and save to path
-     -j                         build parallel, default is 4
+     -j [N]                     build parallel, default is ${FE_UT_PARALLEL:-4}
 
   Eg.
     $0                                            run all unit tests


### PR DESCRIPTION
## Why I'm doing:
Currently, running FE UT parallel requires reading the script file to find how to do it. 
You should find FE_UT_PARALLEL parameter then use that etc... I think it is not common to use.
## What I'm doing:
Added -j parameter like run-be-ut.sh. -j usage is more common and easier. 
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
