### PR TITLE
[BugFix] Fix large number of base compactions block other compaction tasks

### DIFF
--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -61,6 +61,10 @@ public:
 
     void update_tablet(const TabletSharedPtr& tablet);
 
+    void increase_task_num(const TabletSharedPtr& tablet, CompactionType type);
+
+    void decrease_task_num(const TabletSharedPtr& tablet, CompactionType type);
+
     bool register_task(CompactionTask* compaction_task);
 
     void unregister_task(CompactionTask* compaction_task);


### PR DESCRIPTION
## Why I'm doing:
Currently, compaction concurrency control is based on _data_dir_to_task_num_map, but this map is only updated when a compaction task actually starts executing. This can lead to a situation where a large number of compaction tasks are submitted in a short period of time between being added to the thread pool and actually starting execution, without any concurrency restrictions. A common bad case is that a large table may submit a large number of base compaction tasks in a short time, blocking compactions for other tables.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
