### PR TITLE
[BugFix] Fix BE crash when loading a OOM partition

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -34,9 +34,13 @@
 #include "gutil/casts.h"
 #include "runtime/current_thread.h"
 #include "runtime/runtime_state.h"
+#include "util/failpoint/fail_point.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks::pipeline {
+
+DEFINE_FAIL_POINT(spill_hash_join_throw_bad_alloc)
+
 Status SpillableHashJoinProbeOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(HashJoinProbeOperator::prepare(state));
     _need_post_probe = has_post_probe(_join_prober->join_type());
@@ -272,6 +276,8 @@ Status SpillableHashJoinProbeOperator::_load_partition_build_side(workgroup::Yie
             RETURN_IF_ERROR(reader->trigger_restore<spill::SyncTaskExecutor>(state, MemTrackerGuard(tls_mem_tracker)));
             auto chunk_st = reader->restore<spill::SyncTaskExecutor>(state, MemTrackerGuard(tls_mem_tracker));
 
+            FAIL_POINT_TRIGGER_EXECUTE(spill_hash_join_throw_bad_alloc, { throw std::bad_alloc(); });
+
             if (chunk_st.ok() && chunk_st.value() != nullptr && !chunk_st.value()->is_empty()) {
                 int64_t old_mem_usage = hash_table_mem_usage;
                 RETURN_IF_ERROR(builder->append_chunk(std::move(chunk_st.value())));
@@ -307,6 +313,9 @@ Status SpillableHashJoinProbeOperator::_load_all_partition_build_side(RuntimeSta
                     _latch.count_down();
                     yield_ctx.set_finished();
                 });
+                if (!_status().ok()) {
+                    return;
+                }
                 if (!yield_ctx.task_context_data.has_value()) {
                     yield_ctx.task_context_data = std::make_shared<spill::SpillIOTaskContext>();
                 }

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -101,7 +101,9 @@ Status SpillablePartitionSortSinkOperator::set_finishing(RuntimeState* state) {
 
 Status SpillablePartitionSortSinkOperator::set_finished(RuntimeState* state) {
     _is_finished = true;
-    _chunks_sorter->cancel();
+    if (state->is_cancelled()) {
+        _chunks_sorter->cancel();
+    }
     return Status::OK();
 }
 

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -200,7 +200,7 @@ public:
         return _writer->set_flush_all_call_back(flush_call_back);
     }
 
-    bool has_output_data() { return _reader->has_output_data(); }
+    bool has_output_data() { return is_cancel() || _reader->has_output_data(); }
 
     size_t spilled_append_rows() const { return _spilled_append_rows; }
 

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -110,6 +110,9 @@ Status Spiller::flush(RuntimeState* state, MemGuard&& guard) {
 template <class TaskExecutor, class MemGuard>
 StatusOr<ChunkPtr> Spiller::restore(RuntimeState* state, MemGuard&& guard) {
     RETURN_IF_ERROR(task_status());
+    if (is_cancel()) {
+        return Status::Cancelled("cancelled by pipeline");
+    }
 
     ASSIGN_OR_RETURN(auto chunk, _reader->restore<TaskExecutor>(state, guard));
     chunk->check_or_die();
@@ -238,6 +241,9 @@ Status SpillerReader::trigger_restore(RuntimeState* state, MemGuard&& guard) {
             DEFER_GUARD_END(guard);
             {
                 auto defer = CancelableDefer([&]() { _running_restore_tasks--; });
+                if (_spiller->is_cancel() || !_spiller->task_status().ok()) {
+                    return;
+                }
                 Status res;
                 SerdeContext serd_ctx;
                 if (!yield_ctx.task_context_data.has_value()) {

--- a/be/src/util/failpoint/fail_point.h
+++ b/be/src/util/failpoint/fail_point.h
@@ -16,7 +16,7 @@ namespace starrocks::failpoint {
 class FailPoint {
 public:
     FailPoint(std::string name);
-    ~FailPoint() = default;
+    virtual ~FailPoint() = default;
 
     virtual bool shouldFail();
 
@@ -36,9 +36,9 @@ protected:
 class ScopedFailPoint : public FailPoint {
 public:
     ScopedFailPoint(const std::string& name) : FailPoint(name) {}
-    ~ScopedFailPoint() = default;
+    ~ScopedFailPoint() override = default;
 
-    virtual bool shouldFail() override;
+    bool shouldFail() override;
 };
 
 class ScopedFailPointGuard {

--- a/test/sql/test_spill/R/test_spill_with_bad_alloc
+++ b/test/sql/test_spill/R/test_spill_with_bad_alloc
@@ -1,0 +1,30 @@
+-- name: test_spill_with_bad_alloc @sequential
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode="force";
+-- result:
+-- !result
+set pipeline_dop=1;
+-- result:
+-- !result
+CREATE TABLE t0 (
+    k1 INT,
+    k2 VARCHAR(20))
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+admin enable failpoint 'spill_hash_join_throw_bad_alloc';
+-- result:
+-- !result
+[UC] select count(l.k1),count(l.k2),count(r.k1),count(r.k2) from t0 l join t0 r on l.k1=r.k1;
+-- result:
+E: (1064, 'Mem usage has exceed the limit of BE: BE:10004')
+-- !result
+admin disable failpoint 'spill_hash_join_throw_bad_alloc';
+-- result:
+-- !result

--- a/test/sql/test_spill/T/test_spill_with_bad_alloc
+++ b/test/sql/test_spill/T/test_spill_with_bad_alloc
@@ -1,0 +1,16 @@
+-- name: test_spill_with_bad_alloc @sequential
+set enable_spill=true;
+set spill_mode="force";
+set pipeline_dop=1;
+
+CREATE TABLE t0 (
+    k1 INT,
+    k2 VARCHAR(20))
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
+
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  40960));
+
+admin enable failpoint 'spill_hash_join_throw_bad_alloc';
+[UC] select count(l.k1),count(l.k2),count(r.k1),count(r.k2) from t0 l join t0 r on l.k1=r.k1;
+admin disable failpoint 'spill_hash_join_throw_bad_alloc';


### PR DESCRIPTION
## Why I'm doing:

When a query throws bad_alloc the vector of the hash table will be empty and calling append will result in a NPE. We need to check status before loading data.

```
    @     0x14d9b879040d __memmove_avx512_unaligned_erms
    @          0x406cb94 void std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > >::_M_range_insert<unsigned char const*>(__gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char, starrocks::raw::RawAllocator<X^S
    @          0x4070534 starrocks::BinaryColumnBase<unsigned int>::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0x406547e starrocks::NullableColumn::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0x41764d3 starrocks::JoinHashTable::append_chunk(std::shared_ptr<starrocks::Chunk> const&, std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column> > > const&)
    @          0x4707199 starrocks::HashJoinBuilder::append_chunk(std::shared_ptr<starrocks::Chunk> const&)
    @          0x452d18e starrocks::pipeline::SpillableHashJoinProbeOperator::_load_partition_build_side(starrocks::workgroup::YieldContext&, starrocks::RuntimeState*, std::shared_ptr<starrocks::spill::SpillerReader> const&, unsigned long)
    @          0x452d3bc std::_Function_handler<void (starrocks::workgroup::YieldContext&), starrocks::pipeline::SpillableHashJoinProbeOperator::_load_all_partition_build_side(starrocks::RuntimeState*)::{lambda(auto:1&)#1}>::_M_invoke(std::_Any_data const&, starrocks::workgroup::YX^S
    @          0x455a78b starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x397e9f3 starrocks::ThreadPool::dispatch_thread()
    @          0x3976c96 starrocks::Thread::supervise_thread(void*)
    @     0x14d9b8689d22 start_thread
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
