### PR TITLE
[BugFix] Release the cache engine instances before the datacache is freed to clean some related resources in advance

### DIFF
--- a/be/src/cache/datacache.cpp
+++ b/be/src/cache/datacache.cpp
@@ -100,6 +100,8 @@ void DataCache::destroy() {
     LOG(INFO) << "pagecache shutdown successfully";
 
     _block_cache.reset();
+    _local_cache.reset();
+    _remote_cache.reset();
     LOG(INFO) << "datacache shutdown successfully";
 }
 


### PR DESCRIPTION
## Why I'm doing:
Now when BE graceful exit, the follow crash may occur.
```
*** Aborted at 1752050907 (unix time) try "date -d @1752050907" if you are using GNU date ***

PC: @     0x2b0053326387 __GI_raise

*** SIGABRT (@0x3e800000aae) received by PID 2734 (TID 0x2b005105d2c0) LWP(2734) from PID 2734; stack trace: ***

    @         0x20324b87 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)

    @     0x2b005124a20b __pthread_once_slow

    @         0x20324394 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)

    @     0x2b0051253630 (/usr/lib64/libpthread-2.17.so+0xf62f)

    @     0x2b0053326387 __GI_raise

    @     0x2b0053327a78 __GI_abort

    @         0x200740e0 rocksdb::port::Mutex::Lock()

    @         0x1ff86851 rocksdb::PeriodicWorkScheduler::Unregister(rocksdb::DBImpl*)

    @         0x1feb0650 rocksdb::DBImpl::CancelAllBackgroundWork(bool)

    @         0x1fec55bc rocksdb::DBImpl::CloseHelper()

    @         0x1fec5e91 rocksdb::DBImpl::CloseImpl()

    @         0x1fec5f7c rocksdb::DBImpl::Close()

    @         0x1d3682db starcache::RocksDBKV::shutdown()

    @         0x1d358651 starcache::StarCacheImpl::~StarCacheImpl()

    @         0x1d343e41 starcache::StarCache::~StarCache()

    @          0xf71d279 void std::destroy_at<starcache::StarCache>(starcache::StarCache*)

    @          0xf71d25e void std::_Destroy<starcache::StarCache>(starcache::StarCache*)

    @          0xf71cfae std::_Sp_counted_ptr_inplace<starcache::StarCache, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose()

    @          0xda915aa std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()

    @          0xdaa5af0 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count()

    @          0xe2b7b0c std::__shared_ptr<starcache::StarCache, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr()

    @          0xe2b7b4e std::shared_ptr<starcache::StarCache>::~shared_ptr()

    @          0xf71cecb starrocks::StarCacheEngine::~StarCacheEngine()

    @          0xf6feb1b void std::destroy_at<starrocks::StarCacheEngine>(starrocks::StarCacheEngine*)

    @          0xf6fe9ce void std::_Destroy<starrocks::StarCacheEngine>(starrocks::StarCacheEngine*)

    @          0xf6fddfc std::_Sp_counted_ptr_inplace<starrocks::StarCacheEngine, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose()

    @          0xda915aa std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()

    @          0xdaa5af0 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count()

    @          0xf6f249a std::__shared_ptr<starrocks::LocalCacheEngine, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr()

    @          0xf6f24dc std::shared_ptr<starrocks::LocalCacheEngine>::~shared_ptr()

    @          0xf6f2b2e starrocks::DataCache::~DataCache()

    @     0x2b0053329ce9 __run_exit_handlers
```

## What I'm doing:
Release the local cache and remote cache instances before the datacache instance is freed to clean some related resources in advance.

Fix the issue: https://github.com/StarRocks/StarRocksTest/issues/9970

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
