### PR TITLE
[BugFix] Ensure information_schema.task_runs more compatible with null values

### DIFF
--- a/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
@@ -29,10 +29,10 @@ SchemaScanner::ColumnDesc SchemaTaskRunsScanner::_s_tbls_columns[] = {
         {"TASK_NAME", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
         {"CREATE_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
         {"FINISH_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
-        {"STATE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"CATALOG", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"DATABASE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"DEFINITION", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"STATE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
+        {"CATALOG", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
+        {"DATABASE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
+        {"DEFINITION", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
         {"EXPIRE_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(StringValue), true},
         {"ERROR_CODE", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(StringValue), true},
         {"ERROR_MESSAGE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
@@ -148,9 +148,14 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             // STATE
             {
                 ColumnPtr column = (*chunk)->get_column_by_slot_id(5);
-                const std::string* str = &task_run_info.state;
-                Slice value(str->c_str(), str->length());
-                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                if (task_run_info.__isset.state) {
+                    const std::string* str = &task_run_info.state;
+                    Slice value(str->c_str(), str->length());
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                } else {
+                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
+                    nullable_column->append_nulls(1);
+                }
             }
             break;
         }
@@ -158,12 +163,14 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             // CATALOG
             {
                 ColumnPtr column = (*chunk)->get_column_by_slot_id(6);
-                std::string catalog_name = "default_catalog";
                 if (task_run_info.__isset.catalog) {
-                    catalog_name = task_run_info.catalog;
+                    const std::string* str = &task_run_info.catalog;
+                    Slice value(str->c_str(), str->length());
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                } else {
+                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
+                    nullable_column->append_nulls(1);
                 }
-                Slice value(catalog_name.c_str(), catalog_name.length());
-                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
             }
             break;
         }
@@ -171,9 +178,14 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             // DATABASE
             {
                 ColumnPtr column = (*chunk)->get_column_by_slot_id(7);
-                const std::string* db_name = &task_run_info.database;
-                Slice value(db_name->c_str(), db_name->length());
-                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                if (task_run_info.__isset.database) {
+                    const std::string* str = &task_run_info.database;
+                    Slice value(str->c_str(), str->length());
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                } else {
+                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
+                    nullable_column->append_nulls(1);
+                }
             }
             break;
         }
@@ -181,9 +193,14 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             // DEFINITION
             {
                 ColumnPtr column = (*chunk)->get_column_by_slot_id(8);
-                const std::string* str = &task_run_info.definition;
-                Slice value(str->c_str(), str->length());
-                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                if (task_run_info.__isset.definition) {
+                    const std::string* str = &task_run_info.definition;
+                    Slice value(str->c_str(), str->length());
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                } else {
+                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
+                    nullable_column->append_nulls(1);
+                }
             }
             break;
         }
@@ -215,7 +232,8 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                     int64_t value = task_run_info.error_code;
                     fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&value);
                 } else {
-                    fill_data_column_with_null(column.get());
+                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
+                    nullable_column->append_nulls(1);
                 }
             }
             break;
@@ -269,9 +287,14 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             // properties
             {
                 ColumnPtr column = (*chunk)->get_column_by_slot_id(14);
-                const std::string* str = &task_run_info.properties;
-                Slice value(str->c_str(), str->length());
-                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                if (task_run_info.__isset.properties) {
+                    const std::string* str = &task_run_info.properties;
+                    Slice value(str->c_str(), str->length());
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                } else {
+                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
+                    nullable_column->append_nulls(1);
+                }
             }
             break;
         }
@@ -279,9 +302,14 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             // job_id
             {
                 ColumnPtr column = (*chunk)->get_column_by_slot_id(15);
-                const std::string* str = &task_run_info.job_id;
-                Slice value(str->c_str(), str->length());
-                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                if (task_run_info.__isset.job_id) {
+                    const std::string* str = &task_run_info.job_id;
+                    Slice value(str->c_str(), str->length());
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                } else {
+                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
+                    nullable_column->append_nulls(1);
+                }
             }
             break;
         }
@@ -314,7 +342,7 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
 }
 
 Status SchemaTaskRunsScanner::get_next(ChunkPtr* chunk, bool* eos) {
-    if (!_is_init) {
+    if (!_is_init || chunk == nullptr || eos == nullptr) {
         return Status::InternalError("Used before initialized.");
     }
     if (_task_run_index >= _task_run_result.task_runs.size()) {

--- a/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
@@ -153,8 +153,7 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                     Slice value(str->c_str(), str->length());
                     fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
                 } else {
-                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
-                    nullable_column->append_nulls(1);
+                    fill_data_column_with_null(column.get());
                 }
             }
             break;
@@ -168,8 +167,7 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                     Slice value(str->c_str(), str->length());
                     fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
                 } else {
-                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
-                    nullable_column->append_nulls(1);
+                    fill_data_column_with_null(column.get());
                 }
             }
             break;
@@ -183,8 +181,7 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                     Slice value(str->c_str(), str->length());
                     fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
                 } else {
-                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
-                    nullable_column->append_nulls(1);
+                    fill_data_column_with_null(column.get());
                 }
             }
             break;
@@ -198,8 +195,7 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                     Slice value(str->c_str(), str->length());
                     fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
                 } else {
-                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
-                    nullable_column->append_nulls(1);
+                    fill_data_column_with_null(column.get());
                 }
             }
             break;
@@ -232,8 +228,7 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                     int64_t value = task_run_info.error_code;
                     fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&value);
                 } else {
-                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
-                    nullable_column->append_nulls(1);
+                    fill_data_column_with_null(column.get());
                 }
             }
             break;
@@ -247,8 +242,7 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                     Slice value(str->c_str(), str->length());
                     fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
                 } else {
-                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
-                    nullable_column->append_nulls(1);
+                    fill_data_column_with_null(column.get());
                 }
             }
             break;
@@ -262,8 +256,7 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                     Slice value(str->c_str(), str->length());
                     fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
                 } else {
-                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
-                    nullable_column->append_nulls(1);
+                    fill_data_column_with_null(column.get());
                 }
             }
             break;
@@ -277,8 +270,7 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                     Slice value(str->c_str(), str->length());
                     fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
                 } else {
-                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
-                    nullable_column->append_nulls(1);
+                    fill_data_column_with_null(column.get());
                 }
             }
             break;
@@ -292,8 +284,7 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                     Slice value(str->c_str(), str->length());
                     fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
                 } else {
-                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
-                    nullable_column->append_nulls(1);
+                    fill_data_column_with_null(column.get());
                 }
             }
             break;
@@ -307,8 +298,7 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                     Slice value(str->c_str(), str->length());
                     fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
                 } else {
-                    auto* nullable_column = down_cast<NullableColumn*>(column.get());
-                    nullable_column->append_nulls(1);
+                    fill_data_column_with_null(column.get());
                 }
             }
             break;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -73,6 +73,7 @@ set(EXEC_FILES
         ./exec/schema_columns_scanner_test.cpp
         ./exec/schema_fe_tablet_schedules_scanner_test.cpp
         ./exec/schema_materialized_views_scanner_test.cpp
+        ./exec/schema_task_runs_scanner_test.cpp
         ./exec/sink/connector_sink_operator_test.cpp
         ./exec/sink/sink_io_buffer_test.cpp
         ./exec/stream/mem_state_table_test.cpp

--- a/be/test/exec/schema_task_runs_scanner_test.cpp
+++ b/be/test/exec/schema_task_runs_scanner_test.cpp
@@ -414,6 +414,8 @@ TEST_F(SchemaTaskRunsScannerTest, test_task_run_with_large_error_code) {
     TTaskRunInfo task_run;
     task_run.__set_query_id("query_001");
     task_run.__set_task_name("test_task");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverflow"
     task_run.__set_error_code(9223372036854775807LL); // MAX_INT64
     task_run.__set_error_message("Error with maximum error code");
 
@@ -432,6 +434,7 @@ TEST_F(SchemaTaskRunsScannerTest, test_task_run_with_large_error_code) {
     EXPECT_TRUE(row.find("test_task") != std::string::npos);
     EXPECT_TRUE(row.find("-1") != std::string::npos); // ERROR_CODE
     EXPECT_TRUE(row.find("Error with maximum error code") != std::string::npos);
+#pragma GCC diagnostic pop
 }
 
 } // namespace starrocks

--- a/be/test/exec/schema_task_runs_scanner_test.cpp
+++ b/be/test/exec/schema_task_runs_scanner_test.cpp
@@ -1,0 +1,437 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/schema_task_runs_scanner.h"
+
+#include <gtest/gtest.h>
+
+#include "column/column_helper.h"
+#include "runtime/runtime_state.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class SchemaTaskRunsScannerTest : public ::testing::Test {
+private:
+    ChunkPtr create_chunk(const std::vector<SlotDescriptor*> slot_descs) {
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        for (const auto* slot_desc : slot_descs) {
+            MutableColumnPtr column = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
+            chunk->append_column(std::move(column), slot_desc->id());
+        }
+        return chunk;
+    }
+
+    void init_scanner(SchemaTaskRunsScanner& scanner) {
+        EXPECT_OK(scanner.init(&_params, &_pool));
+        scanner._runtime_state = _state.get();
+    }
+
+protected:
+    void SetUp() override {
+        _params.ip = &_ip;
+        _params.port = 9020;
+        _state = std::make_unique<RuntimeState>(TUniqueId(), TQueryOptions(), TQueryGlobals(), nullptr);
+    }
+
+    SchemaScannerParam _params;
+    std::string _ip = "127.0.0.1";
+    ObjectPool _pool;
+    std::unique_ptr<RuntimeState> _state;
+};
+
+TEST_F(SchemaTaskRunsScannerTest, test_scanner_initialization) {
+    SchemaTaskRunsScanner scanner;
+    init_scanner(scanner);
+
+    // Test that scanner has the correct number of columns
+    auto slot_descs = scanner.get_slot_descs();
+    EXPECT_EQ(16, slot_descs.size());
+
+    // Test column names and types
+    EXPECT_EQ("QUERY_ID", slot_descs[0]->col_name());
+    EXPECT_EQ("TASK_NAME", slot_descs[1]->col_name());
+    EXPECT_EQ("CREATE_TIME", slot_descs[2]->col_name());
+    EXPECT_EQ("FINISH_TIME", slot_descs[3]->col_name());
+    EXPECT_EQ("STATE", slot_descs[4]->col_name());
+    EXPECT_EQ("CATALOG", slot_descs[5]->col_name());
+    EXPECT_EQ("DATABASE", slot_descs[6]->col_name());
+    EXPECT_EQ("DEFINITION", slot_descs[7]->col_name());
+    EXPECT_EQ("EXPIRE_TIME", slot_descs[8]->col_name());
+    EXPECT_EQ("ERROR_CODE", slot_descs[9]->col_name());
+    EXPECT_EQ("ERROR_MESSAGE", slot_descs[10]->col_name());
+    EXPECT_EQ("PROGRESS", slot_descs[11]->col_name());
+    EXPECT_EQ("EXTRA_MESSAGE", slot_descs[12]->col_name());
+    EXPECT_EQ("PROPERTIES", slot_descs[13]->col_name());
+    EXPECT_EQ("JOB_ID", slot_descs[14]->col_name());
+    EXPECT_EQ("PROCESS_TIME", slot_descs[15]->col_name());
+}
+
+TEST_F(SchemaTaskRunsScannerTest, test_uninitialized_scanner) {
+    SchemaTaskRunsScanner scanner;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    // Should fail because scanner is not initialized
+    EXPECT_FALSE(scanner.get_next(&chunk, &eos).ok());
+}
+
+TEST_F(SchemaTaskRunsScannerTest, test_null_pointer_parameters) {
+    SchemaTaskRunsScanner scanner;
+    init_scanner(scanner);
+
+    // Test with null chunk pointer
+    bool eos = false;
+    EXPECT_FALSE(scanner.get_next(nullptr, &eos).ok());
+
+    // Test with null eos pointer
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    EXPECT_FALSE(scanner.get_next(&chunk, nullptr).ok());
+}
+
+TEST_F(SchemaTaskRunsScannerTest, test_empty_task_runs_list) {
+    SchemaTaskRunsScanner scanner;
+    init_scanner(scanner);
+
+    // Mock empty task runs result
+    scanner._task_run_result.task_runs.clear();
+    scanner._task_run_index = 0;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_TRUE(eos);
+    EXPECT_EQ(0, chunk->num_rows());
+}
+
+TEST_F(SchemaTaskRunsScannerTest, test_single_task_run) {
+    SchemaTaskRunsScanner scanner;
+    init_scanner(scanner);
+
+    // Mock task run data
+    TTaskRunInfo task_run;
+    task_run.__set_query_id("query_001");
+    task_run.__set_task_name("test_task");
+    task_run.__set_create_time(1640995200); // 2022-01-01 00:00:00
+    task_run.__set_finish_time(1640995500); // 2022-01-01 00:05:00
+    task_run.__set_state("SUCCESS");
+    task_run.__set_catalog("default_catalog");
+    task_run.__set_database("test_db");
+    task_run.__set_definition("SELECT * FROM test_table");
+    task_run.__set_expire_time(1641081600); // 2022-01-02 00:00:00
+    task_run.__set_error_code(0);
+    task_run.__set_error_message("");
+    task_run.__set_progress("100%");
+    task_run.__set_extra_message("Task completed successfully");
+    task_run.__set_properties("{\"priority\":\"high\"}");
+    task_run.__set_job_id("job_001");
+    task_run.__set_process_time(1640995400); // 2022-01-01 00:03:20
+
+    scanner._task_run_result.task_runs = {task_run};
+    scanner._task_run_index = 0;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+
+    auto row = chunk->debug_row(0);
+    EXPECT_TRUE(row.find("query_001") != std::string::npos);                   // QUERY_ID
+    EXPECT_TRUE(row.find("test_task") != std::string::npos);                   // TASK_NAME
+    EXPECT_TRUE(row.find("2022-01-01") != std::string::npos);                  // CREATE_TIME
+    EXPECT_TRUE(row.find("2022-01-01") != std::string::npos);                  // FINISH_TIME
+    EXPECT_TRUE(row.find("SUCCESS") != std::string::npos);                     // STATE
+    EXPECT_TRUE(row.find("default_catalog") != std::string::npos);             // CATALOG
+    EXPECT_TRUE(row.find("test_db") != std::string::npos);                     // DATABASE
+    EXPECT_TRUE(row.find("SELECT * FROM test_table") != std::string::npos);    // DEFINITION
+    EXPECT_TRUE(row.find("2022-01-02") != std::string::npos);                  // EXPIRE_TIME
+    EXPECT_TRUE(row.find("0") != std::string::npos);                           // ERROR_CODE
+    EXPECT_TRUE(row.find("100%") != std::string::npos);                        // PROGRESS
+    EXPECT_TRUE(row.find("Task completed successfully") != std::string::npos); // EXTRA_MESSAGE
+    EXPECT_TRUE(row.find("{\"priority\":\"high\"}") != std::string::npos);     // PROPERTIES
+    EXPECT_TRUE(row.find("job_001") != std::string::npos);                     // JOB_ID
+    EXPECT_TRUE(row.find("2022-01-01") != std::string::npos);                  // PROCESS_TIME
+
+    chunk->reset();
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_TRUE(eos);
+}
+
+TEST_F(SchemaTaskRunsScannerTest, test_multiple_task_runs) {
+    SchemaTaskRunsScanner scanner;
+    init_scanner(scanner);
+
+    // Mock multiple task runs
+    std::vector<TTaskRunInfo> task_runs;
+
+    for (int i = 1; i <= 3; ++i) {
+        TTaskRunInfo task_run;
+        task_run.__set_query_id("query_00" + std::to_string(i));
+        task_run.__set_task_name("task_" + std::to_string(i));
+        task_run.__set_create_time(1640995200 + i * 3600); // Increment by 1 hour
+        task_run.__set_finish_time(1640995500 + i * 3600);
+        task_run.__set_state(i % 2 == 0 ? "SUCCESS" : "FAILED");
+        task_run.__set_catalog("catalog_" + std::to_string(i));
+        task_run.__set_database("db_" + std::to_string(i));
+        task_run.__set_definition("SELECT * FROM table_" + std::to_string(i));
+        task_run.__set_expire_time(1641081600 + i * 3600);
+        task_run.__set_error_code(i % 2 == 0 ? 0 : 1001);
+        task_run.__set_error_message(i % 2 == 0 ? "" : "Task failed");
+        task_run.__set_progress(std::to_string(100 - i * 10) + "%");
+        task_run.__set_extra_message("Extra info " + std::to_string(i));
+        task_run.__set_properties("{\"priority\":\"medium\",\"id\":" + std::to_string(i) + "}");
+        task_run.__set_job_id("job_00" + std::to_string(i));
+        task_run.__set_process_time(1640995400 + i * 3600);
+
+        task_runs.push_back(task_run);
+    }
+
+    scanner._task_run_result.task_runs = task_runs;
+    scanner._task_run_index = 0;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+    int count = 0;
+
+    while (!eos) {
+        EXPECT_OK(scanner.get_next(&chunk, &eos));
+        if (!eos) {
+            EXPECT_EQ(1, chunk->num_rows());
+            auto row = chunk->debug_row(0);
+            EXPECT_TRUE(row.find("task_" + std::to_string(count + 1)) != std::string::npos);
+            count++;
+        }
+        chunk->reset();
+    }
+
+    EXPECT_EQ(3, count);
+}
+
+TEST_F(SchemaTaskRunsScannerTest, test_null_values) {
+    SchemaTaskRunsScanner scanner;
+    init_scanner(scanner);
+
+    // Mock task run with minimal data (most fields will be null)
+    TTaskRunInfo task_run;
+    task_run.__set_query_id("query_001");
+    task_run.__set_task_name("test_task");
+    // All other fields are not set, so they should be null
+
+    scanner._task_run_result.task_runs = {task_run};
+    scanner._task_run_index = 0;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+
+    auto row = chunk->debug_row(0);
+    EXPECT_TRUE(row.find("query_001") != std::string::npos); // QUERY_ID
+    EXPECT_TRUE(row.find("test_task") != std::string::npos); // TASK_NAME
+    EXPECT_TRUE(row.find("NULL") != std::string::npos);      // Should have null values
+}
+
+TEST_F(SchemaTaskRunsScannerTest, test_invalid_timestamp_values) {
+    SchemaTaskRunsScanner scanner;
+    init_scanner(scanner);
+
+    // Mock task run with invalid timestamp values
+    TTaskRunInfo task_run;
+    task_run.__set_query_id("query_001");
+    task_run.__set_task_name("test_task");
+    task_run.__set_create_time(-1);   // Invalid timestamp
+    task_run.__set_finish_time(0);    // Invalid timestamp
+    task_run.__set_expire_time(-100); // Invalid timestamp
+    task_run.__set_process_time(0);   // Invalid timestamp
+
+    scanner._task_run_result.task_runs = {task_run};
+    scanner._task_run_index = 0;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+
+    auto row = chunk->debug_row(0);
+    EXPECT_TRUE(row.find("query_001") != std::string::npos); // QUERY_ID
+    EXPECT_TRUE(row.find("test_task") != std::string::npos); // TASK_NAME
+    // Invalid timestamps should be handled as null
+    EXPECT_TRUE(row.find("NULL") != std::string::npos);
+}
+
+TEST_F(SchemaTaskRunsScannerTest, test_task_run_with_error) {
+    SchemaTaskRunsScanner scanner;
+    init_scanner(scanner);
+
+    // Mock task run with long string values
+    TTaskRunInfo task_run;
+    task_run.__set_query_id("very_long_query_id_that_exceeds_normal_length_123456789");
+    task_run.__set_task_name("very_long_task_name_with_many_characters_abcdefghijklmnopqrstuvwxyz");
+
+    std::string long_definition =
+            "SELECT * FROM very_long_table_name_that_has_many_characters "
+            "WHERE very_long_column_name_that_also_has_many_characters = "
+            "'very_long_string_value_that_might_cause_issues_if_not_handled_properly' "
+            "AND another_very_long_condition = 'another_very_long_value'";
+    task_run.__set_definition(long_definition);
+
+    std::string long_error_message =
+            "This is a very long error message that contains detailed information "
+            "about what went wrong during the task execution. It includes multiple "
+            "lines of text and various technical details that might be useful for "
+            "debugging purposes.";
+    task_run.__set_error_message(long_error_message);
+
+    std::string long_extra_message =
+            "This is a very long extra message that provides additional context "
+            "about the task execution. It might contain debugging information, "
+            "performance metrics, or other relevant details.";
+    task_run.__set_extra_message(long_extra_message);
+
+    std::string long_properties =
+            "{\"very_long_property_name_1\":\"very_long_property_value_1\","
+            "\"very_long_property_name_2\":\"very_long_property_value_2\","
+            "\"very_long_property_name_3\":\"very_long_property_value_3\"}";
+    task_run.__set_properties(long_properties);
+
+    scanner._task_run_result.task_runs = {task_run};
+    scanner._task_run_index = 0;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+
+    auto row = chunk->debug_row(0);
+    EXPECT_TRUE(row.find("very_long_query_id_that_exceeds_normal_length_123456789") != std::string::npos);
+    EXPECT_TRUE(row.find("very_long_task_name_with_many_characters_abcdefghijklmnopqrstuvwxyz") != std::string::npos);
+    EXPECT_TRUE(row.find("SELECT * FROM very_long_table_name_that_has_many_characters") != std::string::npos);
+    EXPECT_TRUE(row.find("This is a very long error message that contains detailed information") != std::string::npos);
+    EXPECT_TRUE(row.find("This is a very long extra message that provides additional context") != std::string::npos);
+    EXPECT_TRUE(row.find("very_long_property_name_1") != std::string::npos);
+}
+
+TEST_F(SchemaTaskRunsScannerTest, test_task_run_with_special_characters) {
+    SchemaTaskRunsScanner scanner;
+    init_scanner(scanner);
+
+    // Mock task run with special characters in strings
+    TTaskRunInfo task_run;
+    task_run.__set_query_id("query_with_special_chars_!@#$%^&*()");
+    task_run.__set_task_name("task_with_unicode_测试任务");
+    task_run.__set_state("RUNNING");
+    task_run.__set_catalog("catalog_with_spaces and special chars");
+    task_run.__set_database("database_with_quotes\"and'apostrophes");
+    task_run.__set_definition("SELECT * FROM table WHERE name = 'test\"quote' AND value = 'test'quote'");
+    task_run.__set_error_message("Error with special chars: \n\t\r\b\f");
+    task_run.__set_extra_message("Extra message with unicode: 测试信息");
+    task_run.__set_properties("{\"key_with_spaces\":\"value with spaces\",\"unicode_key\":\"unicode_value_测试\"}");
+    task_run.__set_job_id("job_with_special_chars_!@#$%^&*()");
+
+    scanner._task_run_result.task_runs = {task_run};
+    scanner._task_run_index = 0;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+
+    auto row = chunk->debug_row(0);
+    EXPECT_TRUE(row.find("query_with_special_chars_!@#$%^&*()") != std::string::npos);
+    EXPECT_TRUE(row.find("task_with_unicode_测试任务") != std::string::npos);
+    EXPECT_TRUE(row.find("RUNNING") != std::string::npos);
+    EXPECT_TRUE(row.find("catalog_with_spaces and special chars") != std::string::npos);
+    EXPECT_TRUE(row.find("database_with_quotes\"and'apostrophes") != std::string::npos);
+    EXPECT_TRUE(row.find("SELECT * FROM table WHERE name = 'test\"quote'") != std::string::npos);
+    EXPECT_TRUE(row.find("Error with special chars:") != std::string::npos);
+    EXPECT_TRUE(row.find("Extra message with unicode: 测试信息") != std::string::npos);
+    EXPECT_TRUE(row.find("key_with_spaces") != std::string::npos);
+    EXPECT_TRUE(row.find("job_with_special_chars_!@#$%^&*()") != std::string::npos);
+}
+
+TEST_F(SchemaTaskRunsScannerTest, test_task_run_with_empty_strings) {
+    SchemaTaskRunsScanner scanner;
+    init_scanner(scanner);
+
+    // Mock task run with empty string values
+    TTaskRunInfo task_run;
+    task_run.__set_query_id("query_001");
+    task_run.__set_task_name("test_task");
+    task_run.__set_state("");
+    task_run.__set_catalog("");
+    task_run.__set_database("");
+    task_run.__set_definition("");
+    task_run.__set_error_message("");
+    task_run.__set_progress("");
+    task_run.__set_extra_message("");
+    task_run.__set_properties("");
+    task_run.__set_job_id("");
+
+    scanner._task_run_result.task_runs = {task_run};
+    scanner._task_run_index = 0;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+
+    auto row = chunk->debug_row(0);
+    EXPECT_TRUE(row.find("query_001") != std::string::npos); // QUERY_ID
+    EXPECT_TRUE(row.find("test_task") != std::string::npos); // TASK_NAME
+    // Empty strings should be handled properly (likely as empty strings, not null)
+}
+
+TEST_F(SchemaTaskRunsScannerTest, test_task_run_with_large_error_code) {
+    SchemaTaskRunsScanner scanner;
+    init_scanner(scanner);
+
+    // Mock task run with large error code
+    TTaskRunInfo task_run;
+    task_run.__set_query_id("query_001");
+    task_run.__set_task_name("test_task");
+    task_run.__set_error_code(9223372036854775807LL); // MAX_INT64
+    task_run.__set_error_message("Error with maximum error code");
+
+    scanner._task_run_result.task_runs = {task_run};
+    scanner._task_run_index = 0;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(1, chunk->num_rows());
+
+    auto row = chunk->debug_row(0);
+    EXPECT_TRUE(row.find("query_001") != std::string::npos);
+    EXPECT_TRUE(row.find("test_task") != std::string::npos);
+    EXPECT_TRUE(row.find("-1") != std::string::npos); // ERROR_CODE
+    EXPECT_TRUE(row.find("Error with maximum error code") != std::string::npos);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
Querying `information_schema.task_runs` table may crash be as below:
```
query_id:0197bd3b-bc99-7daa-9a09-934cee450bac, fragment_instance:0197bd3b-bc99-7daa-9a09-934cee450bae
*** Aborted at 1751226498 (unix time) try "date -d @1751226498" if you are using GNU date ***
PC: @          0x50b8f40 void std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, starrocks::ColumnAllocator<unsigned char> > >::_M_range_insert<unsigned char const*>(__gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char, starrocks::raw::R@
*** SIGSEGV (@0x0) received by PID 2901 (TID 0x2b755a3e1700) LWP(3283) from PID 0; stack trace: ***
    @     0x2b752910f20b __pthread_once_slow
    @          0xc49a2d4 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x2b752a0b0999 PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0]
    @     0x2b752a0b13ee JVM_handle_linux_signal
    @     0x2b7529118630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0x50b8f40 void std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, starrocks::ColumnAllocator<unsigned char> > >::_M_range_insert<unsigned char const*>(__gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char, starrocks::raw::R@
    @          0x50ccc30 starrocks::BinaryColumnBase<unsigned int>::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0x5012b59 starrocks::Chunk::append(starrocks::Chunk const&, unsigned long, unsigned long)
    @          0x7f3b7f4 starrocks::ChunkAccumulator::push(std::shared_ptr<starrocks::Chunk>&&)
    @          0x5b9af67 starrocks::pipeline::SchemaChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @          0x5b89810 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
    @          0x5654d6b auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const [clone .isra.0]
    @          0x5783029 starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x4886ddf starrocks::ThreadPool::dispatch_thread()
    @          0x487e3b0 starrocks::Thread::supervise_thread(void*)
    @     0x2b7529110ea5 start_thread
    @     0x2b752b5e1b0d __clone
```
which is because some columns are nullable but cannot handle null input values.


## What I'm doing:
- Ensure information_schema.task_runs more compatible with null values


Fixes https://github.com/StarRocks/StarRocksTest/issues/9903

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
