### PR TITLE
[BugFix] Fix information_schema.materialized_views table compatible bugs

### DIFF
--- a/be/src/exec/pipeline/scan/schema_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/schema_chunk_source.cpp
@@ -66,6 +66,24 @@ Status SchemaChunkSource::prepare(RuntimeState* state) {
                 slot_desc->type().type = TYPE_DATETIME;
             }
         }
+    } else if (schema_table->schema_table_type() == TSchemaTableType::SCH_MATERIALIZED_VIEWS) {
+        for (auto* slot_desc : dest_slot_descs) {
+            const auto& col_name = slot_desc->col_name();
+            if (slot_desc->type().type == TYPE_VARCHAR && boost::iequals(col_name, "MATERIALIZED_VIEW_ID")) {
+                slot_desc->type().type = TYPE_BIGINT;
+            } else if (slot_desc->type().type == TYPE_VARCHAR && boost::iequals(col_name, "TASK_ID")) {
+                slot_desc->type().type = TYPE_BIGINT;
+            } else if (slot_desc->type().type == TYPE_VARCHAR && boost::iequals(col_name, "LAST_REFRESH_START_TIME")) {
+                slot_desc->type().type = TYPE_DATETIME;
+            } else if (slot_desc->type().type == TYPE_VARCHAR &&
+                       boost::iequals(col_name, "LAST_REFRESH_FINISHED_TIME")) {
+                slot_desc->type().type = TYPE_DATETIME;
+            } else if (slot_desc->type().type == TYPE_VARCHAR && boost::iequals(col_name, "TABLE_ROWS")) {
+                slot_desc->type().type = TYPE_BIGINT;
+            } else if (slot_desc->type().type == TYPE_VARCHAR && boost::iequals(col_name, "LAST_REFRESH_DURATION")) {
+                slot_desc->type().type = TYPE_DOUBLE;
+            }
+        }
     }
 
     int slot_num = dest_slot_descs.size();

--- a/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
@@ -349,8 +349,12 @@ Status SchemaMaterializedViewsScanner::fill_chunk(ChunkPtr* chunk) {
             // TABLE_ROWS
             if (info.__isset.rows) {
                 if (info.__isset.rows) {
-                    int64_t value = std::stoll(info.rows);
-                    fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&value);
+                    try {
+                        int64_t value = std::stoll(info.rows);
+                        fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&value);
+                    } catch (const std::exception& e) {
+                        fill_data_column_with_null(column.get());
+                    }
                 } else {
                     fill_data_column_with_null(column.get());
                 }

--- a/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
@@ -24,46 +24,43 @@ namespace starrocks {
 // Keep tracks with `information_schema.materialized_views` table's schema.
 SchemaScanner::ColumnDesc SchemaMaterializedViewsScanner::_s_tbls_columns[] = {
         //   name,       type,          size,     is_null
-        {"MATERIALIZED_VIEW_ID", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"TABLE_SCHEMA", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"TABLE_NAME", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"REFRESH_TYPE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"IS_ACTIVE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"INACTIVE_REASON", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"PARTITION_TYPE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"TASK_ID", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"TASK_NAME", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"MATERIALIZED_VIEW_ID", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
+        {"TABLE_SCHEMA", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
+        {"TABLE_NAME", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
+        {"REFRESH_TYPE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
+        {"IS_ACTIVE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
+        {"INACTIVE_REASON", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
+        {"PARTITION_TYPE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
+        {"TASK_ID", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
+        {"TASK_NAME", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
 
-        {"LAST_REFRESH_START_TIME", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue),
-         false},
-        {"LAST_REFRESH_PROCESS_TIME", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue),
-         false},
-        {"LAST_REFRESH_FINISHED_TIME", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue),
-         false},
-        {"LAST_REFRESH_DURATION", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"LAST_REFRESH_JOB_ID", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"LAST_REFRESH_STATE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"LAST_REFRESH_START_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
+        {"LAST_REFRESH_FINISHED_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
+        {"LAST_REFRESH_DURATION", TypeDescriptor::from_logical_type(TYPE_DOUBLE), sizeof(double), false},
+        {"LAST_REFRESH_STATE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
         {"LAST_REFRESH_FORCE_REFRESH", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue),
-         false},
+         true},
         {"LAST_REFRESH_START_PARTITION", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue),
-         false},
+         true},
         {"LAST_REFRESH_END_PARTITION", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue),
-         false},
+         true},
         {"LAST_REFRESH_BASE_REFRESH_PARTITIONS", TypeDescriptor::create_varchar_type(sizeof(StringValue)),
-         sizeof(StringValue), false},
+         sizeof(StringValue), true},
         {"LAST_REFRESH_MV_REFRESH_PARTITIONS", TypeDescriptor::create_varchar_type(sizeof(StringValue)),
-         sizeof(StringValue), false},
+         sizeof(StringValue), true},
 
         {"LAST_REFRESH_ERROR_CODE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue),
-         false},
+         true},
         {"LAST_REFRESH_ERROR_MESSAGE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue),
-         false},
-        {"TABLE_ROWS", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+         true},
+        {"TABLE_ROWS", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
         {"MATERIALIZED_VIEW_DEFINITION", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue),
-         false},
-        {"EXTRA_MESSAGE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"QUERY_REWRITE_STATUS", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"CREATOR", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+         true},
+        {"EXTRA_MESSAGE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
+        {"QUERY_REWRITE_STATUS", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
+        {"CREATOR", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
+        {"LAST_REFRESH_PROCESS_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
+        {"LAST_REFRESH_JOB_ID", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
 };
 
 SchemaMaterializedViewsScanner::SchemaMaterializedViewsScanner()
@@ -98,42 +95,345 @@ Status SchemaMaterializedViewsScanner::start(RuntimeState* state) {
 Status SchemaMaterializedViewsScanner::fill_chunk(ChunkPtr* chunk) {
     auto& slot_id_map = (*chunk)->get_slot_id_to_index_map();
     const TMaterializedViewStatus& info = _mv_results.materialized_views[_table_index];
-    std::string db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index - 1]);
-    DatumArray datum_array{Slice(info.id),
-                           Slice(db_name),
-                           Slice(info.name),
-                           Slice(info.refresh_type),
-                           Slice(info.is_active),
-                           Slice(info.inactive_reason),
-                           Slice(info.partition_type),
-                           Slice(info.task_id),
-                           Slice(info.task_name),
-                           Slice(info.last_refresh_start_time),
-                           Slice(info.last_refresh_process_time),
-                           Slice(info.last_refresh_finished_time),
-                           Slice(info.last_refresh_duration),
-                           Slice(info.last_refresh_job_id),
-                           Slice(info.last_refresh_state),
-                           Slice(info.last_refresh_force_refresh),
-                           Slice(info.last_refresh_start_partition),
-                           Slice(info.last_refresh_end_partition),
-                           Slice(info.last_refresh_base_refresh_partitions),
-                           Slice(info.last_refresh_mv_refresh_partitions),
-                           Slice(info.last_refresh_error_code),
-                           Slice(info.last_refresh_error_message),
-                           Slice(info.rows),
-                           Slice(info.text),
-                           Slice(info.extra_message),
-                           Slice(info.query_rewrite_status),
-                           Slice(info.creator)};
+    VLOG(2) << "info: " << apache::thrift::ThriftDebugString(info);
 
+    std::string db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index - 1]);
     for (const auto& [slot_id, index] : slot_id_map) {
-        Column* column = (*chunk)->get_column_by_slot_id(slot_id).get();
-        column->append_datum(datum_array[slot_id - 1]);
+        if (slot_id < 1 || slot_id > std::size(SchemaMaterializedViewsScanner::_s_tbls_columns)) {
+            return Status::InternalError("Invalid slot id: " + std::to_string(slot_id));
+        }
+        ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
+
+        switch (slot_id) {
+        case 1: {
+            // id
+            if (info.__isset.id) {
+                try {
+                    int64_t value = std::stoll(info.id);
+                    fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&value);
+                } catch (const std::exception& e) {
+                    fill_data_column_with_null(column.get());
+                }
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 2: {
+            // database_name
+            if (info.__isset.database_name) {
+                const std::string* str = &info.database_name;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 3: {
+            // name
+            if (info.__isset.name) {
+                const std::string* str = &info.name;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 4: {
+            // refresh_type
+            if (info.__isset.refresh_type) {
+                const std::string* str = &info.refresh_type;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 5: {
+            // is_active
+            if (info.__isset.is_active) {
+                const std::string* str = &info.is_active;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 6: {
+            // INACTIVE_REASON
+            if (info.__isset.inactive_reason) {
+                const std::string* str = &info.inactive_reason;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 7: {
+            // PARTITION_TYPE
+            if (info.__isset.partition_type) {
+                const std::string* db_name = &info.partition_type;
+                Slice value(db_name->c_str(), db_name->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 8: {
+            // TASK_ID
+            if (info.__isset.task_id) {
+                try {
+                    int64_t value = std::stoll(info.task_id);
+                    fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&value);
+                } catch (const std::exception& e) {
+                    fill_data_column_with_null(column.get());
+                }
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 9: {
+            // TASK_NAME
+            if (info.__isset.task_name) {
+                const std::string* str = &info.task_name;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 10: {
+            // LAST_REFRESH_START_TIME
+            if (info.__isset.last_refresh_start_time) {
+                auto* nullable_column = down_cast<NullableColumn*>(column.get());
+                DateTimeValue t;
+                if (!t.from_date_str(info.last_refresh_start_time.data(), info.last_refresh_start_time.size())) {
+                    nullable_column->append_nulls(1);
+                } else {
+                    fill_column_with_slot<TYPE_DATETIME>(column.get(), (void*)&t);
+                }
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 11: {
+            // LAST_REFRESH_FINISHED_TIME
+            if (info.__isset.last_refresh_finished_time) {
+                auto* nullable_column = down_cast<NullableColumn*>(column.get());
+                DateTimeValue t;
+                if (!t.from_date_str(info.last_refresh_finished_time.data(), info.last_refresh_finished_time.size())) {
+                    nullable_column->append_nulls(1);
+                } else {
+                    fill_column_with_slot<TYPE_DATETIME>(column.get(), (void*)&t);
+                }
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 12: {
+            // LAST_REFRESH_DURATION
+            if (info.__isset.last_refresh_duration) {
+                try {
+                    double value = std::stod(info.last_refresh_duration);
+                    fill_column_with_slot<TYPE_DOUBLE>(column.get(), (void*)&value);
+                } catch (const std::exception& e) {
+                    fill_data_column_with_null(column.get());
+                }
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 13: {
+            // LAST_REFRESH_STATE
+            if (info.__isset.last_refresh_state) {
+                const std::string* str = &info.last_refresh_state;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 14: {
+            // LAST_REFRESH_FORCE_REFRESH
+            if (info.__isset.last_refresh_force_refresh) {
+                const std::string* str = &info.last_refresh_force_refresh;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 15: {
+            // LAST_REFRESH_START_PARTITION
+            if (info.__isset.last_refresh_start_partition) {
+                const std::string* str = &info.last_refresh_start_partition;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 16: {
+            // LAST_REFRESH_END_PARTITION
+            if (info.__isset.last_refresh_end_partition) {
+                const std::string* str = &info.last_refresh_end_partition;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 17: {
+            // LAST_REFRESH_BASE_REFRESH_PARTITIONS
+            if (info.__isset.last_refresh_base_refresh_partitions) {
+                const std::string* str = &info.last_refresh_base_refresh_partitions;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 18: {
+            // LAST_REFRESH_MV_REFRESH_PARTITIONS
+            if (info.__isset.last_refresh_mv_refresh_partitions) {
+                const std::string* str = &info.last_refresh_mv_refresh_partitions;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 19: {
+            // LAST_REFRESH_ERROR_CODE
+            if (info.__isset.last_refresh_error_code) {
+                const std::string* str = &info.last_refresh_error_code;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 20: {
+            // LAST_REFRESH_ERROR_MESSAGE
+            if (info.__isset.last_refresh_error_message) {
+                const std::string* str = &info.last_refresh_error_message;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 21: {
+            // TABLE_ROWS
+            if (info.__isset.rows) {
+                if (info.__isset.rows) {
+                    int64_t value = std::stoll(info.rows);
+                    fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&value);
+                } else {
+                    fill_data_column_with_null(column.get());
+                }
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 22: {
+            // MATERIALIZED_VIEW_DEFINITION
+            if (info.__isset.text) {
+                const std::string* db_name = &info.text;
+                Slice value(db_name->c_str(), db_name->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 23: {
+            // EXTRA_MESSAGE
+            if (info.__isset.extra_message) {
+                const std::string* str = &info.extra_message;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 24: {
+            // QUERY_REWRITE_STATUS
+            if (info.__isset.query_rewrite_status) {
+                const std::string* str = &info.query_rewrite_status;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 25: {
+            // CREATOR
+            if (info.__isset.creator) {
+                const std::string* str = &info.creator;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 26: {
+            // LAST_REFRESH_PROCESS_TIME
+            if (info.__isset.last_refresh_process_time) {
+                auto* nullable_column = down_cast<NullableColumn*>(column.get());
+                DateTimeValue t;
+                if (!t.from_date_str(info.last_refresh_process_time.data(), info.last_refresh_process_time.size())) {
+                    nullable_column->append_nulls(1);
+                } else {
+                    fill_column_with_slot<TYPE_DATETIME>(column.get(), (void*)&t);
+                }
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 27: {
+            // LAST_REFRESH_JOB_ID
+            if (info.__isset.last_refresh_job_id) {
+                const std::string* str = &info.last_refresh_job_id;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        default:
+            break;
+        }
     }
     _table_index++;
-    return {};
+    return Status::OK();
 }
+
 Status SchemaMaterializedViewsScanner::get_materialized_views() {
     TGetTablesParams table_params;
     table_params.__set_db(_db_result.dbs[_db_index++]);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -72,6 +72,7 @@ set(EXEC_FILES
         ./exec/query_cache/transform_operator.cpp
         ./exec/schema_columns_scanner_test.cpp
         ./exec/schema_fe_tablet_schedules_scanner_test.cpp
+        ./exec/schema_materialized_views_scanner_test.cpp
         ./exec/sink/connector_sink_operator_test.cpp
         ./exec/sink/sink_io_buffer_test.cpp
         ./exec/stream/mem_state_table_test.cpp

--- a/be/test/exec/schema_materialized_views_scanner_test.cpp
+++ b/be/test/exec/schema_materialized_views_scanner_test.cpp
@@ -129,24 +129,24 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_empty_database_list) {
     EXPECT_EQ(0, chunk->num_rows());
 }
 
-// TEST_F(SchemaMaterializedViewsScannerTest, test_empty_materialized_views) {
-//     SchemaMaterializedViewsScanner scanner;
+TEST_F(SchemaMaterializedViewsScannerTest, test_empty_materialized_views) {
+    SchemaMaterializedViewsScanner scanner;
 
-//     EXPECT_OK(scanner.init(&_params, &_pool));
+    EXPECT_OK(scanner.init(&_params, &_pool));
 
-//     // Mock database with no materialized views
-//     scanner._db_result.dbs = {"test_db"};
-//     scanner._db_index = 0;
-//     scanner._table_index = 0;
-//     scanner._mv_results.materialized_views.clear();
+    // Mock database with no materialized views
+    scanner._db_result.dbs = {"test_db"};
+    scanner._db_index = 1;
+    scanner._table_index = 0;
+    scanner._mv_results.materialized_views.clear();
 
-//     auto chunk = create_chunk(scanner.get_slot_descs());
-//     bool eos = false;
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
 
-//     EXPECT_OK(scanner.get_next(&chunk, &eos));
-//     EXPECT_TRUE(eos);
-//     EXPECT_EQ(0, chunk->num_rows());
-// }
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_TRUE(eos);
+    EXPECT_EQ(0, chunk->num_rows());
+}
 
 TEST_F(SchemaMaterializedViewsScannerTest, test_single_materialized_view) {
     SchemaMaterializedViewsScanner scanner;
@@ -155,7 +155,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_single_materialized_view) {
 
     // Mock database and materialized view data
     scanner._db_result.dbs = {"test_db"};
-    scanner._db_index = 0;
+    scanner._db_index = 1;
     scanner._table_index = 0;
 
     TMaterializedViewStatus mv;
@@ -193,7 +193,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_single_materialized_view) {
     bool eos = false;
 
     EXPECT_OK(scanner.get_next(&chunk, &eos));
-    EXPECT_TRUE(eos);
+    EXPECT_FALSE(eos);
     EXPECT_EQ(1, chunk->num_rows());
 
     auto row = chunk->debug_row(0);
@@ -230,7 +230,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_multiple_materialized_views) {
 
     // Mock database and multiple materialized views
     scanner._db_result.dbs = {"test_db"};
-    scanner._db_index = 0;
+    scanner._db_index = 1;
     scanner._table_index = 0;
 
     std::vector<TMaterializedViewStatus> mvs;
@@ -295,7 +295,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_null_values) {
 
     // Mock database and materialized view with null values
     scanner._db_result.dbs = {"test_db"};
-    scanner._db_index = 0;
+    scanner._db_index = 1;
     scanner._table_index = 0;
 
     TMaterializedViewStatus mv;
@@ -328,7 +328,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_invalid_numeric_values) {
 
     // Mock database and materialized view with invalid numeric values
     scanner._db_result.dbs = {"test_db"};
-    scanner._db_index = 0;
+    scanner._db_index = 1;
     scanner._table_index = 0;
 
     TMaterializedViewStatus mv;

--- a/be/test/exec/schema_materialized_views_scanner_test.cpp
+++ b/be/test/exec/schema_materialized_views_scanner_test.cpp
@@ -1,0 +1,519 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/column_helper.h"
+#include "exec/schema_scanner/schema_fe_tablet_schedules_scanner.h"
+#include "runtime/runtime_state.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class SchemaMaterializedViewsScannerTest : public ::testing::Test {
+private:
+    ChunkPtr create_chunk(const std::vector<SlotDescriptor*> slot_descs) {
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        for (const auto* slot_desc : slot_descs) {
+            MutableColumnPtr column = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
+            chunk->append_column(std::move(column), slot_desc->id());
+        }
+        return chunk;
+    }
+
+protected:
+    void SetUp() override {
+        _params.ip = &_ip;
+        _params.port = 9020;
+        _state = std::make_unique<RuntimeState>(TUniqueId(), TQueryOptions(), TQueryGlobals(), nullptr);
+    }
+
+    SchemaScannerParam _params;
+    std::string _ip = "127.0.0.1";
+    ObjectPool _pool;
+    std::unique_ptr<RuntimeState> _state;
+};
+
+TEST_F(SchemaFeTabletSchedulesScannerTest, test_normal) {
+    SchemaFeTabletSchedulesScanner scanner;
+
+    // prepare tablet schedule data
+    std::vector<TTabletSchedule> infos;
+    // normal
+    auto& s1 = infos.emplace_back();
+    s1.__set_table_id(1);
+    s1.__set_partition_id(2);
+    s1.__set_tablet_id(10);
+    s1.__set_type("REPAIR");
+    s1.__set_priority("HIGH");
+    s1.__set_state("FINISHED");
+    s1.__set_tablet_status("DISK_MIGRATION");
+    s1.__set_create_time(1749711000);
+    s1.__set_schedule_time(1749711001);
+    s1.__set_finish_time(1749711002);
+    s1.__set_clone_src(10001);
+    s1.__set_clone_dest(10002);
+    s1.__set_clone_bytes(1);
+    s1.__set_clone_duration(1);
+    s1.__set_error_msg("success");
+    // xxx_time is null
+    auto& s2 = infos.emplace_back();
+    s2.__set_table_id(1);
+    s2.__set_partition_id(2);
+    s2.__set_tablet_id(11);
+    s2.__set_type("BALANCE");
+    s2.__set_priority("NORMAL");
+    s2.__set_state("PENDING");
+    s2.__set_tablet_status("DISK_MIGRATION");
+    s2.__set_create_time(0);
+    s2.__set_schedule_time(0);
+    s2.__set_finish_time(-0.001);
+    s2.__set_clone_src(10001);
+    s2.__set_clone_dest(10002);
+    s2.__set_clone_bytes(0);
+    s2.__set_clone_duration(0);
+    s2.__set_error_msg("");
+
+    // init and start scanner
+    EXPECT_OK(scanner.init(&_params, &_pool));
+    EXPECT_OK(scanner.TEST_start(_state.get(), infos));
+
+    // check get_next
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ(
+            "[1, 2, 10, 'REPAIR', 'HIGH', 'FINISHED', 'DISK_MIGRATION', 2025-06-12 14:50:00, 2025-06-12 14:50:01, "
+            "2025-06-12 14:50:02, 10001, 10002, 1, 1, 'success']",
+            chunk->debug_row(0));
+
+    chunk->reset();
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ("[1, 2, 11, 'BALANCE', 'NORMAL', 'PENDING', 'DISK_MIGRATION', NULL, NULL, NULL, 10001, 10002, 0, 0, '']",
+              chunk->debug_row(0));
+
+    chunk->reset();
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_TRUE(eos);
+}
+
+TEST_F(SchemaFeTabletSchedulesScannerTest, test_empty_data) {
+    SchemaFeTabletSchedulesScanner scanner;
+
+    // init and start scanner with empty data
+    EXPECT_OK(scanner.init(&_params, &_pool));
+    EXPECT_OK(scanner.TEST_start(_state.get(), {}));
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_TRUE(eos);
+    EXPECT_EQ(0, chunk->num_rows());
+}
+
+TEST_F(SchemaFeTabletSchedulesScannerTest, test_large_values) {
+    SchemaFeTabletSchedulesScanner scanner;
+
+    std::vector<TTabletSchedule> infos;
+    auto& s = infos.emplace_back();
+    s.__set_table_id(INT64_MAX);
+    s.__set_partition_id(INT64_MAX);
+    s.__set_tablet_id(INT64_MAX);
+    s.__set_type("VERY_LONG_TYPE_NAME_THAT_MIGHT_CAUSE_ISSUES");
+    s.__set_priority("VERY_HIGH_PRIORITY_LEVEL");
+    s.__set_state("VERY_LONG_STATE_DESCRIPTION");
+    s.__set_tablet_status("VERY_LONG_TABLET_STATUS_DESCRIPTION");
+    s.__set_create_time(1749711000.123456);
+    s.__set_schedule_time(1749711001.654321);
+    s.__set_finish_time(1749711002.999999);
+    s.__set_clone_src(INT64_MAX);
+    s.__set_clone_dest(INT64_MAX);
+    s.__set_clone_bytes(INT64_MAX);
+    s.__set_clone_duration(DBL_MAX);
+    s.__set_error_msg("Very long error message that might contain special characters: !@#$%^&*()_+-=[]{}|;':\",./<>?");
+
+    EXPECT_OK(scanner.init(&_params, &_pool));
+    EXPECT_OK(scanner.TEST_start(_state.get(), infos));
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+
+    // Verify the large values are handled correctly
+    auto row = chunk->debug_row(0);
+    EXPECT_TRUE(row.find("9223372036854775807") != std::string::npos); // INT64_MAX
+    EXPECT_TRUE(row.find("VERY_LONG_TYPE_NAME_THAT_MIGHT_CAUSE_ISSUES") != std::string::npos);
+    EXPECT_TRUE(row.find("Very long error message") != std::string::npos);
+}
+
+TEST_F(SchemaFeTabletSchedulesScannerTest, test_negative_values) {
+    SchemaFeTabletSchedulesScanner scanner;
+
+    std::vector<TTabletSchedule> infos;
+    auto& s = infos.emplace_back();
+    s.__set_table_id(-1);
+    s.__set_partition_id(-2);
+    s.__set_tablet_id(-3);
+    s.__set_type("REPAIR");
+    s.__set_priority("LOW");
+    s.__set_state("FAILED");
+    s.__set_tablet_status("UNHEALTHY");
+    s.__set_create_time(-1749711000);
+    s.__set_schedule_time(-1749711001);
+    s.__set_finish_time(-1749711002);
+    s.__set_clone_src(-10001);
+    s.__set_clone_dest(-10002);
+    s.__set_clone_bytes(-1000);
+    s.__set_clone_duration(-1.5);
+    s.__set_error_msg("negative test");
+
+    EXPECT_OK(scanner.init(&_params, &_pool));
+    EXPECT_OK(scanner.TEST_start(_state.get(), infos));
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+
+    auto row = chunk->debug_row(0);
+    EXPECT_TRUE(row.find("-1") != std::string::npos);
+    EXPECT_TRUE(row.find("-2") != std::string::npos);
+    EXPECT_TRUE(row.find("-3") != std::string::npos);
+    EXPECT_TRUE(row.find("-10001") != std::string::npos);
+    EXPECT_TRUE(row.find("-10002") != std::string::npos);
+    EXPECT_TRUE(row.find("-1000") != std::string::npos);
+    EXPECT_TRUE(row.find("-1.5") != std::string::npos);
+}
+
+TEST_F(SchemaFeTabletSchedulesScannerTest, test_zero_values) {
+    SchemaFeTabletSchedulesScanner scanner;
+
+    std::vector<TTabletSchedule> infos;
+    auto& s = infos.emplace_back();
+    s.__set_table_id(0);
+    s.__set_partition_id(0);
+    s.__set_tablet_id(0);
+    s.__set_type("");
+    s.__set_priority("");
+    s.__set_state("");
+    s.__set_tablet_status("");
+    s.__set_create_time(0);
+    s.__set_schedule_time(0);
+    s.__set_finish_time(0);
+    s.__set_clone_src(0);
+    s.__set_clone_dest(0);
+    s.__set_clone_bytes(0);
+    s.__set_clone_duration(0);
+    s.__set_error_msg("");
+
+    EXPECT_OK(scanner.init(&_params, &_pool));
+    EXPECT_OK(scanner.TEST_start(_state.get(), infos));
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+
+    auto row = chunk->debug_row(0);
+    EXPECT_TRUE(row.find("0") != std::string::npos);
+    EXPECT_TRUE(row.find("''") != std::string::npos);   // empty strings
+    EXPECT_TRUE(row.find("NULL") != std::string::npos); // null timestamps
+}
+
+TEST_F(SchemaFeTabletSchedulesScannerTest, test_multiple_records) {
+    SchemaFeTabletSchedulesScanner scanner;
+
+    std::vector<TTabletSchedule> infos;
+
+    // Add 10 records with different values
+    for (int i = 0; i < 10; ++i) {
+        auto& s = infos.emplace_back();
+        s.__set_table_id(i + 1);
+        s.__set_partition_id(i + 10);
+        s.__set_tablet_id(i + 100);
+        s.__set_type("TYPE_" + std::to_string(i));
+        s.__set_priority("PRIORITY_" + std::to_string(i));
+        s.__set_state("STATE_" + std::to_string(i));
+        s.__set_tablet_status("STATUS_" + std::to_string(i));
+        s.__set_create_time(1749711000 + i);
+        s.__set_schedule_time(1749711001 + i);
+        s.__set_finish_time(1749711002 + i);
+        s.__set_clone_src(10001 + i);
+        s.__set_clone_dest(10002 + i);
+        s.__set_clone_bytes(1000 + i);
+        s.__set_clone_duration(1.0 + i * 0.1);
+        s.__set_error_msg("error_" + std::to_string(i));
+    }
+
+    EXPECT_OK(scanner.init(&_params, &_pool));
+    EXPECT_OK(scanner.TEST_start(_state.get(), infos));
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+    int count = 0;
+
+    while (!eos) {
+        EXPECT_OK(scanner.get_next(&chunk, &eos));
+        if (!eos) {
+            EXPECT_EQ(1, chunk->num_rows());
+            count++;
+        }
+        chunk->reset();
+    }
+
+    EXPECT_EQ(10, count);
+}
+
+TEST_F(SchemaFeTabletSchedulesScannerTest, test_null_pointer_parameters) {
+    SchemaFeTabletSchedulesScanner scanner;
+
+    std::vector<TTabletSchedule> infos;
+    auto& s = infos.emplace_back();
+    s.__set_table_id(1);
+    s.__set_partition_id(2);
+    s.__set_tablet_id(3);
+    s.__set_type("REPAIR");
+    s.__set_priority("HIGH");
+    s.__set_state("FINISHED");
+    s.__set_tablet_status("HEALTHY");
+    s.__set_create_time(1749711000);
+    s.__set_schedule_time(1749711001);
+    s.__set_finish_time(1749711002);
+    s.__set_clone_src(10001);
+    s.__set_clone_dest(10002);
+    s.__set_clone_bytes(1000);
+    s.__set_clone_duration(1.5);
+    s.__set_error_msg("test");
+
+    EXPECT_OK(scanner.init(&_params, &_pool));
+    EXPECT_OK(scanner.TEST_start(_state.get(), infos));
+
+    // Test with null chunk pointer
+    bool eos = false;
+    EXPECT_FALSE(scanner.get_next(nullptr, &eos).ok());
+
+    // Test with null eos pointer
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    EXPECT_FALSE(scanner.get_next(&chunk, nullptr).ok());
+}
+
+TEST_F(SchemaFeTabletSchedulesScannerTest, test_uninitialized_scanner) {
+    SchemaFeTabletSchedulesScanner scanner;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    // Should fail because scanner is not initialized
+    EXPECT_FALSE(scanner.get_next(&chunk, &eos).ok());
+}
+
+TEST_F(SchemaFeTabletSchedulesScannerTest, test_different_schedule_types) {
+    SchemaFeTabletSchedulesScanner scanner;
+
+    std::vector<TTabletSchedule> infos;
+
+    // Test different schedule types
+    std::vector<std::string> types = {"REPAIR", "BALANCE", "CLONE", "MIGRATE", "COMPACTION"};
+    std::vector<std::string> priorities = {"HIGH", "NORMAL", "LOW"};
+    std::vector<std::string> states = {"PENDING", "RUNNING", "FINISHED", "FAILED", "CANCELLED"};
+    std::vector<std::string> statuses = {"HEALTHY", "UNHEALTHY", "DISK_MIGRATION", "REPLICA_MISSING"};
+
+    for (size_t i = 0; i < types.size(); ++i) {
+        auto& s = infos.emplace_back();
+        s.__set_table_id(i + 1);
+        s.__set_partition_id(i + 10);
+        s.__set_tablet_id(i + 100);
+        s.__set_type(types[i]);
+        s.__set_priority(priorities[i % priorities.size()]);
+        s.__set_state(states[i % states.size()]);
+        s.__set_tablet_status(statuses[i % statuses.size()]);
+        s.__set_create_time(1749711000 + i);
+        s.__set_schedule_time(1749711001 + i);
+        s.__set_finish_time(1749711002 + i);
+        s.__set_clone_src(10001 + i);
+        s.__set_clone_dest(10002 + i);
+        s.__set_clone_bytes(1000 + i);
+        s.__set_clone_duration(1.0 + i * 0.1);
+        s.__set_error_msg("test_" + std::to_string(i));
+    }
+
+    EXPECT_OK(scanner.init(&_params, &_pool));
+    EXPECT_OK(scanner.TEST_start(_state.get(), infos));
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+    int count = 0;
+
+    while (!eos) {
+        EXPECT_OK(scanner.get_next(&chunk, &eos));
+        if (!eos) {
+            EXPECT_EQ(1, chunk->num_rows());
+            auto row = chunk->debug_row(0);
+            EXPECT_TRUE(row.find(types[count]) != std::string::npos);
+            count++;
+        }
+        chunk->reset();
+    }
+
+    EXPECT_EQ(5, count);
+}
+
+TEST_F(SchemaFeTabletSchedulesScannerTest, test_edge_case_timestamps) {
+    SchemaFeTabletSchedulesScanner scanner;
+
+    std::vector<TTabletSchedule> infos;
+
+    // Test edge case timestamps
+    std::vector<double> timestamps = {
+            0.0,               // zero
+            -1.0,              // negative
+            1.0,               // small positive
+            1749711000.0,      // normal timestamp
+            1749711000.999999, // high precision
+            1749711000.000001, // very small fraction
+            DBL_MAX,           // maximum double
+            DBL_MIN,           // minimum positive double
+            -DBL_MAX           // minimum double
+    };
+
+    for (size_t i = 0; i < timestamps.size(); ++i) {
+        auto& s = infos.emplace_back();
+        s.__set_table_id(i + 1);
+        s.__set_partition_id(i + 10);
+        s.__set_tablet_id(i + 100);
+        s.__set_type("REPAIR");
+        s.__set_priority("HIGH");
+        s.__set_state("FINISHED");
+        s.__set_tablet_status("HEALTHY");
+        s.__set_create_time(timestamps[i]);
+        s.__set_schedule_time(timestamps[i]);
+        s.__set_finish_time(timestamps[i]);
+        s.__set_clone_src(10001);
+        s.__set_clone_dest(10002);
+        s.__set_clone_bytes(1000);
+        s.__set_clone_duration(1.5);
+        s.__set_error_msg("timestamp_test_" + std::to_string(i));
+    }
+
+    EXPECT_OK(scanner.init(&_params, &_pool));
+    EXPECT_OK(scanner.TEST_start(_state.get(), infos));
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+    int count = 0;
+
+    while (!eos) {
+        EXPECT_OK(scanner.get_next(&chunk, &eos));
+        if (!eos) {
+            EXPECT_EQ(1, chunk->num_rows());
+            count++;
+        }
+        chunk->reset();
+    }
+
+    EXPECT_EQ(9, count);
+}
+
+TEST_F(SchemaFeTabletSchedulesScannerTest, test_special_characters_in_strings) {
+    SchemaFeTabletSchedulesScanner scanner;
+
+    std::vector<TTabletSchedule> infos;
+    auto& s = infos.emplace_back();
+    s.__set_table_id(1);
+    s.__set_partition_id(2);
+    s.__set_tablet_id(3);
+    s.__set_type("REPAIR_WITH_SPECIAL_CHARS_!@#$%^&*()");
+    s.__set_priority("HIGH_PRIORITY_WITH_SPECIAL_CHARS_[]{}|");
+    s.__set_state("FINISHED_STATE_WITH_SPECIAL_CHARS_\\\"'");
+    s.__set_tablet_status("HEALTHY_STATUS_WITH_SPECIAL_CHARS_<>?");
+    s.__set_create_time(1749711000);
+    s.__set_schedule_time(1749711001);
+    s.__set_finish_time(1749711002);
+    s.__set_clone_src(10001);
+    s.__set_clone_dest(10002);
+    s.__set_clone_bytes(1000);
+    s.__set_clone_duration(1.5);
+    s.__set_error_msg("Error message with special characters: !@#$%^&*()_+-=[]{}|;':\",./<>?\\");
+
+    EXPECT_OK(scanner.init(&_params, &_pool));
+    EXPECT_OK(scanner.TEST_start(_state.get(), infos));
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+
+    auto row = chunk->debug_row(0);
+    EXPECT_TRUE(row.find("REPAIR_WITH_SPECIAL_CHARS_!@#$%^&*()") != std::string::npos);
+    EXPECT_TRUE(row.find("HIGH_PRIORITY_WITH_SPECIAL_CHARS_[]{}|") != std::string::npos);
+    EXPECT_TRUE(row.find("FINISHED_STATE_WITH_SPECIAL_CHARS_\\\"'") != std::string::npos);
+    EXPECT_TRUE(row.find("HEALTHY_STATUS_WITH_SPECIAL_CHARS_<>?") != std::string::npos);
+    EXPECT_TRUE(row.find("Error message with special characters") != std::string::npos);
+}
+
+TEST_F(SchemaFeTabletSchedulesScannerTest, test_unicode_characters) {
+    SchemaFeTabletSchedulesScanner scanner;
+
+    std::vector<TTabletSchedule> infos;
+    auto& s = infos.emplace_back();
+    s.__set_table_id(1);
+    s.__set_partition_id(2);
+    s.__set_tablet_id(3);
+    s.__set_type("REPAIR_中文");
+    s.__set_priority("HIGH_优先级_中文");
+    s.__set_state("FINISHED_状态_中文");
+    s.__set_tablet_status("HEALTHY_健康_中文");
+    s.__set_create_time(1749711000);
+    s.__set_schedule_time(1749711001);
+    s.__set_finish_time(1749711002);
+    s.__set_clone_src(10001);
+    s.__set_clone_dest(10002);
+    s.__set_clone_bytes(1000);
+    s.__set_clone_duration(1.5);
+    s.__set_error_msg("错误信息包含中文和特殊字符：!@#$%^&*()_+-=[]{}|;':\",./<>?\\");
+
+    EXPECT_OK(scanner.init(&_params, &_pool));
+    EXPECT_OK(scanner.TEST_start(_state.get(), infos));
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+
+    auto row = chunk->debug_row(0);
+    EXPECT_TRUE(row.find("REPAIR_中文") != std::string::npos);
+    EXPECT_TRUE(row.find("HIGH_优先级_中文") != std::string::npos);
+    EXPECT_TRUE(row.find("FINISHED_状态_中文") != std::string::npos);
+    EXPECT_TRUE(row.find("HEALTHY_健康_中文") != std::string::npos);
+    EXPECT_TRUE(row.find("错误信息包含中文") != std::string::npos);
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -84,10 +84,8 @@ public class MaterializedViewsSystemTable extends SystemTable {
                         .column("TASK_ID", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("TASK_NAME", ScalarType.createVarchar(50))
                         .column("LAST_REFRESH_START_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("LAST_REFRESH_PROCESS_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("LAST_REFRESH_FINISHED_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("LAST_REFRESH_DURATION", ScalarType.createType(PrimitiveType.DOUBLE))
-                        .column("LAST_REFRESH_JOB_ID", ScalarType.createVarchar(64))
                         .column("LAST_REFRESH_STATE", ScalarType.createVarchar(20))
                         .column("LAST_REFRESH_FORCE_REFRESH", ScalarType.createVarchar(8))
                         .column("LAST_REFRESH_START_PARTITION", ScalarType.createVarchar(1024))
@@ -102,6 +100,8 @@ public class MaterializedViewsSystemTable extends SystemTable {
                         .column("EXTRA_MESSAGE", ScalarType.createVarchar(1024))
                         .column("QUERY_REWRITE_STATUS", ScalarType.createVarcharType(64))
                         .column("CREATOR", ScalarType.createVarchar(64))
+                        .column("LAST_REFRESH_PROCESS_TIME", ScalarType.createType(PrimitiveType.DATETIME))
+                        .column("LAST_REFRESH_JOB_ID", ScalarType.createVarchar(64))
                         .build(), TSchemaTableType.SCH_MATERIALIZED_VIEWS);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -693,14 +693,10 @@ public class ShowMaterializedViewStatus {
         addField(resultRow, Strings.nullToEmpty(this.getTaskName()));
         // start time
         addField(resultRow, TimeUtils.longToTimeString(refreshJobStatus.getMvRefreshStartTime()));
-        // process start time
-        addField(resultRow, TimeUtils.longToTimeString(refreshJobStatus.getMvRefreshProcessTime()));
         // process finish time
         addField(resultRow, TimeUtils.longToTimeString(refreshJobStatus.getMvRefreshEndTime()));
         // process duration
         addField(resultRow, formatDuration(refreshJobStatus.getTotalProcessDuration()));
-        // last refresh job id
-        addField(resultRow, refreshJobStatus.getJobId());
         // last refresh state
         addField(resultRow, refreshJobStatus.getRefreshState());
         // whether it's force refresh
@@ -731,6 +727,10 @@ public class ShowMaterializedViewStatus {
         addField(resultRow, queryRewriteStatus);
         // owner
         addField(resultRow, refreshJobStatus.getTaskOwner());
+        // process start time
+        addField(resultRow, TimeUtils.longToTimeString(refreshJobStatus.getMvRefreshProcessTime()));
+        // last refresh job id
+        addField(resultRow, refreshJobStatus.getJobId());
 
         return resultRow;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -769,8 +769,7 @@ public class TaskManager implements MemoryTrackable {
                 LOG.warn("Illegal TaskRun queryId:{} status transform from {} to {}",
                         statusChange.getQueryId(), fromStatus, toStatus);
             }
-        } else if (fromStatus == Constants.TaskRunState.RUNNING &&
-                (toStatus == Constants.TaskRunState.SUCCESS || toStatus == Constants.TaskRunState.FAILED)) {
+        } else if (fromStatus == Constants.TaskRunState.RUNNING && toStatus.isFinishState()) {
             // NOTE: TaskRuns before the fe restart will be replayed in `replayCreateTaskRun` which
             // will not be rerun because `InsertOverwriteJobRunner.replayStateChange` will replay, so
             // the taskRun's may be PENDING/RUNNING/SUCCESS.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
@@ -53,10 +53,8 @@ public class ShowMaterializedViewsStmt extends ShowStmt {
                     .column("task_id", ScalarType.createType(PrimitiveType.BIGINT))
                     .column("task_name", ScalarType.createVarchar(50))
                     .column("last_refresh_start_time", ScalarType.createType(PrimitiveType.DATETIME))
-                    .column("last_refresh_process_time", ScalarType.createType(PrimitiveType.DATETIME))
                     .column("last_refresh_finished_time", ScalarType.createType(PrimitiveType.DATETIME))
                     .column("last_refresh_duration", ScalarType.createType(PrimitiveType.DOUBLE))
-                    .column("last_refresh_job_id", ScalarType.createVarchar(64))
                     .column("last_refresh_state", ScalarType.createVarchar(20))
                     .column("last_refresh_force_refresh", ScalarType.createVarchar(8))
                     .column("last_refresh_start_partition", ScalarType.createVarchar(1024))
@@ -70,6 +68,8 @@ public class ShowMaterializedViewsStmt extends ShowStmt {
                     .column("extra_message", ScalarType.createVarchar(1024))
                     .column("query_rewrite_status", ScalarType.createVarchar(64))
                     .column("creator", ScalarType.createVarchar(64))
+                    .column("last_refresh_process_time", ScalarType.createType(PrimitiveType.DATETIME))
+                    .column("last_refresh_job_id", ScalarType.createVarchar(64))
                     .build();
 
     private static final Map<String, String> ALIAS_MAP = ImmutableMap.of(

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -38,18 +38,9 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.information.MaterializedViewsSystemTable;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.DDLStmtExecutor;
-import com.starrocks.qe.ShowExecutor;
-import com.starrocks.qe.ShowResultSet;
-import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.ast.CreateCatalogStmt;
-import com.starrocks.sql.ast.DropCatalogStmt;
 import com.starrocks.sql.ast.ShowMaterializedViewsStmt;
-import com.starrocks.sql.ast.ShowStmt;
-import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
@@ -109,10 +100,8 @@ public class ShowMaterializedViewTest {
                         "information_schema.materialized_views.task_id AS task_id, " +
                         "information_schema.materialized_views.task_name AS task_name, " +
                         "information_schema.materialized_views.last_refresh_start_time AS last_refresh_start_time, " +
-                        "information_schema.materialized_views.last_refresh_process_time AS last_refresh_process_time, " +
                         "information_schema.materialized_views.last_refresh_finished_time AS last_refresh_finished_time, " +
                         "information_schema.materialized_views.last_refresh_duration AS last_refresh_duration, " +
-                        "information_schema.materialized_views.last_refresh_job_id AS last_refresh_job_id, " +
                         "information_schema.materialized_views.last_refresh_state AS last_refresh_state, " +
                         "information_schema.materialized_views.last_refresh_force_refresh AS last_refresh_force_refresh, " +
                         "information_schema.materialized_views.last_refresh_start_partition AS last_refresh_start_partition, " +
@@ -127,7 +116,10 @@ public class ShowMaterializedViewTest {
                         "information_schema.materialized_views.MATERIALIZED_VIEW_DEFINITION AS text, " +
                         "information_schema.materialized_views.extra_message AS extra_message, " +
                         "information_schema.materialized_views.query_rewrite_status AS query_rewrite_status, " +
-                        "information_schema.materialized_views.creator AS creator FROM " +
+                        "information_schema.materialized_views.creator AS creator, " +
+                        "information_schema.materialized_views.last_refresh_process_time AS last_refresh_process_time, " +
+                        "information_schema.materialized_views.last_refresh_job_id AS last_refresh_job_id" +
+                        " FROM " +
                         "information_schema.materialized_views " +
                         "WHERE (information_schema.materialized_views.TABLE_SCHEMA = 'abc') AND " +
                         "(information_schema.materialized_views.TABLE_NAME = 'mv1')",

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -1013,7 +1013,6 @@ public class ShowExecutorTest {
                 "\"storage_medium\" = \"SSD\"\n" +
                 ")\n" +
                 "AS select col1, col2 from table1;";
-
         Assert.assertTrue(resultSet.next());
         List<Column> mvSchemaTable = MaterializedViewsSystemTable.create().getFullSchema();
         Assert.assertEquals("1000", resultSet.getString(0));
@@ -1027,21 +1026,21 @@ public class ShowExecutorTest {
         Assert.assertEquals("", resultSet.getString(8));
         Assert.assertEquals("\\N", resultSet.getString(9));
         Assert.assertEquals("\\N", resultSet.getString(10));
-        Assert.assertEquals("\\N", resultSet.getString(11));
-        Assert.assertEquals("0.000", resultSet.getString(12));
-        Assert.assertEquals("", resultSet.getString(13));
-        Assert.assertEquals("", resultSet.getString(14));
-        Assert.assertEquals("false", resultSet.getString(15));
+        Assert.assertEquals("0.000", resultSet.getString(11));
+        Assert.assertEquals("", resultSet.getString(12));
+        Assert.assertEquals("false", resultSet.getString(13));
         System.out.println(resultSet.getResultRows());
-        for (int i = 16; i < mvSchemaTable.size() - 5; i++) {
+        for (int i = 14; i < 20; i++) {
             System.out.println(i);
             Assert.assertEquals("", resultSet.getString(i));
         }
-        Assert.assertEquals("10", resultSet.getString(mvSchemaTable.size() - 5));
-        Assert.assertEquals(expectedSqlText, resultSet.getString(mvSchemaTable.size() - 4));
-        Assert.assertEquals("", resultSet.getString(mvSchemaTable.size() - 3));
-        Assert.assertTrue(resultSet.getString(mvSchemaTable.size() - 2).contains("UNKNOWN"));
-        Assert.assertEquals("", resultSet.getString(mvSchemaTable.size() - 1));
+        Assert.assertEquals("10", resultSet.getString(20));
+        Assert.assertEquals(expectedSqlText, resultSet.getString(21));
+        Assert.assertEquals("", resultSet.getString(22));
+        Assert.assertTrue(resultSet.getString(23).contains("UNKNOWN"));
+        Assert.assertEquals("", resultSet.getString(24));
+        Assert.assertEquals("\\N", resultSet.getString(25));
+        Assert.assertEquals("", resultSet.getString(26));
         Assert.assertFalse(resultSet.next());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
@@ -63,20 +63,20 @@ public class ShowMaterializedViewStatusTest {
         Assert.assertEquals("0", resultSet.get(7)); // task id
         Assert.assertEquals("", resultSet.get(8)); // task name
         Assert.assertEquals("\\N", resultSet.get(9)); // start time
-        Assert.assertEquals("\\N", resultSet.get(10)); // process start time
-        Assert.assertEquals("\\N", resultSet.get(11)); // process finish time
-        Assert.assertEquals("0.000", resultSet.get(12)); // process duration
-        Assert.assertEquals("", resultSet.get(13)); // last refresh job id
-        Assert.assertEquals("", resultSet.get(14)); // last refresh state
-        Assert.assertEquals("false", resultSet.get(15)); // force refresh
-        Assert.assertEquals("", resultSet.get(16)); // partition start
-        Assert.assertEquals("", resultSet.get(17)); // partition end
-        Assert.assertEquals("", resultSet.get(18)); // base partitions
-        Assert.assertEquals("", resultSet.get(19)); // mv partitions
-        Assert.assertEquals("", resultSet.get(20)); // error code
-        Assert.assertEquals("", resultSet.get(21)); // error message
-        Assert.assertEquals("0", resultSet.get(22)); // extra message
-        Assert.assertEquals("", resultSet.get(23)); // query rewrite status
-        Assert.assertEquals("", resultSet.get(24)); // owner
+        Assert.assertEquals("\\N", resultSet.get(10)); // process finish time
+        Assert.assertEquals("0.000", resultSet.get(11)); // process duration
+        Assert.assertEquals("", resultSet.get(12)); // last refresh state
+        Assert.assertEquals("false", resultSet.get(13)); // force refresh
+        Assert.assertEquals("", resultSet.get(14)); // partition start
+        Assert.assertEquals("", resultSet.get(15)); // partition end
+        Assert.assertEquals("", resultSet.get(16)); // base partitions
+        Assert.assertEquals("", resultSet.get(17)); // mv partitions
+        Assert.assertEquals("", resultSet.get(18)); // error code
+        Assert.assertEquals("", resultSet.get(19)); // error message
+        Assert.assertEquals("0", resultSet.get(20)); // extra message
+        Assert.assertEquals("", resultSet.get(21)); // query rewrite status
+        Assert.assertEquals("", resultSet.get(22)); // owner
+        Assert.assertEquals("", resultSet.get(23)); // process start time
+        Assert.assertEquals("", resultSet.get(24)); // last refresh job id
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -568,8 +568,8 @@ public class InformationSchemaDataSourceTest {
         // supported
         starRocksAssert.query("select TABLE_NAME, LAST_REFRESH_STATE,LAST_REFRESH_ERROR_CODE,IS_ACTIVE,INACTIVE_REASON\n" +
                         "from information_schema.materialized_views where table_name = 'test_mv1")
-                .explainContains(" OUTPUT EXPRS:3: TABLE_NAME | 15: LAST_REFRESH_STATE | " +
-                                "21: LAST_REFRESH_ERROR_CODE | 5: IS_ACTIVE | 6: INACTIVE_REASON\n" +
+                .explainContains(" OUTPUT EXPRS:3: TABLE_NAME | 13: LAST_REFRESH_STATE " +
+                                "| 19: LAST_REFRESH_ERROR_CODE | 5: IS_ACTIVE | 6: INACTIVE_REASON\n" +
                                 "  PARTITION: UNPARTITIONED",
                         "'test_mv1' | 'true' | '' | 'SUCCESS' | '0'");
         starRocksAssert.query("select count(1) from information_schema.materialized_views")

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1932,7 +1932,7 @@ class StarrocksSQLApiLib(object):
             if len(results) == 0:
                 return False
             for _res in results:
-                last_refresh_state = _res[14]
+                last_refresh_state = _res[12]
                 if last_refresh_state not in TASK_RUN_SUCCESS_STATES:
                     print("mv %s last refresh state is %s, not in %s" % (mv_name, last_refresh_state, TASK_RUN_SUCCESS_STATES))
                     return False

--- a/test/sql/test_materialized_view/R/test_show_materialized_view
+++ b/test/sql/test_materialized_view/R/test_show_materialized_view
@@ -11,14 +11,17 @@ use test_show_materialized_view;
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
 -- result:
 -- !result
-create materialized view user_tags_mv1  distributed by hash(user_id) as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
+create materialized view user_tags_mv1 
+distributed by hash(user_id) 
+REFRESH DEFERRED MANUAL
+as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
 -- result:
 -- !result
 show create materialized view user_tags_mv1;
 -- result:
 user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
-REFRESH MANUAL
+REFRESH DEFERRED MANUAL
 PROPERTIES (
 "replicated_storage" = "true",
 "replication_num" = "1",
@@ -32,7 +35,7 @@ show create table user_tags_mv1;
 -- result:
 user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
-REFRESH MANUAL
+REFRESH DEFERRED MANUAL
 PROPERTIES (
 "replicated_storage" = "true",
 "replication_num" = "1",
@@ -52,7 +55,7 @@ show create materialized view user_tags_mv1;
 -- result:
 user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
-REFRESH MANUAL
+REFRESH DEFERRED MANUAL
 PROPERTIES (
 "session.insert_timeout" = "3600",
 "replicated_storage" = "true",
@@ -68,7 +71,7 @@ show create table user_tags_mv1;
 -- result:
 user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
-REFRESH MANUAL
+REFRESH DEFERRED MANUAL
 PROPERTIES (
 "session.insert_timeout" = "3600",
 "replicated_storage" = "true",
@@ -119,91 +122,30 @@ select if(@last_refresh_time != @this_refresh_time,
 -- result:
 refreshed
 -- !result
-[UC]show materialized views where name like 'user_tags_mv1';
+select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name = 'user_tags_mv1';
 -- result:
-19074	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	19084	mv-19074	2025-06-26 22:13:39	2025-06-26 22:13:40	0.326	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
-DISTRIBUTED BY HASH(`user_id`)
-REFRESH MANUAL
-PROPERTIES (
-"session.insert_timeout" = "3600",
-"replicated_storage" = "true",
-"mv_rewrite_staleness_second" = "3600",
-"replication_num" = "1",
-"storage_medium" = "HDD"
-)
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197ac96-46f8-7630-a91b-3318130736ed"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-26 22:13:40	0197ac96-46f8-7f7e-ba02-fb5bd9d684de
+user_tags_mv1	0	true	
 -- !result
-[UC]show materialized views where name like '%user_tags_mv1%';
+select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like 'user_tags_mv1';
 -- result:
-19074	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	19084	mv-19074	2025-06-26 22:13:39	2025-06-26 22:13:40	0.326	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
-DISTRIBUTED BY HASH(`user_id`)
-REFRESH MANUAL
-PROPERTIES (
-"session.insert_timeout" = "3600",
-"replicated_storage" = "true",
-"mv_rewrite_staleness_second" = "3600",
-"replication_num" = "1",
-"storage_medium" = "HDD"
-)
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197ac96-46f8-7630-a91b-3318130736ed"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-26 22:13:40	0197ac96-46f8-7f7e-ba02-fb5bd9d684de
+user_tags_mv1	0	true	None
 -- !result
-[UC]show materialized views where name = 'user_tags_mv1';
+select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%user_tags_mv1%';
 -- result:
-19074	test_show_materialized_view	user_tags_mv1	MANUAL	true		UNPARTITIONED	19084	mv-19074	2025-06-26 22:13:39	2025-06-26 22:13:40	0.326	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
-DISTRIBUTED BY HASH(`user_id`)
-REFRESH MANUAL
-PROPERTIES (
-"session.insert_timeout" = "3600",
-"replicated_storage" = "true",
-"mv_rewrite_staleness_second" = "3600",
-"replication_num" = "1",
-"storage_medium" = "HDD"
-)
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197ac96-46f8-7630-a91b-3318130736ed"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-26 22:13:40	0197ac96-46f8-7f7e-ba02-fb5bd9d684de
+user_tags_mv1	0	true	None
 -- !result
-[UC]show materialized views from test_show_materialized_view where name like 'user_tags_mv1';
+select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%%';
 -- result:
-19074	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	19084	mv-19074	2025-06-26 22:13:39	2025-06-26 22:13:40	0.326	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
-DISTRIBUTED BY HASH(`user_id`)
-REFRESH MANUAL
-PROPERTIES (
-"session.insert_timeout" = "3600",
-"replicated_storage" = "true",
-"mv_rewrite_staleness_second" = "3600",
-"replication_num" = "1",
-"storage_medium" = "HDD"
-)
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197ac96-46f8-7630-a91b-3318130736ed"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-26 22:13:40	0197ac96-46f8-7f7e-ba02-fb5bd9d684de
+user_tags_mv1	0	true	None
 -- !result
-[UC]show materialized views from test_show_materialized_view where name like '%user_tags_mv1%';
+select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%bad_name%';
 -- result:
-19074	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	19084	mv-19074	2025-06-26 22:13:39	2025-06-26 22:13:40	0.326	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
-DISTRIBUTED BY HASH(`user_id`)
-REFRESH MANUAL
-PROPERTIES (
-"session.insert_timeout" = "3600",
-"replicated_storage" = "true",
-"mv_rewrite_staleness_second" = "3600",
-"replication_num" = "1",
-"storage_medium" = "HDD"
-)
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197ac96-46f8-7630-a91b-3318130736ed"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-26 22:13:40	0197ac96-46f8-7f7e-ba02-fb5bd9d684de
 -- !result
-[UC]show materialized views from test_show_materialized_view where name = 'user_tags_mv1';
+[UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name = 'user_tags_mv1';
 -- result:
-19074	test_show_materialized_view	user_tags_mv1	MANUAL	true		UNPARTITIONED	19084	mv-19074	2025-06-26 22:13:39	2025-06-26 22:13:40	0.326	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+22021	test_show_materialized_view	user_tags_mv1	MANUAL	true		UNPARTITIONED	22031	mv-22021	2025-06-27 11:15:04	2025-06-27 11:15:05	0.434	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
-REFRESH MANUAL
+REFRESH DEFERRED MANUAL
 PROPERTIES (
 "session.insert_timeout" = "3600",
 "replicated_storage" = "true",
@@ -213,7 +155,154 @@ PROPERTIES (
 )
 AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
 FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197ac96-46f8-7630-a91b-3318130736ed"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-26 22:13:40	0197ac96-46f8-7f7e-ba02-fb5bd9d684de
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197af61-b047-7082-924b-aee3fd7a4ce1"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-27 11:15:05	0197af61-b047-77bb-ad89-c04b4ded602e
+-- !result
+[UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like 'user_tags_mv1';
+-- result:
+22021	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	22031	mv-22021	2025-06-27 11:15:04	2025-06-27 11:15:05	0.434	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197af61-b047-7082-924b-aee3fd7a4ce1"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-27 11:15:05	0197af61-b047-77bb-ad89-c04b4ded602e
+-- !result
+[UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%user_tags_mv1%';
+-- result:
+22021	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	22031	mv-22021	2025-06-27 11:15:04	2025-06-27 11:15:05	0.434	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197af61-b047-7082-924b-aee3fd7a4ce1"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-27 11:15:05	0197af61-b047-77bb-ad89-c04b4ded602e
+-- !result
+[UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%%';
+-- result:
+22021	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	22031	mv-22021	2025-06-27 11:15:04	2025-06-27 11:15:05	0.434	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197af61-b047-7082-924b-aee3fd7a4ce1"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-27 11:15:05	0197af61-b047-77bb-ad89-c04b4ded602e
+-- !result
+[UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%bad_name%';
+-- result:
+-- !result
+[UC] show materialized views from test_show_materialized_view where name like 'user_tags_mv1';
+-- result:
+22021	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	22031	mv-22021	2025-06-27 11:15:04	2025-06-27 11:15:05	0.434	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197af61-b047-7082-924b-aee3fd7a4ce1"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-27 11:15:05	0197af61-b047-77bb-ad89-c04b4ded602e
+-- !result
+[UC] show materialized views from test_show_materialized_view where name like '%user_tags_mv1%';
+-- result:
+22021	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	22031	mv-22021	2025-06-27 11:15:04	2025-06-27 11:15:05	0.434	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197af61-b047-7082-924b-aee3fd7a4ce1"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-27 11:15:05	0197af61-b047-77bb-ad89-c04b4ded602e
+-- !result
+[UC] show materialized views from test_show_materialized_view where name = 'user_tags_mv1';
+-- result:
+22021	test_show_materialized_view	user_tags_mv1	MANUAL	true		UNPARTITIONED	22031	mv-22021	2025-06-27 11:15:04	2025-06-27 11:15:05	0.434	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197af61-b047-7082-924b-aee3fd7a4ce1"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-27 11:15:05	0197af61-b047-77bb-ad89-c04b4ded602e
+-- !result
+[UC] show materialized views where name like 'user_tags_mv1';
+-- result:
+22021	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	22031	mv-22021	2025-06-27 11:15:04	2025-06-27 11:15:05	0.434	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197af61-b047-7082-924b-aee3fd7a4ce1"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-27 11:15:05	0197af61-b047-77bb-ad89-c04b4ded602e
+-- !result
+[UC] show materialized views where name like '%user_tags_mv1%';
+-- result:
+22021	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	22031	mv-22021	2025-06-27 11:15:04	2025-06-27 11:15:05	0.434	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197af61-b047-7082-924b-aee3fd7a4ce1"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-27 11:15:05	0197af61-b047-77bb-ad89-c04b4ded602e
+-- !result
+[UC] show materialized views where name = 'user_tags_mv1';
+-- result:
+22021	test_show_materialized_view	user_tags_mv1	MANUAL	true		UNPARTITIONED	22031	mv-22021	2025-06-27 11:15:04	2025-06-27 11:15:05	0.434	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197af61-b047-7082-924b-aee3fd7a4ce1"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-27 11:15:05	0197af61-b047-77bb-ad89-c04b4ded602e
 -- !result
 drop database test_show_materialized_view;
 -- result:

--- a/test/sql/test_materialized_view/R/test_show_materialized_view
+++ b/test/sql/test_materialized_view/R/test_show_materialized_view
@@ -119,6 +119,102 @@ select if(@last_refresh_time != @this_refresh_time,
 -- result:
 refreshed
 -- !result
+[UC]show materialized views where name like 'user_tags_mv1';
+-- result:
+19074	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	19084	mv-19074	2025-06-26 22:13:39	2025-06-26 22:13:40	0.326	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197ac96-46f8-7630-a91b-3318130736ed"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-26 22:13:40	0197ac96-46f8-7f7e-ba02-fb5bd9d684de
+-- !result
+[UC]show materialized views where name like '%user_tags_mv1%';
+-- result:
+19074	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	19084	mv-19074	2025-06-26 22:13:39	2025-06-26 22:13:40	0.326	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197ac96-46f8-7630-a91b-3318130736ed"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-26 22:13:40	0197ac96-46f8-7f7e-ba02-fb5bd9d684de
+-- !result
+[UC]show materialized views where name = 'user_tags_mv1';
+-- result:
+19074	test_show_materialized_view	user_tags_mv1	MANUAL	true		UNPARTITIONED	19084	mv-19074	2025-06-26 22:13:39	2025-06-26 22:13:40	0.326	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197ac96-46f8-7630-a91b-3318130736ed"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-26 22:13:40	0197ac96-46f8-7f7e-ba02-fb5bd9d684de
+-- !result
+[UC]show materialized views from test_show_materialized_view where name like 'user_tags_mv1';
+-- result:
+19074	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	19084	mv-19074	2025-06-26 22:13:39	2025-06-26 22:13:40	0.326	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197ac96-46f8-7630-a91b-3318130736ed"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-26 22:13:40	0197ac96-46f8-7f7e-ba02-fb5bd9d684de
+-- !result
+[UC]show materialized views from test_show_materialized_view where name like '%user_tags_mv1%';
+-- result:
+19074	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	19084	mv-19074	2025-06-26 22:13:39	2025-06-26 22:13:40	0.326	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197ac96-46f8-7630-a91b-3318130736ed"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-26 22:13:40	0197ac96-46f8-7f7e-ba02-fb5bd9d684de
+-- !result
+[UC]show materialized views from test_show_materialized_view where name = 'user_tags_mv1';
+-- result:
+19074	test_show_materialized_view	user_tags_mv1	MANUAL	true		UNPARTITIONED	19084	mv-19074	2025-06-26 22:13:39	2025-06-26 22:13:40	0.326	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+DISTRIBUTED BY HASH(`user_id`)
+REFRESH MANUAL
+PROPERTIES (
+"session.insert_timeout" = "3600",
+"replicated_storage" = "true",
+"mv_rewrite_staleness_second" = "3600",
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
+FROM `test_show_materialized_view`.`user_tags`
+GROUP BY `user_tags`.`user_id`;	{"queryIds":["0197ac96-46f8-7630-a91b-3318130736ed"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-06-26 22:13:40	0197ac96-46f8-7f7e-ba02-fb5bd9d684de
+-- !result
 drop database test_show_materialized_view;
 -- result:
 -- !result

--- a/test/sql/test_materialized_view/T/test_show_materialized_view
+++ b/test/sql/test_materialized_view/T/test_show_materialized_view
@@ -43,5 +43,12 @@ set @this_refresh_time = (
 select if(@last_refresh_time != @this_refresh_time, 
     'refreshed', concat('no refresh after ', @last_refresh_time));
 
+[UC]show materialized views where name like 'user_tags_mv1';
+[UC]show materialized views where name like '%user_tags_mv1%';
+[UC]show materialized views where name = 'user_tags_mv1';
+
+[UC]show materialized views from test_show_materialized_view where name like 'user_tags_mv1';
+[UC]show materialized views from test_show_materialized_view where name like '%user_tags_mv1%';
+[UC]show materialized views from test_show_materialized_view where name = 'user_tags_mv1';
 
 drop database test_show_materialized_view;

--- a/test/sql/test_materialized_view/T/test_show_materialized_view
+++ b/test/sql/test_materialized_view/T/test_show_materialized_view
@@ -1,10 +1,13 @@
 -- name: test_show_materialized_view
+
 set enable_rewrite_bitmap_union_to_bitamp_agg = false;
 create database test_show_materialized_view;
 use test_show_materialized_view;
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
-create materialized view user_tags_mv1  distributed by hash(user_id) as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
-
+create materialized view user_tags_mv1 
+distributed by hash(user_id) 
+REFRESH DEFERRED MANUAL
+as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
 
 show create materialized view user_tags_mv1;
 show create table user_tags_mv1;
@@ -43,12 +46,21 @@ set @this_refresh_time = (
 select if(@last_refresh_time != @this_refresh_time, 
     'refreshed', concat('no refresh after ', @last_refresh_time));
 
-[UC]show materialized views where name like 'user_tags_mv1';
-[UC]show materialized views where name like '%user_tags_mv1%';
-[UC]show materialized views where name = 'user_tags_mv1';
-
-[UC]show materialized views from test_show_materialized_view where name like 'user_tags_mv1';
-[UC]show materialized views from test_show_materialized_view where name like '%user_tags_mv1%';
-[UC]show materialized views from test_show_materialized_view where name = 'user_tags_mv1';
+select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name = 'user_tags_mv1';
+select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like 'user_tags_mv1';
+select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%user_tags_mv1%';
+select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%%';
+select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%bad_name%';
+[UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name = 'user_tags_mv1';
+[UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like 'user_tags_mv1';
+[UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%user_tags_mv1%';
+[UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%%';
+[UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%bad_name%';
+[UC] show materialized views from test_show_materialized_view where name like 'user_tags_mv1';
+[UC] show materialized views from test_show_materialized_view where name like '%user_tags_mv1%';
+[UC] show materialized views from test_show_materialized_view where name = 'user_tags_mv1';
+[UC] show materialized views where name like 'user_tags_mv1';
+[UC] show materialized views where name like '%user_tags_mv1%';
+[UC] show materialized views where name = 'user_tags_mv1';
 
 drop database test_show_materialized_view;


### PR DESCRIPTION
## Why I'm doing:
#60054  adds more informations for `materialized_views` system table but introduces incompatible bugs:
```
mysql> SHOW MATERIALIZED VIEWS WHERE name LIKE 'order_mv2';
ERROR 1064 (HY000): schema not match.: BE:10007
```

There are two possible compatible bugs by this pr: #60054 

1.  Column types in information_schema .materialized_views in the FE and BE are not compatible which may cause unexpected exceptions
2. information_schema .materialized_views' columns order are disordered.

## What I'm doing:

Fix possible compatible bugs:
1. Correct information_schema .materialized_views column tables in FE and BE, ensure they are the same type
2. Add compatible codes to support lower version FE by referring https://github.com/StarRocks/starrocks/pull/59813
3. Correct new added `last_refresh_process_time` and `last_refresh_job_id` into the last to avoid compatible bugs

### Schema and Data Type Updates:
* Added logic in `SchemaChunkSource::prepare` to map specific column names (e.g., `MATERIALIZED_VIEW_ID`, `TASK_ID`, etc.) to appropriate data types like `BIGINT`, `DATETIME`, and `DOUBLE` for materialized views. (`be/src/exec/pipeline/scan/schema_chunk_source.cpp`)
* Adjusted column definitions in `MaterializedViewsSystemTable` to include `LAST_REFRESH_PROCESS_TIME` and `LAST_REFRESH_JOB_ID` while removing redundant columns. (`fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java`) [[1]](diffhunk://#diff-22bf6dac8cd1dbc1233d7f1cf9dd850344a00e7146da71a8bcce98e6e48bc8b1L87-L90) [[2]](diffhunk://#diff-22bf6dac8cd1dbc1233d7f1cf9dd850344a00e7146da71a8bcce98e6e48bc8b1R103-R104)


Fixes https://github.com/StarRocks/StarRocksTest/issues/9882

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
