### PR TITLE
[BugFix] Fix task run replay state which will ignore SKIPPED state(backport #60370)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -769,8 +769,7 @@ public class TaskManager implements MemoryTrackable {
                 LOG.warn("Illegal TaskRun queryId:{} status transform from {} to {}",
                         statusChange.getQueryId(), fromStatus, toStatus);
             }
-        } else if (fromStatus == Constants.TaskRunState.RUNNING &&
-                (toStatus == Constants.TaskRunState.SUCCESS || toStatus == Constants.TaskRunState.FAILED)) {
+        } else if (fromStatus == Constants.TaskRunState.RUNNING && toStatus.isFinishState()) {
             // NOTE: TaskRuns before the fe restart will be replayed in `replayCreateTaskRun` which
             // will not be rerun because `InsertOverwriteJobRunner.replayStateChange` will replay, so
             // the taskRun's may be PENDING/RUNNING/SUCCESS.


### PR DESCRIPTION
## Why I'm doing:

#59920 introduced `SKIPPED` state, but it will be ignored in replaying from `RUNNING` to `SKIPPED`.


It will cause the final state of `TaskRun` be null if it's Skipped.
```
2025-06-27 10:43:34.498+08:00 WARN (global_state_checkpoint_worker|178) [TaskManager.replayUpdateTaskRun():802] Illegal TaskRun queryId:0197ac96-7cbb-729c-b938-a24d56c844e1 status transform from RUNNING to SKIPPED

```


## What I'm doing:
backport https://github.com/StarRocks/starrocks/pull/60370

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

