### PR TITLE
[BugFix] Fix insert into external table execution error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -303,7 +303,8 @@ public class OlapTableSink extends DataSink {
                 enableAutomaticPartition, automaticBucketSize, getOpenPartitions());
         tSink.setPartition(partitionParam);
         tSink.setLocation(createLocation(dstTable, partitionParam, enableReplicatedStorage, computeResource));
-        tSink.setNodes_info(GlobalStateMgr.getCurrentState().createNodesInfo(computeResource, getSystemInfoService(dstTable)));
+        tSink.setNodes_info(GlobalStateMgr.getCurrentState().createNodesInfo(computeResource,
+                getSystemInfoService(dstTable), dstTable instanceof ExternalOlapTable));
         tSink.setPartial_update_mode(this.partialUpdateMode);
         tSink.setAutomatic_bucket_size(automaticBucketSize);
         if (canUseColocateMVIndex(dstTable)) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -564,6 +564,27 @@ public class GlobalStateMgr {
         return nodesInfo;
     }
 
+    public TNodesInfo createNodesInfo(ComputeResource computeResource,
+                                      SystemInfoService systemInfoService,
+                                      boolean withExtNode) {
+        if (withExtNode) {
+            TNodesInfo nodesInfo = new TNodesInfo();
+            List<Long> computeNodeIds = Lists.newArrayList();
+            computeNodeIds.addAll(systemInfoService.getBackendIds());
+            computeNodeIds.addAll(systemInfoService.getComputeNodeIds(false));
+
+            for (Long cnId : computeNodeIds) {
+                ComputeNode cn = systemInfoService.getBackendOrComputeNode(cnId);
+                if (cn != null) {
+                    nodesInfo.addToNodes(new TNodeInfo(cnId, 0, cn.getIP(), cn.getBrpcPort()));
+                }
+            }
+            return nodesInfo;
+        } else {
+            return createNodesInfo(computeResource, systemInfoService);
+        }
+    }
+
     public HeartbeatMgr getHeartbeatMgr() {
         return heartbeatMgr;
     }


### PR DESCRIPTION
External table DML needs target cluster(shared-data/shared-nothing) be/cn information to execute table insertion. Now insert external table from shared-data cluster to shared-nothing/shared-data cluster execute failed due to source cluster(shared-data) should get cn_id from systemInfoService constructed by external table properties instead of local warehouse. 

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3