### PR TITLE
[Enhancement]make access controller lazily

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -355,20 +355,6 @@ public class CatalogMgr {
                 readUnlock();
             }
 
-            String serviceName = config.get("ranger.plugin.hive.service.name");
-            String accessControl = config.getOrDefault("catalog.access.control", Config.access_control);
-            if (serviceName == null || serviceName.isEmpty()) {
-                if (accessControl.equals("ranger")) {
-                    Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
-                } else if (accessControl.equals("allowall")) {
-                    Authorizer.getInstance().setAccessControl(catalogName, new AllowAllAccessController());
-                } else {
-                    Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
-                }
-            } else {
-                Authorizer.getInstance().setAccessControl(catalogName, new RangerHiveAccessController(serviceName));
-            }
-
             try {
                 catalogConnector = connectorMgr.createConnector(
                         new ConnectorContext(catalogName, type, config), true);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
@@ -121,6 +121,24 @@ public class CatalogStmtTest {
     }
 
     @Test
+    public void testCreateCatalogWithAccessControl() throws Exception {
+        String sql = "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\", \"catalog.access.control\"=\"allowall\")";
+        StatementBase stmt = AnalyzeTestUtil.analyzeSuccess(sql);
+        Assertions.assertTrue(stmt instanceof CreateCatalogStmt);
+        ConnectContext connectCtx = new ConnectContext();
+        connectCtx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        CreateCatalogStmt statement = (CreateCatalogStmt) stmt;
+        DDLStmtExecutor.execute(statement, connectCtx);
+        CatalogMgr catalogMgr = GlobalStateMgr.getCurrentState().getCatalogMgr();
+        ConnectorMgr connectorMgr = GlobalStateMgr.getCurrentState().getConnectorMgr();
+        Assertions.assertTrue(catalogMgr.catalogExists("hive_catalog"));
+        Assertions.assertTrue(connectorMgr.connectorExists("hive_catalog"));
+        catalogMgr.dropCatalog(new DropCatalogStmt("hive_catalog"));
+        Assertions.assertFalse(catalogMgr.catalogExists("hive_catalog"));
+        Assertions.assertFalse(connectorMgr.connectorExists("hive_catalog"));
+    }
+
+    @Test
     public void testCreateExistedCatalog() throws Exception {
         String sql = "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
         String sql_2 = "CREATE EXTERNAL CATALOG IF NOT EXISTS hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";


### PR DESCRIPTION
## Why I'm doing:
When we set access controller for catalog, there is remote access(like access to ranger server), 
so we do it lazily to avoid blocking restart of fe(reply create catalog).

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
