### PR TITLE
[Enhancement] make 'enable_udf' mutable

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -1351,7 +1351,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Default: false
 - Type: Boolean
 - Unit: -
-- Is mutable: No
+- Is mutable: Yes
 - Description: Whether to enable UDF.
 - Introduced in: -
 

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -932,7 +932,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - デフォルト: false
 - タイプ: Boolean
 - 単位: -
-- 変更可能: いいえ
+- 変更可能: はい
 - 説明: UDF を有効にするかどうか。
 - 導入バージョン: -
 

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -1343,7 +1343,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值：false
 - 类型：Boolean
 - 单位：-
-- 是否动态：否
+- 是否动态：是
 - 描述：是否开启 UDF。
 - 引入版本：-
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1371,7 +1371,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int skip_whole_phase_lock_mv_limit = 5;
 
-    @ConfField
+    @ConfField(mutable = true)
     public static boolean enable_udf = false;
 
     @ConfField(mutable = true)


### PR DESCRIPTION
## Why I'm doing:
`enable_udf` is actually a mutable configuration, it should be tagged with 'mutable'.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
