### PR TITLE
[Enhancement] Add expression filter counter to OLAP_SCAN for non-pushdown predicates

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -152,13 +152,17 @@ Status LakeDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
             size_t nrows = chunk_ptr->num_rows();
             _selection.resize(nrows);
             RETURN_IF_ERROR(_non_pushdown_pred_tree.evaluate(chunk_ptr, _selection.data(), 0, nrows));
-            chunk_ptr->filter(_selection);
+            size_t after_rows = chunk_ptr->filter(_selection);
+            COUNTER_UPDATE(_expr_filter_counter, nrows - after_rows);
             DCHECK_CHUNK(chunk_ptr);
         }
         if (!_not_push_down_conjuncts.empty()) {
             SCOPED_TIMER(_expr_filter_timer);
+            size_t before_rows = chunk_ptr->num_rows();
             RETURN_IF_ERROR(ExecNode::eval_conjuncts(_not_push_down_conjuncts, chunk_ptr));
+            size_t after_rows = chunk_ptr->num_rows();
             DCHECK_CHUNK(chunk_ptr);
+            COUNTER_UPDATE(_expr_filter_counter, before_rows - after_rows);
         }
         TRY_CATCH_ALLOC_SCOPE_END()
     } while (chunk_ptr->num_rows() == 0);
@@ -363,6 +367,7 @@ Status LakeDataSource::init_tablet_reader(RuntimeState* runtime_state) {
 
     if (!_not_push_down_conjuncts.empty() || !_non_pushdown_pred_tree.empty()) {
         _expr_filter_timer = ADD_TIMER(_runtime_profile, "ExprFilterTime");
+        _expr_filter_counter = ADD_COUNTER(_runtime_profile, "ExprFilterRows", TUnit::UNIT);
 
         _non_pushdown_predicates_counter = ADD_COUNTER_SKIP_MERGE(_runtime_profile, "NonPushdownPredicates",
                                                                   TUnit::UNIT, TCounterMergeType::SKIP_ALL);

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -117,6 +117,7 @@ private:
     RuntimeProfile::Counter* _rows_read_counter = nullptr;
 
     RuntimeProfile::Counter* _expr_filter_timer = nullptr;
+    RuntimeProfile::Counter* _expr_filter_counter = nullptr;
     RuntimeProfile::Counter* _create_seg_iter_timer = nullptr;
     RuntimeProfile::Counter* _io_timer = nullptr;
     RuntimeProfile::Counter* _read_compressed_counter = nullptr;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -525,6 +525,8 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
 
     if (!_scan_ctx->not_push_down_conjuncts().empty() || !_non_pushdown_pred_tree.empty()) {
         _expr_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ExprFilterTime", IO_TASK_EXEC_TIMER_NAME);
+        _expr_filter_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "ExprFilterRows", TUnit::UNIT, IO_TASK_EXEC_TIMER_NAME);
 
         _non_pushdown_predicates_counter = ADD_COUNTER_SKIP_MERGE(_runtime_profile, "NonPushdownPredicates",
                                                                   TUnit::UNIT, TCounterMergeType::SKIP_ALL);
@@ -604,12 +606,16 @@ Status OlapChunkSource::_read_chunk_from_storage(RuntimeState* state, Chunk* chu
             size_t nrows = chunk->num_rows();
             _selection.resize(nrows);
             RETURN_IF_ERROR(_non_pushdown_pred_tree.evaluate(chunk, _selection.data(), 0, nrows));
-            chunk->filter(_selection);
+            size_t after_rows = chunk->filter(_selection);
             DCHECK_CHUNK(chunk);
+            COUNTER_UPDATE(_expr_filter_counter, nrows - after_rows);
         }
         if (!_scan_ctx->not_push_down_conjuncts().empty()) {
             SCOPED_TIMER(_expr_filter_timer);
+            size_t before_rows = chunk->num_rows();
             RETURN_IF_ERROR(ExecNode::eval_conjuncts(_scan_ctx->not_push_down_conjuncts(), chunk));
+            size_t after_rows = chunk->num_rows();
+            COUNTER_UPDATE(_expr_filter_counter, before_rows - after_rows);
             DCHECK_CHUNK(chunk);
         }
         TRY_CATCH_ALLOC_SCOPE_END()

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -119,17 +119,55 @@ private:
     RuntimeProfile::Counter* _bytes_read_counter = nullptr;
     RuntimeProfile::Counter* _rows_read_counter = nullptr;
 
+    // Filters
+
+    // Expression filter (non-pushdown predicates)
     RuntimeProfile::Counter* _expr_filter_timer = nullptr;
+    RuntimeProfile::Counter* _expr_filter_counter = nullptr;
+
+    // Predicate filter (pushdown predicates)
+    RuntimeProfile::Counter* _pred_filter_counter = nullptr;
+    RuntimeProfile::Counter* _pred_filter_timer = nullptr;
+
+    // Runtime filter
+    RuntimeProfile::Counter* _rf_pred_filter_timer = nullptr;
+
+    // Short key filter
+    RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
+
+    // Zone map filter
+    RuntimeProfile::Counter* _zone_map_filter_timer = nullptr;
+    RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
+
+    // Bloom filter
+    RuntimeProfile::Counter* _bf_filter_timer = nullptr;
+    RuntimeProfile::Counter* _bf_filtered_counter = nullptr;
+
+    // Vector index filter
+    RuntimeProfile::Counter* _vector_index_filtered_counter = nullptr;
+
+    // Segment rowid filter
+    RuntimeProfile::Counter* _seg_rt_filtered_counter = nullptr;
+
+    // Bitmap index filter
+    RuntimeProfile::Counter* _bi_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _bi_filter_timer = nullptr;
+
+    // GIN (Generalized Inverted Index) filter
+    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
+
+    // Rows after skip key filter
+    RuntimeProfile::Counter* _rows_after_sk_filtered_counter = nullptr;
+
     RuntimeProfile::Counter* _create_seg_iter_timer = nullptr;
     RuntimeProfile::Counter* _io_timer = nullptr;
     RuntimeProfile::Counter* _read_compressed_counter = nullptr;
     RuntimeProfile::Counter* _decompress_timer = nullptr;
     RuntimeProfile::Counter* _read_uncompressed_counter = nullptr;
     RuntimeProfile::Counter* _raw_rows_counter = nullptr;
-    RuntimeProfile::Counter* _pred_filter_counter = nullptr;
     RuntimeProfile::Counter* _del_vec_filter_counter = nullptr;
-    RuntimeProfile::Counter* _pred_filter_timer = nullptr;
-    RuntimeProfile::Counter* _rf_pred_filter_timer = nullptr;
     RuntimeProfile::Counter* _rf_pred_input_rows = nullptr;
     RuntimeProfile::Counter* _rf_pred_output_rows = nullptr;
     RuntimeProfile::Counter* _chunk_copy_timer = nullptr;
@@ -139,17 +177,8 @@ private:
     RuntimeProfile::Counter* _seg_init_timer = nullptr;
     RuntimeProfile::Counter* _column_iterator_init_timer = nullptr;
     RuntimeProfile::Counter* _bitmap_index_iterator_init_timer = nullptr;
-    RuntimeProfile::Counter* _zone_map_filter_timer = nullptr;
     RuntimeProfile::Counter* _rows_key_range_filter_timer = nullptr;
     RuntimeProfile::Counter* _rows_key_range_counter = nullptr;
-    RuntimeProfile::Counter* _bf_filter_timer = nullptr;
-    RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _vector_index_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _bf_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _seg_rt_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _rows_after_sk_filtered_counter = nullptr;
     RuntimeProfile::Counter* _block_seek_timer = nullptr;
     RuntimeProfile::Counter* _block_seek_counter = nullptr;
     RuntimeProfile::Counter* _block_load_timer = nullptr;
@@ -157,10 +186,6 @@ private:
     RuntimeProfile::Counter* _block_fetch_timer = nullptr;
     RuntimeProfile::Counter* _read_pages_num_counter = nullptr;
     RuntimeProfile::Counter* _cached_pages_num_counter = nullptr;
-    RuntimeProfile::Counter* _bi_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _bi_filter_timer = nullptr;
-    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
     RuntimeProfile::Counter* _get_row_ranges_by_vector_index_timer = nullptr;
     RuntimeProfile::Counter* _vector_search_timer = nullptr;
     RuntimeProfile::Counter* _process_vector_distance_and_id_timer = nullptr;


### PR DESCRIPTION


## Why I'm doing:

## What I'm doing:


Add a counter in the profile:
- `expr_filter_rows`: the number of rows that filtered by the non-pushdown predicates


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
