### PR TITLE
[BugFix] fix multi_distinct_count crash caused by low_cardinality rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -1174,7 +1174,7 @@ public class FunctionSet {
                     true, false, true));
         }
 
-        // MULTI_DISTINCT_COUNTM
+        // MULTI_DISTINCT_COUNT
         for (Type type : MULTI_DISTINCT_COUNT_TYPES) {
             addBuiltin(AggregateFunction.createBuiltin(FunctionSet.MULTI_DISTINCT_COUNT, Lists.newArrayList(type),
                     Type.BIGINT,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -531,7 +531,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 info.outputStringColumns.union(key.getId());
                 stringRefToDefineExprMap.putIfAbsent(key.getId(), value);
                 expressionStringRefCounter.put(key.getId(), 1);
-            } else if (aggregate.getType().isLocal() || aggregate.getType().isDistinctLocal()) {
+            } else if (aggregate.getType().isLocal() || aggregate.getType().isDistinct()) {
                 // count/count distinct, need output dict-set in 1st stage
                 info.outputStringColumns.union(key.getId());
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2237,4 +2237,39 @@ public class LowCardinalityTest2 extends PlanTestBase {
         Assert.assertFalse("table doesn't contain global dict, we can change its distribution",
                 execPlan.getOptExpression(1).isExistRequiredDistribution());
     }
+
+    @Test
+    public void testMultiDistinctCount() throws Exception {
+        connectContext.getSessionVariable().setNewPlanerAggStage(4);
+        String sql = "select multi_distinct_count(S_ADDRESS), count(distinct S_NATIONKEY) from supplier";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  aggregate: multi_distinct_count[([11: S_ADDRESS, INT, false]); args: INT; result: VARBINARY; " +
+                "args nullable: false; result nullable: false]\n" +
+                "  |  group by: [4: S_NATIONKEY, INT, false]\n" +
+                "  |  cardinality: 1");
+
+        assertContains(plan, "  4:AGGREGATE (update serialize)\n" +
+                "  |  aggregate: multi_distinct_count[([9: multi_distinct_count, BIGINT, false]); " +
+                "args: INT; result: VARBINARY; " +
+                "args nullable: true; result nullable: false], count[([4: S_NATIONKEY, INT, false]); " +
+                "args: INT; result: BIGINT; " +
+                "args nullable: false; result nullable: false]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  3:AGGREGATE (merge serialize)\n" +
+                "  |  aggregate: multi_distinct_count[([9: multi_distinct_count, VARBINARY, false]); " +
+                "args: INT; result: BIGINT; " +
+                "args nullable: true; result nullable: false]\n" +
+                "  |  group by: [4: S_NATIONKEY, INT, false]\n" +
+                "  |  cardinality: 1");
+        assertContains(plan, "  6:AGGREGATE (merge finalize)\n" +
+                "  |  aggregate: multi_distinct_count[([9: multi_distinct_count, VARBINARY, false]); " +
+                "args: INT; result: BIGINT; " +
+                "args nullable: true; result nullable: false], count[([10: count, BIGINT, false]); " +
+                "args: INT; result: BIGINT; " +
+                "args nullable: true; result nullable: false]\n" +
+                "  |  cardinality: 1");
+    }
 }

--- a/test/sql/test_low_cardinality/R/test_low_cardinality2
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality2
@@ -307,11 +307,11 @@ insert into s2 select * from s2;
 -- !result
 [UC] analyze full table s1;
 -- result:
-test_db_b2ce4f72f18e49288a5dbce50a0cb798.s1	analyze	status	OK
+test_db_6570d67f17f747deba02b7e20626ac8d.s1	analyze	status	OK
 -- !result
 [UC] analyze full table s2;
 -- result:
-test_db_b2ce4f72f18e49288a5dbce50a0cb798.s2	analyze	status	OK
+test_db_6570d67f17f747deba02b7e20626ac8d.s2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('v3', 's1')
 -- result:
@@ -488,7 +488,7 @@ FROM
 -- !result
 [UC] analyze full table supplier;
 -- result:
-test_db_b2ce4f72f18e49288a5dbce50a0cb798.supplier	analyze	status	OK
+test_db_6570d67f17f747deba02b7e20626ac8d.supplier	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('s_region', 'supplier')
 -- result:
@@ -528,6 +528,13 @@ select s_region, array_map(x -> concat(x, date_format(cast(concat('202001', s_re
 from supplier where s_suppkey > 4093;
 -- result:
 15	["a202001","b202001","c202001"]
-14	["a202001","b202001","c202001"]
 0	[null,null,null]
+14	["a202001","b202001","c202001"]
+-- !result
+set new_planner_agg_stage=4;
+-- result:
+-- !result
+select multi_distinct_count(v3), count(distinct v4) from s1;
+-- result:
+26	26
 -- !result

--- a/test/sql/test_low_cardinality/T/test_low_cardinality2
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality2
@@ -427,3 +427,5 @@ select l.S_NAME,l.mx_addr from agged_supplier_5 l right join [shuffle] supplier 
 select s_region, array_map(x -> concat(x, date_format(cast(concat('202001', s_region) as datetime), "%Y%m")), ['a', 'b', 'c']) 
 from supplier where s_suppkey > 4093;
 
+set new_planner_agg_stage=4;
+select multi_distinct_count(v3), count(distinct v4) from s1;


### PR DESCRIPTION
## Why I'm doing:

crash stack under debug mode
```text
select_expr_reuse DEBUG (build 0b7b43a)
query_id:0197e3fc-344a-7c95-91ea-9a55fd35e60c, fragment_instance:0197e3fc-344a-7c95-91ea-9a55fd35e60e
F20250707 16:24:05.987935 140174469740096 distinct.h:273] Check failed: src == end
F20250707 16:24:05.987935 140174469740096 distinct.h:273] Check failed: src == end F20250707 16:24:05.988223 140174088398400 distinct.h:273] Check failed: src == end
*** Aborted at 1751876645 (unix time) try "date -d @1751876645" if you are using GNU date ***
F20250707 16:24:05.987935 140174469740096 distinct.h:273] Check failed: src == end F20250707 16:24:05.988223 140174088398400 distinct.h:273] Check failed: src == end F20250707 16:24:05.990735 140174394205760 distinct.h:273] Check failed: src == end
PC: @         0x129b8004 unsigned long starrocks::unaligned_load<unsigned long>(void const*)
*** SIGSEGV (@0x7f7e54dff000) received by PID 1765868 (TID 0x7f7cfb7bf640) LWP(1766758) from PID 1423962112; stack trace: ***
[1751876645.990][thread: 140174394205760] je_mallctl execute purge success
[1751876645.988][thread: 140174088398400] je_mallctl execute purge success
[1751876645.988][thread: 140174469740096] je_mallctl execute purge success
[1751876645.988][thread: 140174377420352] je_mallctl execute purge success
    @     0x7f7e66898ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x1d746fb9 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
[1751876645.990][thread: 140174394205760] je_mallctl execute dontdump success
[1751876645.988][thread: 140174088398400] je_mallctl execute dontdump success
[1751876645.988][thread: 140174469740096] je_mallctl execute dontdump success
[1751876645.988][thread: 140174377420352] je_mallctl execute dontdump success
    @     0x7f7e66841520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @         0x129b8004 unsigned long starrocks::unaligned_load<unsigned long>(void const*)
    @         0x136fc735 starrocks::crc_hash_64_unmixed(void const*, int, unsigned long)
    @         0x136fc683 starrocks::crc_hash_64(void const*, int, unsigned long)
    @         0x136fc64b starrocks::SliceHash::operator()(starrocks::Slice const&) const
    @         0x136fc609 starrocks::SliceWithHash::SliceWithHash(starrocks::Slice const&)
    @         0x14622143 starrocks::AdaptiveSliceHashSet::emplace(starrocks::MemPool*, starrocks::Slice)
    @         0x151f3216 starrocks::DistinctAggregateState<(starrocks::LogicalType)13, (starrocks::LogicalType)13, int>::deserialize_and_merge(starrocks::MemPool*, unsigned char const*, unsigned long)
    @         0x151ff2e2 starrocks::TDistinctAggregateFunction<(starrocks::LogicalType)13, (starrocks::LogicalType)13, starrocks::DistinctAggregateStateV2, (starrocks::AggDistinctType)0, starrocks::Slice>::merge(starrocks::FunctionContext*, starrocks::Column const*, unsigned char*~
    @         0x15200cef starrocks::NullableAggregateFunctionUnary<std::shared_ptr<starrocks::TDistinctAggregateFunction<(starrocks::LogicalType)13, (starrocks::LogicalType)13, starrocks::DistinctAggregateStateV2, (starrocks::AggDistinctType)0, starrocks::Slice> >, starrocks::Null~
    @         0x15200b24 auto starrocks::ColumnHelper::call_nullable_func<starrocks::NullableAggregateFunctionUnary<std::shared_ptr<starrocks::TDistinctAggregateFunction<(starrocks::LogicalType)13, (starrocks::LogicalType)13, starrocks::DistinctAggregateStateV2, (starrocks::AggDis~
    @         0x151fed30 starrocks::NullableAggregateFunctionUnary<std::shared_ptr<starrocks::TDistinctAggregateFunction<(starrocks::LogicalType)13, (starrocks::LogicalType)13, starrocks::DistinctAggregateStateV2, (starrocks::AggDistinctType)0, starrocks::Slice> >, starrocks::Null~
    @         0x146136ac starrocks::AggregateFunction::merge_batch_single_state_exception_safe(starrocks::FunctionContext*, unsigned char*, starrocks::Column const*, unsigned long, unsigned long) const
    @         0x177b2dda starrocks::Aggregator::compute_single_agg_state(starrocks::Chunk*, unsigned long)
    @         0x18dc5618 starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @         0x174675d9 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x18f02dd3 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x18f06198 starrocks::pipeline::GlobalDriverExecutor::initialize(int)::$_0::operator()() const
    @         0x18f06175 void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::$_0&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::$_0&)
    @         0x18f06125 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::$_0&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::$_0&>(starrocks::pipeline::GlobalDriverExecutor::initiali~
    @         0x18f0603d std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::$_0>::_M_invoke(std::_Any_data const&)
    @         0x12935355 std::function<void ()>::operator()() const
    @         0x1971dd09 starrocks::FunctionRunnable::run()
    @         0x19714d6f starrocks::ThreadPool::dispatch_thread()
    @         0x19724a09 void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x1972494d std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x1972491d void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
    @         0x197248d6 void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>()
    @         0x197248a5 void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&)
    @         0x19724865 std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool:~
```

root cause:
When `DecodeCollector` processes the aggregation functions in the `DistinctGlobal` stage, it does not add the related column in outputColumns, which causes the parameter type of the multi_distinct_count function to be incorrect during subsequent rewriting, leading to a crash.

## What I'm doing:



Fixes #60707

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
