### PR TITLE
[Enhancement] Add garbage file checking to facilitate future comprehensive vacuum testing

### DIFF
--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -34,6 +34,7 @@
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_metadata.h"
+#include "storage/lake/vacuum.h"
 #include "storage/primary_key_dump.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"
@@ -307,6 +308,16 @@ public:
         RETURN_IF(!base64_decode(meta_base64, &meta_bytes), "bad base64 string");
         RETURN_IF(!pb.ParseFromString(meta_bytes), "parse encryption meta failed");
         return proto_to_json(pb);
+    }
+
+    static std::string garbage_file_check(const std::string& root_location) {
+        auto val_st = lake::garbage_file_check(root_location);
+        if (!val_st.ok()) {
+            LOG(WARNING) << "garbage_file_check failed: " << val_st.status().to_string();
+            // return empty string to indicate failure
+            return "";
+        }
+        return std::to_string(val_st.value());
     }
 
     static std::shared_ptr<TabletBasicInfo> get_tablet_info(int64_t tablet_id) {
@@ -598,6 +609,7 @@ public:
             REG_STATIC_METHOD(StorageEngineRef, ls_tablet_dir);
             REG_STATIC_METHOD(StorageEngineRef, set_error_state);
             REG_STATIC_METHOD(StorageEngineRef, recover_tablet);
+            REG_STATIC_METHOD(StorageEngineRef, garbage_file_check);
         }
     }
 };

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1425,8 +1425,8 @@ static StatusOr<std::pair<int64_t, int64_t>> path_datafile_gc(std::string_view r
     return total;
 }
 
-Status datafile_gc(std::string_view root_location, std::string_view audit_file_path, int64_t expired_seconds,
-                   bool do_delete) {
+StatusOr<int64_t> datafile_gc(std::string_view root_location, std::string_view audit_file_path, int64_t expired_seconds,
+                              bool do_delete) {
     auto pair_or = path_datafile_gc(root_location, audit_file_path, expired_seconds, do_delete);
     if (!pair_or.ok()) {
         LOG(WARNING) << "Failed to gc: " << root_location << ", status: " << pair_or.status();
@@ -1436,7 +1436,11 @@ Status datafile_gc(std::string_view root_location, std::string_view audit_file_p
     LOG(INFO) << "Finished to gc: " << root_location << ", total orphan data files: " << pair_or.value().first
               << ", total size: " << pair_or.value().second;
 
-    return Status::OK();
+    return pair_or.value().first;
+}
+
+StatusOr<int64_t> garbage_file_check(std::string_view root_location) {
+    return datafile_gc(root_location, "", 0, false);
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/vacuum.h
+++ b/be/src/storage/lake/vacuum.h
@@ -58,7 +58,8 @@ void run_clear_task_async(std::function<void()> task);
 StatusOr<int64_t> datafile_gc(std::string_view root_location, std::string_view audit_file_path,
                               int64_t expired_seconds = 86400, bool do_delete = false);
 
-// Check and delete garbage files in the specified location.
+// Check if there are any garbage files in the given root location.
+// Returns the number of garbage files found.
 StatusOr<int64_t> garbage_file_check(std::string_view root_location);
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/vacuum.h
+++ b/be/src/storage/lake/vacuum.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include "common/statusor.h"
 #include "gen_cpp/lake_service.pb.h"
 
 namespace starrocks {
@@ -54,7 +55,10 @@ std::future<Status> delete_files_callable(std::vector<std::string> files_to_dele
 // Run a clear task async
 void run_clear_task_async(std::function<void()> task);
 
-Status datafile_gc(std::string_view root_location, std::string_view audit_file_path, int64_t expired_seconds = 86400,
-                   bool do_delete = false);
+StatusOr<int64_t> datafile_gc(std::string_view root_location, std::string_view audit_file_path,
+                              int64_t expired_seconds = 86400, bool do_delete = false);
+
+// Check and delete garbage files in the specified location.
+StatusOr<int64_t> garbage_file_check(std::string_view root_location);
 
 } // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2920,8 +2920,8 @@ public class Config extends ConfigBase {
             aliases = {"lake_compaction_disable_tables"})
     public static String lake_compaction_disable_ids = "";
 
-    @ConfField(mutable = true, comment = "partitions which should ignore grace timestamp, test only, format:'id1;id2'")
-    public static String lake_ignore_grace_timestamp_partition_ids = "";
+    @ConfField(mutable = true, comment = "partitions which can be vacuumed immediately, test only, format:'id1;id2'")
+    public static String lake_vacuum_immediately_partition_ids = "";
 
     @ConfField(mutable = true, comment = "the max number of threads for lake table publishing version")
     public static int lake_publish_version_max_threads = 512;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2920,6 +2920,9 @@ public class Config extends ConfigBase {
             aliases = {"lake_compaction_disable_tables"})
     public static String lake_compaction_disable_ids = "";
 
+    @ConfField(mutable = true, comment = "partitions which should ignore grace timestamp, test only, format:'id1;id2'")
+    public static String lake_ignore_grace_timestamp_partition_ids = "";
+
     @ConfField(mutable = true, comment = "the max number of threads for lake table publishing version")
     public static int lake_publish_version_max_threads = 512;
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -241,15 +241,15 @@ public class AutovacuumDaemon extends FrontendDaemon {
             vacuumRequest.minRetainVersion = minRetainVersion;
             vacuumRequest.graceTimestamp =
                     startTime / MILLISECONDS_PER_SECOND - Config.lake_autovacuum_grace_period_minutes * 60;
-            vacuumRequest.graceTimestamp = Math.min(vacuumRequest.graceTimestamp,
-                    Math.max(GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
-                            .getSafeDeletionTimeMs() / MILLISECONDS_PER_SECOND, 1));
             if (vacuumImmediatelyPartition(partition)) {
                 // If the partition is in the ignore list, we set graceTimestamp to startTime.
                 // This means that the vacuum operation will not be delayed by graceTimestamp.
                 // So version will be vacuumed immediately.
                 vacuumRequest.graceTimestamp = startTime / MILLISECONDS_PER_SECOND;
             }
+            vacuumRequest.graceTimestamp = Math.min(vacuumRequest.graceTimestamp,
+                    Math.max(GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
+                            .getSafeDeletionTimeMs() / MILLISECONDS_PER_SECOND, 1));
             vacuumRequest.retainVersions = Lists.newArrayList();
             vacuumRequest.minActiveTxnId = minActiveTxnId;
             vacuumRequest.partitionId = partition.getId();

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -113,7 +113,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
         if (partition.getVisibleVersion() <= 1) {
             return false;
         }
-        if (ignoreVacuumGraceTimestamp(partition)) {
+        if (vacuumImmediatelyPartition(partition)) {
             return true;
         }
         // prevent vacuum too frequent
@@ -244,7 +244,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
             vacuumRequest.graceTimestamp = Math.min(vacuumRequest.graceTimestamp,
                     Math.max(GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
                             .getSafeDeletionTimeMs() / MILLISECONDS_PER_SECOND, 1));
-            if (ignoreVacuumGraceTimestamp(partition)) {
+            if (vacuumImmediatelyPartition(partition)) {
                 // If the partition is in the ignore list, we set graceTimestamp to startTime.
                 // This means that the vacuum operation will not be delayed by graceTimestamp.
                 // So version will be vacuumed immediately.
@@ -341,11 +341,11 @@ public class AutovacuumDaemon extends FrontendDaemon {
         return Math.min(a, b.orElse(Long.MAX_VALUE));
     }
 
-    private boolean ignoreVacuumGraceTimestamp(PhysicalPartition partition) {
-        if (Config.lake_ignore_grace_timestamp_partition_ids.isEmpty()) {
+    private boolean vacuumImmediatelyPartition(PhysicalPartition partition) {
+        if (Config.lake_vacuum_immediately_partition_ids.isEmpty()) {
             return false;
         }
-        String[] ids = Config.lake_ignore_grace_timestamp_partition_ids.split(";");
+        String[] ids = Config.lake_vacuum_immediately_partition_ids.split(";");
         for (String id : ids) {
             if (id.equals(String.valueOf(partition.getId()))) {
                 return true;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -316,4 +316,19 @@ public class VacuumTest {
         Config.lake_autovacuum_detect_vaccumed_version = false;
         Assertions.assertTrue(autovacuumDaemon.shouldVacuum(partition));
     }
+
+    @Test
+    public void testIgnoreVacuumGraceTimestamp() throws Exception {
+        partition = olapTable.getPhysicalPartitions().stream().findFirst().orElse(null);
+        AutovacuumDaemon autovacuumDaemon = new AutovacuumDaemon();
+        long current = System.currentTimeMillis();
+        partition.setVisibleVersion(10L, current);
+        partition.setMinRetainVersion(5L);
+        partition.setLastSuccVacuumVersion(10L);
+        partition.setLastVacuumTime(current);
+        Assertions.assertFalse(autovacuumDaemon.shouldVacuum(partition));
+
+        Config.lake_ignore_grace_timestamp_partition_ids = String.valueOf(partition.getId());
+        Assertions.assertTrue(autovacuumDaemon.shouldVacuum(partition));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -318,7 +318,7 @@ public class VacuumTest {
     }
 
     @Test
-    public void testIgnoreVacuumGraceTimestamp() throws Exception {
+    public void testVacuumImmediatelyGraceTimestamp() throws Exception {
         partition = olapTable.getPhysicalPartitions().stream().findFirst().orElse(null);
         AutovacuumDaemon autovacuumDaemon = new AutovacuumDaemon();
         long current = System.currentTimeMillis();
@@ -328,7 +328,7 @@ public class VacuumTest {
         partition.setLastVacuumTime(current);
         Assertions.assertFalse(autovacuumDaemon.shouldVacuum(partition));
 
-        Config.lake_ignore_grace_timestamp_partition_ids = String.valueOf(partition.getId());
+        Config.lake_vacuum_immediately_partition_ids = String.valueOf(partition.getId());
         Assertions.assertTrue(autovacuumDaemon.shouldVacuum(partition));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
To build a comprehensive vacuum testing framework in the future, the following components need to be added to both BE and FE:
1. `garbage_file_check` tool
```
admin execute on {beid} 'System.print(StorageEngine.garbage_file_check("/s3_path"))';
```
2. support vacuum immediately which will ignore grace timestamp.

## What I'm doing:
This pull request introduces enhancements to garbage file handling and vacuum operations in the `lake` storage engine. Key changes include the addition of a new method to check and delete garbage files, modifications to vacuum logic to allow bypassing grace timestamps for specific partitions, and corresponding updates to configuration and tests.

### Garbage File Handling Enhancements:
* **`be/src/script/script.cpp`:** Added `garbage_file_check` method to `StorageEngineRef` for checking and retrieving the count of garbage files in a specified location. Registered the method for external invocation. [[1]](diffhunk://#diff-c009080bd8f1dfeee87951d012bd527aa6a5c25ba1ed82b90d4a66ae286294c3R313-R322) [[2]](diffhunk://#diff-c009080bd8f1dfeee87951d012bd527aa6a5c25ba1ed82b90d4a66ae286294c3R612)
* **`be/src/storage/lake/vacuum.cpp`:** Introduced `garbage_file_check` method, which utilizes the `datafile_gc` function to check garbage files without performing deletions. Refactored `datafile_gc` to return the count of garbage files instead of just a status. [[1]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750L1428-R1428) [[2]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750L1439-R1443)
* **`be/src/storage/lake/vacuum.h`:** Updated the `datafile_gc` signature to return `StatusOr<int64_t>` and added a declaration for the new `garbage_file_check` method.
* **`be/test/storage/lake/vacuum_test.cpp`:** Added a unit test for `garbage_file_check` to validate its functionality.

### Vacuum Logic Improvements:
* **`fe/fe-core/src/main/java/com/starrocks/common/Config.java`:** Added a new configuration parameter, `lake_ignore_grace_timestamp_partition_ids`, to specify partitions that should bypass grace timestamp checks during vacuum operations.
* **`fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java`:** Enhanced vacuum logic to allow partitions listed in `lake_ignore_grace_timestamp_partition_ids` to skip grace timestamp delays, enabling immediate vacuuming. Added a helper method to check if a partition is in the ignore list. [[1]](diffhunk://#diff-ef2b090ae7f6222d36e455ac002b330a56c8d1cda7f082182d2905870d274859R116-R118) [[2]](diffhunk://#diff-ef2b090ae7f6222d36e455ac002b330a56c8d1cda7f082182d2905870d274859R247-R252) [[3]](diffhunk://#diff-ef2b090ae7f6222d36e455ac002b330a56c8d1cda7f082182d2905870d274859R344-R356)
* **`fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java`:** Added a test case to validate the behavior of partitions bypassing grace timestamp checks.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
