### PR TITLE
[BugFix] Paimon TimeStamp timezone converter problem when the query condition has datetime

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
@@ -17,7 +17,6 @@ package com.starrocks.connector.paimon;
 
 import com.starrocks.analysis.BoolLiteral;
 import com.starrocks.catalog.PrimitiveType;
-import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
@@ -62,7 +61,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.data.Timestamp.fromEpochMillis;
+import static org.apache.paimon.data.Timestamp.fromLocalDateTime;
 
 public class PaimonPredicateConverter extends ScalarOperatorVisitor<Predicate, Void> {
     private static final Logger LOG = LogManager.getLogger(PaimonPredicateConverter.class);
@@ -261,9 +260,7 @@ public class PaimonPredicateConverter extends ScalarOperatorVisitor<Predicate, V
                     LocalDate epochDay = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC).toLocalDate();
                     return (int) ChronoUnit.DAYS.between(epochDay, localDate);
                 case DATETIME:
-                    long localDateTime = operator.getDatetime().atZone(TimeUtils.getTimeZone().toZoneId()).toInstant()
-                            .toEpochMilli();
-                    return fromEpochMillis(localDateTime);
+                    return fromLocalDateTime(operator.getDatetime());
                 default:
                     return null;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
@@ -365,7 +365,7 @@ public class PaimonPredicateConverterTest {
         result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast8, stringTime));
         Assertions.assertTrue(result instanceof LeafPredicate);
         LeafPredicate leafPredicate8 = (LeafPredicate) result;
-        Assertions.assertEquals(1735660800000L, ((Timestamp) (leafPredicate8.literals().get(0))).getMillisecond());
+        Assertions.assertEquals(1735689600000L, ((Timestamp) (leafPredicate8.literals().get(0))).getMillisecond());
         // smallInt to string
         ConstantOperator si = ConstantOperator.createSmallInt((short) 200);
         CastOperator cast9 = new CastOperator(Type.VARCHAR, F1);


### PR DESCRIPTION
## Why I'm doing:
```
mysql> SHOW VARIABLES LIKE '%time_zone%';
+------------------+---------------+
| Variable_name    | Value         |
+------------------+---------------+
| system_time_zone | Asia/Shanghai |
| time_zone        | Asia/Shanghai |
+------------------+---------------+
mysql> select id,r_modified_time from pm_fs.ods.ods_test_user_detail where r_modified_time < '2025-06-19 14:40:20' order by r_modified_time desc limit 2;
+----------+---------------------+
| id       | r_modified_time     |
+----------+---------------------+
| 94917 | 2025-06-19 06:40:14 |
| 42219 | 2025-06-19 06:39:19 |
+----------+---------------------+
```
## What I'm doing:
```
mysql> select  id,r_modified_time from pm_fs.ods.ods_test_user_detail where r_modified_time < '2025-06-19 14:40:20' order by r_modified_time desc limit 2;
+----------+---------------------+
| id       | r_modified_time     |
+----------+---------------------+
| 10222 | 2025-06-19 14:40:19 |
| 10196 | 2025-06-19 14:40:05 |
+----------+---------------------+
```
Fixes #issue
#60131 
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
