### PR TITLE
[BugFix] fix min/max bug on sql like 'select distinct x'

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MinMaxOptOnScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MinMaxOptOnScanRule.java
@@ -62,7 +62,7 @@ public class MinMaxOptOnScanRule extends TransformationRule {
 
         // we can only apply this rule to the queries met all the following conditions:
         // 1. no group by key (only partition columns)
-        // 2. no `having` condition or other filters
+        // 2. no `having` condition or other filters (only partition columns)
         // 3. no limit(???)
         // 4. only contain MIN/MAX agg functions
         // 5. all arguments to agg functions are primitive columns (not necessarily)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MinMaxOptOnScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MinMaxOptOnScanRule.java
@@ -98,6 +98,11 @@ public class MinMaxOptOnScanRule extends TransformationRule {
             return false;
         }
 
+        // not applicable if there is no aggregation functions, like `distinct x`.
+        if (aggregationOperator.getAggregations().isEmpty()) {
+            return false;
+        }
+
         boolean allValid = aggregationOperator.getAggregations().values().stream().allMatch(aggregator -> {
             AggregateFunction aggregateFunction = (AggregateFunction) aggregator.getFunction();
             String functionName = aggregateFunction.functionName();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
@@ -78,7 +78,7 @@ public class PruneScanColumnRule extends TransformationRule {
         }
 
         if (scanOperator.getColRefToColumnMetaMap().keySet().equals(outputColumns)) {
-            scanOperator.getScanOptimizeOption().setCanUseMinMaxOpt(canUseAnyColumn);
+            scanOperator.getScanOptimizeOption().setCanUseAnyColumn(canUseAnyColumn);
             return Collections.emptyList();
         } else {
             Map<ColumnRefOperator, Column> newColumnRefMap = outputColumns.stream()

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -70,7 +70,7 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                 "select min(id), date from iceberg0.partitioned_db.t1 group by date", "true",
                 "select max(id), date from iceberg0.partitioned_db.t1 group by date", "true",
                 "select max(id) as x, date from iceberg0.partitioned_db.t1 group by date having x > 10", "false",
-
+                "select max(id) as x, date from iceberg0.partitioned_db.t1 group by date having date > '2020-01-01'", "true",
         };
         Assertions.assertTrue(sqlString.length % 2 == 0);
         for (int i = 0; i < sqlString.length; i += 2) {
@@ -94,6 +94,7 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                     "select count(*) from lineitem_par",
                     "select count(*) from lineitem_par where l_shipdate = '1998-01-01'",
                     "select count(*), l_shipdate from lineitem_par where l_shipdate = '1998-01-01' group by l_shipdate",
+                    "select count(*), l_shipdate from lineitem_par group by l_shipdate having l_shipdate > '1998-01-01'",
             };
             for (int i = 0; i < sqlString.length; i++) {
                 String sql = sqlString[i];

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -109,7 +109,8 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                     "select count(l_orderkey) from lineitem_par",
                     "select count(*) from lineitem_par where l_shipdate = '1998-01-01' and l_orderkey = 202",
                     "select count(*), count(l_orderkey), l_shipdate from lineitem_par where l_shipdate = '1998-01-01' group by " +
-                            "l_shipdate"
+                            "l_shipdate",
+                    "select count(*) as x, l_shipdate from lineitem_par group by l_shipdate having x > 10",
             };
             for (int i = 0; i < sqlString.length; i++) {
                 String sql = sqlString[i];
@@ -146,7 +147,8 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                     "select count(*) from iceberg0.partitioned_db.t1",
                     "select count(*) from iceberg0.partitioned_db.t1 where date = '2020-01-01'",
                     "select count(*), date from iceberg0.partitioned_db.t1 where date = '2020-01-01' " +
-                            "group by date"
+                            "group by date",
+                    "select count(*), date from iceberg0.partitioned_db.t1 group by date having date > '2020-01-01'",
             };
             for (int i = 0; i < sqlString.length; i++) {
                 String sql = sqlString[i];
@@ -163,7 +165,8 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                             " 202",
                     "select count(*), count(id), date from iceberg0.partitioned_db.t1 where date " +
                             "= '2020-01-01' group by " +
-                            "date"
+                            "date",
+                    "select count(*) as x, date from iceberg0.partitioned_db.t1 group by date having x > 10",
             };
             for (int i = 0; i < sqlString.length; i++) {
                 String sql = sqlString[i];


### PR DESCRIPTION
## Why I'm doing:

sql like `select distinct x from t`
- does have aggregator
- but does not have aggregator.function
- and it can not use min/max optimization

## What I'm doing:

this pr does:
- disable min/max opt when like `distinct x`
- refactor count opt a little bit

Fixes https://github.com/StarRocks/StarRocksTest/issues/9918

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
