### PR TITLE
[Refactor] get storage vol by cluster snapshot job when upload/delete snapshot files from remote

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
@@ -131,7 +131,7 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon {
             job.setState(ClusterSnapshotJobState.UPLOADING);
             job.logJob();
             try {
-                ClusterSnapshotUtils.uploadSnapshotToRemote(job);
+                ClusterSnapshotUtils.uploadClusterSnapshotToRemote(job);
             } catch (StarRocksException e) {
                 errMsg = "upload image failed, err msg: " + e.getMessage();
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
@@ -131,7 +131,7 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon {
             job.setState(ClusterSnapshotJobState.UPLOADING);
             job.logJob();
             try {
-                ClusterSnapshotUtils.uploadAutomatedSnapshotToRemote(job.getSnapshotName());
+                ClusterSnapshotUtils.uploadSnapshotToRemote(job);
             } catch (StarRocksException e) {
                 errMsg = "upload image failed, err msg: " + e.getMessage();
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -116,7 +116,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
             }
 
             try {
-                ClusterSnapshotUtils.clearAutomatedSnapshotFromRemote(job.getSnapshotName());
+                ClusterSnapshotUtils.clearSnapshotFromRemote(job);
                 if (job.isExpired()) {
                     job.setState(ClusterSnapshotJobState.DELETED);
                     job.logJob();
@@ -150,12 +150,12 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         return job;
     }
 
-    public StorageVolume getAutomatedSnapshotStorageVolume() {
-        if (storageVolumeName == null) {
+    public StorageVolume getSnapshotStorageVolumeByJob(ClusterSnapshotJob job) {
+        if (job == null) {
             return null;
         }
 
-        return GlobalStateMgr.getCurrentState().getStorageVolumeMgr().getStorageVolumeByName(storageVolumeName);
+        return GlobalStateMgr.getCurrentState().getStorageVolumeMgr().getStorageVolumeByName(job.getStorageVolumeName());
     }
 
     public ClusterSnapshotJob getLastFinishedAutomatedClusterSnapshotJob() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -116,7 +116,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
             }
 
             try {
-                ClusterSnapshotUtils.clearSnapshotFromRemote(job);
+                ClusterSnapshotUtils.clearClusterSnapshotFromRemote(job);
                 if (job.isExpired()) {
                     job.setState(ClusterSnapshotJobState.DELETED);
                     job.logJob();
@@ -150,7 +150,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         return job;
     }
 
-    public StorageVolume getSnapshotStorageVolumeByJob(ClusterSnapshotJob job) {
+    public StorageVolume getStorageVolumeBySnapshotJob(ClusterSnapshotJob job) {
         if (job == null) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotUtils.java
@@ -26,26 +26,26 @@ public class ClusterSnapshotUtils {
                 GlobalStateMgr.getCurrentState().getStarOSAgent().getRawServiceId(), "meta/image", snapshotName);
     }
 
-    public static void uploadSnapshotToRemote(ClusterSnapshotJob job) throws StarRocksException {
+    public static void uploadClusterSnapshotToRemote(ClusterSnapshotJob job) throws StarRocksException {
         String snapshotName = job.getSnapshotName();
         if (snapshotName == null || snapshotName.isEmpty()) {
             return;
         }
 
-        StorageVolume sv = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getSnapshotStorageVolumeByJob(job);
+        StorageVolume sv = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getStorageVolumeBySnapshotJob(job);
         String snapshotImagePath = getSnapshotImagePath(sv, snapshotName);
         String localImagePath = GlobalStateMgr.getImageDirPath();
 
         HdfsUtil.copyFromLocal(localImagePath, snapshotImagePath, sv.getProperties());
     }
 
-    public static void clearSnapshotFromRemote(ClusterSnapshotJob job) throws StarRocksException {
+    public static void clearClusterSnapshotFromRemote(ClusterSnapshotJob job) throws StarRocksException {
         String snapshotName = job.getSnapshotName();
         if (snapshotName == null || snapshotName.isEmpty()) {
             return;
         }
 
-        StorageVolume sv = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getSnapshotStorageVolumeByJob(job);
+        StorageVolume sv = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getStorageVolumeBySnapshotJob(job);
         BrokerDesc brokerDesc = new BrokerDesc(sv.getProperties());
         String snapshotImagePath = getSnapshotImagePath(sv, snapshotName);
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotUtils.java
@@ -26,28 +26,26 @@ public class ClusterSnapshotUtils {
                 GlobalStateMgr.getCurrentState().getStarOSAgent().getRawServiceId(), "meta/image", snapshotName);
     }
 
-    public static void uploadAutomatedSnapshotToRemote(String snapshotName) throws StarRocksException {
+    public static void uploadSnapshotToRemote(ClusterSnapshotJob job) throws StarRocksException {
+        String snapshotName = job.getSnapshotName();
         if (snapshotName == null || snapshotName.isEmpty()) {
             return;
         }
 
-        StorageVolume sv = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getAutomatedSnapshotStorageVolume();
+        StorageVolume sv = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getSnapshotStorageVolumeByJob(job);
         String snapshotImagePath = getSnapshotImagePath(sv, snapshotName);
         String localImagePath = GlobalStateMgr.getImageDirPath();
 
         HdfsUtil.copyFromLocal(localImagePath, snapshotImagePath, sv.getProperties());
     }
 
-    public static void clearAutomatedSnapshotFromRemote(String snapshotName) throws StarRocksException {
+    public static void clearSnapshotFromRemote(ClusterSnapshotJob job) throws StarRocksException {
+        String snapshotName = job.getSnapshotName();
         if (snapshotName == null || snapshotName.isEmpty()) {
             return;
         }
 
-        StorageVolume sv = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getAutomatedSnapshotStorageVolume();
-        clearClusterSnapshotFromRemote(snapshotName, sv);
-    }
-
-    public static void clearClusterSnapshotFromRemote(String snapshotName, StorageVolume sv) throws StarRocksException {
+        StorageVolume sv = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getSnapshotStorageVolumeByJob(job);
         BrokerDesc brokerDesc = new BrokerDesc(sv.getProperties());
         String snapshotImagePath = getSnapshotImagePath(sv, snapshotName);
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -1050,7 +1050,7 @@ public class StarMgrMetaSyncerTest {
 
         new MockUp<ClusterSnapshotUtils>() {
             @Mock
-            public static void clearSnapshotFromRemote(ClusterSnapshotJob job) {
+            public static void clearClusterSnapshotFromRemote(ClusterSnapshotJob job) {
                 return;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -1050,7 +1050,7 @@ public class StarMgrMetaSyncerTest {
 
         new MockUp<ClusterSnapshotUtils>() {
             @Mock
-            public static void clearAutomatedSnapshotFromRemote(String snapshotName) {
+            public static void clearSnapshotFromRemote(ClusterSnapshotJob job) {
                 return;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
@@ -222,9 +222,9 @@ public class ClusterSnapshotTest {
                 GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getAllSnapshotJobsInfo().getItemsSize() == 1);
 
         ExceptionChecker.expectThrowsNoException(
-                () -> ClusterSnapshotUtils.uploadAutomatedSnapshotToRemote(job.getSnapshotName()));
+                () -> ClusterSnapshotUtils.uploadSnapshotToRemote(job));
         ExceptionChecker.expectThrowsNoException(
-                () -> ClusterSnapshotUtils.clearAutomatedSnapshotFromRemote(job.getSnapshotName()));
+                () -> ClusterSnapshotUtils.clearSnapshotFromRemote(job));
         setAutomatedSnapshotOff(false);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
@@ -222,9 +222,9 @@ public class ClusterSnapshotTest {
                 GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getAllSnapshotJobsInfo().getItemsSize() == 1);
 
         ExceptionChecker.expectThrowsNoException(
-                () -> ClusterSnapshotUtils.uploadSnapshotToRemote(job));
+                () -> ClusterSnapshotUtils.uploadClusterSnapshotToRemote(job));
         ExceptionChecker.expectThrowsNoException(
-                () -> ClusterSnapshotUtils.clearSnapshotFromRemote(job));
+                () -> ClusterSnapshotUtils.clearClusterSnapshotFromRemote(job));
         setAutomatedSnapshotOff(false);
     }
 


### PR DESCRIPTION
## What I'm doing:
get storage vol by cluster snapshot job in upload/delete for future purpose

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
