### PR TITLE
[BugFix] Fix vacuum across metadata switch version

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -214,10 +214,12 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     public long getMinRetainVersion() {
         long retainVersion = minRetainVersion;
-        if (metadataSwitchVersion != 0 && retainVersion != 0) {
-            retainVersion = Math.min(retainVersion, metadataSwitchVersion);
-        } else if (metadataSwitchVersion != 0) {
-            retainVersion = metadataSwitchVersion;
+        if (metadataSwitchVersion != 0) {
+            if (retainVersion != 0) {
+                retainVersion = Math.min(retainVersion, metadataSwitchVersion);
+            } else {
+                retainVersion = metadataSwitchVersion;
+            }
         }
         return retainVersion;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -214,8 +214,10 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     public long getMinRetainVersion() {
         long retainVersion = minRetainVersion;
-        if (metadataSwitchVersion != 0) {
+        if (metadataSwitchVersion != 0 && retainVersion != 0) {
             retainVersion = Math.min(retainVersion, metadataSwitchVersion);
+        } else if (metadataSwitchVersion != 0) {
+            retainVersion = metadataSwitchVersion;
         }
         return retainVersion;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -122,6 +122,9 @@ public class AutovacuumDaemon extends FrontendDaemon {
             long minRetainVersion = partition.getMinRetainVersion();
             if (minRetainVersion <= 0) {
                 minRetainVersion = Math.max(1, partition.getVisibleVersion() - Config.lake_autovacuum_max_previous_versions);
+            } else {
+                minRetainVersion = Math.min(minRetainVersion, 
+                                        partition.getVisibleVersion() - Config.lake_autovacuum_max_previous_versions);
             }
             // the file before minRetainVersion vacuum success
             if (partition.getLastSuccVacuumVersion() >= minRetainVersion) {
@@ -182,7 +185,10 @@ public class AutovacuumDaemon extends FrontendDaemon {
             minRetainVersion = partition.getMinRetainVersion();
             if (minRetainVersion <= 0) {
                 minRetainVersion = Math.max(1, visibleVersion - Config.lake_autovacuum_max_previous_versions);
+            } else {
+                minRetainVersion = Math.min(minRetainVersion, visibleVersion - Config.lake_autovacuum_max_previous_versions);
             }
+
             preExtraFileSize = partition.getExtraFileSize();
             if (partition.getMetadataSwitchVersion() != 0) {
                 // If metadataSwitchVersion is not 0, it means that for versions prior to this, the value of 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AdminSetConfigStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AdminSetConfigStmtTest.java
@@ -169,7 +169,7 @@ public class AdminSetConfigStmtTest {
                 (AdminSetConfigStmt) UtFrameUtils.parseStmtWithNewParser(stmt, connectContext);
         ConfigBase.setConfig(adminSetConfigStmt);
 
-        Assert.assertEquals(60, Config.alter_table_timeout_second);
+        Assertions.assertEquals(60, Config.alter_table_timeout_second);
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
If we change table property `file_bundling`, we will set  `metadataSwitchVersion` to the latest version and vacuum should not across `metadataSwitchVersion` because the metadata formats  is different before and after the `metadataSwitchVersion`.  But when the `minRetainVersion` is 0, we will skip `metadataSwitchVersion` and use partition visible version as the vacuum version which across `metadataSwitchVersion`. And the result is some data file will not be gc successfully.

## What I'm doing:
Fix the minRetainVersion selection bug.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
