### PR TITLE
[Enhancement] Disable the inline mode when writing data to datacache because it may cause a performance degradation.

### DIFF
--- a/be/src/cache/starcache_engine.cpp
+++ b/be/src/cache/starcache_engine.cpp
@@ -86,6 +86,7 @@ Status StarCacheEngine::write(const std::string& key, const IOBuffer& buffer, Wr
         opts.mode = starcache::WriteOptions::WriteMode::WRITE_THROUGH;
     }
     opts.evict_probability = options->evict_probability;
+    opts.ignore_inline = true;
     Status st;
     {
         // The memory when writing starcache is no longer recorded to the query memory.


### PR DESCRIPTION
## Why I'm doing:
The starcache engine supports inline a cache item that smaller than the threshold with its metadata into memory. This can help reduce the waste of disk space. 
However, as the inline cache item only uses memory, sometimes although the disk space is sufficient, we cannot ensure all target data can be cached if reached the inline memory quota. For datalake queries, this will cause a performance degradation because we read the remote data with a coalesce io buffer and may read more data from remote storage and cause a high io latency.


## What I'm doing:
Disable the inline mode when writing data to datacache because it may cause a performance degradation.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
