### PR TITLE
[BugFix] Fix the INSERT OVERWRITE failure for manually created partitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -53,6 +53,7 @@ import com.starrocks.alter.OlapTableRollupJobBuilder;
 import com.starrocks.alter.OptimizeJobV2Builder;
 import com.starrocks.analysis.DescriptorTable.ReferencedPartitionInfo;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
@@ -1303,32 +1304,40 @@ public class OlapTable extends Table {
                 continue;
             }
             // one item
-            List<String> singleValues = listPartitionInfo.getIdToValues().get(partitionId);
-            if (CollectionUtils.isNotEmpty(singleValues)) {
+            List<LiteralExpr> literalValues = listPartitionInfo.getLiteralExprValues().get(partitionId);
+            if (CollectionUtils.isNotEmpty(literalValues)) {
                 List<List<String>> cellValue = Lists.newArrayList();
                 // for one item(single value), treat it as multi values.
-                for (String val : singleValues) {
-                    cellValue.add(Lists.newArrayList(val));
+                for (LiteralExpr val : literalValues) {
+                    cellValue.add(Lists.newArrayList(val.getStringValue()));
                 }
                 partitionItems.put(partitionName, new PListCell(cellValue));
             }
 
             // multi items
-            List<List<String>> multiValues = listPartitionInfo.getIdToMultiValues().get(partitionId);
-            if (CollectionUtils.isNotEmpty(multiValues)) {
-                if (CollectionUtils.isEmpty(colIdxes)) {
-                    partitionItems.put(partitionName, new PListCell(multiValues));
-                } else {
-                    List<List<String>> cellValue = Lists.newArrayList();
-                    for (List<String> multiValue : multiValues) {
-                        List<String> selectedValues = Lists.newArrayList();
-                        for (int idx : colIdxes) {
-                            selectedValues.add(multiValue.get(idx));
+            List<List<LiteralExpr>> multiExprValues = listPartitionInfo.getMultiLiteralExprValues().get(partitionId);
+            if (CollectionUtils.isNotEmpty(multiExprValues)) {
+                List<List<String>> multiValues = Lists.newArrayList();
+                for (List<LiteralExpr> exprValues : multiExprValues) {
+                    List<String> values = Lists.newArrayList();
+                    if (CollectionUtils.isEmpty(colIdxes)) {
+                        for (LiteralExpr literalExpr : exprValues) {
+                            values.add(literalExpr.getStringValue());
                         }
-                        cellValue.add(selectedValues);
+                    } else {
+                        for (int idx : colIdxes) {
+                            if (idx >= 0 && idx < exprValues.size()) {
+                                values.add(exprValues.get(idx).getStringValue());
+                            } else {
+                                // print index and exprValues
+                                throw new SemanticException("Invalid column index during partition processing. " +
+                                        "Index: " + idx + ", ExprValues: " + exprValues);
+                            }
+                        }
                     }
-                    partitionItems.put(partitionName, new PListCell(cellValue));
+                    multiValues.add(values);
                 }
+                partitionItems.put(partitionName, new PListCell(multiValues));
             }
         }
         return partitionItems;

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -272,31 +271,11 @@ public class InsertOverwriteJobRunner {
             return;
         }
 
-        if (insertStmt.isSpecifyPartitionNames()) {
-            List<String> partitionNames = insertStmt.getTargetPartitionNames().getPartitionNames();
-            PartitionInfo partitionInfo = olapTable.getPartitionInfo();
-            for (String partitionName : partitionNames) {
-                Partition partition = olapTable.getPartition(partitionName);
-                if (partition == null) {
-                    throw new RuntimeException("Partition '" + partitionName
-                            + "' does not exist in table '" + olapTable.getName() + "'.");
-                }
-                if (partitionInfo instanceof ListPartitionInfo) {
-                    ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
-                    List<List<LiteralExpr>> lists = listPartitionInfo.getMultiLiteralExprValues().get(partition.getId());
-                    for (List<LiteralExpr> list : lists) {
-                        List<String> values = Lists.newArrayList();
-                        for (LiteralExpr literalExpr : list) {
-                            values.add(literalExpr.getStringValue());
-                        }
-                        partitionValues.add(values);
-                    }
-                } else {
-                    throw new RuntimeException("Specify the partition name, and automatically create partition names. " +
-                            "Currently, only List partitions are supported.");
-                }
-            }
+        if (insertStmt.isSpecifyPartitionNames())  {
+            // The specified partition must already exist; it does not need to be created.
+            return;
         } else {
+            // This is for insert overwrite t partition(k=v) values(...)
             List<Expr> partitionColValues = insertStmt.getTargetPartitionNames().getPartitionColValues();
             // Currently we only support overwriting one partition at a time
             List<String> firstValues = Lists.newArrayList();

--- a/test/sql/test_insert_overwrite/R/test_insert_overwrite_manually_created_partition
+++ b/test/sql/test_insert_overwrite/R/test_insert_overwrite_manually_created_partition
@@ -1,0 +1,73 @@
+-- name: test_insert_overwrite_manually_created_partition
+create table t(k1 int, k2 datetime) partition by (k1,k2);
+-- result:
+-- !result
+insert into t values(1, '2020-01-01');
+-- result:
+-- !result
+alter table t add PARTITION IF NOT EXISTS p1_20200201000000 VALUES IN (('1', '20200201'));
+-- result:
+-- !result
+select * from t;
+-- result:
+1	2020-01-01 00:00:00
+-- !result
+insert overwrite t PARTITION(p1_20200101000000) values(1,'2020-01-01');
+-- result:
+-- !result
+insert overwrite t PARTITION(p1_20200201000000) values(1,'2020-02-01');
+-- result:
+-- !result
+select * from t;
+-- result:
+1	2020-01-01 00:00:00
+1	2020-02-01 00:00:00
+-- !result
+create table t1(k datetime) partition by (k);
+-- result:
+-- !result
+insert into t1 values('2020-01-01');
+-- result:
+-- !result
+alter table t1 add PARTITION IF NOT EXISTS p20200201000000 VALUES IN ('20200201');
+-- result:
+-- !result
+select * from t1;
+-- result:
+2020-01-01 00:00:00
+-- !result
+insert overwrite t1 PARTITION(p20200101000000) values('2020-01-01');
+-- result:
+-- !result
+insert overwrite t1 PARTITION(p20200201000000) values('2020-02-01');
+-- result:
+-- !result
+select * from t1;
+-- result:
+2020-02-01 00:00:00
+2020-01-01 00:00:00
+-- !result
+create table t2(k datetime) partition by (k);
+-- result:
+-- !result
+insert into t2 values('2020-01-01');
+-- result:
+-- !result
+alter table t2 add PARTITION IF NOT EXISTS p20200201000000 VALUES IN ('20200201');
+-- result:
+-- !result
+select * from t2;
+-- result:
+2020-01-01 00:00:00
+-- !result
+insert overwrite t2 PARTITION(k='2020-01-01') values('2020-01-01');
+-- result:
+-- !result
+insert overwrite t2 PARTITION(k='2020-02-01') values('2020-02-01');
+-- result:
+-- !result
+select * from t2;
+-- result:
+2020-01-01 00:00:00
+2020-02-01 00:00:00
+-- !result

--- a/test/sql/test_insert_overwrite/T/test_insert_overwrite_manually_created_partition
+++ b/test/sql/test_insert_overwrite/T/test_insert_overwrite_manually_created_partition
@@ -1,0 +1,27 @@
+-- name: test_insert_overwrite_manually_created_partition
+create table t(k1 int, k2 datetime) partition by (k1,k2);
+insert into t values(1, '2020-01-01');
+alter table t add PARTITION IF NOT EXISTS p1_20200201000000 VALUES IN (('1', '20200201'));
+select * from t;
+insert overwrite t PARTITION(p1_20200101000000) values(1,'2020-01-01');
+insert overwrite t PARTITION(p1_20200201000000) values(1,'2020-02-01');
+select * from t;
+
+create table t1(k datetime) partition by (k);
+insert into t1 values('2020-01-01');
+alter table t1 add PARTITION IF NOT EXISTS p20200201000000 VALUES IN ('20200201');
+select * from t1;
+insert overwrite t1 PARTITION(p20200101000000) values('2020-01-01');
+insert overwrite t1 PARTITION(p20200201000000) values('2020-02-01');
+select * from t1;
+
+create table t2(k datetime) partition by (k);
+insert into t2 values('2020-01-01');
+alter table t2 add PARTITION IF NOT EXISTS p20200201000000 VALUES IN ('20200201');
+select * from t2;
+insert overwrite t2 PARTITION(k='2020-01-01') values('2020-01-01');
+insert overwrite t2 PARTITION(k='2020-02-01') values('2020-02-01');
+select * from t2;
+
+
+


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/54278 introduced logic to compare partitionValue when partitionName is the same. If the partitionValue differs, a new partitionName is generated. This change is meant to address the issue where different cases (e.g., uppercase/lowercase) could result in the same partitionName.

However, in getListPartitionItems, the method getIdToValues is used directly instead of LiteralExprValues. As a result, some semantically equivalent values are treated as different — for example, "2020-01-01" and "2020-01-01 00:00:00".

Manually created partitions use "2020-01-01", while partitions generated via expression-based partitioning for datetime types use "2020-01-01 00:00:00". This mismatch causes parsing failures.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
