### PR TITLE
[BugFix] fix compaction new segments does not clean by abort txn

### DIFF
--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -69,11 +69,13 @@ Status CompactionTask::fill_compaction_segment_info(TxnLogPB_OpCompaction* op_co
         op_compaction->mutable_output_rowset()->set_data_size(writer->data_size() + uncompacted_data_size);
         op_compaction->mutable_output_rowset()->set_overlapped(true);
     } else {
+        op_compaction->set_new_segment_offset(0);
         for (auto& file : writer->files()) {
             op_compaction->mutable_output_rowset()->add_segments(file.path);
             op_compaction->mutable_output_rowset()->add_segment_size(file.size.value());
             op_compaction->mutable_output_rowset()->add_segment_encryption_metas(file.encryption_meta);
         }
+        op_compaction->set_new_segment_count(writer->files().size());
         op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());
         op_compaction->mutable_output_rowset()->set_data_size(writer->data_size());
         op_compaction->mutable_output_rowset()->set_overlapped(false);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

when partial compaction is not used, still need to set correct new segment info, so that abort txn can clean new segments

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
