### PR TITLE
[Feature] Make record predicate available in rowset/segment read path

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -559,8 +559,8 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _segments_read_count = ADD_CHILD_COUNTER(_runtime_profile, "SegmentsReadCount", TUnit::UNIT, segment_read_name);
     _total_columns_data_page_count =
             ADD_CHILD_COUNTER(_runtime_profile, "TotalColumnsDataPageCount", TUnit::UNIT, segment_read_name);
-    _rec_cond_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "RecPredFilter", segment_read_name);
-    _rec_cond_filter_counter = ADD_CHILD_COUNTER(_runtime_profile, "RecPredFilterRows", TUnit::UNIT, segment_read_name);
+    _record_predicate_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "RecPredFilter", segment_read_name);
+    _record_predicate_filter_counter = ADD_CHILD_COUNTER(_runtime_profile, "RecPredFilterRows", TUnit::UNIT, segment_read_name);
 
     // IO statistics
     // IOTime
@@ -647,8 +647,8 @@ void LakeDataSource::update_counter() {
     COUNTER_UPDATE(_pred_filter_counter, _reader->stats().rows_vec_cond_filtered);
     COUNTER_UPDATE(_del_vec_filter_counter, _reader->stats().rows_del_vec_filtered);
 
-    COUNTER_UPDATE(_rec_cond_filter_timer, _reader->stats().rec_cond_evaluate_ns);
-    COUNTER_UPDATE(_rec_cond_filter_counter, _reader->stats().rows_rec_cond_filtered);
+    COUNTER_UPDATE(_record_predicate_filter_timer, _reader->stats().record_predicate_evaluate_ns);
+    COUNTER_UPDATE(_record_predicate_filter_counter, _reader->stats().rows_record_predicate_filtered);
 
     COUNTER_UPDATE(_seg_zm_filtered_counter, _reader->stats().segment_stats_filtered);
     COUNTER_UPDATE(_seg_rt_filtered_counter, _reader->stats().runtime_stats_filtered);

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -560,7 +560,8 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _total_columns_data_page_count =
             ADD_CHILD_COUNTER(_runtime_profile, "TotalColumnsDataPageCount", TUnit::UNIT, segment_read_name);
     _record_predicate_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "RecPredFilter", segment_read_name);
-    _record_predicate_filter_counter = ADD_CHILD_COUNTER(_runtime_profile, "RecPredFilterRows", TUnit::UNIT, segment_read_name);
+    _record_predicate_filter_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "RecPredFilterRows", TUnit::UNIT, segment_read_name);
 
     // IO statistics
     // IOTime

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -559,6 +559,8 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _segments_read_count = ADD_CHILD_COUNTER(_runtime_profile, "SegmentsReadCount", TUnit::UNIT, segment_read_name);
     _total_columns_data_page_count =
             ADD_CHILD_COUNTER(_runtime_profile, "TotalColumnsDataPageCount", TUnit::UNIT, segment_read_name);
+    _rec_cond_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "RecPredFilter", segment_read_name);
+    _rec_cond_filter_counter = ADD_CHILD_COUNTER(_runtime_profile, "RecPredFilterRows", TUnit::UNIT, segment_read_name);
 
     // IO statistics
     // IOTime
@@ -644,6 +646,9 @@ void LakeDataSource::update_counter() {
     COUNTER_UPDATE(_pred_filter_timer, cond_evaluate_ns);
     COUNTER_UPDATE(_pred_filter_counter, _reader->stats().rows_vec_cond_filtered);
     COUNTER_UPDATE(_del_vec_filter_counter, _reader->stats().rows_del_vec_filtered);
+
+    COUNTER_UPDATE(_rec_cond_filter_timer, _reader->stats().rec_cond_evaluate_ns);
+    COUNTER_UPDATE(_rec_cond_filter_counter, _reader->stats().rows_rec_cond_filtered);
 
     COUNTER_UPDATE(_seg_zm_filtered_counter, _reader->stats().segment_stats_filtered);
     COUNTER_UPDATE(_seg_rt_filtered_counter, _reader->stats().runtime_stats_filtered);

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -183,6 +183,9 @@ private:
     RuntimeProfile::Counter* _pushdown_access_paths_counter = nullptr;
     RuntimeProfile::Counter* _access_path_hits_counter = nullptr;
     RuntimeProfile::Counter* _access_path_unhits_counter = nullptr;
+
+    RuntimeProfile::Counter* _rec_cond_filter_timer = nullptr;
+    RuntimeProfile::Counter* _rec_cond_filter_counter = nullptr;
 };
 
 // ================================

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -184,8 +184,8 @@ private:
     RuntimeProfile::Counter* _access_path_hits_counter = nullptr;
     RuntimeProfile::Counter* _access_path_unhits_counter = nullptr;
 
-    RuntimeProfile::Counter* _rec_cond_filter_timer = nullptr;
-    RuntimeProfile::Counter* _rec_cond_filter_counter = nullptr;
+    RuntimeProfile::Counter* _record_predicate_filter_timer = nullptr;
+    RuntimeProfile::Counter* _record_predicate_filter_counter = nullptr;
 };
 
 // ================================

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -24,6 +24,7 @@
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/update_manager.h"
 #include "storage/projection_iterator.h"
+#include "storage/record_predicate/record_predicate_helper.h"
 #include "storage/rowset/rowid_range_option.h"
 #include "storage/rowset/rowset_options.h"
 #include "storage/rowset/segment.h"
@@ -227,13 +228,21 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
         seg_options.short_key_ranges = options.short_key_ranges_option->short_key_ranges;
     }
     seg_options.reader_type = options.reader_type;
+    if (_metadata->has_record_predicate()) {
+        ASSIGN_OR_RETURN(seg_options.record_predicate, RecordPredicateHelper::create(_metadata->record_predicate()));
+    }
 
     std::unique_ptr<Schema> segment_schema_guard;
     auto* segment_schema = const_cast<Schema*>(&schema);
-    // Append the columns with delete condition to segment schema.
-    std::set<ColumnId> delete_columns;
-    seg_options.delete_predicates.get_column_ids(&delete_columns);
-    for (ColumnId cid : delete_columns) {
+    // Append the columns with delete condition and record predicate to segment schema.
+    std::set<ColumnId> need_added_column;
+    seg_options.delete_predicates.get_column_ids(&need_added_column);
+    if (_metadata->has_record_predicate()) {
+        RETURN_IF_ERROR(
+            RecordPredicateHelper::get_column_ids(*seg_options.record_predicate, seg_options.tablet_schema, &need_added_column));
+    }
+
+    for (ColumnId cid : need_added_column) {
         const TabletColumn& col = options.tablet_schema->column(cid);
         if (segment_schema->get_field_by_name(std::string(col.name())) != nullptr) {
             continue;
@@ -324,6 +333,12 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
     SegmentReadOptions seg_options;
     ASSIGN_OR_RETURN(seg_options.fs, FileSystem::CreateSharedFromString(root_loc));
     seg_options.stats = stats;
+
+    if (_metadata->has_record_predicate()) {
+        ASSIGN_OR_RETURN(seg_options.record_predicate, RecordPredicateHelper::create(_metadata->record_predicate()));
+        RETURN_IF_ERROR(RecordPredicateHelper::check_valid_schema(*seg_options.record_predicate, schema));
+    }
+
     for (auto& seg_ptr : segments) {
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {
@@ -358,6 +373,12 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
     seg_options.version = version;
     seg_options.tablet_id = tablet_id();
     seg_options.rowset_id = metadata().id();
+
+    if (_metadata->has_record_predicate()) {
+        ASSIGN_OR_RETURN(seg_options.record_predicate, RecordPredicateHelper::create(_metadata->record_predicate()));
+        RETURN_IF_ERROR(RecordPredicateHelper::check_valid_schema(*seg_options.record_predicate, schema));
+    }
+
     for (auto& seg_ptr : segments) {
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -238,8 +238,8 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     std::set<ColumnId> need_added_column;
     seg_options.delete_predicates.get_column_ids(&need_added_column);
     if (_metadata->has_record_predicate()) {
-        RETURN_IF_ERROR(
-            RecordPredicateHelper::get_column_ids(*seg_options.record_predicate, seg_options.tablet_schema, &need_added_column));
+        RETURN_IF_ERROR(RecordPredicateHelper::get_column_ids(*seg_options.record_predicate, seg_options.tablet_schema,
+                                                              &need_added_column));
     }
 
     for (ColumnId cid : need_added_column) {

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -62,6 +62,8 @@ public:
     // |stats| used for iterator read stats
     // return iterator list, an iterator for each segment,
     // if the segment is empty, it wouln't add this iterator to iterator list
+    // this function does not expect segment schema will be changed, so return error if record predicate exists
+    // but does not match its chunk schema
     StatusOr<std::vector<ChunkIteratorPtr>> get_each_segment_iterator(const Schema& schema, bool file_data_cache,
                                                                       OlapReaderStatistics* stats);
 
@@ -72,6 +74,8 @@ public:
     // |stats| used for iterator read stats
     // return iterator list, an iterator for each segment,
     // if the segment is empty, it wouln't add this iterator to iterator list
+    // this function does not expect segment schema will be changed, so return error if record predicate exists
+    // but does not match its chunk schema
     StatusOr<std::vector<ChunkIteratorPtr>> get_each_segment_iterator_with_delvec(const Schema& schema, int64_t version,
                                                                                   const MetaFileBuilder* builder,
                                                                                   OlapReaderStatistics* stats);

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -241,6 +241,8 @@ struct OlapReaderStatistics {
     int64_t vec_cond_chunk_copy_ns = 0;
     int64_t branchless_cond_evaluate_ns = 0;
     int64_t expr_cond_evaluate_ns = 0;
+    int64_t rec_cond_evaluate_ns = 0;
+    int64_t rows_rec_cond_filtered = 0;
 
     int64_t get_rowsets_ns = 0;
     int64_t get_delvec_ns = 0;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -241,8 +241,8 @@ struct OlapReaderStatistics {
     int64_t vec_cond_chunk_copy_ns = 0;
     int64_t branchless_cond_evaluate_ns = 0;
     int64_t expr_cond_evaluate_ns = 0;
-    int64_t rec_cond_evaluate_ns = 0;
-    int64_t rows_rec_cond_filtered = 0;
+    int64_t record_predicate_evaluate_ns = 0;
+    int64_t rows_record_predicate_filtered = 0;
 
     int64_t get_rowsets_ns = 0;
     int64_t get_delvec_ns = 0;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1697,11 +1697,11 @@ StatusOr<uint16_t> SegmentIterator::_filter_by_expr_predicates(Chunk* chunk, vec
 StatusOr<uint16_t> SegmentIterator::_filter_by_record_predicate(Chunk* chunk, vector<rowid_t>* rowid) {
     size_t chunk_size = chunk->num_rows();
     if (chunk_size > 0 && _opts.record_predicate != nullptr) {
-        SCOPED_RAW_TIMER(&_opts.stats->rec_cond_evaluate_ns);
+        SCOPED_RAW_TIMER(&_opts.stats->record_predicate_evaluate_ns);
         RETURN_IF_ERROR(_opts.record_predicate->evaluate(chunk, _selection.data()));
 
         size_t new_size = _filter_chunk_by_selection(chunk, rowid, 0, chunk_size);
-        _opts.stats->rows_rec_cond_filtered += (chunk_size - new_size);
+        _opts.stats->rows_record_predicate_filtered += (chunk_size - new_size);
         chunk_size = new_size;
     }
     return chunk_size;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1771,7 +1771,7 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
     std::set<ColumnId> record_predicate_cols;
     if (_opts.record_predicate != nullptr) {
         RETURN_IF_ERROR(
-            RecordPredicateHelper::get_column_ids(*_opts.record_predicate, _schema, &record_predicate_cols));
+                RecordPredicateHelper::get_column_ids(*_opts.record_predicate, _schema, &record_predicate_cols));
     }
 
     for (size_t i = 0; i < early_materialize_fields; i++) {

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -25,6 +25,7 @@
 #include "storage/disjunctive_predicates.h"
 #include "storage/options.h"
 #include "storage/predicate_tree/predicate_tree.hpp"
+#include "storage/record_predicate/record_predicate.h"
 #include "storage/runtime_filter_predicate.h"
 #include "storage/runtime_range_pruner.h"
 #include "storage/seek_range.h"
@@ -61,6 +62,8 @@ public:
     RuntimeFilterPredicates runtime_filter_preds;
 
     DisjunctivePredicates delete_predicates;
+
+    RecordPredicateSPtr record_predicate;
 
     // used for updatable tablet to get delvec
     std::shared_ptr<DelvecLoader> delvec_loader;

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -27,6 +27,7 @@
 #include "gtest/gtest.h"
 #include "storage/chunk_helper.h"
 #include "storage/olap_common.h"
+#include "storage/record_predicate/record_predicate_helper.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/segment.h"
 #include "storage/rowset/segment_options.h"
@@ -528,6 +529,136 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
 
     ASSERT_OK(chunk_iter->get_next(res_chunk.get()));
     res_chunk->reset();
+}
+
+TEST_F(SegmentIteratorTest, testBasicColumnHashIsCongruentFilter) {
+    const int slice_num = 6;
+    std::vector<std::string> values;
+    const int overflow_sz = 32;
+    for (int i = 0; i < slice_num; ++i) {
+        std::string bigstr;
+        bigstr.reserve(overflow_sz);
+        for (int j = 0; j < overflow_sz; ++j) {
+            bigstr.push_back(j);
+        }
+        bigstr.push_back(i);
+        values.emplace_back(std::move(bigstr));
+    }
+
+    std::sort(values.begin(), values.end());
+
+    std::vector<Slice> data_strs;
+    for (const auto& data : values) {
+        data_strs.emplace_back(data);
+    }
+
+    using namespace starrocks::test;
+
+    std::string file_name = kSegmentDir + "/basic_column_hash_is_congruent_filter";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema = builder.create(1, false, TYPE_VARCHAR, true)
+                                                          .set_length(2048)
+                                                          .create(2, false, TYPE_VARCHAR, false)
+                                                          .set_length(2048)
+                                                          .build();
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 1024;
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    int32_t chunk_size = config::vector_chunk_size;
+    size_t num_rows = slice_num;
+
+    auto slice_provider = [&data_strs](int32_t i) { return data_strs[i % data_strs.size()]; };
+
+    // tablet data builder
+    TabletDataBuilder segment_data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(segment_data_builder.append(0, slice_provider));
+    ASSERT_OK(segment_data_builder.append(1, slice_provider));
+    ASSERT_OK(segment_data_builder.finalize_footer());
+
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    SegmentReadOptions seg_options;
+    OlapReaderStatistics stats;
+    seg_options.fs = _fs;
+    seg_options.stats = &stats;
+
+    ColumnIdToGlobalDictMap dict_map;
+    GlobalDictMap g_dict;
+    for (int i = 0; i < slice_num; ++i) {
+        g_dict[Slice(values[i])] = i;
+    }
+    dict_map[1] = &g_dict;
+    seg_options.global_dictmaps = &dict_map;
+
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_VARCHAR).add(1, "c1", TYPE_VARCHAR);
+    auto vec_schema = schema_builder.build();
+
+    auto chunk_iter = new_segment_iterator(segment, vec_schema, seg_options);
+    int num_columns = 2;
+    ASSERT_OK(chunk_iter->init_output_schema(std::unordered_set<uint32_t>()));
+
+    auto res_chunk = ChunkHelper::new_chunk(chunk_iter->output_schema(), chunk_size);
+    ASSERT_OK(chunk_iter->get_next(res_chunk.get()));
+    ASSERT_TRUE(res_chunk->num_rows() == 6);
+    ASSERT_TRUE(res_chunk->num_columns() == num_columns);
+
+    std::vector<uint32_t> hashes(num_rows, 0);
+    res_chunk->get_column_by_id(0)->crc32_hash(&(hashes)[0], 0, num_rows);
+    std::vector<uint32_t> mod_values;
+    std::vector<uint32_t> index_mod_0;
+    std::vector<uint32_t> index_mod_1;
+    for (int i = 0; i < hashes.size(); ++i) {
+        int cur_mod = hashes[i] % 2;
+        if (cur_mod == 0) {
+            index_mod_0.push_back(i);
+        } else {
+            index_mod_1.push_back(i);
+        }
+    }
+
+    {
+        // test remainder = 0
+        RecordPredicatePB record_predicate_pb;
+        record_predicate_pb.set_type(RecordPredicatePB::COLUMN_HASH_IS_CONGRUENT);
+        auto column_hash_is_congruent_pb = record_predicate_pb.mutable_column_hash_is_congruent();
+        column_hash_is_congruent_pb->set_modulus(2);
+        column_hash_is_congruent_pb->set_remainder(0);
+        column_hash_is_congruent_pb->add_column_names("c0");
+        seg_options.record_predicate = std::move(RecordPredicateHelper::create(record_predicate_pb).value());
+        auto chunk_iter_mod_0 = new_segment_iterator(segment, vec_schema, seg_options);
+        auto res_chunk_mod_0 = ChunkHelper::new_chunk(chunk_iter->output_schema(), chunk_size);
+        ASSERT_OK(chunk_iter_mod_0->get_next(res_chunk_mod_0.get()));
+        ASSERT_TRUE(res_chunk_mod_0->num_rows() == index_mod_0.size());
+        ASSERT_TRUE(res_chunk_mod_0->num_columns() == num_columns);
+        auto binary_0 = down_cast<BinaryColumn*>(res_chunk_mod_0->get_column_by_index(0).get());
+        for (int i = 0; i < index_mod_0.size(); ++i) {
+            ASSERT_EQ(binary_0->get_slice(i), Slice(values[index_mod_0[i]]));
+        }
+    }
+
+    {
+        // test remainder = 1
+        RecordPredicatePB record_predicate_pb;
+        record_predicate_pb.set_type(RecordPredicatePB::COLUMN_HASH_IS_CONGRUENT);
+        auto column_hash_is_congruent_pb = record_predicate_pb.mutable_column_hash_is_congruent();
+        column_hash_is_congruent_pb->set_modulus(2);
+        column_hash_is_congruent_pb->set_remainder(1);
+        column_hash_is_congruent_pb->add_column_names("c0");
+        seg_options.record_predicate = std::move(RecordPredicateHelper::create(record_predicate_pb).value());
+        auto chunk_iter_mod_1 = new_segment_iterator(segment, vec_schema, seg_options);
+        auto res_chunk_mod_1 = ChunkHelper::new_chunk(chunk_iter->output_schema(), chunk_size);
+        ASSERT_OK(chunk_iter_mod_1->get_next(res_chunk_mod_1.get()));
+        ASSERT_TRUE(res_chunk_mod_1->num_rows() == index_mod_1.size());
+        ASSERT_TRUE(res_chunk_mod_1->num_columns() == num_columns);
+        auto binary_1 = down_cast<BinaryColumn*>(res_chunk_mod_1->get_column_by_index(0).get());
+        for (int i = 0; i < index_mod_1.size(); ++i) {
+            ASSERT_EQ(binary_1->get_slice(i), Slice(values[index_mod_1[i]]));
+        }
+    }
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## What I'm doing:
This is a prerequisite for tablet splitting. In pr #59993 we introduce record predicate and in this pr, we make it available in rowset/segment read path.

Fixes #59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
