### PR TITLE
[Feature] Cross-cluster replication for cloud-native table (Part-2 replication implementation in BE)

### DIFF
--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -41,6 +41,7 @@
 #include "storage/lake/filenames.h"
 #include "storage/olap_common.h"
 #include "util/defer_op.h"
+#include "util/lru_cache.h"
 #include "util/stopwatch.hpp"
 #include "util/string_parser.hpp"
 
@@ -294,7 +295,10 @@ private:
 
 class StarletFileSystem : public FileSystem {
 public:
-    StarletFileSystem() { staros::starlet::fslib::register_builtin_filesystems(); }
+    StarletFileSystem(std::shared_ptr<staros::starlet::fslib::FileSystem> shard_fs = nullptr)
+            : _shard_fs(std::move(shard_fs)) {
+        staros::starlet::fslib::register_builtin_filesystems();
+    }
     ~StarletFileSystem() override = default;
 
     StarletFileSystem(const StarletFileSystem&) = delete;
@@ -613,15 +617,77 @@ public:
 
 private:
     absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>> get_shard_filesystem(int64_t shard_id) {
+        if (_shard_fs != nullptr) {
+            return _shard_fs;
+        }
         return g_worker->get_shard_filesystem(shard_id, _conf);
     }
 
 private:
     staros::starlet::fslib::Configuration _conf;
+    std::shared_ptr<staros::starlet::fslib::FileSystem> _shard_fs;
 };
 
 std::unique_ptr<FileSystem> new_fs_starlet() {
     return std::make_unique<StarletFileSystem>();
+}
+
+// Deleter for LRU cache entries
+static void shard_fs_cache_deleter(const CacheKey& /*key*/, void* value) {
+    delete static_cast<std::shared_ptr<staros::starlet::fslib::FileSystem>*>(value);
+}
+
+std::shared_ptr<FileSystem> new_fs_starlet(int64_t shard_id) {
+    // Lazy initialization of cache (thread-safe)
+    static std::once_flag init_flag;
+    static std::unique_ptr<Cache> shard_fs_cache;
+    std::call_once(init_flag, []() {
+        // The cache here is used to store fslib's shard fs which is used for cross cluster migration,
+        // where each shard fs correspond to one storage volume on source cluster.
+        // We chose a small cache capacity size here, with expect that normally very few storage volumes are used.
+        constexpr size_t kDefaultCacheCapacity = 1024 * 10; // ~10 entries
+        shard_fs_cache.reset(new_lru_cache(kDefaultCacheCapacity));
+    });
+
+    // Build cache key from shard_id
+    std::string key_str = std::to_string(shard_id);
+    CacheKey cache_key(key_str);
+
+    // Try cache lookup
+    Cache::Handle* handle = shard_fs_cache->lookup(cache_key);
+    if (handle != nullptr) {
+        auto* cached_ptr =
+                static_cast<std::shared_ptr<staros::starlet::fslib::FileSystem>*>(shard_fs_cache->value(handle));
+        std::shared_ptr<staros::starlet::fslib::FileSystem> shard_fs = *cached_ptr;
+        shard_fs_cache->release(handle);
+        return std::make_shared<StarletFileSystem>(shard_fs);
+    }
+
+    // Cache miss - create new shard filesystem
+    staros::starlet::fslib::Configuration conf;
+    absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>> fs_st =
+            g_worker->get_shard_filesystem(shard_id, conf);
+    if (!fs_st.ok()) {
+        LOG(WARNING) << "Failed to get shard filesystem, shard_id: " << shard_id << ", error: " << fs_st.status();
+        return nullptr;
+    }
+
+    std::shared_ptr<staros::starlet::fslib::FileSystem> shard_fs = fs_st.value();
+
+    // Insert into cache
+    auto* cache_value = new std::shared_ptr<staros::starlet::fslib::FileSystem>(shard_fs);
+    handle = shard_fs_cache->insert(cache_key, cache_value, 1, shard_fs_cache_deleter);
+    if (handle != nullptr) {
+        shard_fs_cache->release(handle);
+    } else {
+        delete cache_value;
+    }
+
+    LOG(INFO) << "Created new shard filesystem, shard_id: " << shard_id
+              << ", cache_inserts: " << shard_fs_cache->get_insert_count()
+              << ", cache_memory: " << shard_fs_cache->get_memory_usage() << " bytes";
+
+    return std::make_shared<StarletFileSystem>(shard_fs);
 }
 } // namespace starrocks
 

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -641,7 +641,7 @@ std::shared_ptr<FileSystem> new_fs_starlet(int64_t shard_id) {
     // The cache here is used to store fslib's shard fs which is used for cross cluster migration,
     // where each shard fs correspond to one storage volume on source cluster.
     // We chose a small cache capacity size here, with expect that normally very few storage volumes are used.
-    constexpr size_t kDefaultCacheCapacity = 1024 * 10; // ~10 entries
+    constexpr size_t kDefaultCacheCapacity = 1024 * 10;
     static std::unique_ptr<Cache> g_shard_fs_cache(new_lru_cache(kDefaultCacheCapacity));
 
     // Build cache key from shard_id

--- a/be/src/fs/fs_starlet.h
+++ b/be/src/fs/fs_starlet.h
@@ -39,6 +39,10 @@ StatusOr<std::pair<std::string, int64_t>> parse_starlet_uri(std::string_view uri
 
 std::unique_ptr<FileSystem> new_fs_starlet();
 
+// starlet fs used for virtual shard id, a new fs starlet will be created on each call
+// to prevent shard fs re-create everty time, we will reuse the lru cache framework to cache the shard fs
+std::shared_ptr<FileSystem> new_fs_starlet(int64_t virtual_shard_id);
+
 } // namespace starrocks
 
 #endif // USE_STAROS

--- a/be/src/fs/fs_util.h
+++ b/be/src/fs/fs_util.h
@@ -168,6 +168,24 @@ inline StatusOr<int64_t> copy_file(const std::string& src_path, const std::strin
     return ncopy;
 }
 
+// copy the file from src path to dest path, it will overwrite the existing files
+inline Status copy_file(const std::string& src_path, std::shared_ptr<FileSystem> src_fs, const std::string& dst_path,
+                        std::shared_ptr<FileSystem> dst_fs, size_t buffer_size = 8192) {
+    TEST_ERROR_POINT("fs::copy_file");
+    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    if (src_fs == nullptr) {
+        ASSIGN_OR_RETURN(src_fs, FileSystem::CreateSharedFromString(src_path));
+    }
+    if (dst_fs == nullptr) {
+        ASSIGN_OR_RETURN(dst_fs, FileSystem::CreateSharedFromString(dst_path));
+    }
+    ASSIGN_OR_RETURN(auto src_file, src_fs->new_sequential_file(src_path));
+    ASSIGN_OR_RETURN(auto dst_file, dst_fs->new_writable_file(opts, dst_path));
+    RETURN_IF_ERROR(copy(src_file.get(), dst_file.get(), buffer_size));
+    RETURN_IF_ERROR(dst_file->close());
+    return Status::OK();
+}
+
 // copy the file range [offset, offset + size] from src path to dest path, it will overwrite the existing files
 inline Status copy_file_by_range(const std::string& src_path, const std::string& dst_path, int64_t offset,
                                  int64_t size) {

--- a/be/src/fs/fs_util.h
+++ b/be/src/fs/fs_util.h
@@ -168,12 +168,12 @@ inline StatusOr<int64_t> copy_file(const std::string& src_path, const std::strin
     return ncopy;
 }
 
-// copy the file from src path to dest path, it will overwrite the existing files
+// copy the file from src path to dest path with custom WritableFileOptions.
+// This overload supports encryption by passing encryption_info in opts.
 inline StatusOr<int64_t> copy_file(const std::string& src_path, std::shared_ptr<FileSystem> src_fs,
                                    const std::string& dst_path, std::shared_ptr<FileSystem> dst_fs,
-                                   size_t buffer_size = 8192) {
+                                   const WritableFileOptions& opts, size_t buffer_size = 8192) {
     TEST_ERROR_POINT("fs::copy_file");
-    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
     if (src_fs == nullptr) {
         ASSIGN_OR_RETURN(src_fs, FileSystem::CreateSharedFromString(src_path));
     }
@@ -182,7 +182,6 @@ inline StatusOr<int64_t> copy_file(const std::string& src_path, std::shared_ptr<
     }
     ASSIGN_OR_RETURN(auto src_file, src_fs->new_sequential_file(src_path));
     ASSIGN_OR_RETURN(auto dst_file, dst_fs->new_writable_file(opts, dst_path));
-    // record file size
     ASSIGN_OR_RETURN(auto file_size, copy(src_file.get(), dst_file.get(), buffer_size));
     RETURN_IF_ERROR(dst_file->close());
     return file_size;

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -197,6 +197,7 @@ set(STORAGE_FILES
     lake/pk_tablet_sst_writer.cpp
     lake/primary_key_compaction_policy.cpp
     lake/replication_txn_manager.cpp
+    lake/lake_replication_txn_manager.cpp
     lake/rowset.cpp
     lake/schema_change.cpp
     lake/starlet_location_provider.cpp

--- a/be/src/storage/file_stream_converter.h
+++ b/be/src/storage/file_stream_converter.h
@@ -39,6 +39,10 @@ public:
 
     uint64_t output_file_size() const { return _output_file->size(); }
 
+    // Get the final output file size after close() is called
+    // Returns 0 if close() hasn't been called yet
+    uint64_t final_output_file_size() const { return _final_output_file_size; }
+
     virtual Status append(const void* data, size_t size) {
         return _output_file->append(Slice((const char*)data, size));
     }
@@ -49,6 +53,7 @@ public:
                          << ", output_file_size: " << _output_file->size();
             return Status::Corruption("File size not matched, input_file_size");
         }
+        _final_output_file_size = _output_file->size();
         return _output_file->close();
     }
 
@@ -56,6 +61,7 @@ protected:
     const std::string _input_file_name;
     const uint64_t _input_file_size;
     std::unique_ptr<WritableFile> _output_file;
+    uint64_t _final_output_file_size = 0;
 };
 
 } // namespace starrocks

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -167,9 +167,10 @@ inline std::string extract_uuid_from(std::string_view file_name) {
     const size_t uuid_start = TXN_ID_LENGTH + 1;
     const size_t uuid_length = dot_pos - uuid_start;
 
-    // standard UUID format: 8-4-4-4-12 = 36 bit
+    // standard UUID format: 8-4-4-4-12 = 36 characters
     if (uuid_length != 36) {
         LOG(WARNING) << "Invalid UUID length: " << uuid_length << " in file: " << file_name;
+        return {};
     }
 
     return std::string(file_name.substr(uuid_start, uuid_length));

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -1,0 +1,522 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/lake_replication_txn_manager.h"
+
+#include "agent/master_info.h"
+#include "fs/fs_starlet.h"
+#include "fs/fs_util.h"
+#include "fs/key_cache.h"
+#include "gen_cpp/Types_constants.h"
+#include "gen_cpp/lake_types.pb.h"
+#include "persistent_index_sstable.h"
+#include "replication_txn_manager.h"
+#include "storage/lake/filenames.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/segment_stream_converter.h"
+#include "util/dynamic_cache.h"
+#include "vacuum.h"
+
+namespace starrocks::lake {
+
+Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicateSnapshotRequest& request) {
+    auto src_tablet_id = request.src_tablet_id;
+    auto src_visible_version = request.src_visible_version;
+    auto src_db_id = request.src_db_id;
+    auto src_table_id = request.src_table_id;
+    auto src_partition_id = request.src_partition_id;
+
+    auto data_version = request.data_version;
+    auto target_visible_version = request.visible_version;
+    auto target_tablet_id = request.tablet_id;
+
+    auto txn_id = request.transaction_id;
+    auto virtual_tablet_id = request.virtual_tablet_id;
+
+    LOG(INFO) << "Start to replicate lake remote storage, txn_id: " << txn_id << ", tablet_id: " << target_tablet_id
+              << ", src_tablet_id: " << src_tablet_id << ", src_db_id: " << src_db_id
+              << ", src_table_id: " << src_table_id << ", src_partition_id: " << src_partition_id
+              << ", visible_version: " << target_visible_version << ", data_version: " << data_version
+              << ", virtual_tablet_id: " << virtual_tablet_id << ", src_visible_version: " << src_visible_version;
+
+    std::vector<Version> missed_versions;
+    for (auto v = data_version + 1; v <= src_visible_version; ++v) {
+        missed_versions.emplace_back(v, v);
+    }
+    if (UNLIKELY(missed_versions.empty())) {
+        LOG(WARNING) << "Replicate lake remote storage skipped, no missing version"
+                     << ", txn_id: " << txn_id << ", tablet_id: " << target_tablet_id
+                     << ", src_tablet_id: " << src_tablet_id << ", visible_version: " << target_visible_version
+                     << ", data_version: " << data_version << ", src_visible_version: " << src_visible_version;
+        return Status::Corruption("No missing version");
+    }
+
+#ifndef BE_TEST
+    auto src_meta_dir =
+            _remote_location_provider->metadata_root_location(src_tablet_id, src_db_id, src_table_id, src_partition_id);
+    auto src_data_dir =
+            _remote_location_provider->segment_root_location(src_tablet_id, src_db_id, src_table_id, src_partition_id);
+    // `shared_src_fs` is used to access storage of src cluster
+    auto shared_src_fs = new_fs_starlet(virtual_tablet_id);
+    ASSIGN_OR_RETURN(auto src_tablet_meta,
+                     build_source_tablet_meta(src_tablet_id, src_visible_version, src_meta_dir, shared_src_fs));
+#else
+    auto src_meta_dir = "test_lake_replication/meta";
+    auto src_data_dir = "test_lake_replication/data";
+    auto shared_src_fs_st_or = FileSystem::CreateSharedFromString(src_data_dir);
+    auto shared_src_fs = shared_src_fs_st_or.value();
+    ASSIGN_OR_RETURN(auto src_tablet_meta,
+                     _tablet_manager->get_tablet_metadata(src_tablet_id, src_visible_version, false, 0, nullptr));
+#endif
+
+    LOG(INFO) << "Lake replicate storage task, built source meta and data dir, meta dir: " << src_meta_dir
+              << ", data dir: " << src_data_dir << ", txn_id: " << txn_id << ", src_tablet_id: " << src_tablet_id
+              << ", tablet_id: " << target_tablet_id;
+
+    // `file_locations` is the mapping between source and target file locations,
+    // it contains all files that need to replicate from source to target storage
+    std::map<std::string, std::string> file_locations;
+    // `filename_map` is another mapping between source and target file name,
+    // and it's borrowed from lake::ReplicationTxnManager
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+    // `segment_name_to_size_map` is the mapping between segment file name to its file size
+    // we use the `segment_size` field in rowset metadata to get the file size.
+    // for history reasons, the `segment_size` field is not always present, so the resulting map is not guaranteed to
+    // have all segment file sizes.
+    std::unordered_map<std::string, size_t> segment_name_to_size_map;
+
+    auto txn_log = std::make_shared<TxnLog>();
+
+    // fully copy the tablet meta of source cluster
+    // only generate and replace file names to adapt for target storage
+    ASSIGN_OR_RETURN(auto new_metadata, convert_and_build_new_tablet_meta(
+                                                src_tablet_meta, src_tablet_id, target_tablet_id, txn_id, data_version,
+                                                src_data_dir, segment_name_to_size_map, file_locations, filename_map));
+    txn_log->mutable_op_replication()->mutable_tablet_metadata()->CopyFrom(*new_metadata);
+
+    VLOG(3) << "Lake replicate storage task, have built new tablet meta, tablet_id: " << target_tablet_id
+            << ", txn_id:" << txn_id << ", start calculate column unique id map..";
+    // calc column unique id to adapt for fast schema change
+    const TabletSchemaPB* source_schema_pb = &src_tablet_meta->schema();
+    if (source_schema_pb == nullptr) {
+        LOG(WARNING) << "Failed to get source schema, tablet source tablet: " << src_tablet_id
+                     << ", target tablet: " << target_tablet_id;
+        return Status::Corruption("Failed to get source schema");
+    }
+    std::unordered_map<uint32_t, uint32_t> column_unique_id_map;
+    ASSIGN_OR_RETURN(auto target_tablet, _tablet_manager->get_tablet(target_tablet_id));
+    ASSIGN_OR_RETURN(auto target_tablet_metadata, target_tablet.get_metadata(target_visible_version));
+    ReplicationUtils::calc_column_unique_id_map(source_schema_pb->column(), target_tablet_metadata->schema().column(),
+                                                &column_unique_id_map);
+
+    VLOG(3) << "Lake replicate storage task, start to replicate files from src to target cluster, txn_id: " << txn_id;
+    std::vector<std::string> files_to_delete;
+    CancelableDefer clean_files([&files_to_delete]() { lake::delete_files_async(std::move(files_to_delete)); });
+
+    auto file_converters = lake::ReplicationTxnManager::build_file_converters(_tablet_manager, request, filename_map,
+                                                                              column_unique_id_map, files_to_delete);
+    for (const auto& pair : filename_map) {
+        const auto& src_file_name = pair.first;
+        auto src_file_location = join_path(src_data_dir, src_file_name);
+        auto it = file_locations.find(src_file_location);
+        if (it == file_locations.end()) {
+            return Status::Corruption("Found invalid file location, src file location: " + src_file_location);
+        }
+        const auto& target_file_location = it->second;
+
+        VLOG(3) << "Lake replicate storage task, start to replicate file, src file: " << src_file_location
+                << ", target: " << target_file_location;
+        // check if need to convert segment file while downloading
+        if (is_segment(src_file_name) && !column_unique_id_map.empty()) {
+            // file_size might be empty, in that case we'll get it while downloading the file
+            auto file_size = segment_name_to_size_map[src_file_name];
+            RETURN_IF_ERROR(ReplicationUtils::download_lake_segment_file(src_file_location, src_file_name, file_size,
+                                                                         shared_src_fs, file_converters));
+        } else {
+            // since we can't easily get the file size for non-segment files, here we just use fs::copy operation
+            RETURN_IF_ERROR(
+                    fs::copy_file(src_file_location, shared_src_fs, target_file_location, nullptr, 1024 * 1024));
+        }
+        LOG(INFO) << "Finished to replicate lake remote file, src file: " << src_file_location
+                  << ", target: " << target_file_location;
+    }
+
+    // write txn log
+    txn_log->set_tablet_id(target_tablet_id);
+    txn_log->set_txn_id(txn_id);
+
+    auto* txn_meta = txn_log->mutable_op_replication()->mutable_txn_meta();
+    txn_meta->set_tablet_id(target_tablet_id);
+    txn_meta->set_txn_id(txn_id);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_visible_version(target_visible_version);
+    txn_meta->set_data_version(data_version);
+    txn_meta->set_snapshot_version(src_visible_version);
+    // mak full replication for shared-data cluster migration
+    txn_meta->set_incremental_snapshot(false);
+
+    RETURN_IF_ERROR(_tablet_manager->put_txn_log(txn_log));
+
+    LOG(INFO) << "Replicated lake remote files, txn_id: " << txn_id << ", tablet_id: " << target_tablet_id
+              << ", src_tablet_id: " << src_tablet_id << ", src_db_id: " << src_db_id
+              << ", src_table_id: " << src_table_id << ", src_partition_id: " << src_partition_id
+              << ", visible_version: " << target_visible_version << ", data_version: " << data_version
+              << ", virtual_tablet_id: " << virtual_tablet_id << ", src_visible_version: " << src_visible_version;
+
+    clean_files.cancel();
+    return Status::OK();
+}
+
+StatusOr<TabletMetadataPtr> LakeReplicationTxnManager::build_source_tablet_meta(
+        int64_t src_tablet_id, int64_t version, const std::string& meta_dir,
+        const std::shared_ptr<FileSystem>& shared_src_fs) {
+    LOG(INFO) << "Lake replicate storage task, building source tablet meta for tablet: " << src_tablet_id
+              << ", version: " << version;
+    auto src_metadata_file_name = tablet_metadata_filename(src_tablet_id, version);
+    auto src_tablet_meta_path = join_path(meta_dir, src_metadata_file_name);
+    auto src_tablet_meta_or = _tablet_manager->get_tablet_metadata(src_tablet_meta_path, false, 0, shared_src_fs);
+    if (!src_tablet_meta_or.ok()) {
+        LOG(WARNING) << "Lake replicate storage task, failed to build source tablet meta for version: " << version
+                     << ", src_tablet_id: " << src_tablet_id << ", error: " << src_tablet_meta_or;
+        return src_tablet_meta_or;
+    }
+    return src_tablet_meta_or.value();
+}
+
+Status LakeReplicationTxnManager::build_existed_filename_uuids_map(
+        const TabletMetadataPtr& target_data_version_tablet_meta,
+        std::unordered_map<std::string, std::pair<std::string, std::string>>& existed_filename_uuids) {
+    // Collect UUIDs from rowsets (segments and del files)
+    for (const auto& rowset : target_data_version_tablet_meta->rowsets()) {
+        // the condition is very strict, because currently encryption meta for each segment is not bind to the segment
+        // we can only find the encryption meta by index, so the precondition is that the size of segment files
+        // is strictly equal to the size of encryption metas
+        bool has_encryption_meta = rowset.segments_size() == rowset.segment_encryption_metas_size();
+        for (size_t i = 0; i < rowset.segments_size(); ++i) {
+            const auto& segment_name = rowset.segments(i);
+            if (has_encryption_meta) {
+                existed_filename_uuids.emplace(extract_uuid_from(segment_name),
+                                               std::make_pair(segment_name, rowset.segment_encryption_metas(i)));
+            } else {
+                existed_filename_uuids.emplace(extract_uuid_from(segment_name), std::make_pair(segment_name, ""));
+            }
+        }
+        for (const auto& del : rowset.del_files()) {
+            const auto& del_filename = del.name();
+            existed_filename_uuids.emplace(extract_uuid_from(del_filename),
+                                           std::make_pair(del_filename, del.encryption_meta()));
+        }
+    }
+
+    // Collect UUIDs from SST files
+    if (target_data_version_tablet_meta->has_sstable_meta()) {
+        const auto& dest_meta = target_data_version_tablet_meta->sstable_meta();
+        for (const auto& sst : dest_meta.sstables()) {
+            const auto& sst_filename = sst.filename();
+            existed_filename_uuids.emplace(extract_uuid_from(sst_filename),
+                                           std::make_pair(sst_filename, sst.encryption_meta()));
+        }
+    }
+
+    // Collect UUIDs from delvec files
+    if (target_data_version_tablet_meta->has_delvec_meta()) {
+        const auto& dest_meta = target_data_version_tablet_meta->delvec_meta();
+        for (const auto& [_, file_meta_pb] : dest_meta.version_to_file()) {
+            const auto& delvec_filename = file_meta_pb.name();
+            // Note: delvec files don't have separate encryption metas in current implementation
+            existed_filename_uuids.emplace(extract_uuid_from(delvec_filename), std::make_pair(delvec_filename, ""));
+        }
+    }
+
+    // Collect UUIDs from dcg files
+    if (target_data_version_tablet_meta->has_dcg_meta()) {
+        const auto& dcg_meta = target_data_version_tablet_meta->dcg_meta();
+        for (const auto& [_, dcg_ver_pb] : dcg_meta.dcgs()) {
+            bool has_encryption_meta = dcg_ver_pb.column_files_size() == dcg_ver_pb.encryption_metas_size();
+            for (int i = 0; i < dcg_ver_pb.column_files_size(); ++i) {
+                const auto& dcg_filename = dcg_ver_pb.column_files(i);
+                if (has_encryption_meta) {
+                    existed_filename_uuids.emplace(extract_uuid_from(dcg_filename),
+                                                   std::make_pair(dcg_filename, dcg_ver_pb.encryption_metas(i)));
+                } else {
+                    existed_filename_uuids.emplace(extract_uuid_from(dcg_filename), std::make_pair(dcg_filename, ""));
+                }
+            }
+        }
+    }
+
+    return Status::OK();
+}
+
+StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_and_build_new_tablet_meta(
+        const TabletMetadataPtr& src_tablet_meta, int64_t src_tablet_id, int64_t target_tablet_id,
+        TTransactionId txn_id, int64_t data_version, const std::string& src_data_dir,
+        std::unordered_map<std::string, size_t>& segment_name_to_size_map,
+        std::map<std::string, std::string>& file_locations,
+        std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map) {
+    LOG(INFO) << "Lake replicate storage task, building new tablet meta for tablet: " << target_tablet_id
+              << ", src_tablet_id: " << src_tablet_id << ", txn_id: " << txn_id << ", data_version: " << data_version;
+    // find all files that already replicated to target storage in previous txns
+    ASSIGN_OR_RETURN(auto target_data_version_tablet_meta,
+                     _tablet_manager->get_tablet_metadata(target_tablet_id, data_version, false, 0, nullptr));
+    // `existed_filename_uuids` represented files that already replicated to target storage in previous txns
+    // <uuid, pair<existed_filename, encryption_meta>>
+    std::unordered_map<std::string, std::pair<std::string, std::string>> existed_filename_uuids;
+    RETURN_IF_ERROR(build_existed_filename_uuids_map(target_data_version_tablet_meta, existed_filename_uuids));
+
+    VLOG(3) << "Lake replicate storage task, found " << existed_filename_uuids.size() << " existed files";
+    // make new metadata
+    std::shared_ptr<TabletMetadataPB> new_metadata = std::make_shared<TabletMetadataPB>(*src_tablet_meta);
+    // Replace the tablet id with target tablet id
+    new_metadata->set_id(target_tablet_id);
+    new_metadata->mutable_rowsets()->Clear();
+    new_metadata->mutable_dcg_meta()->mutable_dcgs()->clear();
+    new_metadata->mutable_sstable_meta()->Clear();
+
+    // deal with segments and dels
+    for (const auto& src_rowset_meta : src_tablet_meta->rowsets()) {
+        auto new_rowset_meta = new_metadata->add_rowsets();
+        new_rowset_meta->CopyFrom(src_rowset_meta);
+        new_rowset_meta->mutable_segments()->Clear();
+        new_rowset_meta->mutable_segment_encryption_metas()->Clear();
+        // check if segment size is valid
+        auto segment_size_size = src_rowset_meta.segment_size_size();
+        if (segment_size_size > 0) {
+            auto segment_file_size = src_rowset_meta.segments_size();
+            // `segment_size_size` and `segment_file_size` should always be equal
+            if (UNLIKELY(segment_size_size > 0 && segment_size_size != segment_file_size)) {
+                return Status::Corruption(
+                        fmt::format("found invalidate segment_size, src_tablet_id: {}, "
+                                    "rowse_id: {}, segment_size_size: {}, segment_file_size: {}",
+                                    src_tablet_id, src_rowset_meta.id(), segment_size_size, segment_file_size));
+            }
+        }
+
+        // Convert rowset metadata
+        for (int i = 0; i < src_rowset_meta.segments_size(); ++i) {
+            const auto& src_segment_filename = src_rowset_meta.segments(i);
+            std::string final_segment_filename;
+            ASSIGN_OR_RETURN(auto is_existed,
+                             determine_final_filename(src_segment_filename, txn_id, existed_filename_uuids,
+                                                      final_segment_filename, target_tablet_id, src_data_dir,
+                                                      file_locations, filename_map));
+            new_rowset_meta->add_segments(final_segment_filename);
+
+            // Add encryption metadata for files
+            if (config::enable_transparent_data_encryption) {
+                if (!is_existed) {
+                    // segment file doesn't exist, use the newly generated encryption metadata
+                    std::pair<std::string, FileEncryptionPair> pair = filename_map[src_segment_filename];
+                    new_rowset_meta->add_segment_encryption_metas(pair.second.encryption_meta);
+                } else {
+                    // segment file already exists, use the existing encryption metadata from target tablet
+                    auto uuid = extract_uuid_from(src_segment_filename);
+                    auto it = existed_filename_uuids.find(uuid);
+                    if (it != existed_filename_uuids.end()) {
+                        const std::string& existing_encryption_meta = it->second.second;
+                        new_rowset_meta->add_segment_encryption_metas(existing_encryption_meta);
+                    } else {
+                        // should never happend
+                        return Status::Corruption(fmt::format("no existing encryption metadata found for file: {}",
+                                                              src_segment_filename));
+                    }
+                }
+            }
+
+            // build segment_name_to_size_map
+            if (segment_size_size > 0) {
+                auto segment_size = src_rowset_meta.segment_size(i);
+                segment_name_to_size_map.emplace(final_segment_filename, segment_size);
+            }
+        }
+
+        // Convert dels
+        for (int i = 0; i < src_rowset_meta.del_files_size(); ++i) {
+            const DelfileWithRowsetId& src_del = src_rowset_meta.del_files(i);
+            const auto& src_del_filename = src_del.name();
+            std::string final_del_filename;
+            ASSIGN_OR_RETURN(auto is_existed, determine_final_filename(src_del_filename, txn_id, existed_filename_uuids,
+                                                                       final_del_filename, target_tablet_id,
+                                                                       src_data_dir, file_locations, filename_map));
+            auto* new_del = new_rowset_meta->add_del_files();
+            new_del->CopyFrom(src_del);
+            new_del->set_name(final_del_filename);
+
+            if (config::enable_transparent_data_encryption) {
+                if (!is_existed) {
+                    // del doesn't exist, use the newly generated encryption metadata
+                    std::pair<std::string, FileEncryptionPair> pair = filename_map[src_del_filename];
+                    new_del->set_encryption_meta(pair.second.encryption_meta);
+                } else {
+                    // del already exists, use the existing encryption metadata from target tablet
+                    auto uuid = extract_uuid_from(src_del_filename);
+                    auto it = existed_filename_uuids.find(uuid);
+                    if (it != existed_filename_uuids.end()) {
+                        const std::string& existing_encryption_meta = it->second.second;
+                        new_del->set_encryption_meta(existing_encryption_meta);
+                    }
+                }
+            }
+        }
+    }
+
+    // deal with sstable
+    if (src_tablet_meta->has_sstable_meta()) {
+        PersistentIndexSstableMetaPB* dest_meta = new_metadata->mutable_sstable_meta();
+        dest_meta->CopyFrom(src_tablet_meta->sstable_meta());
+        for (int i = 0; i < dest_meta->sstables_size(); ++i) {
+            PersistentIndexSstablePB* sst = dest_meta->mutable_sstables(i);
+            const auto& src_sst_filename = sst->filename();
+            std::string final_sst_filename;
+            ASSIGN_OR_RETURN(auto is_existed, determine_final_filename(src_sst_filename, txn_id, existed_filename_uuids,
+                                                                       final_sst_filename, target_tablet_id,
+                                                                       src_data_dir, file_locations, filename_map));
+            sst->set_filename(final_sst_filename);
+
+            if (config::enable_transparent_data_encryption) {
+                if (!is_existed) {
+                    // sst doesn't exist, use the newly generated encryption metadata
+                    std::pair<std::string, FileEncryptionPair> pair = filename_map[src_sst_filename];
+                    sst->set_encryption_meta(pair.second.encryption_meta);
+                } else {
+                    // sst already exists, use the existing encryption metadata from target tablet
+                    auto uuid = extract_uuid_from(src_sst_filename);
+                    auto it = existed_filename_uuids.find(uuid);
+                    if (it != existed_filename_uuids.end()) {
+                        const std::string& existing_encryption_meta = it->second.second;
+                        sst->set_encryption_meta(existing_encryption_meta);
+                    }
+                }
+            }
+        }
+    }
+
+    // deal with delvec
+    if (src_tablet_meta->has_delvec_meta()) {
+        DelvecMetadataPB* dest_meta = new_metadata->mutable_delvec_meta();
+        dest_meta->CopyFrom(src_tablet_meta->delvec_meta());
+        for (const auto& [version, file_meta_pb] : dest_meta->version_to_file()) {
+            auto src_delvec_filename = file_meta_pb.name();
+            std::string final_delvec_filename;
+            ASSIGN_OR_RETURN(
+                    auto is_existed,
+                    determine_final_filename(src_delvec_filename, txn_id, existed_filename_uuids, final_delvec_filename,
+                                             target_tablet_id, src_data_dir, file_locations, filename_map));
+            auto& item = (*dest_meta->mutable_version_to_file())[version];
+            item.set_name(final_delvec_filename);
+
+            if (config::enable_transparent_data_encryption) {
+                if (!is_existed) {
+                    // del file doesn't exist, use the newly generated encryption metadata
+                    std::pair<std::string, FileEncryptionPair> pair = filename_map[src_delvec_filename];
+                    item.set_encryption_meta(pair.second.encryption_meta);
+                } else {
+                    // del file already exists, use the existing encryption metadata from target tablet
+                    auto uuid = extract_uuid_from(src_delvec_filename);
+                    auto it = existed_filename_uuids.find(uuid);
+                    if (it != existed_filename_uuids.end()) {
+                        const std::string& existing_encryption_meta = it->second.second;
+                        item.set_encryption_meta(existing_encryption_meta);
+                    }
+                }
+            }
+        }
+    }
+
+    // deal with dcg
+    if (src_tablet_meta->has_dcg_meta()) {
+        DeltaColumnGroupMetadataPB* dest_meta = new_metadata->mutable_dcg_meta();
+        dest_meta->CopyFrom(src_tablet_meta->dcg_meta());
+        for (auto& [segment_id, dcg_ver_pb] : *dest_meta->mutable_dcgs()) {
+            for (int i = 0; i < dcg_ver_pb.column_files_size(); ++i) {
+                auto src_dcg_filename = dcg_ver_pb.column_files(i);
+                std::string final_dcg_filename;
+                ASSIGN_OR_RETURN(
+                        auto is_existed,
+                        determine_final_filename(src_dcg_filename, txn_id, existed_filename_uuids, final_dcg_filename,
+                                                 target_tablet_id, src_data_dir, file_locations, filename_map));
+                dcg_ver_pb.set_column_files(i, final_dcg_filename);
+
+                if (config::enable_transparent_data_encryption) {
+                    if (!is_existed) {
+                        // dcg file doesn't exist, use the newly generated encryption metadata
+                        std::pair<std::string, FileEncryptionPair> pair = filename_map[src_dcg_filename];
+                        if (dcg_ver_pb.encryption_metas_size() > i) {
+                            dcg_ver_pb.set_encryption_metas(i, pair.second.encryption_meta);
+                        } else {
+                            dcg_ver_pb.add_encryption_metas(pair.second.encryption_meta);
+                        }
+                    } else {
+                        // dcg file already exists, use the existing encryption metadata from target tablet
+                        auto uuid = extract_uuid_from(src_dcg_filename);
+                        auto it = existed_filename_uuids.find(uuid);
+                        if (it != existed_filename_uuids.end()) {
+                            const std::string& existing_encryption_meta = it->second.second;
+                            if (dcg_ver_pb.encryption_metas_size() > i) {
+                                dcg_ver_pb.set_encryption_metas(i, existing_encryption_meta);
+                            } else {
+                                dcg_ver_pb.add_encryption_metas(existing_encryption_meta);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return new_metadata;
+}
+
+StatusOr<bool> LakeReplicationTxnManager::determine_final_filename(
+        const std::string& src_filename, TTransactionId txn_id,
+        const std::unordered_map<std::string, std::pair<std::string, std::string>>& existed_filename_uuids,
+        std::string& final_filename, const int64_t target_tablet_id, const std::string& src_data_dir,
+        std::map<std::string, std::string>& file_locations,
+        std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map) {
+    auto uuid = extract_uuid_from(src_filename);
+    auto it = existed_filename_uuids.find(uuid);
+    if (it != existed_filename_uuids.end()) {
+        // UUID exists, use the existing target filename
+        final_filename = it->second.first; // pair.first is the filename
+        LOG(INFO) << "File: " << src_filename
+                  << " already exists on target cluster, use existing target filename: " << final_filename;
+        return true;
+    }
+
+    // UUID not exists, generate new filename
+    final_filename = gen_filename_from(txn_id, src_filename);
+    if (UNLIKELY(final_filename.empty())) {
+        return Status::Corruption("Failed to generate new filename from: " + src_filename);
+    }
+    LOG(INFO) << "Generated new file: " << final_filename << " for src file: " << src_filename;
+
+    // Build file_locations map
+    auto target_file_path = _tablet_manager->segment_location(target_tablet_id, final_filename);
+    file_locations.emplace(join_path(src_data_dir, src_filename), target_file_path);
+
+    // Build filename_map
+    FileEncryptionPair encryption_pair;
+    if (config::enable_transparent_data_encryption) {
+        ASSIGN_OR_RETURN(encryption_pair, KeyCache::instance().create_encryption_meta_pair_using_current_kek());
+    }
+    auto pair = filename_map.emplace(src_filename, std::pair(final_filename, std::move(encryption_pair)));
+    if (!pair.second) {
+        return Status::Corruption("Duplicated file: " + pair.first->first);
+    }
+    return false;
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/lake_replication_txn_manager.h
+++ b/be/src/storage/lake/lake_replication_txn_manager.h
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common/status.h"
+#include "fs/encryption.h"
+#include "gen_cpp/AgentService_types.h"
+#include "storage/lake/remote_starlet_location_provider.h"
+#include "storage/lake/tablet_metadata.h"
+#include "storage/replication_utils.h"
+
+namespace starrocks {
+struct FileEncryptionPair;
+class TabletMetadataPB;
+class FileSystem;
+} // namespace starrocks
+
+using starrocks::FileConverterCreatorFunc;
+namespace starrocks::lake {
+
+class TabletManager;
+
+class LakeReplicationTxnManager {
+public:
+    explicit LakeReplicationTxnManager(lake::TabletManager* tablet_manager)
+            : _tablet_manager(tablet_manager),
+              _remote_location_provider(std::make_unique<lake::RemoteStarletLocationProvider>()) {}
+
+    Status replicate_lake_remote_storage(const TReplicateSnapshotRequest& request);
+
+    StatusOr<TabletMetadataPtr> build_source_tablet_meta(int64_t src_tablet_id, int64_t version,
+                                                         const std::string& meta_dir,
+                                                         const std::shared_ptr<FileSystem>& shared_src_fs);
+
+    // Helper function to build existed filename UUIDs map from target tablet metadata
+    // For files that replicated from source storage, we keep the `uuid` part of file name, and use it to decide if the file
+    // is already replicated to target storage. Map from UUID to target filename.
+    // Also, in order to support file encryption, we also need to keep the encryption meta.
+    Status build_existed_filename_uuids_map(
+            const TabletMetadataPtr& target_data_version_tablet_meta,
+            std::unordered_map<std::string, std::pair<std::string, std::string>>& existed_filename_uuids);
+
+    // Helper function to create replication txn log with converted metadata
+    StatusOr<std::shared_ptr<TabletMetadataPB>> convert_and_build_new_tablet_meta(
+            const TabletMetadataPtr& src_tablet_meta, int64_t src_tablet_id, int64_t target_tablet_id,
+            TTransactionId txn_id, int64_t data_version, const std::string& src_data_dir,
+            std::unordered_map<std::string, size_t>& segment_name_to_size_map,
+            std::map<std::string, std::string>& file_locations,
+            std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map);
+
+    // Helper functions for filename conversion and building file mappings
+    StatusOr<bool> determine_final_filename(
+            const std::string& src_filename, TTransactionId txn_id,
+            const std::unordered_map<std::string, std::pair<std::string, std::string>>& existed_filename_uuids,
+            std::string& final_filename, int64_t target_tablet_id, const std::string& src_data_dir,
+            std::map<std::string, std::string>& file_locations,
+            std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map);
+
+private:
+    TabletManager* _tablet_manager;
+    std::unique_ptr<lake::RemoteStarletLocationProvider> _remote_location_provider;
+    std::unordered_map<int64_t, std::shared_ptr<FileSystem>> _faked_starlet_fs_map;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/lake_replication_txn_manager.h
+++ b/be/src/storage/lake/lake_replication_txn_manager.h
@@ -71,13 +71,12 @@ public:
 
     // Update segment sizes in tablet metadata after segment conversion
     // This is needed because segment file size may change after footer rewriting
-    Status update_tablet_metadata_segment_sizes(std::shared_ptr<TabletMetadataPB> tablet_metadata,
+    Status update_tablet_metadata_segment_sizes(const std::shared_ptr<TabletMetadataPB>& tablet_metadata,
                                                 const std::unordered_map<std::string, size_t>& segment_size_changes);
 
 private:
     TabletManager* _tablet_manager;
     std::unique_ptr<lake::RemoteStarletLocationProvider> _remote_location_provider;
-    std::unordered_map<int64_t, std::shared_ptr<FileSystem>> _faked_starlet_fs_map;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/lake_replication_txn_manager.h
+++ b/be/src/storage/lake/lake_replication_txn_manager.h
@@ -53,10 +53,11 @@ public:
             std::unordered_map<std::string, std::pair<std::string, std::string>>& existed_filename_uuids);
 
     // Helper function to create replication txn log with converted metadata
+    // generate and replace file names to adapt for target storage
     StatusOr<std::shared_ptr<TabletMetadataPB>> convert_and_build_new_tablet_meta(
-            const TabletMetadataPtr& src_tablet_meta, int64_t src_tablet_id, int64_t target_tablet_id,
-            TTransactionId txn_id, int64_t data_version, const std::string& src_data_dir,
-            std::unordered_map<std::string, size_t>& segment_name_to_size_map,
+            const TabletMetadataPtr& src_tablet_meta, const TabletMetadataPtr& target_tablet_meta,
+            int64_t src_tablet_id, int64_t target_tablet_id, TTransactionId txn_id, int64_t data_version,
+            const std::string& src_data_dir, std::unordered_map<std::string, size_t>& segment_name_to_size_map,
             std::map<std::string, std::string>& file_locations,
             std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map);
 
@@ -67,6 +68,11 @@ public:
             std::string& final_filename, int64_t target_tablet_id, const std::string& src_data_dir,
             std::map<std::string, std::string>& file_locations,
             std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map);
+
+    // Update segment sizes in tablet metadata after segment conversion
+    // This is needed because segment file size may change after footer rewriting
+    Status update_tablet_metadata_segment_sizes(std::shared_ptr<TabletMetadataPB> tablet_metadata,
+                                                const std::unordered_map<std::string, size_t>& segment_size_changes);
 
 private:
     TabletManager* _tablet_manager;

--- a/be/src/storage/lake/location_provider.h
+++ b/be/src/storage/lake/location_provider.h
@@ -113,7 +113,7 @@ public:
         return join_path(root_location(tablet_id), schema_filename(schema_id));
     }
 
-private:
+protected:
     static std::string join_path(std::string_view parent, std::string_view child) {
         return fmt::format("{}/{}", parent, child);
     }

--- a/be/src/storage/lake/remote_starlet_location_provider.h
+++ b/be/src/storage/lake/remote_starlet_location_provider.h
@@ -1,0 +1,53 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef USE_STAROS
+#pragma once
+
+#include <set>
+#include <string>
+
+#include "gutil/macros.h"
+#include "storage/lake/filenames.h"
+#include "storage/lake/starlet_location_provider.h"
+
+namespace starrocks::lake {
+
+// Used to access locations on remote cluster storage
+class RemoteStarletLocationProvider : public StarletLocationProvider {
+public:
+    RemoteStarletLocationProvider() = default;
+    ~RemoteStarletLocationProvider() override = default;
+
+    DISALLOW_COPY_AND_MOVE(RemoteStarletLocationProvider);
+
+    // build metadata root location using current rule
+    // returned value has following format: `staros://{tablet_id}/db{db_id}/{table_id}/{partition_id}/meta`
+    std::string metadata_root_location(int64_t tablet_id, int64_t db_id, int64_t table_id, int64_t partition_id) {
+        std::string partition_path = fmt::format("db{}/{}/{}", db_id, table_id, partition_id);
+        std::string custom_root_location = join_path(root_location(tablet_id), partition_path);
+        return join_path(custom_root_location, kMetadataDirectoryName);
+    }
+
+    // build metadata root location using current rule
+    // returned value has following format: `staros://{tablet_id}/db{db_id}/{table_id}/{partition_id}/data`
+    std::string segment_root_location(int64_t tablet_id, int64_t db_id, int64_t table_id, int64_t partition_id) {
+        std::string partition_path = fmt::format("db{}/{}/{}", db_id, table_id, partition_id);
+        std::string custom_root_location = join_path(root_location(tablet_id), partition_path);
+        return join_path(custom_root_location, kSegmentDirectoryName);
+    }
+};
+
+} // namespace starrocks::lake
+#endif // USE_STAROS

--- a/be/src/storage/lake/remote_starlet_location_provider.h
+++ b/be/src/storage/lake/remote_starlet_location_provider.h
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef USE_STAROS
 #pragma once
+
+#ifdef USE_STAROS
 
 #include <set>
 #include <string>

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -409,7 +409,7 @@ private:
                 // Same logic for pk and non-pk tables
                 auto old_rowsets = std::move(*_metadata->mutable_rowsets());
 
-                auto copied_tablet_meta = op_replication.tablet_metadata();
+                const auto& copied_tablet_meta = op_replication.tablet_metadata();
                 if (copied_tablet_meta.rowsets_size() > 0) {
                     _metadata->mutable_rowsets()->Clear();
                     _metadata->mutable_rowsets()->CopyFrom(copied_tablet_meta.rowsets());
@@ -433,6 +433,8 @@ private:
                 _metadata->set_next_rowset_id(copied_tablet_meta.next_rowset_id());
                 _metadata->set_cumulative_point(0);
                 old_rowsets.Swap(_metadata->mutable_compaction_inputs());
+
+                _tablet.update_mgr()->unload_primary_index(_tablet.id());
 
                 VLOG(3) << "Apply pk replication log with tablet metadata provided. tablet_id: " << _tablet.id()
                         << ", base_version: " << _base_version << ", new_version: " << _new_version
@@ -841,7 +843,7 @@ private:
                 // Same logic for pk and non-pk tables
                 auto old_rowsets = std::move(*_metadata->mutable_rowsets());
 
-                auto copied_tablet_meta = op_replication.tablet_metadata();
+                const auto& copied_tablet_meta = op_replication.tablet_metadata();
                 if (copied_tablet_meta.rowsets_size() > 0) {
                     _metadata->mutable_rowsets()->Clear();
                     _metadata->mutable_rowsets()->CopyFrom(copied_tablet_meta.rowsets());

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -406,25 +406,32 @@ private:
                       << ", txn_id: " << txn_id;
         } else {
             if (op_replication.has_tablet_metadata()) {
-                // Replace metadata with replication tablet metadata for shared-data cross cluster migration
                 // Same logic for pk and non-pk tables
-                auto old_metadata = std::make_shared<TabletMetadata>(*_metadata);
                 auto old_rowsets = std::move(*_metadata->mutable_rowsets());
 
-                _metadata->CopyFrom(op_replication.tablet_metadata());
-                if (old_metadata->has_prev_garbage_version()) {
-                    _metadata->set_prev_garbage_version(old_metadata->prev_garbage_version());
-                }
-                _metadata->set_commit_time(old_metadata->commit_time());
-                _metadata->set_gtid(old_metadata->gtid());
-
-                if (_metadata->compaction_inputs_size() > 0) {
-                    _metadata->mutable_compaction_inputs()->Clear();
+                auto copied_tablet_meta = op_replication.tablet_metadata();
+                if (copied_tablet_meta.rowsets_size() > 0) {
+                    _metadata->mutable_rowsets()->Clear();
+                    _metadata->mutable_rowsets()->CopyFrom(copied_tablet_meta.rowsets());
                 }
 
-                if (_metadata->orphan_files_size() > 0) {
-                    _metadata->mutable_orphan_files()->Clear();
+                if (copied_tablet_meta.has_dcg_meta()) {
+                    _metadata->mutable_dcg_meta()->Clear();
+                    _metadata->mutable_dcg_meta()->CopyFrom(copied_tablet_meta.dcg_meta());
                 }
+
+                if (copied_tablet_meta.has_sstable_meta()) {
+                    _metadata->mutable_sstable_meta()->Clear();
+                    _metadata->mutable_sstable_meta()->CopyFrom(copied_tablet_meta.sstable_meta());
+                }
+
+                if (copied_tablet_meta.has_delvec_meta()) {
+                    _metadata->mutable_delvec_meta()->Clear();
+                    _metadata->mutable_delvec_meta()->CopyFrom(copied_tablet_meta.delvec_meta());
+                }
+
+                _metadata->set_next_rowset_id(copied_tablet_meta.next_rowset_id());
+                _metadata->set_cumulative_point(0);
                 old_rowsets.Swap(_metadata->mutable_compaction_inputs());
 
                 VLOG(3) << "Apply pk replication log with tablet metadata provided. tablet_id: " << _tablet.id()
@@ -831,25 +838,32 @@ private:
                       << ", txn_id: " << txn_meta.txn_id();
         } else {
             if (op_replication.has_tablet_metadata()) {
-                // Replace metadata with replication tablet metadata for shared-data cross cluster migration
                 // Same logic for pk and non-pk tables
-                auto old_metadata = std::make_shared<TabletMetadata>(*_metadata);
                 auto old_rowsets = std::move(*_metadata->mutable_rowsets());
 
-                _metadata->CopyFrom(op_replication.tablet_metadata());
-                if (old_metadata->has_prev_garbage_version()) {
-                    _metadata->set_prev_garbage_version(old_metadata->prev_garbage_version());
-                }
-                _metadata->set_commit_time(old_metadata->commit_time());
-                _metadata->set_gtid(old_metadata->gtid());
-
-                if (_metadata->compaction_inputs_size() > 0) {
-                    _metadata->mutable_compaction_inputs()->Clear();
+                auto copied_tablet_meta = op_replication.tablet_metadata();
+                if (copied_tablet_meta.rowsets_size() > 0) {
+                    _metadata->mutable_rowsets()->Clear();
+                    _metadata->mutable_rowsets()->CopyFrom(copied_tablet_meta.rowsets());
                 }
 
-                if (_metadata->orphan_files_size() > 0) {
-                    _metadata->mutable_orphan_files()->Clear();
+                if (copied_tablet_meta.has_dcg_meta()) {
+                    _metadata->mutable_dcg_meta()->Clear();
+                    _metadata->mutable_dcg_meta()->CopyFrom(copied_tablet_meta.dcg_meta());
                 }
+
+                if (copied_tablet_meta.has_sstable_meta()) {
+                    _metadata->mutable_sstable_meta()->Clear();
+                    _metadata->mutable_sstable_meta()->CopyFrom(copied_tablet_meta.sstable_meta());
+                }
+
+                if (copied_tablet_meta.has_delvec_meta()) {
+                    _metadata->mutable_delvec_meta()->Clear();
+                    _metadata->mutable_delvec_meta()->CopyFrom(copied_tablet_meta.delvec_meta());
+                }
+
+                _metadata->set_next_rowset_id(copied_tablet_meta.next_rowset_id());
+                _metadata->set_cumulative_point(0);
                 old_rowsets.Swap(_metadata->mutable_compaction_inputs());
 
                 VLOG(3) << "Apply replication log with tablet metadata provided. tablet_id: " << _tablet.id()

--- a/be/src/storage/replication_utils.h
+++ b/be/src/storage/replication_utils.h
@@ -19,6 +19,9 @@
 
 namespace starrocks {
 
+using FileConverterCreatorFunc =
+        std::function<StatusOr<std::unique_ptr<FileStreamConverter>>(const std::string& file_name, uint64_t file_size)>;
+
 class TabletSchemaPB;
 class ReplicationUtils {
 public:
@@ -34,8 +37,7 @@ public:
     static Status download_remote_snapshot(const std::string& host, int32_t http_port, const std::string& remote_token,
                                            const std::string& remote_snapshot_path, TTabletId remote_tablet_id,
                                            TSchemaHash remote_schema_hash,
-                                           const std::function<StatusOr<std::unique_ptr<FileStreamConverter>>(
-                                                   const std::string& file_name, uint64_t file_size)>& file_converters,
+                                           const FileConverterCreatorFunc& file_converters,
                                            DataDir* data_dir = nullptr);
 
     static StatusOr<std::string> download_remote_snapshot_file(const std::string& host, int32_t http_port,
@@ -44,6 +46,10 @@ public:
                                                                TTabletId remote_tablet_id,
                                                                TSchemaHash remote_schema_hash,
                                                                const std::string& file_name, uint64_t timeout_sec);
+
+    static Status download_lake_segment_file(const std::string& src_file_path, const std::string& src_file_name,
+                                             size_t src_file_size, const std::shared_ptr<FileSystem>& src_fs,
+                                             const FileConverterCreatorFunc& file_converters);
 
     static constexpr uint32_t kFakeColumnUniqueId = INT_MAX;
 

--- a/be/src/storage/replication_utils.h
+++ b/be/src/storage/replication_utils.h
@@ -49,7 +49,8 @@ public:
 
     static Status download_lake_segment_file(const std::string& src_file_path, const std::string& src_file_name,
                                              size_t src_file_size, const std::shared_ptr<FileSystem>& src_fs,
-                                             const FileConverterCreatorFunc& file_converters);
+                                             const FileConverterCreatorFunc& file_converters,
+                                             size_t* final_file_size = nullptr);
 
     static constexpr uint32_t kFakeColumnUniqueId = INT_MAX;
 

--- a/be/src/storage/segment_stream_converter.cpp
+++ b/be/src/storage/segment_stream_converter.cpp
@@ -112,6 +112,12 @@ Status SegmentStreamConverter::close() {
 
     RETURN_IF_ERROR(Segment::write_segment_footer(_output_file.get(), segment_footer_pb));
 
+    // Record the final output file size (may differ from input size due to footer changes)
+    _final_output_file_size = _output_file->size();
+
+    LOG(INFO) << "Segment conversion completed, input_file: " << _input_file_name
+              << ", input_size: " << _input_file_size << ", output_size: " << _final_output_file_size;
+
     return _output_file->close();
 }
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -481,6 +481,7 @@ SET(DW_TEST_FILES
     ./storage/lake/compaction_task_context_test.cpp
     ./storage/lake/condition_update_test.cpp
     ./storage/lake/delta_writer_test.cpp
+    ./storage/lake/filenames_test.cpp
     ./storage/lake/lake_data_source_test.cpp
     ./storage/lake/lake_persistent_index_test.cpp
     ./storage/lake/lake_primary_key_consistency_test.cpp
@@ -495,6 +496,7 @@ SET(DW_TEST_FILES
     ./storage/lake/replication_txn_manager_test.cpp
     ./storage/lake/rowset_test.cpp
     ./storage/lake/schema_change_test.cpp
+    ./storage/lake/lake_replication_txn_manager_test.cpp
     ./storage/lake/spill_mem_table_sink_test.cpp
     ./storage/lake/starlet_location_provider_test.cpp
     ./storage/lake/tablet_manager_test.cpp

--- a/be/test/storage/lake/filenames_test.cpp
+++ b/be/test/storage/lake/filenames_test.cpp
@@ -1,0 +1,155 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/filenames.h"
+
+#include <gtest/gtest.h>
+
+#include "gutil/strings/util.h"
+#include "util/string_parser.hpp"
+
+namespace starrocks::lake {
+
+class FilenamesTest : public testing::Test {
+public:
+    FilenamesTest() = default;
+    ~FilenamesTest() override = default;
+};
+
+TEST_F(FilenamesTest, extract_uuid_from) {
+    // Test valid segment file names
+    {
+        std::string file_name = "0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
+        std::string uuid = extract_uuid_from(file_name);
+        ASSERT_EQ("6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b", uuid);
+    }
+
+    // Test valid del file names
+    {
+        std::string file_name = "0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.del";
+        std::string uuid = extract_uuid_from(file_name);
+        ASSERT_EQ("6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b", uuid);
+    }
+
+    // Test valid sst file names
+    {
+        std::string file_name = "6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.sst";
+        std::string uuid = extract_uuid_from(file_name);
+        ASSERT_EQ("6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b", uuid);
+    }
+
+    // Test valid delvec file names
+    {
+        std::string file_name = "0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.delvec";
+        std::string uuid = extract_uuid_from(file_name);
+        ASSERT_EQ("6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b", uuid);
+    }
+
+    // Test valid cols file names
+    {
+        std::string file_name = "0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.cols";
+        std::string uuid = extract_uuid_from(file_name);
+        ASSERT_EQ("6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b", uuid);
+    }
+
+    // Test invalid file names - wrong extension
+    {
+        std::string file_name = "0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.txt";
+        std::string uuid = extract_uuid_from(file_name);
+        ASSERT_TRUE(uuid.empty());
+    }
+
+    // Test invalid file names - wrong position of underscore
+    {
+        std::string file_name = "00000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
+        std::string uuid = extract_uuid_from(file_name);
+        ASSERT_TRUE(uuid.empty());
+    }
+
+    // Test invalid file names - too short
+    {
+        std::string file_name = "6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
+        std::string uuid = extract_uuid_from(file_name);
+        ASSERT_TRUE(uuid.empty());
+    }
+
+    // Test invalid file names - empty string
+    {
+        std::string file_name = "";
+        std::string uuid = extract_uuid_from(file_name);
+        ASSERT_TRUE(uuid.empty());
+    }
+}
+
+TEST_F(FilenamesTest, gen_segment_filename_from) {
+    int64_t new_txn_id = 4;
+
+    // Test valid segment file generation
+    {
+        std::string old_file_name = "0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
+        std::string new_file_name = gen_filename_from(new_txn_id, old_file_name);
+        ASSERT_EQ("0000000000000004_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat", new_file_name);
+    }
+
+    // Test valid del file input
+    {
+        std::string old_file_name = "0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.del";
+        std::string new_file_name = gen_filename_from(new_txn_id, old_file_name);
+        ASSERT_EQ("0000000000000004_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.del", new_file_name);
+    }
+
+    // Test valid sst file input (sst file only has uuid as name, no txn id)
+    {
+        std::string old_file_name = "6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.sst";
+        std::string new_file_name = gen_filename_from(new_txn_id, old_file_name);
+        // file name never changed
+        ASSERT_EQ(old_file_name, new_file_name);
+    }
+
+    // Test valid delvec file input
+    {
+        std::string old_file_name = "0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.delvec";
+        std::string new_file_name = gen_filename_from(new_txn_id, old_file_name);
+        ASSERT_EQ("0000000000000004_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.delvec", new_file_name);
+    }
+
+    // Test valid cols file input
+    {
+        std::string old_file_name = "0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.cols";
+        std::string new_file_name = gen_filename_from(new_txn_id, old_file_name);
+        ASSERT_EQ("0000000000000004_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.cols", new_file_name);
+    }
+
+    // Test invalid old file name
+    {
+        std::string old_file_name = "invalid_filename.txt";
+        std::string new_file_name = gen_filename_from(new_txn_id, old_file_name);
+        ASSERT_TRUE(new_file_name.empty());
+    }
+
+    // Test empty old file name
+    {
+        std::string old_file_name = "";
+        std::string new_file_name = gen_filename_from(new_txn_id, old_file_name);
+        ASSERT_TRUE(new_file_name.empty());
+    }
+
+    // Test file name with correct UUID but wrong extension
+    {
+        std::string old_file_name = "0000000000000123_abcdef1234567890.log";
+        std::string new_file_name = gen_filename_from(new_txn_id, old_file_name);
+        ASSERT_TRUE(new_file_name.empty());
+    }
+}
+} // namespace starrocks::lake

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -1,0 +1,362 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/lake_replication_txn_manager.h"
+
+#include <fmt/format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "column/chunk.h"
+#include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "column/vectorized_fwd.h"
+#include "common/config.h"
+#include "fs/key_cache.h"
+#include "gutil/strings/join.h"
+#include "runtime/exec_env.h"
+#include "service/staros_worker.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/delta_writer.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/meta_file.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reader.h"
+#include "storage/lake/transactions.h"
+#include "storage/lake/update_manager.h"
+#include "storage/options.h"
+#include "storage/rowset/rowset_options.h"
+#include "storage/rowset/segment.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+
+namespace starrocks::lake {
+
+// UT for shared data cross-cluster replication
+class SharedDataReplicationTxnManagerTest : public testing::TestWithParam<KeysType> {
+public:
+    SharedDataReplicationTxnManagerTest() { _test_dir = kTestDirectory; }
+
+    ~SharedDataReplicationTxnManagerTest() override = default;
+
+protected:
+    void SetUp() override {
+        (void)fs::remove_all(_test_dir);
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kSegmentDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kMetadataDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kTxnLogDirectoryName)));
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(_test_dir);
+        _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider, _mem_tracker.get());
+        _tablet_mgr = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 16384);
+        _replication_txn_manager = std::make_unique<lake::LakeReplicationTxnManager>(_tablet_mgr.get());
+
+        _src_tablet_metadata = generate_tablet_metadata(GetParam());
+        _target_tablet_metadata = generate_tablet_metadata(GetParam());
+
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_src_tablet_metadata));
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_target_tablet_metadata));
+
+        _src_tablet_id = _src_tablet_metadata->id();
+        _target_tablet_id = _target_tablet_metadata->id();
+        // target visible version
+        _version = _target_tablet_metadata->version();
+    }
+
+    void TearDown() override {
+        if (config::starlet_cache_dir.compare(0, 5, std::string("/tmp/")) == 0) {
+            // Clean cache directory
+            std::string cmd = fmt::format("rm -rf {}", config::starlet_cache_dir);
+            ::system(cmd.c_str());
+        }
+
+        config::enable_transparent_data_encryption = false;
+
+        // check primary index cache's ref
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        // check trash files already removed
+        for (const auto& file : _trash_files) {
+            EXPECT_FALSE(fs::path_exist(file));
+        }
+        ASSERT_OK(fs::remove_all(_test_dir));
+    }
+
+    std::shared_ptr<TabletMetadataPB> generate_tablet_metadata(KeysType keys_type) {
+        auto metadata = std::make_shared<TabletMetadata>();
+        metadata->set_id(next_id());
+        metadata->set_version(1);
+        metadata->set_cumulative_point(0);
+        metadata->set_next_rowset_id(1);
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        //  |   c1   |  INT | NO  |  NO  |
+        auto schema = metadata->mutable_schema();
+        schema->set_keys_type(keys_type);
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+            c1->set_aggregation(keys_type == DUP_KEYS ? "NONE" : "REPLACE");
+        }
+        return metadata;
+    }
+
+    Chunk generate_data(int64_t chunk_size, int shift, int update_ratio) {
+        std::vector<int> v0(chunk_size);
+        std::vector<int> v1(chunk_size);
+        std::vector<int> v2(chunk_size);
+        for (int i = 0; i < chunk_size; i++) {
+            v0[i] = i + shift * chunk_size;
+        }
+        auto rng = std::default_random_engine{};
+        std::shuffle(v0.begin(), v0.end(), rng);
+        for (int i = 0; i < chunk_size; i++) {
+            v1[i] = v0[i] * update_ratio;
+        }
+
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+
+        for (int i = 0; i < chunk_size; i++) {
+            v2[i] = v0[i] * 4;
+        }
+        auto c2 = Int32Column::create();
+        c2->append_numbers(v2.data(), v2.size() * sizeof(int));
+        return Chunk({std::move(c0), std::move(c1), std::move(c2)}, _slot_cid_map);
+    }
+
+    void write_src_tablet_data() {
+        auto chunk0 = generate_data(kChunkSize, 0, 3);
+        auto chunk1 = generate_data(kChunkSize, 0, 3);
+        auto indexes = std::vector<uint32_t>(kChunkSize);
+        for (int i = 0; i < kChunkSize; i++) {
+            indexes[i] = i;
+        }
+
+        auto version = 1;
+        // normal write
+        for (int i = 0; i < 3; i++) {
+            auto txn_id = next_id();
+            ASSIGN_OR_ABORT(auto delta_writer, lake::DeltaWriterBuilder()
+                                                       .set_tablet_manager(_tablet_mgr.get())
+                                                       .set_tablet_id(_src_tablet_id)
+                                                       .set_txn_id(txn_id)
+                                                       .set_partition_id(_src_partition_id)
+                                                       .set_mem_tracker(_mem_tracker.get())
+                                                       .set_schema_id(_src_tablet_metadata->schema().id())
+                                                       .build());
+            ASSERT_OK(delta_writer->open());
+            ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+            ASSERT_OK(delta_writer->finish_with_txnlog());
+            delta_writer->close();
+            // Publish version
+            auto txn_info = TxnInfoPB();
+            txn_info.set_txn_id(txn_id);
+            txn_info.set_combined_txn_log(false);
+            txn_info.set_commit_time(0);
+            auto txn_info_span = std::span<const TxnInfoPB>(&txn_info, 1);
+            ASSERT_OK(lake::publish_version(_tablet_mgr.get(), _src_tablet_id, version, version + 1, txn_info_span,
+                                            false));
+            version++;
+        }
+        ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(_src_tablet_id, version));
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+        EXPECT_EQ(new_tablet_metadata->version(), 4);
+        // src visible version
+        _src_version = new_tablet_metadata->version();
+    }
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_lake_replication";
+    constexpr static int kChunkSize = 12;
+
+    std::unique_ptr<TabletManager> _tablet_mgr;
+    std::shared_ptr<lake::LocationProvider> _location_provider;
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::unique_ptr<lake::UpdateManager> _update_manager;
+    std::unique_ptr<lake::LakeReplicationTxnManager> _replication_txn_manager;
+
+    int64_t _src_tablet_id = 10000;
+    int64_t _target_tablet_id = 20000;
+
+    std::shared_ptr<TabletMetadata> _src_tablet_metadata;
+    std::shared_ptr<TabletMetadata> _target_tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+    std::vector<std::string> _trash_files;
+    std::vector<SlotDescriptor> _slots;
+    std::vector<SlotDescriptor*> _slot_pointers;
+    Chunk::SlotHashMap _slot_cid_map;
+
+    std::string _test_dir;
+
+    int64_t _transaction_id = 300;
+    int64_t _table_id = 30001;
+    int64_t _partition_id = 30002;
+    int64_t _version = 1;
+    int64_t _src_version = 1;
+    int32_t _schema_hash = 368169781;
+    int64_t _virtual_tablet_id = 40001;
+    int64_t _src_db_id = 40002;
+    int64_t _src_table_id = 40003;
+    int64_t _src_partition_id = 40004;
+};
+
+TEST_P(SharedDataReplicationTxnManagerTest, test_replicate_no_missing_versions) {
+    TReplicateSnapshotRequest request;
+    request.__set_transaction_id(_transaction_id);
+    request.__set_table_id(_table_id);
+    request.__set_partition_id(_partition_id);
+    request.__set_tablet_id(_target_tablet_id);
+    request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    request.__set_schema_hash(_schema_hash);
+    request.__set_visible_version(_version);
+    request.__set_data_version(_version);
+    // src tablet
+    request.__set_src_tablet_id(_src_tablet_id);
+    request.__set_src_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    request.__set_src_visible_version(_version); // same as `data_version`
+    request.__set_src_db_id(_src_db_id);
+    request.__set_src_table_id(_src_tablet_id);
+    request.__set_src_partition_id(_src_partition_id);
+
+    // virtual tablet
+    request.__set_virtual_tablet_id(_virtual_tablet_id);
+
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request);
+    EXPECT_FALSE(status.ok());
+}
+
+TEST_P(SharedDataReplicationTxnManagerTest, test_replicate_normal) {
+    // write data
+    write_src_tablet_data();
+
+    TReplicateSnapshotRequest request;
+    request.__set_transaction_id(_transaction_id);
+    request.__set_table_id(_table_id);
+    request.__set_partition_id(_partition_id);
+    request.__set_tablet_id(_target_tablet_id);
+    request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    request.__set_schema_hash(_schema_hash);
+    request.__set_visible_version(_version);
+    request.__set_data_version(_version);
+    // src tablet
+    request.__set_src_tablet_id(_src_tablet_id);
+    request.__set_src_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    request.__set_src_visible_version(_src_version);
+    request.__set_src_db_id(_src_db_id);
+    request.__set_src_table_id(_src_table_id);
+    request.__set_src_partition_id(_src_partition_id);
+
+    // virtual tablet
+    request.__set_virtual_tablet_id(_virtual_tablet_id);
+
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request);
+    EXPECT_TRUE(status.ok()) << status;
+
+    auto txn_info = TxnInfoPB();
+    txn_info.set_txn_id(_transaction_id);
+    txn_info.set_combined_txn_log(false);
+    txn_info.set_commit_time(0);
+    auto txn_info_span = std::span<const TxnInfoPB>(&txn_info, 1);
+    auto status_or =
+            lake::publish_version(_tablet_mgr.get(), _target_tablet_id, _version, _src_version, txn_info_span, false);
+    EXPECT_TRUE(status_or.ok()) << status_or.status();
+
+    EXPECT_EQ(_src_version, status_or.value()->version());
+}
+
+TEST_P(SharedDataReplicationTxnManagerTest, test_replicate_normal_encrypted) {
+    EncryptionKeyPB pb;
+    pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
+    pb.set_type(EncryptionKeyTypePB::NORMAL_KEY);
+    pb.set_algorithm(EncryptionAlgorithmPB::AES_128);
+    pb.set_plain_key("0000000000000000");
+    std::unique_ptr<EncryptionKey> root_encryption_key = EncryptionKey::create_from_pb(pb).value();
+    auto val_st = root_encryption_key->generate_key();
+    EXPECT_TRUE(val_st.ok());
+    std::unique_ptr<EncryptionKey> encryption_key = std::move(val_st.value());
+    encryption_key->set_id(2);
+    KeyCache::instance().add_key(root_encryption_key);
+    KeyCache::instance().add_key(encryption_key);
+
+    // write source tablet data (without encryption)
+    write_src_tablet_data();
+
+    // enable transparent data encryption
+    config::enable_transparent_data_encryption = true;
+
+    TReplicateSnapshotRequest request;
+    request.__set_transaction_id(_transaction_id);
+    request.__set_table_id(_table_id);
+    request.__set_partition_id(_partition_id);
+    request.__set_tablet_id(_target_tablet_id);
+    request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    request.__set_schema_hash(_schema_hash);
+    request.__set_visible_version(_version);
+    request.__set_data_version(_version);
+    // src tablet
+    request.__set_src_tablet_id(_src_tablet_id);
+    request.__set_src_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    request.__set_src_visible_version(_src_version);
+    request.__set_src_db_id(_src_db_id);
+    request.__set_src_table_id(_src_table_id);
+    request.__set_src_partition_id(_src_partition_id);
+
+    // virtual tablet
+    request.__set_virtual_tablet_id(_virtual_tablet_id);
+
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request);
+    EXPECT_TRUE(status.ok()) << status;
+
+    auto txn_info = TxnInfoPB();
+    txn_info.set_txn_id(_transaction_id);
+    txn_info.set_combined_txn_log(false);
+    txn_info.set_commit_time(0);
+    auto txn_info_span = std::span<const TxnInfoPB>(&txn_info, 1);
+    auto status_or =
+            lake::publish_version(_tablet_mgr.get(), _target_tablet_id, _version, _src_version, txn_info_span, false);
+    EXPECT_TRUE(status_or.ok()) << status_or.status();
+
+    EXPECT_EQ(_src_version, status_or.value()->version());
+}
+
+INSTANTIATE_TEST_SUITE_P(SharedDataReplicationTxnManagerTest, SharedDataReplicationTxnManagerTest,
+                         testing::Values(KeysType::DUP_KEYS, KeysType::AGG_KEYS, KeysType::PRIMARY_KEYS));
+
+} // namespace starrocks::lake

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -273,6 +273,8 @@ message TxnLogPB {
         repeated OpWrite op_writes = 2;
         map<uint32, DelvecDataPB> delvecs = 3;
         optional TabletSchemaPB source_schema = 4;
+        // used for shared-data replication to store the tablet meta replicated
+        optional TabletMetadataPB tablet_metadata = 5;
     }
 
     optional int64 tablet_id = 1;

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -427,6 +427,10 @@ struct TRemoteSnapshotRequest {
      13: optional list<Types.TSnapshotInfo> src_snapshot_infos
      14: optional binary encryption_meta
      15: optional Types.TVersion data_version
+     16: optional Types.TTabletId virtual_tablet_id
+     17: optional Types.TDatabaseId src_db_id
+     18: optional Types.TTableId src_table_id
+     19: optional Types.TPartitionId src_partition_id
  }
 
 enum TTabletMetaType {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -41,6 +41,7 @@ typedef i32 TPlanNodeId
 typedef i32 TTupleId
 typedef i32 TSlotId
 typedef i64 TTableId
+typedef i64 TDatabaseId
 typedef i64 TTabletId
 typedef i64 TVersion
 typedef i64 TVersionHash


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR introduces comprehensive support for data migration between StarRocks shared-data clusters. The implementation enables seamless cross-cluster data transfer while maintaining data integrity and consistency.


   - Implemented efficient file copy mechanisms between different cluster storage systems
   - Enhanced file system utilities to handle remote storage access
   - Added support for constructing metadata and segment paths in remote clusters
   - Enhanced replication transaction manager to support cross-cluster data transfer

This work establishes the foundation for StarRocks shared-data clusters to perform live data migration, enabling use cases such as disaster recovery, cluster scaling, and multi-region deployments.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds cross-cluster replication for Lake tablets with remote Starlet FS caching, encrypted file copy/conversion, filename remapping, txn log/apply support, and Thrift/Proto extensions.
> 
> - **Lake/Replication**:
>   - Implement `LakeReplicationTxnManager` to replicate Lake data from remote clusters (build source meta, map/copy files, handle encryption, update segment sizes, emit txn log with `tablet_metadata`).
>   - Integrate into `ReplicationTxnManager` (Lake path selection, shared file-converter factory).
>   - `TxnLogApplier`: support full replication via embedded `tablet_metadata` for PK and non-PK.
> - **Filesystem**:
>   - `fs_starlet`: add ctor accepting shard FS and `new_fs_starlet(int64_t)` with LRU-cached shard filesystems for virtual shard IDs.
> - **Storage Utils**:
>   - `fs_util`: new `copy_file` overload accepting custom `WritableFileOptions` (encryption).
>   - `replication_utils`: define `FileConverterCreatorFunc`; add `download_lake_segment_file` streaming with conversion; refactor snapshot download.
>   - `segment_stream_converter`/`file_stream_converter`: expose final output size; log conversion results.
> - **Filenames/Locations**:
>   - `filenames.h`: add `is_cols`, `extract_uuid_from`, `gen_filename_from` for UUID-based remapping.
>   - `LocationProvider::join_path` made protected; add `RemoteStarletLocationProvider` for remote partitioned paths.
> - **APIs/IDL**:
>   - Proto: `TxnLogPB.OpReplication` gains `tablet_metadata`.
>   - Thrift: `TReplicateSnapshotRequest` adds `virtual_tablet_id`, `src_db_id`, `src_table_id`, `src_partition_id`; add `TDatabaseId`.
> - **Build/Tests**:
>   - Wire new sources in CMake.
>   - Add UTs for filenames and Lake replication.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66e4b48649ac775b97054e6fc955a5969832a371. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->