### PR TITLE
[BugFix] Make TaskRun's status be compatible with lower version (backport #60438)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -26,7 +26,10 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.ThreadUtil;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.persist.ImageWriter;
+import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.scheduler.history.TaskRunHistory;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.server.GlobalStateMgr;
@@ -885,5 +888,50 @@ public class TaskManagerTest {
 
         String definition = taskRun1.getStatus().getDefinition();
         Assert.assertTrue(definition == null);
+    }
+
+    @Test
+    public void saveTasksV2SkipsSkippedTaskRunStatuses() throws Exception {
+        UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
+        {
+            TaskManager taskManager = new TaskManager();
+            ImageWriter imageWriter = image.getImageWriter();
+
+            Task task = new Task("task");
+            task.setId(1L);
+            taskManager.replayCreateTask(task);
+
+            TaskRunStatus skippedStatus = new TaskRunStatus();
+            skippedStatus.setTaskId(1);
+            skippedStatus.setQueryId("task_run_1");
+            skippedStatus.setTaskName("task_run_1");
+            skippedStatus.setState(Constants.TaskRunState.SKIPPED);
+            skippedStatus.setExpireTime(System.currentTimeMillis() + 1000000);
+            taskManager.replayCreateTaskRun(skippedStatus);
+
+            TaskRunStatus validStatus = new TaskRunStatus();
+            validStatus.setTaskId(2);
+            validStatus.setQueryId("task_run_2");
+            validStatus.setTaskName("task_run_2");
+            validStatus.setState(Constants.TaskRunState.SUCCESS);
+            validStatus.setExpireTime(System.currentTimeMillis() + 1000000);
+            taskManager.replayCreateTaskRun(validStatus);
+
+            TaskRunHistory taskRunHistory = taskManager.getTaskRunHistory();
+            Assert.assertEquals(2, taskRunHistory.getTaskRunCount());
+
+            taskManager.saveTasksV2(imageWriter);
+        }
+
+        SRMetaBlockReader imageReader = image.getMetaBlockReader();
+        {
+            TaskManager taskManager = new TaskManager();
+            taskManager.loadTasksV2(imageReader);
+            TaskRunHistory taskRunHistory = taskManager.getTaskRunHistory();
+            Assert.assertEquals(2, taskRunHistory.getTaskRunCount());
+            taskRunHistory.getInMemoryHistory()
+                    .stream()
+                    .forEach(status -> Assert.assertEquals(status.getState(), Constants.TaskRunState.SUCCESS));
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

backport from https://github.com/StarRocks/starrocks/pull/60438


## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9905

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
