### PR TITLE
[Enhancement] remove the compatibility of backend HbResponse without reboot time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -592,7 +592,8 @@ public class ComputeNode implements IComputable, Writable, GsonPostProcessable {
             }
 
             this.lastUpdateMs = hbResponse.getHbTime();
-            // RebootTime will be `-1` if not set from backend.
+            // NOTE: remove the compatibility where the reboot time is not set.
+            // The RebootTime must be set in the heartbeat response if the backend version is >= 2.4.
             if (hbResponse.getRebootTime() > this.lastStartTime) {
                 this.lastStartTime = hbResponse.getRebootTime();
                 isChanged = true;
@@ -604,11 +605,6 @@ public class ComputeNode implements IComputable, Writable, GsonPostProcessable {
 
             if (!isAlive.get()) {
                 isChanged = true;
-                if (hbResponse.getRebootTime() == -1) {
-                    // Only update lastStartTime by hbResponse.hbTime if the RebootTime is not set from an OK-response.
-                    // Just for backwards compatibility purpose in case the response is from an ancient version
-                    this.lastStartTime = hbResponse.getHbTime();
-                }
                 LOG.info("{} is alive, last start time: {}, hbTime: {}", this.toString(), this.lastStartTime,
                         hbResponse.getHbTime());
                 setAlive(true);


### PR DESCRIPTION
* it's been long long ago, the compatibility is not necessary any more.
* remove the compatibility code to make the logic straight forward.

## Why I'm doing:

## What I'm doing:

Refs #10335 where the rebootTime is introduced.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
