### PR TITLE
[Enhancement] datafile_gc support bundle tablet meta 

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1216,8 +1216,8 @@ static StatusOr<std::map<std::string, DirEntry>> find_orphan_data_files(FileSyst
             LOG(INFO) << location << " is deleted by other node";
             continue;
         } else if (!res.ok()) {
-            LOG(WARNING) << "Failed to get meta file: " << location << ", status: " << res.status();
-            continue;
+            LOG(WARNING) << "Failed to read metadata file: " << location << ", error: " << res.status();
+            return res.status();
         }
         const auto& metadata = res.value();
         for (const auto& rowset : metadata->rowsets()) {

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -1654,6 +1654,10 @@ TEST_P(LakeVacuumTest, test_datafile_gc) {
     EXPECT_TRUE(file_exist("0000000000022222_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst"));
 }
 
+TEST_P(LakeVacuumTest, test_datafile_gc_with_bundle_metadata) {
+    // TODO test datafile_gc when meet bundle metadata.
+}
+
 TEST_P(LakeVacuumTest, test_vacuum_combined_txn_log) {
     ASSERT_OK(_tablet_mgr->put_combined_txn_log(*json_to_pb<CombinedTxnLogPB>(R"DEL(
         {

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -1655,7 +1655,99 @@ TEST_P(LakeVacuumTest, test_datafile_gc) {
 }
 
 TEST_P(LakeVacuumTest, test_datafile_gc_with_bundle_metadata) {
-    // TODO test datafile_gc when meet bundle metadata.
+    WritableFileOptions options;
+    options.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+    ASSIGN_OR_ABORT(auto f, fs::new_writable_file(options, join_path(kTestDir, "test_datafile_gc.txt")));
+    ASSERT_OK(f->append("111"));
+    ASSERT_OK(f->close());
+
+    create_data_file("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat");
+    create_data_file("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat");
+    create_data_file("0000000000011111_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst");
+    create_data_file("0000000000022222_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst");
+
+    TabletSchemaPB schema_pb1;
+    {
+        schema_pb1.set_id(0);
+        schema_pb1.set_num_short_key_columns(1);
+        schema_pb1.set_keys_type(DUP_KEYS);
+    }
+
+    auto t600_v1 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 600,
+        "version": 1,
+        "rowsets": []
+        }
+        )DEL");
+    auto t601_v1 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 601,
+        "version": 1,
+        "rowsets": []
+        }
+        )DEL");
+    auto t600_v2 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 600,
+        "version": 2,
+        "rowsets": [
+            {
+                "segments": [
+                    "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
+                ],
+                "data_size": 4096
+            }
+        ],
+        "sstable_meta": {
+            "sstables": [
+                {
+                    "filename": "0000000000022222_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst"
+                }
+            ]
+        }
+        }
+        )DEL");
+    auto t601_v2 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 601,
+        "version": 2,
+        "rowsets": [
+            {
+                "segments": [
+                    "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
+                ],
+                "data_size": 4096
+            }
+        ]
+        }
+        )DEL");
+
+    t600_v1->mutable_schema()->CopyFrom(schema_pb1);
+    t601_v1->mutable_schema()->CopyFrom(schema_pb1);
+    t600_v2->mutable_schema()->CopyFrom(schema_pb1);
+    t601_v2->mutable_schema()->CopyFrom(schema_pb1);
+
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v1;
+    tablet_metas_v1[600] = *t600_v1;
+    tablet_metas_v1[601] = *t601_v1;
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v1));
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v2;
+    tablet_metas_v2[600] = *t600_v2;
+    tablet_metas_v2[601] = *t601_v2;
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v2));
+
+    ASSERT_OK(datafile_gc(kTestDir, join_path(kTestDir, "audit.log"), 0, false));
+    EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+    EXPECT_TRUE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+    EXPECT_TRUE(file_exist("0000000000011111_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst"));
+    EXPECT_TRUE(file_exist("0000000000022222_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst"));
+
+    ASSERT_OK(datafile_gc(kTestDir, "", 0, true));
+    EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+    EXPECT_FALSE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+    EXPECT_FALSE(file_exist("0000000000011111_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst"));
+    EXPECT_TRUE(file_exist("0000000000022222_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst"));
 }
 
 TEST_P(LakeVacuumTest, test_vacuum_combined_txn_log) {

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -1673,20 +1673,6 @@ TEST_P(LakeVacuumTest, test_datafile_gc_with_bundle_metadata) {
         schema_pb1.set_keys_type(DUP_KEYS);
     }
 
-    auto t600_v1 = json_to_pb<TabletMetadataPB>(R"DEL(
-        {
-        "id": 600,
-        "version": 1,
-        "rowsets": []
-        }
-        )DEL");
-    auto t601_v1 = json_to_pb<TabletMetadataPB>(R"DEL(
-        {
-        "id": 601,
-        "version": 1,
-        "rowsets": []
-        }
-        )DEL");
     auto t600_v2 = json_to_pb<TabletMetadataPB>(R"DEL(
         {
         "id": 600,
@@ -1723,15 +1709,9 @@ TEST_P(LakeVacuumTest, test_datafile_gc_with_bundle_metadata) {
         }
         )DEL");
 
-    t600_v1->mutable_schema()->CopyFrom(schema_pb1);
-    t601_v1->mutable_schema()->CopyFrom(schema_pb1);
     t600_v2->mutable_schema()->CopyFrom(schema_pb1);
     t601_v2->mutable_schema()->CopyFrom(schema_pb1);
 
-    std::map<int64_t, TabletMetadataPB> tablet_metas_v1;
-    tablet_metas_v1[600] = *t600_v1;
-    tablet_metas_v1[601] = *t601_v1;
-    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v1));
     std::map<int64_t, TabletMetadataPB> tablet_metas_v2;
     tablet_metas_v2[600] = *t600_v2;
     tablet_metas_v2[601] = *t601_v2;


### PR DESCRIPTION
## Why I'm doing:
Add support for handling bundle tablet meta in `datafile_gc`. Currently, `datafile_gc` can be triggered by:
```
./meta_tool.sh --operation=lake_datafile_gc --root_path=<path> --expired_sec=<86400> --conf_file=<path> --audit_file=<path> --do_delete=<true|false>
```

## What I'm doing:
This pull request enhances the handling of bundle metadata files in the `lake/vacuum` module and adds corresponding unit tests. The changes primarily focus on improving the identification and processing of bundle metadata files during garbage collection operations.

### Enhancements to bundle metadata handling:

* [`be/src/storage/lake/vacuum.cpp`](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750L1113-R1136): Updated the `list_meta_files` function to differentiate between regular metadata files and bundle metadata files, returning them as separate lists. Improved logging to include counts for both types of files.
* [`be/src/storage/lake/vacuum.cpp`](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750L1175-R1187): Modified the `find_orphan_data_files` function to process bundle metadata files, including validation and parsing of tablet metadata pages within bundle files. Added detailed logging and error handling for invalid or mismatched metadata. [[1]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750L1175-R1187) [[2]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750L1192-R1208) [[3]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750R1233-R1275)

### Unit tests for bundle metadata:

* [`be/test/storage/lake/vacuum_test.cpp`](diffhunk://#diff-d94022a29b009225bf18d165ff7a70635bce8158db300aa8432743a522691e37R1657-R1732): Added a new test case `test_datafile_gc_with_bundle_metadata` to verify the garbage collection behavior with bundle metadata files. The test ensures proper file handling and validates the expected outcomes for different scenarios.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
