### PR TITLE
[Enhancement] Fixing reports on clang-tidy

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.h
@@ -165,8 +165,6 @@ private:
     DECLARE_ONCE_DETECTOR(_set_finishing_once);
     spill::SpillStrategy _spill_strategy = spill::SpillStrategy::NO_SPILL;
 
-    int32_t _continuous_low_reduction_chunk_num = 0;
-
     bool _is_finished = false;
 
     RuntimeProfile::Counter* _hash_table_spill_times = nullptr;


### PR DESCRIPTION
## Why I'm doing:

1. Move constructors should be marked noexcept clang-tidy performance-noexcept-move-constructor
2. Move assignment operators should be marked noexcept clang-tidy performance-noexcept-move-constructor
3. unused private variables

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
