### PR TITLE
[Enhancement]make access controller lazily-create & alter (backport #60671)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -20,15 +20,11 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.starrocks.authorization.NativeAccessController;
-import com.starrocks.authorization.ranger.hive.RangerHiveAccessController;
-import com.starrocks.authorization.ranger.starrocks.RangerStarRocksAccessController;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.ExternalCatalog;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Resource;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.proc.BaseProcResult;
@@ -56,7 +52,6 @@ import com.starrocks.sql.ast.AlterCatalogStmt;
 import com.starrocks.sql.ast.CreateCatalogStmt;
 import com.starrocks.sql.ast.DropCatalogStmt;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -117,16 +112,6 @@ public class CatalogMgr {
 
             try {
                 Preconditions.checkState(!catalogs.containsKey(catalogName), "Catalog '%s' already exists", catalogName);
-                String serviceName = properties.get("ranger.plugin.hive.service.name");
-                if (serviceName == null || serviceName.isEmpty()) {
-                    if (Config.access_control.equals("ranger")) {
-                        Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
-                    } else {
-                        Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
-                    }
-                } else {
-                    Authorizer.getInstance().setAccessControl(catalogName, new RangerHiveAccessController(serviceName));
-                }
 
                 connector = connectorMgr.createConnector(
                         new ConnectorContext(catalogName, type, properties), false);
@@ -186,19 +171,6 @@ public class CatalogMgr {
 
             // replace old connector with new connector
             connectorMgr.addConnector(catalogName, newConnector);
-
-            if (newProperties.containsKey("ranger.plugin.hive.service.name")) {
-                String serviceName = newProperties.get("ranger.plugin.hive.service.name");
-                if (StringUtils.isEmpty(serviceName)) {
-                    if ("ranger".equals(Config.access_control)) {
-                        Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
-                    } else {
-                        Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
-                    }
-                } else {
-                    Authorizer.getInstance().setAccessControl(catalogName, new RangerHiveAccessController(serviceName));
-                }
-            }
 
             catalog.getConfig().putAll(alterProperties);
         } catch (Exception e) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
follow https://github.com/StarRocks/starrocks/pull/60614, set access controller lazily for create catalog, alter catalog and reply alter catalog.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

