### PR TITLE
[Enhancement] extend the date cache to 2050

### DIFF
--- a/be/src/runtime/time_types.cpp
+++ b/be/src/runtime/time_types.cpp
@@ -31,12 +31,12 @@ const uint64_t LOG_10_INT[] = {1,         10,         100,         1000,        
 JulianToDateEntry g_julian_to_date_cache[CACHE_JULIAN_DAYS];
 
 static const uint32_t CACHE_DATE_LITERAL_START = 19900101;
-static const uint32_t CACHE_DATE_LITERAL_END = 20250101;
+static const uint32_t CACHE_DATE_LITERAL_END = 20500101;
 static JulianDate g_date_literal_to_julian_cache[CACHE_DATE_LITERAL_END - CACHE_DATE_LITERAL_START];
 
 // MySQL DATE CACHE
 static const int CACHE_DATE_LOGIC_START = (1990 << 9) | (1 << 5) | (1);
-static const int CACHE_DATE_LOGIC_END = (2025 << 9) | (1 << 5) | (1);
+static const int CACHE_DATE_LOGIC_END = (2050 << 9) | (1 << 5) | (1);
 static JulianDate g_mysql_date_to_julian_cache[CACHE_DATE_LOGIC_END - CACHE_DATE_LOGIC_START];
 
 void date::init_date_cache() {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Extend the date cache from 2025 to 2050, which will affect the performance of some time functions.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
