### PR TITLE
[BugFix] fix short circuit query core with out of order value column sql

### DIFF
--- a/be/src/storage/local_tablet_reader.cpp
+++ b/be/src/storage/local_tablet_reader.cpp
@@ -137,7 +137,6 @@ Status LocalTabletReader::multi_get(const Chunk& keys, const std::vector<uint32_
     vector<uint32_t> idxes;
     plan_read_by_rssid(rowids, found, rowids_by_rssid, idxes);
 
-    auto read_column_schema = ChunkHelper::convert_schema(tablet_schema, value_column_ids);
     vector<std::pair<uint32_t, uint32_t>> value_column_ids_by_order_with_orig_idx;
     for (uint32_t i = 0; i < value_column_ids.size(); ++i) {
         value_column_ids_by_order_with_orig_idx.emplace_back(value_column_ids[i], i);
@@ -147,6 +146,7 @@ Status LocalTabletReader::multi_get(const Chunk& keys, const std::vector<uint32_
     for (const auto& p : value_column_ids_by_order_with_orig_idx) {
         value_column_ids_by_order.push_back(p.first);
     }
+    auto read_column_schema = ChunkHelper::convert_schema(tablet_schema, value_column_ids_by_order);
     MutableColumns read_columns(value_column_ids_by_order.size());
     for (uint32_t i = 0; i < read_columns.size(); ++i) {
         read_columns[i] = ChunkHelper::column_from_field(*read_column_schema.field(i).get())->clone_empty();


### PR DESCRIPTION
## Why I'm doing:
Found the core in 3.3.11 and 3.2.11, with out of order value column query could cause BE to core 
as LocalTabletReader read columns in order with out of order (incorrect) read_column_schema 
```c++
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f5f7cc13535 in __GI_abort () at abort.c:79
#2  0x000000000cfd1495 in starrocks::failure_function () at be/src/common/logconfig.cpp:169
#3  0x0000000012b816fa in google::LogMessage::Fail () at ./glog-0.7.1/src/logging.cc:2074
#4  0x0000000012b82ac5 in google::LogMessageFatal::~LogMessageFatal (this=0x7f5e77e3df40, __in_chrg=<optimized out>) at ./glog-0.7.1/src/logging.cc:2766
#5  0x000000001131f54e in starrocks::BinaryDictPageDecoder<(starrocks::LogicalType)17>::next_batch (this=0x7f5e7806b930, range=..., dst=0x7f5e7abdec20) at be/src/storage/rowset/binary_dict_page.cpp:265
#6  0x000000001131efd2 in starrocks::BinaryDictPageDecoder<(starrocks::LogicalType)17>::next_batch (this=0x7f5e7806b930, n=0x7f5e77e3e248, dst=0x7f5e7abdec20) at be/src/storage/rowset/binary_dict_page.cpp:225
#7  0x000000001138740a in starrocks::ParsedPageV2::read (this=0x7f5e79fa8b00, column=0x7f5e77fb9b00, count=0x7f5e77e3e248) at be/src/storage/rowset/parsed_page.cpp:237
#8  0x00000000112f2e67 in operator() (__closure=0x7f5e77e3e4f8, column=0x7f5e77fb9b00, count=0x7f5e77e3e248) at be/src/storage/rowset/scalar_column_iterator.cpp:615
#9  0x00000000112f38b0 in starrocks::ScalarColumnIterator::_fetch_by_rowid<starrocks::ScalarColumnIterator::fetch_values_by_rowid(const rowid_t*, std::size_t, starrocks::Column*)::<lambda(starrocks::Column*, std::size_t*)>&>(const starrocks::rowid_t *, std::size_t, starrocks::Column *, struct {...} &) (this=0x7f5f62e55b00, rowids=0x7f5e8ff28258, size=1, values=0x7f5e77fb9b00, page_parse=...)
    at be/src/storage/rowset/scalar_column_iterator.cpp:602
#10 0x00000000112f2eb8 in starrocks::ScalarColumnIterator::fetch_values_by_rowid (this=0x7f5f62e55b00, rowids=0x7f5e8ff28258, size=1, values=0x7f5e77fb9b00) at be/src/storage/rowset/scalar_column_iterator.cpp:616
#11 0x0000000010575a20 in starrocks::TabletUpdates::get_column_values (this=0x7f5f66fe7100, column_ids=..., read_version=1537, with_default=false, rowids_by_rssid=..., columns=0x7f5e77e3f380, state=0x0, 
    read_tablet_schema=..., column_to_expr_value=0x0) at be/src/storage/tablet_updates.cpp:5269
#12 0x00000000103335ef in starrocks::LocalTabletReader::multi_get (this=0x7f5e7ab9f060, keys=..., value_column_ids=..., found=..., values=...) at be/src/storage/local_tablet_reader.cpp:154
#13 0x0000000010332b84 in starrocks::LocalTabletReader::multi_get (this=0x7f5e7ab9f060, keys=..., value_columns=..., found=..., values=...) at be/src/storage/local_tablet_reader.cpp:99
#14 0x0000000010726082 in starrocks::TableReader::multi_get (this=0x7f5e79fb1a70, keys=..., value_columns=..., found=..., values=...) at be/src/storage/table_reader.cpp:106
#15 0x0000000011b52743 in starrocks::ShortCircuitHybridScanNode::_process_value_chunk (this=0x7f5e7ab4d500, found=...) at be/src/exec/short_circuit_hybrid.cpp:202
#16 0x0000000011b50dc6 in starrocks::ShortCircuitHybridScanNode::get_next (this=0x7f5e7ab4d500, state=0x7f5f62eb0410, chunk=0x7f5e77e407e0, eos=0x7f5e77e407df) at be/src/exec/short_circuit_hybrid.cpp:76
#17 0x000000000d55bc0c in starrocks::ProjectNode::get_next (this=0x7f5f7584a780, state=0x7f5f62eb0410, chunk=0x7f5e77e407e0, eos=0x7f5e77e407df) at be/src/exec/project_node.cpp:127
#18 0x0000000011b4b66f in starrocks::ShortCircuitExecutor::execute (this=0x7f5e77e40970) at be/src/exec/short_circuit.cpp:196
#19 0x000000001167f05e in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_short_circuit (this=0x7ffc376ccc90, cntl=0x7f5e8fe96200, request=0x7f5f62eb4440, response=0x7f5eab64a720)
    at be/src/service/internal_service.cpp:1220
#20 0x00000000116785a7 in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_short_circuit (this=0x7ffc376ccc90, cntl_base=0x7f5e8fe96200, request=0x7f5f62eb4440, response=0x7f5eab64a720, 
    done=0x7f5f76a4aec0) at be/src/service/internal_service.cpp:1242
#21 0x000000000cc4825d in starrocks::PInternalService::CallMethod (this=0x7ffc376ccc90, method=0x7f5f7651c030, controller=0x7f5e8fe96200, request=0x7f5f62eb4440, response=0x7f5eab64a720, done=0x7f5f76a4aec0)
    at be/src/gen_cpp/build/gen_cpp/internal_service.pb.cc:28593
#22 0x0000000012e18da4 in brpc::policy::ProcessRpcRequest (msg_base=<optimized out>) at src/brpc/policy/baidu_rpc_protocol.cpp:541
#23 0x0000000012d45967 in brpc::ProcessInputMessage (void_arg=<optimized out>) at src/brpc/input_messenger.cpp:173
#24 0x0000000012d46ce5 in brpc::InputMessenger::OnNewMessages (m=0x7f5f75616080) at src/brpc/input_messenger.cpp:349
#25 0x0000000012d3524e in brpc::Socket::ProcessEvent (arg=0x7f5f75616080) at src/brpc/socket.cpp:1201
#26 0x0000000012d062d2 in bthread::TaskGroup::task_runner (skip_remained=<optimized out>) at src/bthread/task_group.cpp:305
#27 0x0000000012e5a131 in bthread_make_fcontext ()
#28 0x0000000000000000 in ?? ()
```

## What I'm doing:
correct read_column_schema with ordered read_column_schema

Fixes #58708

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
- [x] 3.5
- [x] 3.4
- [x] 3.3
