### PR TITLE
[Enhancement]make access controller lazily (backport #60614)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/LazyConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/LazyConnector.java
@@ -14,8 +14,13 @@
 
 package com.starrocks.connector;
 
+import com.starrocks.authorization.NativeAccessController;
+import com.starrocks.authorization.ranger.hive.RangerHiveAccessController;
+import com.starrocks.authorization.ranger.starrocks.RangerStarRocksAccessController;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.sql.analyzer.Authorizer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -41,6 +46,21 @@ public class LazyConnector implements Connector {
         synchronized (this) {
             if (delegate == null) {
                 try {
+                    // init access control
+                    String serviceName = context.getProperties().get("ranger.plugin.hive.service.name");
+                    if (serviceName == null || serviceName.isEmpty()) {
+                        if (Config.access_control.equals("ranger")) {
+                            Authorizer.getInstance()
+                                    .setAccessControl(context.getCatalogName(), new RangerStarRocksAccessController());
+                        } else {
+                            Authorizer.getInstance()
+                                    .setAccessControl(context.getCatalogName(), new NativeAccessController());
+                        }
+                    } else {
+                        Authorizer.getInstance()
+                                .setAccessControl(context.getCatalogName(), new RangerHiveAccessController(serviceName));
+                    }
+                    // create connector
                     delegate = ConnectorFactory.createRealConnector(context);
                 } catch (Exception e) {
                     LOG.error("Failed to init connector [type: {}, name: {}]",

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -348,17 +348,6 @@ public class CatalogMgr {
                 readUnlock();
             }
 
-            String serviceName = config.get("ranger.plugin.hive.service.name");
-            if (serviceName == null || serviceName.isEmpty()) {
-                if (Config.access_control.equals("ranger")) {
-                    Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
-                } else {
-                    Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
-                }
-            } else {
-                Authorizer.getInstance().setAccessControl(catalogName, new RangerHiveAccessController(serviceName));
-            }
-
             try {
                 catalogConnector = connectorMgr.createConnector(
                         new ConnectorContext(catalogName, type, config), true);


### PR DESCRIPTION
## Why I'm doing:
When we set access controller for catalog, there is remote access(like access to ranger server),
so we do it lazily to avoid blocking restart of fe(reply create catalog).

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

