### PR TITLE
[BugFix]fix ngram_search use after free 

### DIFF
--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -45,7 +45,6 @@ struct Ngramstate {
         std::thread::id current_thread_id = std::this_thread::get_id();
 
         std::vector<NgramHash>* result = nullptr;
-        driver_maps.if_contains(current_thread_id, [&](const auto& value) { result = value.get(); });
         driver_maps.lazy_emplace_l(
                 current_thread_id, [&](const auto& value) { result = value.get(); },
                 [&](auto build) {

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -211,8 +211,7 @@ private:
             DCHECK(needle_not_overlap_with_haystack <= needle_gram_count);
 
             // now get the result
-            double row_result =
-                    1.0f - (needle_not_overlap_with_haystack) * 1.0f / std::max(needle_gram_count, (size_t)1);
+            double row_result = 1.0f - (needle_not_overlap_with_haystack)*1.0f / std::max(needle_gram_count, (size_t)1);
 
             res->get_data()[i] = row_result;
         }
@@ -246,7 +245,7 @@ private:
         size_t needle_gram_count = state->needle_gram_count;
         size_t needle_not_overlap_with_haystack = calculateDistanceWithHaystack<false>(
                 map, cur_haystack, map_restore_helper, needle_gram_count, gram_num);
-        float result = 1.0f - (needle_not_overlap_with_haystack) * 1.0f / std::max(needle_gram_count, (size_t)1);
+        float result = 1.0f - (needle_not_overlap_with_haystack)*1.0f / std::max(needle_gram_count, (size_t)1);
         DCHECK(needle_not_overlap_with_haystack <= needle_gram_count);
         return result;
     }

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -32,7 +32,7 @@ struct Ngramstate {
     using DriverMap = phmap::parallel_flat_hash_map<std::thread::id, std::unique_ptr<std::vector<NgramHash>>,
                                                     phmap::Hash<std::thread::id>, phmap::EqualTo<std::thread::id>,
                                                     phmap::Allocator<std::thread::id>, NUM_LOCK_SHARD_LOG, std::mutex>;
-    Ngramstate(size_t hash_map_len) : publicHashMap(hash_map_len, 0) {};
+    Ngramstate(size_t hash_map_len) : publicHashMap(hash_map_len, 0){};
     // unmodified map, only used for driver to copy
     std::vector<NgramHash> publicHashMap;
     DriverMap driver_maps; // hashMap for each pipeline_driver, to make it driver-local

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -235,6 +235,8 @@ select split_part(c1, "##", -3) from t1;
 -- result:
 abc
 -- !result
+
+
 -- name: test_url_extract_host
 select url_extract_host('https://starrocks.com/test/api/v1');
 -- result:
@@ -271,6 +273,8 @@ select url_extract_host(url) from test_url_extract_host;
 starrocks.com
 starrocks.快速.com
 -- !result
+
+
 -- name: test_url_encode
 select url_encode('https://docs.starrocks.io/en-us/latest/quick_start/Deploy');
 -- result:
@@ -420,6 +424,8 @@ select crc32(c2) from crc01;
 -- result:
 2291122336
 -- !result
+
+
 -- name: test_ngram_search
 select ngram_search("chinese","china",4);
 -- result:
@@ -512,6 +518,8 @@ select sum(result) from ( select ngram_search("normal_string", "normal_string", 
 -- result:
 4097.0
 -- !result
+
+
 -- name: test_ngram_search_with_low_cardinality
 CREATE TABLE __row_util_1 (
   k1 bigint null
@@ -528,8 +536,7 @@ insert into __row_util_1 select generate_series from TABLE(generate_series(0, 50
 -- !result
 CREATE TABLE left_table (
     id int,
-    nation string,
-    exsit_hot_value int
+    nation string
 )
 ENGINE=olap
 DUPLICATE KEY(id)
@@ -543,21 +550,22 @@ insert into left_table
 select
     cast(rand() * 100000000 as int),
     CASE 
-        WHEN RAND() > 0.8 THEN 'china'
-        WHEN RAND() > 0.6 THEN 'usa'
-        WHEN RAND() > 0.4 THEN 'russian'
-        WHEN RAND() > 0.2 THEN 'canada'
+        WHEN k1 % 5 = 0 THEN 'china'
+        WHEN k1 % 5 = 1 THEN 'usa'
+        WHEN k1 % 5 = 2 THEN 'russian'
+        WHEN k1 % 5 = 3 THEN 'canada'
         ELSE 'japan'
-    END,
-   case when RAND() > 0.99 THEN k1
-       ELSE k1 % 5 
-   END
+    END
 from __row_util_1;
 -- result:
 -- !result
 select sum(c0) > 500 from (select ngram_search(nation, 'china', 4) as c0 from left_table)t0;
 -- result:
 1
+-- !result
+select count(1) from left_table where ngram_search(nation, 'china', 4) > 0;
+-- result:
+1001
 -- !result
 -- name: test_lower_upper_utf8
 create table t (

--- a/test/sql/test_string_functions/T/test_string_functions
+++ b/test/sql/test_string_functions/T/test_string_functions
@@ -211,11 +211,10 @@ PROPERTIES (
 insert into __row_util_1 select generate_series from TABLE(generate_series(0, 5000));
 
 
--- id随机，nation低基数，exsit_hot_value中1%随机，99%的低基（只有5种取值）
+-- id随机，nation低基数
 CREATE TABLE left_table (
     id int,
-    nation string,
-    exsit_hot_value int
+    nation string
 )
 ENGINE=olap
 DUPLICATE KEY(id)
@@ -228,17 +227,16 @@ insert into left_table
 select
     cast(rand() * 100000000 as int),
     CASE 
-        WHEN RAND() > 0.8 THEN 'china'
-        WHEN RAND() > 0.6 THEN 'usa'
-        WHEN RAND() > 0.4 THEN 'russian'
-        WHEN RAND() > 0.2 THEN 'canada'
+        WHEN k1 % 5 = 0 THEN 'china'
+        WHEN k1 % 5 = 1 THEN 'usa'
+        WHEN k1 % 5 = 2 THEN 'russian'
+        WHEN k1 % 5 = 3 THEN 'canada'
         ELSE 'japan'
-    END,
-   case when RAND() > 0.99 THEN k1
-       ELSE k1 % 5 
-   END
+    END
 from __row_util_1;
 select sum(c0) > 500 from (select ngram_search(nation, 'china', 4) as c0 from left_table)t0;
+
+select count(1) from left_table where ngram_search(nation, 'china', 4) > 0;
 
 -- name: test_lower_upper_utf8
 create table t (


### PR DESCRIPTION
## Why I'm doing:
ngram_search has a map in function's state, key is driver id and value is per-thread vector, every thread will get or create its own vector and read/modify this vector. Everything goes well if in pipeline thread pool. But if ngram_search is pushed down into storage engine, driver id is not unique for each thread. Two thread can have same thread id, and both create a new vector, so one thread's vector will be replaced and this thread will still visit this vector, cause use-after-free
  
## What I'm doing:
1. use thread-id instead of driver-id as map's key
2. use phmap's lazy_emplace_l, lazy_emplace_l first arg is key, second arg is lambda which will be called if this key is already exist in map, third arg is lambda  which will be called if this key doens't exist in map

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
