### PR TITLE
[Feature] Introduce splitting tablets and merging tablets for dynamic tablet splitting and merging

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTablets.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTablets.java
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.dynamictablet;
+
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.Pair;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/*
+ * DynamicTablets is the base class of DynamicTablets and MergingTablets.
+ * DynamicTablets saves the old and new tablets during tablet splitting or merging for a materialized index
+ */
+public interface DynamicTablets {
+
+    void addSplittingTablet(long oldTabletId, List<Tablet> newTablets);
+
+    Map<Long, List<Tablet>> getSplittingTablets();
+
+    void addMergingTablet(List<Long> oldTabletIds, Tablet newTablet);
+
+    List<Pair<List<Long>, Tablet>> getMergingTablets();
+
+    Set<Long> getOldTabletIds();
+
+    List<Tablet> getNewTablets();
+
+    boolean isEmpty();
+
+    void clear();
+
+    List<Long> calcNewVirtualBuckets(List<Long> oldVirtualBuckets);
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/MergingTablets.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/MergingTablets.java
@@ -1,0 +1,135 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.dynamictablet;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.Pair;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
+
+/*
+ * MergingTablets saves the old and new tablets during tablet merging for a materialized index
+ */
+public class MergingTablets implements DynamicTablets {
+
+    @SerializedName(value = "mergingTablets")
+    private List<Pair<List<Long>, Tablet>> mergingTablets = new ArrayList<>();
+
+    public MergingTablets() {
+    }
+
+    @Override
+    public void addMergingTablet(List<Long> oldTabletIds, Tablet newTablet) {
+        // Old tablet size is usaully 2, but we allow a power of 2
+        Preconditions.checkState(
+                oldTabletIds.size() > 0 && (oldTabletIds.size() & (oldTabletIds.size() - 1)) == 0,
+                "Old tablet size must be a power of 2, actual: " + oldTabletIds.size());
+
+        mergingTablets.add(Pair.create(oldTabletIds, newTablet));
+    }
+
+    @Override
+    public List<Pair<List<Long>, Tablet>> getMergingTablets() {
+        return mergingTablets;
+    }
+
+    @Override
+    public Set<Long> getOldTabletIds() {
+        Set<Long> oldTabletsIds = new HashSet<>();
+        for (Pair<List<Long>, Tablet> mergingTablet : mergingTablets) {
+            for (Long id : mergingTablet.first) {
+                Preconditions.checkState(
+                        oldTabletsIds.add(id),
+                        "Duplicated old tablet: " + id);
+            }
+        }
+        return oldTabletsIds;
+    }
+
+    @Override
+    public List<Tablet> getNewTablets() {
+        List<Tablet> newTablets = new ArrayList<>();
+        for (Pair<List<Long>, Tablet> mergingTablet : mergingTablets) {
+            newTablets.add(mergingTablet.second);
+        }
+        return newTablets;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return mergingTablets.isEmpty();
+    }
+
+    @Override
+    public void clear() {
+        mergingTablets.clear();
+    }
+
+    @Override
+    public List<Long> calcNewVirtualBuckets(List<Long> oldVirtualBuckets) {
+        Map<Long, Tablet> oldToNewTablets = new HashMap<>();
+        for (Pair<List<Long>, Tablet> mergingTablet : mergingTablets) {
+            for (Long id : mergingTablet.first) {
+                Preconditions.checkState(
+                        oldToNewTablets.put(id, mergingTablet.second) == null,
+                        "Duplicated old tablet: " + id);
+            }
+        }
+
+        List<Long> newVirtualBuckets = new ArrayList<>(oldVirtualBuckets);
+
+        // Replace old tablet id with new tablet id in new virtual buckets
+        for (ListIterator<Long> it = newVirtualBuckets.listIterator(); it.hasNext(); /* */) {
+            Tablet newTablet = oldToNewTablets.get(it.next());
+            if (newTablet == null) {
+                continue;
+            }
+
+            it.set(newTablet.getId());
+        }
+
+        // Try to half new virtual buckets
+        while ((newVirtualBuckets.size() & 1) == 0) {
+            int mid = newVirtualBuckets.size() / 2;
+            List<Long> frontHalfList = newVirtualBuckets.subList(0, mid);
+            List<Long> backHalfList = newVirtualBuckets.subList(mid, newVirtualBuckets.size());
+            if (frontHalfList.equals(backHalfList)) {
+                newVirtualBuckets = frontHalfList;
+            } else {
+                break;
+            }
+        }
+
+        return newVirtualBuckets;
+    }
+
+    @Override
+    public void addSplittingTablet(long oldTabletId, List<Tablet> newTablets) {
+        throw new UnsupportedOperationException("Unimplemented method 'addSplittingTablet'");
+    }
+
+    @Override
+    public Map<Long, List<Tablet>> getSplittingTablets() {
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplittingTablets.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplittingTablets.java
@@ -1,0 +1,156 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.dynamictablet;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.Pair;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
+
+/*
+ * SplittingTablets saves the old and new tablets during tablet splitting for a materialized index
+ */
+public class SplittingTablets implements DynamicTablets {
+    @SerializedName(value = "splittingTablets")
+    private final Map<Long, List<Tablet>> splittingTablets = new HashMap<>();
+
+    public SplittingTablets() {
+    }
+
+    @Override
+    public void addSplittingTablet(long oldTabletId, List<Tablet> newTablets) {
+        // New tablet size is usaully 2, but we allow a power of 2
+        Preconditions.checkState(
+                newTablets.size() > 0 && (newTablets.size() & (newTablets.size() - 1)) == 0,
+                "New tablet size must be a power of 2, actual: " + newTablets.size());
+
+        Preconditions.checkState(
+                splittingTablets.put(oldTabletId, newTablets) == null,
+                "Duplicated old tablet: " + oldTabletId);
+    }
+
+    @Override
+    public Map<Long, List<Tablet>> getSplittingTablets() {
+        return splittingTablets;
+    }
+
+    @Override
+    public Set<Long> getOldTabletIds() {
+        return splittingTablets.keySet();
+    }
+
+    @Override
+    public List<Tablet> getNewTablets() {
+        List<Tablet> newTablets = new ArrayList<>();
+        for (List<Tablet> tablets : splittingTablets.values()) {
+            newTablets.addAll(tablets);
+        }
+        return newTablets;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return splittingTablets.isEmpty();
+    }
+
+    @Override
+    public void clear() {
+        splittingTablets.clear();
+    }
+
+    @Override
+    public List<Long> calcNewVirtualBuckets(List<Long> oldVirtualBuckets) {
+        // Temporary class
+        class Context {
+            int counter = 0;
+            final List<Tablet> tablets;
+
+            Context(List<Tablet> tablets) {
+                this.tablets = tablets;
+            }
+        }
+
+        // Prepare splitting tablet context
+        Map<Long, Context> idToContext = new HashMap<>();
+        for (Map.Entry<Long, List<Tablet>> entry : splittingTablets.entrySet()) {
+            idToContext.put(entry.getKey(), new Context(entry.getValue()));
+        }
+
+        // Calculate old virtual bucket number for each splitting tablet
+        for (Long id : oldVirtualBuckets) {
+            Context context = idToContext.get(id);
+            if (context == null) {
+                continue;
+            }
+
+            ++context.counter;
+        }
+
+        // Calculate the times that old virtual bucket number needs to be multiplied
+        long maxTimes = 0;
+        for (Map.Entry<Long, Context> entry : idToContext.entrySet()) {
+            Context context = entry.getValue();
+            Preconditions.checkState(
+                    context.counter > 0,
+                    "Cannot find tablet " + entry.getKey() + " in virtual buckets: " + oldVirtualBuckets);
+            long times = context.tablets.size() / context.counter;
+            if (times > maxTimes) {
+                maxTimes = times;
+            }
+            // Reset counter
+            context.counter = 0;
+        }
+
+        // Caculate new virtual buckets
+        List<Long> newVirtualBuckets = new ArrayList<>(oldVirtualBuckets);
+        for (long i = 2; i <= maxTimes; i *= 2) {
+            // Double
+            newVirtualBuckets.addAll(newVirtualBuckets);
+        }
+
+        // Replace old tablet id with new tablet id in new virtual buckets
+        for (ListIterator<Long> it = newVirtualBuckets.listIterator(); it.hasNext(); /* */) {
+            Context context = idToContext.get(it.next());
+            if (context == null) {
+                continue;
+            }
+
+            it.set(context.tablets.get(context.counter).getId());
+            // Round robin
+            if (++context.counter >= context.tablets.size()) {
+                context.counter = 0;
+            }
+        }
+
+        return newVirtualBuckets;
+    }
+
+    @Override
+    public void addMergingTablet(List<Long> oldTabletIds, Tablet newTablet) {
+        throw new UnsupportedOperationException("Unimplemented method 'addMergingTablet'");
+    }
+
+    @Override
+    public List<Pair<List<Long>, Tablet>> getMergingTablets() {
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -71,6 +71,9 @@ import com.starrocks.alter.OnlineOptimizeJobV2;
 import com.starrocks.alter.OptimizeJobV2;
 import com.starrocks.alter.RollupJobV2;
 import com.starrocks.alter.SchemaChangeJobV2;
+import com.starrocks.alter.dynamictablet.DynamicTablets;
+import com.starrocks.alter.dynamictablet.MergingTablets;
+import com.starrocks.alter.dynamictablet.SplittingTablets;
 import com.starrocks.authentication.FileGroupProvider;
 import com.starrocks.authentication.GroupProvider;
 import com.starrocks.authentication.JWTSecurityIntegration;
@@ -429,6 +432,11 @@ public class GsonUtils {
             RuntimeTypeAdapterFactory.of(ComputeResource.class, "clazz")
                     .registerSubtype(WarehouseComputeResource.class, "WarehouseComputeResource", true);
 
+    public static final RuntimeTypeAdapterFactory<DynamicTablets> DYNAMIC_TABLETS_RUNTIME_TYPE_ADAPTER_FACTORY = 
+            RuntimeTypeAdapterFactory.of(DynamicTablets.class, "clazz")
+                    .registerSubtype(SplittingTablets.class, "SplittingTablets")
+                    .registerSubtype(MergingTablets.class, "MergingTablets");
+
     private static final JsonSerializer<LocalDateTime> LOCAL_DATE_TIME_TYPE_SERIALIZER =
             (dateTime, type, jsonSerializationContext) -> new JsonPrimitive(dateTime.toEpochSecond(ZoneOffset.UTC));
 
@@ -491,6 +499,7 @@ public class GsonUtils {
             .registerTypeAdapterFactory(ANALYZE_STATUS_RUNTIME_TYPE_ADAPTER_FACTORY)
             .registerTypeAdapterFactory(ANALYZE_JOB_RUNTIME_TYPE_ADAPTER_FACTORY)
             .registerTypeAdapterFactory(COMPUTE_RESOURCE_RUNTIME_TYPE_ADAPTER_FACTORY)
+            .registerTypeAdapterFactory(DYNAMIC_TABLETS_RUNTIME_TYPE_ADAPTER_FACTORY)
             .registerTypeAdapter(LocalDateTime.class, LOCAL_DATE_TIME_TYPE_SERIALIZER)
             .registerTypeAdapter(LocalDateTime.class, LOCAL_DATE_TIME_TYPE_DESERIALIZER)
             .registerTypeAdapter(QueryDumpInfo.class, DUMP_INFO_SERIALIZER)

--- a/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/MergingTabletsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/MergingTabletsTest.java
@@ -1,0 +1,212 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.dynamictablet;
+
+import com.starrocks.catalog.LocalTablet;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class MergingTabletsTest {
+    @Test
+    public void testCalcNewVirtualBuckets() {
+        MergingTablets mergingTablets = new MergingTablets();
+        Assertions.assertTrue(mergingTablets.isEmpty());
+        Assertions.assertTrue(mergingTablets.getMergingTablets().isEmpty());
+
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> mergingTablets.addSplittingTablet(0, null));
+        Assertions.assertNull(mergingTablets.getSplittingTablets());
+
+        mergingTablets.addMergingTablet(
+                List.of(101L, 102L),
+                new LocalTablet(1));
+        mergingTablets.addMergingTablet(
+                List.of(201L, 202L),
+                new LocalTablet(2));
+        Assertions.assertFalse(mergingTablets.isEmpty());
+
+        Assertions.assertEquals(List.of(1L, 2L, 3L, 4L, 5L),
+                mergingTablets.calcNewVirtualBuckets(List.of(
+                        101L, 201L, 3L, 4L, 5L,
+                        102L, 202L, 3L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                1L, 2L, 301L, 4L, 5L,
+                1L, 2L, 302L, 4L, 5L),
+                mergingTablets.calcNewVirtualBuckets(
+                        List.of(101L, 201L, 301L, 4L, 5L,
+                                102L, 202L, 302L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                1L, 2L, 301L, 4L, 5L,
+                1L, 2L, 302L, 4L, 5L,
+                1L, 2L, 303L, 4L, 5L,
+                1L, 2L, 304L, 4L, 5L),
+                mergingTablets.calcNewVirtualBuckets(
+                        List.of(101L, 201L, 301L, 4L, 5L,
+                                102L, 202L, 302L, 4L, 5L,
+                                101L, 201L, 303L, 4L, 5L,
+                                102L, 202L, 304L, 4L, 5L)));
+
+        mergingTablets.clear();
+        Assertions.assertTrue(mergingTablets.isEmpty());
+
+        mergingTablets.addMergingTablet(
+                List.of(201L, 202L, 203L, 204L),
+                new LocalTablet(2));
+        mergingTablets.addMergingTablet(
+                List.of(301L, 302L),
+                new LocalTablet(3));
+
+        Assertions.assertEquals(List.of(1L, 2L, 3L, 4L, 5L),
+                mergingTablets.calcNewVirtualBuckets(List.of(
+                        1L, 201L, 301L, 4L, 5L,
+                        1L, 202L, 302L, 4L, 5L,
+                        1L, 203L, 301L, 4L, 5L,
+                        1L, 204L, 302L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                101L, 2L, 3L, 4L, 5L,
+                102L, 2L, 3L, 4L, 5L),
+                mergingTablets.calcNewVirtualBuckets(
+                        List.of(101L, 201L, 301L, 4L, 5L,
+                                102L, 202L, 302L, 4L, 5L,
+                                101L, 203L, 301L, 4L, 5L,
+                                102L, 204L, 302L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                101L, 2L, 3L, 4L, 5L,
+                102L, 2L, 3L, 4L, 5L,
+                103L, 2L, 3L, 4L, 5L,
+                104L, 2L, 3L, 4L, 5L),
+                mergingTablets.calcNewVirtualBuckets(
+                        List.of(101L, 201L, 301L, 4L, 5L,
+                                102L, 202L, 302L, 4L, 5L,
+                                103L, 203L, 301L, 4L, 5L,
+                                104L, 204L, 302L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                101L, 2L, 3L, 4L, 5L,
+                102L, 2L, 3L, 4L, 5L,
+                103L, 2L, 3L, 4L, 5L,
+                104L, 2L, 3L, 4L, 5L,
+                105L, 2L, 3L, 4L, 5L,
+                106L, 2L, 3L, 4L, 5L,
+                107L, 2L, 3L, 4L, 5L,
+                108L, 2L, 3L, 4L, 5L),
+                mergingTablets.calcNewVirtualBuckets(
+                        List.of(101L, 201L, 301L, 4L, 5L,
+                                102L, 202L, 302L, 4L, 5L,
+                                103L, 203L, 301L, 4L, 5L,
+                                104L, 204L, 302L, 4L, 5L,
+                                105L, 201L, 301L, 4L, 5L,
+                                106L, 202L, 302L, 4L, 5L,
+                                107L, 203L, 301L, 4L, 5L,
+                                108L, 204L, 302L, 4L, 5L)));
+
+        mergingTablets.clear();
+        Assertions.assertTrue(mergingTablets.isEmpty());
+
+        mergingTablets.addMergingTablet(
+                List.of(10101L, 10102L, 10103L, 10104L),
+                new LocalTablet(101));
+        mergingTablets.addMergingTablet(
+                List.of(201L, 202L, 203L, 204L),
+                new LocalTablet(2));
+
+        Assertions.assertEquals(List.of(
+                101L, 2L, 3L, 4L, 5L,
+                102L, 2L, 3L, 4L, 5L),
+                mergingTablets.calcNewVirtualBuckets(List.of(
+                        10101L, 201L, 3L, 4L, 5L,
+                        102L, 202L, 3L, 4L, 5L,
+                        10102L, 203L, 3L, 4L, 5L,
+                        102L, 204L, 3L, 4L, 5L,
+                        10103L, 201L, 3L, 4L, 5L,
+                        102L, 202L, 3L, 4L, 5L,
+                        10104L, 203L, 3L, 4L, 5L,
+                        102L, 204L, 3L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                101L, 2L, 301L, 4L, 5L,
+                102L, 2L, 302L, 4L, 5L,
+                101L, 2L, 303L, 4L, 5L,
+                102L, 2L, 304L, 4L, 5L),
+                mergingTablets.calcNewVirtualBuckets(List.of(
+                        10101L, 201L, 301L, 4L, 5L,
+                        102L, 202L, 302L, 4L, 5L,
+                        10102L, 203L, 303L, 4L, 5L,
+                        102L, 204L, 304L, 4L, 5L,
+                        10103L, 201L, 301L, 4L, 5L,
+                        102L, 202L, 302L, 4L, 5L,
+                        10104L, 203L, 303L, 4L, 5L,
+                        102L, 204L, 304L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                101L, 2L, 301L, 4L, 5L,
+                102L, 2L, 302L, 4L, 5L,
+                101L, 2L, 303L, 4L, 5L,
+                102L, 2L, 304L, 4L, 5L,
+                101L, 2L, 305L, 4L, 5L,
+                102L, 2L, 306L, 4L, 5L,
+                101L, 2L, 307L, 4L, 5L,
+                102L, 2L, 308L, 4L, 5L),
+                mergingTablets.calcNewVirtualBuckets(List.of(
+                        10101L, 201L, 301L, 4L, 5L,
+                        102L, 202L, 302L, 4L, 5L,
+                        10102L, 203L, 303L, 4L, 5L,
+                        102L, 204L, 304L, 4L, 5L,
+                        10103L, 201L, 305L, 4L, 5L,
+                        102L, 202L, 306L, 4L, 5L,
+                        10104L, 203L, 307L, 4L, 5L,
+                        102L, 204L, 308L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                101L, 2L, 301L, 4L, 5L,
+                102L, 2L, 302L, 4L, 5L,
+                101L, 2L, 303L, 4L, 5L,
+                102L, 2L, 304L, 4L, 5L,
+                101L, 2L, 305L, 4L, 5L,
+                102L, 2L, 306L, 4L, 5L,
+                101L, 2L, 307L, 4L, 5L,
+                102L, 2L, 308L, 4L, 5L,
+                101L, 2L, 309L, 4L, 5L,
+                102L, 2L, 310L, 4L, 5L,
+                101L, 2L, 311L, 4L, 5L,
+                102L, 2L, 312L, 4L, 5L,
+                101L, 2L, 313L, 4L, 5L,
+                102L, 2L, 314L, 4L, 5L,
+                101L, 2L, 315L, 4L, 5L,
+                102L, 2L, 316L, 4L, 5L),
+                mergingTablets.calcNewVirtualBuckets(List.of(
+                        10101L, 201L, 301L, 4L, 5L,
+                        102L, 202L, 302L, 4L, 5L,
+                        10102L, 203L, 303L, 4L, 5L,
+                        102L, 204L, 304L, 4L, 5L,
+                        10103L, 201L, 305L, 4L, 5L,
+                        102L, 202L, 306L, 4L, 5L,
+                        10104L, 203L, 307L, 4L, 5L,
+                        102L, 204L, 308L, 4L, 5L,
+                        10101L, 201L, 309L, 4L, 5L,
+                        102L, 202L, 310L, 4L, 5L,
+                        10102L, 203L, 311L, 4L, 5L,
+                        102L, 204L, 312L, 4L, 5L,
+                        10103L, 201L, 313L, 4L, 5L,
+                        102L, 202L, 314L, 4L, 5L,
+                        10104L, 203L, 315L, 4L, 5L,
+                        102L, 204L, 316L, 4L, 5L)));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/SplittingTabletsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/SplittingTabletsTest.java
@@ -1,0 +1,219 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.dynamictablet;
+
+import com.starrocks.catalog.LocalTablet;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class SplittingTabletsTest {
+    @Test
+    public void testCalcNewVirtualBuckets() {
+        SplittingTablets splittingTablets = new SplittingTablets();
+        Assertions.assertTrue(splittingTablets.isEmpty());
+        Assertions.assertTrue(splittingTablets.getSplittingTablets().isEmpty());
+
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> splittingTablets.addMergingTablet(null, null));
+        Assertions.assertNull(splittingTablets.getMergingTablets());
+
+        splittingTablets.addSplittingTablet(1,
+                List.of(new LocalTablet(101),
+                        new LocalTablet(102)));
+        splittingTablets.addSplittingTablet(2,
+                List.of(new LocalTablet(201),
+                        new LocalTablet(202)));
+        Assertions.assertFalse(splittingTablets.isEmpty());
+
+        Assertions.assertEquals(List.of(
+                101L, 201L, 3L, 4L, 5L,
+                102L, 202L, 3L, 4L, 5L),
+                splittingTablets.calcNewVirtualBuckets(List.of(1L, 2L, 3L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                101L, 201L, 301L, 4L, 5L,
+                102L, 202L, 302L, 4L, 5L),
+                splittingTablets.calcNewVirtualBuckets(
+                        List.of(1L, 2L, 301L, 4L, 5L,
+                                1L, 2L, 302L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                101L, 201L, 301L, 4L, 5L,
+                102L, 202L, 302L, 4L, 5L,
+                101L, 201L, 303L, 4L, 5L,
+                102L, 202L, 304L, 4L, 5L),
+                splittingTablets.calcNewVirtualBuckets(
+                        List.of(1L, 2L, 301L, 4L, 5L,
+                                1L, 2L, 302L, 4L, 5L,
+                                1L, 2L, 303L, 4L, 5L,
+                                1L, 2L, 304L, 4L, 5L)));
+
+        splittingTablets.clear();
+        Assertions.assertTrue(splittingTablets.isEmpty());
+
+        splittingTablets.addSplittingTablet(2,
+                List.of(new LocalTablet(201),
+                        new LocalTablet(202),
+                        new LocalTablet(203),
+                        new LocalTablet(204)));
+        splittingTablets.addSplittingTablet(3,
+                List.of(new LocalTablet(301),
+                        new LocalTablet(302)));
+
+        Assertions.assertEquals(List.of(
+                1L, 201L, 301L, 4L, 5L,
+                1L, 202L, 302L, 4L, 5L,
+                1L, 203L, 301L, 4L, 5L,
+                1L, 204L, 302L, 4L, 5L),
+                splittingTablets.calcNewVirtualBuckets(List.of(1L, 2L, 3L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                101L, 201L, 301L, 4L, 5L,
+                102L, 202L, 302L, 4L, 5L,
+                101L, 203L, 301L, 4L, 5L,
+                102L, 204L, 302L, 4L, 5L),
+                splittingTablets.calcNewVirtualBuckets(
+                        List.of(101L, 2L, 3L, 4L, 5L,
+                                102L, 2L, 3L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                101L, 201L, 301L, 4L, 5L,
+                102L, 202L, 302L, 4L, 5L,
+                103L, 203L, 301L, 4L, 5L,
+                104L, 204L, 302L, 4L, 5L),
+                splittingTablets.calcNewVirtualBuckets(
+                        List.of(101L, 2L, 3L, 4L, 5L,
+                                102L, 2L, 3L, 4L, 5L,
+                                103L, 2L, 3L, 4L, 5L,
+                                104L, 2L, 3L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                101L, 201L, 301L, 4L, 5L,
+                102L, 202L, 302L, 4L, 5L,
+                103L, 203L, 301L, 4L, 5L,
+                104L, 204L, 302L, 4L, 5L,
+                105L, 201L, 301L, 4L, 5L,
+                106L, 202L, 302L, 4L, 5L,
+                107L, 203L, 301L, 4L, 5L,
+                108L, 204L, 302L, 4L, 5L),
+                splittingTablets.calcNewVirtualBuckets(
+                        List.of(101L, 2L, 3L, 4L, 5L,
+                                102L, 2L, 3L, 4L, 5L,
+                                103L, 2L, 3L, 4L, 5L,
+                                104L, 2L, 3L, 4L, 5L,
+                                105L, 2L, 3L, 4L, 5L,
+                                106L, 2L, 3L, 4L, 5L,
+                                107L, 2L, 3L, 4L, 5L,
+                                108L, 2L, 3L, 4L, 5L)));
+
+        splittingTablets.clear();
+        Assertions.assertTrue(splittingTablets.isEmpty());
+
+        splittingTablets.addSplittingTablet(101,
+                List.of(new LocalTablet(10101),
+                        new LocalTablet(10102),
+                        new LocalTablet(10103),
+                        new LocalTablet(10104)));
+        splittingTablets.addSplittingTablet(2,
+                List.of(new LocalTablet(201),
+                        new LocalTablet(202),
+                        new LocalTablet(203),
+                        new LocalTablet(204)));
+
+        Assertions.assertEquals(List.of(
+                10101L, 201L, 3L, 4L, 5L,
+                102L, 202L, 3L, 4L, 5L,
+                10102L, 203L, 3L, 4L, 5L,
+                102L, 204L, 3L, 4L, 5L,
+                10103L, 201L, 3L, 4L, 5L,
+                102L, 202L, 3L, 4L, 5L,
+                10104L, 203L, 3L, 4L, 5L,
+                102L, 204L, 3L, 4L, 5L),
+                splittingTablets.calcNewVirtualBuckets(List.of(
+                        101L, 2L, 3L, 4L, 5L,
+                        102L, 2L, 3L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                10101L, 201L, 301L, 4L, 5L,
+                102L, 202L, 302L, 4L, 5L,
+                10102L, 203L, 303L, 4L, 5L,
+                102L, 204L, 304L, 4L, 5L,
+                10103L, 201L, 301L, 4L, 5L,
+                102L, 202L, 302L, 4L, 5L,
+                10104L, 203L, 303L, 4L, 5L,
+                102L, 204L, 304L, 4L, 5L),
+                splittingTablets.calcNewVirtualBuckets(List.of(
+                        101L, 2L, 301L, 4L, 5L,
+                        102L, 2L, 302L, 4L, 5L,
+                        101L, 2L, 303L, 4L, 5L,
+                        102L, 2L, 304L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                10101L, 201L, 301L, 4L, 5L,
+                102L, 202L, 302L, 4L, 5L,
+                10102L, 203L, 303L, 4L, 5L,
+                102L, 204L, 304L, 4L, 5L,
+                10103L, 201L, 305L, 4L, 5L,
+                102L, 202L, 306L, 4L, 5L,
+                10104L, 203L, 307L, 4L, 5L,
+                102L, 204L, 308L, 4L, 5L),
+                splittingTablets.calcNewVirtualBuckets(List.of(
+                        101L, 2L, 301L, 4L, 5L,
+                        102L, 2L, 302L, 4L, 5L,
+                        101L, 2L, 303L, 4L, 5L,
+                        102L, 2L, 304L, 4L, 5L,
+                        101L, 2L, 305L, 4L, 5L,
+                        102L, 2L, 306L, 4L, 5L,
+                        101L, 2L, 307L, 4L, 5L,
+                        102L, 2L, 308L, 4L, 5L)));
+
+        Assertions.assertEquals(List.of(
+                10101L, 201L, 301L, 4L, 5L,
+                102L, 202L, 302L, 4L, 5L,
+                10102L, 203L, 303L, 4L, 5L,
+                102L, 204L, 304L, 4L, 5L,
+                10103L, 201L, 305L, 4L, 5L,
+                102L, 202L, 306L, 4L, 5L,
+                10104L, 203L, 307L, 4L, 5L,
+                102L, 204L, 308L, 4L, 5L,
+                10101L, 201L, 309L, 4L, 5L,
+                102L, 202L, 310L, 4L, 5L,
+                10102L, 203L, 311L, 4L, 5L,
+                102L, 204L, 312L, 4L, 5L,
+                10103L, 201L, 313L, 4L, 5L,
+                102L, 202L, 314L, 4L, 5L,
+                10104L, 203L, 315L, 4L, 5L,
+                102L, 204L, 316L, 4L, 5L),
+                splittingTablets.calcNewVirtualBuckets(List.of(
+                        101L, 2L, 301L, 4L, 5L,
+                        102L, 2L, 302L, 4L, 5L,
+                        101L, 2L, 303L, 4L, 5L,
+                        102L, 2L, 304L, 4L, 5L,
+                        101L, 2L, 305L, 4L, 5L,
+                        102L, 2L, 306L, 4L, 5L,
+                        101L, 2L, 307L, 4L, 5L,
+                        102L, 2L, 308L, 4L, 5L,
+                        101L, 2L, 309L, 4L, 5L,
+                        102L, 2L, 310L, 4L, 5L,
+                        101L, 2L, 311L, 4L, 5L,
+                        102L, 2L, 312L, 4L, 5L,
+                        101L, 2L, 313L, 4L, 5L,
+                        102L, 2L, 314L, 4L, 5L,
+                        101L, 2L, 315L, 4L, 5L,
+                        102L, 2L, 316L, 4L, 5L)));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
This is a preliminary work for later PRs for tablet splitting and merging.
During tablet splitting and merging, we need a class to save some information for a materialized index. 
This pr introduce `SplittingTablets` and `MergingTablets` to save some information for a materialized index during tablet splitting and merging.

## What I'm doing:
Introduce `SplittingTablets` and `MergingTablets` for dynamic tablet splitting and merging

Fixes https://github.com/StarRocks/starrocks/issues/59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
