### PR TITLE
[BugFix] fix thread unsafe gmtime to gmtime_r

### DIFF
--- a/be/src/connector/utils.cpp
+++ b/be/src/connector/utils.cpp
@@ -141,16 +141,18 @@ StatusOr<std::string> HiveUtils::iceberg_column_value(const TypeDescriptor& type
     } else if (transform_expr == "day") {
         const auto days_from_epoch = ColumnViewer<TYPE_BIGINT>(column).value(idx);
         std::time_t seconds = static_cast<std::time_t>(days_from_epoch) * 86400;
-        std::tm* gmt = std::gmtime(&seconds);
+        std::tm tm_utc;
+        gmtime_r(&seconds, &tm_utc);
         char buffer[20];
-        std::strftime(buffer, sizeof(buffer), "%Y-%m-%d", gmt);
+        std::strftime(buffer, sizeof(buffer), "%Y-%m-%d", &tm_utc);
         value = std::string(buffer);
     } else if (transform_expr == "hour") {
         const auto hours_from_epoch = ColumnViewer<TYPE_BIGINT>(column).value(idx);
         std::time_t seconds = static_cast<std::time_t>(hours_from_epoch) * 3600;
-        std::tm* gmt = std::gmtime(&seconds);
+        std::tm tm_utc;
+        gmtime_r(&seconds, &tm_utc);
         char buffer[20];
-        std::strftime(buffer, sizeof(buffer), "%Y-%m-%d-%H", gmt);
+        std::strftime(buffer, sizeof(buffer), "%Y-%m-%d-%H", &tm_utc);
         value = std::string(buffer);
     } else if (transform_expr.compare(0, 8, "truncate") == 0) {
         ASSIGN_OR_RETURN(value, column_value(type_desc, column, idx));

--- a/be/src/formats/avro/cpp/utils.cpp
+++ b/be/src/formats/avro/cpp/utils.cpp
@@ -63,8 +63,9 @@ int128_t AvroUtils::bytes_to_decimal_integer(const std::vector<uint8_t>& from) {
 
 DateValue AvroUtils::int_to_date_value(int32_t from) {
     auto time = static_cast<std::time_t>(from) * 86400;
-    std::tm* tm = std::gmtime(&time);
-    return DateValue::create(tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday);
+    std::tm tm;
+    gmtime_r(&time, &tm);
+    return DateValue::create(tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday);
 }
 
 StatusOr<TimestampValue> AvroUtils::long_to_timestamp_value(const avro::GenericDatum& datum,


### PR DESCRIPTION
## Why I'm doing:
std::gmtime is not thread safe, its result will use a static memory. So it should be changed to gmtime_r.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
