### PR TITLE
[Refactor] Fix spelling errors in variable names

### DIFF
--- a/be/src/storage/index/inverted/clucene/clucene_inverted_reader.cpp
+++ b/be/src/storage/index/inverted/clucene/clucene_inverted_reader.cpp
@@ -65,8 +65,8 @@ Status FullTextCLuceneInvertedReader::query(OlapReaderStatistics* stats, const s
     std::unique_ptr<MatchOperator> match_operator;
 
     auto* directory = lucene::store::FSDirectory::getDirectory(_index_path.c_str());
-    // defer must define before IndexSearcher. Because the destory order is matter.
-    // Make sure IndexSearcher destory first and decrement __cl_refcount first.
+    // defer must define before IndexSearcher. Because the destroy order is matter.
+    // Make sure IndexSearcher destroy first and decrement __cl_refcount first.
     DeferOp defer([&]() { CLOSE_DIR(directory) });
     lucene::search::IndexSearcher index_searcher(directory);
 
@@ -109,8 +109,8 @@ Status FullTextCLuceneInvertedReader::query(OlapReaderStatistics* stats, const s
     try {
         RETURN_IF_ERROR(match_operator->match(&result));
     } catch (CLuceneError& e) {
-        LOG(WARNING) << "CLuceneError occured, error msg: " << e.what();
-        return Status::InternalError(fmt::format("CLuceneError occured, error msg: {}", e.what()));
+        LOG(WARNING) << "CLuceneError occurred, error msg: " << e.what();
+        return Status::InternalError(fmt::format("CLuceneError occurred, error msg: {}", e.what()));
     }
     bit_map->swap(result);
     return Status::OK();
@@ -124,7 +124,7 @@ Status FullTextCLuceneInvertedReader::query_null(OlapReaderStatistics* stats, co
         // try to get query bitmap result from cache and return immediately on cache hit
         dir = lucene::store::FSDirectory::getDirectory(_index_path.c_str());
 
-        // ownership of null_bitmap and its deletion will be transfered to cache
+        // ownership of null_bitmap and its deletion will be transferred to cache
         std::shared_ptr<roaring::Roaring> null_bitmap = std::make_shared<roaring::Roaring>();
         auto null_bitmap_file_name = IndexDescriptor::get_temporary_null_bitmap_file_name();
         if (dir->fileExists(null_bitmap_file_name.c_str())) {


### PR DESCRIPTION
## Why I'm doing:

**Fixed spelling mistakes in inverted index related classes:**
- vaild → valid
- destory → destroy
- transfered → transferred


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
