### PR TITLE
[BugFix] fix pivot resolve fields

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1311,13 +1311,11 @@ public class QueryAnalyzer {
 
             List<Field> queryFields = queryScope.getRelationFields().getAllFields();
             Set<String> usedColumns = node.getUsedColumns().keySet();
-            ImmutableList.Builder<Expr> outputExpressionBuilder = ImmutableList.builder();
             ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
             for (Field field : queryFields) {
                 if (!usedColumns.contains(field.getName())) {
-                    outputExpressionBuilder.add(field.getOriginExpression());
                     outputFields.add(field);
-                    Expr expr = field.getOriginExpression().clone();
+                    Expr expr = new SlotRef(field.getRelationAlias(), field.getName());
                     analyzeExpression(expr, analyzeState, queryScope);
                     node.addGroupByKey(expr);
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PivotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PivotTest.java
@@ -1,0 +1,30 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.jupiter.api.Test;
+
+public class PivotTest extends PlanTestBase {
+
+    @Test
+    public void testSubqueryPivot() throws Exception {
+        String sql = "select * from (select t1b, t1c, t1d, t1g, t1a from test_all_type_not_null) t"
+                + " pivot (sum(t1g) for t1a in ('a', 'b'))";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n"
+                + "  |  output: sum(11: case), sum(12: case)\n"
+                + "  |  group by: 2: t1b, 3: t1c, 4: t1d");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

```
SELECT *
FROM (
    SELECT studio, game, pbc_item, year, month, amount 
    FROM dws_finance_management_report_log
) t
PIVOT (
    SUM(amount) AS amount
    FOR month IN (1, 2)
);
```

error log:
ERROR 1064 (HY000): Getting analyzing error. Detail message: Column '`test`.`dws_finance_management_report_log`.`studio`' cannot be resolved.



## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
