### PR TITLE
[Enhancement] Remove MV and base table's partition columns exact remapping limitation 

### DIFF
--- a/docs/en/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
@@ -240,11 +240,11 @@ Valid values:
   - `str2date` function: The function used to transform string type partitions of the base table into date types. `PARTITION BY str2date(dt, "%Y%m%d")` means that the `dt` column is a STRING date type whose date format is `"%Y%m%d"`. The `str2date` function supports a lot of date formats, you can refer to [str2date](../../sql-functions/date-time-functions/str2date.md) for more information. Supported from v3.1.4.
   - `time_slice` function: From v3.1 onwards, you can further use these functions to convert the given time into the beginning or end of a time interval based on the specified time granularity, for example, `PARTITION BY date_trunc("MONTH", time_slice(dt, INTERVAL 7 DAY))` where time_slice must have a finer granularity than date_trunc. You can use them to specify a GROUP BY column with a finer granularity than that of the partitioning key, for example, `GROUP BY time_slice(dt, INTERVAL 1 MINUTE) PARTITION BY date_trunc('DAY', ts)`.
 
-From v3.5.0 onwards, asynchronous materialized views support multi-column partition expressions. You can specify multiple partition columns for the materialized view, and one-to-one map them to the partition columns of the base tables.
+From v3.5.0 onwards, asynchronous materialized views support multi-column partition expressions. You can specify multiple partition columns for the materialized view to map all or part of the partition columns of the base tables.
 
 **Notes for multi-column partition expressions**:
 
-- Currently, multi-column partitions in materialized views can only be mapped one-to-one or in an N:1 relationship with the base table's partitions, not an M:N relationship. For example, if the base table has partition columns `(col1, col2, ..., coln)`, the materialized view partition expression can only be a single column partition, such as `col1`, `col2`, or `coln`, or a one-to-one mapping to the base table’s partition columns, that is, `(col1, col2, ..., coln)`. This limitation is designed to simplify the partition mapping logic between the base table and the materialized view, avoiding the complexity introduced by M:N relationships.
+- Currently, multi-column partitions in materialized views can only be directly mapped to the base table's partition columns. Mapping using functions or expressions on the base table's partition columns is not supported.
 - Because Iceberg partition expressions support the `transform` function, additional handling is required when mapping Iceberg partition expressions to StarRocks materialized view partition expressions. The mapping relationship is as follows:
 
   | Iceberg Transform | Iceberg partition expression   | Materialized view partition expression   |

--- a/docs/zh/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
+++ b/docs/zh/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
@@ -238,11 +238,11 @@ AS
   - `str2date` 函数：用于将基表的字符串类型分区键转化为物化视图的分区键所需的日期类型。`PARTITION BY str2date(dt, "%Y%m%d")` 表示 `dt` 列是一个 STRING 类型日期，其日期格式为 `"%Y%m%d"`。`str2date` 函数支持多种日期格式。更多信息，参考[str2date](../../sql-functions/date-time-functions/str2date.md)。自 v3.1.4 起支持。
   - `time_slice` 函数：从 v3.1 开始，您可以进一步使用 time_slice 函数根据指定的时间粒度周期，将给定的时间转化到其所在的时间粒度周期的起始或结束时刻，例如 `PARTITION BY date_trunc("MONTH", time_slice(dt, INTERVAL 7 DAY))`，其中 time_slice 的时间粒度必须比 `date_trunc` 的时间粒度更细。你可以使用它们来指定一个比分区键更细时间粒度的 GROUP BY 列，例如，`GROUP BY time_slice(dt, INTERVAL 1 MINUTE) PARTITION BY date_trunc('DAY', ts)`。
 
-自 v3.5.0 起，异步物化视图支持多列分区表达式。您可以为物化视图指定多个分区列，一一映射基表的分区列。
+自 v3.5.0 起，异步物化视图支持多列分区表达式。您可以为物化视图指定多个分区列映射基表的全部或者部分分区列。
 
 **多列分区表达式相关说明**:
 
-- 当前物化视图支持的多列分区只能与基表的多列分区一一映射，或者是 N:1 关系，而不能是 M:N 关系。例如，如果基表的分区列为 `(col1, col2, ..., coln)`，则物化视图定义时的分区只能是单列分区，如 `col1`、`col2`、`coln`，或者与基表分区列一一映射，如 `(col1, col2, ..., coln)`。这是因为通用的 M:N 关系会导致基表与物化视图之间的分区映射逻辑复杂，通过一一映射可以简化刷新和分区补偿逻辑。
+- 当前物化视图支持的多列分区只能与基表的分区列直接映射，不支持基表分区列+函数表达式加工后映射。
 - 由于 Iceberg 分区表达式支持 Transform 功能，若 Iceberg 的分区表达式映射到 StarRocks 时，需要额外处理分区表达式。以下为两者对应关系：
 
   | Iceberg Transform | Iceberg 分区表达式      | 物化视图分区表达式             |

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -1015,11 +1015,6 @@ public class MaterializedViewAnalyzer {
                         throw new SemanticException("Materialized view partition expression %s could only ref to base table",
                                 slotRef.toSql());
                     }
-                    if (refBaseTable.getPartitionColumns().size() != partitionRefTableExprs.size()) {
-                        throw new SemanticException(String.format("Materialized view partition columns size(%s)" +
-                                        " must be same with ref base table(%d)", partitionRefTableExprs.size(),
-                                refBaseTable.getPartitionColumns().size()), partitionRefTableExpr.getPos());
-                    }
                 }
                 statement.setPartitionType(PartitionType.LIST);
                 return;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -4910,10 +4910,9 @@ public class CreateMaterializedViewTest extends MVTestBase {
                         "REFRESH DEFERRED MANUAL \n" +
                         "properties ('partition_refresh_number' = '-1')" +
                         "as select dt, province, max(age) from t3 group by dt, province;");
-                Assertions.fail();
+                starRocksAssert.dropMaterializedView("mv1");
             } catch (Exception e) {
-                Assertions.assertTrue(e.getMessage().contains("Materialized view partition columns size(2) must be same with " +
-                        "ref base table(3)."));
+                Assertions.fail();
             }
         }
 
@@ -4927,8 +4926,8 @@ public class CreateMaterializedViewTest extends MVTestBase {
                         "as select dt, province, sum(age) from t3 group by dt, province;");
                 Assertions.fail();
             } catch (Exception e) {
-                Assertions.assertTrue(e.getMessage().contains("Materialized view partition columns size(2) must " +
-                        "be same with ref base table(3)."));
+                Assertions.assertTrue(e.getMessage().contains("List materialized view's partition expression can only refer " +
+                        "ref-base-table's partition expression without transforms but contains"));
             }
         }
         starRocksAssert.dropTable("t3");

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_multi_columns2
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_multi_columns2
@@ -1,0 +1,229 @@
+-- name: test_mv_refresh_list_partitions_multi_columns2
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+    province string,
+    num int,
+    year string,
+    month string,
+    day string,
+    hour string
+)
+PARTITION BY (year, month, day, hour);
+-- result:
+-- !result
+INSERT INTO t1 VALUES 
+    ("beijing",  1, "2020", "07", "01", "00"), 
+    ("chengdu",  2, "2020", "07", "01", "00"),
+    ("beijing",  3, "2020", "07", "02", "00"), 
+    ("hangzhou", 4, "2020", "07", "02", "00"),
+    ("chengdu",  1, "2020", "07", "03", "00"),
+    ("hangzhou", 1, "2020", "07", "04", "00"),
+    ("beijing",  2, "2020", "07", "04", "00"),
+    ("hangzhou", 3, "2020", "07", "05", "00"),
+    ("beijing",  4, "2020", NULL, NULL, "00"),
+    ("chengdu",  5, NULL, NULL, NULL, "00");
+-- result:
+-- !result
+set enable_materialized_view_rewrite = true;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY (year, month, day)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+SELECT year, month, day, province,sum(num) FROM t1 GROUP BY year, month, day, province;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv2
+PARTITION BY (year, month)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+SELECT year, month, province,sum(num) FROM t1 GROUP BY year, month, province;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv3
+PARTITION BY (year)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+SELECT year, province,sum(num) FROM t1 GROUP BY year, province;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW mv3 WITH SYNC MODE;
+select * from mv1 order by year, month, day, province;
+-- result:
+None	None	None	chengdu	5
+2020	None	None	beijing	4
+2020	07	01	beijing	1
+2020	07	01	chengdu	2
+2020	07	02	beijing	3
+2020	07	02	hangzhou	4
+2020	07	03	chengdu	1
+2020	07	04	beijing	2
+2020	07	04	hangzhou	1
+2020	07	05	hangzhou	3
+-- !result
+select * from mv2 order by year, month, province;
+-- result:
+None	None	chengdu	5
+2020	None	beijing	4
+2020	07	beijing	6
+2020	07	chengdu	3
+2020	07	hangzhou	8
+-- !result
+select * from mv3 order by year, province;
+-- result:
+None	chengdu	5
+2020	beijing	10
+2020	chengdu	3
+2020	hangzhou	8
+-- !result
+function: print_hit_materialized_view("SELECT year, month, day, province,sum(num) FROM t1 GROUP BY year, month, day, province;", "mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT year, month, province,sum(num) FROM t1 GROUP BY year, month, province;", "mv2")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT year, province,sum(num) FROM t1 GROUP BY year, province;", "mv3")
+-- result:
+True
+-- !result
+SELECT year, month, day, province,sum(num) FROM t1 GROUP BY year, month, day, province ORDER BY year, month, day, province;
+-- result:
+None	None	None	chengdu	5
+2020	None	None	beijing	4
+2020	07	01	beijing	1
+2020	07	01	chengdu	2
+2020	07	02	beijing	3
+2020	07	02	hangzhou	4
+2020	07	03	chengdu	1
+2020	07	04	beijing	2
+2020	07	04	hangzhou	1
+2020	07	05	hangzhou	3
+-- !result
+SELECT year, month, province,sum(num) FROM t1 GROUP BY year, month, province ORDER BY year, month, province;
+-- result:
+None	None	chengdu	5
+2020	None	beijing	4
+2020	07	beijing	6
+2020	07	chengdu	3
+2020	07	hangzhou	8
+-- !result
+SELECT year, sum(num) FROM t1 GROUP BY year ORDER BY year;
+-- result:
+None	5
+2020	21
+-- !result
+SELECT year, month, day, sum(num) FROM t1 GROUP BY year, month, day ORDER BY year, month, day;
+-- result:
+None	None	None	5
+2020	None	None	4
+2020	07	01	3
+2020	07	02	7
+2020	07	03	1
+2020	07	04	3
+2020	07	05	3
+-- !result
+INSERT INTO t1 VALUES 
+    ("beijing",  2, "2020", "07", "04", "00"),
+    ("hangzhou", 3, "2020", "07", "05", "00"),
+    ("beijing",  4, "2020", NULL, NULL, "00"),
+    ("chengdu",  5, NULL, NULL, NULL, "00");
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT year, month, day, province,sum(num) FROM t1 GROUP BY year, month, day, province;", "mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT year, month, province,sum(num) FROM t1 GROUP BY year, month, province;", "mv2")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT year, province,sum(num) FROM t1 GROUP BY year, province;", "mv3")
+-- result:
+False
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW mv3 WITH SYNC MODE;
+select * from mv1 order by year, month, day, province;
+-- result:
+None	None	None	chengdu	10
+2020	None	None	beijing	8
+2020	07	01	beijing	1
+2020	07	01	chengdu	2
+2020	07	02	beijing	3
+2020	07	02	hangzhou	4
+2020	07	03	chengdu	1
+2020	07	04	beijing	4
+2020	07	04	hangzhou	1
+2020	07	05	hangzhou	6
+-- !result
+select * from mv2 order by year, month, province;
+-- result:
+None	None	chengdu	10
+2020	None	beijing	8
+2020	07	beijing	8
+2020	07	chengdu	3
+2020	07	hangzhou	11
+-- !result
+select * from mv3 order by year, province;
+-- result:
+None	chengdu	10
+2020	beijing	16
+2020	chengdu	3
+2020	hangzhou	11
+-- !result
+SELECT year, month, day, province,sum(num) FROM t1 GROUP BY year, month, day, province ORDER BY year, month, day, province;
+-- result:
+None	None	None	chengdu	10
+2020	None	None	beijing	8
+2020	07	01	beijing	1
+2020	07	01	chengdu	2
+2020	07	02	beijing	3
+2020	07	02	hangzhou	4
+2020	07	03	chengdu	1
+2020	07	04	beijing	4
+2020	07	04	hangzhou	1
+2020	07	05	hangzhou	6
+-- !result
+SELECT year, month, province,sum(num) FROM t1 GROUP BY year, month, province ORDER BY year, month, province;
+-- result:
+None	None	chengdu	10
+2020	None	beijing	8
+2020	07	beijing	8
+2020	07	chengdu	3
+2020	07	hangzhou	11
+-- !result
+SELECT year, sum(num) FROM t1 GROUP BY year ORDER BY year;
+-- result:
+None	10
+2020	30
+-- !result
+SELECT year, month, day, sum(num) FROM t1 GROUP BY year, month, day ORDER BY year, month, day;
+-- result:
+None	None	None	10
+2020	None	None	8
+2020	07	01	3
+2020	07	02	7
+2020	07	03	1
+2020	07	04	5
+2020	07	05	6
+-- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_multi_columns_iceberg
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_multi_columns_iceberg
@@ -1,0 +1,259 @@
+-- name: test_mv_refresh_list_partitions_multi_columns_iceberg
+set new_planner_optimize_timeout=10000;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set enable_materialized_view_rewrite = true;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t1(
+    province string,
+    num int,
+    dt datetime,
+    year string,
+    month string,
+    day string,
+    hour string
+   
+)
+partition by  day(dt), year, month, day, hour;
+-- result:
+-- !result
+insert into t1 values ('beijing', 1, '2024-01-01 00:00:00', '2024', '01', '01', '00'),
+                      ('beijing', 2, '2024-01-01 00:00:00', '2024', '01', '01', '00'),
+                      ('beijing', 3, '2024-01-01 00:00:00', '2024', '01', '01', '00'),
+                      ('beijing', 4, '2024-01-01 00:00:00', '2024', '01', '01', '00'),
+                      ('beijing', 5, '2024-01-01 00:00:00', '2024', '01', '01', '00'),
+                      ('shanghai', 1, NULL, NULL, NULL, NULL, NULL);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database mv_db_${uuid0};
+-- result:
+-- !result
+use mv_db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY (year, month, day)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS
+  SELECT year, month, day, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, day, province;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv2
+PARTITION BY (year, month)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS
+  SELECT year, month, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, province;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv3
+PARTITION BY (year)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS
+  SELECT year, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, province;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv4
+PARTITION BY (year, month, dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS
+  SELECT year, month, date_trunc('day', dt) as dt, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, date_trunc('day', dt), province;
+-- result:
+-- !result
+[UC] REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+0197cf60-71f9-7d20-b5ff-c416876064fb
+-- !result
+[UC] REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+-- result:
+0197cf60-7bd8-76df-883e-d333f1661a59
+-- !result
+[UC] REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+-- result:
+0197cf60-83a6-72e6-9b16-a254df9a0be7
+-- !result
+[UC] REFRESH MATERIALIZED VIEW test_mv4 WITH SYNC MODE;
+-- result:
+0197cf60-8b59-7abb-a337-1f65b5d539c8
+-- !result
+select * from test_mv1 order by year, month, day, province;
+-- result:
+None	None	None	shanghai	1
+2024	01	01	beijing	15
+-- !result
+select * from test_mv2 order by year, month, province;
+-- result:
+None	None	shanghai	1
+2024	01	beijing	15
+-- !result
+select * from test_mv3 order by year, province;
+-- result:
+None	shanghai	1
+2024	beijing	15
+-- !result
+select * from test_mv4 order by year, month;
+-- result:
+None	None	None	shanghai	1
+2024	01	2024-01-01 00:00:00	beijing	15
+-- !result
+function: print_hit_materialized_view("SELECT year, month, day, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, day, province order by year, month, day, province;", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT year, month, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, province order by year, month, province;", "test_mv2")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT year, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, province order by year, province;", "test_mv3")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT year, month, date_trunc('day', dt), province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, date_trunc('day', dt), province order by year, month, date_trunc('day', dt), province;", "test_mv4")
+-- result:
+True
+-- !result
+SELECT year, month, day, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, day, province order by year, month, day, province;
+-- result:
+None	None	None	shanghai	1
+2024	01	01	beijing	15
+-- !result
+SELECT year, month, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, province order by year, month, province;
+-- result:
+None	None	shanghai	1
+2024	01	beijing	15
+-- !result
+SELECT year, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, province order by year, province;
+-- result:
+None	shanghai	1
+2024	beijing	15
+-- !result
+SELECT year, month, date_trunc('day', dt), province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, date_trunc('day', dt), province order by year, month, date_trunc('day', dt), province;
+-- result:
+None	None	None	shanghai	1
+2024	01	2024-01-01 00:00:00	beijing	15
+-- !result
+insert into t1 values ('beijing', 1, '2024-01-01 00:00:00', '2024', '01', '01', '00'),
+                      ('beijing', 2, '2024-01-01 00:00:00', '2024', '01', '01', '00');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table t1 is not found.')
+-- !result
+[UC] REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+0197cf60-a3b5-7185-9724-8ec0bc4026b9
+-- !result
+[UC] REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+-- result:
+0197cf60-a420-7dd8-a545-cd9dfc140da2
+-- !result
+[UC] REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+-- result:
+0197cf60-a80b-7443-b81c-24ffb71300dd
+-- !result
+[UC] REFRESH MATERIALIZED VIEW test_mv4 WITH SYNC MODE;
+-- result:
+0197cf60-abf2-716e-b66a-a71ecdff09bd
+-- !result
+select * from test_mv1 order by year, month, day, province;
+-- result:
+None	None	None	shanghai	1
+2024	01	01	beijing	15
+-- !result
+select * from test_mv2 order by year, month, province;
+-- result:
+None	None	shanghai	1
+2024	01	beijing	15
+-- !result
+select * from test_mv3 order by year, province;
+-- result:
+None	shanghai	1
+2024	beijing	15
+-- !result
+select * from test_mv4 order by year, month;
+-- result:
+None	None	None	shanghai	1
+2024	01	2024-01-01 00:00:00	beijing	15
+-- !result
+function: print_hit_materialized_view("SELECT year, month, day, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, day, province order by year, month, day, province;", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT year, month, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, province order by year, month, province;", "test_mv2")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT year, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, province order by year, province;", "test_mv3")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT year, month, date_trunc('day', dt), province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, date_trunc('day', dt), province order by year, month, date_trunc('day', dt), province;", "test_mv4")
+-- result:
+True
+-- !result
+SELECT year, month, day, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, day, province order by year, month, day, province;
+-- result:
+None	None	None	shanghai	1
+2024	01	01	beijing	15
+-- !result
+SELECT year, month, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, province order by year, month, province;
+-- result:
+None	None	shanghai	1
+2024	01	beijing	15
+-- !result
+SELECT year, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, province order by year, province;
+-- result:
+None	shanghai	1
+2024	beijing	15
+-- !result
+SELECT year, month, date_trunc('day', dt), province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, date_trunc('day', dt), province order by year, month, date_trunc('day', dt), province;
+-- result:
+None	None	None	shanghai	1
+2024	01	2024-01-01 00:00:00	beijing	15
+-- !result
+DROP DATABASE IF EXISTS mv_iceberg_${uuid0}.mv_db_${uuid0};
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_multi_columns2
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_multi_columns2
@@ -1,0 +1,95 @@
+-- name: test_mv_refresh_list_partitions_multi_columns2
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE t1 (
+    province string,
+    num int,
+    year string,
+    month string,
+    day string,
+    hour string
+)
+PARTITION BY (year, month, day, hour);
+
+INSERT INTO t1 VALUES 
+    ("beijing",  1, "2020", "07", "01", "00"), 
+    ("chengdu",  2, "2020", "07", "01", "00"),
+    ("beijing",  3, "2020", "07", "02", "00"), 
+    ("hangzhou", 4, "2020", "07", "02", "00"),
+    ("chengdu",  1, "2020", "07", "03", "00"),
+    ("hangzhou", 1, "2020", "07", "04", "00"),
+    ("beijing",  2, "2020", "07", "04", "00"),
+    ("hangzhou", 3, "2020", "07", "05", "00"),
+    ("beijing",  4, "2020", NULL, NULL, "00"),
+    ("chengdu",  5, NULL, NULL, NULL, "00");
+
+set enable_materialized_view_rewrite = true;
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY (year, month, day)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+SELECT year, month, day, province,sum(num) FROM t1 GROUP BY year, month, day, province;
+
+CREATE MATERIALIZED VIEW mv2
+PARTITION BY (year, month)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+SELECT year, month, province,sum(num) FROM t1 GROUP BY year, month, province;
+
+CREATE MATERIALIZED VIEW mv3
+PARTITION BY (year)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+SELECT year, province,sum(num) FROM t1 GROUP BY year, province;
+
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW mv3 WITH SYNC MODE;
+
+select * from mv1 order by year, month, day, province;
+select * from mv2 order by year, month, province;
+select * from mv3 order by year, province;
+
+function: print_hit_materialized_view("SELECT year, month, day, province,sum(num) FROM t1 GROUP BY year, month, day, province;", "mv1")
+function: print_hit_materialized_view("SELECT year, month, province,sum(num) FROM t1 GROUP BY year, month, province;", "mv2")
+function: print_hit_materialized_view("SELECT year, province,sum(num) FROM t1 GROUP BY year, province;", "mv3")
+
+SELECT year, month, day, province,sum(num) FROM t1 GROUP BY year, month, day, province ORDER BY year, month, day, province;
+SELECT year, month, province,sum(num) FROM t1 GROUP BY year, month, province ORDER BY year, month, province;
+SELECT year, sum(num) FROM t1 GROUP BY year ORDER BY year;
+SELECT year, month, day, sum(num) FROM t1 GROUP BY year, month, day ORDER BY year, month, day;
+
+INSERT INTO t1 VALUES 
+    ("beijing",  2, "2020", "07", "04", "00"),
+    ("hangzhou", 3, "2020", "07", "05", "00"),
+    ("beijing",  4, "2020", NULL, NULL, "00"),
+    ("chengdu",  5, NULL, NULL, NULL, "00");
+
+
+function: print_hit_materialized_view("SELECT year, month, day, province,sum(num) FROM t1 GROUP BY year, month, day, province;", "mv1")
+function: print_hit_materialized_view("SELECT year, month, province,sum(num) FROM t1 GROUP BY year, month, province;", "mv2")
+function: print_hit_materialized_view("SELECT year, province,sum(num) FROM t1 GROUP BY year, province;", "mv3")
+
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW mv3 WITH SYNC MODE;
+
+select * from mv1 order by year, month, day, province;
+select * from mv2 order by year, month, province;
+select * from mv3 order by year, province;
+
+SELECT year, month, day, province,sum(num) FROM t1 GROUP BY year, month, day, province ORDER BY year, month, day, province;
+SELECT year, month, province,sum(num) FROM t1 GROUP BY year, month, province ORDER BY year, month, province;
+SELECT year, sum(num) FROM t1 GROUP BY year ORDER BY year;
+SELECT year, month, day, sum(num) FROM t1 GROUP BY year, month, day ORDER BY year, month, day;

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_multi_columns_iceberg
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_multi_columns_iceberg
@@ -1,0 +1,126 @@
+-- name: test_mv_refresh_list_partitions_multi_columns_iceberg
+
+set new_planner_optimize_timeout=10000;
+
+-- create mv
+create database db_${uuid0};
+use db_${uuid0};
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set enable_materialized_view_rewrite = true;
+set catalog mv_iceberg_${uuid0};
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t1(
+    province string,
+    num int,
+    dt datetime,
+    year string,
+    month string,
+    day string,
+    hour string
+   
+)
+partition by  day(dt), year, month, day, hour;
+
+insert into t1 values ('beijing', 1, '2024-01-01 00:00:00', '2024', '01', '01', '00'),
+                      ('beijing', 2, '2024-01-01 00:00:00', '2024', '01', '01', '00'),
+                      ('beijing', 3, '2024-01-01 00:00:00', '2024', '01', '01', '00'),
+                      ('beijing', 4, '2024-01-01 00:00:00', '2024', '01', '01', '00'),
+                      ('beijing', 5, '2024-01-01 00:00:00', '2024', '01', '01', '00'),
+                      ('shanghai', 1, NULL, NULL, NULL, NULL, NULL);
+
+set catalog default_catalog;
+
+create database mv_db_${uuid0};
+use mv_db_${uuid0};
+
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY (year, month, day)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS
+  SELECT year, month, day, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, day, province;
+
+CREATE MATERIALIZED VIEW test_mv2
+PARTITION BY (year, month)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS
+  SELECT year, month, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, province;
+
+CREATE MATERIALIZED VIEW test_mv3
+PARTITION BY (year)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS
+  SELECT year, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, province;
+
+
+CREATE MATERIALIZED VIEW test_mv4
+PARTITION BY (year, month, dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS
+  SELECT year, month, date_trunc('day', dt) as dt, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, date_trunc('day', dt), province;
+
+[UC] REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC] REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+[UC] REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+[UC] REFRESH MATERIALIZED VIEW test_mv4 WITH SYNC MODE;
+
+select * from test_mv1 order by year, month, day, province;
+select * from test_mv2 order by year, month, province;
+select * from test_mv3 order by year, province;
+select * from test_mv4 order by year, month;
+
+function: print_hit_materialized_view("SELECT year, month, day, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, day, province order by year, month, day, province;", "test_mv1")
+function: print_hit_materialized_view("SELECT year, month, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, province order by year, month, province;", "test_mv2")
+function: print_hit_materialized_view("SELECT year, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, province order by year, province;", "test_mv3")
+function: print_hit_materialized_view("SELECT year, month, date_trunc('day', dt), province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, date_trunc('day', dt), province order by year, month, date_trunc('day', dt), province;", "test_mv4")
+SELECT year, month, day, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, day, province order by year, month, day, province;
+SELECT year, month, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, province order by year, month, province;
+SELECT year, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, province order by year, province;
+SELECT year, month, date_trunc('day', dt), province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, date_trunc('day', dt), province order by year, month, date_trunc('day', dt), province;
+
+insert into t1 values ('beijing', 1, '2024-01-01 00:00:00', '2024', '01', '01', '00'),
+                      ('beijing', 2, '2024-01-01 00:00:00', '2024', '01', '01', '00');
+
+
+[UC] REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC] REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+[UC] REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+[UC] REFRESH MATERIALIZED VIEW test_mv4 WITH SYNC MODE;
+
+select * from test_mv1 order by year, month, day, province;
+select * from test_mv2 order by year, month, province;
+select * from test_mv3 order by year, province;
+select * from test_mv4 order by year, month;
+
+function: print_hit_materialized_view("SELECT year, month, day, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, day, province order by year, month, day, province;", "test_mv1")
+function: print_hit_materialized_view("SELECT year, month, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, province order by year, month, province;", "test_mv2")
+function: print_hit_materialized_view("SELECT year, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, province order by year, province;", "test_mv3")
+function: print_hit_materialized_view("SELECT year, month, date_trunc('day', dt), province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, date_trunc('day', dt), province order by year, month, date_trunc('day', dt), province;", "test_mv4")
+SELECT year, month, day, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, day, province order by year, month, day, province;
+SELECT year, month, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, province order by year, month, province;
+SELECT year, province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, province order by year, province;
+SELECT year, month, date_trunc('day', dt), province,sum(num) FROM mv_iceberg_${uuid0}.db_${uuid0}.t1 GROUP BY year, month, date_trunc('day', dt), province order by year, month, date_trunc('day', dt), province;
+
+DROP DATABASE IF EXISTS mv_iceberg_${uuid0}.mv_db_${uuid0};
+drop catalog mv_iceberg_${uuid0};
+drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

If base table contains(year, month, day, hour) partition columns, starrocks cannot create mv with subset of the partitions and must be 1:1 with base tables'partitions. eg:
```
CREATE TABLE t1 (
    province string,
    num int,
    year string,
    month string,
    day string,
    hour string
)
PARTITION BY (year, month, day, hour);


CREATE MATERIALIZED VIEW mv2
PARTITION BY (year, month)
REFRESH DEFERRED MANUAL 
PROPERTIES (
    "replication_num" = "1"
)
AS 
SELECT year, month, province,sum(num) FROM t1 GROUP BY year, month, province;
```

But sometime mv's data is much more less than base table's data, we can remove this limitation.

## What I'm doing:
- Remove MV and base table's partition columns exact remapping limitation 

Fixes #issue


TODO:
- Update documents.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
