### PR TITLE
[BugFix] merge project operator after rewriting `count(1)`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -679,6 +679,7 @@ public class QueryOptimizer extends Optimizer {
 
         scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
         scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.META_SCAN_REWRITE_RULES);
+        scheduler.rewriteOnce(tree, rootTaskContext, new MergeTwoProjectRule());
         scheduler.rewriteOnce(tree, rootTaskContext, new PartitionColumnValueOnlyOnScanRule());
         // before MergeProjectWithChildRule, after INLINE_CTE and MergeApplyWithTableFunction
         scheduler.rewriteIterative(tree, rootTaskContext, RewriteUnnestBitmapRule.getInstance());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -418,7 +418,7 @@ public class RuleSet {
                     new PushDownAggToMetaScanRule(),
                     new PushDownFlatJsonMetaToMetaScanRule(),
                     new RewriteSimpleAggToMetaScanRule(),
-                    new RewriteSimpleAggToHDFSScanRule(),
+                    RewriteSimpleAggToHDFSScanRule.SCAN_AND_PROJECT,
                     new MinMaxCountOptOnScanRule()
             ));
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -63,15 +63,18 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
     public static final RewriteSimpleAggToHDFSScanRule SCAN_NO_PROJECT =
             new RewriteSimpleAggToHDFSScanRule(false);
 
+    public static final RewriteSimpleAggToHDFSScanRule SCAN_AND_PROJECT =
+            new RewriteSimpleAggToHDFSScanRule();
+
     private final boolean hasProjectOperator;
 
-    private RewriteSimpleAggToHDFSScanRule(boolean withoutProject) {
+    private RewriteSimpleAggToHDFSScanRule(boolean /* unused */ noProject) {
         super(RuleType.TF_REWRITE_SIMPLE_AGG, Pattern.create(OperatorType.LOGICAL_AGGR)
                 .addChildren(MultiOpPattern.of(SUPPORTED)));
-        hasProjectOperator = withoutProject;
+        hasProjectOperator = false;
     }
 
-    public RewriteSimpleAggToHDFSScanRule() {
+    private RewriteSimpleAggToHDFSScanRule() {
         super(RuleType.TF_REWRITE_SIMPLE_AGG, Pattern.create(OperatorType.LOGICAL_AGGR)
                 .addChildren(Pattern.create(OperatorType.LOGICAL_PROJECT).addChildren(MultiOpPattern.of(SUPPORTED))));
         hasProjectOperator = true;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -87,9 +87,12 @@ public class HiveScanTest extends ConnectorPlanTestBase {
         // positive cases.
         {
             String[] sqlString = {
+                    "select count(*) + 1 from lineitem_par",
+                    "select count(*) + 1 from lineitem_par where l_shipdate = '1998-01-01'",
+                    "select count(*) + 1, l_shipdate from lineitem_par where l_shipdate = '1998-01-01' group by l_shipdate",
                     "select count(*) from lineitem_par",
                     "select count(*) from lineitem_par where l_shipdate = '1998-01-01'",
-                    "select count(*), l_shipdate from lineitem_par where l_shipdate = '1998-01-01' group by l_shipdate"
+                    "select count(*), l_shipdate from lineitem_par where l_shipdate = '1998-01-01' group by l_shipdate",
             };
             for (int i = 0; i < sqlString.length; i++) {
                 String sql = sqlString[i];
@@ -134,6 +137,10 @@ public class HiveScanTest extends ConnectorPlanTestBase {
         // positive cases.
         {
             String[] sqlString = {
+                    "select count(*) + 1 from iceberg0.partitioned_db.t1",
+                    "select count(*) + 1 from iceberg0.partitioned_db.t1 where date = '2020-01-01'",
+                    "select count(*) + 1, date from iceberg0.partitioned_db.t1 where date = '2020-01-01' " +
+                            "group by date",
                     "select count(*) from iceberg0.partitioned_db.t1",
                     "select count(*) from iceberg0.partitioned_db.t1 where date = '2020-01-01'",
                     "select count(*), date from iceberg0.partitioned_db.t1 where date = '2020-01-01' " +


### PR DESCRIPTION
## Why I'm doing:

when running following sql, hit following error message

```
mysql root@127.0.0.1:hive238.hive_db> select count(1) + 2 from `hive238`.`hive_extbl_test`.`hive_hdfs_parquet`;
(1064, "Shouldn't set projection to Project Operator")
```

It's because when rewriting `count(1)` and to fix null if there is no scan range, I add a project expression `ifnull(x, 0)` on top of that.  (https://github.com/StarRocks/starrocks/pull/60215)

However there could be two project operators after writing at the same time. So I need to merge those two project operators.

## What I'm doing:

Run MergeProjectOperatorRules after rewriting.

Fixes https://github.com/StarRocks/StarRocksTest/issues/9889

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
