### PR TITLE
[Enhancement] min/max optimization can be applied when group partition column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -97,6 +97,10 @@ public final class IcebergUtil {
     }
 
     private static final Set<Type.TypeID> MIN_MAX_SUPPORTED_TYPES = Set.of(
+            // TODO(yanz): to support more types.
+            // datetime and timestamp: need to consider timezone.
+            // decimal: need to consider precision and scale.
+            // binary: min/max is not accurate for binary type.
             Type.TypeID.BOOLEAN,
             Type.TypeID.INTEGER,
             Type.TypeID.LONG,

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergMetadataScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergMetadataScanNode.java
@@ -138,7 +138,6 @@ public class IcebergMetadataScanNode extends ScanNode {
         msg.node_type = TPlanNodeType.HDFS_SCAN_NODE;
         THdfsScanNode tHdfsScanNode = new THdfsScanNode();
         tHdfsScanNode.setTuple_id(desc.getId().asInt());
-        tHdfsScanNode.setCan_use_min_max_opt(false);
 
         String explainString = getExplainString(conjuncts);
         LOG.info("Explain string: " + explainString);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OdpsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OdpsScanNode.java
@@ -172,7 +172,6 @@ public class OdpsScanNode extends ScanNode {
         msg.node_type = TPlanNodeType.HDFS_SCAN_NODE;
         THdfsScanNode tHdfsScanNode = new THdfsScanNode();
         tHdfsScanNode.setTuple_id(desc.getId().asInt());
-        tHdfsScanNode.setCan_use_min_max_opt(false);
 
         String explainString = getExplainString(conjuncts);
         LOG.info("Explain string: " + explainString);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AdminSetConfigStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AdminSetConfigStmtTest.java
@@ -169,7 +169,7 @@ public class AdminSetConfigStmtTest {
                 (AdminSetConfigStmt) UtFrameUtils.parseStmtWithNewParser(stmt, connectContext);
         ConfigBase.setConfig(adminSetConfigStmt);
 
-        Assert.assertEquals(60, Config.alter_table_timeout_second);
+        Assertions.assertEquals(60, Config.alter_table_timeout_second);
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -69,6 +69,8 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                 "select count(id) from iceberg0.partitioned_db.t1 where date = '2020-01-01'", "false",
                 "select min(id), date from iceberg0.partitioned_db.t1 group by date", "true",
                 "select max(id), date from iceberg0.partitioned_db.t1 group by date", "true",
+                "select max(id) as x, date from iceberg0.partitioned_db.t1 group by date having x > 10", "false",
+
         };
         Assertions.assertTrue(sqlString.length % 2 == 0);
         for (int i = 0; i < sqlString.length; i += 2) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -69,7 +69,6 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                 "select count(id) from iceberg0.partitioned_db.t1 where date = '2020-01-01'", "false",
                 "select min(id), date from iceberg0.partitioned_db.t1 group by date", "true",
                 "select max(id), date from iceberg0.partitioned_db.t1 group by date", "true",
-                "select count(id),min(id), date from iceberg0.partitioned_db.t  group by date", "true",
         };
         Assertions.assertTrue(sqlString.length % 2 == 0);
         for (int i = 0; i < sqlString.length; i += 2) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -67,12 +67,9 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                 "select min(id) from iceberg0.partitioned_db.t1 where date = '2020-01-01'", "true",
                 "select max(id) from iceberg0.partitioned_db.t1 where date = '2020-01-01'", "true",
                 "select count(id) from iceberg0.partitioned_db.t1 where date = '2020-01-01'", "false",
-                "select min(id), date from iceberg0.partitioned_db.t1 where date = '2020-01-01' " +
-                        "group by date", "false",
-                "select max(id), date from iceberg0.partitioned_db.t1 where date = '2020-01-01' " +
-                        "group by date", "false",
-                "select count(id),min(id), date from iceberg0.partitioned_db.t1 where date = '2020-01-01' " +
-                        "group by date", "false",
+                "select min(id), date from iceberg0.partitioned_db.t1 group by date", "true",
+                "select max(id), date from iceberg0.partitioned_db.t1 group by date", "true",
+                "select count(id),min(id), date from iceberg0.partitioned_db.t  group by date", "true",
         };
         Assertions.assertTrue(sqlString.length % 2 == 0);
         for (int i = 0; i < sqlString.length; i += 2) {


### PR DESCRIPTION
## Why I'm doing:

Original PR: #60385

Actually `min/max` optimization can be used when group partition column.

Because for each iceberg data file: partition column is a fixed value, and when doing group by this partition column,  we can still use (null/min/max) rows.

## What I'm doing:

Fixes #60385

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
