### PR TITLE
[Enhancement] TimeDriftConstraints predicate derivation support date_trunc and time_slice

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/RangePredicateInference.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/RangePredicateInference.java
@@ -14,16 +14,21 @@
 
 package com.starrocks.sql.optimizer.rewrite;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.BoundType;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -33,6 +38,63 @@ public class RangePredicateInference extends ScalarOperatorVisitor<MinMax, Void>
     private RangePredicateInference() {
     }
 
+    private static final Map<String, Integer> DEVIATION_TABLE = ImmutableMap.<String, Integer>builder()
+            .put("microsecond", 1)
+            .put("millisecond", 1)
+            .put("second", 1)
+            .put("minute", 60)
+            .put("hour", 3600)
+            .put("day", 3600 * 24)
+            .put("week", 3600 * 24 * 7)
+            .put("month", 3600 * 24 * 31)
+            .put("quarter", 3600 * 24 * 31 * 3)
+            .put("year", 3600 * 24 * 366)
+            .build();
+
+    private static Optional<MinMax> getDeviation(ScalarOperator expr) {
+        if (expr.isColumnRef()) {
+            return Optional.of(
+                    MinMax.of(Range.closed(ConstantOperator.createInt(0), ConstantOperator.createInt(0))));
+        }
+        if (!(expr instanceof CallOperator)) {
+            return Optional.empty();
+        }
+        CallOperator call = expr.cast();
+        if (call.getFnName().equalsIgnoreCase(FunctionSet.DATE_TRUNC)) {
+            if (!call.getChild(0).isConstant() || !call.getChild(1).isColumnRef()) {
+                return Optional.empty();
+            }
+            String timeUnit = ((ConstantOperator) call.getChild(0)).getVarchar().toLowerCase();
+            return Optional.ofNullable(DEVIATION_TABLE.get(timeUnit))
+                    .map(dev -> MinMax.of(
+                            Range.closed(ConstantOperator.createInt(0), ConstantOperator.createInt(dev))));
+        } else if (call.getFnName().equalsIgnoreCase(FunctionSet.TIME_SLICE)) {
+            if (!call.getChild(0).isColumnRef() || !call.getChildren().stream().skip(1).allMatch(
+                    ScalarOperator::isConstant)) {
+                return Optional.empty();
+            }
+            int interval = ((ConstantOperator) call.getChild(1)).getInt();
+            String timeUnit = ((ConstantOperator) call.getChild(2)).getVarchar();
+            String boundary = ((ConstantOperator) call.getChild(3)).getVarchar();
+            Optional<ConstantOperator> optDev = Optional.ofNullable(DEVIATION_TABLE.get(timeUnit))
+                    .map(d -> ConstantOperator.createInt(d * interval));
+            if (optDev.isEmpty()) {
+                return Optional.empty();
+            }
+            ConstantOperator dev = optDev.get();
+            if (boundary.equalsIgnoreCase("floor")) {
+                return Optional.of(MinMax.of(Range.closed(ConstantOperator.createInt(0), dev)));
+            } else if (boundary.equalsIgnoreCase("ceil")) {
+                dev = ConstantOperator.createInt(-dev.getInt());
+                return Optional.of(MinMax.of(Range.closed(dev, ConstantOperator.createInt(0))));
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.empty();
+    }
+
     @Override
     public MinMax visit(ScalarOperator scalarOperator, Void context) {
         return MinMax.ALL;
@@ -40,44 +102,58 @@ public class RangePredicateInference extends ScalarOperatorVisitor<MinMax, Void>
 
     @Override
     public MinMax visitInPredicate(InPredicateOperator predicate, Void context) {
-        if (!predicate.getChild(0).isColumnRef() ||
+        Optional<MinMax> optDev = getDeviation(predicate.getChild(0));
+        if (optDev.isEmpty() ||
                 predicate.getChildren().stream().skip(1).anyMatch(Predicate.not(ScalarOperator::isConstant))) {
             return MinMax.ALL;
         }
 
+        MinMax dev = optDev.get();
+        Preconditions.checkState(dev.getMax().isPresent() && dev.getMin().isPresent());
         Optional<ConstantOperator> maxValue =
                 predicate.getChildren().stream().skip(1).map(child -> (ConstantOperator) child)
                         .max(ConstantOperator::compareTo);
         Optional<ConstantOperator> minValue =
                 predicate.getChildren().stream().skip(1).map(child -> (ConstantOperator) child)
                         .min(ConstantOperator::compareTo);
+        maxValue = maxValue.map(v -> ScalarOperatorFunctions.secondsAdd(v, dev.getMax().get()));
+        minValue = minValue.map(v -> ScalarOperatorFunctions.secondsAdd(v, dev.getMin().get()));
         return MinMax.of(minValue, true, maxValue, true);
     }
 
     @Override
     public MinMax visitBinaryPredicate(BinaryPredicateOperator predicate, Void context) {
-        if (!predicate.getChild(0).isColumnRef() || !predicate.getChild(1).isConstant()) {
+        Optional<MinMax> optDev = getDeviation(predicate.getChild(0));
+        if (optDev.isEmpty() || !predicate.getChild(1).isConstant()) {
             return MinMax.ALL;
         }
+        MinMax dev = optDev.get();
+        Preconditions.checkState(dev.getMax().isPresent() && dev.getMin().isPresent());
         ConstantOperator value = (ConstantOperator) predicate.getChild(1);
         switch (predicate.getBinaryType()) {
             case EQ -> {
-                return MinMax.of(Range.closed(value, value));
+                ConstantOperator lower = ScalarOperatorFunctions.secondsAdd(value, dev.getMin().get());
+                ConstantOperator upper = ScalarOperatorFunctions.secondsAdd(value, dev.getMax().get());
+                return MinMax.of(Range.closed(lower, upper));
             }
             case NE, EQ_FOR_NULL -> {
                 return MinMax.ALL;
             }
             case LE -> {
-                return MinMax.of(Range.atMost(value));
+                ConstantOperator upper = ScalarOperatorFunctions.secondsAdd(value, dev.getMax().get());
+                return MinMax.of(Range.atMost(upper));
             }
             case GE -> {
-                return MinMax.of(Range.atLeast(value));
+                ConstantOperator lower = ScalarOperatorFunctions.secondsAdd(value, dev.getMin().get());
+                return MinMax.of(Range.atLeast(lower));
             }
             case LT -> {
-                return MinMax.of(Range.upTo(value, BoundType.OPEN));
+                ConstantOperator upper = ScalarOperatorFunctions.secondsAdd(value, dev.getMax().get());
+                return MinMax.of(Range.upTo(upper, BoundType.OPEN));
             }
             case GT -> {
-                return MinMax.of(Range.downTo(value, BoundType.OPEN));
+                ConstantOperator lower = ScalarOperatorFunctions.secondsAdd(value, dev.getMin().get());
+                return MinMax.of(Range.downTo(lower, BoundType.OPEN));
             }
         }
         return MinMax.ALL;


### PR DESCRIPTION
## Why I'm doing:
If  predicates involving TimeDriftConstaints'  targetColumns contains date_trunc or time_slice, predicates involving reference columns can not be derived. so this PR support date_trunc and time_slice.

for an example:

```
CREATE table t0 (
  col_1 varchar(1048576) NULL COMMENT "",
  col_2 varchar(1048576) NULL COMMENT "",
  eventTime varchar(1048576) NULL COMMENT "",
  col_4 varchar(1048576) NULL COMMENT "",
  col_5 varchar(1048576) NULL COMMENT "",
  col_6 double NULL COMMENT "",
  site varchar(10) NULL COMMENT ""
  eventTs datetime AS str_to_date(eventTime, '%Y-%m-%dT%H:%i:%s+0000'),
  localEventTs datetime AS CASE 
    WHEN site IN ('MY', 'SG', 'PH') THEN hours_add(str_to_date(eventTime, '%Y-%m-%dT%H:%i:%s+0000'), 8) 
    WHEN site IN ('TH', 'VN', 'KH', 'ID') THEN hours_add(str_to_date(eventTime, '%Y-%m-%dT%H:%i:%s+0000'), 7) 
    WHEN site = 'MM' THEN minutes_add(hours_add(str_to_date(eventTime, '%Y-%m-%dT%H:%i:%s+0000'), 6), 30) 
    ELSE str_to_date(eventTime, '%Y-%m-%dT%H:%i:%s+0000') 
  END
) ENGINE=OLAP 
DUPLICATE KEY(col_1)
COMMENT "OLAP"
PARTITION BY time_slice(eventTs, interval 1 day, FLOOR)
DISTRIBUTED BY HASH(col_5)
PROPERTIES (
  "compression" = "LZ4",
  "datacache.enable" = "true",
  "enable_async_write_back" = "false",
  "replication_num" = "1",
  "time_drift_constraint" = "localEventTs between DAYS_ADD(eventTs, -2) and DAYS_ADD(eventTs, 2)"
);
```

so query as follows should derive a predicate `eventTs <= '2013-07-06 19:25:59', eventTs >= '2013-07-01 12:11:17'`
```
select * 
from  t0 
where date_trunc('minute', localEventTs)  between '2013-07-03 12:11:17' and '2013-07-04 19:24:59';
```


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
