### PR TITLE
[UT] fix unstable ColocateTableBalancerTest

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -54,6 +54,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.leader.TabletCollector;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
@@ -107,6 +108,9 @@ public class ColocateTableBalancerTest {
         starRocksAssert = new StarRocksAssert(ctx);
         GlobalStateMgr.getCurrentState().getHeartbeatMgr().setStop();
         GlobalStateMgr.getCurrentState().getTabletScheduler().setStop();
+        TabletCollector collector = (TabletCollector) Deencapsulation.getField(GlobalStateMgr.getCurrentState(),
+                "tabletCollector");
+        collector.setStop();
         ColocateTableBalancer.getInstance().setStop();
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
Missing 1 invocation to:
com.starrocks.system.SystemInfoService#getBackends()
   on mock instance: com.starrocks.system.SystemInfoService@759c6acd
Caused by: Missing invocations
	at com.starrocks.leader.TabletCollector.updateQueue(TabletCollector.java:61)
	at com.starrocks.leader.TabletCollector.runAfterCatalogReady(TabletCollector.java:55)
	at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:78)
	at com.starrocks.common.util.Daemon.run(Daemon.java:98)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
