### PR TITLE
[Enhancement] Support different compaction strategy for different table in shared-data mode

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -396,6 +396,9 @@ CONF_Bool(enable_event_based_compaction_framework, "true");
 
 CONF_Bool(enable_size_tiered_compaction_strategy, "true");
 CONF_mBool(enable_pk_size_tiered_compaction_strategy, "true");
+// We support real-time compaction strategy for primary key tables in shared-data mode.
+// This real-time compaction strategy enables compacting rowsets across multiple levels simultaneously.
+// The parameter `size_tiered_max_compaction_level` defines the maximum compaction level allowed in a single compaction task.
 CONF_mInt32(size_tiered_max_compaction_level, "3");
 CONF_mInt64(size_tiered_min_level_size, "131072");
 CONF_mInt64(size_tiered_level_multiple, "5");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -396,6 +396,7 @@ CONF_Bool(enable_event_based_compaction_framework, "true");
 
 CONF_Bool(enable_size_tiered_compaction_strategy, "true");
 CONF_mBool(enable_pk_size_tiered_compaction_strategy, "true");
+CONF_mInt(size_tiered_max_compaction_level, "3");
 CONF_mInt64(size_tiered_min_level_size, "131072");
 CONF_mInt64(size_tiered_level_multiple, "5");
 CONF_mInt64(size_tiered_level_multiple_dupkey, "10");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -396,7 +396,7 @@ CONF_Bool(enable_event_based_compaction_framework, "true");
 
 CONF_Bool(enable_size_tiered_compaction_strategy, "true");
 CONF_mBool(enable_pk_size_tiered_compaction_strategy, "true");
-CONF_mInt(size_tiered_max_compaction_level, "3");
+CONF_mInt32(size_tiered_max_compaction_level, "3");
 CONF_mInt64(size_tiered_min_level_size, "131072");
 CONF_mInt64(size_tiered_level_multiple, "5");
 CONF_mInt64(size_tiered_level_multiple_dupkey, "10");

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -233,8 +233,6 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                     }
                     if (res.ok()) {
                         auto metadata = std::move(res).value();
-                        // TODO(zhangqiang)
-                        // just for test, set real time compaction
                         auto score = compaction_score(_tablet_mgr, metadata);
                         std::lock_guard l(response_mtx);
                         response->mutable_compaction_scores()->insert({tablet_id, score});

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -233,6 +233,8 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                     }
                     if (res.ok()) {
                         auto metadata = std::move(res).value();
+                        // TODO(zhangqiang)
+                        // just for test, set real time compaction
                         auto score = compaction_score(_tablet_mgr, metadata);
                         std::lock_guard l(response_mtx);
                         response->mutable_compaction_scores()->insert({tablet_id, score});

--- a/be/src/storage/lake/compaction_policy.cpp
+++ b/be/src/storage/lake/compaction_policy.cpp
@@ -80,6 +80,12 @@ private:
 
 StatusOr<uint32_t> primary_compaction_score_by_policy(TabletManager* tablet_mgr,
                                                       const std::shared_ptr<const TabletMetadataPB>& metadata) {
+    bool is_real_time = false;
+    if (metadata->has_compaction_strategy() && metadata->compaction_strategy() == CompactionStrategyPB::REAL_TIME) {
+        is_real_time = true;
+    }
+    uint32_t update_compaction_delvec_file_io_amp_ratio =
+            is_real_time ? 1 : config::update_compaction_delvec_file_io_amp_ratio;
     PrimaryCompactionPolicy policy(tablet_mgr, metadata, false /* force_base_compaction */);
     std::vector<bool> has_dels;
     ASSIGN_OR_RETURN(auto pick_rowset_indexes, policy.pick_rowset_indexes(metadata, true, &has_dels));
@@ -90,7 +96,7 @@ StatusOr<uint32_t> primary_compaction_score_by_policy(TabletManager* tablet_mgr,
         auto current_score = pick_rowset.overlapped() ? pick_rowset.segments_size() : 1;
         if (has_del) {
             // if delvec file exist, expand score by config.
-            current_score *= config::update_compaction_delvec_file_io_amp_ratio;
+            current_score *= update_compaction_delvec_file_io_amp_ratio;
         }
         segment_num_score += current_score;
     }

--- a/be/src/storage/lake/compaction_policy.cpp
+++ b/be/src/storage/lake/compaction_policy.cpp
@@ -79,11 +79,7 @@ private:
 };
 
 bool CompactionPolicy::is_real_time_compaction_strategy(const std::shared_ptr<const TabletMetadataPB>& metadata) {
-    bool is_real_time = false;
-    if (metadata->has_compaction_strategy() && metadata->compaction_strategy() == CompactionStrategyPB::REAL_TIME) {
-        is_real_time = true;
-    }
-    return is_real_time;
+    return metadata->has_compaction_strategy() && metadata->compaction_strategy() == CompactionStrategyPB::REAL_TIME;
 }
 
 StatusOr<uint32_t> primary_compaction_score_by_policy(TabletManager* tablet_mgr,

--- a/be/src/storage/lake/compaction_policy.cpp
+++ b/be/src/storage/lake/compaction_policy.cpp
@@ -78,17 +78,21 @@ private:
     };
 };
 
-StatusOr<uint32_t> primary_compaction_score_by_policy(TabletManager* tablet_mgr,
-                                                      const std::shared_ptr<const TabletMetadataPB>& metadata) {
+bool CompactionPolicy::is_real_time_compaction_strategy(const std::shared_ptr<const TabletMetadataPB>& metadata) {
     bool is_real_time = false;
     if (metadata->has_compaction_strategy() && metadata->compaction_strategy() == CompactionStrategyPB::REAL_TIME) {
         is_real_time = true;
     }
-    uint32_t update_compaction_delvec_file_io_amp_ratio =
-            is_real_time ? 1 : config::update_compaction_delvec_file_io_amp_ratio;
+    return is_real_time;
+}
+
+StatusOr<uint32_t> primary_compaction_score_by_policy(TabletManager* tablet_mgr,
+                                                      const std::shared_ptr<const TabletMetadataPB>& metadata) {
     PrimaryCompactionPolicy policy(tablet_mgr, metadata, false /* force_base_compaction */);
+    uint32_t update_compaction_delvec_file_io_amp_ratio =
+            policy.is_real_time_compaction_strategy(metadata) ? 1 : config::update_compaction_delvec_file_io_amp_ratio;
     std::vector<bool> has_dels;
-    ASSIGN_OR_RETURN(auto pick_rowset_indexes, policy.pick_rowset_indexes(metadata, true, &has_dels));
+    ASSIGN_OR_RETURN(auto pick_rowset_indexes, policy.pick_rowset_indexes(metadata, &has_dels));
     uint32_t segment_num_score = 0;
     for (int i = 0; i < pick_rowset_indexes.size(); i++) {
         const auto& pick_rowset = metadata->rowsets(pick_rowset_indexes[i]);

--- a/be/src/storage/lake/compaction_policy.h
+++ b/be/src/storage/lake/compaction_policy.h
@@ -44,7 +44,7 @@ public:
                                                 std::shared_ptr<const TabletMetadataPB> tablet_metadata,
                                                 bool force_base_compaction);
 
-    bool is_real_time_compaction_strategy(const std::shared_ptr<const TabletMetadataPB>& metadata);
+    static bool is_real_time_compaction_strategy(const std::shared_ptr<const TabletMetadataPB>& metadata);
 
 protected:
     explicit CompactionPolicy(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> tablet_metadata,

--- a/be/src/storage/lake/compaction_policy.h
+++ b/be/src/storage/lake/compaction_policy.h
@@ -44,6 +44,8 @@ public:
                                                 std::shared_ptr<const TabletMetadataPB> tablet_metadata,
                                                 bool force_base_compaction);
 
+    bool is_real_time_compaction_strategy(const std::shared_ptr<const TabletMetadataPB>& metadata);
+
 protected:
     explicit CompactionPolicy(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> tablet_metadata,
                               bool force_base_compaction)

--- a/be/src/storage/lake/primary_key_compaction_policy.cpp
+++ b/be/src/storage/lake/primary_key_compaction_policy.cpp
@@ -67,8 +67,7 @@ StatusOr<std::unique_ptr<PKSizeTieredLevel>> PrimaryCompactionPolicy::pick_max_l
     if (!calc_score && top_level_ptr->rowsets.size() == 1 &&
         !top_level_ptr->rowsets.top().multi_segment_with_overlapped() && !order_levels.empty()) {
         auto second_level_ptr = std::make_unique<PKSizeTieredLevel>(order_levels.top());
-        //second_level_ptr->merge_top(*top_level_ptr);
-        top_level_ptr->merge_top(*second_level_ptr);
+        top_level_ptr->merge_level(*second_level_ptr);
         order_levels.pop();
     }
 
@@ -164,7 +163,6 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
         }
         pick_level_ptr->rowsets.pop();
     }
-
     if (is_real_time && !reach_max_input_per_compaction) {
         for (int i = 0; i < pick_level_ptr->candidate_rowsets.size(); i++) {
             const auto& rowset_candidate = pick_level_ptr->candidate_rowsets[i];

--- a/be/src/storage/lake/primary_key_compaction_policy.cpp
+++ b/be/src/storage/lake/primary_key_compaction_policy.cpp
@@ -72,7 +72,8 @@ StatusOr<std::unique_ptr<PKSizeTieredLevel>> PrimaryCompactionPolicy::pick_max_l
         compaction_level++;
     }
 
-    while (!order_levels.empty() && compaction_level <= config::size_tiered_max_compaction_level) {
+    int32_t max_compaction_levels = config::size_tiered_max_compaction_level;
+    while (!order_levels.empty() && compaction_level <= max_compaction_levels) {
         auto next_level_ptr = std::make_unique<PKSizeTieredLevel>(order_levels.top());
         order_levels.pop();
         if (next_level_ptr->get_compact_level() < top_level_ptr->get_compact_level()) {

--- a/be/src/storage/lake/primary_key_compaction_policy.cpp
+++ b/be/src/storage/lake/primary_key_compaction_policy.cpp
@@ -76,7 +76,7 @@ StatusOr<std::unique_ptr<PKSizeTieredLevel>> PrimaryCompactionPolicy::pick_max_l
         auto next_level_ptr = std::make_unique<PKSizeTieredLevel>(order_levels.top());
         order_levels.pop();
         if (next_level_ptr->get_compact_level() < top_level_ptr->get_compact_level()) {
-            top_level_ptr->add_candidate_rowsets(*next_level_ptr);
+            top_level_ptr->add_other_level_rowsets(*next_level_ptr);
             compaction_level++;
         }
     }
@@ -159,8 +159,8 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
         pick_level_ptr->rowsets.pop();
     }
     if (is_real_time && !reach_max_input_per_compaction) {
-        for (int i = 0; i < pick_level_ptr->candidate_rowsets.size(); i++) {
-            const auto& rowset_candidate = pick_level_ptr->candidate_rowsets[i];
+        for (int i = 0; i < pick_level_ptr->other_level_rowsets.size(); i++) {
+            const auto& rowset_candidate = pick_level_ptr->other_level_rowsets[i];
             cur_compaction_result_bytes += rowset_candidate.read_bytes();
             rowset_indexes.push_back(rowset_candidate.rowset_index);
             if (has_dels != nullptr) {

--- a/be/src/storage/lake/primary_key_compaction_policy.h
+++ b/be/src/storage/lake/primary_key_compaction_policy.h
@@ -113,8 +113,6 @@ struct PKSizeTieredLevel {
         }
     }
 
-    void set_compact_leve(int64_t compact_level) { this->compact_level = compact_level; }
-
     int64_t get_compact_level() { return compact_level; }
 
     bool operator<(const PKSizeTieredLevel& other) const { return score < other.score; }

--- a/be/src/storage/lake/primary_key_compaction_policy.h
+++ b/be/src/storage/lake/primary_key_compaction_policy.h
@@ -104,11 +104,11 @@ struct PKSizeTieredLevel {
         }
     }
 
-    // Add other level's rowset into candidate rowsets
-    void add_candidate_rowsets(PKSizeTieredLevel& other) {
+    // Add other level's rowsets.
+    void add_other_level_rowsets(PKSizeTieredLevel& other) {
         while (!other.rowsets.empty()) {
             const auto& top_rowset = other.rowsets.top();
-            candidate_rowsets.push_back(top_rowset);
+            other_level_rowsets.push_back(top_rowset);
             other.rowsets.pop();
         }
     }
@@ -118,7 +118,7 @@ struct PKSizeTieredLevel {
     bool operator<(const PKSizeTieredLevel& other) const { return score < other.score; }
 
     std::priority_queue<RowsetCandidate> rowsets;
-    std::vector<RowsetCandidate> candidate_rowsets;
+    std::vector<RowsetCandidate> other_level_rowsets;
     double score = 0.0;
     int64_t compact_level = 0;
 };

--- a/be/src/storage/lake/primary_key_compaction_policy.h
+++ b/be/src/storage/lake/primary_key_compaction_policy.h
@@ -96,18 +96,17 @@ struct PKSizeTieredLevel {
         }
     }
 
-    // Merge another level's top rowset
-    void merge_top(const PKSizeTieredLevel& other) {
-        DCHECK(other.rowsets.size() == 1);
-        if (!other.rowsets.empty()) {
+    // Merge another level's rowset
+    void merge_level(PKSizeTieredLevel& other) {
+        while (!other.rowsets.empty()) {
             const auto& top_rowset = other.rowsets.top();
-            // Rowset with overlap segments shouldn't be merged here.
-            DCHECK(!top_rowset.multi_segment_with_overlapped());
             rowsets.push(top_rowset);
             score += top_rowset.score;
+            other.rowsets.pop();
         }
     }
 
+    // Add other level's rowset into candidate rowsets
     void add_candidate_rowsets(PKSizeTieredLevel& other) {
         while (!other.rowsets.empty()) {
             const auto& top_rowset = other.rowsets.top();

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -475,7 +475,10 @@ Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo&
     }
 
     if (tablet_meta_info.__isset.compaction_strategy) {
-        metadata_update_info->set_compaction_strategy(tablet_meta_info.compaction_strategy);
+        CompactionStrategyPB compaction_strategy = tablet_meta_info.compaction_strategy == TCompactionStrategy::DEFAULT
+                                                           ? CompactionStrategyPB::DEFAULT
+                                                           : CompactionStrategyPB::REAL_TIME;
+        metadata_update_info->set_compaction_strategy(compaction_strategy);
     }
 
     RETURN_IF_ERROR(tablet.put_txn_log(std::move(txn_log)));

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -474,6 +474,10 @@ Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo&
         metadata_update_info->set_bundle_tablet_metadata(tablet_meta_info.bundle_tablet_metadata);
     }
 
+    if (tablet_meta_info.__isset.compaction_strategy) {
+        metadata_update_info->set_compaction_strategy(tablet_meta_info.compaction_strategy);
+    }
+
     RETURN_IF_ERROR(tablet.put_txn_log(std::move(txn_log)));
     return Status::OK();
 }

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -196,6 +196,20 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
         }
     }
 
+    if (req.__isset.compaction_strategy) {
+        switch (req.compaction_strategy) {
+        case TCompactionStrategy::DEFAULT:
+            tablet_metadata_pb->set_compaction_strategy(CompactionStrategyPB::DEFAULT);
+            break;
+        case TCompactionStrategy::REAL_TIME:
+            tablet_metadata_pb->set_compaction_strategy(CompactionStrategyPB::REAL_TIME);
+            break;
+        default:
+            return Status::InternalError(
+                    strings::Substitute("Unknown compaction strategy, tabletId:$0", req.tablet_id));
+        }
+    }
+
     auto compress_type = req.__isset.compression_type ? req.compression_type : TCompressionType::LZ4_FRAME;
     RETURN_IF_ERROR(
             convert_t_schema_to_pb_schema(req.tablet_schema, compress_type, tablet_metadata_pb->mutable_schema()));

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -208,6 +208,8 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
             return Status::InternalError(
                     strings::Substitute("Unknown compaction strategy, tabletId:$0", req.tablet_id));
         }
+    } else {
+        tablet_metadata_pb->set_compaction_strategy(CompactionStrategyPB::DEFAULT);
     }
 
     auto compress_type = req.__isset.compression_type ? req.compression_type : TCompressionType::LZ4_FRAME;

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -88,6 +88,13 @@ Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMe
         if (alter_meta.has_bundle_tablet_metadata()) {
             // do nothing
         }
+
+        if (alter_meta.has_compaction_strategy()) {
+            LOG(INFO) << fmt::format("alter compaction strategy from {} to {} for tablet id: {}",
+                                     CompactionStrategyPB_Name(metadata->compaction_strategy()),
+                                     CompactionStrategyPB_Name(alter_meta.compaction_strategy()), metadata->id());
+            metadata->set_compaction_strategy(alter_meta.compaction_strategy());
+        }
     }
     return Status::OK();
 }

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -700,6 +700,91 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_score_by_policy) {
     config::lake_pk_compaction_max_input_rowsets = 1000;
 }
 
+TEST_P(LakePrimaryKeyCompactionTest, test_compaction_score_by_policy2) {
+    // Prepare data for writing
+    std::vector<Chunk> chunks;
+    for (int i = 0; i < 2; i++) {
+        chunks.push_back(generate_data(kChunkSize, i));
+    }
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < 2; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunks[i], indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    {
+        auto indexes2 = std::vector<uint32_t>(kChunkSize * 20);
+        for (int i = 0; i < kChunkSize * 20; i++) {
+            indexes2[i] = i;
+        }
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(generate_data(kChunkSize * 20, 0), indexes2.data(), indexes2.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    ASSERT_EQ(kChunkSize * 20, read(version));
+    ASSIGN_OR_ABORT(auto tablet_meta, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), tablet_meta, false /* force_base_compaction */));
+    config::lake_pk_compaction_max_input_rowsets = 1000;
+    ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
+    EXPECT_EQ(3, input_rowsets.size());
+    EXPECT_EQ(5, compaction_score(_tablet_mgr.get(), tablet_meta));
+
+    auto non_const_tablet_meta = const_cast<TabletMetadataPB*>(tablet_meta.get());
+    non_const_tablet_meta->set_compaction_strategy(CompactionStrategyPB::REAL_TIME);
+    ASSIGN_OR_ABORT(auto input_rowsets2, compaction_policy->pick_rowsets());
+    EXPECT_EQ(3, input_rowsets2.size());
+    EXPECT_EQ(3, compaction_score(_tablet_mgr.get(), tablet_meta));
+
+    config::lake_pk_compaction_max_input_rowsets = 2;
+    ASSIGN_OR_ABORT(auto input_rowsets3, compaction_policy->pick_rowsets());
+    EXPECT_EQ(2, input_rowsets3.size());
+    EXPECT_EQ(2, compaction_score(_tablet_mgr.get(), tablet_meta));
+
+    config::lake_pk_compaction_max_input_rowsets = 1;
+    ASSIGN_OR_ABORT(auto input_rowsets4, compaction_policy->pick_rowsets());
+    EXPECT_EQ(1, input_rowsets4.size());
+    EXPECT_EQ(1, compaction_score(_tablet_mgr.get(), tablet_meta));
+    config::lake_pk_compaction_max_input_rowsets = 1000;
+}
+
 TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {
     // Prepare data for writing
     std::vector<Chunk> chunks;

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -691,12 +691,12 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_score_by_policy) {
     config::lake_pk_compaction_max_input_rowsets = 2;
     ASSIGN_OR_ABORT(auto input_rowsets2, compaction_policy->pick_rowsets());
     EXPECT_EQ(2, input_rowsets2.size());
-    EXPECT_EQ(3, compaction_score(_tablet_mgr.get(), tablet_meta));
+    EXPECT_EQ(2, compaction_score(_tablet_mgr.get(), tablet_meta));
 
     config::lake_pk_compaction_max_input_rowsets = 1;
     ASSIGN_OR_ABORT(auto input_rowsets3, compaction_policy->pick_rowsets());
     EXPECT_EQ(1, input_rowsets3.size());
-    EXPECT_EQ(3, compaction_score(_tablet_mgr.get(), tablet_meta));
+    EXPECT_EQ(1, compaction_score(_tablet_mgr.get(), tablet_meta));
     config::lake_pk_compaction_max_input_rowsets = 1000;
 }
 
@@ -1204,7 +1204,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_size_tiered_compaction_strategy) {
     generate_test_rowsets({1000 * 1024 * 1024, 200 * 1024 * 1024, 40 * 1024 * 1024, 8 * 1024 * 1024, 1 * 1024 * 1024,
                            200 * 1024, 10 * 1024},
                           &rowset_metas, &rowset_vec);
-    ASSIGN_OR_ABORT(auto pick_level_ptr, PrimaryCompactionPolicy::pick_max_level(false, rowset_vec));
+    ASSIGN_OR_ABORT(auto pick_level_ptr, PrimaryCompactionPolicy::pick_max_level(rowset_vec));
     EXPECT_TRUE(pick_level_ptr != nullptr);
     EXPECT_EQ(pick_level_ptr->rowsets.size(), 2);
     EXPECT_EQ(pick_level_ptr->rowsets.top().rowset_index, 6);
@@ -1212,14 +1212,12 @@ TEST_P(LakePrimaryKeyCompactionTest, test_size_tiered_compaction_strategy) {
     EXPECT_EQ(pick_level_ptr->rowsets.top().rowset_index, 5);
 
     // calculate score
-    ASSIGN_OR_ABORT(pick_level_ptr, PrimaryCompactionPolicy::pick_max_level(true, rowset_vec));
+    ASSIGN_OR_ABORT(pick_level_ptr, PrimaryCompactionPolicy::pick_max_level(rowset_vec));
     EXPECT_TRUE(pick_level_ptr != nullptr);
-    EXPECT_EQ(pick_level_ptr->rowsets.size(), 7);
+    EXPECT_EQ(pick_level_ptr->rowsets.size(), 2);
     EXPECT_EQ(pick_level_ptr->rowsets.top().rowset_index, 6);
     pick_level_ptr->rowsets.pop();
     EXPECT_EQ(pick_level_ptr->rowsets.top().rowset_index, 5);
-    pick_level_ptr->rowsets.pop();
-    EXPECT_EQ(pick_level_ptr->rowsets.top().rowset_index, 4);
     rowset_metas.clear();
     rowset_vec.clear();
 
@@ -1228,7 +1226,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_size_tiered_compaction_strategy) {
     generate_test_rowsets(
             {500 * 1024 * 1024, 500 * 1024 * 1024, 400 * 1024 * 1024, 100 * 1024, 100 * 1024, 50 * 1024, 10 * 1024},
             &rowset_metas, &rowset_vec);
-    ASSIGN_OR_ABORT(pick_level_ptr, PrimaryCompactionPolicy::pick_max_level(false, rowset_vec));
+    ASSIGN_OR_ABORT(pick_level_ptr, PrimaryCompactionPolicy::pick_max_level(rowset_vec));
     EXPECT_TRUE(pick_level_ptr != nullptr);
     EXPECT_EQ(pick_level_ptr->rowsets.size(), 4);
     EXPECT_EQ(pick_level_ptr->rowsets.top().rowset_index, 6);
@@ -1247,7 +1245,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_size_tiered_compaction_strategy) {
     generate_test_rowsets(
             {400 * 1024 * 1024, 100 * 1024, 100 * 1024, 50 * 1024, 10 * 1024, 500 * 1024 * 1024, 500 * 1024 * 1024},
             &rowset_metas, &rowset_vec);
-    ASSIGN_OR_ABORT(pick_level_ptr, PrimaryCompactionPolicy::pick_max_level(false, rowset_vec));
+    ASSIGN_OR_ABORT(pick_level_ptr, PrimaryCompactionPolicy::pick_max_level(rowset_vec));
     EXPECT_TRUE(pick_level_ptr != nullptr);
     EXPECT_EQ(pick_level_ptr->rowsets.size(), 4);
     EXPECT_EQ(pick_level_ptr->rowsets.top().rowset_index, 4);
@@ -1264,7 +1262,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_size_tiered_compaction_strategy) {
     // Case-4
     // 127KB, 50KB, 10KB, 1KB, 128
     generate_test_rowsets({127 * 1024, 50 * 1024, 10 * 1024, 1024, 128}, &rowset_metas, &rowset_vec);
-    ASSIGN_OR_ABORT(pick_level_ptr, PrimaryCompactionPolicy::pick_max_level(false, rowset_vec));
+    ASSIGN_OR_ABORT(pick_level_ptr, PrimaryCompactionPolicy::pick_max_level(rowset_vec));
     EXPECT_TRUE(pick_level_ptr != nullptr);
     EXPECT_EQ(pick_level_ptr->rowsets.size(), 5);
     EXPECT_EQ(pick_level_ptr->rowsets.top().rowset_index, 4);
@@ -1285,7 +1283,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_size_tiered_compaction_strategy) {
     generate_test_rowsets(
             {400 * 1024 * 1024, 100 * 1024, 10 * 1024, 50 * 1024, 40 * 1024, 500 * 1024 * 1024, 500 * 1024 * 1024},
             &rowset_metas, &rowset_vec);
-    ASSIGN_OR_ABORT(pick_level_ptr, PrimaryCompactionPolicy::pick_max_level(false, rowset_vec));
+    ASSIGN_OR_ABORT(pick_level_ptr, PrimaryCompactionPolicy::pick_max_level(rowset_vec));
     EXPECT_TRUE(pick_level_ptr != nullptr);
     EXPECT_EQ(pick_level_ptr->rowsets.size(), 4);
     EXPECT_EQ(pick_level_ptr->rowsets.top().rowset_index, 2);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -436,7 +436,8 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
                         TTabletMetaType.PRIMARY_INDEX_CACHE_EXPIRE_SEC);
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)
-                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_FILE_BUNDLING)) {
+                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_FILE_BUNDLING)
+                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY)) {
                 if (table.isCloudNativeTable()) {
                     Locker locker = new Locker();
                     locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -231,6 +231,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                             .setTabletSchema(tabletSchema)
                             .setEnableTabletCreationOptimization(enableTabletCreationOptimization)
                             .setGtid(gtid)
+                            .setCompactionStrategy(table.getCompactionStrategy())
                             .build();
 
                     // For each partition, the schema file is created only when the first Tablet is created

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -43,6 +43,9 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
     @SerializedName(value = "enableFileBundling")
     private boolean enableFileBundling;
 
+    @SerializedName(value = "compactionStrategy")
+    private String compactionStrategy;
+
     // for deserialization
     public LakeTableAlterMetaJob() {
         super(JobType.SCHEMA_CHANGE);
@@ -52,18 +55,20 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
                                  long timeoutMs, TTabletMetaType metaType, boolean metaValue,
                                  String persistentIndexType) {
         this(jobId, dbId, tableId, tableName, timeoutMs, metaType, metaValue, persistentIndexType,
-                false);
+                false, "DEFAULT");
     }
 
     public LakeTableAlterMetaJob(long jobId, long dbId, long tableId, String tableName,
                                  long timeoutMs, TTabletMetaType metaType, boolean metaValue,
                                  String persistentIndexType,
-                                 boolean enableFileBundling) {
+                                 boolean enableFileBundling,
+                                 String compactionStrategy) {
         super(jobId, JobType.SCHEMA_CHANGE, dbId, tableId, tableName, timeoutMs);
         this.metaType = metaType;
         this.metaValue = metaValue;
         this.persistentIndexType = persistentIndexType;
         this.enableFileBundling = enableFileBundling;
+        this.compactionStrategy = compactionStrategy;
     }
 
     @Override
@@ -76,6 +81,10 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
         if (metaType == TTabletMetaType.ENABLE_FILE_BUNDLING) {
             return TabletMetadataUpdateAgentTaskFactory.createUpdateFileBundlingTask(nodeId, tablets,
                         enableFileBundling);
+        }
+        if (metaType == TTabletMetaType.COMPACTION_STRATEGY) {
+            return TabletMetadataUpdateAgentTaskFactory.createUpdateCompactionStrategyTask(nodeId, tablets,
+                        compactionStrategy);
         }
         return null;
     }
@@ -104,6 +113,11 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
         if (metaType == TTabletMetaType.ENABLE_FILE_BUNDLING) {
             table.setFileBundling(enableFileBundling);
         }
+        if (metaType == TTabletMetaType.COMPACTION_STRATEGY) {
+            table.getTableProperty().modifyTableProperties(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY,
+                    String.valueOf(compactionStrategy));
+            table.getTableProperty().buildCompactionStrategy();
+        }
     }
 
     @Override
@@ -113,6 +127,7 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
         this.metaValue = other.metaValue;
         this.persistentIndexType = other.persistentIndexType;
         this.enableFileBundling = other.enableFileBundling;
+        this.compactionStrategy = other.compactionStrategy;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -443,6 +443,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                                 .setTabletSchema(tabletSchema)
                                 .setEnableTabletCreationOptimization(enableTabletCreationOptimization)
                                 .setGtid(gtid)
+                                .setCompactionStrategy(table.getCompactionStrategy())
                                 .build();
                         // For each partition, the schema file is created only when the first Tablet is created
                         createSchemaFile = false;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2123,6 +2123,7 @@ public class SchemaChangeHandler extends AlterHandler {
             String persistentIndexType = "";
             boolean enableFileBundling = false;
             TTabletMetaType metaType = TTabletMetaType.ENABLE_PERSISTENT_INDEX;
+            String compactionStrategy = "";
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)) {
                 enablePersistentIndex = PropertyAnalyzer.analyzeBooleanProp(properties,
                         PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, false);
@@ -2165,6 +2166,10 @@ public class SchemaChangeHandler extends AlterHandler {
                     return null;
                 }
                 metaType = TTabletMetaType.ENABLE_FILE_BUNDLING;
+            } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY)) {
+                compactionStrategy = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY,
+                        TableProperty.DEFAULT_COMPACTION_STRATEGY);
+                metaType = TTabletMetaType.COMPACTION_STRATEGY;
             } else {
                 throw new DdlException("does not support alter " + properties.entrySet().iterator().next().getKey() +
                         " in shared_data mode");
@@ -2174,7 +2179,7 @@ public class SchemaChangeHandler extends AlterHandler {
             alterMetaJob = new LakeTableAlterMetaJob(GlobalStateMgr.getCurrentState().getNextId(),
                     db.getId(),
                     olapTable.getId(), olapTable.getName(), timeoutSecond * 1000 /* should be ms*/,
-                    metaType, enablePersistentIndex, persistentIndexType, enableFileBundling);
+                    metaType, enablePersistentIndex, persistentIndexType, enableFileBundling, compactionStrategy);
         } else {
             // shouldn't happen
             throw new DdlException("only support alter enable_persistent_index in shared_data mode");

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1553,7 +1553,7 @@ public class PropertyAnalyzer {
             } else if (strategy.equalsIgnoreCase(TableProperty.REAL_TIME_COMPACTION_STRATEGY)) {
                 return TCompactionStrategy.REAL_TIME;
             } else {
-                throw new AnalysisException("Invalid compaction stragety: " + strategy);
+                throw new AnalysisException("Invalid compaction strategy: " + strategy);
             }
         }
         return TCompactionStrategy.DEFAULT;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -91,6 +91,7 @@ import com.starrocks.sql.optimizer.rule.transformation.partition.PartitionSelect
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TCompactionStrategy;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TStorageMedium;
@@ -256,6 +257,8 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_DEFAULT_PREFIX = "default.";
 
     public static final String PROPERTIES_FILE_BUNDLING = "file_bundling";
+
+    public static final String PROPERTIES_COMPACTION_STRATEGY = "compaction_strategy";
 
     /**
      * Matches location labels like : ["*", "a:*", "bcd_123:*", "123bcd_:val_123", "  a :  b  "],
@@ -1539,6 +1542,21 @@ public class PropertyAnalyzer {
         }
         return Config.enable_cloud_native_persistent_index_by_default ? TPersistentIndexType.CLOUD_NATIVE
                 : TPersistentIndexType.LOCAL;
+    }
+
+    public static TCompactionStrategy analyzecompactionStrategy(Map<String, String> properties) throws AnalysisException {
+        if (properties != null && properties.containsKey(PROPERTIES_COMPACTION_STRATEGY)) {
+            String type = properties.get(PROPERTIES_COMPACTION_STRATEGY);
+            properties.remove(PROPERTIES_COMPACTION_STRATEGY);
+            if (type.equalsIgnoreCase(TableProperty.DEFAULT_COMPACTION_STRATEGY)) {
+                return TCompactionStrategy.DEFAULT;
+            } else if (type.equalsIgnoreCase(TableProperty.REAL_TIME_COMPACTION_STRATEGY)) {
+                return TCompactionStrategy.REAL_TIME;
+            } else {
+                throw new AnalysisException("Invalid compaction stragety");
+            }
+        }
+        return TCompactionStrategy.DEFAULT;
     }
 
     public static PeriodDuration analyzeStorageCoolDownTTL(Map<String, String> properties,

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1546,14 +1546,14 @@ public class PropertyAnalyzer {
 
     public static TCompactionStrategy analyzecompactionStrategy(Map<String, String> properties) throws AnalysisException {
         if (properties != null && properties.containsKey(PROPERTIES_COMPACTION_STRATEGY)) {
-            String type = properties.get(PROPERTIES_COMPACTION_STRATEGY);
+            String strategy = properties.get(PROPERTIES_COMPACTION_STRATEGY);
             properties.remove(PROPERTIES_COMPACTION_STRATEGY);
-            if (type.equalsIgnoreCase(TableProperty.DEFAULT_COMPACTION_STRATEGY)) {
+            if (strategy.equalsIgnoreCase(TableProperty.DEFAULT_COMPACTION_STRATEGY)) {
                 return TCompactionStrategy.DEFAULT;
-            } else if (type.equalsIgnoreCase(TableProperty.REAL_TIME_COMPACTION_STRATEGY)) {
+            } else if (strategy.equalsIgnoreCase(TableProperty.REAL_TIME_COMPACTION_STRATEGY)) {
                 return TCompactionStrategy.REAL_TIME;
             } else {
-                throw new AnalysisException("Invalid compaction stragety");
+                throw new AnalysisException("Invalid compaction stragety: " + strategy);
             }
         }
         return TCompactionStrategy.DEFAULT;

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -389,7 +389,7 @@ public class OlapTableFactory implements AbstractTableFactory {
                 // REAL_TIME strategy only work for primary key table right now, so set compaction strategy to DEFAULT
                 // if table is not primary key table.
                 if (table.getKeysType() != KeysType.PRIMARY_KEYS && compactionStrategy != TCompactionStrategy.DEFAULT) {
-                    throw new DdlException("non-pk table only support default compaction strategy right now");
+                    throw new DdlException("Only default compaction strategy is allowed for non-pk table.");
                 }
                 table.setCompactionStrategy(compactionStrategy);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -68,6 +68,7 @@ import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.thrift.TCompactionStrategy;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TStorageType;
@@ -376,6 +377,16 @@ public class OlapTableFactory implements AbstractTableFactory {
                             "when ComputeNode without storage_path, nodeId:" + cnUnSetStoragePath);
                 }
                 table.setPersistentIndexType(persistentIndexType);
+            }
+
+            if (table.isCloudNativeTable()) {
+                TCompactionStrategy compactionStrategy;
+                try {
+                    compactionStrategy = PropertyAnalyzer.analyzecompactionStrategy(properties);
+                } catch (AnalysisException e) {
+                    throw new DdlException(e.getMessage());
+                }
+                table.setCompactionStrategy(compactionStrategy);
             }
 
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -386,6 +386,11 @@ public class OlapTableFactory implements AbstractTableFactory {
                 } catch (AnalysisException e) {
                     throw new DdlException(e.getMessage());
                 }
+                // REAL_TIME strategy only work for primary key table right now, so set compaction strategy to DEFAULT
+                // if table is not primary key table.
+                if (table.getKeysType() != KeysType.PRIMARY_KEYS && compactionStrategy != TCompactionStrategy.DEFAULT) {
+                    throw new DdlException("non-pk table only support default compaction strategy right now");
+                }
                 table.setCompactionStrategy(compactionStrategy);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -415,6 +415,12 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                                     " haven't been enabled");
                 }
             }
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY)) {
+            if (!properties.get(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY).equalsIgnoreCase("default") &&
+                    !properties.get(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY).equalsIgnoreCase("real_time")) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "unknown compaction strategy: " + 
+                            properties.get(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY));
+            }
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -421,16 +421,16 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "unknown compaction strategy: " + 
                             properties.get(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY));
             }
-            if (!table.isCloudNativeTable()) {
+            if (!table.isCloudNativeTableOrMaterializedView()) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
                             "Property " + PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY +
-                                    " only support cloud native table");
+                                    " can be only set to the cloud native table");
             }
 
             OlapTable olapTable = (OlapTable) table;
             if (olapTable.getKeysType() != KeysType.PRIMARY_KEYS) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "only primary key table support change " + 
-                            "compaction strategy right now");
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "The compaction strategy can be only " +
+                            "update for a primary key table. ");
             }
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -421,6 +421,17 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "unknown compaction strategy: " + 
                             properties.get(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY));
             }
+            if (!table.isCloudNativeTable()) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                            "Property " + PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY +
+                                    " only support cloud native table");
+            }
+
+            OlapTable olapTable = (OlapTable) table;
+            if (olapTable.getKeysType() != KeysType.PRIMARY_KEYS) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "only primary key table support change " + 
+                            "compaction strategy right now");
+            }
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -40,6 +40,7 @@ import com.starrocks.catalog.FlatJsonConfig;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.thrift.TBinlogConfig;
+import com.starrocks.thrift.TCompactionStrategy;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TCreateTabletReq;
 import com.starrocks.thrift.TFlatJsonConfig;
@@ -89,6 +90,7 @@ public class CreateReplicaTask extends AgentTask {
     private final TTabletSchema tabletSchema;
     private long gtid = 0;
     private long timeoutMs = -1;
+    private TCompactionStrategy compactionStrategy = TCompactionStrategy.DEFAULT;
 
     private CreateReplicaTask(Builder builder) {
         super(null, builder.getNodeId(), TTaskType.CREATE, builder.getDbId(), builder.getTableId(),
@@ -112,6 +114,7 @@ public class CreateReplicaTask extends AgentTask {
         this.inRestoreMode = builder.isInRestoreMode();
         this.gtid = builder.getGtid();
         this.timeoutMs = builder.getTimeoutMs();
+        this.compactionStrategy = builder.getCompactionStrategy();
     }
 
     public static Builder newBuilder() {
@@ -195,6 +198,9 @@ public class CreateReplicaTask extends AgentTask {
         createTabletReq.setEnable_tablet_creation_optimization(enableTabletCreationOptimization);
         createTabletReq.setGtid(gtid);
         createTabletReq.setTimeout_ms(timeoutMs);
+        if (compactionStrategy != null) {
+            createTabletReq.setCompaction_strategy(compactionStrategy);
+        }
         return createTabletReq;
     }
 
@@ -226,6 +232,7 @@ public class CreateReplicaTask extends AgentTask {
         private TTabletSchema tabletSchema;
         private long gtid = 0;
         private long timeoutMs = -1;
+        private TCompactionStrategy compactionStrategy = TCompactionStrategy.DEFAULT;
 
         private Builder() {
         }
@@ -452,6 +459,15 @@ public class CreateReplicaTask extends AgentTask {
 
         public Builder setTimeoutMs(long timeoutMs) {
             this.timeoutMs = timeoutMs;
+            return this;
+        }
+
+        public TCompactionStrategy getCompactionStrategy() {
+            return compactionStrategy;
+        }
+
+        public Builder setCompactionStrategy(TCompactionStrategy compactionStrategy) {
+            this.compactionStrategy = compactionStrategy;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -287,6 +287,7 @@ public class TabletTaskExecutor {
                         .setCreateSchemaFile(createSchemaFile)
                         .setEnableTabletCreationOptimization(option.isEnableTabletCreationOptimization())
                         .setGtid(option.getGtid())
+                        .setCompactionStrategy(table.getCompactionStrategy())
                         .build();
                 tasks.add(task);
                 createSchemaFile = false;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -540,7 +540,7 @@ public class LakeTableAlterMetaJobTest {
                         "CREATE TABLE non_pk(c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
                         "PROPERTIES('compaction_strategy'='real_time')");
         } catch (Exception e) {
-            Assertions.assertTrue(e.getMessage().contains("only support default compaction strategy"));
+            Assertions.assertTrue(e.getMessage().contains("Only default compaction strategy is allowed"));
         }
 
         try {
@@ -550,7 +550,7 @@ public class LakeTableAlterMetaJobTest {
             AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr, connectContext);
             DDLStmtExecutor.execute(alterTableStmt, connectContext);
         } catch (Exception e) {
-            Assertions.assertTrue(e.getMessage().contains("only primary key table support change compaction strategy"));
+            Assertions.assertTrue(e.getMessage().contains("can be only update for a primary key table"));
         }
     
         LakeTable table2 = createTable(connectContext,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -22,6 +22,7 @@ import com.staros.proto.StarStatus;
 import com.staros.proto.StatusCode;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -42,6 +43,7 @@ import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
 import com.starrocks.task.TabletMetadataUpdateAgentTask;
 import com.starrocks.task.TabletMetadataUpdateAgentTaskFactory;
+import com.starrocks.thrift.TCompactionStrategy;
 import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TTabletMetaType;
 import com.starrocks.thrift.TTabletType;
@@ -529,5 +531,49 @@ public class LakeTableAlterMetaJobTest {
         }
         Assertions.assertEquals(AlterJobV2.JobState.FINISHED, job2.getJobState());
         Assertions.assertFalse(table2.isFileBundling());
+    }
+
+    @Test
+    public void testModifyPropertyCompactionStrategy() throws Exception {
+        LakeTable table2 = createTable(connectContext,
+                    "CREATE TABLE t13(c0 INT) PRIMARY KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1");
+        Assert.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.DEFAULT);
+        try {
+            String alterStmtStr = "alter table test.t13 set ('compaction_strategy'='unknown')";
+            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr, connectContext);
+            DDLStmtExecutor.execute(alterTableStmt, connectContext);
+        } catch (Exception e) {
+            Assert.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.DEFAULT);
+        }
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("compaction_strategy", "real_time");
+        ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+        AlterJobV2 job = schemaChangeHandler.createAlterMetaJob(modify, db, table2);
+        Assert.assertNotNull(job);
+        Assert.assertEquals(AlterJobV2.JobState.PENDING, job.getJobState());
+        job.runPendingJob();
+        Assert.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
+        Assert.assertNotEquals(-1L, job.getTransactionId().orElse(-1L).longValue());
+        job.runRunningJob();
+        Assert.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+        while (job.getJobState() != AlterJobV2.JobState.FINISHED) {
+            job.runFinishedRewritingJob();
+            Thread.sleep(100);
+        }
+        Assert.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
+        Assert.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.REAL_TIME);
+        try {
+            String alterStmtStr = "alter table test.t13 set ('compaction_strategy'='DEFAULT')";
+            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr, connectContext);
+            DDLStmtExecutor.execute(alterTableStmt, connectContext);
+        } catch (Exception e) {
+            Assert.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.REAL_TIME);
+        }
+        while (table2.getState() != OlapTable.OlapTableState.NORMAL) {
+            Thread.sleep(100);
+        }
+        Assert.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.DEFAULT);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -535,6 +535,24 @@ public class LakeTableAlterMetaJobTest {
 
     @Test
     public void testModifyPropertyCompactionStrategy() throws Exception {
+        try {
+            LakeTable nonPKTable = createTable(connectContext,
+                        "CREATE TABLE non_pk(c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                        "PROPERTIES('compaction_strategy'='real_time')");
+        } catch (Exception e) {
+            Assertions.assertTrue(e.getMessage().contains("only support default compaction strategy"));
+        }
+
+        try {
+            LakeTable nonPKTable = createTable(connectContext,
+                        "CREATE TABLE non_pk(c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1");
+            String alterStmtStr = "alter table test.non_pk set ('compaction_strategy'='real_time')";
+            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr, connectContext);
+            DDLStmtExecutor.execute(alterTableStmt, connectContext);
+        } catch (Exception e) {
+            Assertions.assertTrue(e.getMessage().contains("only primary key table support change compaction strategy"));
+        }
+    
         LakeTable table2 = createTable(connectContext,
                     "CREATE TABLE t13(c0 INT) PRIMARY KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1");
         Assertions.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.DEFAULT);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -537,13 +537,13 @@ public class LakeTableAlterMetaJobTest {
     public void testModifyPropertyCompactionStrategy() throws Exception {
         LakeTable table2 = createTable(connectContext,
                     "CREATE TABLE t13(c0 INT) PRIMARY KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1");
-        Assert.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.DEFAULT);
+        Assertions.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.DEFAULT);
         try {
             String alterStmtStr = "alter table test.t13 set ('compaction_strategy'='unknown')";
             AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr, connectContext);
             DDLStmtExecutor.execute(alterTableStmt, connectContext);
         } catch (Exception e) {
-            Assert.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.DEFAULT);
+            Assertions.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.DEFAULT);
         }
 
         Map<String, String> properties = new HashMap<>();
@@ -551,29 +551,29 @@ public class LakeTableAlterMetaJobTest {
         ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
         SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
         AlterJobV2 job = schemaChangeHandler.createAlterMetaJob(modify, db, table2);
-        Assert.assertNotNull(job);
-        Assert.assertEquals(AlterJobV2.JobState.PENDING, job.getJobState());
+        Assertions.assertNotNull(job);
+        Assertions.assertEquals(AlterJobV2.JobState.PENDING, job.getJobState());
         job.runPendingJob();
-        Assert.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
-        Assert.assertNotEquals(-1L, job.getTransactionId().orElse(-1L).longValue());
+        Assertions.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
+        Assertions.assertNotEquals(-1L, job.getTransactionId().orElse(-1L).longValue());
         job.runRunningJob();
-        Assert.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
         while (job.getJobState() != AlterJobV2.JobState.FINISHED) {
             job.runFinishedRewritingJob();
             Thread.sleep(100);
         }
-        Assert.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
-        Assert.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.REAL_TIME);
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
+        Assertions.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.REAL_TIME);
         try {
             String alterStmtStr = "alter table test.t13 set ('compaction_strategy'='DEFAULT')";
             AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr, connectContext);
             DDLStmtExecutor.execute(alterTableStmt, connectContext);
         } catch (Exception e) {
-            Assert.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.REAL_TIME);
+            Assertions.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.REAL_TIME);
         }
         while (table2.getState() != OlapTable.OlapTableState.NORMAL) {
             Thread.sleep(100);
         }
-        Assert.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.DEFAULT);
+        Assertions.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.DEFAULT);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
@@ -354,7 +354,7 @@ public class PropertyAnalyzerTest {
             property4.put(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY, "BATCH");
             TCompactionStrategy strategy = PropertyAnalyzer.analyzecompactionStrategy(property4);
         } catch (AnalysisException e) {
-            Assertions.assertTrue(e.getMessage().contains("Invalid compaction stragety: BATCH"));
+            Assertions.assertTrue(e.getMessage().contains("Invalid compaction strategy: BATCH"));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
@@ -47,6 +47,7 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.RunMode;
+import com.starrocks.thrift.TCompactionStrategy;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TStorageMedium;
@@ -332,5 +333,28 @@ public class PropertyAnalyzerTest {
                 "Does not support the table property \"version_info\" in share data mode, please remove " +
                         "it from the statement", () ->
                     PropertyAnalyzer.analyzeVersionInfo(properties));
+    }
+
+    @Test
+    public void testAnalyzeCompactionStrategy() {
+        // empty property
+        try {
+            Map<String, String> property = new HashMap<>();
+            Assert.assertEquals(TCompactionStrategy.DEFAULT, PropertyAnalyzer.analyzecompactionStrategy(property));
+
+            Map<String, String> property2 = new HashMap<>();
+            property2.put(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY, "DEFAULT");
+            Assert.assertEquals(TCompactionStrategy.DEFAULT, PropertyAnalyzer.analyzecompactionStrategy(property2));
+
+            Map<String, String> property3 = new HashMap<>();
+            property3.put(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY, "REAL_TIME");
+            Assert.assertEquals(TCompactionStrategy.REAL_TIME, PropertyAnalyzer.analyzecompactionStrategy(property3));
+
+            Map<String, String> property4 = new HashMap<>();
+            property4.put(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY, "BATCH");
+            TCompactionStrategy strategy = PropertyAnalyzer.analyzecompactionStrategy(property4);
+        } catch (AnalysisException e) {
+            Assert.assertTrue(e.getMessage().contains("Invalid compaction stragety: BATCH"));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
@@ -340,21 +340,21 @@ public class PropertyAnalyzerTest {
         // empty property
         try {
             Map<String, String> property = new HashMap<>();
-            Assert.assertEquals(TCompactionStrategy.DEFAULT, PropertyAnalyzer.analyzecompactionStrategy(property));
+            Assertions.assertEquals(TCompactionStrategy.DEFAULT, PropertyAnalyzer.analyzecompactionStrategy(property));
 
             Map<String, String> property2 = new HashMap<>();
             property2.put(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY, "DEFAULT");
-            Assert.assertEquals(TCompactionStrategy.DEFAULT, PropertyAnalyzer.analyzecompactionStrategy(property2));
+            Assertions.assertEquals(TCompactionStrategy.DEFAULT, PropertyAnalyzer.analyzecompactionStrategy(property2));
 
             Map<String, String> property3 = new HashMap<>();
             property3.put(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY, "REAL_TIME");
-            Assert.assertEquals(TCompactionStrategy.REAL_TIME, PropertyAnalyzer.analyzecompactionStrategy(property3));
+            Assertions.assertEquals(TCompactionStrategy.REAL_TIME, PropertyAnalyzer.analyzecompactionStrategy(property3));
 
             Map<String, String> property4 = new HashMap<>();
             property4.put(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY, "BATCH");
             TCompactionStrategy strategy = PropertyAnalyzer.analyzecompactionStrategy(property4);
         } catch (AnalysisException e) {
-            Assert.assertTrue(e.getMessage().contains("Invalid compaction stragety: BATCH"));
+            Assertions.assertTrue(e.getMessage().contains("Invalid compaction stragety: BATCH"));
         }
     }
 }

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -130,6 +130,11 @@ enum PersistentIndexTypePB {
     CLOUD_NATIVE = 1;
 }
 
+enum CompactionStrategyPB {
+    DEFAULT = 0;
+    REAL_TIME = 1;
+}
+
 message TabletMetadataPB {
     optional int64 id = 1;
     optional int64 version = 2;
@@ -166,6 +171,8 @@ message TabletMetadataPB {
     map<uint32, int64> rowset_to_schema = 18;
     // global transaction id
     optional int64 gtid = 19 [default=0];
+    // compaction strategy
+    optional CompactionStrategyPB compaction_strategy = 20;
 }
 
 message MetadataUpdateInfoPB {
@@ -174,6 +181,7 @@ message MetadataUpdateInfoPB {
     optional TabletSchemaPB tablet_schema = 2;
     optional PersistentIndexTypePB persistent_index_type = 3;
     optional bool bundle_tablet_metadata = 4;
+    optional CompactionStrategyPB compaction_strategy = 5;
 }
 
 message BundleTabletMetadataPB {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -96,6 +96,11 @@ enum TPersistentIndexType {
     CLOUD_NATIVE = 1
 }
 
+enum TCompactionStrategy {
+    DEFAULT = 0
+    REAL_TIME = 1
+}
+
 struct TCreateTabletReq {
     1: required Types.TTabletId tablet_id
     2: required TTabletSchema tablet_schema
@@ -130,6 +135,7 @@ struct TCreateTabletReq {
     // Global transaction id
     24: optional i64 gtid = 0;
     25: optional TFlatJsonConfig flat_json_config;
+    26: optional TCompactionStrategy compaction_strategy;
 }
 
 struct TDropTabletReq {
@@ -438,7 +444,8 @@ enum TTabletMetaType {
     ENABLE_LOAD_PROFILE,
     BASE_COMPACTION_FORBIDDEN_TIME_RANGES,
     FLAT_JSON_CONFIG,
-    ENABLE_FILE_BUNDLING
+    ENABLE_FILE_BUNDLING,
+    COMPACTION_STRATEGY
 }
 
 struct TTabletMetaInfo {
@@ -456,6 +463,7 @@ struct TTabletMetaInfo {
     11: optional TPersistentIndexType persistent_index_type;
     12: optional TFlatJsonConfig flat_json_config;
     13: optional bool bundle_tablet_metadata;
+    14: optional TCompactionStrategy compaction_strategy;
 }
 
 struct TUpdateTabletMetaInfoReq {


### PR DESCRIPTION
## Why I'm doing:
After enabling `file_bundling`, we have reduced the number of API calls generated during imports and compaction by 60%. However, in real-time scenarios, compaction is triggered very frequently. In test scenarios, the number of compactions is roughly equivalent to the number of imports (with a 10-second import interval). Since all tables in StarRocks use a unified compaction strategy, it is difficult to handle multiple different user scenarios simultaneously. For example, the compaction strategy preferences for large batch imports and real-time import scenarios differ. Therefore, this PR supports setting different compaction strategies for different tables, enabling support for more scenarios.

## What I'm doing:
1. Introduced the compaction_strategy property to support configuring different compaction strategies. Currently supports two strategies: DEFAULT and REAL_TIME, with DEFAULT as the default to maintain historical behavior.
2. REAL_TIME is suitable for real-time import scenarios. Under the REAL_TIME strategy, there are several behavioral changes compared to historical implementations:
    - Modified the compaction score calculation strategy for PK tables. In `REAL_TIME` strategy, the impact of `update_compaction_delvec_file_io_amp_ratio` on score calculation is removed.
    -  When calculating the compaction score for PK tables under the `REAL_TIME` strategy, scores are also computed hierarchically based on rowset size.
    - Under the `REAL_TIME` strategy, PK tables allow partial rowset cross-level merging. When executing a compaction task, the rowset level with the highest score is selected first, and rowsets from levels with smaller rowset sizes are also merged into it.

## Test Result
use table `store_sales` in TPCDS as test table:
```
CREATE TABLE `store_sales` (
  `ss_item_sk` int(11) NOT NULL COMMENT "",
  `ss_ticket_number` int(11) NOT NULL COMMENT "",
  `ss_sold_date_sk` int(11) NULL COMMENT "",
  `ss_sold_time_sk` int(11) NULL COMMENT "",
  `ss_customer_sk` int(11) NULL COMMENT "",
  `ss_cdemo_sk` int(11) NULL COMMENT "",
  `ss_hdemo_sk` int(11) NULL COMMENT "",
  `ss_addr_sk` int(11) NULL COMMENT "",
  `ss_store_sk` int(11) NULL COMMENT "",
  `ss_promo_sk` int(11) NULL COMMENT "",
  `ss_quantity` int(11) NULL COMMENT "",
  `ss_wholesale_cost` decimal(7, 2) NULL COMMENT "",
  `ss_list_price` decimal(7, 2) NULL COMMENT "",
  `ss_sales_price` decimal(7, 2) NULL COMMENT "",
  `ss_ext_discount_amt` decimal(7, 2) NULL COMMENT "",
  `ss_ext_sales_price` decimal(7, 2) NULL COMMENT "",
  `ss_ext_wholesale_cost` decimal(7, 2) NULL COMMENT "",
  `ss_ext_list_price` decimal(7, 2) NULL COMMENT "",
  `ss_ext_tax` decimal(7, 2) NULL COMMENT "",
  `ss_coupon_amt` decimal(7, 2) NULL COMMENT "",
  `ss_net_paid` decimal(7, 2) NULL COMMENT "",
  `ss_net_paid_inc_tax` decimal(7, 2) NULL COMMENT "",
  `ss_net_profit` decimal(7, 2) NULL COMMENT ""
) ENGINE=OLAP
PRIMARY KEY(`ss_item_sk`, `ss_ticket_number`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`ss_item_sk`, `ss_ticket_number`) BUCKETS 3
PROPERTIES (
"compression" = "LZ4",
"datacache.enable" = "true",
"enable_async_write_back" = "false",
"enable_persistent_index" = "true",
"persistent_index_type" = "CLOUD_NATIVE",
"replication_num" = "1",
"storage_volume" = "builtin_storage_volume",
"compaction_strategy" = "REAL_TIME" 
);
``` 
Import 6,000 rows of data every 10 seconds for 60 consecutive minutes, and execute the query during the import:
```
select count(1) from store_sales2 where ss_sold_date_sk=2451634;
```
Statistic the query time consumption, the number of compactions, and the write amplification of compactions.

The following is test result:

### query cost time：
1. enable starlet cache:
    
![image](https://github.com/user-attachments/assets/e6f011b3-d69b-4be7-aac6-477136c75848)

| compaction strategy | compaction times | compaction write bytes |
| ---- | ---- | ---- |
| default | 272 | 633174015 |
| real_time | 35 | 228015297 |

2. disable starlet cache:

![image](https://github.com/user-attachments/assets/ed7838d1-086a-4828-b909-18611e98e10d)
| compaction strategy | compaction times | compaction write bytes |
| ---- | ---- | ---- |
| default | 258 | 576481031 |
| real_time | 36 | 228015297 |

#### summary
1. The `REAL_TIME` strategy results in fewer compaction executions and less byte writes in real-time scenarios, reducing API calls and performance consumption.  

2. The query performance under the `REAL_TIME` strategy in real-time scenarios is basically consistent with that of the `DEFAULT` strategy.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
