### PR TITLE
[BugFix] GC inverted index path after segment data deleted

### DIFF
--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -750,8 +750,9 @@ void DataDir::perform_path_scan() {
                     std::string tablet_schema_hash_path = tablet_id_path + "/" + schema_hash;
                     _all_tablet_schemahash_paths.insert(tablet_schema_hash_path);
                     std::set<std::string> rowset_files;
+                    std::set<std::string> inverted_dirs;
 
-                    ret = fs::list_dirs_files(_fs.get(), tablet_schema_hash_path, nullptr, &rowset_files);
+                    ret = fs::list_dirs_files(_fs.get(), tablet_schema_hash_path, &inverted_dirs, &rowset_files);
                     if (!ret.ok()) {
                         LOG(WARNING) << "fail to walk dir. [path=" << tablet_schema_hash_path << "] error["
                                      << ret.to_string() << "]";
@@ -763,6 +764,12 @@ void DataDir::perform_path_scan() {
                             _all_check_dcg_files.insert(rowset_file_path);
                         } else {
                             _all_check_paths.insert(rowset_file_path);
+                        }
+                    }
+                    for (const auto& inverted_dir : inverted_dirs) {
+                        std::string inverted_index_path = tablet_schema_hash_path + "/" + inverted_dir;
+                        if (inverted_index_path.ends_with(".ivt")) {
+                            _all_check_paths.insert(inverted_index_path);
                         }
                     }
                 }


### PR DESCRIPTION
## Why I'm doing:

![image](https://github.com/user-attachments/assets/d814dadf-0567-4195-807b-35724339f4c9)

If rowset data is deleted by garbage collection, the inverted index will not be removed because path scanning ignores all of the directories under the tablet schema hash path.

## What I'm doing:

Path scanning will scan inverted index paths.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
