### PR TITLE
[BugFix] Fix submit task with properties bugs

### DIFF
--- a/docs/en/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
@@ -29,7 +29,20 @@ SUBMIT TASK <task_name>
 [PROPERTIES(<"key" = "value"[, ...]>)]
 AS <etl_statement>
 ```
+## PROPERTIES
 
+You can add `session.` with session variables to change the Task running connect context configurations.
+
+
+For example, the following statement submits a task named `test_task` with session properties which enables query profile and increase query timeout:
+```SQL
+SUBMIT TASK test_task
+PROPERTIES (
+    "session.enable_profile" = "true",
+    "session.query_timeout" = "10000"
+)
+AS insert into t2 select * from t1;
+```
 ## Parameters
 
 | **Parameter**      | **Required** | **Description**                                                                                     |
@@ -114,4 +127,15 @@ INSERT OVERWRITE insert_wiki_edit
     SELECT dt, user_id, count(*) 
     FROM source_wiki_edit 
     GROUP BY dt, user_id;
+```
+
+Example 6: Create a task with custom session properties:
+
+```SQL
+SUBMIT TASK test_task
+PROPERTIES (
+    "session.enable_profile" = "true",
+    "session.query_timeout" = "10000"
+)
+AS insert into t2 select * from t1;
 ```

--- a/docs/ja/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
+++ b/docs/ja/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
@@ -31,6 +31,20 @@ SUBMIT TASK <task_name>
 [PROPERTIES(<"key" = "value"[, ...]>)]
 AS <etl_statement>
 ```
+## PROPERTIES
+
+`session.` プレフィックスを持つセッション変数を追加することで、タスク実行時の接続コンテキスト設定を変更できます。
+
+例えば、以下のステートメントは、クエリプロファイルを有効にし、クエリタイムアウトを増加させるセッションプロパティを持つ `test_task` という名前のタスクを送信します：
+
+```SQL
+SUBMIT TASK test_task
+PROPERTIES (
+    "session.enable_profile" = "true",
+    "session.query_timeout" = "10000"
+)
+AS insert into t2 select * from t1;
+```
 
 ## パラメータ
 
@@ -116,4 +130,15 @@ INSERT OVERWRITE insert_wiki_edit
     SELECT dt, user_id, count(*) 
     FROM source_wiki_edit 
     GROUP BY dt, user_id;
+```
+
+例 6: カスタムセッションプロパティを持つタスクを作成します:
+
+```SQL
+SUBMIT TASK test_task
+PROPERTIES (
+    "session.enable_profile" = "true",
+    "session.query_timeout" = "10000"
+)
+AS insert into t2 select * from t1;
 ```

--- a/docs/zh/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
+++ b/docs/zh/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
@@ -31,6 +31,20 @@ SUBMIT TASK <task_name>
 [PROPERTIES(<"key" = "value"[, ...]>)]
 AS <etl_statement>
 ```
+## PROPERTIES
+
+您可以通过添加 `session.` 前缀的会话变量来更改任务运行时的连接上下文配置。
+
+例如，以下语句提交了一个名为 `test_task` 的任务，并启用了查询分析和增加了查询超时时间：
+
+```SQL
+SUBMIT TASK test_task
+PROPERTIES (
+    "session.enable_profile" = "true",
+    "session.query_timeout" = "10000"
+)
+AS insert into t2 select * from t1;
+```
 
 ## 参数说明
 
@@ -116,4 +130,14 @@ INSERT OVERWRITE insert_wiki_edit
     SELECT dt, user_id, count(*) 
     FROM source_wiki_edit 
     GROUP BY dt, user_id;
+```
+示例六：创建具有自定义会话属性的任务：
+
+```SQL
+SUBMIT TASK test_task
+PROPERTIES (
+    "session.enable_profile" = "true",
+    "session.query_timeout" = "10000"
+)
+AS insert into t2 select * from t1;
 ```

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -117,7 +117,7 @@ public class TaskRun implements Comparable<TaskRun> {
 
     private ExecuteOption executeOption;
 
-    TaskRun() {
+    public TaskRun() {
         future = new CompletableFuture<>();
         taskRunId = UUIDUtil.genUUID().toString();
     }
@@ -274,9 +274,15 @@ public class TaskRun implements Comparable<TaskRun> {
         Map<String, String> newProperties = refreshTaskProperties(runCtx);
         properties.putAll(newProperties);
         Map<String, String> taskRunContextProperties = Maps.newHashMap();
-        for (String key : properties.keySet()) {
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            String key = entry.getKey();
+            // if task contains session properties, we should remove the prefix
+            if (key.startsWith(PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX)) {
+                key = key.substring(PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX.length());
+            }
+            String value = entry.getValue();
             try {
-                runCtx.modifySystemVariable(new SystemVariable(key, new StringLiteral(properties.get(key))), true);
+                runCtx.modifySystemVariable(new SystemVariable(key, new StringLiteral(value)), true);
             } catch (DdlException e) {
                 // not session variable
                 taskRunContextProperties.put(key, properties.get(key));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -235,19 +235,23 @@ public class MVTestBase extends StarRocksTestBase {
         return getOptimizedPlan(sql, connectContext, OptimizerOptions.defaultOpt());
     }
 
-    public static OptExpression getOptimizedPlan(String sql, ConnectContext connectContext,
-                                                 OptimizerOptions optimizerOptions) {
-        StatementBase mvStmt;
+    public static StatementBase getAnalyzedPlan(String sql, ConnectContext connectContext) {
+        StatementBase statementBase;
         try {
             List<StatementBase> statementBases =
                     com.starrocks.sql.parser.SqlParser.parse(sql, connectContext.getSessionVariable());
             Preconditions.checkState(statementBases.size() == 1);
-            mvStmt = statementBases.get(0);
+            statementBase = statementBases.get(0);
         } catch (Exception e) {
             return null;
         }
-        Preconditions.checkState(mvStmt instanceof QueryStatement);
-        Analyzer.analyze(mvStmt, connectContext);
+        Analyzer.analyze(statementBase, connectContext);
+        return statementBase;
+    }
+
+    public static OptExpression getOptimizedPlan(String sql, ConnectContext connectContext,
+                                                 OptimizerOptions optimizerOptions) {
+        StatementBase mvStmt = getAnalyzedPlan(sql, connectContext);
         QueryRelation query = ((QueryStatement) mvStmt).getQueryRelation();
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
         LogicalPlan logicalPlan =

--- a/test/sql/test_task/R/test_submit_task_with_properties
+++ b/test/sql/test_task/R/test_submit_task_with_properties
@@ -1,0 +1,44 @@
+-- name: test_submit_task_with_properties
+create database test_task_${uuid0};
+-- result:
+-- !result
+use test_task_${uuid0};
+-- result:
+-- !result
+create table t1(c1 int, c2 int);
+-- result:
+-- !result
+create table t2(c1 int, c2 int);
+-- result:
+-- !result
+insert into t1 values(1, 1);
+-- result:
+-- !result
+[UC] submit task task2_${uuid0}
+properties(
+    "session.enable_profile" = "true",
+    "session.query_timeout" = "10000"
+)
+as insert into t2 select * from t1;
+-- result:
+task2_64cff75fff3743188724d719bf294d73	SUBMITTED
+-- !result
+select `PROPERTIES`, DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name ='task2_${uuid0}';
+-- result:
+('session.enable_profile'='true','warehouse'='default_warehouse','session.query_timeout'='10000')	insert into t2 select * from t1;
+-- !result
+drop task task2_${uuid0};
+-- result:
+-- !result
+select `PROPERTIES`, DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name ='task2_${uuid0}';
+-- result:
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop table t2;
+-- result:
+-- !result
+drop database test_task_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_task/T/test_submit_task_with_properties
+++ b/test/sql/test_task/T/test_submit_task_with_properties
@@ -1,0 +1,20 @@
+-- name: test_submit_task_with_properties
+create database test_task_${uuid0};
+use test_task_${uuid0};
+
+create table t1(c1 int, c2 int);
+create table t2(c1 int, c2 int);
+insert into t1 values(1, 1);
+[UC] submit task task2_${uuid0}
+properties(
+    "session.enable_profile" = "true",
+    "session.query_timeout" = "10000"
+)
+as insert into t2 select * from t1;
+
+select `PROPERTIES`, DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name ='task2_${uuid0}';
+drop task task2_${uuid0};
+select `PROPERTIES`, DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name ='task2_${uuid0}';
+drop table t1;
+drop table t2;
+drop database test_task_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
Task with `session` properties are not taken cared in task runs which is not like mv tasks:

```
submit task task3
PROPERTIES (
    "session.query_timeout" = "100000",
    "session.enable_profile" = "true"
)

 as insert into allstring select * from (select 'C8' union select 'A10' union select sleep(10) ) tb;
```
And for users, it's difficult to change session variables for tasks since it's running in the background thread but current user thread.


## What I'm doing:
- Fix submit task with properties bugs

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3