### PR TITLE
[Enhancement] Enable Oauth2 token refresh by default for iceberg rest catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import static com.starrocks.connector.iceberg.rest.IcebergRESTCatalog.Security.JWT;
 import static com.starrocks.connector.iceberg.rest.IcebergRESTCatalog.Security.NONE;
 import static com.starrocks.connector.iceberg.rest.IcebergRESTCatalog.Security.OAUTH2;
+import static com.starrocks.connector.iceberg.rest.OAuth2SecurityConfig.TOKEN_REFRESH_ENABLED;
 
 public class OAuth2SecurityConfig {
 
@@ -45,8 +46,8 @@ public class OAuth2SecurityConfig {
     public static String OAUTH2_TOKEN = "oauth2.token";
     // The endpoint to retrieve access token from OAuth2 Server
     public static String SERVER_URI = "oauth2.server-uri";
-
     public static String OAUTH2_AUDIENCE = "oauth2.audience";
+    public static String TOKEN_REFRESH_ENABLED = "oauth2.token-refresh-enabled";
 
     public IcebergRESTCatalog.Security getSecurity() {
         return security;
@@ -142,7 +143,8 @@ class OAuth2SecurityConfigBuilder {
                 .setScope(properties.get(OAuth2SecurityConfig.OAUTH2_SCOPE))
                 .setToken(properties.get(OAuth2SecurityConfig.OAUTH2_TOKEN))
                 .setAudience(properties.get(OAuth2SecurityConfig.OAUTH2_AUDIENCE))
-                .setTokenRefreshEnabled(Boolean.valueOf(properties.get(OAuth2Properties.TOKEN_REFRESH_ENABLED)));
+                .setTokenRefreshEnabled(Boolean.valueOf(properties.getOrDefault(TOKEN_REFRESH_ENABLED,
+                        String.valueOf(OAuth2Properties.TOKEN_REFRESH_ENABLED_DEFAULT))));
 
         String serverUri = properties.get(OAuth2SecurityConfig.SERVER_URI);
         if (serverUri != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfigTest.java
@@ -41,6 +41,14 @@ public class OAuth2SecurityConfigTest {
         Assertions.assertEquals(OAUTH2, config.getSecurity());
         Assertions.assertEquals("smith:cruise", config.getCredential().get());
         Assertions.assertEquals("PRINCIPAL", config.getScope().get());
+        // check default token refresh enabled
+        Assertions.assertTrue(config.isTokenRefreshEnabled().isPresent());
+        Assertions.assertTrue(config.isTokenRefreshEnabled().get());
+        // check disabled token refresh
+        properties.put("oauth2.token-refresh-enabled", "false");
+        config = OAuth2SecurityConfigBuilder.build(properties);
+        Assertions.assertTrue(config.isTokenRefreshEnabled().isPresent());
+        Assertions.assertFalse(config.isTokenRefreshEnabled().get());
 
         properties = new HashMap<>();
         properties.put("security", "oaUth2");


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Enable Oauth2 token refresh by default for iceberg rest catalog
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
