### PR TITLE
[BugFix] Fix find master NPE bug when starting FE from cluster snapshot

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
@@ -46,6 +46,7 @@ public class RestoreClusterSnapshotMgr {
 
     private ClusterSnapshotConfig config;
     private boolean oldStartWithIncompleteMeta;
+    private boolean oldResetElectionGroup;
     private RestoredSnapshotInfo restoredSnapshotInfo;
 
     private RestoreClusterSnapshotMgr(String clusterSnapshotYamlFile) throws StarRocksException {
@@ -110,10 +111,15 @@ public class RestoreClusterSnapshotMgr {
         oldStartWithIncompleteMeta = Config.start_with_incomplete_meta;
         // Allow starting with only image no bdb log
         Config.start_with_incomplete_meta = true;
+        // Save the old config
+        oldResetElectionGroup = Config.bdbje_reset_election_group;
+        // Reset election group
+        Config.bdbje_reset_election_group = true;
     }
 
     private void rollbackConfig() {
         Config.start_with_incomplete_meta = oldStartWithIncompleteMeta;
+        Config.bdbje_reset_election_group = oldResetElectionGroup;
     }
 
     private void downloadSnapshot() throws StarRocksException {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
@@ -46,7 +46,6 @@ public class RestoreClusterSnapshotMgr {
 
     private ClusterSnapshotConfig config;
     private boolean oldStartWithIncompleteMeta;
-    private boolean oldResetElectionGroup;
     private RestoredSnapshotInfo restoredSnapshotInfo;
 
     private RestoreClusterSnapshotMgr(String clusterSnapshotYamlFile) throws StarRocksException {
@@ -111,15 +110,10 @@ public class RestoreClusterSnapshotMgr {
         oldStartWithIncompleteMeta = Config.start_with_incomplete_meta;
         // Allow starting with only image no bdb log
         Config.start_with_incomplete_meta = true;
-        // Save the old config
-        oldResetElectionGroup = Config.bdbje_reset_election_group;
-        // Reset election group
-        Config.bdbje_reset_election_group = true;
     }
 
     private void rollbackConfig() {
         Config.start_with_incomplete_meta = oldStartWithIncompleteMeta;
-        Config.bdbje_reset_election_group = oldResetElectionGroup;
     }
 
     private void downloadSnapshot() throws StarRocksException {

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -1188,6 +1188,7 @@ public class NodeMgr {
 
         int fid = allocateNextFrontendId();
         Frontend self = new Frontend(fid, role, nodeName, selfNode.first, selfNode.second);
+        self.setAlive(true);
         frontends.put(self.getNodeName(), self);
         frontendIds.put(fid, self);
         // reset helper nodes


### PR DESCRIPTION
## Why I'm doing:
Set selfNode to alive, because the init of ReplicationGroupAdmin only collect the alive frontends node. The reason this bug doesn't always appear is that HeartBeatMgr also sets selfNode to alive, but this is asynchronous and depends on how fast HeartBeatMgr runs.

## What I'm doing:

Fixes 
``` java
[StarRocksFE.start():210] StarRocksFE start failed
java.lang.NullPointerException: null
        at com.sleepycat.je.rep.util.ReplicationGroupAdmin.getMasterSocket(ReplicationGroupAdmin.java:191) ~[starrocks-bdb-je-18.3.20.jar:?]
        at com.sleepycat.je.rep.util.ReplicationGroupAdmin.doMessageExchange(ReplicationGroupAdmin.java:607) ~[starrocks-bdb-je-18.3.20.jar:?]
        at com.sleepycat.je.rep.util.ReplicationGroupAdmin.getGroup(ReplicationGroupAdmin.java:406) ~[starrocks-bdb-je-18.3.20.jar:?]
        at com.starrocks.ha.BDBHA.removeNodeIfExist(BDBHA.java:219) ~[starrocks-fe.jar:?]
        at com.starrocks.server.NodeMgr.addFrontend(NodeMgr.java:791) ~[starrocks-fe.jar:?]
        at com.starrocks.lake.snapshot.RestoreClusterSnapshotMgr.updateFrontends(RestoreClusterSnapshotMgr.java:207) ~[starrocks-fe.jar:?]
        at com.starrocks.lake.snapshot.RestoreClusterSnapshotMgr.finishRestoring(RestoreClusterSnapshotMgr.java:93) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.start(StarRocksFE.java:199) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.main(StarRocksFE.java:99) ~[starrocks-fe.jar:?]
```
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
