### PR TITLE
[BugFix] Throw exception when bucket size setting is not allowed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2277,6 +2277,10 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         } else if (metaType == TTabletMetaType.BUCKET_SIZE) {
             long bucketSize = Long.parseLong(properties.get(PropertyAnalyzer.PROPERTIES_BUCKET_SIZE));
+            if (!olapTable.allowBucketSizeSetting()) {
+                throw new DdlException("Setting bucket size is not allowed: only supported for tables with RANDOM distribution " +
+                        "and when 'enable_automatic_bucket' is enabled.");
+            }
             if (bucketSize == olapTable.getAutomaticBucketSize()) {
                 return;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2678,6 +2678,10 @@ public class OlapTable extends Table {
         tableProperty.buildReplicatedStorage();
     }
 
+    public boolean allowBucketSizeSetting() {
+        return (defaultDistributionInfo instanceof RandomDistributionInfo) && Config.enable_automatic_bucket;
+    }
+
     public Long getAutomaticBucketSize() {
         if (!(defaultDistributionInfo instanceof RandomDistributionInfo) || !Config.enable_automatic_bucket) {
             return (long) 0;

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -452,6 +452,10 @@ public class OlapTableFactory implements AbstractTableFactory {
                 long bucketSize = PropertyAnalyzer.analyzeLongProp(properties,
                         PropertyAnalyzer.PROPERTIES_BUCKET_SIZE, Config.default_automatic_bucket_size);
                 if (bucketSize >= 0) {
+                    if (!table.allowBucketSizeSetting()) {
+                        throw new DdlException("Setting bucket size is not allowed: only supported for tables with RANDOM " +
+                                "distribution and when 'enable_automatic_bucket' is enabled.");
+                    }
                     table.setAutomaticBucketSize(bucketSize);
                 } else {
                     throw new DdlException("Illegal bucket size: " + bucketSize);


### PR DESCRIPTION
## Why I'm doing:
Throw an exception when bucket_size is set but not allowed, instead of silently ignoring it. This improves clarity and prevents misconfiguration.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
