### PR TITLE
[BugFix] fix some cases when LakeAggregator can't find useful cn node

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -110,8 +110,8 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                     if (pickBackendId == -1) {
                         ComputeNode cn = LakeAggregator.chooseAggregatorNode(computeResource);
                         if (cn == null) {
-                            LOG.error("No alive compute node for aggregate operation.");
-                            throw new NoAliveBackendException("No alive compute node for aggregate operation");
+                            LOG.error("No available compute node found for the operation.");
+                            throw new NoAliveBackendException("No available compute node found for the operation");
                         }
                         pickBackendId = cn.getId();
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -110,7 +110,6 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                     if (pickBackendId == -1) {
                         ComputeNode cn = LakeAggregator.chooseAggregatorNode(computeResource);
                         if (cn == null) {
-                            LOG.error("No available compute node found for the operation.");
                             throw new NoAliveBackendException("No available compute node found for the operation");
                         }
                         pickBackendId = cn.getId();

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -29,6 +29,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.NetUtils;
@@ -107,7 +108,12 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             try {
                 if (isFileBundling) {
                     if (pickBackendId == -1) {
-                        pickBackendId = LakeAggregator.chooseAggregatorNode(computeResource).getId();
+                        ComputeNode cn = LakeAggregator.chooseAggregatorNode(computeResource);
+                        if (cn == null) {
+                            LOG.error("No alive compute node for aggregate operation.");
+                            throw new NoAliveBackendException("No alive compute node for aggregate operation");
+                        }
+                        pickBackendId = cn.getId();
                     }
                 } else {
                     pickBackendId = starOSAgent.getPrimaryComputeNodeIdByShard(shardId, computeResource.getWorkerGroupId());

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -438,7 +438,7 @@ public class CompactionScheduler extends Daemon {
         LakeAggregator aggregator = new LakeAggregator();
         ComputeNode aggregatorNode = aggregator.chooseAggregatorNode(computeResource);
         if (aggregatorNode == null) {
-            throw new NoAliveBackendException("No alive compute node for handle aggregate compaction");
+            throw new NoAliveBackendException("No alive compute node available for aggregate compaction");
         }
         LakeService service = BrpcProxy.getLakeService(aggregatorNode.getHost(), aggregatorNode.getBrpcPort());
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -26,6 +26,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DuplicatedRequestException;
 import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.Daemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -436,6 +437,9 @@ public class CompactionScheduler extends Daemon {
         WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         LakeAggregator aggregator = new LakeAggregator();
         ComputeNode aggregatorNode = aggregator.chooseAggregatorNode(computeResource);
+        if (aggregatorNode == null) {
+            throw new NoAliveBackendException("No alive compute node for handle aggregate compaction");
+        }
         LakeService service = BrpcProxy.getLakeService(aggregatorNode.getHost(), aggregatorNode.getBrpcPort());
 
         // 3. build AggregateCompactionTask

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -947,6 +947,23 @@ public class StarMgrMetaSyncerTest {
         Assert.assertTrue(starMgrMetaSyncer.syncTableMetaInternal(db, (OlapTable) table, true));
         Assert.assertEquals(3, shards.size());
 
+        // test aggregator
+        new MockUp<LakeAggregator>() {
+            @Mock
+            public static ComputeNode chooseAggregatorNode(ComputeResource computeResource) {
+                return null;
+            }
+        };
+        shards.clear();
+        shards.add(111L);
+        shards.add(222L);
+        shards.add(333L);
+        shards.add(555L);
+        OlapTable olapTable = (OlapTable) table;
+        olapTable.setFileBundling(true);
+        Assert.assertTrue(starMgrMetaSyncer.syncTableMetaInternal(db, olapTable, true));
+        Assert.assertEquals(3, shards.size());
+
         shards.clear();
         shards.add(111L);
         shards.add(222L);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -462,11 +462,13 @@ public class CompactionSchedulerTest {
                 globalTransactionMgr, globalStateMgr, "");
 
         Method method = CompactionScheduler.class.getDeclaredMethod("createAggregateCompactionTask",
-                long.class, Map.class, long.class, PartitionStatistics.CompactionPriority.class);
+                long.class, Map.class, long.class, PartitionStatistics.CompactionPriority.class,
+                ComputeResource.class);
         method.setAccessible(true);
         ExceptionChecker.expectThrows(InvocationTargetException.class,
                 () -> {
-                    method.invoke(scheduler, currentVersion, beToTablets, txnId, priority);
+                    method.invoke(scheduler, currentVersion, beToTablets, txnId, priority,
+                            WarehouseManager.DEFAULT_RESOURCE);
                 });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
+import com.starrocks.common.ExceptionChecker;
 import com.starrocks.lake.LakeAggregator;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.proto.AggregateCompactRequest;
@@ -48,6 +49,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
@@ -423,5 +425,48 @@ public class CompactionSchedulerTest {
         Assert.assertEquals(2, compactionScheduler.getRunningCompactions().size());
 
         Config.lake_compaction_max_tasks = old;
+    }
+
+    @Test
+    public void testCreateAggregateCompactionTaskWithNull() throws Exception {
+        long currentVersion = 1000L;
+        long txnId = 2000L;
+        Map<Long, List<Long>> beToTablets = new HashMap<>();
+        beToTablets.put(1001L, Lists.newArrayList(101L, 102L));
+        beToTablets.put(1002L, Lists.newArrayList(201L, 202L));
+        PartitionStatistics.CompactionPriority priority = PartitionStatistics.CompactionPriority.DEFAULT;
+
+        CompactionMgr compactionManager = new CompactionMgr();
+
+        ComputeNode node1 = new ComputeNode(1001L, "192.168.0.1", 9040);
+        node1.setBrpcPort(9050);
+        ComputeNode node2 = new ComputeNode(1002L, "192.168.0.2", 9040);
+        node2.setBrpcPort(9050);
+
+        new Expectations() {
+            {
+                systemInfoService.getBackendOrComputeNode(1001L);
+                result = node1;
+                systemInfoService.getBackendOrComputeNode(1002L);
+                result = node2;
+
+                globalStateMgr.getWarehouseMgr();
+                result = warehouseManager;
+
+                lakeAggregator.chooseAggregatorNode(WarehouseManager.DEFAULT_RESOURCE);
+                result = null;
+            }
+        };
+
+        CompactionScheduler scheduler = new CompactionScheduler(compactionManager, systemInfoService,
+                globalTransactionMgr, globalStateMgr, "");
+
+        Method method = CompactionScheduler.class.getDeclaredMethod("createAggregateCompactionTask",
+                long.class, Map.class, long.class, PartitionStatistics.CompactionPriority.class);
+        method.setAccessible(true);
+        ExceptionChecker.expectThrows(InvocationTargetException.class,
+                () -> {
+                    method.invoke(scheduler, currentVersion, beToTablets, txnId, priority);
+                });
     }
 }


### PR DESCRIPTION
## Why I'm doing:
In some case, `chooseAggregatorNode` could return null when LakeAggregator can't find useful cn node, and we need to handle it correctly.

## What I'm doing:
This pull request introduces a new exception handling mechanism for scenarios where no alive compute nodes are available during aggregation or compaction operations. It also adds corresponding unit tests to ensure robustness. The most important changes include the addition of the `NoAliveBackendException` class, modifications to handle null compute nodes in aggregation and compaction logic, and new test cases for these scenarios.

### Exception Handling Enhancements:
* [`fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java`](diffhunk://#diff-d1c7d332276bcc5e02842e06806119dfdd6f840d1a49b7ff2ee731ac7890feadL110-R116): Added logic to check for null compute nodes during aggregation operations and throw a `NoAliveBackendException` if no alive compute node is found.
* [`fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java`](diffhunk://#diff-14172f29582d5c45b5f04863493bb95ffcdb733ffa71d9ffbf69898a139349c7R425-R427): Incorporated a similar null check for compute nodes during compaction task creation and added logic to throw `NoAliveBackendException` when necessary.

### Unit Test Additions:
* [`fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java`](diffhunk://#diff-c45568fe68d3949fb1bbb9fc084ec4324853c7331f238e3649fdd115421d6848R950-R966): Added a test case to simulate a scenario where no compute node is available during aggregation operations. Mocked the `LakeAggregator.chooseAggregatorNode` method to return `null` for testing purposes.
* [`fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java`](diffhunk://#diff-a836381871cfb8da0c8aa9912583d4df34c9c7aa2b03e8b0ba4a9d5efb987156R356-R398): Added a test case to verify the behavior of `createAggregateCompactionTask` when no compute node is available, ensuring that the appropriate exception is thrown.

### Minor Changes:
* `fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java` and `fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java`: Imported `NoAliveBackendException` to support the new exception handling logic. [[1]](diffhunk://#diff-d1c7d332276bcc5e02842e06806119dfdd6f840d1a49b7ff2ee731ac7890feadR32) [[2]](diffhunk://#diff-14172f29582d5c45b5f04863493bb95ffcdb733ffa71d9ffbf69898a139349c7R29)
* [`fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java`](diffhunk://#diff-a836381871cfb8da0c8aa9912583d4df34c9c7aa2b03e8b0ba4a9d5efb987156R25): Added imports for `ExceptionChecker` and `InvocationTargetException` to facilitate testing of exception scenarios. [[1]](diffhunk://#diff-a836381871cfb8da0c8aa9912583d4df34c9c7aa2b03e8b0ba4a9d5efb987156R25) [[2]](diffhunk://#diff-a836381871cfb8da0c8aa9912583d4df34c9c7aa2b03e8b0ba4a9d5efb987156R51)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
