### PR TITLE
[Tool] print bundle tablet meta proto as string

### DIFF
--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -1226,6 +1226,8 @@ int meta_tool_main(int argc, char** argv) {
             return -1;
         }
         const auto& bundle_metadata = bundle_metadata_or.value();
+        // print bundle metadata proto as string
+        std::cout << "Bundle Metadata: " << bundle_metadata->Utf8DebugString() << '\n';
         // foreach tablet_meta from bundle_metadata.tablet_meta_pages
         for (const auto& page : bundle_metadata->tablet_meta_pages()) {
             const starrocks::PagePointerPB& page_pointer = page.second;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request adds functionality to print the bundle metadata in a readable format for debugging purposes. The change involves outputting the metadata as a UTF-8 encoded string.

Debugging improvement:

* [`be/src/tools/meta_tool.cpp`](diffhunk://#diff-3f296e98e8e57359f4e1a2c482313ed695c00d30731eb106c4f36c0328aadf95R1229-R1230): Added a line to print the bundle metadata using `Utf8DebugString()` for easier readability during debugging.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
