### PR TITLE
[BugFix] Fix JVM crash bug caused by async-profiler

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
@@ -69,7 +69,7 @@ public class ProcProfileCollector extends FrontendDaemon {
         String fileName = MEM_FILE_NAME_PREFIX + currentTimeString() + ".html";
         AsyncProfiler profiler = AsyncProfiler.getInstance();
         try {
-            profiler.execute(String.format("start,quiet,event=alloc,alloc=2m,file=%s", profileLogDir + "/" + fileName));
+            profiler.execute(String.format("start,quiet,event=alloc,alloc=2m,cstack=vm,file=%s", profileLogDir + "/" + fileName));
             Thread.sleep(Config.proc_profile_collect_time_s * 1000L);
             profiler.execute(String.format("stop,file=%s", profileLogDir + "/" + fileName));
         } catch (Exception e) {
@@ -87,7 +87,7 @@ public class ProcProfileCollector extends FrontendDaemon {
         String fileName = CPU_FILE_NAME_PREFIX + currentTimeString() + ".html";
         AsyncProfiler profiler = AsyncProfiler.getInstance();
         try {
-            profiler.execute(String.format("start,quiet,event=cpu,file=%s", profileLogDir + "/" + fileName));
+            profiler.execute(String.format("start,quiet,event=cpu,cstack=vm,file=%s", profileLogDir + "/" + fileName));
             Thread.sleep(Config.proc_profile_collect_time_s * 1000L);
             profiler.execute(String.format("stop,file=%s", profileLogDir + "/" + fileName));
         } catch (Exception e) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Add  cstack=vm options according to https://github.com/async-profiler/async-profiler/issues/1364

Fixes 
```
---------------  T H R E A D  ---------------

Current thread (0x0000c5be04053800):  JavaThread "deltalake-metastore-refresh-1407" [_thread_in_Java, id=432687, stack(0x0000e275f9c00000,0x0000e275f9e00000)]

Stack: [0x0000e275f9c00000,0x0000e275f9e00000],  sp=0x0000e275f9dfaeb0,  free space=2027k
Native frames: (J=compiled Java code, A=aot compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x5c52c4]  frame::safe_for_sender(JavaThread*)+0x274
V  [libjvm.so+0x5bf558]  vframeStreamForte::forte_next()+0x68
V  [libjvm.so+0x5bfe94]  forte_fill_call_trace_given_top(JavaThread*, ASGCT_CallTrace*, int, frame)+0x2d0
V  [libjvm.so+0x5c036c]  AsyncGetCallTrace+0x1ec
C  [libasyncProfiler.so+0x2a154]  Profiler::getJavaTraceAsync(void*, ASGCT_CallFrame*, int, StackContext*)+0xf0
C  [libasyncProfiler.so+0x2ba34]  Profiler::recordSample(void*, unsigned long long, EventType, Event*)+0x44c
C  [libasyncProfiler.so+0x2c9e4]  PerfEvents::signalHandler(int, siginfo_t*, void*)+0x10c
C  [linux-vdso.so.1+0x8f8]  __kernel_rt_sigreturn+0x0
J 282699 c2 java.util.regex.Matcher.replaceAll(Ljava/lang/String;)Ljava/lang/String; java.base@11.0.27 (59 bytes) @ 0x0000e2779336586c [0x0000e27793365040+0x000000000000082c]
C  0xffffffffffffffff
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

