### PR TITLE
[BugFix] Add compact to LakeService_RecoverableStub and optimize the error messages returned by aggregation compaction

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1135,7 +1135,8 @@ static void aggregate_compact_cb(brpc::Controller* cntl, CompactResponse* respon
 
     // 2. check status
     if (cntl->Failed()) {
-        ac_context->handle_failure("link rpc channel failed");
+        ac_context->handle_failure(fmt::format("fail to call compact, error={}, error_text={}",
+                                               berror(cntl->ErrorCode()), cntl->ErrorText()));
         return;
     } else if (response->status().status_code() != 0) {
         std::string msg;

--- a/be/src/util/lake_service_recoverable_stub.cpp
+++ b/be/src/util/lake_service_recoverable_stub.cpp
@@ -68,4 +68,12 @@ void LakeService_RecoverableStub::publish_version(::google::protobuf::RpcControl
     stub()->publish_version(controller, request, response, closure);
 }
 
+void LakeService_RecoverableStub::compact(::google::protobuf::RpcController* controller,
+                                          const ::starrocks::CompactRequest* request,
+                                          ::starrocks::CompactResponse* response, ::google::protobuf::Closure* done) {
+    using RecoverableClosureType = RecoverableClosure<LakeService_RecoverableStub>;
+    auto closure = new RecoverableClosureType(shared_from_this(), controller, done);
+    stub()->compact(controller, request, response, closure);
+}
+
 } // namespace starrocks

--- a/be/src/util/lake_service_recoverable_stub.h
+++ b/be/src/util/lake_service_recoverable_stub.h
@@ -40,6 +40,9 @@ public:
                          const ::starrocks::PublishVersionRequest* request,
                          ::starrocks::PublishVersionResponse* response, ::google::protobuf::Closure* done);
 
+    void compact(::google::protobuf::RpcController* controller, const ::starrocks::CompactRequest* request,
+                 ::starrocks::CompactResponse* response, ::google::protobuf::Closure* done);
+
 private:
     std::shared_ptr<starrocks::LakeService_Stub> _stub;
     const butil::EndPoint _endpoint;

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1085,8 +1085,7 @@ TEST_F(LakeServiceTest, test_aggregate_compact) {
         AggregateCompactRequest agg_request;
         CompactRequest request;
         ComputeNodePB cn;
-        std::string host = butil::ip2str(server_addr.ip);
-        cn.set_host(host);
+        cn.set_host("127.0.0.1");
         cn.set_brpc_port(port);
         cn.set_id(1);
         CompactResponse response;
@@ -1159,8 +1158,7 @@ TEST_F(LakeServiceTest, test_aggregate_compact_with_error) {
         AggregateCompactRequest agg_request;
         CompactRequest request;
         ComputeNodePB cn;
-        std::string host = butil::ip2str(server_addr.ip);
-        cn.set_host(host);
+        cn.set_host("127.0.0.1");
         cn.set_brpc_port(port);
         cn.set_id(1);
         CompactResponse response;
@@ -1177,6 +1175,8 @@ TEST_F(LakeServiceTest, test_aggregate_compact_with_error) {
         ASSERT_EQ(TStatusCode::INTERNAL_ERROR, response.status().status_code());
         // check error messages
         ASSERT_EQ(1, response.status().error_msgs_size());
+        // check error msge
+        ASSERT_EQ("injected error", response.status().error_msgs(0));
     }
 }
 

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -16,6 +16,7 @@
 
 #include <brpc/controller.h>
 #include <brpc/server.h>
+#include <butil/endpoint.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -1084,7 +1085,8 @@ TEST_F(LakeServiceTest, test_aggregate_compact) {
         AggregateCompactRequest agg_request;
         CompactRequest request;
         ComputeNodePB cn;
-        cn.set_host("127.0.0.1");
+        std::string host = butil::ip2str(server_addr.ip);
+        cn.set_host(host);
         cn.set_brpc_port(port);
         cn.set_id(1);
         CompactResponse response;
@@ -1157,7 +1159,8 @@ TEST_F(LakeServiceTest, test_aggregate_compact_with_error) {
         AggregateCompactRequest agg_request;
         CompactRequest request;
         ComputeNodePB cn;
-        cn.set_host("127.0.0.1");
+        std::string host = butil::ip2str(server_addr.ip);
+        cn.set_host(host);
         cn.set_brpc_port(port);
         cn.set_id(1);
         CompactResponse response;

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1174,7 +1174,6 @@ TEST_F(LakeServiceTest, test_aggregate_compact_with_error) {
         ASSERT_EQ(TStatusCode::INTERNAL_ERROR, response.status().status_code());
         // check error messages
         ASSERT_EQ(1, response.status().error_msgs_size());
-        ASSERT_EQ("injected error", response.status().error_msgs(0));
     }
 }
 

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1124,6 +1124,59 @@ TEST_F(LakeServiceTest, test_aggregate_compact) {
     }
 }
 
+TEST_F(LakeServiceTest, test_aggregate_compact_with_error) {
+    auto agg_compact = [this](::google::protobuf::RpcController* cntl, const AggregateCompactRequest* request,
+                              CompactResponse* response) {
+        CountDownLatch latch(1);
+        auto cb = ::google::protobuf::NewCallback(&latch, &CountDownLatch::count_down);
+        _lake_service.aggregate_compact(cntl, request, response, cb);
+        latch.wait();
+    };
+
+    brpc::ServerOptions options;
+    options.num_threads = 1;
+    brpc::Server server;
+    MockLakeServiceImpl mock_service;
+    ASSERT_EQ(server.AddService(&mock_service, brpc::SERVER_DOESNT_OWN_SERVICE), 0);
+    ASSERT_EQ(server.Start(0, &options), 0);
+
+    butil::EndPoint server_addr = server.listen_address();
+    const int port = server_addr.port;
+    EXPECT_CALL(mock_service, compact(_, _, _, _))
+            .WillRepeatedly(Invoke([&](::google::protobuf::RpcController*, const CompactRequest*, CompactResponse* resp,
+                                       ::google::protobuf::Closure* done) {
+                resp->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
+                resp->mutable_status()->add_error_msgs("injected error");
+                done->Run();
+            }));
+
+    // compact failed - single cn
+    {
+        brpc::Controller cntl;
+        AggregateCompactRequest agg_request;
+        CompactRequest request;
+        ComputeNodePB cn;
+        cn.set_host("127.0.0.1");
+        cn.set_brpc_port(port);
+        cn.set_id(1);
+        CompactResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.set_txn_id(txn_id);
+        request.set_version(1);
+        request.set_timeout_ms(3000);
+        // add request to agg_request
+        agg_request.add_requests()->CopyFrom(request);
+        agg_request.add_compute_nodes()->CopyFrom(cn);
+        agg_compact(&cntl, &agg_request, &response);
+        ASSERT_FALSE(cntl.Failed());
+        // check status
+        ASSERT_EQ(TStatusCode::INTERNAL_ERROR, response.status().status_code());
+        // check error messages
+        ASSERT_EQ(1, response.status().error_msgs_size());
+        ASSERT_EQ("injected error", response.status().error_msgs(0));
+    }
+}
+
 TEST_F(LakeServiceTest, test_drop_table) {
     ASSERT_OK(FileSystem::Default()->path_exists(kRootLocation));
     DropTableRequest request;

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1150,6 +1150,7 @@ TEST_F(LakeServiceTest, test_aggregate_compact_with_error) {
                 done->Run();
             }));
 
+    auto txn_id = next_id();
     // compact failed - single cn
     {
         brpc::Controller cntl;


### PR DESCRIPTION
## Why I'm doing:
1. The error message return by `aggregate_compact` is not clear enough.
2. `compact` rpc function is missing in `LakeService_RecoverableStub`, which will lead to error when run `aggregate_compact`

## What I'm doing:
This pull request introduces enhancements and fixes to the `LakeService` functionality, including improved error handling, the addition of a new `compact` method, and expanded test coverage to ensure robustness. Below are the most significant changes grouped by theme:

### Error Handling Improvements:
* Enhanced error logging in `aggregate_compact_cb` to include detailed error messages and formatted error text for better debugging. (`be/src/service/service_be/lake_service.cpp`, [be/src/service/service_be/lake_service.cppL1138-R1147](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaL1138-R1147))

### New Method Implementation:
* Added a new `compact` method to the `LakeService_RecoverableStub` class, enabling recoverable compact operations with a custom closure. (`be/src/util/lake_service_recoverable_stub.cpp`, [[1]](diffhunk://#diff-5a50f68fa29e8bfdbe299295e54add577191a7ff224fddb000a6b67e38ef76f3R71-R78); `be/src/util/lake_service_recoverable_stub.h`, [[2]](diffhunk://#diff-c0a9dd9dbf1c1408bfb7fe99b6586b265c75b59aa503001b6fdb50ffbcb1f3e5R43-R45)

### Test Coverage Expansion:
* Introduced a new test case, `test_aggregate_compact_with_error`, to validate error handling in the `aggregate_compact` operation, including injected errors and error message assertions. (`be/test/service/lake_service_test.cpp`, [be/test/service/lake_service_test.cppR1128-R1182](diffhunk://#diff-7e7546a285303649b12ec94135003c7c099a4b032ebe2ae95a044ea791386d5fR1128-R1182))

### Dependency Updates:
* Added `butil/endpoint.h` to the test file to support the new test case and ensure proper handling of server endpoints. (`be/test/service/lake_service_test.cpp`, [be/test/service/lake_service_test.cppR19](diffhunk://#diff-7e7546a285303649b12ec94135003c7c099a4b032ebe2ae95a044ea791386d5fR19))

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
