### PR TITLE
[Feature] Introduce predicate for sstable

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -250,6 +250,8 @@ set(STORAGE_FILES
     lake/persistent_index_sstable.cpp
     lake/lake_primary_key_compaction_conflict_resolver.cpp
     lake/column_mode_partial_update_handler.cpp
+    lake/sstable_predicate.cpp
+    lake/key_to_chunk_converter.cpp
     primary_key_dump.cpp
     dictionary_cache_manager.cpp
     rows_mapper.cpp

--- a/be/src/storage/lake/key_to_chunk_converter.cpp
+++ b/be/src/storage/lake/key_to_chunk_converter.cpp
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/key_to_chunk_converter.h"
+
+#include "storage/chunk_helper.h"
+#include "storage/primary_key_encoder.h"
+#include "storage/tablet_schema.h"
+
+namespace starrocks::lake {
+
+StatusOr<KeyToChunkConverterUPtr> KeyToChunkConverter::create(const TabletSchemaPB& tablet_schema_pb) {
+    // convert context for key
+    std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(tablet_schema_pb);
+    std::vector<ColumnId> pk_columns(tablet_schema->num_key_columns());
+    for (auto i = 0; i < tablet_schema->num_key_columns(); i++) {
+        pk_columns[i] = (ColumnId)i;
+    }
+    auto pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+    auto pk_chunk = ChunkHelper::new_chunk(pkey_schema, 1);
+    MutableColumnPtr pk_column;
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+
+    auto converter = std::make_unique<KeyToChunkConverter>(pkey_schema, pk_chunk, pk_column);
+    return converter;
+}
+
+StatusOr<ChunkUniquePtr> KeyToChunkConverter::convert_to_chunk(const std::string& key) {
+    auto chunk = _pk_chunk->clone_empty();
+
+    _pk_column->reset_column();
+    if (_pk_column->is_binary()) {
+        Slice slice(key.data(), key.size());
+        down_cast<BinaryColumn*>(_pk_column.get())->append(slice);
+    } else if (_pk_column->is_large_binary()) {
+        Slice slice(key.data(), key.size());
+        down_cast<LargeBinaryColumn*>(_pk_column.get())->append(slice);
+    } else {
+        _pk_column->deserialize_and_append(reinterpret_cast<const uint8_t*>(key.data()));
+    }
+    RETURN_IF_ERROR(PrimaryKeyEncoder::decode(_pkey_schema, *_pk_column, 0, 1, chunk.get(), nullptr));
+    return chunk;
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/key_to_chunk_converter.h
+++ b/be/src/storage/lake/key_to_chunk_converter.h
@@ -27,9 +27,7 @@ using KeyToChunkConverterUPtr = std::unique_ptr<KeyToChunkConverter>;
 class KeyToChunkConverter {
 public:
     KeyToChunkConverter(Schema pkey_schema, ChunkUniquePtr& pk_chunk, MutableColumnPtr& pk_column)
-            : _pkey_schema(pkey_schema),
-              _pk_chunk(std::move(pk_chunk)),
-              _pk_column(std::move(pk_column)) {}
+            : _pkey_schema(pkey_schema), _pk_chunk(std::move(pk_chunk)), _pk_column(std::move(pk_column)) {}
     ~KeyToChunkConverter() = default;
 
     static StatusOr<KeyToChunkConverterUPtr> create(const TabletSchemaPB& tablet_schema_pb);
@@ -37,7 +35,6 @@ public:
     StatusOr<ChunkUniquePtr> convert_to_chunk(const std::string& key);
 
 private:
-
     // convert context for key
     Schema _pkey_schema;
     ChunkUniquePtr _pk_chunk;

--- a/be/src/storage/lake/key_to_chunk_converter.h
+++ b/be/src/storage/lake/key_to_chunk_converter.h
@@ -1,0 +1,48 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "column/chunk.h"
+#include "column/column.h"
+
+namespace starrocks {
+class Schema;
+
+namespace lake {
+class KeyToChunkConverter;
+using KeyToChunkConverterUPtr = std::unique_ptr<KeyToChunkConverter>;
+
+class KeyToChunkConverter {
+public:
+    KeyToChunkConverter(Schema pkey_schema, ChunkUniquePtr& pk_chunk, MutableColumnPtr& pk_column)
+            : _pkey_schema(pkey_schema),
+              _pk_chunk(std::move(pk_chunk)),
+              _pk_column(std::move(pk_column)) {}
+    ~KeyToChunkConverter() = default;
+
+    static StatusOr<KeyToChunkConverterUPtr> create(const TabletSchemaPB& tablet_schema_pb);
+    // Convert key from sstable to a chunk
+    StatusOr<ChunkUniquePtr> convert_to_chunk(const std::string& key);
+
+private:
+
+    // convert context for key
+    Schema _pkey_schema;
+    ChunkUniquePtr _pk_chunk;
+    MutableColumnPtr _pk_column;
+};
+
+} // namespace lake
+} // namespace starrocks

--- a/be/src/storage/lake/sstable_predicate.cpp
+++ b/be/src/storage/lake/sstable_predicate.cpp
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/sstable_predicate.h"
+
+#include "storage/record_predicate/record_predicate_helper.h"
+
+namespace starrocks::lake {
+
+StatusOr<SstablePredicateUPtr> SstablePredicate::create(const TabletSchemaPB& tablet_schema_pb,
+                                                        const PersistentIndexSstablePredicatePB& sstable_predicate_pb) {
+    ASSIGN_OR_RETURN(auto converter, KeyToChunkConverter::create(tablet_schema_pb));
+    auto predicate = std::make_unique<SstablePredicate>();
+    RETURN_IF_ERROR(predicate->_init(sstable_predicate_pb, converter));
+    return predicate;
+}
+
+Status SstablePredicate::evaluate(const std::string& row, uint8_t* selection) {
+    ASSIGN_OR_RETURN(auto chunk, _converter->convert_to_chunk(row));
+    DCHECK(chunk->num_rows() == 1);
+    RETURN_IF_ERROR(_record_predicate->evaluate(chunk.get(), selection));
+    return Status::OK();
+}
+
+Status SstablePredicate::_init(const PersistentIndexSstablePredicatePB& predicate_pb,
+                               KeyToChunkConverterUPtr& converter) {
+    ASSIGN_OR_RETURN(_record_predicate, RecordPredicateHelper::create(predicate_pb.record_predicate()));
+    _converter = std::move(converter);
+    return Status::OK();
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/sstable_predicate.h
+++ b/be/src/storage/lake/sstable_predicate.h
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage/lake/key_to_chunk_converter.h"
+#include "storage/record_predicate/record_predicate.h"
+
+namespace starrocks {
+
+namespace lake {
+
+class SstablePredicate;
+using SstablePredicateUPtr = std::unique_ptr<SstablePredicate>;
+using SstablePredicateSPtr = std::shared_ptr<SstablePredicate>;
+
+class SstablePredicate {
+public:
+    SstablePredicate() : _record_predicate(nullptr), _converter(nullptr) {}
+    ~SstablePredicate() = default;
+
+    static StatusOr<SstablePredicateUPtr> create(const TabletSchemaPB& tablet_schema_pb,
+                                                 const PersistentIndexSstablePredicatePB& predicate_pb);
+
+    Status evaluate(const std::string& row, uint8_t* selection);
+
+private:
+    Status _init(const PersistentIndexSstablePredicatePB& predicate_pb, KeyToChunkConverterUPtr& converter);
+
+    RecordPredicateUPtr _record_predicate;
+    KeyToChunkConverterUPtr _converter;
+};
+
+} // namespace lake
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -549,6 +549,7 @@ set(EXEC_FILES
         ./storage/lake/tablet_retain_info_test.cpp
         ./storage/record_predicate/column_hash_is_congruent_test.cpp
         ./storage/record_predicate/record_predicate_helper_test.cpp
+        ./storage/lake/sstable_predicate_test.cpp
         ./cache/datacache_utils_test.cpp
         ./cache/block_cache/block_cache_hit_rate_counter_test.cpp
         ./cache/peer_cache_test.cpp

--- a/be/test/storage/lake/sstable_predicate_test.cpp
+++ b/be/test/storage/lake/sstable_predicate_test.cpp
@@ -1,0 +1,159 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/sstable_predicate.h"
+
+#include <gtest/gtest.h>
+
+#include "storage/chunk_helper.h"
+#include "storage/primary_key_encoder.h"
+#include "storage/record_predicate/column_hash_is_congruent.h"
+#include "storage/record_predicate/record_predicate_helper.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+namespace lake {
+class SstablePredicateTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _schema_pb_1.set_keys_type(PRIMARY_KEYS);
+        _schema_pb_1.set_num_short_key_columns(1);
+        _schema_pb_1.set_num_rows_per_row_block(5);
+        _schema_pb_1.set_next_column_unique_id(2);
+
+        ColumnPB& col = *(_schema_pb_1.add_column());
+        col.set_unique_id(1);
+        col.set_name("col1");
+        col.set_type("INT");
+        col.set_is_key(true);
+        col.set_is_nullable(false);
+        col.set_default_value("1");
+
+        ColumnPB& col2 = *(_schema_pb_1.add_column());
+        col2.set_unique_id(2);
+        col2.set_name("col2");
+        col2.set_type("INT");
+        col2.set_is_key(false);
+        col2.set_is_nullable(false);
+        col2.set_default_value("2");
+
+        _schema_pb_2.set_keys_type(PRIMARY_KEYS);
+        _schema_pb_2.set_num_short_key_columns(1);
+        _schema_pb_2.set_num_rows_per_row_block(5);
+        _schema_pb_2.set_next_column_unique_id(2);
+
+        ColumnPB& col3 = *(_schema_pb_2.add_column());
+        col3.set_unique_id(1);
+        col3.set_name("col1");
+        col3.set_type("INT");
+        col3.set_is_key(true);
+        col3.set_is_nullable(false);
+        col3.set_default_value("1");
+
+        ColumnPB& col4 = *(_schema_pb_2.add_column());
+        col4.set_unique_id(2);
+        col4.set_name("col2");
+        col4.set_type("INT");
+        col4.set_is_key(true);
+        col4.set_is_nullable(false);
+        col4.set_default_value("2");
+    }
+
+private:
+    TabletSchemaPB _schema_pb_1;
+    TabletSchemaPB _schema_pb_2;
+};
+
+TEST_F(SstablePredicateTest, basicSstablePredicateTest) {
+    {
+        PersistentIndexSstablePredicatePB sstable_predicate_pb;
+        auto record_predicate_pb = sstable_predicate_pb.mutable_record_predicate();
+        record_predicate_pb->set_type(RecordPredicatePB::COLUMN_HASH_IS_CONGRUENT);
+        auto column_hash_is_congruent_pb = record_predicate_pb->mutable_column_hash_is_congruent();
+        column_hash_is_congruent_pb->set_modulus(2);
+        column_hash_is_congruent_pb->set_remainder(0);
+        column_hash_is_congruent_pb->add_column_names("col1");
+        ASSIGN_OR_ABORT(auto sstable_predicate, SstablePredicate::create(_schema_pb_1, sstable_predicate_pb));
+
+        std::shared_ptr<TabletSchema> tablet_schema_1 = std::make_shared<TabletSchema>(_schema_pb_1);
+        ASSERT_EQ(tablet_schema_1->num_key_columns(), 1);
+        std::vector<ColumnId> pk_columns(tablet_schema_1->num_key_columns());
+        for (auto i = 0; i < tablet_schema_1->num_key_columns(); i++) {
+            pk_columns[i] = (ColumnId)i;
+        }
+        auto pkey_schema = ChunkHelper::convert_schema(tablet_schema_1, pk_columns);
+        auto pk_chunk = ChunkHelper::new_chunk(pkey_schema, 1);
+        pk_chunk->get_column_by_name("col1")->append_datum(Datum(12345));
+        ASSERT_EQ(pk_chunk->num_rows(), 1);
+
+        uint32_t hashes = 0;
+        pk_chunk->get_column_by_name("col1")->crc32_hash(&(hashes), 0, 1);
+        bool expected = (hashes % 2 == 0);
+
+        MutableColumnPtr encoded_columns;
+        ASSERT_OK(PrimaryKeyEncoder::create_column(pkey_schema, &encoded_columns));
+        PrimaryKeyEncoder::encode(pkey_schema, *pk_chunk, 0, 1, encoded_columns.get());
+        auto key_size = PrimaryKeyEncoder::get_encoded_fixed_size(pkey_schema);
+        Slice key(encoded_columns->continuous_data(), key_size);
+        std::string row = key.to_string();
+
+        uint8_t selection;
+        ASSERT_OK(sstable_predicate->evaluate(row, &selection));
+        ASSERT_EQ(selection, expected);
+    }
+
+    {
+        PersistentIndexSstablePredicatePB sstable_predicate_pb;
+        auto record_predicate_pb = sstable_predicate_pb.mutable_record_predicate();
+        record_predicate_pb->set_type(RecordPredicatePB::COLUMN_HASH_IS_CONGRUENT);
+        auto column_hash_is_congruent_pb = record_predicate_pb->mutable_column_hash_is_congruent();
+        column_hash_is_congruent_pb->set_modulus(2);
+        column_hash_is_congruent_pb->set_remainder(0);
+        column_hash_is_congruent_pb->add_column_names("col1");
+        column_hash_is_congruent_pb->add_column_names("col2");
+        ASSIGN_OR_ABORT(auto sstable_predicate, SstablePredicate::create(_schema_pb_2, sstable_predicate_pb));
+
+        std::shared_ptr<TabletSchema> tablet_schema_2 = std::make_shared<TabletSchema>(_schema_pb_2);
+        ASSERT_EQ(tablet_schema_2->num_key_columns(), 2);
+        std::vector<ColumnId> pk_columns(tablet_schema_2->num_key_columns());
+        for (auto i = 0; i < tablet_schema_2->num_key_columns(); i++) {
+            pk_columns[i] = (ColumnId)i;
+        }
+        auto pkey_schema = ChunkHelper::convert_schema(tablet_schema_2, pk_columns);
+        auto pk_chunk = ChunkHelper::new_chunk(pkey_schema, 1);
+        pk_chunk->get_column_by_name("col1")->append_datum(Datum(12345));
+        pk_chunk->get_column_by_name("col2")->append_datum(Datum(66666));
+        ASSERT_EQ(pk_chunk->num_rows(), 1);
+
+        uint32_t hashes = 0;
+        pk_chunk->get_column_by_name("col1")->crc32_hash(&(hashes), 0, 1);
+        pk_chunk->get_column_by_name("col2")->crc32_hash(&(hashes), 0, 1);
+        bool expected = (hashes % 2 == 0);
+
+        MutableColumnPtr encoded_columns;
+        ASSERT_OK(PrimaryKeyEncoder::create_column(pkey_schema, &encoded_columns));
+        PrimaryKeyEncoder::encode(pkey_schema, *pk_chunk, 0, 1, encoded_columns.get());
+        ASSERT_TRUE(encoded_columns->is_binary() || encoded_columns->is_large_binary());
+        std::string row = reinterpret_cast<const Slice*>(encoded_columns->raw_data())->to_string();
+
+        uint8_t selection;
+        ASSERT_OK(sstable_predicate->evaluate(row, &selection));
+        ASSERT_EQ(selection, expected);
+    }
+}
+
+} // namespace lake
+} // namespace starrocks

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -202,6 +202,10 @@ message RecordPredicatePB {
     optional ColumnHashIsCongruentPB column_hash_is_congruent = 3;
 }
 
+message PersistentIndexSstablePredicatePB {
+    optional RecordPredicatePB record_predicate = 1;
+}
+
 message IndexValueWithVerPB {
     // will be set after mvcc support
     optional int64 version = 1;


### PR DESCRIPTION
## What I'm doing:
This pr introduce predicate which can be evaluted for key for sstable of lake persistent index. This pr is prerequisite pr for tablet split. We only introduce the predicate definition and the read path filtering will be added in next pr

Fixes #59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
