### PR TITLE
[BugFix] Fix ldap not catch PartialResultException bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPAuthProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPAuthProvider.java
@@ -28,6 +28,7 @@ import java.util.Hashtable;
 import java.util.Optional;
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
+import javax.naming.PartialResultException;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
@@ -178,8 +179,9 @@ public class LDAPAuthProvider implements AuthenticationProvider {
 
             String userDN = null;
             int matched = 0;
-            for (; ; ) {
-                if (results.hasMore()) {
+
+            try {
+                while (results.hasMore()) {
                     matched++;
                     if (matched > 1) {
                         throw new AuthenticationException("searched more than one entry from ldap server for user " + user);
@@ -187,9 +189,9 @@ public class LDAPAuthProvider implements AuthenticationProvider {
 
                     SearchResult result = results.next();
                     userDN = result.getNameInNamespace();
-                } else {
-                    break;
                 }
+            } catch (PartialResultException e) {
+                LOG.warn("ldap search partial result exception", e);
             }
 
             if (matched != 1) {


### PR DESCRIPTION
## Why I'm doing:
AD Server may have items that need to be redirected to other servers, which we do not currently support.
## What I'm doing:

Fixes #issue
skip redirect item
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
