### PR TITLE
[Refactor] refact the code of cluster snapshot job reset when FE restart

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AdminSetConfigStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AdminSetConfigStmtTest.java
@@ -169,7 +169,7 @@ public class AdminSetConfigStmtTest {
                 (AdminSetConfigStmt) UtFrameUtils.parseStmtWithNewParser(stmt, connectContext);
         ConfigBase.setConfig(adminSetConfigStmt);
 
-        Assert.assertEquals(60, Config.alter_table_timeout_second);
+        Assertions.assertEquals(60, Config.alter_table_timeout_second);
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
@@ -404,7 +404,7 @@ public class ClusterSnapshotTest {
         job1.setState(ClusterSnapshotJobState.FINISHED);
         ClusterSnapshotJob job2 = localClusterSnapshotMgr.createAutomatedSnapshotJob();
         RestoredSnapshotInfo restoredSnapshotInfo = new RestoredSnapshotInfo(job2.getSnapshotName(), 666L, 6666L);
-        localClusterSnapshotMgr.setLastJobFinishedAfterRestored(restoredSnapshotInfo);
+        localClusterSnapshotMgr.setJobFinishedIfRestoredFromIt(restoredSnapshotInfo);
 
         Assertions.assertTrue(job2.getFeJournalId() == 666L);
         Assertions.assertTrue(job2.getStarMgrJournalId() == 6666L);


### PR DESCRIPTION
## What I'm doing:
refact he code of cluster snapshot job reset when FE restart for future purpose.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
