### PR TITLE
[BugFix] [UT] Fix task run replay ignoring SKIPPED state

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -769,8 +769,7 @@ public class TaskManager implements MemoryTrackable {
                 LOG.warn("Illegal TaskRun queryId:{} status transform from {} to {}",
                         statusChange.getQueryId(), fromStatus, toStatus);
             }
-        } else if (fromStatus == Constants.TaskRunState.RUNNING &&
-                (toStatus == Constants.TaskRunState.SUCCESS || toStatus == Constants.TaskRunState.FAILED)) {
+        } else if (fromStatus == Constants.TaskRunState.RUNNING && toStatus.isFinishState()) {
             // NOTE: TaskRuns before the fe restart will be replayed in `replayCreateTaskRun` which
             // will not be rerun because `InsertOverwriteJobRunner.replayStateChange` will replay, so
             // the taskRun's may be PENDING/RUNNING/SUCCESS.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatusChange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatusChange.java
@@ -134,8 +134,6 @@ public class TaskRunStatusChange implements Writable {
         return GsonUtils.GSON.fromJson(json, TaskRunStatusChange.class);
     }
 
-
-
     @Override
     public String toString() {
         return "TaskRunStatus{" +

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerTest.java
@@ -18,6 +18,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.DefaultWarehouse;
@@ -127,8 +129,8 @@ public class TaskRunManagerTest {
     }
 
     private Map<String, String> makeMVTaskRunProperties(String partitionStart,
-                                                      String partitionEnd,
-                                                      boolean isForce) {
+                                                        String partitionEnd,
+                                                        boolean isForce) {
         Map<String, String> result = Maps.newHashMap();
         result.put(TaskRun.PARTITION_START, partitionStart);
         result.put(TaskRun.PARTITION_END, partitionEnd);
@@ -189,5 +191,663 @@ public class TaskRunManagerTest {
             ExecuteOption option2 = makeExecuteOption(true, false, 2, prop2);
             Assert.assertTrue(option1.isMergeableWith(option2));
         }
+    }
+
+    @Test
+    public void testReplayCreateTaskRunWithExpiredFinishState() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setState(Constants.TaskRunState.SUCCESS);
+        status.setExpireTime(System.currentTimeMillis() - 1000); // Expired
+
+        // Should return early without processing
+        taskManager.replayCreateTaskRun(status);
+
+        // Verify no task runs were added
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+    }
+
+    @Test
+    public void testReplayCreateTaskRunPendingState() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.PENDING);
+        status.setExpireTime(System.currentTimeMillis() + 3600000); // Not expired
+
+        taskManager.replayCreateTaskRun(status);
+
+        // Verify task run was added to pending queue
+        Assert.assertEquals(1, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+    }
+
+    @Test
+    public void testReplayCreateTaskRunPendingStateWithNullTask() {
+        TaskManager taskManager = new TaskManager();
+        // Don't create the task
+
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("non_existent_task");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.PENDING);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+
+        taskManager.replayCreateTaskRun(status);
+
+        // Should not add anything since task doesn't exist
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+    }
+
+    @Test
+    public void testReplayCreateTaskRunRunningState() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.RUNNING);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+
+        taskManager.replayCreateTaskRun(status);
+
+        // Should be marked as FAILED and added to history
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        // Verify it was added to history with FAILED state
+        List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
+        Assert.assertEquals(1, history.size());
+        Assert.assertEquals(Constants.TaskRunState.FAILED, history.get(0).getState());
+    }
+
+    @Test
+    public void testReplayCreateTaskRunFailedState() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.FAILED);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+
+        taskManager.replayCreateTaskRun(status);
+
+        // Should be added to history
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
+        Assert.assertEquals(1, history.size());
+        Assert.assertEquals(Constants.TaskRunState.FAILED, history.get(0).getState());
+    }
+
+    @Test
+    public void testReplayCreateTaskRunMergedState() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.MERGED);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+
+        taskManager.replayCreateTaskRun(status);
+
+        // Should be added to history with progress 100
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
+        Assert.assertEquals(1, history.size());
+        Assert.assertEquals(Constants.TaskRunState.MERGED, history.get(0).getState());
+        Assert.assertEquals(100, history.get(0).getProgress());
+    }
+
+    @Test
+    public void testReplayCreateTaskRunSuccessState() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.SUCCESS);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+
+        taskManager.replayCreateTaskRun(status);
+
+        // Should be added to history with progress 100
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
+        Assert.assertEquals(1, history.size());
+        Assert.assertEquals(Constants.TaskRunState.SUCCESS, history.get(0).getState());
+        Assert.assertEquals(100, history.get(0).getProgress());
+    }
+
+    @Test
+    public void testReplayCreateTaskRunSkippedState() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.SKIPPED);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+
+        taskManager.replayCreateTaskRun(status);
+
+        // Should be added to history with progress 0
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
+        Assert.assertEquals(1, history.size());
+        Assert.assertEquals(Constants.TaskRunState.SKIPPED, history.get(0).getState());
+        Assert.assertEquals(0, history.get(0).getProgress());
+    }
+
+    @Test
+    public void testReplayUpdateTaskRunPendingToRunning() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        // First create a pending task run
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.PENDING);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+        taskManager.replayCreateTaskRun(status);
+
+        // Now update it from PENDING to RUNNING
+        TaskRunStatusChange change = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
+        taskManager.replayUpdateTaskRun(change);
+
+        // Should be moved from pending to running
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(1, taskManager.getTaskRunScheduler().getRunningTaskCount());
+    }
+
+    @Test
+    public void testReplayUpdateTaskRunPendingToMerged() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        // First create a pending task run
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.PENDING);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+        taskManager.replayCreateTaskRun(status);
+
+        // Now update it from PENDING to MERGED
+        TaskRunStatusChange change = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.MERGED);
+        change.setErrorMessage("Merged by other task");
+        change.setErrorCode(0);
+        change.setFinishTime(System.currentTimeMillis());
+        taskManager.replayUpdateTaskRun(change);
+
+        // Should be removed from pending and added to history
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
+        Assert.assertEquals(1, history.size());
+        Assert.assertEquals(Constants.TaskRunState.MERGED, history.get(0).getState());
+        Assert.assertEquals(100, history.get(0).getProgress());
+        Assert.assertEquals("Merged by other task", history.get(0).getErrorMessage());
+    }
+
+    @Test
+    public void testReplayUpdateTaskRunPendingToFailed() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        // First create a pending task run
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.PENDING);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+        taskManager.replayCreateTaskRun(status);
+
+        // Now update it from PENDING to FAILED
+        TaskRunStatusChange change = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.FAILED);
+        change.setErrorMessage("Task failed");
+        change.setErrorCode(-1);
+        taskManager.replayUpdateTaskRun(change);
+
+        // Should be removed from pending and added to history
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
+        Assert.assertEquals(1, history.size());
+        Assert.assertEquals(Constants.TaskRunState.FAILED, history.get(0).getState());
+        Assert.assertEquals("Task failed", history.get(0).getErrorMessage());
+        Assert.assertEquals(-1, history.get(0).getErrorCode());
+    }
+
+    @Test
+    public void testReplayUpdateTaskRunPendingToSuccess() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        // First create a pending task run
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.PENDING);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+        taskManager.replayCreateTaskRun(status);
+
+        // Now update it from PENDING to SUCCESS
+        TaskRunStatusChange change = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.SUCCESS);
+        taskManager.replayUpdateTaskRun(change);
+
+        // Should be removed from pending and added to history
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
+        Assert.assertEquals(1, history.size());
+        Assert.assertEquals(Constants.TaskRunState.SUCCESS, history.get(0).getState());
+    }
+
+    @Test
+    public void testReplayUpdateTaskRunRunningToFailed() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        // First create a pending task run and move it to running
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.PENDING);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+        taskManager.replayCreateTaskRun(status);
+
+        TaskRunStatusChange changeToRunning = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
+        taskManager.replayUpdateTaskRun(changeToRunning);
+
+        // Now update it from RUNNING to FAILED
+        TaskRunStatusChange changeToFailed = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.RUNNING, Constants.TaskRunState.FAILED);
+        changeToFailed.setErrorMessage("Task failed during execution");
+        changeToFailed.setErrorCode(-2);
+        changeToFailed.setFinishTime(System.currentTimeMillis());
+        changeToFailed.setExtraMessage("Extra error info");
+        taskManager.replayUpdateTaskRun(changeToFailed);
+
+        // Should be removed from running and added to history
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
+        Assert.assertEquals(1, history.size());
+        Assert.assertEquals(Constants.TaskRunState.FAILED, history.get(0).getState());
+        Assert.assertEquals("Task failed during execution", history.get(0).getErrorMessage());
+        Assert.assertEquals(-2, history.get(0).getErrorCode());
+        Assert.assertEquals("Extra error info", history.get(0).getExtraMessage());
+        Assert.assertEquals(100, history.get(0).getProgress());
+    }
+
+    @Test
+    public void testReplayUpdateTaskRunRunningToSuccess() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        // First create a pending task run and move it to running
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.PENDING);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+        taskManager.replayCreateTaskRun(status);
+
+        TaskRunStatusChange changeToRunning = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
+        taskManager.replayUpdateTaskRun(changeToRunning);
+
+        // Now update it from RUNNING to SUCCESS
+        TaskRunStatusChange changeToSuccess = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.RUNNING, Constants.TaskRunState.SUCCESS);
+        changeToSuccess.setFinishTime(System.currentTimeMillis());
+        changeToSuccess.setExtraMessage("Task completed successfully");
+        taskManager.replayUpdateTaskRun(changeToSuccess);
+
+        // Should be removed from running and added to history
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
+        Assert.assertEquals(1, history.size());
+        Assert.assertEquals(Constants.TaskRunState.SUCCESS, history.get(0).getState());
+        Assert.assertEquals("Task completed successfully", history.get(0).getExtraMessage());
+        Assert.assertEquals(100, history.get(0).getProgress());
+    }
+
+    @Test
+    public void testReplayUpdateTaskRunWithNonMatchingQueryId() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        // First create a pending task run
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.PENDING);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+        taskManager.replayCreateTaskRun(status);
+
+        // Create a different status with different query ID
+        TaskRunStatus differentStatus = new TaskRunStatus();
+        differentStatus.setTaskName("test");
+        differentStatus.setQueryId("different_query_id");
+        differentStatus.setCreateTime(System.currentTimeMillis());
+        differentStatus.setState(Constants.TaskRunState.PENDING);
+
+        // Try to update with non-matching query ID
+        TaskRunStatusChange change = new TaskRunStatusChange(task.getId(), differentStatus,
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
+        taskManager.replayUpdateTaskRun(change);
+
+        // Should not be moved to running due to query ID mismatch
+        Assert.assertEquals(1, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+    }
+
+    @Test
+    public void testReplayUpdateTaskRunWithNonExistentPendingTask() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        // Don't create any pending task run
+
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.PENDING);
+
+        // Try to update non-existent pending task
+        TaskRunStatusChange change = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
+        taskManager.replayUpdateTaskRun(change);
+
+        // Should not affect anything
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+    }
+
+    @Test
+    public void testReplayUpdateTaskRunRunningToFinishedWithHistoryLookup() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        // Create a task run status and add it to history first
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.RUNNING);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+        taskManager.getTaskRunHistory().addHistory(status);
+
+        // Now update it from RUNNING to SUCCESS (simulating a task that was running before restart)
+        TaskRunStatusChange change = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.RUNNING, Constants.TaskRunState.SUCCESS);
+        change.setFinishTime(System.currentTimeMillis());
+        change.setExtraMessage("Task completed after restart");
+        taskManager.replayUpdateTaskRun(change);
+
+        // Should update the existing history entry
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
+        Assert.assertEquals(1, history.size());
+        Assert.assertEquals(Constants.TaskRunState.SUCCESS, history.get(0).getState());
+        Assert.assertEquals("Task completed after restart", history.get(0).getExtraMessage());
+    }
+
+    @Test
+    public void testReplayUpdateTaskRunIllegalStateTransition() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.PENDING);
+
+        // Try illegal transition: PENDING to PENDING
+        TaskRunStatusChange change = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.PENDING);
+        taskManager.replayUpdateTaskRun(change);
+
+        // Should not affect anything due to illegal transition
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+    }
+
+    @Test
+    public void testReplayUpdateTaskRunFromRunningToNonFinishState() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        // First create a pending task run and move it to running
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("query_123");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.PENDING);
+        status.setExpireTime(System.currentTimeMillis() + 3600000);
+        taskManager.replayCreateTaskRun(status);
+
+        TaskRunStatusChange changeToRunning = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
+        taskManager.replayUpdateTaskRun(changeToRunning);
+
+        // Try illegal transition: RUNNING to PENDING
+        TaskRunStatusChange illegalChange = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.RUNNING, Constants.TaskRunState.PENDING);
+        taskManager.replayUpdateTaskRun(illegalChange);
+
+        // Should not affect anything due to illegal transition
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(1, taskManager.getTaskRunScheduler().getRunningTaskCount());
+    }
+
+    @Test
+    public void testReplayUpdateTaskRunWithNullHistoryEntry() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        TaskRunStatus status = new TaskRunStatus();
+        status.setTaskName("test");
+        status.setQueryId("non_existent_query");
+        status.setCreateTime(System.currentTimeMillis());
+        status.setState(Constants.TaskRunState.RUNNING);
+
+        // Try to update a running task that doesn't exist in history
+        TaskRunStatusChange change = new TaskRunStatusChange(task.getId(), status,
+                Constants.TaskRunState.RUNNING, Constants.TaskRunState.SUCCESS);
+        change.setFinishTime(System.currentTimeMillis());
+        change.setExtraMessage("Should not be updated");
+        taskManager.replayUpdateTaskRun(change);
+
+        // Should not affect anything since the task doesn't exist in history
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+        Assert.assertEquals(0, taskManager.getTaskRunHistory().getInMemoryHistory().size());
+    }
+
+    @Test
+    public void testReplayCreateTaskRunWithMultipleStates() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        // Test multiple task runs with different states
+        Constants.TaskRunState[] states = {
+                Constants.TaskRunState.PENDING,
+                Constants.TaskRunState.RUNNING,
+                Constants.TaskRunState.FAILED,
+                Constants.TaskRunState.SUCCESS,
+                Constants.TaskRunState.MERGED,
+                Constants.TaskRunState.SKIPPED
+        };
+
+        for (int i = 0; i < states.length; i++) {
+            TaskRunStatus status = new TaskRunStatus();
+            status.setTaskName("test");
+            status.setQueryId("query_" + i);
+            status.setCreateTime(System.currentTimeMillis());
+            status.setState(states[i]);
+            status.setExpireTime(System.currentTimeMillis() + 3600000);
+
+            taskManager.replayCreateTaskRun(status);
+        }
+
+        // Only PENDING state should be in pending queue
+        Assert.assertEquals(1, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        // All finish states should be in history
+        List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
+        Assert.assertEquals(5, history.size()); // RUNNING, FAILED, SUCCESS, MERGED, SKIPPED
+    }
+
+    @Test
+    public void testReplayUpdateTaskRunComplexScenario() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        // Create multiple pending task runs
+        for (int i = 0; i < 3; i++) {
+            TaskRunStatus status = new TaskRunStatus();
+            status.setTaskName("test");
+            status.setQueryId("query_" + i);
+            status.setCreateTime(System.currentTimeMillis());
+            status.setState(Constants.TaskRunState.PENDING);
+            status.setExpireTime(System.currentTimeMillis() + 3600000);
+            taskManager.replayCreateTaskRun(status);
+        }
+
+        Assert.assertEquals(3, taskManager.getTaskRunScheduler().getPendingQueueCount());
+
+        // Move first one to running
+        TaskRunStatus firstStatus = new TaskRunStatus();
+        firstStatus.setTaskName("test");
+        firstStatus.setQueryId("query_0");
+        TaskRunStatusChange changeToRunning = new TaskRunStatusChange(task.getId(), firstStatus,
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
+        taskManager.replayUpdateTaskRun(changeToRunning);
+
+        Assert.assertEquals(2, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(1, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        // Move first one to success
+        TaskRunStatusChange changeToSuccess = new TaskRunStatusChange(task.getId(), firstStatus,
+                Constants.TaskRunState.RUNNING, Constants.TaskRunState.SUCCESS);
+        changeToSuccess.setFinishTime(System.currentTimeMillis());
+        taskManager.replayUpdateTaskRun(changeToSuccess);
+
+        Assert.assertEquals(2, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        // Move second one to failed
+        TaskRunStatus secondStatus = new TaskRunStatus();
+        secondStatus.setTaskName("test");
+        secondStatus.setQueryId("query_1");
+        TaskRunStatusChange changeToFailed = new TaskRunStatusChange(task.getId(), secondStatus,
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.FAILED);
+        changeToFailed.setErrorMessage("Task failed");
+        changeToFailed.setErrorCode(-1);
+        taskManager.replayUpdateTaskRun(changeToFailed);
+
+        Assert.assertEquals(1, taskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assert.assertEquals(0, taskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        // Verify history
+        List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
+        Assert.assertEquals(2, history.size()); // SUCCESS and FAILED
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`test_show_materialized_view` is unstable recently, and I found  https://github.com/StarRocks/starrocks/pull/59920 introduced SKIPPED state, but it will be ignored in replaying from RUNNING to SKIPPED.

It will cause the final state of `TaskRun` be null if it's Skipped.
```
2025-06-27 10:43:34.498+08:00 WARN (global_state_checkpoint_worker|178) [TaskManager.replayUpdateTaskRun():802] Illegal TaskRun queryId:0197ac96-7cbb-729c-b938-a24d56c844e1 status transform from RUNNING to SKIPPED

```
## What I'm doing:
- Ensure `Running` to `SKIPPED`(final state) is  successfully replayed.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
