### PR TITLE
[BugFix] Remove unused output_scale variable in expr

### DIFF
--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -100,7 +100,6 @@ Expr::Expr(const Expr& expr)
           _is_nullable(expr._is_nullable),
           _is_monotonic(expr._is_monotonic),
           _type(expr._type),
-          _output_scale(expr._output_scale),
           _fn(expr._fn),
           _fn_context_index(expr._fn_context_index) {}
 
@@ -111,7 +110,6 @@ Expr::Expr(TypeDescriptor type, bool is_slotref)
           // _vector_opcode(TExprOpcode::INVALID_OPCODE),
           _is_slotref(is_slotref),
           _type(std::move(type)),
-          _output_scale(-1),
           _fn_context_index(-1) {
     if (is_slotref) {
         _node_type = (TExprNodeType::SLOT_REF);
@@ -193,7 +191,6 @@ Expr::Expr(const TExprNode& node, bool is_slotref)
           _is_slotref(is_slotref),
           _is_nullable(node.is_nullable),
           _type(TypeDescriptor::from_thrift(node.type)),
-          _output_scale(node.output_scale),
           _fn_context_index(-1) {
     if (node.__isset.fn) {
         _fn = node.fn;

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -91,12 +91,6 @@ public:
         }
     }
 
-    // Get the number of digits after the decimal that should be displayed for this
-    // value. Returns -1 if no scale has been specified (currently the scale is only set for
-    // doubles set by RoundUpTo). get_value() must have already been called.
-    // TODO: this will be unnecessary once we support the DECIMAL(precision, scale) type
-    int output_scale() const { return _output_scale; }
-
     void add_child(Expr* expr) { _children.push_back(expr); }
 
     // only the expr after clone can call this function
@@ -349,7 +343,6 @@ protected:
     // analysis is done, types are fixed at this point
     TypeDescriptor _type;
     std::vector<Expr*> _children = std::vector<Expr*>();
-    int _output_scale;
 
     /// Function description.
     TFunction _fn;

--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -144,16 +144,6 @@ Status VectorizedFunctionCallExpr::open(starrocks::RuntimeState* state, starrock
         RETURN_IF_ERROR(_fn_desc->prepare_function(fn_ctx, FunctionContext::THREAD_LOCAL));
     }
 
-    // Todo: We will use output_scale in the result_writer to format the
-    //  output in row engine, but we need set output scale in vectorized engine?
-    if (_fn.name.function_name == "round" && _type.type == TYPE_DOUBLE) {
-        if (_children[1]->is_constant()) {
-            ASSIGN_OR_RETURN(ColumnPtr ptr, _children[1]->evaluate_checked(context, nullptr));
-            _output_scale = Int32Column::static_pointer_cast(ConstColumn::static_pointer_cast(ptr)->data_column())
-                                    ->get_data()[0];
-        }
-    }
-
     return Status::OK();
 }
 

--- a/be/src/exprs/jit/jit_expr.cpp
+++ b/be/src/exprs/jit/jit_expr.cpp
@@ -37,7 +37,6 @@ JITExpr* JITExpr::create(ObjectPool* pool, Expr* expr) {
     node.opcode = TExprOpcode::JIT;
     node.is_nullable = expr->is_nullable();
     node.type = expr->type().to_thrift();
-    node.output_scale = expr->output_scale();
     node.is_monotonic = expr->is_monotonic();
     return pool->add(new JITExpr(node, expr));
 }

--- a/test/sql/test_function/R/test_round
+++ b/test/sql/test_function/R/test_round
@@ -1,0 +1,74 @@
+-- name: test_round
+CREATE TABLE test_all_null (
+    id_int int null,
+    id_boolean boolean null,
+    id_tinyint tinyint null,
+    id_smallint smallint null,
+    id_bigint bigint null,
+    id_largeint largeint null,
+    id_float float null,
+    id_double double null,
+    id_decimal32 decimal32(8, 5) null,
+    id_decimal64 decimal64(8, 5) null,
+    id_decimal128 decimal128(8, 5) null,
+    id_date date null,
+    id_datetime datetime null,
+    id_varchar varchar(2000) null,
+    id_json json,
+    id_any_element int null,
+    id_any_array array<int> null,
+    id_array_boolean array<boolean> null,
+    id_array_tinyint array<tinyint> null,
+    id_array_smallint array<smallint> null,
+    id_array_int array<int> null,
+    id_array_bigint array<bigint> null,
+    id_array_largeint array<largeint> null,
+    id_array_float array<float> null,
+    id_array_double array<double> null,
+    id_array_varchar array<varchar(2000)> null,
+    id_array_date array<date> null,
+    id_array_datetime array<datetime> null
+) ENGINE=OLAP
+DUPLICATE KEY(`id_int`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id_int`) BUCKETS 10
+PROPERTIES (
+    "storage_format" = "DEFAULT"
+);
+-- result:
+-- !result
+insert into test_all_null select t.* from (select 1 as d) x left join test_all_null t on x.d = t.id_int;
+-- result:
+-- !result
+select (round(id_double)) <=> (round(NULL)) from test_all_null;
+-- result:
+1
+-- !result
+select (dround(id_double)) <=> (dround(NULL)) from test_all_null;
+-- result:
+1
+-- !result
+select (round(id_double, id_int)) <=> (round(NULL, NULL)) from test_all_null;
+-- result:
+1
+-- !result
+select (round(id_double, id_int)) <=> (round(id_double, NULL)) from test_all_null;
+-- result:
+1
+-- !result
+select (round(id_double, id_int)) <=> (round(NULL, id_int)) from test_all_null;
+-- result:
+1
+-- !result
+select (dround(id_double, id_int)) <=> (dround(NULL, NULL)) from test_all_null;
+-- result:
+1
+-- !result
+select (dround(id_double, id_int)) <=> (dround(id_double, NULL)) from test_all_null;
+-- result:
+1
+-- !result
+select (dround(id_double, id_int)) <=> (dround(NULL, id_int)) from test_all_null;
+-- result:
+1
+-- !result

--- a/test/sql/test_function/T/test_round
+++ b/test/sql/test_function/T/test_round
@@ -1,0 +1,49 @@
+-- name: test_round
+CREATE TABLE test_all_null (
+    id_int int null,
+    id_boolean boolean null,
+    id_tinyint tinyint null,
+    id_smallint smallint null,
+    id_bigint bigint null,
+    id_largeint largeint null,
+    id_float float null,
+    id_double double null,
+    id_decimal32 decimal32(8, 5) null,
+    id_decimal64 decimal64(8, 5) null,
+    id_decimal128 decimal128(8, 5) null,
+    id_date date null,
+    id_datetime datetime null,
+    id_varchar varchar(2000) null,
+    id_json json,
+    id_any_element int null,
+    id_any_array array<int> null,
+    id_array_boolean array<boolean> null,
+    id_array_tinyint array<tinyint> null,
+    id_array_smallint array<smallint> null,
+    id_array_int array<int> null,
+    id_array_bigint array<bigint> null,
+    id_array_largeint array<largeint> null,
+    id_array_float array<float> null,
+    id_array_double array<double> null,
+    id_array_varchar array<varchar(2000)> null,
+    id_array_date array<date> null,
+    id_array_datetime array<datetime> null
+) ENGINE=OLAP
+DUPLICATE KEY(`id_int`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id_int`) BUCKETS 10
+PROPERTIES (
+    "storage_format" = "DEFAULT"
+);
+
+
+insert into test_all_null select t.* from (select 1 as d) x left join test_all_null t on x.d = t.id_int;
+
+select (round(id_double)) <=> (round(NULL)) from test_all_null;
+select (dround(id_double)) <=> (dround(NULL)) from test_all_null;
+select (round(id_double, id_int)) <=> (round(NULL, NULL)) from test_all_null;
+select (round(id_double, id_int)) <=> (round(id_double, NULL)) from test_all_null;
+select (round(id_double, id_int)) <=> (round(NULL, id_int)) from test_all_null;
+select (dround(id_double, id_int)) <=> (dround(NULL, NULL)) from test_all_null;
+select (dround(id_double, id_int)) <=> (dround(id_double, NULL)) from test_all_null;
+select (dround(id_double, id_int)) <=> (dround(NULL, id_int)) from test_all_null;


### PR DESCRIPTION
## Why I'm doing:

```
Crash Log: 
starrocks_be: be/src/gutil/casts.h:79: To down_cast(From*) [with To = const starrocks::FixedLengthColumn<int>*; From = const starrocks::Column]: Assertion `f == __null || dynamic_cast<To>(f) != __null' failed.
main ASAN (build 47faaa0)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000
*** Aborted at 1752035742 (unix time) try "date -d @1752035742" if you are using GNU date ***
PC: @     0x2acc5c88a387 __GI_raise
*** SIGABRT (@0x3e800000ab5) received by PID 2741 (TID 0x2acd16dce700) LWP(2998) from PID 2741; stack trace: ***
   @         0x20324b87 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
   @     0x2acc5a7ae20b __pthread_once_slow
   @         0x20324394 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
   @     0x2acc5a7b7630 (/usr/lib64/libpthread-2.17.so+0xf62f)
   @     0x2acc5c88a387 __GI_raise
   @     0x2acc5c88ba78 __GI_abort
   @     0x2acc5c8831a6 __assert_fail_base
   @     0x2acc5c883252 __GI___assert_fail
   @          0xfa51680 starrocks::FixedLengthColumn<int> const* down_cast<starrocks::FixedLengthColumn<int> const*, starrocks::Column const>(starrocks::Column const*)
   @          0xfa51877 starrocks::CowFactory<starrocks::ColumnFactory<starrocks::FixedLengthColumnBase<int>, starrocks::FixedLengthColumn<int> >, starrocks::FixedLengthColumn<int>, starrocks::Column>::static_pointer_cast(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Col@
   @         0x17f53905 starrocks::VectorizedFunctionCallExpr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope)
   @         0x1627d9ee starrocks::Expr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope)
   @         0x1626a075 starrocks::ExprContext::open(starrocks::RuntimeState*)
   @         0x1627d4ff starrocks::Expr::open(std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const&, starrocks::RuntimeState*)
   @         0x1168c35c starrocks::pipeline::ProjectOperatorFactory::prepare(starrocks::RuntimeState*)
   @         0x11c4f5ff starrocks::pipeline::Pipeline::prepare(starrocks::RuntimeState*)
   @         0x11c4a54d starrocks::pipeline::NormalExecutionGroup::prepare_pipelines(starrocks::RuntimeState*)
   @         0x119fc9a5 starrocks::pipeline::FragmentContext::prepare_all_pipelines()
   @         0x115eb522 starrocks::pipeline::FragmentExecutor::_prepare_pipeline_driver(starrocks::ExecEnv*, starrocks::pipeline::UnifiedExecPlanFragmentParams const&)
   @         0x115ef879 starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
   @         0x1b7d3548 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
   @         0x1b7d2fcd starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*)
   @         0x1b7cba8c starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)
   @         0x1b7da31e starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}::operator()() @
   @         0x1b7e3cb8 void std::__invoke_impl<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*@
   @         0x1b7e1cb3 std::enable_if<is_invocable_r_v<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::@
   @         0x1b7df563 std::_Function_handler<void (), starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closur@
   @          0xdcd8b20 std::function<void ()>::operator()() const
   @          0xdcced3d starrocks::PriorityThreadPool::work_thread(int)
   @          0xdd22d39 void std::__invoke_impl<void, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(std::__invoke_memfun_deref, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&)
   @          0xdd22b77 std::__invoke_result<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>::type std::__invoke<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(void (starrocks::PriorityThread@
   @          0xdd22b05 decltype (__invoke((*this)._M_pmf, (forward<starrocks::PriorityThreadPool*&>)({parm#1}), (forward<int&>)({parm#1}))) std::_Mem_fn_base<void (starrocks::PriorityThreadPool::*)(int), true>::operator()<starrocks::PriorityThreadPool*&, int&>(starrocks::Priorit@
[1752035743.906][thread: 47060340238080] je_mallctl execute purge success
[1752035743.906][thread: 47060340238080] je_mallctl execute dontdump success

```
## What I'm doing:
- `output_scale` is unused, remove to maintain it.

Fixes  https://github.com/StarRocks/StarRocksTest/issues/9969

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
