### PR TITLE
[BugFix] Let submitted tasks without execution can be awared in starrocks::LakeServiceImpl to set a correct response and status (backport #59814)

### DIFF
--- a/be/src/exec/write_combined_txn_log.cpp
+++ b/be/src/exec/write_combined_txn_log.cpp
@@ -38,8 +38,8 @@ void mark_failure(const Status& status, std::atomic<bool>* has_error, Status* fi
 }
 
 std::function<void()> create_txn_log_task(const CombinedTxnLogPB* logs, lake::TabletManager* tablet_mgr,
-                                          std::atomic<bool>* has_error, Status* final_status) {
-    return [logs, tablet_mgr, has_error, final_status]() {
+                                          std::atomic<bool>* has_error, Status* final_status, CountDownLatch* latch) {
+    return [logs, tablet_mgr, has_error, final_status, latch]() {
         try {
             Status status = tablet_mgr->put_combined_txn_log(*logs);
             if (!status.ok()) {
@@ -50,6 +50,7 @@ std::function<void()> create_txn_log_task(const CombinedTxnLogPB* logs, lake::Ta
         } catch (...) {
             mark_failure(Status::Unknown("Unknown exception in write combined txn log task"), has_error, final_status);
         }
+        latch->count_down();
     };
 }
 
@@ -58,18 +59,30 @@ Status write_combined_txn_log_parallel(const std::map<int64_t, CombinedTxnLogPB>
     std::atomic<bool> has_error(false);
     Status final_status;
     {
-        std::vector<std::shared_ptr<AutoCleanRunnable>> tasks;
+        std::vector<std::shared_ptr<CancellableRunnable>> tasks;
         for (const auto& [partition_id, logs] : txn_log_map) {
             auto task_logic = create_txn_log_task(&logs, ExecEnv::GetInstance()->lake_tablet_manager(), &has_error,
-                                                  &final_status);
-            auto task = std::make_shared<AutoCleanRunnable>(std::move(task_logic), [&latch]() { latch.count_down(); });
+                                                  &final_status, &latch);
+            auto task =
+                    std::make_shared<CancellableRunnable>(std::move(task_logic), [&latch, &has_error, &final_status]() {
+                        Status st = Status::Cancelled("Task cancelled before execution");
+                        mark_failure(st, &has_error, &final_status);
+                        latch.count_down();
+                    });
             tasks.emplace_back(std::move(task));
         }
+        bool submit_failed = false;
         for (const auto& task : tasks) {
+            if (submit_failed) {
+                latch.count_down(); // Skip further tasks if one has already failed
+                continue;
+            }
+
             Status submit_status = ExecEnv::GetInstance()->put_combined_txn_log_thread_pool()->submit(task);
             if (!submit_status.ok()) {
+                submit_failed = true;
                 mark_failure(submit_status, &has_error, &final_status);
-                break;
+                latch.count_down();
             }
         }
     }

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -61,7 +61,7 @@ public:
 
     ~ChannelOpenTask() override {
         if (!_is_done) {
-            cancel(Status::ServiceUnavailable("Thread pool was shut down"));
+            cancel_task(Status::ServiceUnavailable("Thread pool was shut down"));
         }
     }
 
@@ -71,7 +71,7 @@ public:
         }
     }
 
-    void cancel(const Status& status) {
+    void cancel_task(const Status& status) {
         if (_try_mark_done()) {
             ClosureGuard closure_guard(_open_context.done);
             status.to_protobuf(_open_context.response->mutable_status());
@@ -164,7 +164,7 @@ void LoadChannelMgr::open(brpc::Controller* cntl, const PTabletWriterOpenRequest
     auto task = std::make_shared<ChannelOpenTask>(this, std::move(open_context));
     Status status = _async_rpc_pool->submit(task);
     if (!status.ok()) {
-        task->cancel(status);
+        task->cancel_task(status);
     }
 }
 

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -176,8 +176,9 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
         rebuild_pindex_tablets.insert(id);
     }
     for (auto tablet_id : request->tablet_ids()) {
-        auto task = std::make_shared<AutoCleanRunnable>(
+        auto task = std::make_shared<CancellableRunnable>(
                 [&, tablet_id] {
+                    DeferOp defer([&] { latch.count_down(); });
                     scoped_refptr<Trace> child_trace(new Trace);
                     Trace* sub_trace = child_trace.get();
                     trace->AddChildTrace("PublishTablet", sub_trace);
@@ -254,7 +255,18 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                     TRACE("finished");
                     g_publish_tablet_version_latency << (butil::gettimeofday_us() - run_ts);
                 },
-                [&] { latch.count_down(); });
+                [&] {
+                    g_publish_version_failed_tasks << 1;
+                    Status st = Status::Cancelled(
+                            fmt::format("publish version task has been cancelled, tablet_id={}", tablet_id));
+                    LOG(WARNING) << st;
+                    std::lock_guard l(response_mtx);
+                    response->add_failed_tablets(tablet_id);
+                    if (response->status().status_code() == 0) {
+                        st.to_protobuf(response->mutable_status());
+                    }
+                    latch.count_down();
+                });
 
         auto st = thread_pool_token.submit(std::move(task), timeout_deadline);
         if (!st.ok()) {
@@ -264,6 +276,7 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
             std::lock_guard l(response_mtx);
             response->add_failed_tablets(tablet_id);
             st.to_protobuf(response->mutable_status());
+            latch.count_down();
         }
     }
 
@@ -292,8 +305,9 @@ void LakeServiceImpl::_submit_publish_log_version_task(const int64_t* tablet_ids
 
     for (int i = 0; i < tablet_size; i++) {
         auto tablet_id = tablet_ids[i];
-        auto task = std::make_shared<AutoCleanRunnable>(
+        auto task = std::make_shared<CancellableRunnable>(
                 [&, tablet_id] {
+                    DeferOp defer([&] { latch.count_down(); });
                     auto st = lake::publish_log_version(_tablet_mgr, tablet_id, txn_infos, log_versions);
                     if (!st.ok()) {
                         g_publish_version_failed_tasks << 1;
@@ -304,7 +318,14 @@ void LakeServiceImpl::_submit_publish_log_version_task(const int64_t* tablet_ids
                         response->add_failed_tablets(tablet_id);
                     }
                 },
-                [&] { latch.count_down(); });
+                [&] {
+                    g_publish_version_failed_tasks << 1;
+                    LOG(WARNING) << "submit publish log version task has been cancelled: "
+                                 << " tablet_id=" << tablet_id;
+                    std::lock_guard l(response_mtx);
+                    response->add_failed_tablets(tablet_id);
+                    latch.count_down();
+                });
 
         auto st = thread_pool->submit(std::move(task));
         if (!st.ok()) {
@@ -314,6 +335,7 @@ void LakeServiceImpl::_submit_publish_log_version_task(const int64_t* tablet_ids
                          << " versions=" << JoinElementsIterator(log_versions, log_versions + txn_size, ",");
             std::lock_guard l(response_mtx);
             response->add_failed_tablets(tablet_id);
+            latch.count_down();
         }
     }
 
@@ -418,8 +440,9 @@ void LakeServiceImpl::abort_txn(::google::protobuf::RpcController* controller,
 
     auto thread_pool = abort_txn_thread_pool(_env);
     auto latch = BThreadCountDownLatch(1);
-    auto task = std::make_shared<AutoCleanRunnable>(
+    auto task = std::make_shared<CancellableRunnable>(
             [&] {
+                DeferOp defer([&] { latch.count_down(); });
                 std::vector<TxnInfoPB> txn_infos;
                 if (request->txn_infos_size() > 0) {
                     txn_infos.insert(txn_infos.begin(), request->txn_infos().begin(), request->txn_infos().end());
@@ -438,10 +461,14 @@ void LakeServiceImpl::abort_txn(::google::protobuf::RpcController* controller,
                     lake::abort_txn(_tablet_mgr, tablet_id, txn_infos);
                 }
             },
-            [&] { latch.count_down(); });
+            [&] {
+                LOG(WARNING) << "abort transaction task has been cancelled";
+                latch.count_down();
+            });
     auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit abort transaction task: " << st;
+        latch.count_down();
     }
 
     latch.wait();
@@ -464,12 +491,22 @@ void LakeServiceImpl::delete_tablet(::google::protobuf::RpcController* controlle
         return;
     }
     auto latch = BThreadCountDownLatch(1);
-    auto task = std::make_shared<AutoCleanRunnable>([&] { lake::delete_tablets(_tablet_mgr, *request, response); },
-                                                    [&] { latch.count_down(); });
+    auto task = std::make_shared<CancellableRunnable>(
+            [&] {
+                DeferOp defer([&] { latch.count_down(); });
+                lake::delete_tablets(_tablet_mgr, *request, response);
+            },
+            [&] {
+                Status st = Status::Cancelled("delete tablet task has been cancelled");
+                LOG(WARNING) << st;
+                st.to_protobuf(response->mutable_status());
+                latch.count_down();
+            });
     auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit delete tablet task: " << st;
         st.to_protobuf(response->mutable_status());
+        latch.count_down();
     }
 
     latch.wait();
@@ -503,14 +540,22 @@ void LakeServiceImpl::delete_txn_log(::google::protobuf::RpcController* controll
     }
 
     auto latch = BThreadCountDownLatch(1);
-    auto task = std::make_shared<AutoCleanRunnable>([&] { lake::delete_txn_log(_tablet_mgr, *request, response); },
-                                                    [&] { latch.count_down(); });
+    auto task = std::make_shared<CancellableRunnable>(
+            [&] {
+                DeferOp defer([&] { latch.count_down(); });
+                lake::delete_txn_log(_tablet_mgr, *request, response);
+            },
+            [&] {
+                Status st = Status::Cancelled("txn log vacuum task has been cancelled");
+                LOG(WARNING) << st;
+                st.to_protobuf(response->mutable_status());
+                latch.count_down();
+            });
     auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit vacuum task: " << st;
         st.to_protobuf(response->mutable_status());
-    } else {
-        Status::OK().to_protobuf(response->mutable_status());
+        latch.count_down();
     }
 
     latch.wait();
@@ -573,8 +618,9 @@ void LakeServiceImpl::drop_table(::google::protobuf::RpcController* controller,
               << " queued_tasks=" << thread_pool->num_queued_tasks();
 
     auto latch = BThreadCountDownLatch(1);
-    auto task = std::make_shared<AutoCleanRunnable>(
+    auto task = std::make_shared<CancellableRunnable>(
             [&] {
+                DeferOp defer([&] { latch.count_down(); });
                 TEST_SYNC_POINT("LakeService::drop_table:task_run");
                 auto location = _tablet_mgr->tablet_root_location(request->tablet_id());
                 auto st = fs::remove_all(location);
@@ -587,13 +633,20 @@ void LakeServiceImpl::drop_table(::google::protobuf::RpcController* controller,
                               << " path=" << request->path() << " is_not_found=" << st.is_not_found();
                 }
             },
-            [&] { latch.count_down(); });
+            [&] {
+                Status st = Status::Cancelled(
+                        fmt::format("drop table task has been cancelled, tablet id: {}", request->tablet_id()));
+                LOG(WARNING) << st;
+                st.to_protobuf(response->mutable_status());
+                latch.count_down();
+            });
 
     auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit drop table task: " << st << " tablet_id=" << request->tablet_id()
                      << " path=" << request->path();
         st.to_protobuf(response->mutable_status());
+        latch.count_down();
     }
 
     latch.wait();
@@ -622,8 +675,9 @@ void LakeServiceImpl::delete_data(::google::protobuf::RpcController* controller,
     auto latch = BThreadCountDownLatch(request->tablet_ids_size());
     bthread::Mutex response_mtx;
     for (auto tablet_id : request->tablet_ids()) {
-        auto task = std::make_shared<AutoCleanRunnable>(
+        auto task = std::make_shared<CancellableRunnable>(
                 [&, tablet_id] {
+                    DeferOp defer([&] { latch.count_down(); });
                     auto tablet = _tablet_mgr->get_tablet(tablet_id);
                     if (!tablet.ok()) {
                         LOG(WARNING) << "Fail to get tablet " << tablet_id << ": " << tablet.status();
@@ -639,13 +693,19 @@ void LakeServiceImpl::delete_data(::google::protobuf::RpcController* controller,
                         response->add_failed_tablets(tablet_id);
                     }
                 },
-                [&] { latch.count_down(); });
+                [&] {
+                    LOG(WARNING) << "delete data task has been cancelled. tablet_id: " << tablet_id;
+                    std::lock_guard l(response_mtx);
+                    response->add_failed_tablets(tablet_id);
+                    latch.count_down();
+                });
 
         auto st = thread_pool->submit(std::move(task));
         if (!st.ok()) {
             LOG(WARNING) << "Fail to submit delete data task: " << st;
             std::lock_guard l(response_mtx);
             response->add_failed_tablets(tablet_id);
+            latch.count_down();
         }
     }
 
@@ -675,8 +735,9 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
     auto latch = BThreadCountDownLatch(request->tablet_infos_size());
     bthread::Mutex response_mtx;
     for (const auto& tablet_info : request->tablet_infos()) {
-        auto task = std::make_shared<AutoCleanRunnable>(
+        auto task = std::make_shared<CancellableRunnable>(
                 [&, tablet_info] {
+                    DeferOp defer([&] { latch.count_down(); });
                     int64_t tablet_id = tablet_info.tablet_id();
                     int64_t version = tablet_info.version();
                     if (std::chrono::system_clock::now() >= timeout_deadline) {
@@ -708,10 +769,14 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
                     tablet_stat->set_num_rows(num_rows);
                     tablet_stat->set_data_size(data_size);
                 },
-                [&] { latch.count_down(); });
+                [&] {
+                    LOG(WARNING) << "get tablet stats task has been cancelled ";
+                    latch.count_down();
+                });
         TEST_SYNC_POINT_CALLBACK("LakeServiceImpl::get_tablet_stats:before_submit", nullptr);
         if (auto st = thread_pool_token.submit(std::move(task), timeout_deadline); !st.ok()) {
             LOG(WARNING) << "Fail to get tablet stats task: " << st;
+            latch.count_down();
         }
     }
 
@@ -750,19 +815,26 @@ void LakeServiceImpl::upload_snapshots(::google::protobuf::RpcController* contro
 
     auto thread_pool = _env->agent_server()->get_thread_pool(TTaskType::UPLOAD);
     auto latch = BThreadCountDownLatch(1);
-    auto task = std::make_shared<AutoCleanRunnable>(
+    auto task = std::make_shared<CancellableRunnable>(
             [&] {
+                DeferOp defer([&] { latch.count_down(); });
                 auto loader = std::make_unique<LakeSnapshotLoader>(_env);
                 auto st = loader->upload(request);
                 if (!st.ok()) {
                     cntl->SetFailed("Fail to upload snapshot");
                 }
             },
-            [&] { latch.count_down(); });
+            [&] {
+                Status st = Status::Cancelled("upload snapshots task has been cancelled");
+                LOG(WARNING) << st;
+                cntl->SetFailed(std::string(st.message()));
+                latch.count_down();
+            });
     auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit upload snapshots task: " << st;
         cntl->SetFailed(std::string(st.message()));
+        latch.count_down();
     }
     latch.wait();
 }
@@ -781,19 +853,26 @@ void LakeServiceImpl::restore_snapshots(::google::protobuf::RpcController* contr
 
     auto thread_pool = _env->agent_server()->get_thread_pool(TTaskType::DOWNLOAD);
     auto latch = BThreadCountDownLatch(1);
-    auto task = std::make_shared<AutoCleanRunnable>(
+    auto task = std::make_shared<CancellableRunnable>(
             [&] {
+                DeferOp defer([&] { latch.count_down(); });
                 auto loader = std::make_unique<LakeSnapshotLoader>(_env);
                 auto st = loader->restore(request);
                 if (!st.ok()) {
                     cntl->SetFailed("Fail to restore snapshot");
                 }
             },
-            [&] { latch.count_down(); });
+            [&] {
+                Status st = Status::Cancelled("restore snapshots task has been cancelled");
+                LOG(WARNING) << st;
+                cntl->SetFailed(std::string(st.message()));
+                latch.count_down();
+            });
     auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit restore snapshots task: " << st;
         cntl->SetFailed(std::string(st.message()));
+        latch.count_down();
     }
     latch.wait();
 }
@@ -872,12 +951,22 @@ void LakeServiceImpl::vacuum(::google::protobuf::RpcController* controller, cons
     TEST_SYNC_POINT("LakeServiceImpl::vacuum:2");
 
     auto latch = BThreadCountDownLatch(1);
-    auto task = std::make_shared<AutoCleanRunnable>([&] { lake::vacuum(_tablet_mgr, *request, response); },
-                                                    [&] { latch.count_down(); });
+    auto task = std::make_shared<CancellableRunnable>(
+            [&] {
+                DeferOp defer([&] { latch.count_down(); });
+                lake::vacuum(_tablet_mgr, *request, response);
+            },
+            [&] {
+                Status st = Status::Cancelled("vacuum task has been cancelled");
+                LOG(WARNING) << st;
+                st.to_protobuf(response->mutable_status());
+                latch.count_down();
+            });
     auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit vacuum task: " << st;
         st.to_protobuf(response->mutable_status());
+        latch.count_down();
     }
 
     latch.wait();
@@ -894,12 +983,21 @@ void LakeServiceImpl::vacuum_full(::google::protobuf::RpcController* controller,
         return;
     }
     auto latch = BThreadCountDownLatch(1);
-    auto task = std::make_shared<AutoCleanRunnable>([&] { lake::vacuum_full(_tablet_mgr, *request, response); },
-                                                    [&] { latch.count_down(); });
+    auto task = std::make_shared<CancellableRunnable>(
+            [&] {
+                DeferOp defer([&] { latch.count_down(); });
+                lake::vacuum_full(_tablet_mgr, *request, response);
+            },
+            [&] {
+                Status st = Status::Cancelled("full vacuum task has been cancelled");
+                st.to_protobuf(response->mutable_status());
+                latch.count_down();
+            });
     auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit vacuum task: " << st;
         st.to_protobuf(response->mutable_status());
+        latch.count_down();
     }
 
     latch.wait();

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -44,6 +44,7 @@
 #include "gutil/sysinfo.h"
 #include "testutil/sync_point.h"
 #include "util/cpu_info.h"
+#include "util/defer_op.h"
 #include "util/scoped_cleanup.h"
 #include "util/stack_util.h"
 #include "util/thread.h"
@@ -129,6 +130,12 @@ void ThreadPoolToken::shutdown() {
     // are destructed after the lock is released. This is important because the task's
     // destructors may acquire locks, etc., so this also prevents lock inversions.
     PriorityQueue<ThreadPool::NUM_PRIORITY, ThreadPool::Task> to_release;
+    DeferOp defer([&]() {
+        // PriorityQueue is not iterateable unless we pop the front element.
+        // But it is safe to do that because to_release will be destroyed just
+        // after the defer.
+        ThreadPool::_pop_and_cancel_tasks_in_queue(to_release);
+    });
     std::unique_lock l(_pool->_lock);
     _pool->check_not_pool_thread_unlocked();
 
@@ -296,6 +303,14 @@ void ThreadPool::shutdown() {
     // are destructed after the lock is released. This is important because the task's
     // destructors may acquire locks, etc., so this also prevents lock inversions.
     std::deque<PriorityQueue<NUM_PRIORITY, Task>> to_release;
+    DeferOp defer([&]() {
+        // PriorityQueue is not iterateable unless we pop the front element.
+        // But it is safe to do that because to_release will be destroyed just
+        // after the defer.
+        for (auto& pq : to_release) {
+            ThreadPool::_pop_and_cancel_tasks_in_queue(pq);
+        }
+    });
     std::unique_lock l(_lock);
     check_not_pool_thread_unlocked();
 
@@ -421,6 +436,8 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
         need_a_thread = true;
         _num_threads_pending_start++;
     }
+
+    TEST_SYNC_POINT_CALLBACK("ThreadPool::do_submit:replace_task", &r);
 
     Task task;
     task.runnable = std::move(r);
@@ -701,15 +718,39 @@ void ThreadPool::check_not_pool_thread_unlocked() {
     }
 }
 
+void ThreadPool::_pop_and_cancel_tasks_in_queue(PriorityQueue<ThreadPool::NUM_PRIORITY, ThreadPool::Task>& pq) {
+    while (!pq.empty()) {
+        try {
+            (pq.front().runnable)->cancel();
+        } catch (...) {
+            LOG(WARNING) << "Exception while cancelling runnable";
+        }
+        pq.pop_front();
+    }
+}
+
 Status ConcurrencyLimitedThreadPoolToken::submit(std::shared_ptr<Runnable> task,
                                                  std::chrono::system_clock::time_point deadline) {
     if (!_sem->try_acquire_until(deadline)) {
         auto t = MilliSecondsSinceEpochFromTimePoint(deadline);
         return Status::TimedOut(fmt::format("acquire semaphore reached deadline={}", t));
     }
-    auto token_task =
-            std::make_shared<AutoCleanRunnable>([t = std::move(task)] { t->run(); }, [sem = _sem] { sem->release(); });
-    return _pool->submit(std::move(token_task));
+    auto runnable_task = std::move(task); // Disable compilation warnings
+    auto token_task = std::make_shared<CancellableRunnable>(
+            [t = runnable_task, sem = _sem] {
+                t->run();
+                sem->release();
+            },
+            [t = runnable_task, sem = _sem] {
+                t->cancel();
+                sem->release();
+            });
+    auto st = _pool->submit(std::move(token_task));
+    if (!st.ok()) {
+        // handle submit failure manually
+        _sem->release();
+    }
+    return st;
 }
 
 Status ConcurrencyLimitedThreadPoolToken::submit_func(std::function<void()> f,

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -2283,4 +2283,136 @@ TEST_F(LakeServiceTest, test_delete_data_ok) {
     EXPECT_EQ(0L, response.failed_tablets().size());
 }
 
+TEST_F(LakeServiceTest, test_task_cleared_in_thread_pool_queue) {
+    class MockRunnable : public Runnable {
+    public:
+        MockRunnable() {}
+        virtual ~MockRunnable() override {}
+        virtual void run() override {}
+        virtual void cancel() override {}
+    };
+
+    SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:replace_task", [](void* arg) {
+        auto ptr = (*(std::shared_ptr<Runnable>*)arg);
+        ptr->cancel();
+        (*(std::shared_ptr<Runnable>*)arg) = std::make_shared<MockRunnable>();
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:replace_task");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    {
+        brpc::Controller cntl;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
+        request.set_base_version(1);
+        request.set_new_version(2);
+        request.add_tablet_ids(_tablet_id);
+        request.add_txn_ids(1000);
+        _lake_service.publish_version(&cntl, &request, &response, nullptr);
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+        ASSERT_TRUE(MatchPattern(response.status().error_msgs(0), "*has been cancelled*"));
+    }
+
+    {
+        auto txn_id = next_id();
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.set_txn_id(txn_id);
+        request.set_version(10);
+        brpc::Controller cntl;
+        _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+    }
+
+    {
+        AbortTxnRequest request;
+        request.add_tablet_ids(_tablet_id);
+        request.set_skip_cleanup(false);
+        request.add_txn_ids(next_id());
+        AbortTxnResponse response;
+        _lake_service.abort_txn(nullptr, &request, &response, nullptr);
+    }
+
+    {
+        brpc::Controller cntl;
+        DeleteTabletRequest request;
+        DeleteTabletResponse response;
+        request.add_tablet_ids(_tablet_id);
+        _lake_service.delete_tablet(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+        ASSERT_TRUE(MatchPattern(response.status().error_msgs(0), "*has been cancelled*"));
+    }
+
+    {
+        std::vector<TxnLog> logs;
+
+        // TxnLog with 2 segments
+        logs.emplace_back(generate_write_txn_log(2, 101, 4096));
+        ASSERT_OK(_tablet_mgr->put_txn_log(logs.back()));
+
+        brpc::Controller cntl;
+        DeleteTxnLogRequest request;
+        DeleteTxnLogResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.add_txn_ids(logs.back().txn_id());
+        _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(MatchPattern(response.status().error_msgs(0), "*has been cancelled*"));
+    }
+
+    {
+        ASSERT_OK(FileSystem::Default()->path_exists(kRootLocation));
+        DropTableRequest request;
+        DropTableResponse response;
+
+        brpc::Controller cntl;
+        request.set_tablet_id(_tablet_id);
+        _lake_service.drop_table(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(response.has_status());
+        ASSERT_TRUE(MatchPattern(response.status().error_msgs(0), "*has been cancelled*"));
+    }
+
+    {
+        DeleteDataRequest request;
+        request.add_tablet_ids(_tablet_id);
+        request.set_txn_id(12345);
+        request.mutable_delete_predicate()->set_version(1);
+
+        DeleteDataResponse response;
+        _lake_service.delete_data(nullptr, &request, &response, nullptr);
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+    }
+
+    {
+        TabletStatRequest request;
+        TabletStatResponse response;
+        auto* info = request.add_tablet_infos();
+        info->set_tablet_id(_tablet_id);
+        info->set_version(1);
+
+        // Prune metadata cache before getting tablet stats
+        _tablet_mgr->metacache()->prune();
+
+        _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+        ASSERT_EQ(0, response.tablet_stats_size());
+    }
+
+    {
+        brpc::Controller cntl;
+        VacuumRequest request;
+        VacuumResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.set_partition_id(next_id());
+        _lake_service.vacuum(&cntl, &request, &response, nullptr);
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

