### PR TITLE
[BugFix] Fix do schema change with partial MaterializedIndex

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -59,6 +59,7 @@ import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.lake.Utils;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
 import com.starrocks.qe.ConnectContext;
@@ -806,54 +807,51 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             txnInfo.commitTime = finishedTimeMs / 1000;
             txnInfo.gtid = watershedGtid;
 
+            // txnId is -1 means that BE do nothing, just upgrade the tablet_meta version
             TxnInfoPB originTxnInfo = new TxnInfoPB();
             originTxnInfo.txnId = -1L;
             originTxnInfo.combinedTxnLog = false;
             originTxnInfo.commitTime = finishedTimeMs / 1000;
             originTxnInfo.txnType = TxnTypePB.TXN_EMPTY;
             originTxnInfo.gtid = watershedGtid;
+            AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
 
-            List<Tablet> tablets = new ArrayList<>();
-            List<Tablet> unchangedMaterializedIndexTablets = new ArrayList<>();
-            Set<Long> originIndexIds = indexIdMap.keySet();
             for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
                 long commitVersion = commitVersionMap.get(partitionId);
-                tablets.clear();
-                unchangedMaterializedIndexTablets.clear();
                 Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(partitionId);
                 for (MaterializedIndex shadowIndex : shadowIndexMap.values()) {
                     if (!isFileBundling) {
                         Utils.publishVersion(shadowIndex.getTablets(), txnInfo, 1, commitVersion, computeResource,
                                 isFileBundling);
                     } else {
-                        tablets.addAll(shadowIndex.getTablets());
+                        Utils.createSubRequestForAggregatePublish(shadowIndex.getTablets(),
+                                Lists.newArrayList(txnInfo), 1, commitVersion, null, computeResource, request);
                     }
-                }
-                if (isFileBundling) {
-                    Utils.aggregatePublishVersion(tablets, Lists.newArrayList(txnInfo), 1, commitVersion,
-                            null, null, computeResource, null);
                 }
 
                 // For indexes whose schema have not changed, we still need to upgrade the version
-                List<MaterializedIndex> indices;
+                List<MaterializedIndex> originMaterializedIndex;
+                List<Tablet> allOtherPartitionTablets = new ArrayList<>();
                 try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
                     OlapTable table = getTableOrThrow(db, tableId);
                     PhysicalPartition partition = table.getPhysicalPartition(partitionId);
-                    indices = partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE).
-                            stream().filter(index -> !(originIndexIds.contains(index.getId()))).toList();
+                    originMaterializedIndex = partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE);
                 }
-                for (MaterializedIndex unchangedMaterializedIndex : indices) {
-                    if (!isFileBundling) {
-                        Utils.publishVersion(unchangedMaterializedIndex.getTablets(), originTxnInfo,
-                                commitVersion - 1, commitVersion, computeResource, isFileBundling);
-                    } else {
-                        unchangedMaterializedIndexTablets.addAll(unchangedMaterializedIndex.getTablets());
-                    }
+
+                for (MaterializedIndex index : originMaterializedIndex) {
+                    allOtherPartitionTablets.addAll(index.getTablets());
                 }
+
+                if (!isFileBundling) {
+                    Utils.publishVersion(allOtherPartitionTablets, originTxnInfo, 1, commitVersion, computeResource,
+                            isFileBundling);
+                } else {
+                    Utils.createSubRequestForAggregatePublish(allOtherPartitionTablets, Lists.newArrayList(originTxnInfo),
+                            commitVersion - 1, commitVersion, null, computeResource, request);
+                }
+
                 if (isFileBundling) {
-                    Utils.aggregatePublishVersion(unchangedMaterializedIndexTablets, Lists.newArrayList(txnInfo),
-                            commitVersion - 1, commitVersion, null,
-                            null, computeResource, null);
+                    Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null);
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -814,9 +814,9 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             originTxnInfo.commitTime = finishedTimeMs / 1000;
             originTxnInfo.txnType = TxnTypePB.TXN_EMPTY;
             originTxnInfo.gtid = watershedGtid;
-            AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
 
             for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
+                AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
                 long commitVersion = commitVersionMap.get(partitionId);
                 Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(partitionId);
                 for (MaterializedIndex shadowIndex : shadowIndexMap.values()) {

--- a/test/sql/test_rollup/R/test_lake_rollup
+++ b/test/sql/test_rollup/R/test_lake_rollup
@@ -36,3 +36,17 @@ SELECT v1 FROM rollup1 [_SYNC_MV_] ORDER BY v1;
 100
 300
 -- !result
+
+ALTER TABLE tbl1 MODIFY COLUMN k2 BIGINT;
+-- result:
+-- !result
+function: wait_alter_table_finish("COLUMN")
+-- result:
+None
+-- !result
+
+SELECT v1 FROM rollup1 [_SYNC_MV_] ORDER BY v1;
+-- result:
+100
+300
+-- !result

--- a/test/sql/test_rollup/T/test_lake_rollup
+++ b/test/sql/test_rollup/T/test_lake_rollup
@@ -21,3 +21,8 @@ function: wait_alter_table_finish("ROLLUP")
 INSERT INTO tbl1 VALUES("2020-01-11",6,100);
 
 SELECT v1 FROM rollup1 [_SYNC_MV_] ORDER BY v1;
+
+ALTER TABLE tbl1 MODIFY COLUMN k2 BIGINT;
+function: wait_alter_table_finish("COLUMN")
+
+SELECT v1 FROM rollup1 [_SYNC_MV_] ORDER BY v1;


### PR DESCRIPTION
## Why I'm doing:
If the schema change Job only modifies the schema of partial MaterializedIndex, not all,  then the tablets of MaterializedIndex  whose schema have not been changed also need to upgrade their versions. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
