### PR TITLE
[Refactor] Refactor dropTable method to accept Table object directly and remove isSetIfExists parameter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -256,17 +256,15 @@ public class Database extends MetaObject implements Writable {
         }
     }
 
-    public void dropTable(String tableName, boolean isSetIfExists, boolean isForce) throws DdlException {
-        Table table;
+    public void dropTable(Table table, boolean isSetIfExists, boolean isForce) throws DdlException {
+        if (table == null && isSetIfExists) {
+            return;
+        }
         Locker locker = new Locker();
         locker.lockDatabase(id, LockType.WRITE);
         try {
-            table = nameToTable.get(tableName);
-            if (table == null && isSetIfExists) {
-                return;
-            }
             if (table == null) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
+                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, table.getName());
                 return;
             }
             if (!isForce &&
@@ -288,7 +286,7 @@ public class Database extends MetaObject implements Writable {
         }
 
         LOG.info("Finished log drop table '{}' from database '{}'. tableId: {} tableType: {} force: {}",
-                tableName, fullQualifiedName, table.getId(), table.getType(), isForce);
+                table.getName(), fullQualifiedName, table.getId(), table.getType(), isForce);
     }
 
     public void dropTemporaryTable(long tableId, String tableName, boolean isSetIfExists, boolean isForce) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -256,7 +256,7 @@ public class Database extends MetaObject implements Writable {
         }
     }
 
-    public void dropTable(Table table, boolean isSetIfExists, boolean isForce) throws DdlException {
+    public void dropTable(Table table, String tableName, boolean isSetIfExists, boolean isForce) throws DdlException {
         if (table == null && isSetIfExists) {
             return;
         }
@@ -264,7 +264,7 @@ public class Database extends MetaObject implements Writable {
         locker.lockDatabase(id, LockType.WRITE);
         try {
             if (table == null) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, table.getName());
+                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
                 return;
             }
             if (!isForce &&
@@ -286,7 +286,7 @@ public class Database extends MetaObject implements Writable {
         }
 
         LOG.info("Finished log drop table '{}' from database '{}'. tableId: {} tableType: {} force: {}",
-                table.getName(), fullQualifiedName, table.getId(), table.getType(), isForce);
+                tableName, fullQualifiedName, table.getId(), table.getType(), isForce);
     }
 
     public void dropTemporaryTable(long tableId, String tableName, boolean isSetIfExists, boolean isForce) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -256,17 +256,10 @@ public class Database extends MetaObject implements Writable {
         }
     }
 
-    public void dropTable(Table table, String tableName, boolean isSetIfExists, boolean isForce) throws DdlException {
-        if (table == null && isSetIfExists) {
-            return;
-        }
+    public void dropTable(Table table, boolean isForce) throws DdlException {
         Locker locker = new Locker();
         locker.lockDatabase(id, LockType.WRITE);
         try {
-            if (table == null) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
-                return;
-            }
             if (!isForce &&
                     GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().existCommittedTxns(id, table.getId(), null)) {
                 throw new DdlException("There are still some transactions in the COMMITTED state waiting to be completed. " +
@@ -286,7 +279,7 @@ public class Database extends MetaObject implements Writable {
         }
 
         LOG.info("Finished log drop table '{}' from database '{}'. tableId: {} tableType: {} force: {}",
-                tableName, fullQualifiedName, table.getId(), table.getType(), isForce);
+                table.getName(), fullQualifiedName, table.getId(), table.getType(), isForce);
     }
 
     public void dropTemporaryTable(long tableId, String tableName, boolean isSetIfExists, boolean isForce) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2274,7 +2274,13 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         } finally {
             locker.unLockDatabase(db.getId(), LockType.READ);
         }
-        db.dropTable(table, tableName, stmt.isSetIfExists(), stmt.isForceDrop());
+        if (table == null) {
+            if (!stmt.isSetIfExists()) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
+            }
+            return;
+        }
+        db.dropTable(table, stmt.isForceDrop());
     }
 
     public void dropTemporaryTable(String dbName, long tableId, String tableName,
@@ -3253,7 +3259,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         stmt.getDbMvName().getTbl());
             }
 
-            db.dropTable(table, table.getName(), stmt.isSetIfExists(), true);
+            db.dropTable(table, true);
         } else {
             stateMgr.getAlterJobMgr().processDropMaterializedView(stmt);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2274,7 +2274,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         } finally {
             locker.unLockDatabase(db.getId(), LockType.READ);
         }
-        db.dropTable(table, stmt.isSetIfExists(), stmt.isForceDrop());
+        db.dropTable(table, tableName, stmt.isSetIfExists(), stmt.isForceDrop());
     }
 
     public void dropTemporaryTable(String dbName, long tableId, String tableName,
@@ -3253,7 +3253,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         stmt.getDbMvName().getTbl());
             }
 
-            db.dropTable(table, stmt.isSetIfExists(), true);
+            db.dropTable(table, table.getName(), stmt.isSetIfExists(), true);
         } else {
             stateMgr.getAlterJobMgr().processDropMaterializedView(stmt);
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

- Use `table` instead of `tableName`
	- 	When dropping the `MV`, the `table` has already been obtained, so there is no need to acquire the table again through locking.
- Remove the `isSetIfExists` parameter
	- 	When dropping the `MV`, the table must exist when calling the `com.starrocks.catalog.Database#dropTable` function.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
