### PR TITLE
[Enhancement] add some metrics for aggregate publish version & compaction

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -121,7 +121,7 @@ bvar::PassiveStatus<int> g_publish_version_active_tasks("lake_publish_version_ac
                                                         get_num_publish_active_tasks, nullptr);
 bvar::PassiveStatus<int> g_vacuum_queued_tasks("lake_vacuum_queued_tasks", get_num_vacuum_queued_tasks, nullptr);
 bvar::PassiveStatus<int> g_vacuum_active_tasks("lake_vacuum_active_tasks", get_num_vacuum_active_tasks, nullptr);
-// metrcis for aggregate publish version & compaction
+// metrics for aggregate publish version & compaction
 bvar::Adder<int64_t> g_aggregate_publish_version_failed_tasks("lake_aggregate_publish_version_failed_tasks");
 bvar::Adder<int64_t> g_aggregate_publish_version_total_tasks("lake_aggregate_publish_version_total_tasks");
 bvar::LatencyRecorder g_aggregate_publish_version_wait_resp_latency("lake_aggregate_publish_version_wait_resp");

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -121,7 +121,7 @@ bvar::PassiveStatus<int> g_publish_version_active_tasks("lake_publish_version_ac
                                                         get_num_publish_active_tasks, nullptr);
 bvar::PassiveStatus<int> g_vacuum_queued_tasks("lake_vacuum_queued_tasks", get_num_vacuum_queued_tasks, nullptr);
 bvar::PassiveStatus<int> g_vacuum_active_tasks("lake_vacuum_active_tasks", get_num_vacuum_active_tasks, nullptr);
-// file bundling
+// metrcis for aggregate publish version & compaction
 bvar::Adder<int64_t> g_aggregate_publish_version_failed_tasks("lake_publish_version_failed_tasks");
 bvar::Adder<int64_t> g_aggregate_publish_version_total_tasks("lake_publish_version_total_tasks");
 bvar::LatencyRecorder g_aggregate_publish_version_wait_resp_latency("lake_aggregate_publish_version_wait_resp");

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -122,8 +122,8 @@ bvar::PassiveStatus<int> g_publish_version_active_tasks("lake_publish_version_ac
 bvar::PassiveStatus<int> g_vacuum_queued_tasks("lake_vacuum_queued_tasks", get_num_vacuum_queued_tasks, nullptr);
 bvar::PassiveStatus<int> g_vacuum_active_tasks("lake_vacuum_active_tasks", get_num_vacuum_active_tasks, nullptr);
 // metrcis for aggregate publish version & compaction
-bvar::Adder<int64_t> g_aggregate_publish_version_failed_tasks("lake_publish_version_failed_tasks");
-bvar::Adder<int64_t> g_aggregate_publish_version_total_tasks("lake_publish_version_total_tasks");
+bvar::Adder<int64_t> g_aggregate_publish_version_failed_tasks("lake_aggregate_publish_version_failed_tasks");
+bvar::Adder<int64_t> g_aggregate_publish_version_total_tasks("lake_aggregate_publish_version_total_tasks");
 bvar::LatencyRecorder g_aggregate_publish_version_wait_resp_latency("lake_aggregate_publish_version_wait_resp");
 bvar::LatencyRecorder g_aggregate_publish_version_write_meta_latency("lake_aggregate_publish_version_write_meta");
 bvar::Adder<int64_t> g_aggregate_compaction_failed_tasks("lake_aggregate_compaction_failed_tasks");

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -121,6 +121,15 @@ bvar::PassiveStatus<int> g_publish_version_active_tasks("lake_publish_version_ac
                                                         get_num_publish_active_tasks, nullptr);
 bvar::PassiveStatus<int> g_vacuum_queued_tasks("lake_vacuum_queued_tasks", get_num_vacuum_queued_tasks, nullptr);
 bvar::PassiveStatus<int> g_vacuum_active_tasks("lake_vacuum_active_tasks", get_num_vacuum_active_tasks, nullptr);
+// file bundling
+bvar::Adder<int64_t> g_aggregate_publish_version_failed_tasks("lake_publish_version_failed_tasks");
+bvar::Adder<int64_t> g_aggregate_publish_version_total_tasks("lake_publish_version_total_tasks");
+bvar::LatencyRecorder g_aggregate_publish_version_wait_resp_latency("lake_aggregate_publish_version_wait_resp");
+bvar::LatencyRecorder g_aggregate_publish_version_write_meta_latency("lake_aggregate_publish_version_write_meta");
+bvar::Adder<int64_t> g_aggregate_compaction_failed_tasks("lake_aggregate_compaction_failed_tasks");
+bvar::Adder<int64_t> g_aggregate_compaction_total_tasks("lake_aggregate_compaction_total_tasks");
+bvar::LatencyRecorder g_aggregate_compaction_wait_resp_latency("lake_aggregate_compaction_wait_resp");
+bvar::LatencyRecorder g_aggregate_compaction_write_meta_latency("lake_aggregate_compaction_write_meta");
 
 std::string txn_info_string(const TxnInfoPB& info) {
     return info.DebugString();
@@ -316,9 +325,12 @@ struct AggregatePublishContext {
     std::unique_ptr<BThreadCountDownLatch> latch;
     PublishVersionResponse* response;
     Status publish_status = Status::OK();
+    int64_t begin_us = 0;
 
     using PublishRequestCtx = RequestContext<PublishVersionResponse>;
     std::vector<PublishRequestCtx> publish_request_ctx;
+
+    AggregatePublishContext() : begin_us(butil::gettimeofday_us()) {}
 
     void handle_failure(const std::string& error) {
         std::lock_guard l(mutex);
@@ -357,6 +369,8 @@ struct AggregatePublishContext {
         if (latch) {
             latch->wait();
         }
+        g_aggregate_publish_version_wait_resp_latency << (butil::gettimeofday_us() - begin_us);
+        begin_us = butil::gettimeofday_us();
         // clear pending resource
         std::lock_guard l(mutex);
         publish_request_ctx.clear();
@@ -387,7 +401,11 @@ struct AggregatePublishContext {
                 }
                 latch.wait();
             }
+        } else {
+            g_aggregate_publish_version_failed_tasks << 1;
         }
+        g_aggregate_publish_version_write_meta_latency << (butil::gettimeofday_us() - begin_us);
+        g_aggregate_publish_version_total_tasks << 1;
     }
 };
 
@@ -1062,9 +1080,12 @@ struct AggregateCompactContext {
     Status final_status = Status::OK();
     std::unique_ptr<BThreadCountDownLatch> latch;
     CombinedTxnLogPB combined_txn_log;
+    int64_t begin_us = 0;
 
     using CompactRequestCtx = RequestContext<CompactResponse>;
     std::vector<CompactRequestCtx> compact_request_ctx;
+
+    AggregateCompactContext() : begin_us(butil::gettimeofday_us()) {}
 
     void handle_failure(const std::string& error) {
         std::lock_guard l(response_mtx);
@@ -1087,6 +1108,8 @@ struct AggregateCompactContext {
         if (latch) {
             latch->wait();
         }
+        g_aggregate_compaction_wait_resp_latency << (butil::gettimeofday_us() - begin_us);
+        begin_us = butil::gettimeofday_us();
         std::lock_guard l(response_mtx);
         compact_request_ctx.clear();
     }
@@ -1123,7 +1146,11 @@ struct AggregateCompactContext {
                 }
                 latch.wait();
             }
+        } else {
+            g_aggregate_compaction_failed_tasks << 1;
         }
+        g_aggregate_compaction_write_meta_latency << (butil::gettimeofday_us() - begin_us);
+        g_aggregate_compaction_total_tasks << 1;
     }
 };
 


### PR DESCRIPTION
## Why I'm doing:
Add some metrics for aggregate publish version & compaction, will record:
1. total count
2. failure count
3. latency

## What I'm doing:
This pull request introduces new monitoring metrics and latency tracking for publish version and compaction tasks in the `lake_service.cpp` file. The changes enhance observability and debugging capabilities by adding counters and latency recorders, as well as initializing and updating these metrics in relevant contexts.

### Monitoring and Metrics Enhancements:

* Added new `bvar` metrics for publish version and compaction tasks, including counters for failed and total tasks, and latency recorders for response wait times and metadata write times. (`be/src/service/service_be/lake_service.cpp`, [be/src/service/service_be/lake_service.cppR124-R132](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaR124-R132))

### Latency Tracking:

* Introduced `begin_us` timestamp in `AggregatePublishContext` and `AggregateCompactContext` to track task latencies. (`be/src/service/service_be/lake_service.cpp`, [[1]](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaR328-R334) [[2]](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaR1083-R1089)
* Updated latency metrics (`g_aggregate_publish_version_wait_resp_latency`, `g_aggregate_publish_version_write_meta_latency`, `g_aggregate_compaction_wait_resp_latency`, `g_aggregate_compaction_write_meta_latency`) at appropriate points in the task lifecycle. (`be/src/service/service_be/lake_service.cpp`, [[1]](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaR372-R373) [[2]](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaR1111-R1112)

### Failure and Success Tracking:

* Incremented counters for failed and total tasks (`g_aggregate_publish_version_failed_tasks`, `g_aggregate_publish_version_total_tasks`, `g_aggregate_compaction_failed_tasks`, `g_aggregate_compaction_total_tasks`) to provide visibility into task outcomes. (`be/src/service/service_be/lake_service.cpp`, [[1]](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaR404-R408) [[2]](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaR1149-R1153)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
