### PR TITLE
[BugFix] tablet meta of the old tablet should not be vacuumed after schema change

### DIFF
--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -2723,4 +2723,8 @@ TEST_P(LakeVacuumTest, test_garbage_file_check) {
     EXPECT_EQ(1, res.value());
 }
 
+TEST_P(LakeVacuumTest, test_first_visible_version_in_vacuum) {
+    // TODO : add test case to cover the case that first visible version has been set.
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -2736,8 +2736,7 @@ TEST_P(LakeVacuumTest, test_first_visible_version_in_vacuum) {
         {
         "id": 600,
         "version": 1,
-        "rowsets": [],
-        "commit_time": 1687331157
+        "rowsets": []
         }
         )DEL");
     auto t600_v2 = json_to_pb<TabletMetadataPB>(R"DEL(
@@ -2752,8 +2751,7 @@ TEST_P(LakeVacuumTest, test_first_visible_version_in_vacuum) {
                 "data_size": 4096
             }
         ],
-        "prev_garbage_version": 1,
-        "commit_time": 1687331158
+        "prev_garbage_version": 1
         }
         )DEL");
     auto t600_v3 = json_to_pb<TabletMetadataPB>(R"DEL(
@@ -2768,8 +2766,7 @@ TEST_P(LakeVacuumTest, test_first_visible_version_in_vacuum) {
                 "data_size": 4096
             }
         ],
-        "prev_garbage_version": 2,
-        "commit_time": 1687331159
+        "prev_garbage_version": 2
         }
         )DEL");
     auto t600_v4 = json_to_pb<TabletMetadataPB>(R"DEL(
@@ -2784,8 +2781,7 @@ TEST_P(LakeVacuumTest, test_first_visible_version_in_vacuum) {
                 "data_size": 4096
             }
         ],
-        "prev_garbage_version": 3,
-        "commit_time": 1687331161
+        "prev_garbage_version": 3
         }
         )DEL");
 
@@ -2828,7 +2824,7 @@ TEST_P(LakeVacuumTest, test_first_visible_version_in_vacuum) {
     EXPECT_FALSE(file_exist(tablet_metadata_filename(600, 1)));
     EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 1)));
     EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 2)));
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 3)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 3)));
     EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 4)));
 
     SyncPoint::GetInstance()->ClearCallBack("collect_files_to_vacuum:get_file_modified_time");

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -1014,6 +1014,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             Preconditions.checkState(commitVersion == partition.getVisibleVersion() + 1,
                     commitVersion + " vs " + partition.getVisibleVersion());
             partition.setVisibleVersion(commitVersion, finishedTimeMs);
+            partition.setFirstVisibleVersion(commitVersion);
             LOG.debug("update visible version of partition {} to {}. jobId={}", partition.getId(),
                     commitVersion, jobId);
             TStorageMedium medium = table.getPartitionInfo().getDataProperty(partition.getParentId()).getStorageMedium();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -134,6 +134,15 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
     
     private final AtomicLong extraFileSize = new AtomicLong(0);
 
+    /**
+     * `first_visible_version` will be set to the first visible version after the schema change.
+     * It is used to skip tablet meta that does not need deletion,
+     * because no tablet meta prior to `first_visible_version` exists
+     * except for the initial version.
+     */
+    @SerializedName(value = "firstVisibleVersion")
+    private volatile long firstVisibleVersion = 0;
+
     private PhysicalPartition() {
 
     }
@@ -211,6 +220,15 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     public void setLastVacuumTime(long lastVacuumTime) {
         this.lastVacuumTime.set(lastVacuumTime);
+    }
+
+    // get and set of firstVisibleVersion
+    public long getFirstVisibleVersion() {
+        return firstVisibleVersion;
+    }
+
+    public void setFirstVisibleVersion(long firstVisibleVersion) {
+        this.firstVisibleVersion = firstVisibleVersion;
     }
 
     public long getMinRetainVersion() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -257,6 +257,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
             vacuumRequest.partitionId = partition.getId();
             vacuumRequest.deleteTxnLog = needDeleteTxnLog;
             vacuumRequest.enableFileBundling = fileBundling;
+            vacuumRequest.firstVisibleVersion = partition.getFirstVisibleVersion();
             // Perform deletion of txn log on the first node only.
             needDeleteTxnLog = false;
             try {

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -313,6 +313,10 @@ message VacuumRequest {
     // All tablet metadata and their data files of these verisons should be retained and can not be
     // vaccummed.
     repeated int64 retain_versions = 9;
+    // `first_visible_version` will be set to the first visible version after the schema change.
+    // It is used to skip tablet meta that does not need deletion,
+    // because no tablet meta prior to `first_visible_version` exists except for the initial version.
+    optional int64 first_visible_version = 10;
 }
 
 message VacuumResponse {


### PR DESCRIPTION
## Why I'm doing:
We assume a scenario: before version t1, there are N old tablets under a partition, and they use the old schema. After the schema change is completed at t1, all tablets under the partition from t1 onward use the new schema.

At this point, if we execute a vacuum, according to the current strategy, all bundle tablet meta files from version 1 to t1 -1 will be reclaimed. This results in the bundle tablet meta files belonging to the old tablets being reclaimed as well. Consequently, during the subsequent `delete_tablets` call, the system cannot find the corresponding meta files, making it impossible to vacuum the old data files. This leads to residual data files being left behind.

E.g.
```
0000_0001.meta -> tablets (a, b, c) with schema1
0000_0002.meta -> tablets (a, b, c) with schema1
0000_0003.meta -> tablets (a, b, c) with schema1
---- schema change begin ------
0000_0004.meta -> tablets (a, b, c) with schema1
0000_0005.meta -> tablets (a, b, c) with schema1
---- schema change end ------
0000_0006.meta -> tablets (d, e, f) with schema2
0000_0007.meta -> tablets (d, e, f) with schema2
```

So, vacuum after version6 shouldn't reclaim meta files before then version6, because their tablets are different. So I introduced `firstVisibleVersion` to record the version6 which is the first visible version of new tablets, and vacuum after version6 won't reclaim bundle tablet meta before `firstVisibleVersion`.

## What I'm doing:
This pull request introduces support for a new `first_visible_version` parameter in the vacuum process, which is used to optimize metadata deletion by skipping unnecessary tablet metadata. The changes span multiple files, including updates to the vacuum implementation, schema change handling, and associated tests.

### Vacuum process optimization:

* [`be/src/storage/lake/vacuum.cpp`](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750L528-R530): Added the `first_visible_version` parameter to the `vacuum_tablet_metadata` function and updated the logic to skip tablet metadata prior to `first_visible_version`. This ensures unnecessary metadata is not processed during vacuum operations. [[1]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750L528-R530) [[2]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750L591-R592) [[3]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750R681-R684) [[4]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750L695-R703)
* [`gensrc/proto/lake_service.proto`](diffhunk://#diff-5bc50165e4af00c12c8ba0f59f743353ad2f5420e0045cb23d6ae82b867aa337R316-R319): Introduced the `first_visible_version` field in the `VacuumRequest` message to pass this parameter during vacuum operations.

### Schema change handling:

* [`fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java`](diffhunk://#diff-5fe351568eca9f762009640d9868685bc9b02fa18d0e1595a59bca97d5d6635aR1017): Updated schema change logic to set the `first_visible_version` for partitions after committing a schema change.
* [`fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java`](diffhunk://#diff-e9ede0265623b9646560d71213b256ff75a444b67ec851fe6950398e47de2006R137-R145): Added a new `firstVisibleVersion` field to track the first visible version for each partition, along with getter and setter methods. [[1]](diffhunk://#diff-e9ede0265623b9646560d71213b256ff75a444b67ec851fe6950398e47de2006R137-R145) [[2]](diffhunk://#diff-e9ede0265623b9646560d71213b256ff75a444b67ec851fe6950398e47de2006R225-R233)

### Test coverage:

* [`be/test/storage/lake/vacuum_test.cpp`](diffhunk://#diff-d94022a29b009225bf18d165ff7a70635bce8158db300aa8432743a522691e37R2695-R2802): Added a new test case, `test_first_visible_version_in_vacuum`, to verify that the vacuum process correctly skips metadata prior to the `first_visible_version`.

### Autovacuum integration:

* [`fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java`](diffhunk://#diff-ef2b090ae7f6222d36e455ac002b330a56c8d1cda7f082182d2905870d274859R251): Updated the autovacuum logic to include the `first_visible_version` parameter in vacuum requests.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
