### PR TITLE
[BugFix] fix error tablet pruning

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashDistributionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashDistributionPruner.java
@@ -108,7 +108,8 @@ public class HashDistributionPruner implements DistributionPruner {
             // equal one value
             if (filter.lowerBoundInclusive && filter.upperBoundInclusive
                     && lowerBound != null && upperBound != null
-                    && 0 == lowerBound.compareLiteral(upperBound)) {
+                    && 0 == lowerBound.compareLiteral(upperBound)
+                    && !filter.isFromFunctionCall()) {
                 try {
                     boolean isConvertToDate = PartitionUtil.isConvertToDate(keyColumn.getType(), lowerBound.getType());
                     hashKey.pushColumn(filter.getLowerBound(isConvertToDate), keyColumn.getType());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PartitionColumnFilter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PartitionColumnFilter.java
@@ -64,6 +64,14 @@ public class PartitionColumnFilter {
     // fact use
     private List<LiteralExpr> inPredicateLiterals;
 
+    /**
+     * Indicates whether the filter bounds are derived from function call predicates.
+     * Used for tablet pruning optimization:
+     * - true: predicate left side is a function call (e.g., func(column) > value), disable tablet pruning
+     * - false: predicate left side is a direct column reference (e.g., column > value), allow tablet pruning
+     */
+    private boolean fromFunctionCall = false;
+
     public InPredicate getInPredicate() {
         return inPredicate;
     }
@@ -73,6 +81,16 @@ public class PartitionColumnFilter {
         this.inPredicateLiterals = Lists.newArrayList();
         for (int i = 1; i < inPredicate.getChildren().size(); i++) {
             inPredicateLiterals.add((LiteralExpr) inPredicate.getChild(i));
+        }
+    }
+
+    public boolean isFromFunctionCall() {
+        return fromFunctionCall;
+    }
+
+    public void setFromFunctionCall() {
+        if (!this.fromFunctionCall) {
+            this.fromFunctionCall = true;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -367,8 +367,11 @@ public class ColumnFilterConverter {
 
             ColumnRefOperator column = Utils.extractColumnRef(predicate.getChild(0)).get(0);
             ConstantOperator child = (ConstantOperator) predicate.getChild(1);
-
             PartitionColumnFilter filter = context.getOrDefault(column.getName(), new PartitionColumnFilter());
+            if (!predicate.getChild(0).isColumnRef()) {
+                filter.setFromFunctionCall();
+            }
+
             try {
                 switch (predicate.getBinaryType()) {
                     case EQ:

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AdminSetConfigStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AdminSetConfigStmtTest.java
@@ -169,7 +169,7 @@ public class AdminSetConfigStmtTest {
                 (AdminSetConfigStmt) UtFrameUtils.parseStmtWithNewParser(stmt, connectContext);
         ConfigBase.setConfig(adminSetConfigStmt);
 
-        Assert.assertEquals(60, Config.alter_table_timeout_second);
+        Assertions.assertEquals(60, Config.alter_table_timeout_second);
     }
 }
 

--- a/test/sql/test_partition_by_expr/R/test_partition_bucket_same_column
+++ b/test/sql/test_partition_by_expr/R/test_partition_bucket_same_column
@@ -1,0 +1,37 @@
+-- name: test_partition_bucket_same_column
+DROP DATABASE IF EXISTS test_partition_bucket_same_column;
+-- result:
+-- !result
+CREATE DATABASE test_partition_bucket_same_column;
+-- result:
+-- !result
+USE test_partition_bucket_same_column;
+-- result:
+-- !result
+CREATE TABLE t0(
+ ts datetime,
+ v1 INT,
+ v2 INT)
+ DUPLICATE KEY(ts)
+ PARTITION BY date_trunc('day', ts)
+DISTRIBUTED BY HASH(ts)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t0 VALUES
+  ('2020-01-22 12:12:12', 0,1),
+  ('2020-02-23 12:12:12',1,1),
+  ('2020-03-24 12:12:12',1,2),
+  ('2020-04-25 12:12:12',3,3),
+  ('2020-05-22 12:12:12', 0,1),
+  ('2020-06-23 12:12:12',1,1),
+  ('2020-07-24 12:12:12',1,2),
+  ('2020-08-24 12:12:12',1,2),
+  ('2020-09-24 12:12:12',1,2),
+  ('2020-10-25 12:12:12',3,3);
+-- result:
+-- !result
+select * from t0 where ts > '2020-02-23 12:12:00' and date_trunc('hour', ts) <= '2020-02-23 12:12:00'  order by 1;
+-- result:
+2020-02-23 12:12:12	1	1
+-- !result

--- a/test/sql/test_partition_by_expr/T/test_partition_bucket_same_column
+++ b/test/sql/test_partition_by_expr/T/test_partition_bucket_same_column
@@ -1,0 +1,28 @@
+-- name: test_partition_bucket_same_column
+
+DROP DATABASE IF EXISTS test_partition_bucket_same_column;
+CREATE DATABASE test_partition_bucket_same_column;
+USE test_partition_bucket_same_column;
+
+CREATE TABLE t0(
+ ts datetime,
+ v1 INT,
+ v2 INT)
+ DUPLICATE KEY(ts)
+ PARTITION BY date_trunc('day', ts)
+DISTRIBUTED BY HASH(ts)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t0 VALUES
+  ('2020-01-22 12:12:12', 0,1),
+  ('2020-02-23 12:12:12',1,1),
+  ('2020-03-24 12:12:12',1,2),
+  ('2020-04-25 12:12:12',3,3),
+  ('2020-05-22 12:12:12', 0,1),
+  ('2020-06-23 12:12:12',1,1),
+  ('2020-07-24 12:12:12',1,2),
+  ('2020-08-24 12:12:12',1,2),
+  ('2020-09-24 12:12:12',1,2),
+  ('2020-10-25 12:12:12',3,3);
+
+select * from t0 where ts > '2020-02-23 12:12:00' and date_trunc('hour', ts) <= '2020-02-23 12:12:00'  order by 1;


### PR DESCRIPTION
## Why I'm doing:

When the low and upper bounds derived from bucket column predicates are equal, we can precisely calculate whether a bucket can be hit through the hash function. However, currently for predicates where the left-hand side is func(bucket_column), we directly use the right-hand value as the predicate for bucket_column to derive low and upper bounds. This is incorrect and can easily hit wrong buckets, causing incorrect results.


## What I'm doing:
PartitionColumnFilter records whether it is derived from a function call expression. If true, tablet pruning will be disabled.
Since we have applied some base rewrite rule before DistributionPruneRule, we can consider that when the left-hand side of a predicate is not a columnRefOperator, tablet pruning should not be performed.

Fixes #issue
https://github.com/StarRocks/starrocks/issues/56855

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
