### PR TITLE
[Enhancement] support collection array column ndv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -375,6 +375,7 @@ public class FunctionSet {
 
     // Hash functions:
     public static final String MURMUR_HASH3_32 = "murmur_hash3_32";
+    public static final String CRC32_HASH = "crc32_hash";
 
     // Percentile functions:
     public static final String PERCENTILE_APPROX_RAW = "percentile_approx_raw";

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2201,6 +2201,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "collect multi-column combined statistics max column nums")
     public static int statistics_max_multi_column_combined_num = 10;
 
+    @ConfField(mutable = true, comment = "Whether to allow manual collection of the NDV of array columns")
+    public static boolean enable_manual_collect_array_ndv = false;
+
+    @ConfField(mutable = true, comment = "Whether to allow auto collection of the NDV of array columns")
+    public static boolean enable_auto_collect_array_ndv = false;
+
     /**
      * default bucket size of histogram statistics
      */

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1661,7 +1661,8 @@ public class StmtExecutor {
                                 StatsConstants.ScheduleType.ONCE,
                                 analyzeStmt.getProperties(),
                                 analyzeTypeDesc.getStatsTypes(),
-                                analyzeStmt.getColumnNames() != null ? List.of(analyzeStmt.getColumnNames()) : null),
+                                analyzeStmt.getColumnNames() != null ? List.of(analyzeStmt.getColumnNames()) : null,
+                                true),
                         analyzeStatus,
                         // Sync load cache, auto-populate column statistic cache after Analyze table manually
                         false, false /* resetWarehouse */);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/MultiColumnHyperStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/MultiColumnHyperStatisticsCollectJob.java
@@ -37,7 +37,8 @@ public class MultiColumnHyperStatisticsCollectJob extends HyperStatisticsCollect
                                                 StatsConstants.ScheduleType scheduleType, Map<String, String> properties,
                                                 List<StatsConstants.StatisticsType> statsTypes,
                                                 List<List<String>> columnGroups) {
-        super(db, table, partitionIdList, columnNames, columnTypes, type, scheduleType, properties, statsTypes, columnGroups);
+        super(db, table, partitionIdList, columnNames, columnTypes, type, scheduleType,
+                properties, statsTypes, columnGroups, false);
     }
 
     public StatementBase createInsertStmt() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -113,7 +113,8 @@ public class StatisticsCollectJobFactory {
                                                                  StatsConstants.ScheduleType scheduleType,
                                                                  Map<String, String> properties,
                                                                  List<StatsConstants.StatisticsType> statisticsTypes,
-                                                                 List<List<String>> columnGroup) {
+                                                                 List<List<String>> columnGroup,
+                                                                 boolean isManualJob) {
         if (CollectionUtils.isEmpty(columnNames)) {
             columnNames = StatisticUtils.getCollectibleColumns(table);
             columnTypes = columnNames.stream().map(col -> table.getColumn(col).getType()).collect(Collectors.toList());
@@ -136,7 +137,7 @@ public class StatisticsCollectJobFactory {
         if (analyzeType.equals(StatsConstants.AnalyzeType.SAMPLE) && statisticsTypes.isEmpty()) {
             if (Config.statistic_use_meta_statistics) {
                 return new HyperStatisticsCollectJob(db, table, partitionIdList, columnNames, columnTypes,
-                        StatsConstants.AnalyzeType.SAMPLE, scheduleType, properties);
+                        StatsConstants.AnalyzeType.SAMPLE, scheduleType, properties, isManualJob);
             } else {
                 return new SampleStatisticsCollectJob(db, table, columnNames, columnTypes,
                         StatsConstants.AnalyzeType.SAMPLE, scheduleType, properties);
@@ -146,7 +147,7 @@ public class StatisticsCollectJobFactory {
         } else if (analyzeType.equals(StatsConstants.AnalyzeType.FULL) && statisticsTypes.isEmpty()) {
             if (Config.statistic_use_meta_statistics) {
                 return new HyperStatisticsCollectJob(db, table, partitionIdList, columnNames, columnTypes,
-                        StatsConstants.AnalyzeType.FULL, scheduleType, properties);
+                        StatsConstants.AnalyzeType.FULL, scheduleType, properties, isManualJob);
             } else {
                 return new FullStatisticsCollectJob(db, table, partitionIdList, columnNames, columnTypes,
                         StatsConstants.AnalyzeType.FULL, scheduleType, properties);
@@ -336,7 +337,7 @@ public class StatisticsCollectJobFactory {
                     GlobalStateMgr.getCurrentState().getStatisticStorage()
                             .getConnectorTableStatisticsSync(table, columnNames);
             List<ConnectorTableColumnStats> validColumnStatistics = columnStatisticList.stream().
-                    filter(columnStatistic -> !columnStatistic.isUnknown()).collect(Collectors.toList());
+                    filter(columnStatistic -> !columnStatistic.isUnknown()).toList();
 
             // use small table row count as default table row count
             long tableRowCount = Config.statistic_auto_collect_small_table_rows - 1;
@@ -596,7 +597,7 @@ public class StatisticsCollectJobFactory {
         }
 
         StatisticsCollectJob sample = buildStatisticsCollectJob(db, table, partitionIdList, columnNames, columnTypes,
-                StatsConstants.AnalyzeType.SAMPLE, job.getScheduleType(), job.getProperties(), List.of(), List.of());
+                StatsConstants.AnalyzeType.SAMPLE, job.getScheduleType(), job.getProperties(), List.of(), List.of(), false);
         sample.setPriority(priority);
         allTableJobMap.add(sample);
     }
@@ -605,7 +606,7 @@ public class StatisticsCollectJobFactory {
                                            Database db, Table table, List<String> columnNames,
                                            List<Type> columnTypes, StatisticsCollectJob.Priority priority) {
         StatisticsCollectJob sample = buildStatisticsCollectJob(db, table, null, columnNames, columnTypes,
-                StatsConstants.AnalyzeType.HISTOGRAM, job.getScheduleType(), job.getProperties(), List.of(), List.of());
+                StatsConstants.AnalyzeType.HISTOGRAM, job.getScheduleType(), job.getProperties(), List.of(), List.of(), false);
         sample.setPriority(priority);
         allTableJobMap.add(sample);
     }
@@ -617,7 +618,7 @@ public class StatisticsCollectJobFactory {
         StatsConstants.AnalyzeType analyzeType;
         List<Partition> partitionList = table.getPartitions().stream()
                 .filter(partition -> !StatisticUtils.isPartitionStatsHealthy(table, partition, stats))
-                .collect(Collectors.toList());
+                .toList();
 
         long totalDataSize = partitionList.stream().mapToLong(Partition::getDataSize).sum();
         if (job.isDefaultJob() && totalDataSize > Config.statistic_max_full_collect_data_size) {
@@ -631,7 +632,7 @@ public class StatisticsCollectJobFactory {
         if (!partitionList.isEmpty()) {
             StatisticsCollectJob statisticsCollectJob = buildStatisticsCollectJob(db, table,
                     partitionList.stream().map(Partition::getId).collect(Collectors.toList()), columnNames, columnTypes,
-                    analyzeType, job.getScheduleType(), Maps.newHashMap(), List.of(), List.of());
+                    analyzeType, job.getScheduleType(), Maps.newHashMap(), List.of(), List.of(), false);
             statisticsCollectJob.setPriority(priority);
             allTableJobMap.add(statisticsCollectJob);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -201,7 +201,7 @@ public class StatisticsCollectionTrigger {
                         StatisticsCollectJob job = StatisticsCollectJobFactory.buildStatisticsCollectJob(db, table,
                                 new ArrayList<>(partitionIds), null, null,
                                 analyzeType, StatsConstants.ScheduleType.ONCE,
-                                analyzeStatus.getProperties(), List.of(), List.of());
+                                analyzeStatus.getProperties(), List.of(), List.of(), false);
                         if (!partitionTabletRowCounts.isEmpty()) {
                             job.setPartitionTabletRowCounts(partitionTabletRowCounts);
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/base/ColumnClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/base/ColumnClassifier.java
@@ -32,8 +32,14 @@ public class ColumnClassifier {
 
     private final List<ColumnStats> unSupportStats = Lists.newArrayList();
 
-    public static ColumnClassifier of(List<String> columnNames, List<Type> columnTypes, Table table) {
-        ColumnClassifier columnClassifier = new ColumnClassifier();
+    private final boolean isManualJob;
+
+    public ColumnClassifier(boolean isManualJob) {
+        this.isManualJob = isManualJob;
+    }
+
+    public static ColumnClassifier of(List<String> columnNames, List<Type> columnTypes, Table table, boolean isManualJob) {
+        ColumnClassifier columnClassifier = new ColumnClassifier(isManualJob);
         columnClassifier.classifyColumnStats(columnNames, columnTypes, table);
         return columnClassifier;
     }
@@ -48,7 +54,7 @@ public class ColumnClassifier {
                     if (!columnType.isCollectionType()) {
                         columnStats.add(new PrimitiveTypeColumnStats(columnName, columnType));
                     } else {
-                        columnStats.add(new CollectionTypeColumnStats(columnName, columnType));
+                        columnStats.add(new CollectionTypeColumnStats(columnName, columnType, isManualJob));
                     }
                 } else {
                     unSupportStats.add(new ComplexTypeColumnStats(columnName, columnType));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/base/SubFieldColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/base/SubFieldColumnStats.java
@@ -34,7 +34,7 @@ public class SubFieldColumnStats extends PrimitiveTypeColumnStats {
         if (!columnType.canStatistic()) {
             complexStats = new ComplexTypeColumnStats("name", columnType);
         } else if (columnType.isCollectionType()) {
-            complexStats = new CollectionTypeColumnStats("name", columnType);
+            complexStats = new CollectionTypeColumnStats("name", columnType, false);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperQueryJob.java
@@ -236,8 +236,8 @@ public abstract class HyperQueryJob {
 
     public static List<HyperQueryJob> createFullQueryJobs(ConnectContext context, Database db, Table table,
                                                           List<String> columnNames, List<Type> columnTypes,
-                                                          List<Long> partitionIdList, int batchLimit) {
-        ColumnClassifier classifier = ColumnClassifier.of(columnNames, columnTypes, table);
+                                                          List<Long> partitionIdList, int batchLimit, boolean isManualJob) {
+        ColumnClassifier classifier = ColumnClassifier.of(columnNames, columnTypes, table, isManualJob);
 
         List<ColumnStats> supportedStats = classifier.getColumnStats();
         List<ColumnStats> dataCollectColumns =
@@ -260,8 +260,8 @@ public abstract class HyperQueryJob {
     public static List<HyperQueryJob> createSampleQueryJobs(ConnectContext context, Database db, Table table,
                                                             List<String> columnNames, List<Type> columnTypes,
                                                             List<Long> partitionIdList, int batchLimit,
-                                                            PartitionSampler sampler) {
-        ColumnClassifier classifier = ColumnClassifier.of(columnNames, columnTypes, table);
+                                                            PartitionSampler sampler, boolean isManualJob) {
+        ColumnClassifier classifier = ColumnClassifier.of(columnNames, columnTypes, table, isManualJob);
         List<ColumnStats> supportedStats = classifier.getColumnStats();
 
         List<ColumnStats> metaCollectColumns =

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -788,6 +788,7 @@ vectorized_functions = [
     [100010, 'murmur_hash3_32', True, False, 'INT', ['VARCHAR', '...'], 'HashFunctions::murmur_hash3_32'],
     [100021, 'xx_hash3_64', True, False, 'BIGINT', ['VARCHAR', '...'], 'HashFunctions::xx_hash3_64'],
     [100022, 'xx_hash3_128', True, False, 'LARGEINT', ['VARCHAR', '...'], 'HashFunctions::xx_hash3_128'],
+    [100023, 'crc32_hash', True, False, 'BIGINT', ['ANY_ARRAY'], 'HashFunctions::crc32_hash'],
 
 
     # Utility functions

--- a/test/sql/test_collect_statistics/R/test_array_stats
+++ b/test/sql/test_collect_statistics/R/test_array_stats
@@ -1,0 +1,409 @@
+-- name: test_array_stats
+DROP DATABASE IF EXISTS test_array_stats;
+-- result:
+-- !result
+CREATE DATABASE test_array_stats;
+-- result:
+-- !result
+USE test_array_stats;
+-- result:
+-- !result
+create table test_array_ndv(
+    k1 int,
+    int_arr array<int>,
+    str_arr array<string>,
+    nested_arr_int array<array<int>>
+) properties("replication_num"="1");
+-- result:
+-- !result
+insert into test_array_ndv values
+(1, [1,2,3], ['a', 'b', 'c'], [[12], [34], [4444]]),
+(3, [1, null], null, [[1, null], null]),
+(null, null, null, null),
+(4, [], [], []);
+-- result:
+-- !result
+select column_name, hll_cardinality(ndv) from _statistics_.column_statistics where table_name = 'test_array_stats.test_array_ndv' order by column_name;
+-- result:
+int_arr	0
+k1	3
+nested_arr_int	0
+str_arr	0
+-- !result
+admin set frontend config ("enable_manual_collect_array_ndv"="true");
+-- result:
+-- !result
+analyze table test_array_ndv;
+-- result:
+test_array_stats.test_array_ndv	analyze	status	OK
+-- !result
+select column_name, hll_cardinality(ndv) from _statistics_.column_statistics where table_name = 'test_array_stats.test_array_ndv' order by column_name;
+-- result:
+int_arr	3
+k1	3
+nested_arr_int	3
+str_arr	2
+-- !result
+function: assert_explain_costs_contains('select * from test_array_stats.test_array_ndv', 'int_arr-->[-Infinity, Infinity, 0.0, 6.5, 3.0]', ' nested_arr_int-->[-Infinity, Infinity, 0.0, 26.5, 3.0]')
+-- result:
+None
+-- !result
+drop stats test_array_ndv;
+-- result:
+-- !result
+select column_name, hll_cardinality(ndv) from _statistics_.column_statistics where table_name = 'test_array_stats.test_array_ndv' order by column_name;
+-- result:
+-- !result
+select int_arr, crc32_hash(int_arr) from test_array_ndv order by 1;
+-- result:
+None	None
+[]	1696784233
+[1,null]	2813423272
+[1,2,3]	1799959227
+-- !result
+select crc32_hash(NULL);
+-- result:
+None
+-- !result
+select crc32_hash([]);
+-- result:
+1696784233
+-- !result
+select crc32_hash([cast(1 as int), null]);
+-- result:
+2813423272
+-- !result
+select crc32_hash([cast(1 as int), cast(2 as int), cast(3 as int)]);
+-- result:
+1799959227
+-- !result
+CREATE TABLE test_array_comprehensive_ndv(
+    k1 int,
+    -- Arrays of basic data types
+    arr_int array<int>,
+    arr_bigint array<bigint>,
+    arr_float array<float>,
+    arr_double array<double>,
+    arr_string array<string>,
+    arr_varchar array<varchar(100)>,
+    arr_boolean array<boolean>,
+    arr_date array<date>,
+    arr_datetime array<datetime>,
+    arr_decimal array<decimal(10,2)>,
+    -- Arrays of maps
+    arr_map_int array<map<int, int>>,
+    arr_map_str array<map<string, string>>,
+    arr_map_mixed array<map<string, int>>,
+    -- Arrays of structs
+    arr_struct_simple array<struct<k1 int, k2 string>>,
+    arr_struct_complex array<struct<id int, name string, score double, active boolean>>,
+    -- Multi-level nested arrays
+    arr_arr_int array<array<int>>,
+    arr_arr_str array<array<string>>
+) PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+INSERT INTO test_array_comprehensive_ndv VALUES
+(1, 
+ [1,2,3], 
+ [100,200,300], 
+ [1.1,2.2,3.3], 
+ [10.01,20.02,30.03],
+ ['apple','banana','cherry'], 
+ ['red','green','blue'],
+ [true,false,true], 
+ ['2023-01-01','2023-02-01','2023-03-01'],
+ ['2023-01-01 10:00:00','2023-02-01 11:00:00'],
+ [99.99,199.99,299.99],
+ [map(1,10), map(2,20), map(3,30)],
+ [map('name','Alice'), map('city','Beijing'), map('country','China')],
+ [map('user1',100), map('user2',200)],
+ [row(1,'first'), row(2,'second'), row(3,'third')],
+ [row(101,'John',85.5,true), row(102,'Jane',92.0,false)],
+ [[1,2],[3,4],[5,6]],
+ [['a','b'],['c','d'],['e','f']]
+),
+
+(2,
+ [1,null,3],
+ [null,200],
+ [1.1,null],
+ [null],
+ ['hello',null,'world'],
+ [null,'test'],
+ [true,null],
+ [null,'2023-01-01'],
+ ['2023-01-01 10:00:00',null],
+ [null,99.99],
+ [map(1,null), map(null,20)],
+ [map('key',null), map(null,'value')],
+ [map('test',null)],
+ [row(null,'test'), row(1,null)],
+ [row(null,'Alice',null,true)],
+ [[1,null],[null,4]],
+ [['a',null],[null,'d']]
+),
+
+(3,
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ []
+),
+
+(4,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null
+),
+
+(5,
+ [1,1,2,2,3,3],
+ [100,100,200],
+ [1.1,1.1,2.2],
+ [10.01,10.01],
+ ['apple','apple','banana'],
+ ['red','red','green'],
+ [true,true,false],
+ ['2023-01-01','2023-01-01'],
+ ['2023-01-01 10:00:00','2023-01-01 10:00:00'],
+ [99.99,99.99],
+ [map(1,10), map(1,10), map(2,20)],
+ [map('name','Alice'), map('name','Alice')],
+ [map('user1',100), map('user1',100)],
+ [row(1,'first'), row(1,'first'), row(2,'second')],
+ [row(101,'John',85.5,true), row(101,'John',85.5,true)],
+ [[1,2],[1,2],[3,4]],
+ [['a','b'],['a','b']]
+),
+
+(6,
+ [1,2,3,4,5,6,7,8,9,10],
+ [1000,2000,3000,4000,5000],
+ [0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0],
+ [100.1,200.2,300.3,400.4,500.5],
+ ['item1','item2','item3','item4','item5','item6','item7','item8'],
+ ['val1','val2','val3','val4','val5'],
+ [true,false,true,false,true],
+ ['2023-01-01','2023-02-01','2023-03-01','2023-04-01','2023-05-01'],
+ ['2023-01-01 08:00:00','2023-01-01 12:00:00','2023-01-01 18:00:00'],
+ [10.5,20.5,30.5,40.5,50.5,60.5],
+ [map(1,100), map(2,200), map(3,300), map(4,400)],
+ [map('a','alpha'), map('b','beta'), map('c','gamma')],
+ [map('score1',95), map('score2',87), map('score3',92)],
+ [row(1,'alpha'), row(2,'beta'), row(3,'gamma'), row(4,'delta')],
+ [row(201,'Alice',95.5,true), row(202,'Bob',87.0,false), row(203,'Charlie',92.5,true)],
+ [[1,2,3],[4,5,6],[7,8,9],[10,11,12]],
+ [['x','y','z'],['p','q','r'],['m','n','o']]
+);
+-- result:
+-- !result
+SELECT column_name, hll_cardinality(ndv) 
+FROM _statistics_.column_statistics 
+WHERE table_name = 'test_array_stats.test_array_comprehensive_ndv' 
+ORDER BY column_name;
+-- result:
+arr_arr_int	0
+arr_arr_str	0
+arr_bigint	0
+arr_boolean	0
+arr_date	0
+arr_datetime	0
+arr_decimal	0
+arr_double	0
+arr_float	0
+arr_int	0
+arr_map_int	0
+arr_map_mixed	0
+arr_map_str	0
+arr_string	0
+arr_struct_complex	0
+arr_struct_simple	0
+arr_varchar	0
+k1	6
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_manual_collect_array_ndv"="true");
+-- result:
+-- !result
+ANALYZE TABLE test_array_comprehensive_ndv;
+-- result:
+test_array_stats.test_array_comprehensive_ndv	analyze	status	OK
+-- !result
+SELECT column_name, hll_cardinality(ndv) 
+FROM _statistics_.column_statistics 
+WHERE table_name = 'test_array_stats.test_array_comprehensive_ndv' 
+ORDER BY column_name;
+-- result:
+arr_arr_int	5
+arr_arr_str	5
+arr_bigint	5
+arr_boolean	5
+arr_date	5
+arr_datetime	5
+arr_decimal	5
+arr_double	5
+arr_float	5
+arr_int	5
+arr_map_int	5
+arr_map_mixed	5
+arr_map_str	5
+arr_string	5
+arr_struct_complex	5
+arr_struct_simple	5
+arr_varchar	5
+k1	6
+-- !result
+SELECT 'Basic Arrays Hash Test' as test_type;
+-- result:
+Basic Arrays Hash Test
+-- !result
+SELECT arr_int, crc32_hash(arr_int) FROM test_array_comprehensive_ndv ORDER BY k1;
+-- result:
+[1,2,3]	1799959227
+[1,null,3]	694957510
+[]	1696784233
+None	None
+[1,1,2,2,3,3]	1134956290
+[1,2,3,4,5,6,7,8,9,10]	3373193218
+-- !result
+SELECT arr_string, crc32_hash(arr_string) FROM test_array_comprehensive_ndv ORDER BY k1;
+-- result:
+["apple","banana","cherry"]	896925029
+["hello",null,"world"]	2519103527
+[]	1696784233
+None	None
+["apple","apple","banana"]	3746459941
+["item1","item2","item3","item4","item5","item6","item7","item8"]	3941009823
+-- !result
+SELECT arr_boolean, crc32_hash(arr_boolean) FROM test_array_comprehensive_ndv ORDER BY k1;
+-- result:
+[1,0,1]	2225114444
+[1,null]	1380506233
+[]	1696784233
+None	None
+[1,1,0]	3938225307
+[1,0,1,0,1]	1509852800
+-- !result
+SELECT 'Map Arrays Hash Test' as test_type;
+-- result:
+Map Arrays Hash Test
+-- !result
+SELECT arr_map_int, crc32_hash(arr_map_int) FROM test_array_comprehensive_ndv ORDER BY k1;
+-- result:
+[{1:10},{2:20},{3:30}]	868535172
+[{1:null},{null:20}]	1778422670
+[]	1696784233
+None	None
+[{1:10},{1:10},{2:20}]	505143816
+[{1:100},{2:200},{3:300},{4:400}]	651342674
+-- !result
+SELECT arr_map_str, crc32_hash(arr_map_str) FROM test_array_comprehensive_ndv ORDER BY k1;
+-- result:
+[{"name":"Alice"},{"city":"Beijing"},{"country":"China"}]	1138474844
+[{"key":null},{null:"value"}]	1574883760
+[]	1696784233
+None	None
+[{"name":"Alice"},{"name":"Alice"}]	2742607400
+[{"a":"alpha"},{"b":"beta"},{"c":"gamma"}]	1684503393
+-- !result
+SELECT 'Struct Arrays Hash Test' as test_type;
+-- result:
+Struct Arrays Hash Test
+-- !result
+SELECT arr_struct_simple, crc32_hash(arr_struct_simple) FROM test_array_comprehensive_ndv ORDER BY k1;
+-- result:
+[{"k1":1,"k2":"first"},{"k1":2,"k2":"second"},{"k1":3,"k2":"third"}]	1872512112
+[{"k1":null,"k2":"test"},{"k1":1,"k2":null}]	11414018
+[]	1696784233
+None	None
+[{"k1":1,"k2":"first"},{"k1":1,"k2":"first"},{"k1":2,"k2":"second"}]	3183025692
+[{"k1":1,"k2":"alpha"},{"k1":2,"k2":"beta"},{"k1":3,"k2":"gamma"},{"k1":4,"k2":"delta"}]	2732652744
+-- !result
+SELECT arr_struct_complex, crc32_hash(arr_struct_complex) FROM test_array_comprehensive_ndv ORDER BY k1;
+-- result:
+[{"id":101,"name":"John","score":85.5,"active":1},{"id":102,"name":"Jane","score":92,"active":0}]	4158916217
+[{"id":null,"name":"Alice","score":null,"active":1}]	787122329
+[]	1696784233
+None	None
+[{"id":101,"name":"John","score":85.5,"active":1},{"id":101,"name":"John","score":85.5,"active":1}]	314551468
+[{"id":201,"name":"Alice","score":95.5,"active":1},{"id":202,"name":"Bob","score":87,"active":0},{"id":203,"name":"Charlie","score":92.5,"active":1}]	2205081798
+-- !result
+SELECT 'Nested Arrays Hash Test' as test_type;
+-- result:
+Nested Arrays Hash Test
+-- !result
+SELECT arr_arr_int, crc32_hash(arr_arr_int) FROM test_array_comprehensive_ndv ORDER BY k1;
+-- result:
+[[1,2],[3,4],[5,6]]	350047771
+[[1,null],[null,4]]	3711354232
+[]	1696784233
+None	None
+[[1,2],[1,2],[3,4]]	631496397
+[[1,2,3],[4,5,6],[7,8,9],[10,11,12]]	610106645
+-- !result
+SELECT arr_arr_str, crc32_hash(arr_arr_str) FROM test_array_comprehensive_ndv ORDER BY k1;
+-- result:
+[["a","b"],["c","d"],["e","f"]]	2992981800
+[["a",null],[null,"d"]]	1059449746
+[]	1696784233
+None	None
+[["a","b"],["a","b"]]	691371630
+[["x","y","z"],["p","q","r"],["m","n","o"]]	896362076
+-- !result
+SELECT 'Edge Cases Hash Test' as test_type;
+-- result:
+Edge Cases Hash Test
+-- !result
+SELECT crc32_hash(CAST(NULL AS array<int>)) as null_array_hash;
+-- result:
+None
+-- !result
+SELECT crc32_hash([]) as empty_array_hash;
+-- result:
+1696784233
+-- !result
+SELECT crc32_hash([CAST(NULL AS int)]) as array_with_null_hash;
+-- result:
+3765471744
+-- !result
+SELECT crc32_hash([map(1,NULL)]) as array_map_with_null_hash;
+-- result:
+3433205882
+-- !result
+SELECT crc32_hash([row(NULL,'test')]) as array_struct_with_null_hash;
+-- result:
+3152575444
+-- !result
+drop stats test_array_comprehensive_ndv;
+-- result:
+-- !result
+drop stats test_array_ndv;
+-- result:
+-- !result

--- a/test/sql/test_collect_statistics/T/test_array_stats
+++ b/test/sql/test_collect_statistics/T/test_array_stats
@@ -1,0 +1,239 @@
+-- name: test_array_stats
+
+DROP DATABASE IF EXISTS test_array_stats;
+CREATE DATABASE test_array_stats;
+USE test_array_stats;
+
+create table test_array_ndv(
+    k1 int,
+    int_arr array<int>,
+    str_arr array<string>,
+    nested_arr_int array<array<int>>
+) properties("replication_num"="1");
+
+insert into test_array_ndv values
+(1, [1,2,3], ['a', 'b', 'c'], [[12], [34], [4444]]),
+(3, [1, null], null, [[1, null], null]),
+(null, null, null, null),
+(4, [], [], []);
+
+select column_name, hll_cardinality(ndv) from _statistics_.column_statistics where table_name = 'test_array_stats.test_array_ndv' order by column_name;
+admin set frontend config ("enable_manual_collect_array_ndv"="true");
+analyze table test_array_ndv;
+select column_name, hll_cardinality(ndv) from _statistics_.column_statistics where table_name = 'test_array_stats.test_array_ndv' order by column_name;
+function: assert_explain_costs_contains('select * from test_array_stats.test_array_ndv', 'int_arr-->[-Infinity, Infinity, 0.0, 6.5, 3.0]', ' nested_arr_int-->[-Infinity, Infinity, 0.0, 26.5, 3.0]')
+
+drop stats test_array_ndv;
+-- insert into can not trigger statistics collection
+select column_name, hll_cardinality(ndv) from _statistics_.column_statistics where table_name = 'test_array_stats.test_array_ndv' order by column_name;
+
+-- check if the hash values are equal
+select int_arr, crc32_hash(int_arr) from test_array_ndv order by 1;
+select crc32_hash(NULL);
+select crc32_hash([]);
+select crc32_hash([cast(1 as int), null]);
+select crc32_hash([cast(1 as int), cast(2 as int), cast(3 as int)]);
+
+-- Create table with various array nested types
+CREATE TABLE test_array_comprehensive_ndv(
+    k1 int,
+    -- Arrays of basic data types
+    arr_int array<int>,
+    arr_bigint array<bigint>,
+    arr_float array<float>,
+    arr_double array<double>,
+    arr_string array<string>,
+    arr_varchar array<varchar(100)>,
+    arr_boolean array<boolean>,
+    arr_date array<date>,
+    arr_datetime array<datetime>,
+    arr_decimal array<decimal(10,2)>,
+    -- Arrays of maps
+    arr_map_int array<map<int, int>>,
+    arr_map_str array<map<string, string>>,
+    arr_map_mixed array<map<string, int>>,
+    -- Arrays of structs
+    arr_struct_simple array<struct<k1 int, k2 string>>,
+    arr_struct_complex array<struct<id int, name string, score double, active boolean>>,
+    -- Multi-level nested arrays
+    arr_arr_int array<array<int>>,
+    arr_arr_str array<array<string>>
+) PROPERTIES("replication_num"="1");
+
+-- Insert test data
+INSERT INTO test_array_comprehensive_ndv VALUES
+-- Row 1: Normal data
+(1, 
+ [1,2,3], 
+ [100,200,300], 
+ [1.1,2.2,3.3], 
+ [10.01,20.02,30.03],
+ ['apple','banana','cherry'], 
+ ['red','green','blue'],
+ [true,false,true], 
+ ['2023-01-01','2023-02-01','2023-03-01'],
+ ['2023-01-01 10:00:00','2023-02-01 11:00:00'],
+ [99.99,199.99,299.99],
+ [map(1,10), map(2,20), map(3,30)],
+ [map('name','Alice'), map('city','Beijing'), map('country','China')],
+ [map('user1',100), map('user2',200)],
+ [row(1,'first'), row(2,'second'), row(3,'third')],
+ [row(101,'John',85.5,true), row(102,'Jane',92.0,false)],
+ [[1,2],[3,4],[5,6]],
+ [['a','b'],['c','d'],['e','f']]
+),
+
+-- Row 2: Data with null values
+(2,
+ [1,null,3],
+ [null,200],
+ [1.1,null],
+ [null],
+ ['hello',null,'world'],
+ [null,'test'],
+ [true,null],
+ [null,'2023-01-01'],
+ ['2023-01-01 10:00:00',null],
+ [null,99.99],
+ [map(1,null), map(null,20)],
+ [map('key',null), map(null,'value')],
+ [map('test',null)],
+ [row(null,'test'), row(1,null)],
+ [row(null,'Alice',null,true)],
+ [[1,null],[null,4]],
+ [['a',null],[null,'d']]
+),
+
+-- Row 3: Empty arrays
+(3,
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ [],
+ []
+),
+
+-- Row 4: All null values
+(4,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null,
+ null
+),
+
+-- Row 5: Duplicate data for NDV testing
+(5,
+ [1,1,2,2,3,3],
+ [100,100,200],
+ [1.1,1.1,2.2],
+ [10.01,10.01],
+ ['apple','apple','banana'],
+ ['red','red','green'],
+ [true,true,false],
+ ['2023-01-01','2023-01-01'],
+ ['2023-01-01 10:00:00','2023-01-01 10:00:00'],
+ [99.99,99.99],
+ [map(1,10), map(1,10), map(2,20)],
+ [map('name','Alice'), map('name','Alice')],
+ [map('user1',100), map('user1',100)],
+ [row(1,'first'), row(1,'first'), row(2,'second')],
+ [row(101,'John',85.5,true), row(101,'John',85.5,true)],
+ [[1,2],[1,2],[3,4]],
+ [['a','b'],['a','b']]
+),
+
+-- Row 6: Large data volume test
+(6,
+ [1,2,3,4,5,6,7,8,9,10],
+ [1000,2000,3000,4000,5000],
+ [0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0],
+ [100.1,200.2,300.3,400.4,500.5],
+ ['item1','item2','item3','item4','item5','item6','item7','item8'],
+ ['val1','val2','val3','val4','val5'],
+ [true,false,true,false,true],
+ ['2023-01-01','2023-02-01','2023-03-01','2023-04-01','2023-05-01'],
+ ['2023-01-01 08:00:00','2023-01-01 12:00:00','2023-01-01 18:00:00'],
+ [10.5,20.5,30.5,40.5,50.5,60.5],
+ [map(1,100), map(2,200), map(3,300), map(4,400)],
+ [map('a','alpha'), map('b','beta'), map('c','gamma')],
+ [map('score1',95), map('score2',87), map('score3',92)],
+ [row(1,'alpha'), row(2,'beta'), row(3,'gamma'), row(4,'delta')],
+ [row(201,'Alice',95.5,true), row(202,'Bob',87.0,false), row(203,'Charlie',92.5,true)],
+ [[1,2,3],[4,5,6],[7,8,9],[10,11,12]],
+ [['x','y','z'],['p','q','r'],['m','n','o']]
+);
+
+-- Check statistics before collection
+SELECT column_name, hll_cardinality(ndv) 
+FROM _statistics_.column_statistics 
+WHERE table_name = 'test_array_stats.test_array_comprehensive_ndv' 
+ORDER BY column_name;
+
+-- Enable array NDV collection
+ADMIN SET FRONTEND CONFIG ("enable_manual_collect_array_ndv"="true");
+
+-- Collect statistics
+ANALYZE TABLE test_array_comprehensive_ndv;
+
+-- Check statistics after collection
+SELECT column_name, hll_cardinality(ndv) 
+FROM _statistics_.column_statistics 
+WHERE table_name = 'test_array_stats.test_array_comprehensive_ndv' 
+ORDER BY column_name;
+
+-- Test hash values for various array types
+SELECT 'Basic Arrays Hash Test' as test_type;
+SELECT arr_int, crc32_hash(arr_int) FROM test_array_comprehensive_ndv ORDER BY k1;
+SELECT arr_string, crc32_hash(arr_string) FROM test_array_comprehensive_ndv ORDER BY k1;
+SELECT arr_boolean, crc32_hash(arr_boolean) FROM test_array_comprehensive_ndv ORDER BY k1;
+
+SELECT 'Map Arrays Hash Test' as test_type;
+SELECT arr_map_int, crc32_hash(arr_map_int) FROM test_array_comprehensive_ndv ORDER BY k1;
+SELECT arr_map_str, crc32_hash(arr_map_str) FROM test_array_comprehensive_ndv ORDER BY k1;
+
+SELECT 'Struct Arrays Hash Test' as test_type;
+SELECT arr_struct_simple, crc32_hash(arr_struct_simple) FROM test_array_comprehensive_ndv ORDER BY k1;
+SELECT arr_struct_complex, crc32_hash(arr_struct_complex) FROM test_array_comprehensive_ndv ORDER BY k1;
+
+SELECT 'Nested Arrays Hash Test' as test_type;
+SELECT arr_arr_int, crc32_hash(arr_arr_int) FROM test_array_comprehensive_ndv ORDER BY k1;
+SELECT arr_arr_str, crc32_hash(arr_arr_str) FROM test_array_comprehensive_ndv ORDER BY k1;
+
+-- Test hash values for edge cases
+SELECT 'Edge Cases Hash Test' as test_type;
+SELECT crc32_hash(CAST(NULL AS array<int>)) as null_array_hash;
+SELECT crc32_hash([]) as empty_array_hash;
+SELECT crc32_hash([CAST(NULL AS int)]) as array_with_null_hash;
+SELECT crc32_hash([map(1,NULL)]) as array_map_with_null_hash;
+SELECT crc32_hash([row(NULL,'test')]) as array_struct_with_null_hash;
+
+drop stats test_array_comprehensive_ndv;
+drop stats test_array_ndv;
+admin set frontend config ("enable_manual_collect_array_ndv"="false");
+
+


### PR DESCRIPTION
## Why I'm doing:
Currently, StarRocks mocks NDV as `0` for complex types (array/map/struct) in statistics storage and defaults to `1` during query planning. This leads to inaccurate cardinality estimation for `GROUP BY array_column` queries, resulting in wrong query plans. Users heavily relying on array columns experience persistent performance issues due to this limitation.

We need to implement array NDV collection to improve plan accuracy.

## What I'm doing:
1. implement a hash function named `crc32_hash` to calucate the hash value of a row of array data type. input is `array`, output is `bigint`. 
2. the projection of `ndv` in the statistics collection SQL.

```
hex(hll_serialize(IFNULL(hll_raw(crc32_hash(`arr_col`)), hll_empty()))) 
```
3. provide two fe config to control if starrocks can collect array ndv.
- `enable_manual_collect_array_ndv` Whether to allow manual collection of the NDV of array columns. default value is false.
- `enable_auto_collect_array_ndv` Whether to allow auto collection of the NDV of array columns. default value is false.

Since collecting array ndv requires reading each row of data, the performance is relatively poor. It is recommended that when array ndv is a necessary condition, users enable manual analyze array ndv and only perform sample analyze on the required array columns. 

The accuracy of array ndv has been verified through testing to be basically consistent with other data types.

Fixes #issue
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
