### PR TITLE
[Feature] Cross-cluster replication for cloud-native table (Part-1: implementation in FE )

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -257,6 +257,13 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                       shardGroupId);
             return false;
         }
+
+        if (GlobalStateMgr.getCurrentState().getStorageVolumeMgr().hasStorageVolumeBindAsVirtualGroup(shardGroupId)) {
+            LOG.debug("shard group {} can not be deleted for now, because it has been bind to storage volume",
+                    shardGroupId);
+            return false;
+        }
+
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -266,6 +266,17 @@ public class StarOSAgent {
         }
     }
 
+    public FilePathInfo allocateFilePath(String storageVolumeId, String rootDir) throws DdlException {
+        prepare();
+        try {
+            FilePathInfo pathInfo = client.allocateFilePath(serviceId, storageVolumeId, "", rootDir);
+            LOG.info("Allocate file path from starmgr: {}", pathInfo);
+            return pathInfo;
+        } catch (StarClientException e) {
+            throw new DdlException("Failed to allocate file path from StarMgr, error: " + e.getMessage());
+        }
+    }
+
     public boolean registerAndBootstrapService() {
         try {
             client.registerService("starrocks");
@@ -477,7 +488,25 @@ public class StarOSAgent {
         } catch (StarClientException e) {
             throw new DdlException("Failed to create shard group. error: " + e.getMessage());
         }
-        return shardGroupInfos.stream().map(ShardGroupInfo::getGroupId).collect(Collectors.toList()).get(0);
+        return shardGroupInfos.get(0).getGroupId();
+    }
+
+    // Used only for shared-data cluster replication
+    public long createShardGroupForVirtualTablet() throws DdlException {
+        prepare();
+        List<ShardGroupInfo> shardGroupInfos;
+        try {
+            List<CreateShardGroupInfo> createShardGroupInfos = new ArrayList<>();
+            createShardGroupInfos.add(CreateShardGroupInfo.newBuilder()
+                    .setPolicy(PlacementPolicy.SPREAD)
+                    .putProperties("createTime", String.valueOf(System.currentTimeMillis()))
+                    .build());
+            shardGroupInfos = client.createShardGroup(serviceId, createShardGroupInfos);
+            Preconditions.checkState(shardGroupInfos.size() == 1);
+        } catch (StarClientException e) {
+            throw new DdlException("Failed to create shard group. error: " + e.getMessage());
+        }
+        return shardGroupInfos.get(0).getGroupId();
     }
 
     public void deleteShardGroup(List<Long> groupIds) {
@@ -590,6 +619,35 @@ public class StarOSAgent {
             LOG.debug("Create shards success. shard infos: {}", shardInfos);
         } catch (Exception e) {
             throw new DdlException("Failed to create shards. error: " + e.getMessage());
+        }
+    }
+
+    // Used only for shared-data cluster replication
+    public void createShardWithVirtualTabletId(FilePathInfo pathInfo, FileCacheInfo cacheInfo, long groupId,
+                                      @NotNull Map<String, String> properties, long vTabletId,
+                                      ComputeResource computeResource) throws DdlException {
+        Preconditions.checkState(vTabletId != 0);
+        long workerGroupId = computeResource.getWorkerGroupId();
+        prepare();
+        List<ShardInfo> shardInfos = null;
+        try {
+            List<CreateShardInfo> createShardInfoList = new ArrayList<>(1);
+
+            CreateShardInfo.Builder builder = CreateShardInfo.newBuilder();
+            builder.setReplicaCount(1)
+                    .addGroupIds(groupId)
+                    .setPathInfo(pathInfo)
+                    .setCacheInfo(cacheInfo)
+                    .putAllShardProperties(properties)
+                    .setScheduleToWorkerGroup(workerGroupId);
+
+            builder.setShardId(vTabletId);
+            createShardInfoList.add(builder.build());
+            shardInfos = client.createShard(serviceId, createShardInfoList);
+            Preconditions.checkState(shardInfos != null && shardInfos.size() == 1);
+            LOG.debug("Create virtual shards success. shard infos: {}", shardInfos);
+        } catch (Exception e) {
+            throw new DdlException("Failed to create virtual shard. error: " + e.getMessage());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -185,6 +185,8 @@ import com.starrocks.persist.PartitionPersistInfoV2;
 import com.starrocks.persist.RangePartitionPersistInfo;
 import com.starrocks.persist.SinglePartitionPersistInfo;
 import com.starrocks.proto.EncryptionKeyPB;
+import com.starrocks.replication.LakeReplicationJob;
+import com.starrocks.replication.ReplicationJob;
 import com.starrocks.replication.ReplicationTxnCommitAttachment;
 import com.starrocks.server.SharedDataStorageVolumeMgr;
 import com.starrocks.server.SharedNothingStorageVolumeMgr;
@@ -467,6 +469,11 @@ public class GsonUtils {
                     .registerSubtype(TvrTableSnapshot.class, "TvrTableSnapshot")
                     .registerSubtype(TvrTableDelta.class, "TvrTableDelta");
 
+    private static final RuntimeTypeAdapterFactory<ReplicationJob> REPLICATION_JOB_TYPE_ADAPTER_FACTORY =
+            RuntimeTypeAdapterFactory.of(ReplicationJob.class, "clazz")
+                    .registerSubtype(ReplicationJob.class, "ReplicationJob", true)
+                    .registerSubtype(LakeReplicationJob.class, "LakeReplicationJob");
+
     private static final JsonSerializer<LocalDateTime> LOCAL_DATE_TIME_TYPE_SERIALIZER =
             (dateTime, type, jsonSerializationContext) -> new JsonPrimitive(dateTime.toEpochSecond(ZoneOffset.UTC));
 
@@ -536,6 +543,7 @@ public class GsonUtils {
                 .registerTypeAdapterFactory(TABLET_RESHARD_RUNTIME_TYPE_ADAPTER_FACTORY)
                 .registerTypeAdapterFactory(TVR_DELTA_RUNTIME_TYPE_ADAPTER_FACTORY)
                 .registerTypeAdapterFactory(VARIANT_RUNTIME_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(REPLICATION_JOB_TYPE_ADAPTER_FACTORY)
                 .registerTypeAdapter(LocalDateTime.class, LOCAL_DATE_TIME_TYPE_SERIALIZER)
                 .registerTypeAdapter(LocalDateTime.class, LOCAL_DATE_TIME_TYPE_DESERIALIZER)
                 .registerTypeAdapter(QueryDumpInfo.class, DUMP_INFO_SERIALIZER)

--- a/fe/fe-core/src/main/java/com/starrocks/replication/LakeReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/LakeReplicationJob.java
@@ -16,13 +16,13 @@ package com.starrocks.replication;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.ReplicateSnapshotTask;
 import com.starrocks.thrift.TTableReplicationRequest;
+import org.apache.arrow.util.Preconditions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.TestOnly;
@@ -48,8 +48,9 @@ public class LakeReplicationJob extends ReplicationJob {
         this.virtualTabletId = virtualTabletId;
     }
 
-    public LakeReplicationJob(TTableReplicationRequest request) throws MetaNotFoundException, DdlException {
+    public LakeReplicationJob(TTableReplicationRequest request) throws MetaNotFoundException {
         super(request);
+        Preconditions.checkArgument(request.src_database_id > 0 && request.src_table_id > 0);
         this.srcDatabaseId = request.src_database_id;
         this.srcTableId = request.src_table_id;
         this.virtualTabletId = GlobalStateMgr.getCurrentState().getStorageVolumeMgr()

--- a/fe/fe-core/src/main/java/com/starrocks/replication/LakeReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/LakeReplicationJob.java
@@ -1,0 +1,125 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.replication;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.task.ReplicateSnapshotTask;
+import com.starrocks.thrift.TTableReplicationRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.TestOnly;
+
+public class LakeReplicationJob extends ReplicationJob {
+    private static final Logger LOG = LogManager.getLogger(LakeReplicationJob.class);
+
+    @SerializedName(value = "virtualTabletId")
+    private final long virtualTabletId;
+
+    @SerializedName(value = "srcDatabaseId")
+    protected long srcDatabaseId;
+
+    @SerializedName(value = "srcTableId")
+    protected long srcTableId;
+
+    @TestOnly
+    public LakeReplicationJob(String jobId, long virtualTabletId, long srcDatabaseId, long srcTableId, long databaseId,
+                              OlapTable table, OlapTable srcTable, SystemInfoService srcSystemInfoService) {
+        super(jobId, null, databaseId, table, srcTable, srcSystemInfoService);
+        this.srcDatabaseId = srcDatabaseId;
+        this.srcTableId = srcTableId;
+        this.virtualTabletId = virtualTabletId;
+    }
+
+    public LakeReplicationJob(TTableReplicationRequest request) throws MetaNotFoundException, DdlException {
+        super(request);
+        this.srcDatabaseId = request.src_database_id;
+        this.srcTableId = request.src_table_id;
+        this.virtualTabletId = GlobalStateMgr.getCurrentState().getStorageVolumeMgr()
+                .getOrCreateVirtualTabletId(request.src_storage_volume_name, request.src_service_id);
+    }
+
+    @Override
+    public void run() {
+        try {
+            if (super.getState().equals(ReplicationJobState.INITIALIZING)) {
+                beginTransaction();
+                sendReplicateLakeRemoteStorageTasks();
+                setState(ReplicationJobState.REPLICATING);
+            } else if (super.getState().equals(ReplicationJobState.REPLICATING)) {
+                if (isTransactionAborted()) {
+                    setState(ReplicationJobState.ABORTED);
+                } else if (isCrashRecovery()) {
+                    sendReplicateLakeRemoteStorageTasks();
+                    LOG.info("Lake replication job recovered, state: {}, database id: {}, table id: {}, transaction id: {}",
+                            super.getState(), super.getDatabaseId(), super.getTableId(), super.getTransactionId());
+                } else if (isAllTaskFinished()) {
+                    commitTransaction();
+                    setState(ReplicationJobState.COMMITTED);
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Lake replication job exception, state: {}, database id: {}, table id: {}, transaction id: {}",
+                    super.getState(), super.getDatabaseId(), super.getTableId(), super.getTransactionId(), e);
+            abortTransaction(e.getMessage());
+            setState(ReplicationJobState.ABORTED);
+        }
+    }
+
+    private void sendReplicateLakeRemoteStorageTasks() throws Exception {
+        runningTasks.clear();
+        WarehouseManager warehouseMgr = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        byte[] encryptionMeta = GlobalStateMgr.getCurrentState().getKeyMgr().getCurrentKEKAsEncryptionMeta();
+        for (PartitionInfo partitionInfo : super.getPartitionInfos().values()) {
+            for (IndexInfo indexInfo : partitionInfo.getIndexInfos().values()) {
+                for (TabletInfo tabletInfo : indexInfo.getTabletInfos().values()) {
+                    Long computeNodeId = warehouseMgr
+                            .getComputeNodeId(WarehouseManager.DEFAULT_RESOURCE, tabletInfo.getTabletId());
+                    if (computeNodeId == null) {
+                        throw new RuntimeException("Send lake replicate task failed, no compute node found for tablet: "
+                                + tabletInfo.getTabletId());
+                    }
+                    ReplicateSnapshotTask task = new ReplicateSnapshotTask(computeNodeId, super.getDatabaseId(),
+                            super.getTableId(), partitionInfo.getPartitionId(), indexInfo.getIndexId(),
+                            tabletInfo.getTabletId(), getTabletType(super.getTableType()), super.getTransactionId(),
+                            indexInfo.getSchemaHash(), partitionInfo.getVersion(),
+                            partitionInfo.getDataVersion(), tabletInfo.getSrcTabletId(),
+                            getTabletType(super.getSrcTableType()),
+                            indexInfo.getSrcSchemaHash(), partitionInfo.getSrcVersion(), encryptionMeta,
+                            virtualTabletId, srcDatabaseId, srcTableId, partitionInfo.getSrcPartitionId());
+                    LOG.info("Add lake replicate snapshot task, tablet id: {}, txn id: {}, src partition info: {}/{}/{}",
+                            tabletInfo.getTabletId(), super.getTransactionId(), srcDatabaseId, srcTableId,
+                            partitionInfo.getSrcPartitionId());
+                    runningTasks.put(task, task);
+                }
+            }
+        }
+        taskNum = runningTasks.size();
+        LOG.info("Send lake replicate snapshot task, task num: {}, database id: {}, table id: {}, transaction id: {}",
+                taskNum, super.getDatabaseId(), super.getTableId(), super.getTransactionId());
+        sendRunningTasks();
+    }
+
+    @Override
+    public long getReplicationReplicaCount() {
+        return 1;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/replication/LakeReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/LakeReplicationJob.java
@@ -119,7 +119,12 @@ public class LakeReplicationJob extends ReplicationJob {
 
     @Override
     public long getReplicationReplicaCount() {
-        return 1;
+        long count = 0;
+        for (PartitionInfo partitionInfo : getPartitionInfos().values()) {
+            for (IndexInfo indexInfo : partitionInfo.getIndexInfos().values()) {
+                count += indexInfo.getTabletInfos().size();
+            }
+        }
+        return count;
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
@@ -66,9 +66,14 @@ public class ReplicationMgr extends FrontendDaemon {
 
     public void addReplicationJob(TTableReplicationRequest request) throws StarRocksException {
         LOG.info("Adding replication job, request: {}", request.toString());
-        ReplicationJob job = (request.src_cluster_run_mode == RunMode.toTRunMode(RunMode.SHARED_DATA)) ?
+        ReplicationJob job = isLakeReplicationJob(request) ?
                 new LakeReplicationJob(request) : new ReplicationJob(request);
         addReplicationJob(job);
+    }
+
+    private boolean isLakeReplicationJob(TTableReplicationRequest request) {
+        return request != null && request.src_cluster_run_mode != null
+                && request.src_cluster_run_mode == RunMode.toTRunMode(RunMode.SHARED_DATA);
     }
 
     public void addReplicationJob(ReplicationJob job) throws AlreadyExistsException {

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
@@ -28,6 +28,7 @@ import com.starrocks.persist.metablock.SRMetaBlockID;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockWriter;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.task.RemoteSnapshotTask;
 import com.starrocks.task.ReplicateSnapshotTask;
 import com.starrocks.thrift.TFinishTaskRequest;
@@ -64,7 +65,9 @@ public class ReplicationMgr extends FrontendDaemon {
     }
 
     public void addReplicationJob(TTableReplicationRequest request) throws StarRocksException {
-        ReplicationJob job = new ReplicationJob(request);
+        LOG.info("Adding replication job, request: {}", request.toString());
+        ReplicationJob job = (request.src_cluster_run_mode == RunMode.toTRunMode(RunMode.SHARED_DATA)) ?
+                new LakeReplicationJob(request) : new ReplicationJob(request);
         addReplicationJob(job);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1461,6 +1461,9 @@ public class GlobalStateMgr {
             // Need to rebuild active lake compaction transactions before lake scheduler starting to run
             // Lake compactionMgr is started on all FE nodes and scheduler only starts to run when the FE is leader
             compactionMgr.buildActiveCompactionTransactionMap();
+            // restore storage volumes to virtual tablet group mappings while FE is leader
+            // (include after transferring to leader role)
+            ((SharedDataStorageVolumeMgr) storageVolumeMgr).restoreStorageVolumeToVTabletGroupMappings();
 
             starMgrMetaSyncer.start();
             autovacuumDaemon.start();

--- a/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
@@ -14,7 +14,9 @@
 
 package com.starrocks.server;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.staros.proto.FileCacheInfo;
 import com.staros.proto.FilePathInfo;
 import com.staros.proto.FileStoreInfo;
 import com.staros.util.LockCloseable;
@@ -28,15 +30,18 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.InvalidConfException;
+import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.StorageInfo;
 import com.starrocks.persist.TableStorageInfo;
 import com.starrocks.persist.TableStorageInfos;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.storagevolume.StorageVolume;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -50,12 +55,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static com.starrocks.server.GlobalStateMgr.NEXT_ID_INIT_VALUE;
+import static com.starrocks.storagevolume.StorageVolume.V_SHARD_GROUP_ID;
 
 public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
     private static final Logger LOG = LogManager.getLogger(SharedDataStorageVolumeMgr.class);
+
+    private final Map<String, Long> storageVolumeIdToVTabletGroupId = new ConcurrentHashMap<>();
 
     @Override
     public StorageVolume getStorageVolumeByName(String svName) {
@@ -95,6 +104,32 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
         }
     }
 
+    /**
+     * restore `storageVolumeIdToVTabletGroupId` at startup time of FE leader
+     */
+    public void restoreStorageVolumeToVTabletGroupMappings() {
+        // make sure to clean all expired keys who might have already been removed on other leader FE
+        // before this FE transferred to leader.
+        storageVolumeIdToVTabletGroupId.clear();
+        try {
+            List<FileStoreInfo> fileStoreInfos = GlobalStateMgr.getCurrentState().getStarOSAgent().listFileStore();
+            for (FileStoreInfo fsInfo : fileStoreInfos) {
+                String vTabletIdGroupId = fsInfo.getPropertiesMap().get(V_SHARD_GROUP_ID);
+                if (StringUtils.isEmpty(vTabletIdGroupId)) {
+                    continue;
+                }
+                try {
+                    storageVolumeIdToVTabletGroupId.put(fsInfo.getFsName(), Long.parseLong(vTabletIdGroupId));
+                } catch (NumberFormatException e) {
+                    LOG.warn("found invalid v_shard_group_id" +
+                            " while restoring storage volume to virtual tablet group mapping: {}", vTabletIdGroupId);
+                }
+            }
+        } catch (DdlException e) {
+            LOG.warn("failed to restore storage volume to tablet", e);
+        }
+    }
+
     @Override
     protected String createInternalNoLock(String name, String svType, List<String> locations,
             Map<String, String> params, Optional<Boolean> enabled, String comment)
@@ -117,6 +152,17 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
     @Override
     protected void removeInternalNoLock(StorageVolume sv) throws DdlException {
         GlobalStateMgr.getCurrentState().getStarOSAgent().removeFileStoreByName(sv.getName());
+
+        // remove virtual tablets
+        if (sv.getVTabletId() != -1) {
+            GlobalStateMgr.getCurrentState().getStarOSAgent().deleteShards(Collections.singleton(sv.getVTabletId()));
+        }
+
+        if (sv.getVTabletGroupId() != -1) {
+            GlobalStateMgr.getCurrentState().getStarOSAgent().deleteShardGroup(
+                    Collections.singletonList(sv.getVTabletGroupId()));
+            storageVolumeIdToVTabletGroupId.remove(sv.getName());
+        }
     }
 
     @Override
@@ -622,6 +668,66 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
                 return "";
             default:
                 return "";
+        }
+    }
+
+    @Override
+    public void updateStorageVolumeVTabletMapping(String name, long vTabletId, long vTabletGroupId)
+            throws DdlException {
+        try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
+            StorageVolume sv = getStorageVolumeByName(name);
+            Preconditions.checkState(sv != null, "Storage volume '%s' does not exist", name);
+            StorageVolume copied = new StorageVolume(sv);
+            // reset global unique id
+            copied.setVTabletId(vTabletId);
+            copied.setVTabletGroupId(vTabletGroupId);
+            updateInternalNoLock(copied);
+            storageVolumeIdToVTabletGroupId.put(name, vTabletGroupId);
+        }
+    }
+
+    @Override
+    public boolean hasStorageVolumeBindAsVirtualGroup(long shardGroupId) {
+        return storageVolumeIdToVTabletGroupId.values().stream().anyMatch(vTabletGroupId -> shardGroupId == vTabletGroupId);
+    }
+
+    public long getOrCreateVirtualTabletId(String storageVolumeName, String srcServiceId)
+            throws MetaNotFoundException {
+        try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
+            StorageVolume storageVolume = this.getStorageVolumeByName(storageVolumeName);
+            if (storageVolume == null) {
+                throw new MetaNotFoundException("Unknown src storage volume while creating virtual tablet: " + storageVolumeName);
+            }
+
+            long vTabletId = storageVolume.getVTabletId();
+            if (vTabletId != -1) {
+                return vTabletId;
+            }
+
+            long shardGroupId = -1;
+            try {
+                StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
+                FilePathInfo pathInfo = starOSAgent.allocateFilePath(storageVolume.getId(), srcServiceId);
+                FileCacheInfo cacheInfo =
+                        FileCacheInfo.newBuilder().setEnableCache(false).setTtlSeconds(-1).setAsyncWriteBack(false).build();
+                // assume each shard group has only one shard
+                shardGroupId = starOSAgent.createShardGroupForVirtualTablet();
+                Map<String, String> properties = new HashMap<>();
+                // create a new id as tablet id
+                vTabletId = GlobalStateMgr.getCurrentState().getNextId();
+
+                starOSAgent.createShardWithVirtualTabletId(pathInfo, cacheInfo, shardGroupId, properties, vTabletId,
+                        WarehouseManager.DEFAULT_RESOURCE);
+                LOG.info("Created shard for storage volume: {}, vTablet id: {}, group id: {}, src service id: {}",
+                        storageVolumeName, vTabletId, shardGroupId, srcServiceId);
+
+                // update storage volume
+                updateStorageVolumeVTabletMapping(storageVolumeName, vTabletId, shardGroupId);
+                return vTabletId;
+            } catch (Exception e) {
+                LOG.error("Failed to create shard for storage volume {} ", storageVolumeName, e);
+                throw new RuntimeException("Failed to create shard for storage volume: " + storageVolumeName, e);
+            }
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
@@ -732,6 +732,7 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
                 updateStorageVolumeVTabletMapping(storageVolumeName, vTabletId, shardGroupId);
                 return vTabletId;
             } catch (Exception e) {
+                // StarMgrMetaSyncer would clean the orphaned shards & shard groups
                 LOG.error("Failed to create shard for storage volume {} ", storageVolumeName, e);
                 throw new RuntimeException("Failed to create shard for storage volume: " + storageVolumeName, e);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/SharedNothingStorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/SharedNothingStorageVolumeMgr.java
@@ -18,6 +18,7 @@ import com.google.gson.annotations.SerializedName;
 import com.staros.util.LockCloseable;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.InvalidConfException;
+import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.persist.DropStorageVolumeLog;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -169,5 +170,15 @@ public class SharedNothingStorageVolumeMgr extends StorageVolumeMgr {
     @Override
     protected void updateTableStorageInfo(String storageVolumeId) throws DdlException {
 
+    }
+
+    @Override
+    public long getOrCreateVirtualTabletId(String storageVolumeName, String srcServiceId) throws MetaNotFoundException {
+        return -1;
+    }
+
+    @Override
+    public boolean hasStorageVolumeBindAsVirtualGroup(long shardGroupId) {
+        return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
@@ -263,6 +263,15 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
                 validateLocations(svType, locations);
                 newStorageVolume = new StorageVolume(oldStorageVolume.getId(), name, svType, locations, params,
                         enabled.orElse(oldStorageVolume.getEnabled()), comment);
+
+                if (oldStorageVolume.getVTabletId() != -1) {
+                    newStorageVolume.setVTabletId(oldStorageVolume.getVTabletId());
+                }
+
+                if (oldStorageVolume.getVTabletGroupId() != -1) {
+                    newStorageVolume.setVTabletGroupId(oldStorageVolume.getVTabletGroupId());
+                }
+
                 locationChangedStorageVolumeId = newStorageVolume.getId();
             }
 
@@ -272,6 +281,11 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
         if (locationChangedStorageVolumeId != null) {
             updateTableStorageInfo(locationChangedStorageVolumeId);
         }
+    }
+
+    public void updateStorageVolumeVTabletMapping(String name, long vTabletId, long vTabletGroupId)
+            throws DdlException {
+        throw new DdlException("Not implemented");
     }
 
     public void setDefaultStorageVolume(SetDefaultStorageVolumeStmt stmt) {
@@ -525,4 +539,9 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
     protected abstract List<List<Long>> getBindingsOfBuiltinStorageVolume();
 
     protected abstract void updateTableStorageInfo(String storageVolumeId) throws DdlException;
+
+    public abstract long getOrCreateVirtualTabletId(String storageVolumeName, String srcServiceId)
+            throws MetaNotFoundException;
+
+    public abstract boolean hasStorageVolumeBindAsVirtualGroup(long shardGroupId);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/ReplicateSnapshotTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ReplicateSnapshotTask.java
@@ -37,6 +37,12 @@ public class ReplicateSnapshotTask extends AgentTask {
     private final List<TSnapshotInfo> srcSnapshotInfos;
     private final byte[] encryptionMeta;
 
+    // for lake
+    private final long virtualTabletId;
+    private final long srcDbId;
+    private final long srcTableId;
+    private final long srcPartitionId;
+
     public ReplicateSnapshotTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
             TTabletType tabletType, long transactionId, int schemaHash, long visibleVersion, long dataVersion,
             String srcToken, long srcTabletId, TTabletType srcTabletType, int srcSchemaHash,
@@ -55,6 +61,40 @@ public class ReplicateSnapshotTask extends AgentTask {
         this.srcVisibleVersion = srcVisibleVersion;
         this.srcSnapshotInfos = srcSnapshotInfos;
         this.encryptionMeta = encryptionMeta;
+
+        this.virtualTabletId = -1;
+        this.srcDbId = -1;
+        this.srcTableId = -1;
+        this.srcPartitionId = -1;
+    }
+
+    // for lake
+    public ReplicateSnapshotTask(long backendId, long dbId, long tableId, long partitionId, long indexId,
+                                          long tabletId, TTabletType tabletType, long transactionId,
+                                          int schemaHash, long visibleVersion, long dataVersion,
+                                          long srcTabletId, TTabletType srcTabletType,
+                                          int srcSchemaHash, long srcVisibleVersion,
+                                          byte[] encryptionMeta, long virtualTabletId,
+                                          long srcDbId, long srcTableId, long srcPartitionId) {
+        super(null, backendId, TTaskType.REPLICATE_SNAPSHOT, dbId, tableId, partitionId, indexId, tabletId, tabletId,
+                System.currentTimeMillis());
+        this.transactionId = transactionId;
+        this.tabletType = tabletType;
+        this.schemaHash = schemaHash;
+        this.visibleVersion = visibleVersion;
+        this.dataVersion = dataVersion;
+        this.srcTabletId = srcTabletId;
+        this.srcTabletType = srcTabletType;
+        this.srcSchemaHash = srcSchemaHash;
+        this.srcVisibleVersion = srcVisibleVersion;
+        this.encryptionMeta = encryptionMeta;
+        this.virtualTabletId = virtualTabletId;
+        this.srcDbId = srcDbId;
+        this.srcTableId = srcTableId;
+        this.srcPartitionId = srcPartitionId;
+
+        this.srcToken = null;
+        this.srcSnapshotInfos = null;
     }
 
     public TReplicateSnapshotRequest toThrift() {
@@ -77,6 +117,11 @@ public class ReplicateSnapshotTask extends AgentTask {
         request.setSrc_snapshot_infos(srcSnapshotInfos);
         request.setEncryption_meta(encryptionMeta);
 
+        request.setVirtual_tablet_id(virtualTabletId);
+        request.setSrc_db_id(srcDbId);
+        request.setSrc_table_id(srcTableId);
+        request.setSrc_partition_id(srcPartitionId);
+
         return request;
     }
 
@@ -93,6 +138,9 @@ public class ReplicateSnapshotTask extends AgentTask {
         sb.append(", src visible version: ").append(srcVisibleVersion);
         sb.append(", src snapshot infos: ").append(srcSnapshotInfos);
         sb.append(", dest backend: ").append(backendId);
+        sb.append(", src db id: ").append(srcDbId);
+        sb.append(", src table id: ").append(srcTableId);
+        sb.append(", src partition id: ").append(srcPartitionId);
         return sb.toString();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -61,6 +61,8 @@ import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.NodeMgr;
+import com.starrocks.server.SharedDataStorageVolumeMgr;
+import com.starrocks.server.StorageVolumeMgr;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
@@ -122,6 +124,7 @@ public class StarMgrMetaSyncerTest {
     private EditLog editLog;
 
     private ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
+    private StorageVolumeMgr storageVolumeMgr = new SharedDataStorageVolumeMgr();
 
     private StarMgrMetaSyncer starMgrMetaSyncer;
 
@@ -176,6 +179,10 @@ public class StarMgrMetaSyncerTest {
                 globalStateMgr.getClusterSnapshotMgr();
                 minTimes = 0;
                 result = clusterSnapshotMgr;
+
+                globalStateMgr.getStorageVolumeMgr();
+                minTimes = 0;
+                result = storageVolumeMgr;
             }
         };
 
@@ -241,7 +248,6 @@ public class StarMgrMetaSyncerTest {
                         "p1", baseIndex, distributionInfo));
             }
         };
-
         UtFrameUtils.mockInitWarehouseEnv();
 
         // skip all the initialization in MetricRepo

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -1019,7 +1019,7 @@ public class StarOSAgentTest {
         };
 
         ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                "Failed to create fake shard. error: INTERNAL:Mocked error",
+                "Failed to create virtual shard. error: INTERNAL:Mocked error",
                 () -> starosAgent.createShardWithVirtualTabletId(pathInfo, cacheInfo, groupId, properties, vTabletId,
                         WarehouseManager.DEFAULT_RESOURCE));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -197,6 +197,34 @@ public class StarOSAgentTest {
     }
 
     @Test
+    public void testAllocateFilePathWithRootDir() throws StarClientException {
+        String serviceId = "1";
+        String storageVolumeId = "test-sv-1";
+        String rootDir = "/tmp/test-root";
+
+        Deencapsulation.setField(starosAgent, "serviceId", serviceId);
+        new Expectations(client) {
+            {
+                client.allocateFilePath(serviceId, storageVolumeId, "", rootDir);
+                result = FilePathInfo.newBuilder().build();
+            }
+        };
+
+        ExceptionChecker.expectThrowsNoException(() -> starosAgent.allocateFilePath(storageVolumeId, rootDir));
+
+        new Expectations(client) {
+            {
+                client.allocateFilePath(serviceId, storageVolumeId, "", rootDir);
+                result = new StarClientException(StatusCode.INVALID_ARGUMENT, "mocked exception");
+            }
+        };
+
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "Failed to allocate file path from StarMgr, error: INVALID_ARGUMENT:mocked exception",
+                () -> starosAgent.allocateFilePath(storageVolumeId, rootDir));
+    }
+
+    @Test
     public void testAddAndRemoveWorker() throws StarClientException {
         long expectedWorkerId = 10;
         new Expectations(client) {
@@ -903,4 +931,97 @@ public class StarOSAgentTest {
         Deencapsulation.setField(starosAgent, "serviceId", "1");
         Assertions.assertThrows(DdlException.class, () -> starosAgent.getWorkerGroupInfo(workerGroupId));
     }
+
+    @Test
+    public void testCreateShardGroupForVirtualTablet() throws StarClientException {
+        String serviceId = "1";
+
+        long groupId = 333;
+        ShardGroupInfo info = ShardGroupInfo.newBuilder().setGroupId(groupId).build();
+        List<ShardGroupInfo> shardGroupInfos = new ArrayList<>(1);
+        shardGroupInfos.add(info);
+
+        Deencapsulation.setField(starosAgent, "serviceId", "1");
+
+        // normal case
+        new Expectations(client) {
+            {
+                client.createShardGroup(serviceId, (List<CreateShardGroupInfo>) any);
+                result = shardGroupInfos;
+                client.listShardGroup(serviceId);
+                result = shardGroupInfos;
+            }
+        };
+
+        ExceptionChecker.expectThrowsNoException(() -> {
+            long ret = starosAgent.createShardGroupForVirtualTablet();
+            Assertions.assertEquals(groupId, ret);
+
+            // list shard group
+            List<ShardGroupInfo> realGroupIds = starosAgent.listShardGroup();
+            Assertions.assertEquals(1, realGroupIds.size());
+            Assertions.assertEquals(groupId, realGroupIds.get(0).getGroupId());
+        });
+
+        // inject error
+        new Expectations(client) {
+            {
+                client.createShardGroup(serviceId, (List<CreateShardGroupInfo>) any);
+                result = new StarClientException(StatusCode.INTERNAL, "Mocked error");
+            }
+        };
+        Assertions.assertThrows(DdlException.class, () -> starosAgent.createShardGroupForVirtualTablet());
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "Failed to create shard group. error: INTERNAL:Mocked error",
+                () -> starosAgent.createShardGroupForVirtualTablet());
+    }
+
+    @Test
+    public void testCreateShardWithVirtualTabletId() throws StarClientException {
+        long groupId = 333L;
+        long vTabletId = 1000L;
+        String serviceId = "1";
+
+        ShardInfo shardInfo = ShardInfo.newBuilder().setShardId(vTabletId).build();
+        List<ShardInfo> shardInfos = Lists.newArrayList(shardInfo);
+
+        Deencapsulation.setField(starosAgent, "serviceId", serviceId);
+
+        // normal case
+        new Expectations(client) {
+            {
+                client.createShard(serviceId, (List<CreateShardInfo>) any);
+                result = shardInfos;
+                client.getShardInfo(serviceId, Lists.newArrayList(vTabletId), StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                result = shardInfos;
+            }
+        };
+
+        FilePathInfo pathInfo = FilePathInfo.newBuilder().build();
+        FileCacheInfo cacheInfo = FileCacheInfo.newBuilder().build();
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("testProperty", "testValue");
+
+        ExceptionChecker.expectThrowsNoException(() -> {
+            starosAgent.createShardWithVirtualTabletId(pathInfo, cacheInfo, groupId, properties, vTabletId,
+                    WarehouseManager.DEFAULT_RESOURCE);
+            ShardInfo info = starosAgent.getShardInfo(vTabletId, StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+            Assertions.assertNotNull(info);
+            Assertions.assertEquals(vTabletId, info.getShardId());
+        });
+
+        // inject error
+        new Expectations(client) {
+            {
+                client.createShard(serviceId, (List<CreateShardInfo>) any);
+                result = new StarClientException(StatusCode.INTERNAL, "Mocked error");
+            }
+        };
+
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "Failed to create fake shard. error: INTERNAL:Mocked error",
+                () -> starosAgent.createShardWithVirtualTabletId(pathInfo, cacheInfo, groupId, properties, vTabletId,
+                        WarehouseManager.DEFAULT_RESOURCE));
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/replication/LakeReplicationJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/LakeReplicationJobTest.java
@@ -1,0 +1,190 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.replication;
+
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.io.DeepCopy;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.leader.LeaderImpl;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.AgentTask;
+import com.starrocks.task.AgentTaskExecutor;
+import com.starrocks.task.ReplicateSnapshotTask;
+import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class LakeReplicationJobTest extends ReplicationJobTest {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        AnalyzeTestUtil.init();
+        starRocksAssert = new StarRocksAssert(AnalyzeTestUtil.getConnectContext());
+        starRocksAssert.withDatabase("test").useDatabase("test");
+
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+
+        String sql = "create table single_partition_duplicate_key (key1 int, key2 varchar(10))\n" +
+                "distributed by hash(key1) buckets 1\n" +
+                "properties('replication_num' = '1'); ";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql,
+                AnalyzeTestUtil.getConnectContext());
+        StarRocksAssert.utCreateTableWithRetry(createTableStmt);
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "single_partition_duplicate_key");
+        srcTable = DeepCopy.copyWithGson(table, OlapTable.class);
+
+        partition = table.getPartitions().iterator().next();
+        srcPartition = srcTable.getPartitions().iterator().next();
+
+        new MockUp<AgentTaskExecutor>() {
+            @Mock
+            public void submit(AgentBatchTask task) {
+
+            }
+        };
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        long virtualTabletId = 1000;
+        long srcDatabaseId = 100;
+        long srcTableId = 100;
+        job = new LakeReplicationJob(null, virtualTabletId, srcDatabaseId, srcTableId, db.getId(), table, srcTable,
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+    }
+
+    @Test
+    @Override
+    public void testNormal() throws Exception {
+        Assertions.assertFalse(ReplicationJobState.INITIALIZING.equals(job));
+        Assertions.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+        Assertions.assertEquals(ReplicationJobState.INITIALIZING.name(), job.getState().name());
+        Assertions.assertEquals(ReplicationJobState.INITIALIZING.toString(), job.getState().toString());
+        Assertions.assertEquals(ReplicationJobState.INITIALIZING.hashCode(), job.getState().hashCode());
+
+        Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
+
+        job.run();
+        Assertions.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        for (AgentTask task : runningTasks.values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            job.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
+
+            Deencapsulation.invoke(new LeaderImpl(), "finishReplicateSnapshotTask",
+                    (ReplicateSnapshotTask) task, request);
+            ((ReplicateSnapshotTask) task).toThrift();
+            task.toString();
+        }
+
+        job.run();
+        Assertions.assertEquals(ReplicationJobState.COMMITTED, job.getState());
+
+        Assertions.assertEquals(partition.getDefaultPhysicalPartition().getCommittedVersion(),
+                srcPartition.getDefaultPhysicalPartition().getVisibleVersion());
+    }
+
+    @Test
+    @Override
+    public void testCommittedCancel() {
+        Assertions.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        job.run();
+        Assertions.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        job.run();
+        Assertions.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
+        for (AgentTask task : runningTasks.values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            job.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
+        }
+
+        job.run();
+        Assertions.assertEquals(ReplicationJobState.COMMITTED, job.getState());
+
+        job.cancel();
+        Assertions.assertEquals(ReplicationJobState.COMMITTED, job.getState());
+    }
+
+    @Test
+    @Override
+    public void testReplicatingCancel() {
+        Assertions.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        job.run();
+        Assertions.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        job.cancel();
+        Assertions.assertEquals(ReplicationJobState.ABORTED, job.getState());
+
+        job.run();
+        Assertions.assertEquals(ReplicationJobState.ABORTED, job.getState());
+    }
+
+    @Test
+    @Override
+    public void testReplicatingFailed() throws Exception {
+        Assertions.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        job.run();
+
+        Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
+
+        Assertions.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        for (AgentTask task : runningTasks.values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.addToError_msgs("failed");
+            request.setTask_status(status);
+            job.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
+        }
+
+        job.run();
+        Assertions.assertEquals(ReplicationJobState.ABORTED, job.getState());
+    }
+
+    @Override
+    public void testSnapshotingCancel() {
+        // skip
+    }
+
+    @Override
+    public void testSnapshotingFailed() {
+        // skip
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobSerializationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobSerializationTest.java
@@ -1,0 +1,235 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.replication;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.common.io.DeepCopy;
+import com.starrocks.persist.ReplicationJobLog;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.AgentTaskExecutor;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ReplicationJobSerializationTest {
+
+    private static StarRocksAssert starRocksAssert;
+    private static Database db;
+    private static OlapTable table;
+    private static OlapTable srcTable;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_NOTHING);
+        AnalyzeTestUtil.init();
+        starRocksAssert = new StarRocksAssert(AnalyzeTestUtil.getConnectContext());
+        starRocksAssert.withDatabase("test_serialization").useDatabase("test_serialization");
+
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test_serialization");
+
+        String sql = "create table test_table (key1 int, key2 varchar(10))\n" +
+                "distributed by hash(key1) buckets 1\n" +
+                "properties('replication_num' = '1'); ";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql,
+                AnalyzeTestUtil.getConnectContext());
+        StarRocksAssert.utCreateTableWithRetry(createTableStmt);
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "test_table");
+        srcTable = DeepCopy.copyWithGson(table, OlapTable.class);
+
+        Partition partition = table.getPartitions().iterator().next();
+        Partition srcPartition = srcTable.getPartitions().iterator().next();
+        partition.getDefaultPhysicalPartition().updateVersionForRestore(10);
+        srcPartition.getDefaultPhysicalPartition().updateVersionForRestore(100);
+        partition.getDefaultPhysicalPartition().setDataVersion(8);
+        partition.getDefaultPhysicalPartition().setNextDataVersion(9);
+        srcPartition.getDefaultPhysicalPartition().setDataVersion(98);
+        srcPartition.getDefaultPhysicalPartition().setNextDataVersion(99);
+
+        new MockUp<AgentTaskExecutor>() {
+            @Mock
+            public void submit(AgentBatchTask task) {
+            }
+        };
+    }
+
+    @Test
+    public void testReplicationJobSerialization() {
+        // Create a ReplicationJob
+        ReplicationJob job = new ReplicationJob(null, "test_token", db.getId(), table, srcTable,
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+
+        // Serialize to JSON
+        String json = GsonUtils.GSON.toJson(job);
+
+        // Verify JSON contains clazz field for type identification
+        Assertions.assertTrue(json.contains("\"clazz\":\"ReplicationJob\""),
+                "Serialized JSON should contain clazz field for ReplicationJob");
+
+        // Deserialize back
+        ReplicationJob deserializedJob = GsonUtils.GSON.fromJson(json, ReplicationJob.class);
+
+        // Verify deserialized object
+        Assertions.assertNotNull(deserializedJob);
+        Assertions.assertEquals(job.getJobId(), deserializedJob.getJobId());
+        Assertions.assertEquals(job.getDatabaseId(), deserializedJob.getDatabaseId());
+        Assertions.assertEquals(job.getTableId(), deserializedJob.getTableId());
+        Assertions.assertEquals(job.getState(), deserializedJob.getState());
+        Assertions.assertEquals(ReplicationJob.class, deserializedJob.getClass());
+    }
+
+    @Test
+    public void testLakeReplicationJobSerialization() {
+        // Create a LakeReplicationJob
+        long virtualTabletId = 12345L;
+        long srcDatabaseId = 67890L;
+        long srcTableId = 11111L;
+        LakeReplicationJob job = new LakeReplicationJob("test_job_id", virtualTabletId, srcDatabaseId, srcTableId,
+                db.getId(), table, srcTable,
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+
+        // Serialize to JSON
+        String json = GsonUtils.GSON.toJson(job);
+
+        // Verify JSON contains clazz field for type identification
+        Assertions.assertTrue(json.contains("\"clazz\":\"LakeReplicationJob\""),
+                "Serialized JSON should contain clazz field for LakeReplicationJob");
+
+        // Verify subclass-specific fields are serialized
+        Assertions.assertTrue(json.contains("\"virtualTabletId\":" + virtualTabletId),
+                "Serialized JSON should contain virtualTabletId");
+        Assertions.assertTrue(json.contains("\"srcDatabaseId\":" + srcDatabaseId),
+                "Serialized JSON should contain srcDatabaseId");
+        Assertions.assertTrue(json.contains("\"srcTableId\":" + srcTableId),
+                "Serialized JSON should contain srcTableId");
+
+        // Deserialize back as base class type (simulates ReplicationJobLog behavior)
+        ReplicationJob deserializedJob = GsonUtils.GSON.fromJson(json, ReplicationJob.class);
+
+        // Verify it's actually a LakeReplicationJob instance
+        Assertions.assertNotNull(deserializedJob);
+        Assertions.assertTrue(deserializedJob instanceof LakeReplicationJob,
+                "Deserialized object should be instance of LakeReplicationJob");
+        Assertions.assertEquals(LakeReplicationJob.class, deserializedJob.getClass());
+
+        // Verify common fields
+        Assertions.assertEquals(job.getJobId(), deserializedJob.getJobId());
+        Assertions.assertEquals(job.getDatabaseId(), deserializedJob.getDatabaseId());
+        Assertions.assertEquals(job.getTableId(), deserializedJob.getTableId());
+        Assertions.assertEquals(job.getState(), deserializedJob.getState());
+    }
+
+    @Test
+    public void testReplicationJobLogWithLakeReplicationJob() {
+        // Create a LakeReplicationJob
+        long virtualTabletId = 12345L;
+        long srcDatabaseId = 67890L;
+        long srcTableId = 11111L;
+        LakeReplicationJob lakeJob = new LakeReplicationJob("test_lake_job_id", virtualTabletId, srcDatabaseId, srcTableId,
+                db.getId(), table, srcTable,
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+
+        // Wrap in ReplicationJobLog (simulates EditLog behavior)
+        ReplicationJobLog jobLog = new ReplicationJobLog(lakeJob);
+
+        // Serialize ReplicationJobLog to JSON
+        String json = GsonUtils.GSON.toJson(jobLog);
+
+        // Verify JSON contains type information for the nested job
+        Assertions.assertTrue(json.contains("\"clazz\":\"LakeReplicationJob\""),
+                "Serialized ReplicationJobLog should preserve LakeReplicationJob type");
+
+        // Deserialize back
+        ReplicationJobLog deserializedJobLog = GsonUtils.GSON.fromJson(json, ReplicationJobLog.class);
+
+        // Verify the deserialized job is LakeReplicationJob
+        ReplicationJob deserializedJob = deserializedJobLog.getReplicationJob();
+        Assertions.assertNotNull(deserializedJob);
+        Assertions.assertTrue(deserializedJob instanceof LakeReplicationJob,
+                "Deserialized job from ReplicationJobLog should be LakeReplicationJob");
+        Assertions.assertEquals(LakeReplicationJob.class, deserializedJob.getClass());
+
+        // Verify all fields are preserved
+        Assertions.assertEquals(lakeJob.getJobId(), deserializedJob.getJobId());
+        Assertions.assertEquals(lakeJob.getDatabaseId(), deserializedJob.getDatabaseId());
+        Assertions.assertEquals(lakeJob.getTableId(), deserializedJob.getTableId());
+        Assertions.assertEquals(lakeJob.getState(), deserializedJob.getState());
+    }
+
+    @Test
+    public void testReplicationJobLogWithBaseReplicationJob() {
+        // Create a base ReplicationJob
+        ReplicationJob job = new ReplicationJob("test_base_job_id", "test_token", db.getId(), table, srcTable,
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+
+        // Wrap in ReplicationJobLog
+        ReplicationJobLog jobLog = new ReplicationJobLog(job);
+
+        // Serialize ReplicationJobLog to JSON
+        String json = GsonUtils.GSON.toJson(jobLog);
+
+        // Verify JSON contains type information
+        Assertions.assertTrue(json.contains("\"clazz\":\"ReplicationJob\""),
+                "Serialized ReplicationJobLog should contain ReplicationJob type");
+
+        // Deserialize back
+        ReplicationJobLog deserializedJobLog = GsonUtils.GSON.fromJson(json, ReplicationJobLog.class);
+
+        // Verify the deserialized job is base ReplicationJob
+        ReplicationJob deserializedJob = deserializedJobLog.getReplicationJob();
+        Assertions.assertNotNull(deserializedJob);
+        Assertions.assertEquals(ReplicationJob.class, deserializedJob.getClass());
+        Assertions.assertFalse(deserializedJob instanceof LakeReplicationJob,
+                "Deserialized base ReplicationJob should not be LakeReplicationJob");
+
+        // Verify fields
+        Assertions.assertEquals(job.getJobId(), deserializedJob.getJobId());
+        Assertions.assertEquals(job.getDatabaseId(), deserializedJob.getDatabaseId());
+        Assertions.assertEquals(job.getTableId(), deserializedJob.getTableId());
+    }
+
+    @Test
+    public void testBackwardCompatibilityWithoutClazzField() {
+        // Simulate old serialized data without clazz field
+        // This tests backward compatibility - old data should deserialize as base ReplicationJob
+        // Note: ReplicationJobState is serialized as {"id":1} not as a string
+        String oldFormatJson = "{\"jobId\":\"old_job_id\",\"createdTimeMs\":1234567890," +
+                "\"finishedTimeMs\":0,\"srcToken\":\"token\"," +
+                "\"databaseId\":" + db.getId() + ",\"tableId\":" + table.getId() + "," +
+                "\"tableType\":\"OLAP\",\"srcTableType\":\"OLAP\"," +
+                "\"replicationDataSize\":0,\"replicationReplicaCount\":0," +
+                "\"partitionInfos\":{},\"transactionId\":0,\"state\":{\"id\":1}}";
+
+        // Deserialize old format JSON - should succeed and create ReplicationJob
+        ReplicationJob deserializedJob = GsonUtils.GSON.fromJson(oldFormatJson, ReplicationJob.class);
+
+        Assertions.assertNotNull(deserializedJob);
+        Assertions.assertEquals(ReplicationJob.class, deserializedJob.getClass());
+        Assertions.assertEquals("old_job_id", deserializedJob.getJobId());
+        Assertions.assertEquals(ReplicationJobState.INITIALIZING, deserializedJob.getState());
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
@@ -58,14 +58,14 @@ import java.util.List;
 import java.util.Map;
 
 public class ReplicationJobTest {
-    private static StarRocksAssert starRocksAssert;
+    protected static StarRocksAssert starRocksAssert;
 
-    private static Database db;
-    private static OlapTable table;
-    private static OlapTable srcTable;
-    private static Partition partition;
-    private static Partition srcPartition;
-    private ReplicationJob job;
+    protected static Database db;
+    protected static OlapTable table;
+    protected static OlapTable srcTable;
+    protected static Partition partition;
+    protected static Partition srcPartition;
+    protected ReplicationJob job;
 
     @BeforeAll
     public static void beforeClass() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -1046,7 +1046,7 @@ public class SharedDataStorageVolumeMgrTest {
 
                 properties = new HashMap<>();
                 properties.put(StorageVolume.V_SHARD_ID, String.valueOf(existedShardId));
-                properties.put(StorageVolume.V_SHARD_GROUP_ID, String.valueOf("not valid format number"));
+                properties.put(StorageVolume.V_SHARD_GROUP_ID, "not valid format number");
                 FileStoreInfo fsInfo3 = FileStoreInfo.newBuilder().setFsKey(String.valueOf(id++))
                         .putAllProperties(properties).build();
                 return List.of(fsInfo1, fsInfo2, fsInfo3);
@@ -1058,7 +1058,8 @@ public class SharedDataStorageVolumeMgrTest {
 
         Assert.assertTrue(svm.hasStorageVolumeBindAsVirtualGroup(20001L));
 
-        // Test restore fail while listFileStore failed with DDL exception
+        // corner case: listFileStore failed with DDL exception
+        // storage mapping should keep unmodified
         new MockUp<StarOSAgent>() {
 
             @Mock
@@ -1068,7 +1069,7 @@ public class SharedDataStorageVolumeMgrTest {
         };
 
         svm.restoreStorageVolumeToVTabletGroupMappings();
-        Assert.assertFalse(svm.hasStorageVolumeBindAsVirtualGroup(20001L));
+        Assert.assertTrue(svm.hasStorageVolumeBindAsVirtualGroup(20001L));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -16,6 +16,9 @@ package com.starrocks.server;
 
 import com.google.common.collect.Lists;
 import com.google.gson.stream.JsonReader;
+import com.staros.client.StarClientException;
+import com.staros.proto.FileCacheInfo;
+import com.staros.proto.FilePathInfo;
 import com.staros.proto.FileStoreInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -32,6 +35,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
+import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.InvalidConfException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.jmockit.Deencapsulation;
@@ -62,6 +66,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.wildfly.common.Assert;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -1010,6 +1015,203 @@ public class SharedDataStorageVolumeMgrTest {
         // remove
         DdlException ex = Assertions.assertThrows(DdlException.class, () -> svm.removeStorageVolume(svName));
         Assertions.assertEquals("Snapshot enabled on storage volume 'test_snap', drop volume failed.", ex.getMessage());
+    }
 
+    @Test
+    public void testRestoreStorageVolumeToVTabletGroupMappings() {
+        new MockUp<GlobalStateMgr>() {
+
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return starOSAgent;
+            }
+        };
+
+
+        // Test normal
+        new MockUp<StarOSAgent>() {
+            private long id = 1;
+            final long existedShardId = 10001L;
+            final long existedGroupId = 20001L;
+
+            @Mock
+            public List<FileStoreInfo> listFileStore() throws DdlException {
+                Map<String, String> properties = new HashMap<>();
+                properties.put(StorageVolume.V_SHARD_ID, String.valueOf(existedShardId));
+                properties.put(StorageVolume.V_SHARD_GROUP_ID, String.valueOf(existedGroupId));
+                FileStoreInfo fsInfo1 = FileStoreInfo.newBuilder().setFsKey(String.valueOf(id++))
+                        .putAllProperties(properties).build();
+
+                FileStoreInfo fsInfo2 = FileStoreInfo.newBuilder().setFsKey(String.valueOf(id++)).build();
+
+                properties = new HashMap<>();
+                properties.put(StorageVolume.V_SHARD_ID, String.valueOf(existedShardId));
+                properties.put(StorageVolume.V_SHARD_GROUP_ID, String.valueOf("not valid format number"));
+                FileStoreInfo fsInfo3 = FileStoreInfo.newBuilder().setFsKey(String.valueOf(id++))
+                        .putAllProperties(properties).build();
+                return List.of(fsInfo1, fsInfo2, fsInfo3);
+            }
+        };
+
+        SharedDataStorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        svm.restoreStorageVolumeToVTabletGroupMappings();
+
+        Assert.assertTrue(svm.hasStorageVolumeBindAsVirtualGroup(20001L));
+
+        // Test restore fail while listFileStore failed with DDL exception
+        new MockUp<StarOSAgent>() {
+
+            @Mock
+            public List<FileStoreInfo> listFileStore() throws DdlException {
+                throw new DdlException("Mocked exception");
+            }
+        };
+
+        svm.restoreStorageVolumeToVTabletGroupMappings();
+        Assert.assertFalse(svm.hasStorageVolumeBindAsVirtualGroup(20001L));
+    }
+
+    @Test
+    public void testGetOrCreateVirtualTabletIdStorageVolumeNotExist() {
+        String storageVolumeName = "test_sv";
+        String srcServiceId = "test_service_id";
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+
+        ExceptionChecker.expectThrowsWithMsg(MetaNotFoundException.class,
+                "Unknown src storage volume while creating virtual tablet: " + storageVolumeName,
+                () -> svm.getOrCreateVirtualTabletId(storageVolumeName, srcServiceId));
+    }
+
+    @Test
+    public void testGetOrCreateVirtualTabletIdNormal()
+            throws DdlException, AlreadyExistsException, StarClientException, MetaNotFoundException {
+
+        long expectedVirtualTabletId = 20001;
+        new MockUp<GlobalStateMgr>() {
+
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return starOSAgent;
+            }
+
+            @Mock
+            public long getNextId() {
+                return expectedVirtualTabletId;
+            }
+        };
+
+        String storageVolumeName = "test_sv";
+        String srcServiceId = "test_service_id";
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+
+        // create
+        List<String> locations = Arrays.asList("s3://abc");
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AWS_S3_REGION, "region");
+        storageParams.put(AWS_S3_ENDPOINT, "endpoint");
+        storageParams.put(AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
+        String svKey = svm.createStorageVolume(storageVolumeName, "S3", locations, storageParams, Optional.empty(), "");
+        Assertions.assertTrue(svm.exists(storageVolumeName));
+        Assertions.assertEquals(storageVolumeName, svm.getStorageVolumeName(svKey));
+
+        long groupId = 1001L;
+        FilePathInfo pathInfo = FilePathInfo.newBuilder().build();
+        new Expectations() {
+            {
+                starOSAgent.allocateFilePath(anyString, srcServiceId);
+                result = pathInfo;
+
+                starOSAgent.createShardGroupForVirtualTablet();
+                result = groupId;
+
+                starOSAgent.createShardWithVirtualTabletId(pathInfo, (FileCacheInfo) any, groupId, (HashMap) any,
+                        expectedVirtualTabletId, WarehouseManager.DEFAULT_RESOURCE);
+                result = null;
+            }
+        };
+
+        ExceptionChecker.expectThrowsNoException(() -> {
+            Assertions.assertEquals(expectedVirtualTabletId, svm.getOrCreateVirtualTabletId(storageVolumeName, srcServiceId));
+        });
+
+        svm.removeStorageVolume(storageVolumeName);
+    }
+
+    @Test
+    public void testGetOrCreateVirtualTabletIdWhileStorageVolumeAlreadyHasVirtualTabletId()
+            throws DdlException, AlreadyExistsException, MetaNotFoundException {
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return starOSAgent;
+            }
+        };
+
+        new MockUp<StarOSAgent>() {
+            Map<String, FileStoreInfo> fileStores = new HashMap<>();
+            private long id = 1;
+            final long existedShardId = 10001L;
+            final long existedGroupId = 20001L;
+
+            @Mock
+            public String addFileStore(FileStoreInfo fsInfo) {
+                if (fsInfo.getFsKey().isEmpty()) {
+                    Map<String, String> properties = new HashMap<>();
+                    properties.put(StorageVolume.V_SHARD_ID, String.valueOf(existedShardId));
+                    properties.put(StorageVolume.V_SHARD_GROUP_ID, String.valueOf(existedGroupId));
+                    fsInfo = fsInfo.toBuilder().setFsKey(String.valueOf(id++)).putAllProperties(properties).build();
+                }
+                fileStores.put(fsInfo.getFsKey(), fsInfo);
+                return fsInfo.getFsKey();
+            }
+
+            @Mock
+            public FileStoreInfo getFileStoreByName(String fsName) {
+                for (FileStoreInfo fsInfo : fileStores.values()) {
+                    if (fsInfo.getFsName().equals(fsName)) {
+                        return fsInfo;
+                    }
+                }
+                return null;
+            }
+
+            @Mock
+            public FileStoreInfo getFileStore(String fsKey) {
+                return fileStores.get(fsKey);
+            }
+        };
+
+        String storageVolumeName = "test_sv";
+        String srcServiceId = "test_service_id";
+
+        // create
+        List<String> locations = Arrays.asList("s3://abc");
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AWS_S3_REGION, "region");
+        storageParams.put(AWS_S3_ENDPOINT, "endpoint");
+        storageParams.put(AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
+
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        String svKey = svm.createStorageVolume(storageVolumeName, "S3", locations, storageParams, Optional.empty(), "");
+        Assertions.assertTrue(svm.exists(storageVolumeName));
+        Assertions.assertEquals(storageVolumeName, svm.getStorageVolumeName(svKey));
+
+        long existedShardId = 10001L;
+        long existedGroupId = 20001L;
+        StorageVolume storageVolume = svm.getStorageVolumeByName(storageVolumeName);
+        storageVolume.setVTabletId(existedShardId);
+        storageVolume.setVTabletGroupId(existedGroupId);
+
+        ExceptionChecker.expectThrowsNoException(() -> {
+            Assertions.assertEquals(existedShardId, svm.getOrCreateVirtualTabletId(storageVolumeName, srcServiceId));
+        });
+
+        long notExistedGroupId = 30001L;
+        svm.updateStorageVolumeVTabletMapping(storageVolumeName, existedShardId, existedGroupId);
+        Assertions.assertTrue(svm.hasStorageVolumeBindAsVirtualGroup(existedGroupId));
+        Assertions.assertFalse(svm.hasStorageVolumeBindAsVirtualGroup(notExistedGroupId));
+
+        svm.removeStorageVolume(storageVolumeName);
     }
 }

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -429,6 +429,10 @@ struct TRemoteSnapshotRequest {
      13: optional list<Types.TSnapshotInfo> src_snapshot_infos
      14: optional binary encryption_meta
      15: optional Types.TVersion data_version
+     16: optional Types.TTabletId virtual_tablet_id
+     17: optional Types.TDatabaseId src_db_id
+     18: optional Types.TTableId src_table_id
+     19: optional Types.TPartitionId src_partition_id
  }
 
 enum TTabletMetaType {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1929,6 +1929,7 @@ struct TPartitionReplicationInfo {
     2: optional i64 src_version
     3: optional map<i64, TIndexReplicationInfo> index_replication_infos
     4: optional i64 src_version_epoch
+    5: optional i64 src_partition_id
 }
 
 struct TTableReplicationRequest {
@@ -1941,6 +1942,11 @@ struct TTableReplicationRequest {
     7: optional i64 src_table_data_size
     8: optional map<i64, TPartitionReplicationInfo> partition_replication_infos
     9: optional string job_id
+    10: optional Types.TRunMode src_cluster_run_mode
+    11: optional string src_storage_volume_name
+    12: optional string src_service_id
+    13: optional i64 src_database_id
+    14: optional i64 src_table_id
 }
 
 struct TTableReplicationResponse {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -41,6 +41,7 @@ typedef i32 TPlanNodeId
 typedef i32 TTupleId
 typedef i32 TSlotId
 typedef i64 TTableId
+typedef i64 TDatabaseId
 typedef i64 TTabletId
 typedef i64 TVersion
 typedef i64 TVersionHash


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This PR introduces an online data migration solution tailored for shared-data clusters, complementing the earlier storage-coupled migration strategy.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds LakeReplicationJob and virtual-tablet-backed storage volume plumbing to replicate from shared-data clusters, with StarMgr/Thrift/serialization updates and extensive tests.
> 
> - **Replication**:
>   - Introduces `LakeReplicationJob` (shared-data replication path) and integrates selection in `ReplicationMgr` based on `TRunMode`.
>   - Extends `ReplicationJob` to expose internals, track `srcPartitionId`, derive `srcTableType` by run mode, and reuse helpers; updates state flow and task handling.
>   - `ReplicateSnapshotTask` carries lake fields: `virtual_tablet_id`, `src_db_id`, `src_table_id`, `src_partition_id`.
> - **Storage/StarMgr integration**:
>   - `SharedDataStorageVolumeMgr`: persists `vTabletId`/`vTabletGroupId`, restores mappings on leader, blocks shard-group deletion if bound, and can create/update virtual tablets via `StarOSAgent`.
>   - `StarMgrMetaSyncer`: prevents deleting shard groups bound to storage volumes.
>   - `GlobalStateMgr`: restores storage-volume→vTabletGroup mappings on leader start.
>   - `StarOSAgent`: adds `allocateFilePath(fsId, rootDir)`, `createShardGroupForVirtualTablet()`, and `createShardWithVirtualTabletId(...)`; minor streamline.
> - **Thrift/API**:
>   - `AgentService`: extends `TReplicateSnapshotRequest` with lake/virtual tablet fields.
>   - `FrontendService`: enhances `TTableReplicationRequest` with source run mode/volume/service/db/table IDs and adds `src_partition_id` to partition info.
>   - `Types`: introduces `TDatabaseId`.
> - **Serialization**:
>   - `GsonUtils`: registers runtime adapter for `ReplicationJob`/`LakeReplicationJob`.
>   - `StorageVolume`: persists v-shard IDs in filestore properties; round-trip parsing.
> - **Tests**:
>   - Adds UTs for StarOS agent new APIs, volume manager virtual tablet mapping/creation, Lake replication job flow, and replication job serialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 918c3b82d060e09793a26541784c771cce78a36c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->