### PR TITLE
[BugFix] fix cloud native pk index memory statistic leak

### DIFF
--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -15,6 +15,7 @@
 #include "storage/lake/persistent_index_memtable.h"
 
 #include "storage/lake/persistent_index_sstable.h"
+#include "util/string_util.h"
 #include "util/trace.h"
 
 namespace starrocks::lake {
@@ -30,11 +31,11 @@ Status PersistentIndexMemtable::upsert(size_t n, const Slice* keys, const IndexV
     TRACE_COUNTER_SCOPE_LATENCY_US("pindex_memtable_upsert_us");
     size_t nfound = 0;
     for (size_t i = 0; i < n; ++i) {
-        auto key = keys[i].to_string();
+        auto key = std::string_view(keys[i]);
         const auto value = values[i];
         if (auto [it, inserted] = _map.emplace(key, std::make_pair(version, value)); inserted) {
             not_founds->insert(i);
-            _keys_size += key.capacity() + sizeof(std::string);
+            _keys_heap_size += is_string_heap_allocated(it->first) ? it->first.capacity() : 0;
         } else {
             auto& old_index_value_ver = it->second;
             auto old_value = old_index_value_ver.second;
@@ -51,18 +52,17 @@ Status PersistentIndexMemtable::upsert(size_t n, const Slice* keys, const IndexV
 Status PersistentIndexMemtable::insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version) {
     TRACE_COUNTER_SCOPE_LATENCY_US("pindex_memtable_insert_us");
     for (size_t i = 0; i < n; ++i) {
-        auto key = keys[i].to_string();
-        auto size = keys[i].get_size();
+        auto key = std::string_view(keys[i]);
         const auto value = values[i];
         if (auto [it, inserted] = _map.emplace(key, std::make_pair(version, value)); inserted) {
-            _keys_size += key.capacity() + sizeof(std::string);
+            _keys_heap_size += is_string_heap_allocated(it->first) ? it->first.capacity() : 0;
         } else {
             auto& old_index_value_ver = it->second;
             auto old_index_value = old_index_value_ver.second;
             if (old_index_value.get_value() != NullIndexValue) {
                 // shouldn't happen
-                std::string msg = strings::Substitute("PersistentIndexMemtable<$0> insert found duplicate key $1", size,
-                                                      hexdump((const char*)key.data(), size));
+                std::string msg = strings::Substitute("PersistentIndexMemtable<$0> insert found duplicate key $1",
+                                                      key.size(), hexdump((const char*)key.data(), key.size()));
                 LOG(ERROR) << msg;
                 if (!config::experimental_lake_ignore_pk_consistency_check) {
                     return Status::AlreadyExist(msg);
@@ -84,11 +84,11 @@ Status PersistentIndexMemtable::erase(size_t n, const Slice* keys, IndexValue* o
     TRACE_COUNTER_SCOPE_LATENCY_US("pindex_memtable_erase_us");
     size_t nfound = 0;
     for (size_t i = 0; i < n; ++i) {
-        auto key = keys[i].to_string();
+        auto key = std::string_view(keys[i]);
         if (auto [it, inserted] = _map.emplace(key, std::make_pair(version, IndexValue(NullIndexValue))); inserted) {
             old_values[i] = NullIndexValue;
             not_founds->insert(i);
-            _keys_size += key.capacity() + sizeof(std::string);
+            _keys_heap_size += is_string_heap_allocated(it->first) ? it->first.capacity() : 0;
         } else {
             auto& old_index_value_ver = it->second;
             auto old_index_value = old_index_value_ver.second;
@@ -110,9 +110,9 @@ Status PersistentIndexMemtable::erase_with_filter(size_t n, const Slice* keys, c
             // skip
             continue;
         }
-        auto key = keys[i].to_string();
+        auto key = std::string_view(keys[i]);
         if (auto [it, inserted] = _map.emplace(key, std::make_pair(version, IndexValue(NullIndexValue))); inserted) {
-            _keys_size += key.capacity() + sizeof(std::string);
+            _keys_heap_size += is_string_heap_allocated(it->first) ? it->first.capacity() : 0;
         } else {
             auto& old_index_value_ver = it->second;
             update_index_value(&old_index_value_ver, version, IndexValue(NullIndexValue));
@@ -127,12 +127,12 @@ Status PersistentIndexMemtable::replace(const Slice* keys, const IndexValue* val
                                         const std::vector<size_t>& replace_idxes, int64_t version) {
     TRACE_COUNTER_SCOPE_LATENCY_US("pindex_memtable_replace_us");
     for (unsigned long idx : replace_idxes) {
-        auto key = keys[idx].to_string();
+        auto key = std::string_view(keys[idx]);
         const auto value = values[idx];
         if (auto [it, inserted] = _map.emplace(key, std::make_pair(version, value)); !inserted) {
             update_index_value(&it->second, version, value);
         } else {
-            _keys_size += key.capacity() + sizeof(std::string);
+            _keys_heap_size += is_string_heap_allocated(it->first) ? it->first.capacity() : 0;
         }
         _max_rss_rowid = std::max(_max_rss_rowid, value.get_value());
     }
@@ -176,7 +176,8 @@ Status PersistentIndexMemtable::get(const Slice* keys, IndexValue* values, const
 }
 
 size_t PersistentIndexMemtable::memory_usage() const {
-    return _keys_size + _map.size() * sizeof(IndexValueWithVer);
+    // The memory usage of the map is not
+    return _keys_heap_size + _map.bytes_used();
 }
 
 Status PersistentIndexMemtable::flush(WritableFile* wf, uint64_t* filesize) {
@@ -185,6 +186,7 @@ Status PersistentIndexMemtable::flush(WritableFile* wf, uint64_t* filesize) {
 
 void PersistentIndexMemtable::clear() {
     _map.clear();
+    _keys_heap_size = 0;
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -176,7 +176,9 @@ Status PersistentIndexMemtable::get(const Slice* keys, IndexValue* values, const
 }
 
 size_t PersistentIndexMemtable::memory_usage() const {
-    // The memory usage of the map is not
+    // _keys_heap_size is the memory usage of std::string which are heap allocated.
+    // _map.bytes_used() is the memory usage of the btree.
+    // The total memory usage is the sum of these two.
     return _keys_heap_size + _map.bytes_used();
 }
 

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -78,7 +78,7 @@ private:
 private:
     // The size can be up to 230K. The performance of std::map may be poor.
     phmap::btree_map<std::string, IndexValueWithVer, std::less<>> _map;
-    int64_t _keys_size{0};
+    int64_t _keys_heap_size{0};
     uint64_t _max_rss_rowid{0};
 };
 

--- a/be/src/util/string_util.cpp
+++ b/be/src/util/string_util.cpp
@@ -48,4 +48,12 @@ size_t hash_of_path(const std::string& identifier, const std::string& path) {
     return hash;
 }
 
+// This function checks if a std::string is heap allocated, which means it doesn't use Small String Optimization
+bool is_string_heap_allocated(const std::string& s) {
+    const void* data_ptr = s.data();
+    const void* obj_ptr = static_cast<const void*>(&s);
+    return reinterpret_cast<uintptr_t>(data_ptr) < reinterpret_cast<uintptr_t>(obj_ptr) ||
+           reinterpret_cast<uintptr_t>(data_ptr) >= reinterpret_cast<uintptr_t>(obj_ptr) + sizeof(std::string);
+}
+
 } // namespace starrocks

--- a/be/src/util/string_util.cpp
+++ b/be/src/util/string_util.cpp
@@ -50,10 +50,9 @@ size_t hash_of_path(const std::string& identifier, const std::string& path) {
 
 // This function checks if a std::string is heap allocated, which means it doesn't use Small String Optimization
 bool is_string_heap_allocated(const std::string& s) {
-    const void* data_ptr = s.data();
-    const void* obj_ptr = static_cast<const void*>(&s);
-    return reinterpret_cast<uintptr_t>(data_ptr) < reinterpret_cast<uintptr_t>(obj_ptr) ||
-           reinterpret_cast<uintptr_t>(data_ptr) >= reinterpret_cast<uintptr_t>(obj_ptr) + sizeof(std::string);
+    uintptr_t data_ptr = reinterpret_cast<uintptr_t>(s.data());
+    uintptr_t obj_ptr = reinterpret_cast<uintptr_t>(&s);
+    return data_ptr < obj_ptr || data_ptr >= obj_ptr + sizeof(std::string);
 }
 
 } // namespace starrocks

--- a/be/src/util/string_util.h
+++ b/be/src/util/string_util.h
@@ -76,6 +76,7 @@ public:
 };
 
 size_t hash_of_path(const std::string& identifier, const std::string& path);
+bool is_string_heap_allocated(const std::string& s);
 
 using StringCaseSet = std::set<std::string, StringCaseLess>;
 using StringCaseUnorderedSet = std::unordered_set<std::string, StringCaseHasher, StringCaseEqual>;

--- a/be/test/util/string_util_test.cpp
+++ b/be/test/util/string_util_test.cpp
@@ -104,4 +104,13 @@ TEST_F(StringUtilTest, normal) {
     }
 }
 
+TEST_F(StringUtilTest, test_is_string_heap_allocated) {
+    std::string s1 = "hello";
+    ASSERT_FALSE(is_string_heap_allocated(s1));
+    std::string s2 = "he";
+    ASSERT_FALSE(is_string_heap_allocated(s1));
+    std::string s3 = std::string(100, 'a'); // large enough to be heap allocated
+    ASSERT_TRUE(is_string_heap_allocated(s3));
+}
+
 } // namespace starrocks

--- a/be/test/util/string_util_test.cpp
+++ b/be/test/util/string_util_test.cpp
@@ -108,7 +108,7 @@ TEST_F(StringUtilTest, test_is_string_heap_allocated) {
     std::string s1 = "hello";
     ASSERT_FALSE(is_string_heap_allocated(s1));
     std::string s2 = "he";
-    ASSERT_FALSE(is_string_heap_allocated(s1));
+    ASSERT_FALSE(is_string_heap_allocated(s2));
     std::string s3 = std::string(100, 'a'); // large enough to be heap allocated
     ASSERT_TRUE(is_string_heap_allocated(s3));
 }


### PR DESCRIPTION
## Why I'm doing:
In the current cloud-native PK index memtable implementation, we only account for the memory usage of keys and values. However, since we're using a B-tree for storage, the memory consumption of the B-tree's internal nodes is not being accurately tracked.
The B-tree provides a bytes_used interface to retrieve its total memory usage. However, since keys use std::string, the heap memory allocated by these strings isn't included in the bytes_used count. We need to implement additional tracking for this memory.

## What I'm doing:
This pull request refactors the `PersistentIndexMemtable` implementation in `be/src/storage/lake/persistent_index_memtable.cpp` to improve memory tracking and efficiency. The changes include replacing `std::string` with `std::string_view` for key handling, introducing a new method to check heap allocation for strings, and updating memory usage calculations.

### Refactoring for Memory Efficiency:
* Replaced `std::string` with `std::string_view` for keys in methods like `upsert`, `insert`, `erase`, `erase_with_filter`, `replace`, and `get` to reduce unnecessary string allocations. (`[[1]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L33-R38)`, `[[2]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L54-R65)`, `[[3]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L87-R91)`, `[[4]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L113-R115)`, `[[5]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L130-R135)`, `[[6]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L179-R180)`)
* Added a new function `is_string_heap_allocated` in `be/src/util/string_util.cpp` to determine whether a `std::string` uses heap memory, and updated `_keys_heap_size` calculations accordingly. (`[[1]](diffhunk://#diff-58984ee0cc1ce8771537ac8af37a9bb3447abc880f413364470f5bbfc989a265R51-R58)`, `[[2]](diffhunk://#diff-987ba58807d358f61be1b8ea0c619122113532bdb5b574f922986a6a79eada42R79)`)
* Modified `PersistentIndexMemtable::memory_usage()` to use `_keys_heap_size` and `_map.bytes_used()` for more accurate memory usage tracking. (`[be/src/storage/lake/persistent_index_memtable.cppL179-R180](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L179-R180)`)
* Renamed `_keys_size` to `_keys_heap_size` and reset it in the `clear()` method to ensure proper memory management. (`[[1]](diffhunk://#diff-0fa7a9fa792819b27a25ea176c8c8154af0ed664f12dfd466c8ed781e304b2aeL81-R81)`, `[[2]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728R189)`)

### Testing Enhancements:
* Added a unit test `test_is_string_heap_allocated` in `be/test/util/string_util_test.cpp` to verify the behavior of the `is_string_heap_allocated` function for both small and large strings. (`[be/test/util/string_util_test.cppR107-R115](diffhunk://#diff-ca9144c8e70f0db720811da5c0d9413dc7a706795fc7ae268380b3cd55f669b0R107-R115)`)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
