### PR TITLE
[Enhancement] Add lake service stub cache

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -392,7 +392,7 @@ void LakeServiceImpl::aggregate_publish_version(::google::protobuf::RpcControlle
         auto res = LakeServiceBrpcStubCache::getInstance()->get_stub(compute_node.host(), compute_node.brpc_port());
         if (!res.ok()) {
             LOG(WARNING) << "aggregate publish failed because get stub failed: " << res.status();
-            ctx.handle_failure(fmt::format("get stub failed: ", res.status().to_string()));
+            ctx.handle_failure(fmt::format("get stub failed: {}", res.status().to_string()));
             ctx.count_down();
             continue;
         }
@@ -1060,7 +1060,7 @@ void LakeServiceImpl::aggregate_compact(::google::protobuf::RpcController* contr
         auto res = LakeServiceBrpcStubCache::getInstance()->get_stub(compute_node.host(), compute_node.brpc_port());
         if (!res.ok()) {
             LOG(WARNING) << "aggregate compact failed because get stub failed: " << res.status();
-            ac_context.handle_failure(fmt::format("get stub failed: ", res.status().to_string()));
+            ac_context.handle_failure(fmt::format("get stub failed: {}", res.status().to_string()));
             ac_context.count_down();
             continue;
         }

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -27,6 +27,7 @@ set(UTIL_FILES
   base85.cpp
   bloom_filter.cpp
   block_split_bloom_filter.cpp
+  brpc_stub_cache.cpp
   compression/block_compression.cpp
   compression/compression_context_pool_singletons.cpp
   compression/stream_compression.cpp

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -112,6 +112,7 @@ set(UTIL_FILES
   hash_util.cpp
   debug_action.cpp
   internal_service_recoverable_stub.cpp
+  lake_service_recoverable_stub.cpp
   byte_buffer.cpp
 )
 

--- a/be/src/util/base_recoverable_stub.h
+++ b/be/src/util/base_recoverable_stub.h
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <shared_mutex>
+
+#include "common/status.h"
+#include "service/brpc.h"
+
+namespace starrocks {
+
+template <typename StubType>
+class RecoverableClosure : public ::google::protobuf::Closure {
+public:
+    RecoverableClosure(std::shared_ptr<StubType> stub, ::google::protobuf::RpcController* controller,
+                       ::google::protobuf::Closure* done)
+            : _stub(std::move(stub)),
+              _controller(controller),
+              _done(done),
+              _next_connection_group(_stub->connection_group() + 1) {}
+
+    void Run() override {
+        auto* cntl = static_cast<brpc::Controller*>(_controller);
+        if (cntl->Failed() && cntl->ErrorCode() == EHOSTDOWN) {
+            auto st = _stub->reset_channel(_next_connection_group);
+            if (!st.ok()) {
+                LOG(WARNING) << "Fail to reset channel: " << st.to_string();
+            }
+        }
+        _done->Run();
+        delete this;
+    }
+
+private:
+    std::shared_ptr<StubType> _stub;
+    ::google::protobuf::RpcController* _controller;
+    ::google::protobuf::Closure* _done;
+    int64_t _next_connection_group;
+};
+
+class BaseRecoverableStub {
+public:
+    BaseRecoverableStub(const butil::EndPoint& endpoint, std::string protocol)
+            : _endpoint(endpoint), _protocol(std::move(protocol)), _connection_group(0) {}
+
+    virtual ~BaseRecoverableStub() = default;
+
+    int64_t connection_group() const { return _connection_group.load(); }
+
+    Status reset_channel_base(int64_t next_connection_group,
+                              std::function<void(brpc::ChannelOptions&)> options_customizer) {
+        if (next_connection_group == 0) {
+            next_connection_group = _connection_group.load() + 1;
+        }
+        if (next_connection_group != _connection_group + 1) {
+            return Status::OK();
+        }
+
+        brpc::ChannelOptions options;
+        options.connect_timeout_ms = config::rpc_connect_timeout_ms;
+        options.max_retry = 3;
+
+        if (options_customizer) {
+            options_customizer(options);
+        }
+
+        std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
+        if (channel->Init(_endpoint, &options)) {
+            LOG(WARNING) << "Fail to init channel " << _endpoint;
+            return Status::InternalError("Fail to init channel");
+        }
+
+        return reset_channel_impl(std::move(channel), next_connection_group);
+    }
+
+protected:
+    virtual Status reset_channel_impl(std::unique_ptr<brpc::Channel> channel, int64_t next_connection_group) = 0;
+
+    butil::EndPoint _endpoint;
+    std::string _protocol;
+    std::atomic<int64_t> _connection_group;
+    mutable std::shared_mutex _mutex;
+};
+
+} // namespace starrocks

--- a/be/src/util/brpc_stub_cache.cpp
+++ b/be/src/util/brpc_stub_cache.cpp
@@ -1,0 +1,193 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/brpc_stub_cache.h"
+
+#include "common/config.h"
+#include "gen_cpp/internal_service.pb.h"
+#include "gen_cpp/lake_service.pb.h"
+#include "util/failpoint/fail_point.h"
+#include "util/starrocks_metrics.h"
+
+namespace starrocks {
+
+BrpcStubCache::BrpcStubCache() {
+    _stub_map.init(239);
+    REGISTER_GAUGE_STARROCKS_METRIC(brpc_endpoint_stub_count, [this]() {
+        std::lock_guard<SpinLock> l(_lock);
+        return _stub_map.size();
+    });
+}
+
+BrpcStubCache::~BrpcStubCache() {
+    for (auto& stub : _stub_map) {
+        delete stub.second;
+    }
+}
+
+std::shared_ptr<PInternalService_RecoverableStub> BrpcStubCache::get_stub(const butil::EndPoint& endpoint) {
+    std::lock_guard<SpinLock> l(_lock);
+    auto stub_pool = _stub_map.seek(endpoint);
+    if (stub_pool == nullptr) {
+        StubPool* pool = new StubPool();
+        _stub_map.insert(endpoint, pool);
+        return pool->get_or_create(endpoint);
+    }
+    return (*stub_pool)->get_or_create(endpoint);
+}
+
+std::shared_ptr<PInternalService_RecoverableStub> BrpcStubCache::get_stub(const TNetworkAddress& taddr) {
+    return get_stub(taddr.hostname, taddr.port);
+}
+
+std::shared_ptr<PInternalService_RecoverableStub> BrpcStubCache::get_stub(const std::string& host, int port) {
+    butil::EndPoint endpoint;
+    std::string realhost;
+    std::string brpc_url;
+    realhost = host;
+    if (!is_valid_ip(host)) {
+        Status status = hostname_to_ip(host, realhost);
+        if (!status.ok()) {
+            LOG(WARNING) << "failed to get ip from host:" << status.to_string();
+            return nullptr;
+        }
+    }
+    brpc_url = get_host_port(realhost, port);
+    if (str2endpoint(brpc_url.c_str(), &endpoint)) {
+        LOG(WARNING) << "unknown endpoint, host=" << host;
+        return nullptr;
+    }
+    return get_stub(endpoint);
+}
+
+BrpcStubCache::StubPool::StubPool() : _idx(-1) {
+    _stubs.reserve(config::brpc_max_connections_per_server);
+}
+
+std::shared_ptr<PInternalService_RecoverableStub> BrpcStubCache::StubPool::get_or_create(
+        const butil::EndPoint& endpoint) {
+    if (UNLIKELY(_stubs.size() < config::brpc_max_connections_per_server)) {
+        auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint, "");
+        if (!stub->reset_channel().ok()) {
+            return nullptr;
+        }
+        _stubs.push_back(stub);
+        return stub;
+    }
+    if (++_idx >= config::brpc_max_connections_per_server) {
+        _idx = 0;
+    }
+    return _stubs[_idx];
+}
+
+HttpBrpcStubCache* HttpBrpcStubCache::getInstance() {
+    static HttpBrpcStubCache cache;
+    return &cache;
+}
+
+HttpBrpcStubCache::HttpBrpcStubCache() {
+    _stub_map.init(500);
+}
+
+StatusOr<std::shared_ptr<PInternalService_RecoverableStub>> HttpBrpcStubCache::get_http_stub(
+        const TNetworkAddress& taddr) {
+    butil::EndPoint endpoint;
+    std::string realhost;
+    std::string brpc_url;
+    realhost = taddr.hostname;
+    if (!is_valid_ip(taddr.hostname)) {
+        Status status = hostname_to_ip(taddr.hostname, realhost);
+        if (!status.ok()) {
+            LOG(WARNING) << "failed to get ip from host:" << status.to_string();
+            return nullptr;
+        }
+    }
+    brpc_url = get_host_port(realhost, taddr.port);
+    if (str2endpoint(brpc_url.c_str(), &endpoint)) {
+        return Status::RuntimeError("unknown endpoint, host = " + taddr.hostname);
+    }
+    // get is exist
+    std::lock_guard<SpinLock> l(_lock);
+    auto stub_ptr = _stub_map.seek(endpoint);
+    if (stub_ptr != nullptr) {
+        return *stub_ptr;
+    }
+    // create
+    auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint, "http");
+    if (!stub->reset_channel().ok()) {
+        return Status::RuntimeError("init brpc http channel error on " + taddr.hostname + ":" +
+                                    std::to_string(taddr.port));
+    }
+    _stub_map.insert(endpoint, stub);
+    return stub;
+}
+
+LakeServiceBrpcStubCache* LakeServiceBrpcStubCache::getInstance() {
+    static LakeServiceBrpcStubCache cache;
+    return &cache;
+}
+
+LakeServiceBrpcStubCache::LakeServiceBrpcStubCache() {
+    _stub_map.init(500);
+}
+
+DEFINE_FAIL_POINT(get_stub_return_nullptr);
+StatusOr<std::shared_ptr<starrocks::LakeService_Stub>> LakeServiceBrpcStubCache::get_stub(const std::string& host,
+                                                                                          int port) {
+    butil::EndPoint endpoint;
+    std::string realhost;
+    std::string brpc_url;
+    realhost = host;
+    if (!is_valid_ip(host)) {
+        RETURN_IF_ERROR(hostname_to_ip(host, realhost));
+    }
+    brpc_url = get_host_port(realhost, port);
+    if (str2endpoint(brpc_url.c_str(), &endpoint)) {
+        return Status::RuntimeError("unknown endpoint, host = " + host);
+    }
+    // get if exist
+    {
+        std::lock_guard<SpinLock> l(_lock);
+        auto stub_ptr = _stub_map.seek(endpoint);
+        FAIL_POINT_TRIGGER_EXECUTE(get_stub_return_nullptr, { stub_ptr = nullptr; });
+        if (stub_ptr != nullptr) {
+            return *stub_ptr;
+        }
+    }
+    // create
+    brpc::ChannelOptions options;
+    options.connect_timeout_ms = config::rpc_connect_timeout_ms;
+    options.max_retry = 3;
+    options.connection_group = std::to_string(_stub_map.size());
+    options.connection_type = config::brpc_connection_type;
+    std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
+    if (channel->Init(endpoint, &options)) {
+        return Status::RuntimeError("brpc channel init failed");
+    }
+    auto stub = std::make_shared<starrocks::LakeService_Stub>(channel.release(),
+                                                              google::protobuf::Service::STUB_OWNS_CHANNEL);
+    {
+        // double check
+        // There may be multiple threads concurrently getting the same brpc channel.
+        std::lock_guard<SpinLock> l(_lock);
+        auto stub_ptr = _stub_map.seek(endpoint);
+        if (stub_ptr != nullptr) {
+            return *stub_ptr;
+        }
+        _stub_map.insert(endpoint, stub);
+    }
+    return stub;
+}
+
+} // namespace starrocks

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -32,100 +32,37 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#pragma once
-
 #include <memory>
 #include <mutex>
 #include <vector>
 
-#include "common/config.h"
 #include "common/statusor.h"
 #include "gen_cpp/Types_types.h" // TNetworkAddress
-#include "gen_cpp/internal_service.pb.h"
-#include "gen_cpp/lake_service.pb.h"
 #include "service/brpc.h"
 #include "util/internal_service_recoverable_stub.h"
 #include "util/network_util.h"
 #include "util/spinlock.h"
-#include "util/starrocks_metrics.h"
 
 namespace starrocks {
 
-// map used
+class LakeService_Stub;
+
 class BrpcStubCache {
 public:
-    BrpcStubCache() {
-        _stub_map.init(239);
-        REGISTER_GAUGE_STARROCKS_METRIC(brpc_endpoint_stub_count, [this]() {
-            std::lock_guard<SpinLock> l(_lock);
-            return _stub_map.size();
-        });
-    }
-    ~BrpcStubCache() {
-        for (auto& stub : _stub_map) {
-            delete stub.second;
-        }
-    }
+    BrpcStubCache();
+    ~BrpcStubCache();
 
-    std::shared_ptr<PInternalService_RecoverableStub> get_stub(const butil::EndPoint& endpoint) {
-        std::lock_guard<SpinLock> l(_lock);
-        auto stub_pool = _stub_map.seek(endpoint);
-        if (stub_pool == nullptr) {
-            StubPool* pool = new StubPool();
-            _stub_map.insert(endpoint, pool);
-            return pool->get_or_create(endpoint);
-        }
-        return (*stub_pool)->get_or_create(endpoint);
-    }
-
-    std::shared_ptr<PInternalService_RecoverableStub> get_stub(const TNetworkAddress& taddr) {
-        return get_stub(taddr.hostname, taddr.port);
-    }
-
-    std::shared_ptr<PInternalService_RecoverableStub> get_stub(const std::string& host, int port) {
-        butil::EndPoint endpoint;
-        std::string realhost;
-        std::string brpc_url;
-        realhost = host;
-        if (!is_valid_ip(host)) {
-            Status status = hostname_to_ip(host, realhost);
-            if (!status.ok()) {
-                LOG(WARNING) << "failed to get ip from host:" << status.to_string();
-                return nullptr;
-            }
-        }
-        brpc_url = get_host_port(realhost, port);
-        if (str2endpoint(brpc_url.c_str(), &endpoint)) {
-            LOG(WARNING) << "unknown endpoint, host=" << host;
-            return nullptr;
-        }
-        return get_stub(endpoint);
-    }
+    std::shared_ptr<PInternalService_RecoverableStub> get_stub(const butil::EndPoint& endpoint);
+    std::shared_ptr<PInternalService_RecoverableStub> get_stub(const TNetworkAddress& taddr);
+    std::shared_ptr<PInternalService_RecoverableStub> get_stub(const std::string& host, int port);
 
 private:
-    // StubPool is used to store all stubs with a single endpoint, and the client in the same BE process maintains up to
-    // brpc_max_connections_per_server single connections with each server.
-    // These connections will be created during the first few accesses and will be reused later.
     struct StubPool {
-        StubPool() { _stubs.reserve(config::brpc_max_connections_per_server); }
-
-        std::shared_ptr<PInternalService_RecoverableStub> get_or_create(const butil::EndPoint& endpoint) {
-            if (UNLIKELY(_stubs.size() < config::brpc_max_connections_per_server)) {
-                auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint, "");
-                if (!stub->reset_channel().ok()) {
-                    return nullptr;
-                }
-                _stubs.push_back(stub);
-                return stub;
-            }
-            if (++_idx >= config::brpc_max_connections_per_server) {
-                _idx = 0;
-            }
-            return _stubs[_idx];
-        }
+        StubPool();
+        std::shared_ptr<PInternalService_RecoverableStub> get_or_create(const butil::EndPoint& endpoint);
 
         std::vector<std::shared_ptr<PInternalService_RecoverableStub>> _stubs;
-        int64_t _idx = -1;
+        int64_t _idx;
     };
 
     SpinLock _lock;
@@ -134,47 +71,13 @@ private:
 
 class HttpBrpcStubCache {
 public:
-    static HttpBrpcStubCache* getInstance() {
-        static HttpBrpcStubCache cache;
-        return &cache;
-    }
-
-    StatusOr<std::shared_ptr<PInternalService_RecoverableStub>> get_http_stub(const TNetworkAddress& taddr) {
-        butil::EndPoint endpoint;
-        std::string realhost;
-        std::string brpc_url;
-        realhost = taddr.hostname;
-        if (!is_valid_ip(taddr.hostname)) {
-            Status status = hostname_to_ip(taddr.hostname, realhost);
-            if (!status.ok()) {
-                LOG(WARNING) << "failed to get ip from host:" << status.to_string();
-                return nullptr;
-            }
-        }
-        brpc_url = get_host_port(realhost, taddr.port);
-        if (str2endpoint(brpc_url.c_str(), &endpoint)) {
-            return Status::RuntimeError("unknown endpoint, host = " + taddr.hostname);
-        }
-        // get is exist
-        std::lock_guard<SpinLock> l(_lock);
-        auto stub_ptr = _stub_map.seek(endpoint);
-        if (stub_ptr != nullptr) {
-            return *stub_ptr;
-        }
-        // create
-        auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint, "http");
-        if (!stub->reset_channel().ok()) {
-            return Status::RuntimeError("init brpc http channel error on " + taddr.hostname + ":" +
-                                        std::to_string(taddr.port));
-        }
-        _stub_map.insert(endpoint, stub);
-        return stub;
-    }
+    static HttpBrpcStubCache* getInstance();
+    StatusOr<std::shared_ptr<PInternalService_RecoverableStub>> get_http_stub(const TNetworkAddress& taddr);
 
 private:
-    HttpBrpcStubCache() { _stub_map.init(500); }
-    HttpBrpcStubCache(const HttpBrpcStubCache& cache) = delete;
-    HttpBrpcStubCache& operator=(const HttpBrpcStubCache& cache) = delete;
+    HttpBrpcStubCache();
+    HttpBrpcStubCache(const HttpBrpcStubCache&) = delete;
+    HttpBrpcStubCache& operator=(const HttpBrpcStubCache&) = delete;
 
     SpinLock _lock;
     butil::FlatMap<butil::EndPoint, std::shared_ptr<PInternalService_RecoverableStub>> _stub_map;
@@ -182,52 +85,13 @@ private:
 
 class LakeServiceBrpcStubCache {
 public:
-    static LakeServiceBrpcStubCache* getInstance() {
-        static LakeServiceBrpcStubCache cache;
-        return &cache;
-    }
-
-    StatusOr<std::shared_ptr<starrocks::LakeService_Stub>> get_stub(const std::string& host, int port) {
-        butil::EndPoint endpoint;
-        std::string realhost;
-        std::string brpc_url;
-        realhost = host;
-        if (!is_valid_ip(host)) {
-            RETURN_IF_ERROR(hostname_to_ip(host, realhost));
-        }
-        brpc_url = get_host_port(realhost, port);
-        if (str2endpoint(brpc_url.c_str(), &endpoint)) {
-            return Status::RuntimeError("unknown endpoint, host = " + host);
-        }
-        // get if exist
-        std::lock_guard<SpinLock> l(_lock);
-        auto stub_ptr = _stub_map.seek(endpoint);
-        if (stub_ptr != nullptr) {
-            return *stub_ptr;
-        }
-        // create
-        brpc::ChannelOptions options;
-        options.connect_timeout_ms = config::rpc_connect_timeout_ms;
-        options.max_retry = 3;
-        // the single connection of brpc will only maintain one connection with the same server by default,
-        // all requests are sent on this connection and the throughput will be limited by this.
-        // we use `connection_group` to create multiple single connections to remove this bottleneck.
-        options.connection_group = std::to_string(_stub_map.size());
-        options.connection_type = config::brpc_connection_type;
-        std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
-        if (channel->Init(endpoint, &options)) {
-            return Status::RuntimeError("brpc channel init failed");
-        }
-        auto stub = std::make_shared<starrocks::LakeService_Stub>(channel.release(),
-                                                                  google::protobuf::Service::STUB_OWNS_CHANNEL);
-        _stub_map.insert(endpoint, stub);
-        return stub;
-    }
+    static LakeServiceBrpcStubCache* getInstance();
+    StatusOr<std::shared_ptr<starrocks::LakeService_Stub>> get_stub(const std::string& host, int port);
 
 private:
-    LakeServiceBrpcStubCache() { _stub_map.init(500); }
-    LakeServiceBrpcStubCache(const LakeServiceBrpcStubCache& cache) = delete;
-    LakeServiceBrpcStubCache& operator=(const LakeServiceBrpcStubCache& cache) = delete;
+    LakeServiceBrpcStubCache();
+    LakeServiceBrpcStubCache(const LakeServiceBrpcStubCache&) = delete;
+    LakeServiceBrpcStubCache& operator=(const LakeServiceBrpcStubCache&) = delete;
 
     SpinLock _lock;
     butil::FlatMap<butil::EndPoint, std::shared_ptr<starrocks::LakeService_Stub>> _stub_map;

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -32,6 +32,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -40,12 +42,11 @@
 #include "gen_cpp/Types_types.h" // TNetworkAddress
 #include "service/brpc.h"
 #include "util/internal_service_recoverable_stub.h"
+#include "util/lake_service_recoverable_stub.h"
 #include "util/network_util.h"
 #include "util/spinlock.h"
 
 namespace starrocks {
-
-class LakeService_Stub;
 
 class BrpcStubCache {
 public:
@@ -86,7 +87,7 @@ private:
 class LakeServiceBrpcStubCache {
 public:
     static LakeServiceBrpcStubCache* getInstance();
-    StatusOr<std::shared_ptr<starrocks::LakeService_Stub>> get_stub(const std::string& host, int port);
+    StatusOr<std::shared_ptr<starrocks::LakeService_RecoverableStub>> get_stub(const std::string& host, int port);
 
 private:
     LakeServiceBrpcStubCache();
@@ -94,7 +95,7 @@ private:
     LakeServiceBrpcStubCache& operator=(const LakeServiceBrpcStubCache&) = delete;
 
     SpinLock _lock;
-    butil::FlatMap<butil::EndPoint, std::shared_ptr<starrocks::LakeService_Stub>> _stub_map;
+    butil::FlatMap<butil::EndPoint, std::shared_ptr<LakeService_RecoverableStub>> _stub_map;
 };
 
 } // namespace starrocks

--- a/be/src/util/internal_service_recoverable_stub.cpp
+++ b/be/src/util/internal_service_recoverable_stub.cpp
@@ -22,32 +22,40 @@ namespace starrocks {
 
 PInternalService_RecoverableStub::PInternalService_RecoverableStub(const butil::EndPoint& endpoint,
                                                                    std::string protocol)
-        : BaseRecoverableStub(endpoint, std::move(protocol)) {}
+        : _endpoint(endpoint), _protocol(std::move(protocol)) {}
 
 PInternalService_RecoverableStub::~PInternalService_RecoverableStub() = default;
 
 Status PInternalService_RecoverableStub::reset_channel(int64_t next_connection_group) {
-    auto customizer = [this, next_connection_group](brpc::ChannelOptions& options) {
-        if (!this->_protocol.empty()) {
-            options.protocol = this->_protocol;
-        }
-        if (this->_protocol != "http") {
-            // http does not support these.
-            options.connection_type = config::brpc_connection_type;
-            options.connection_group = std::to_string(next_connection_group);
-        }
-    };
-
-    return reset_channel_base(next_connection_group, customizer);
-}
-
-Status PInternalService_RecoverableStub::reset_channel_impl(std::unique_ptr<brpc::Channel> channel,
-                                                            int64_t next_connection_group) {
-    auto ptr = std::make_shared<PInternalService_Stub>(channel.release(), google::protobuf::Service::STUB_OWNS_CHANNEL);
+    if (next_connection_group == 0) {
+        next_connection_group = _connection_group.load() + 1;
+    }
+    if (next_connection_group != _connection_group + 1) {
+        // need to take int64_t overflow into consideration
+        return Status::OK();
+    }
+    brpc::ChannelOptions options;
+    options.connect_timeout_ms = config::rpc_connect_timeout_ms;
+    if (!_protocol.empty()) {
+        options.protocol = _protocol;
+    }
+    if (_protocol != "http") {
+        // http does not support these.
+        options.connection_type = config::brpc_connection_type;
+        options.connection_group = std::to_string(next_connection_group);
+    }
+    options.max_retry = 3;
+    std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
+    if (channel->Init(_endpoint, &options)) {
+        LOG(WARNING) << "Fail to init channel " << _endpoint;
+        return Status::InternalError("Fail to init channel");
+    }
+    auto ptr = std::make_unique<PInternalService_Stub>(channel.release(), google::protobuf::Service::STUB_OWNS_CHANNEL);
     std::unique_lock l(_mutex);
     if (next_connection_group == _connection_group.load() + 1) {
+        // prevent the underlying _stub been reset again by the same epoch calls
         ++_connection_group;
-        _stub = ptr;
+        _stub.reset(ptr.release());
     }
     return Status::OK();
 }

--- a/be/src/util/internal_service_recoverable_stub.cpp
+++ b/be/src/util/internal_service_recoverable_stub.cpp
@@ -14,76 +14,40 @@
 
 #include "util/internal_service_recoverable_stub.h"
 
-#include <utility>
+#include <functional>
 
 #include "common/config.h"
 
 namespace starrocks {
 
-class RecoverableClosure : public ::google::protobuf::Closure {
-public:
-    RecoverableClosure(std::shared_ptr<starrocks::PInternalService_RecoverableStub> stub,
-                       ::google::protobuf::RpcController* controller, ::google::protobuf::Closure* done)
-            : _stub(std::move(stub)),
-              _controller(controller),
-              _done(done),
-              _next_connection_group(_stub->connection_group() + 1) {}
-
-    void Run() override {
-        auto* cntl = static_cast<brpc::Controller*>(_controller);
-        if (cntl->Failed() && cntl->ErrorCode() == EHOSTDOWN) {
-            auto st = _stub->reset_channel(_next_connection_group);
-            if (!st.ok()) {
-                LOG(WARNING) << "Fail to reset channel: " << st.to_string();
-            }
-        }
-        _done->Run();
-        delete this;
-    }
-
-private:
-    std::shared_ptr<starrocks::PInternalService_RecoverableStub> _stub;
-    ::google::protobuf::RpcController* _controller;
-    ::google::protobuf::Closure* _done;
-    int64_t _next_connection_group;
-};
-
 PInternalService_RecoverableStub::PInternalService_RecoverableStub(const butil::EndPoint& endpoint,
                                                                    std::string protocol)
-        : _endpoint(endpoint), _protocol(std::move(protocol)) {}
+        : BaseRecoverableStub(endpoint, std::move(protocol)) {}
 
 PInternalService_RecoverableStub::~PInternalService_RecoverableStub() = default;
 
 Status PInternalService_RecoverableStub::reset_channel(int64_t next_connection_group) {
-    if (next_connection_group == 0) {
-        next_connection_group = _connection_group.load() + 1;
-    }
-    if (next_connection_group != _connection_group + 1) {
-        // need to take int64_t overflow into consideration
-        return Status::OK();
-    }
-    brpc::ChannelOptions options;
-    options.connect_timeout_ms = config::rpc_connect_timeout_ms;
-    if (!_protocol.empty()) {
-        options.protocol = _protocol;
-    }
-    if (_protocol != "http") {
-        // http does not support these.
-        options.connection_type = config::brpc_connection_type;
-        options.connection_group = std::to_string(next_connection_group);
-    }
-    options.max_retry = 3;
-    std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
-    if (channel->Init(_endpoint, &options)) {
-        LOG(WARNING) << "Fail to init channel " << _endpoint;
-        return Status::InternalError("Fail to init channel");
-    }
-    auto ptr = std::make_unique<PInternalService_Stub>(channel.release(), google::protobuf::Service::STUB_OWNS_CHANNEL);
+    auto customizer = [this, next_connection_group](brpc::ChannelOptions& options) {
+        if (!this->_protocol.empty()) {
+            options.protocol = this->_protocol;
+        }
+        if (this->_protocol != "http") {
+            // http does not support these.
+            options.connection_type = config::brpc_connection_type;
+            options.connection_group = std::to_string(next_connection_group);
+        }
+    };
+
+    return reset_channel_base(next_connection_group, customizer);
+}
+
+Status PInternalService_RecoverableStub::reset_channel_impl(std::unique_ptr<brpc::Channel> channel,
+                                                            int64_t next_connection_group) {
+    auto ptr = std::make_shared<PInternalService_Stub>(channel.release(), google::protobuf::Service::STUB_OWNS_CHANNEL);
     std::unique_lock l(_mutex);
     if (next_connection_group == _connection_group.load() + 1) {
-        // prevent the underlying _stub been reset again by the same epoch calls
         ++_connection_group;
-        _stub.reset(ptr.release());
+        _stub = ptr;
     }
     return Status::OK();
 }
@@ -92,7 +56,7 @@ void PInternalService_RecoverableStub::tablet_writer_open(::google::protobuf::Rp
                                                           const ::starrocks::PTabletWriterOpenRequest* request,
                                                           ::starrocks::PTabletWriterOpenResult* response,
                                                           ::google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->tablet_writer_open(controller, request, response, closure);
 }
 
@@ -100,7 +64,7 @@ void PInternalService_RecoverableStub::tablet_writer_cancel(::google::protobuf::
                                                             const ::starrocks::PTabletWriterCancelRequest* request,
                                                             ::starrocks::PTabletWriterCancelResult* response,
                                                             ::google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->tablet_writer_cancel(controller, request, response, closure);
 }
 
@@ -108,7 +72,7 @@ void PInternalService_RecoverableStub::transmit_chunk(::google::protobuf::RpcCon
                                                       const ::starrocks::PTransmitChunkParams* request,
                                                       ::starrocks::PTransmitChunkResult* response,
                                                       ::google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->transmit_chunk(controller, request, response, closure);
 }
 
@@ -124,35 +88,35 @@ void PInternalService_RecoverableStub::tablet_writer_add_chunk(::google::protobu
                                                                const ::starrocks::PTabletWriterAddChunkRequest* request,
                                                                ::starrocks::PTabletWriterAddBatchResult* response,
                                                                ::google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->tablet_writer_add_chunk(controller, request, response, closure);
 }
 
 void PInternalService_RecoverableStub::tablet_writer_add_chunks(
         ::google::protobuf::RpcController* controller, const ::starrocks::PTabletWriterAddChunksRequest* request,
         ::starrocks::PTabletWriterAddBatchResult* response, ::google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->tablet_writer_add_chunks(controller, request, response, closure);
 }
 
 void PInternalService_RecoverableStub::tablet_writer_add_chunk_via_http(
         ::google::protobuf::RpcController* controller, const ::starrocks::PHttpRequest* request,
         ::starrocks::PTabletWriterAddBatchResult* response, ::google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->tablet_writer_add_chunk_via_http(controller, request, response, closure);
 }
 
 void PInternalService_RecoverableStub::tablet_writer_add_chunks_via_http(
         ::google::protobuf::RpcController* controller, const ::starrocks::PHttpRequest* request,
         ::starrocks::PTabletWriterAddBatchResult* response, ::google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->tablet_writer_add_chunks_via_http(controller, request, response, closure);
 }
 
 void PInternalService_RecoverableStub::tablet_writer_add_segment(
         ::google::protobuf::RpcController* controller, const ::starrocks::PTabletWriterAddSegmentRequest* request,
         ::starrocks::PTabletWriterAddSegmentResult* response, ::google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->tablet_writer_add_segment(controller, request, response, closure);
 }
 
@@ -160,7 +124,7 @@ void PInternalService_RecoverableStub::get_load_replica_status(google::protobuf:
                                                                const PLoadReplicaStatusRequest* request,
                                                                PLoadReplicaStatusResult* response,
                                                                google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->get_load_replica_status(controller, request, response, closure);
 }
 
@@ -168,7 +132,7 @@ void PInternalService_RecoverableStub::load_diagnose(::google::protobuf::RpcCont
                                                      const ::starrocks::PLoadDiagnoseRequest* request,
                                                      ::starrocks::PLoadDiagnoseResult* response,
                                                      ::google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->load_diagnose(controller, request, response, closure);
 }
 
@@ -176,14 +140,14 @@ void PInternalService_RecoverableStub::transmit_runtime_filter(::google::protobu
                                                                const ::starrocks::PTransmitRuntimeFilterParams* request,
                                                                ::starrocks::PTransmitRuntimeFilterResult* response,
                                                                ::google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->transmit_runtime_filter(controller, request, response, closure);
 }
 
 void PInternalService_RecoverableStub::local_tablet_reader_multi_get(
         ::google::protobuf::RpcController* controller, const ::starrocks::PTabletReaderMultiGetRequest* request,
         ::starrocks::PTabletReaderMultiGetResult* response, ::google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->local_tablet_reader_multi_get(controller, request, response, closure);
 }
 
@@ -191,14 +155,14 @@ void PInternalService_RecoverableStub::execute_command(::google::protobuf::RpcCo
                                                        const ::starrocks::ExecuteCommandRequestPB* request,
                                                        ::starrocks::ExecuteCommandResultPB* response,
                                                        ::google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->execute_command(controller, request, response, closure);
 }
 
 void PInternalService_RecoverableStub::process_dictionary_cache(
         ::google::protobuf::RpcController* controller, const ::starrocks::PProcessDictionaryCacheRequest* request,
         ::starrocks::PProcessDictionaryCacheResult* response, ::google::protobuf::Closure* done) {
-    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
     stub()->process_dictionary_cache(controller, request, response, closure);
 }
 

--- a/be/src/util/lake_service_recoverable_stub.cpp
+++ b/be/src/util/lake_service_recoverable_stub.cpp
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/lake_service_recoverable_stub.h"
+
+#include <utility>
+
+#include "common/config.h"
+
+namespace starrocks {
+
+LakeService_RecoverableStub::LakeService_RecoverableStub(const butil::EndPoint& endpoint, std::string protocol)
+        : BaseRecoverableStub(endpoint, std::move(protocol)) {}
+
+LakeService_RecoverableStub::~LakeService_RecoverableStub() = default;
+
+Status LakeService_RecoverableStub::reset_channel(int64_t next_connection_group) {
+    return reset_channel_base(next_connection_group, nullptr);
+}
+
+Status LakeService_RecoverableStub::reset_channel_impl(std::unique_ptr<brpc::Channel> channel,
+                                                       int64_t next_connection_group) {
+    auto ptr = std::make_shared<LakeService_Stub>(channel.release(), google::protobuf::Service::STUB_OWNS_CHANNEL);
+    std::unique_lock l(_mutex);
+    if (next_connection_group == _connection_group.load() + 1) {
+        ++_connection_group;
+        _stub = ptr;
+    }
+    return Status::OK();
+}
+
+void LakeService_RecoverableStub::publish_version(::google::protobuf::RpcController* controller,
+                                                  const ::starrocks::PublishVersionRequest* request,
+                                                  ::starrocks::PublishVersionResponse* response,
+                                                  ::google::protobuf::Closure* done) {
+    using RecoverableClosureType = RecoverableClosure<LakeService_RecoverableStub>;
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
+    stub()->publish_version(controller, request, response, closure);
+}
+
+} // namespace starrocks

--- a/be/src/util/lake_service_recoverable_stub.h
+++ b/be/src/util/lake_service_recoverable_stub.h
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "gen_cpp/lake_service.pb.h"
+#include "util/base_recoverable_stub.h"
+
+namespace starrocks {
+
+class LakeService_RecoverableStub : public LakeService,
+                                    public BaseRecoverableStub,
+                                    public std::enable_shared_from_this<LakeService_RecoverableStub> {
+public:
+    LakeService_RecoverableStub(const butil::EndPoint& endpoint, std::string protocol = "");
+    ~LakeService_RecoverableStub();
+
+    Status reset_channel(int64_t next_connection_group = 0);
+
+    std::shared_ptr<starrocks::LakeService_Stub> stub() const {
+        std::shared_lock l(_mutex);
+        return _stub;
+    }
+
+    void publish_version(::google::protobuf::RpcController* controller,
+                         const ::starrocks::PublishVersionRequest* request,
+                         ::starrocks::PublishVersionResponse* response, ::google::protobuf::Closure* done);
+
+protected:
+    Status reset_channel_impl(std::unique_ptr<brpc::Channel> channel, int64_t next_connection_group) override;
+
+private:
+    std::shared_ptr<starrocks::LakeService_Stub> _stub;
+};
+
+} // namespace starrocks

--- a/be/test/util/brpc_stub_cache_test.cpp
+++ b/be/test/util/brpc_stub_cache_test.cpp
@@ -67,4 +67,23 @@ TEST_F(BrpcStubCacheTest, reset) {
     ASSERT_NE(istub1, istub2);
 }
 
+TEST_F(BrpcStubCacheTest, lake_service_stub_normal) {
+    LakeServiceBrpcStubCache cache;
+    TNetworkAddress address;
+    std::string hostname = "127.0.0.1";
+    int32_t port1 = 123;
+    auto stub1 = cache.get_stub(hostname, port1);
+    ASSERT_TRUE(stub1.ok());
+    int32_t port2 = 124;
+    auto stub2 = cache.get_stub(hostname, port2);
+    ASSERT_TRUE(stub2.ok());
+    ASSERT_NE(*stub1, *stub2);
+    auto stub3 = cache.get_stub(hostname, port1);
+    ASSERT_TRUE(stub3.ok());
+    ASSERT_EQ(*stub1, *stub3);
+
+    auto stub4 = cache.get_stub("invalid.cm.invalid", 123);
+    ASSERT_FALSE(stub4.ok());
+}
+
 } // namespace starrocks

--- a/be/test/util/brpc_stub_cache_test.cpp
+++ b/be/test/util/brpc_stub_cache_test.cpp
@@ -83,17 +83,6 @@ TEST_F(BrpcStubCacheTest, lake_service_stub_normal) {
     auto stub3 = cache.get_stub(hostname, port1);
     ASSERT_TRUE(stub3.ok());
     ASSERT_EQ(*stub1, *stub3);
-
-    PFailPointTriggerMode trigger_mode;
-    trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
-    auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("get_stub_return_nullptr");
-    fp->setMode(trigger_mode);
-    auto istub3 = cache.get_stub(hostname, port1);
-    ASSERT_TRUE(istub3.ok());
-    ASSERT_EQ(*stub1, *istub3);
-    trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
-    fp->setMode(trigger_mode);
-
     auto stub4 = cache.get_stub("invalid.cm.invalid", 123);
     ASSERT_FALSE(stub4.ok());
 }


### PR DESCRIPTION
## Why I'm doing:
After support `file_bundling`,  we will create brpc channels between CN nodes during each publish operation which may affect publish performance. 

## What I'm doing:
Add lake service stub cache to avoid creating brpc channels on each publish

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
