### PR TITLE
[BugFix] fix compaction new segments does not clean by abort txn (backport #60673)

### DIFF
--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -61,11 +61,13 @@ Status CompactionTask::fill_compaction_segment_info(TxnLogPB_OpCompaction* op_co
         op_compaction->mutable_output_rowset()->set_data_size(writer->data_size() + uncompacted_data_size);
         op_compaction->mutable_output_rowset()->set_overlapped(true);
     } else {
+        op_compaction->set_new_segment_offset(0);
         for (auto& file : writer->files()) {
             op_compaction->mutable_output_rowset()->add_segments(file.path);
             op_compaction->mutable_output_rowset()->add_segment_size(file.size.value());
             op_compaction->mutable_output_rowset()->add_segment_encryption_metas(file.encryption_meta);
         }
+        op_compaction->set_new_segment_count(writer->files().size());
         op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());
         op_compaction->mutable_output_rowset()->set_data_size(writer->data_size());
         op_compaction->mutable_output_rowset()->set_overlapped(false);

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -24,6 +24,9 @@
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/transactions.h"
+#include "storage/lake/versioned_tablet.h"
+#include "storage/lake/vertical_compaction_task.h"
+#include "storage/rowset/rowset_options.h"
 #include "storage/tablet_schema.h"
 #include "test_util.h"
 #include "testutil/assert.h"
@@ -210,17 +213,6 @@ TEST_F(LakeRowsetTest, test_segment_update_cache_size) {
 TEST_F(LakeRowsetTest, test_partial_compaction) {
     create_rowsets_for_testing();
 
-    auto rs = std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 1 /* compaction_segment_limit */);
-    ASSERT_TRUE(rs->partial_segments_compaction());
-
-    ASSIGN_OR_ABORT(auto segments, rs->segments(false));
-
-    TxnLogPB txn_log;
-    auto op_compaction = txn_log.mutable_op_compaction();
-    uint64_t num_rows = 0;
-    uint64_t data_size = 0;
-    EXPECT_EQ(op_compaction->output_rowset().segments_size(), 0);
-
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     int64_t txn_id = next_id();
     ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
@@ -246,21 +238,54 @@ TEST_F(LakeRowsetTest, test_partial_compaction) {
         ASSERT_EQ(2, writer->files().size());
     }
 
-    // segments in old rowset will be a b c
-    // segments in new rowset will be a x y c
-    // x and y should be deleted
-    EXPECT_TRUE(rs->add_partial_compaction_segments_info(op_compaction, writer.get(), num_rows, data_size).ok());
-    EXPECT_EQ(op_compaction->output_rowset().segments_size(), 4);
-    EXPECT_EQ(op_compaction->new_segment_offset(), 1);
-    EXPECT_EQ(op_compaction->new_segment_count(), 2);
-    EXPECT_TRUE(num_rows > 0);
-    EXPECT_TRUE(data_size > 0);
+    {
+        TxnLogPB txn_log;
+        auto op_compaction = txn_log.mutable_op_compaction();
+        EXPECT_EQ(op_compaction->output_rowset().segments_size(), 0);
 
-    std::vector<string> files_to_delete;
-    collect_files_in_log(_tablet_mgr.get(), txn_log, &files_to_delete);
-    EXPECT_EQ(files_to_delete.size(), 2);
-    EXPECT_TRUE(files_to_delete[0].find(writer->files()[0].path) != std::string::npos);
-    EXPECT_TRUE(files_to_delete[1].find(writer->files()[1].path) != std::string::npos);
+        auto rs = std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 1
+                                                 /* compaction_segment_limit */);
+        ASSERT_TRUE(rs->partial_segments_compaction());
+        // segments in old rowset will be a b c
+        // segments in new rowset will be a x y c
+        // x and y should be deleted
+        CompactionTaskContext context(txn_id, _tablet_metadata->id(), 456, false, nullptr);
+        VersionedTablet vt(nullptr, _tablet_metadata);
+        VerticalCompactionTask task(vt, {rs}, &context, _tablet_schema);
+        EXPECT_TRUE(task.fill_compaction_segment_info(op_compaction, writer.get()).ok());
+        EXPECT_EQ(op_compaction->output_rowset().segments_size(), 4);
+        EXPECT_EQ(op_compaction->new_segment_offset(), 1);
+        EXPECT_EQ(op_compaction->new_segment_count(), 2);
+
+        std::vector<string> files_to_delete;
+        collect_files_in_log(_tablet_mgr.get(), txn_log, &files_to_delete);
+        EXPECT_EQ(files_to_delete.size(), 2);
+        EXPECT_TRUE(files_to_delete[0].find(writer->files()[0].path) != std::string::npos);
+        EXPECT_TRUE(files_to_delete[1].find(writer->files()[1].path) != std::string::npos);
+    }
+
+    {
+        TxnLogPB txn_log;
+        auto op_compaction = txn_log.mutable_op_compaction();
+        EXPECT_EQ(op_compaction->output_rowset().segments_size(), 0);
+
+        auto rs = std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0,
+                                                 0 /* compaction_segment_limit */);
+        ASSERT_FALSE(rs->partial_segments_compaction());
+        CompactionTaskContext context(txn_id, _tablet_metadata->id(), 456, false, nullptr);
+        VersionedTablet vt(nullptr, _tablet_metadata);
+        VerticalCompactionTask task(vt, {rs}, &context, _tablet_schema);
+        EXPECT_TRUE(task.fill_compaction_segment_info(op_compaction, writer.get()).ok());
+        EXPECT_EQ(op_compaction->output_rowset().segments_size(), 2);
+        EXPECT_EQ(op_compaction->new_segment_offset(), 0);
+        EXPECT_EQ(op_compaction->new_segment_count(), 2);
+
+        std::vector<string> files_to_delete;
+        collect_files_in_log(_tablet_mgr.get(), txn_log, &files_to_delete);
+        EXPECT_EQ(files_to_delete.size(), 2);
+        EXPECT_TRUE(files_to_delete[0].find(writer->files()[0].path) != std::string::npos);
+        EXPECT_TRUE(files_to_delete[1].find(writer->files()[1].path) != std::string::npos);
+    }
 }
 
 } // namespace starrocks::lake


### PR DESCRIPTION


when partial compaction is not used, still need to set correct new segment info, so that abort txn can clean new segments

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

