### PR TITLE
[BugFix] Fix the isInternalStmt flag is missing bug when stmt is forward to leader

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -884,7 +884,7 @@ public class ConnectProcessor {
 
                 StatementBase statement = SqlParser.parseSingleStatement(request.modified_variables_sql,
                         ctx.getSessionVariable().getSqlMode());
-                executor = new StmtExecutor(ctx, statement);
+                executor = StmtExecutor.newInternalExecutor(ctx, statement);
                 executor.setProxy();
                 executor.execute();
             }
@@ -903,7 +903,11 @@ public class ConnectProcessor {
             }.visit(statement);
             statement.setOrigStmt(new OriginStatement(request.getSql(), idx));
 
-            executor = new StmtExecutor(ctx, statement);
+            if (request.isIsInternalStmt()) {
+                executor = StmtExecutor.newInternalExecutor(ctx, statement);
+            } else {
+                executor = new StmtExecutor(ctx, statement);
+            }
             ctx.setExecutor(executor);
             executor.setProxy();
             executor.execute();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
@@ -78,6 +78,7 @@ public class LeaderOpExecutor {
     private final OriginStatement originStmt;
     private StatementBase parsedStmt;
     private final ConnectContext ctx;
+    private final boolean isInternalStmt;
     private TMasterOpResult result;
 
     private int waitTimeoutMs;
@@ -86,17 +87,17 @@ public class LeaderOpExecutor {
     private final Pair<String, Integer> ipAndPort;
 
     public LeaderOpExecutor(OriginStatement originStmt, ConnectContext ctx, RedirectStatus status) {
-        this(null, originStmt, ctx, status);
+        this(null, originStmt, ctx, status, false);
     }
 
     public LeaderOpExecutor(StatementBase parsedStmt, OriginStatement originStmt,
-                            ConnectContext ctx, RedirectStatus status) {
+                            ConnectContext ctx, RedirectStatus status, boolean isInternalStmt) {
         this(GlobalStateMgr.getCurrentState().getNodeMgr().getLeaderIpAndRpcPort(), parsedStmt, originStmt, ctx,
-                status);
+                status, isInternalStmt);
     }
 
     public LeaderOpExecutor(Pair<String, Integer> ipAndPort, StatementBase parsedStmt, OriginStatement originStmt,
-                            ConnectContext ctx, RedirectStatus status) {
+                            ConnectContext ctx, RedirectStatus status, boolean isInternalStmt) {
         this.ipAndPort = ipAndPort;
         this.originStmt = originStmt;
         this.ctx = ctx;
@@ -112,6 +113,7 @@ public class LeaderOpExecutor {
             this.thriftTimeoutMs = ctx.getExecTimeout() * 1000;
         }
         this.parsedStmt = parsedStmt;
+        this.isInternalStmt = isInternalStmt;
     }
 
     public void execute() throws Exception {
@@ -283,6 +285,7 @@ public class LeaderOpExecutor {
 
         params.setWarehouse_id(ctx.getCurrentWarehouseId());
 
+        params.setIsInternalStmt(isInternalStmt);
         return params;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1046,7 +1046,7 @@ public class StmtExecutor {
         }
         try {
             context.incPendingForwardRequest();
-            leaderOpExecutor = new LeaderOpExecutor(parsedStmt, originStmt, context, redirectStatus);
+            leaderOpExecutor = new LeaderOpExecutor(parsedStmt, originStmt, context, redirectStatus, isInternalStmt);
             LOG.debug("need to transfer to Leader. stmt: {}", context.getStmtId());
             leaderOpExecutor.execute();
         } finally {
@@ -1237,7 +1237,7 @@ public class StmtExecutor {
             for (Frontend fe : GlobalStateMgr.getCurrentState().getNodeMgr().getFrontends(null /* all */)) {
                 LeaderOpExecutor leaderOpExecutor =
                         new LeaderOpExecutor(Pair.create(fe.getHost(), fe.getRpcPort()), parsedStmt, originStmt,
-                                context, redirectStatus);
+                                context, redirectStatus, false);
                 try {
                     leaderOpExecutor.execute();
                     // if query is successfully killed by this fe, it can return now

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -54,7 +54,10 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.DDLTestBase;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.thrift.TMasterOpRequest;
+import com.starrocks.thrift.TMasterOpResult;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.thrift.TUserIdentity;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mock;
@@ -68,6 +71,7 @@ import org.xnio.StreamConnection;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ConnectProcessorTest extends DDLTestBase {
@@ -624,5 +628,43 @@ public class ConnectProcessorTest extends DDLTestBase {
         Assertions.assertFalse(Strings.isNullOrEmpty(QueryDetailQueue.getQueryDetailsAfterTime(0).get(0).getSql()));
     }
 
+    @Test
+    public void testProxyExecute() throws Exception {
+        // 构造请求
+        TMasterOpRequest request = new TMasterOpRequest();
+        request.setCatalog("default");
+        request.setDb("testDb1");
+        request.setUser("root");
+        request.setSql("select 1");
+        request.setIsInternalStmt(true);
+        request.setModified_variables_sql("set query_timeout = 10");
+        request.setCurrent_user_ident(new TUserIdentity());
+        request.setQueryId(UUIDUtil.genTUniqueId());
+        request.setSession_id(UUID.randomUUID().toString());
+        request.setIsLastStmt(true);
 
+        // mock context
+        ConnectContext ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        ctx.setCurrentCatalog("default");
+        ctx.setDatabase("testDb1");
+        ctx.setQualifiedUser("root");
+        ctx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx.setCurrentRoleIds(UserIdentity.ROOT);
+        ctx.setSessionId(java.util.UUID.randomUUID());
+        ctx.setThreadLocalInfo();
+
+        ConnectProcessor processor = new ConnectProcessor(ctx);
+        new mockit.MockUp<StmtExecutor>() {
+            @mockit.Mock
+            public void execute() {}
+            @mockit.Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        TMasterOpResult result = processor.proxyExecute(request);
+        Assertions.assertNotNull(result);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -630,7 +630,6 @@ public class ConnectProcessorTest extends DDLTestBase {
 
     @Test
     public void testProxyExecute() throws Exception {
-        // 构造请求
         TMasterOpRequest request = new TMasterOpRequest();
         request.setCatalog("default");
         request.setDb("testDb1");

--- a/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorTest.java
@@ -93,7 +93,7 @@ public class LeaderOpExecutorTest {
         String sql = "insert into t1 select * from t1";
         StatementBase stmtBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         LeaderOpExecutor executor =
-                new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(), connectContext, RedirectStatus.FORWARD_NO_SYNC);
+                new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(), connectContext, RedirectStatus.FORWARD_NO_SYNC, false);
 
         mockFrontendService(new MockFrontendServiceClient());
         executor.execute();
@@ -174,7 +174,7 @@ public class LeaderOpExecutorTest {
                             -> ThriftRPCRequestExecutor.call(Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
                     .thenReturn(tMasterOpResult);
             LeaderOpExecutor executor =
-                    new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(), connectContext, RedirectStatus.FORWARD_NO_SYNC);
+                    new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(), connectContext, RedirectStatus.FORWARD_NO_SYNC, false);
             executor.execute();
 
             Assertions.assertEquals(1, connectContext.getTxnId());

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -836,6 +836,7 @@ struct TMasterOpRequest {
     35: optional string session_id
     36: optional i32 connectionId
     37: optional i64 txn_id;
+    38: optional bool isInternalStmt;
 
     101: optional i64 warehouse_id    // begin from 101, in case of conflict with other's change
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Add `isInternalStmt` param in TMasterOpRequest.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
