### PR TITLE
[Refactor] Refactor historical node manager by the compute node resource.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/UpdateHistoricalNodeLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/UpdateHistoricalNodeLog.java
@@ -27,6 +27,12 @@ public class UpdateHistoricalNodeLog implements Writable {
     @SerializedName(value = "warehouse")
     private String warehouse;
 
+    @SerializedName(value = "warehouseId")
+    private long warehouseId;
+
+    @SerializedName(value = "workerGroupId")
+    private long workerGroupId;
+
     @SerializedName(value = "updateTime")
     private long updateTime;
 
@@ -36,8 +42,10 @@ public class UpdateHistoricalNodeLog implements Writable {
     @SerializedName(value = "computeNodeIds")
     private List<Long> computeNodeIds;
 
-    public UpdateHistoricalNodeLog(String warehouse, long updateTime, List<Long> backendIds, List<Long> computeNodeIds) {
-        this.warehouse = warehouse;
+    public UpdateHistoricalNodeLog(long warehouseId, long workerGroupId, long updateTime, List<Long> backendIds,
+                                   List<Long> computeNodeIds) {
+        this.warehouseId = warehouseId;
+        this.workerGroupId = workerGroupId;
         this.updateTime = updateTime;
         this.backendIds = backendIds;
         this.computeNodeIds = computeNodeIds;
@@ -45,6 +53,14 @@ public class UpdateHistoricalNodeLog implements Writable {
 
     public String getWarehouse() {
         return warehouse;
+    }
+
+    public long getWarehouseId() {
+        return warehouseId;
+    }
+
+    public long getWorkerGroupId() {
+        return workerGroupId;
     }
 
     public long getUpdateTime() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -42,7 +42,6 @@ import com.starrocks.qe.scheduler.CandidateWorkerProvider;
 import com.starrocks.qe.scheduler.NonRecoverableException;
 import com.starrocks.qe.scheduler.WorkerProvider;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.HistoricalNodeMgr;
@@ -51,7 +50,7 @@ import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TScanRangeParams;
-import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -189,11 +188,11 @@ public class HDFSBackendSelector implements BackendSelector {
     }
 
     private boolean isCacheSharingExpired(long cacheSharingWorkPeriod) {
-        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-        Warehouse warehouse = warehouseManager.getWarehouse(workerProvider.getComputeResource().getWarehouseId());
         HistoricalNodeMgr historicalNodeMgr = GlobalStateMgr.getCurrentState().getHistoricalNodeMgr();
+        ComputeResource computeResource = workerProvider.getComputeResource();
 
-        long lastUpdateTime = historicalNodeMgr.getLastUpdateTime(warehouse.getName());
+        long lastUpdateTime = historicalNodeMgr.getLastUpdateTime(computeResource.getWarehouseId(),
+                computeResource.getWorkerGroupId());
         long currentTime = System.currentTimeMillis();
         if (currentTime - lastUpdateTime > cacheSharingWorkPeriod * 1000) {
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/CandidateWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/CandidateWorkerProvider.java
@@ -21,11 +21,9 @@ import com.google.common.collect.ImmutableMap;
 import com.starrocks.qe.SessionVariableConstants;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
-import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.HistoricalNodeMgr;
 import com.starrocks.system.SystemInfoService;
-import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -58,15 +56,12 @@ public class CandidateWorkerProvider extends DefaultWorkerProvider implements Wo
                 boolean preferComputeNode, int numUsedComputeNodes,
                 SessionVariableConstants.ComputationFragmentSchedulingPolicy computationFragmentSchedulingPolicy,
                 ComputeResource computeResource) {
-            WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-            Warehouse warehouse = warehouseManager.getWarehouse(computeResource.getWarehouseId());
             HistoricalNodeMgr historicalNodeMgr = GlobalStateMgr.getCurrentState().getHistoricalNodeMgr();
-
             ImmutableMap<Long, ComputeNode> idToBackend = getHistoricalBackends(systemInfoService, historicalNodeMgr,
-                    warehouse.getName());
+                    computeResource);
             ImmutableMap<Long, ComputeNode> idToComputeNode =
                     buildComputeNodeInfo(systemInfoService, historicalNodeMgr, idToBackend, numUsedComputeNodes,
-                            computationFragmentSchedulingPolicy, warehouse.getName(), computeResource);
+                            computationFragmentSchedulingPolicy, computeResource);
 
             if (LOG.isDebugEnabled()) {
                 LOG.debug("idToBackend: {}", idToBackend);
@@ -94,11 +89,10 @@ public class CandidateWorkerProvider extends DefaultWorkerProvider implements Wo
             ImmutableMap<Long, ComputeNode> idToBackend,
             int numUsedComputeNodes,
             SessionVariableConstants.ComputationFragmentSchedulingPolicy computationFragmentSchedulingPolicy,
-            String warehouse,
             ComputeResource computeResource) {
         //get CN and BE from historicalNodeMgr
         ImmutableMap<Long, ComputeNode> idToComputeNode = getHistoricalComputeNodes(
-                systemInfoService, historicalNodeMgr, warehouse);
+                systemInfoService, historicalNodeMgr, computeResource);
         if (RunMode.isSharedDataMode()) {
             return idToComputeNode;
         }
@@ -143,9 +137,10 @@ public class CandidateWorkerProvider extends DefaultWorkerProvider implements Wo
     private static ImmutableMap<Long, ComputeNode> getHistoricalBackends(
             SystemInfoService systemInfoService,
             HistoricalNodeMgr historicalNodeMgr,
-            String warehouse) {
+            ComputeResource computeResource) {
         ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
-        ImmutableList<Long> backendIds = historicalNodeMgr.getHistoricalBackendIds(warehouse);
+        ImmutableList<Long> backendIds = historicalNodeMgr.getHistoricalBackendIds(computeResource.getWarehouseId(),
+                computeResource.getWorkerGroupId());
         for (long nodeId : backendIds) {
             ComputeNode backend = systemInfoService.getBackendOrComputeNode(nodeId);
             if (backend != null) {
@@ -158,9 +153,10 @@ public class CandidateWorkerProvider extends DefaultWorkerProvider implements Wo
     private static ImmutableMap<Long, ComputeNode> getHistoricalComputeNodes(
             SystemInfoService systemInfoService,
             HistoricalNodeMgr historicalNodeMgr,
-            String warehouse) {
+            ComputeResource computeResource) {
         ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
-        ImmutableList<Long> computeNodeIds = historicalNodeMgr.getHistoricalComputeNodeIds(warehouse);
+        ImmutableList<Long> computeNodeIds = historicalNodeMgr.getHistoricalComputeNodeIds(computeResource.getWarehouseId(),
+                computeResource.getWorkerGroupId());
         for (long nodeId : computeNodeIds) {
             ComputeNode computeNode = systemInfoService.getBackendOrComputeNode(nodeId);
             if (computeNode != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/HistoricalNodeProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/HistoricalNodeProcNodeTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.common.proc;
 
 import com.starrocks.common.AnalysisException;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.HistoricalNodeMgr;
@@ -34,16 +35,17 @@ public class HistoricalNodeProcNodeTest {
 
         HistoricalNodeMgr historicalNodeMgr = GlobalStateMgr.getCurrentState().getHistoricalNodeMgr();
 
-        String warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
+        long workerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
         List<Long> computeNodeIds = Arrays.asList(201L, 202L);
         long updateTime = System.currentTimeMillis();
-        historicalNodeMgr.updateHistoricalComputeNodeIds(computeNodeIds, updateTime, warehouse);
+        historicalNodeMgr.updateHistoricalComputeNodeIds(warehouseId, workerGroupId, computeNodeIds, updateTime);
 
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouse).size(), computeNodeIds.size());
-        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(warehouse), updateTime);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouseId, workerGroupId).size(),
+                computeNodeIds.size());
+        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(warehouseId, workerGroupId), updateTime);
         Assertions.assertEquals(historicalNodeMgr.getAllHistoricalNodeSet().size(), 1);
     }
-
     @Test
     public void testFetchResult() throws AnalysisException {
         HistoricalNodeProcNode node = new HistoricalNodeProcNode(GlobalStateMgr.getCurrentState());
@@ -52,14 +54,16 @@ public class HistoricalNodeProcNodeTest {
 
         List<List<String>> rows = result.getRows();
         List<String> list1 = rows.get(0);
-        Assertions.assertEquals(list1.size(), 4);
+        Assertions.assertEquals(list1.size(), 5);
         // Warehouse
         Assertions.assertEquals(list1.get(0), WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+        // WorkerGroupId
+        Assertions.assertEquals(list1.get(1), String.valueOf(StarOSAgent.DEFAULT_WORKER_GROUP_ID));
         // BackendIds
-        Assertions.assertEquals(list1.get(1), "[]");
+        Assertions.assertEquals(list1.get(2), "[]");
         // ComputeNodeIds
-        Assertions.assertEquals(list1.get(2), "[201, 202]");
+        Assertions.assertEquals(list1.get(3), "[201, 202]");
         // UpdateTime
-        Assertions.assertNotEquals(list1.get(3), "0");
+        Assertions.assertNotEquals(list1.get(4), "0");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/persist/UpdateHistoricalNodeLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/UpdateHistoricalNodeLogTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.persist;
 
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.HistoricalNodeMgr;
@@ -42,7 +43,8 @@ public class UpdateHistoricalNodeLogTest {
 
     @Test
     public void testNormal() throws IOException {
-        String warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
+        long workerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
         List<Long> backendIds = Arrays.asList(101L, 102L, 103L);
         List<Long> computeNodeIds = Arrays.asList(201L, 202L, 203L);
         long updateTime = System.currentTimeMillis();
@@ -52,7 +54,7 @@ public class UpdateHistoricalNodeLogTest {
         file.createNewFile();
         DataOutputStream out = new DataOutputStream(Files.newOutputStream(file.toPath()));
         UpdateHistoricalNodeLog writeLog =
-                new UpdateHistoricalNodeLog(warehouse, updateTime, backendIds, computeNodeIds);
+                new UpdateHistoricalNodeLog(warehouseId, workerGroupId, updateTime, backendIds, computeNodeIds);
         writeLog.write(out);
         out.flush();
         out.close();
@@ -60,7 +62,8 @@ public class UpdateHistoricalNodeLogTest {
         // 2. Read objects from file
         DataInputStream in = new DataInputStream(Files.newInputStream(file.toPath()));
         UpdateHistoricalNodeLog readLog = UpdateHistoricalNodeLog.read(in);
-        Assertions.assertEquals(readLog.getWarehouse(), warehouse);
+        Assertions.assertEquals(readLog.getWarehouseId(), warehouseId);
+        Assertions.assertEquals(readLog.getWorkerGroupId(), workerGroupId);
         Assertions.assertEquals(readLog.getUpdateTime(), updateTime);
         Assertions.assertEquals(readLog.getBackendIds(), backendIds);
         Assertions.assertEquals(readLog.getComputeNodeIds(), computeNodeIds);
@@ -70,7 +73,8 @@ public class UpdateHistoricalNodeLogTest {
         SystemInfoService systemInfoService = new SystemInfoService();
         HistoricalNodeMgr historicalNodeMgr = GlobalStateMgr.getCurrentState().getHistoricalNodeMgr();
         systemInfoService.replayUpdateHistoricalNode(readLog);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(warehouse).size(), backendIds.size());
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouse).size(), computeNodeIds.size());
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(warehouseId, workerGroupId).size(), backendIds.size());
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouseId, workerGroupId).size(),
+                computeNodeIds.size());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.common.util.ConsistentHashRing;
 import com.starrocks.common.util.HashRing;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.planner.HdfsScanNode;
 import com.starrocks.qe.scheduler.DefaultWorkerProvider;
 import com.starrocks.server.GlobalStateMgr;
@@ -425,8 +426,8 @@ public class HDFSBackendSelectorTest {
         ImmutableMap.Entry<Long, ComputeNode> candidateNode = computeNodes.entrySet().asList().get(0);
         List<Long> candidateNodeIds = Collections.singletonList(candidateNode.getKey());
         HistoricalNodeMgr historicalNodeMgr = GlobalStateMgr.getCurrentState().getHistoricalNodeMgr();
-        historicalNodeMgr.updateHistoricalComputeNodeIds(candidateNodeIds, System.currentTimeMillis(),
-                WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+        historicalNodeMgr.updateHistoricalComputeNodeIds(WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                StarOSAgent.DEFAULT_WORKER_GROUP_ID, candidateNodeIds, System.currentTimeMillis());
 
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
         systemInfoService.addComputeNode(candidateNode.getValue());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/CandidateWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/CandidateWorkerProviderTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.qe.scheduler;
 
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.qe.SessionVariableConstants.ComputationFragmentSchedulingPolicy;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.server.GlobalStateMgr;
@@ -73,8 +74,11 @@ public class CandidateWorkerProviderTest {
         String warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
         //List<Long> computeNodeIds = Arrays.asList(201L, 202L);
         long updateTime = System.currentTimeMillis();
-        historicalNodeMgr.updateHistoricalBackendIds(id2Backend.keySet().asList(), updateTime, warehouse);
-        historicalNodeMgr.updateHistoricalComputeNodeIds(id2ComputeNode.keySet().asList(), updateTime, warehouse);
+        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
+        long workerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
+        historicalNodeMgr.updateHistoricalBackendIds(warehouseId, workerGroupId, id2Backend.keySet().asList(), updateTime);
+        historicalNodeMgr.updateHistoricalComputeNodeIds(warehouseId, workerGroupId, id2ComputeNode.keySet().asList(),
+                updateTime);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/system/HistoricalNodeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/HistoricalNodeMgrTest.java
@@ -15,11 +15,14 @@
 package com.starrocks.system;
 
 import com.google.gson.stream.JsonReader;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +38,9 @@ import java.util.Arrays;
 import java.util.List;
 
 public class HistoricalNodeMgrTest {
+    private final long defaultWarehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
+    private final long defaultWorkerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
+
     @BeforeEach
     public void setUp() throws IOException {
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
@@ -44,52 +50,67 @@ public class HistoricalNodeMgrTest {
     @Test
     public void testUpdateHistoricalBackendIds() throws Exception {
         HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
-        String warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
 
         List<Long> backendIds = Arrays.asList(101L, 102L, 103L);
         long updateTime = System.currentTimeMillis();
-        historicalNodeMgr.updateHistoricalBackendIds(backendIds, updateTime, warehouse);
+        historicalNodeMgr.updateHistoricalBackendIds(defaultWarehouseId, defaultWorkerGroupId, backendIds, updateTime);
 
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(warehouse).size(), backendIds.size());
-        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(warehouse), updateTime);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(defaultWarehouseId, defaultWorkerGroupId).size(),
+                backendIds.size());
+        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(defaultWarehouseId, defaultWorkerGroupId), updateTime);
         Assertions.assertEquals(historicalNodeMgr.getAllHistoricalNodeSet().size(), 1);
     }
 
     @Test
     public void testUpdateHistoricalComputeNodeIds() throws Exception {
         HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
-        String warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
 
         List<Long> computeNodeIds = Arrays.asList(201L, 202L, 203L);
         long updateTime = System.currentTimeMillis();
-        historicalNodeMgr.updateHistoricalComputeNodeIds(computeNodeIds, updateTime, warehouse);
+        historicalNodeMgr.updateHistoricalComputeNodeIds(defaultWarehouseId, defaultWorkerGroupId, computeNodeIds, updateTime);
 
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouse).size(), computeNodeIds.size());
-        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(warehouse), updateTime);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(defaultWarehouseId, defaultWorkerGroupId).size(),
+                computeNodeIds.size());
+        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(defaultWarehouseId, defaultWorkerGroupId), updateTime);
         Assertions.assertEquals(historicalNodeMgr.getAllHistoricalNodeSet().size(), 1);
     }
 
     @Test
     public void testNonExistWarehouseNodeSet() throws Exception {
         HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
-        String warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
 
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(warehouse).size(), 0);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouse).size(), 0);
-        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(warehouse), 0);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(defaultWarehouseId, defaultWorkerGroupId).size(), 0);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(defaultWarehouseId, defaultWorkerGroupId).size(),
+                0);
+        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(defaultWarehouseId, defaultWorkerGroupId), 0);
+    }
+
+    @Test
+    public void testInvalidComputeResourceKey() {
+        HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
+        Assertions.assertEquals(historicalNodeMgr.isResourceAvailable("invalidWarehouse"), false);
+        Assertions.assertEquals(historicalNodeMgr.isResourceAvailable("1001-abc"), false);
+        Assertions.assertEquals(historicalNodeMgr.isResourceAvailable("1001-2-3"), false);
     }
 
     @Test
     public void testSaveAndLoadImage() throws Exception {
+        new MockUp<HistoricalNodeMgr>() {
+            @Mock
+            public boolean isResourceAvailable(String computeResourceKey) {
+                return true;
+            }
+        };
+
         HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
         String warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
-
         List<Long> computeNodeIds = Arrays.asList(201L, 202L, 203L);
         long updateTime = System.currentTimeMillis();
-        historicalNodeMgr.updateHistoricalComputeNodeIds(computeNodeIds, updateTime, warehouse);
+        historicalNodeMgr.updateHistoricalComputeNodeIds(defaultWarehouseId, defaultWorkerGroupId, computeNodeIds, updateTime);
         Assertions.assertEquals(historicalNodeMgr.getAllHistoricalNodeSet().size(), 1);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouse).size(), computeNodeIds.size());
-        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(warehouse), updateTime);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(defaultWarehouseId, defaultWorkerGroupId).size(),
+                computeNodeIds.size());
+        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(defaultWarehouseId, defaultWorkerGroupId), updateTime);
 
         File tempFile = File.createTempFile("HistoricalNodeMgrTest", ".image");
 
@@ -110,8 +131,9 @@ public class HistoricalNodeMgrTest {
         historicalNodeMgr.load(srMetaBlockReader);
         dis.close();
         Assertions.assertEquals(historicalNodeMgr.getAllHistoricalNodeSet().size(), 1);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouse).size(), computeNodeIds.size());
-        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(warehouse), updateTime);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(defaultWarehouseId, defaultWorkerGroupId).size(),
+                computeNodeIds.size());
+        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(defaultWarehouseId, defaultWorkerGroupId), updateTime);
 
         tempFile.delete();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
@@ -18,6 +18,7 @@ import com.google.api.client.util.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.UpdateHistoricalNodeLog;
 import com.starrocks.server.GlobalStateMgr;
@@ -228,6 +229,57 @@ public class SystemInfoServiceTest {
     }
 
     @Test
+    public void testDropComputeNode() throws Exception {
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+
+        Boolean savedConfig = Config.enable_trace_historical_node;
+        Config.enable_trace_historical_node = true;
+
+        ComputeNode cn = new ComputeNode(10001, "newHost", 1000);
+        service.addComputeNode(cn);
+
+        LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
+
+        WarehouseManager warehouseManager = new WarehouseManager();
+        warehouseManager.initDefaultWarehouse();
+
+        new Expectations() {
+            {
+                service.getComputeNodeWithHeartbeatPort("newHost", 1000);
+                minTimes = 0;
+                result = cn;
+
+                globalStateMgr.getLocalMetastore();
+                minTimes = 0;
+                result = localMetastore;
+
+                globalStateMgr.getWarehouseMgr();
+                minTimes = 0;
+                result = warehouseManager;
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public ComputeResource acquireComputeResource(CRAcquireContext acquireContext) {
+                return WarehouseManager.DEFAULT_RESOURCE;
+            }
+        };
+        service.addComputeNode(cn);
+        cn.setStarletPort(1001);
+        service.dropComputeNode("newHost", 1000, WarehouseManager.DEFAULT_WAREHOUSE_NAME, "");
+        ComputeNode cnIP = service.getComputeNodeWithHeartbeatPort("newHost", 1000);
+        Assertions.assertTrue(cnIP == null);
+
+        Config.enable_trace_historical_node = savedConfig;
+    }
+
+    @Test
     public void testReplayUpdateHistoricalNode() throws Exception {
         new MockUp<RunMode>() {
             @Mock
@@ -251,12 +303,54 @@ public class SystemInfoServiceTest {
         List<Long> backendIds = Arrays.asList(101L, 102L);
         List<Long> computeNodeIds = Arrays.asList(201L, 202L, 203L);
         long updateTime = System.currentTimeMillis();
-        String warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
-        UpdateHistoricalNodeLog log = new UpdateHistoricalNodeLog(warehouse, updateTime, backendIds, computeNodeIds);
+        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
+        long workerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
+        UpdateHistoricalNodeLog log = new UpdateHistoricalNodeLog(warehouseId, workerGroupId, updateTime, backendIds,
+                computeNodeIds);
 
         service.replayUpdateHistoricalNode(log);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(warehouse).size(), 2);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouse).size(), 3);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(warehouseId, workerGroupId).size(), 2);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouseId, workerGroupId).size(), 3);
+    }
+
+    @Test
+    public void testReplayOldFormatOfUpdateHistoricalNode() throws Exception {
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+
+        new MockUp<UpdateHistoricalNodeLog>() {
+            @Mock
+            public String getWarehouse() {
+                return WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+            }
+        };
+
+        HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+
+                globalStateMgr.getHistoricalNodeMgr();
+                result = historicalNodeMgr;
+            }
+        };
+
+        List<Long> backendIds = Arrays.asList(101L, 102L);
+        List<Long> computeNodeIds = Arrays.asList(201L, 202L, 203L);
+        long updateTime = System.currentTimeMillis();
+        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
+        long workerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
+        UpdateHistoricalNodeLog log = new UpdateHistoricalNodeLog(warehouseId, workerGroupId, updateTime, backendIds,
+                computeNodeIds);
+
+        service.replayUpdateHistoricalNode(log);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(warehouseId, workerGroupId).size(), 2);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouseId, workerGroupId).size(), 3);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
After we introduce the compute resource unit, one query will be scheduled for a specific compute resource.
So we need to modify the old historical node manager to mange the historical node by compute resource, so that the cache sharing can work during each compute resource scope.

## What I'm doing:
Refactor historical node manager by the compute node resource.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
