### PR TITLE
[Enhancement] make predicate expr reuse controllable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -891,6 +891,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_REWRITE_UNNEST_BITMAP_TO_ARRAY = "enable_rewrite_unnest_bitmap_to_array";
 
     public static final String ENABLE_SCAN_PREDICATE_EXPR_REUSE = "enable_scan_predicate_expr_reuse";
+    public static final String ENABLE_PREDICATE_EXPR_REUSE = "enable_predicate_expr_reuse";
     public static final String ENABLE_PARQUET_READER_BLOOM_FILTER = "enable_parquet_reader_bloom_filter";
     public static final String ENABLE_PARQUET_READER_PAGE_INDEX = "enable_parquet_reader_page_index";
 
@@ -1798,6 +1799,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_SCAN_PREDICATE_EXPR_REUSE, flag = VariableMgr.INVISIBLE)
     private boolean enableScanPredicateExprReuse = true;
+
+    @VarAttr(name = ENABLE_PREDICATE_EXPR_REUSE, flag = VariableMgr.INVISIBLE)
+    private boolean enablePredicateExprReuse = true;
 
     @VarAttr(name = TOPN_FILTER_BACK_PRESSURE_MODE)
     private int topnFilterBackPressureMode = 0;
@@ -4912,6 +4916,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableScanPredicateExprReuse() {
         return enableScanPredicateExprReuse;
+    }
+
+    public void setEnablePredicateExprReuse(boolean enablePredicateExprReuse) {
+        this.enablePredicateExprReuse = enablePredicateExprReuse;
+    }
+
+    public boolean isEnablePredicateExprReuse() {
+        return enablePredicateExprReuse;
     }
 
     public int getConnectorIncrementalScanRangeNumber() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PullUpScanPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PullUpScanPredicateRule.java
@@ -54,7 +54,8 @@ public class PullUpScanPredicateRule extends TransformationRule {
     @Override
     public boolean check(final OptExpression input, OptimizerContext context) {
         ScalarOperator predicates = input.getOp().getPredicate();
-        if (!context.getSessionVariable().isEnableScanPredicateExprReuse() || predicates == null) {
+        if (!context.getSessionVariable().isEnablePredicateExprReuse() ||
+                !context.getSessionVariable().isEnableScanPredicateExprReuse() || predicates == null) {
             return false;
         }
         return true;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/ScanPredicateExprReuseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/ScanPredicateExprReuseTest.java
@@ -315,6 +315,20 @@ public class ScanPredicateExprReuseTest extends PlanTestBase {
                     "     Pruned type: 7 <-> [MAP<INT,INT>]\n" +
                     "     ColumnAccessPath: [/v1/OFFSET, /v5/b/a/OFFSET, /v6/OFFSET]");
         }
+    }
 
+    @Test
+    public void testWithoutEnablePredicateExprReuse() throws Exception {
+        {
+            // if we disable predicate expr reuse, ScanPredicateExprReuse should not take effect.
+            connectContext.getSessionVariable().setEnablePredicateExprReuse(false);
+            String sql = "select * from t0 where v1 + v2 > 10 and v1 + v2 + v3 > 20 and v1 = 5";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  0:OlapScanNode\n" +
+                    "     TABLE: t0\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 1: v1 + 2: v2 > 10, 1: v1 + 2: v2 + 3: v3 > 20, 1: v1 = 5");
+            connectContext.getSessionVariable().setEnablePredicateExprReuse(true);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRuleTest.java
@@ -94,4 +94,24 @@ public class ScalarOperatorsReuseRuleTest extends PlanTestBase {
                     "  |  <slot 3> : uuid()");
         }
     }
+
+    @Test
+    public void testPredicateExprReuse() throws Exception {
+        {
+            String query = "select * from (select rand() as rnd) t where t.rnd < 10 or t.rnd > 20";
+            String plan = getFragmentPlan(query);
+            assertContains(plan, "  1:SELECT\n" +
+                    "  |  predicates: (3: rand < 10.0) OR (3: rand > 20.0)\n" +
+                    "  |    common sub expr:\n" +
+                    "  |    <slot 3> : rand()");
+        }
+        {
+            connectContext.getSessionVariable().setEnablePredicateExprReuse(false);
+            String query = "select * from (select rand() as rnd) t where t.rnd < 10 or t.rnd > 20";
+            String plan = getFragmentPlan(query);
+            assertContains(plan, "  1:SELECT\n" +
+                    "  |  predicates: (rand() < 10.0) OR (rand() > 20.0)");
+            connectContext.getSessionVariable().setEnablePredicateExprReuse(true);
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


In https://github.com/StarRocks/starrocks/pull/52889, we support the reuse of predicate expressions on scan operators. This change will cause the predicate expressions on all Select operators to be reused, and this behavior is uncontrollable and cannot be turned off. In this PR, I added a session variable, enable_predicate_expr_reuse, to control whether the reuse of predicate expressions is enabled, so as to facilitate troubleshooting.



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
