### PR TITLE
[BugFix] Fix memory/row count inaccuracies that can cause aggregate stucked

### DIFF
--- a/be/src/exec/limited_pipeline_chunk_buffer.h
+++ b/be/src/exec/limited_pipeline_chunk_buffer.h
@@ -29,14 +29,21 @@ public:
     LimitedPipelineChunkBuffer(BufferMetrics* metrics, size_t max_dop, size_t max_memory_usage, size_t max_chunk_count)
             : _metrics(metrics), _buffer_mem_manager(max_dop, max_memory_usage, max_chunk_count) {}
 
-    bool is_full() const { return _buffer_mem_manager.is_full(); }
+    bool is_full() const {
+#ifndef NDEBUG
+        std::lock_guard l(_buffer_mutex);
+        DCHECK(!(_buffer_mem_manager.is_full() && _element_size == 0));
+#endif
+        return _buffer_mem_manager.is_full();
+    }
 
     void push(const ChunkPtr& chunk) {
-        size_t mem_usage = chunk->memory_usage();
-        size_t num_rows = chunk->num_rows();
+        ChunkWithInfo chunk_with_info(chunk);
+        size_t mem_usage = chunk_with_info.mem_usage;
+        size_t num_rows = chunk_with_info.num_rows;
         {
             std::lock_guard l(_buffer_mutex);
-            _buffer.push(chunk);
+            _buffer.push(std::move(chunk_with_info));
         }
         _element_size++;
         _buffer_mem_manager.update_memory_usage(mem_usage, num_rows);
@@ -45,26 +52,29 @@ public:
     }
 
     ChunkPtr pull() {
-        ChunkPtr chunk;
+        ChunkWithInfo chunk_with_info;
         {
             std::lock_guard l(_buffer_mutex);
             if (_buffer.empty()) {
                 return nullptr;
             }
-            chunk = _buffer.front();
+            chunk_with_info = std::move(_buffer.front());
             _buffer.pop();
         }
         _element_size--;
-        size_t mem_usage = chunk->memory_usage();
-        size_t num_rows = chunk->num_rows();
+        size_t mem_usage = chunk_with_info.mem_usage;
+        size_t num_rows = chunk_with_info.num_rows;
         _buffer_mem_manager.update_memory_usage(-mem_usage, -num_rows);
+
+        DCHECK_EQ(mem_usage, chunk_with_info.chunk->memory_usage());
+        DCHECK_EQ(num_rows, chunk_with_info.chunk->num_rows());
 
         COUNTER_ADD(_metrics->chunk_buffer_peak_memory, -mem_usage);
         COUNTER_ADD(_metrics->chunk_buffer_peak_size, -1);
-        return chunk;
+        return chunk_with_info.chunk;
     }
 
-    bool is_empty() { return _element_size == 0; }
+    bool is_empty() const { return _element_size == 0; }
 
     void clear() {
         std::lock_guard l(_buffer_mutex);
@@ -75,8 +85,21 @@ public:
 
 private:
     std::atomic_size_t _element_size{};
-    std::mutex _buffer_mutex;
-    std::queue<ChunkPtr> _buffer;
+    mutable std::mutex _buffer_mutex;
+
+    struct ChunkWithInfo {
+        ChunkWithInfo() = default;
+        ChunkWithInfo(ChunkPtr chunk_) : chunk(std::move(chunk_)) {
+            mem_usage = chunk->memory_usage();
+            num_rows = chunk->num_rows();
+        }
+
+        size_t mem_usage;
+        size_t num_rows;
+        ChunkPtr chunk;
+    };
+
+    std::queue<ChunkWithInfo> _buffer;
     BufferMetrics* _metrics;
     pipeline::ChunkBufferMemoryManager _buffer_mem_manager;
 };


### PR DESCRIPTION
## Why I'm doing:

Currently there is no root cause found for inaccurate memory stats. this PR mainly defends against that. And adds some DCHECK.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
