### PR TITLE
[Feature] Implement split tablet job factory for dynamic tablet splitting and merging

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -672,7 +672,8 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
 
     @Override
     public Void visitSplitTabletClause(SplitTabletClause clause, ConnectContext context) {
-        unsupportedException("Not support: " + clause);
+        ErrorReport.wrapWithRuntimeException(() -> GlobalStateMgr.getCurrentState().getDynamicTabletJobMgr()
+                .createDynamicTabletJob(db, (OlapTable) table, clause));
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTablet.java
@@ -14,29 +14,15 @@
 
 package com.starrocks.alter.dynamictablet;
 
-import com.starrocks.catalog.Tablet;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 /*
- * DynamicTablets is the base class of DynamicTablets and MergingTablets.
- * DynamicTablets saves the old and new tablets during tablet splitting or merging for a materialized index
+ * DynamicTablet saves the old and new tablets info during tablet splitting or merging
+ * DynamicTablet is the base class of DynamicTablet and MergingTablet.
  */
-public interface DynamicTablets {
+public interface DynamicTablet {
 
-    Map<Long, SplittingTablet> getSplittingTablets();
+    SplittingTablet getSplittingTablet();
 
-    List<MergingTablet> getMergingTablets();
-
-    Set<Long> getOldTabletIds();
-
-    List<Tablet> getNewTablets();
+    MergingTablet getMergingTablet();
 
     long getParallelTablets();
-
-    boolean isEmpty();
-
-    List<Long> calcNewVirtualBuckets(List<Long> oldVirtualBuckets);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTabletJobFactory.java
@@ -14,29 +14,13 @@
 
 package com.starrocks.alter.dynamictablet;
 
-import com.starrocks.catalog.Tablet;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import com.starrocks.common.StarRocksException;
 
 /*
- * DynamicTablets is the base class of DynamicTablets and MergingTablets.
- * DynamicTablets saves the old and new tablets during tablet splitting or merging for a materialized index
+ * DynamicTabletJobFactory is for creating DynamicTabletJob.
+ * This is the base class of SplitTabletJobFactory and MergeTabletJobFactory.
  */
-public interface DynamicTablets {
+public interface DynamicTabletJobFactory {
 
-    Map<Long, SplittingTablet> getSplittingTablets();
-
-    List<MergingTablet> getMergingTablets();
-
-    Set<Long> getOldTabletIds();
-
-    List<Tablet> getNewTablets();
-
-    long getParallelTablets();
-
-    boolean isEmpty();
-
-    List<Long> calcNewVirtualBuckets(List<Long> oldVirtualBuckets);
+    DynamicTabletJob createDynamicTabletJob() throws StarRocksException;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTabletJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTabletJobMgr.java
@@ -16,7 +16,10 @@ package com.starrocks.alter.dynamictablet;
 
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
@@ -25,51 +28,55 @@ import com.starrocks.persist.metablock.SRMetaBlockID;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockWriter;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.SplitTabletClause;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Map;
 
 public class DynamicTabletJobMgr extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(DynamicTabletJobMgr.class);
 
-    @SerializedName(value = "jobs")
-    protected final Map<Long, DynamicTabletJob> jobs = Maps.newConcurrentMap();
+    @SerializedName(value = "dynamicTabletJobs")
+    protected final Map<Long, DynamicTabletJob> dynamicTabletJobs = Maps.newConcurrentMap();
 
     public DynamicTabletJobMgr() {
         super("DynamicTabletJobMgr", Config.dynamic_tablet_job_scheduler_interval_ms);
     }
 
-    public Map<Long, DynamicTabletJob> getJobs() {
-        return jobs;
+    public DynamicTabletJob getDynamicTabletJob(long dynamicJobId) {
+        return dynamicTabletJobs.get(dynamicJobId);
     }
 
-    public boolean addDynamicTabletJob(DynamicTabletJob dynamicTabletJob) {
-        if (dynamicTabletJob.getJobState() != DynamicTabletJob.JobState.PENDING) {
-            throw new RuntimeException("Dynamic tablet job state is not pending. " + dynamicTabletJob);
-        }
+    public Map<Long, DynamicTabletJob> getDynamicTabletJobs() {
+        return dynamicTabletJobs;
+    }
 
-        if (getTotalParalelTablets()
-                + dynamicTabletJob.getParallelTablets() > Config.dynamic_tablet_max_parallel_tablets) {
-            return false;
-        }
+    public void createDynamicTabletJob(Database db, OlapTable table, SplitTabletClause splitTabletClause)
+            throws StarRocksException {
+        DynamicTabletJob job = new SplitTabletJobFactory(db, table, splitTabletClause).createDynamicTabletJob();
+        addDynamicTabletJob(job);
+    }
 
-        DynamicTabletJob existingJob = jobs.putIfAbsent(dynamicTabletJob.getJobId(), dynamicTabletJob);
-        if (existingJob != null) {
-            throw new RuntimeException("Running dynamic tablet job is already existed. " + existingJob);
+    public void addDynamicTabletJob(DynamicTabletJob dynamicTabletJob) throws StarRocksException {
+        synchronized (this) {
+            checkDynamicTabletJob(dynamicTabletJob);
+
+            DynamicTabletJob existingJob = dynamicTabletJobs.putIfAbsent(dynamicTabletJob.getJobId(), dynamicTabletJob);
+            if (existingJob != null) {
+                throw new StarRocksException("Dynamic tablet job is already existed. " + existingJob);
+            }
         }
 
         GlobalStateMgr.getCurrentState().getEditLog().logUpdateDynamicTabletJob(dynamicTabletJob);
 
-        LOG.info("Added running dynamic tablet job. {}", dynamicTabletJob);
-        return true;
+        LOG.info("Added dynamic tablet job. {}", dynamicTabletJob);
     }
 
     public long getTotalParalelTablets() {
         long totalParallelTablets = 0;
-        for (DynamicTabletJob job : jobs.values()) {
+        for (DynamicTabletJob job : dynamicTabletJobs.values()) {
             if (job.isDone()) {
                 continue;
             }
@@ -80,11 +87,11 @@ public class DynamicTabletJobMgr extends FrontendDaemon {
 
     public void replayUpdateDynamicTabletJob(DynamicTabletJob dynamicTabletJob) {
         dynamicTabletJob.replay();
-        jobs.put(dynamicTabletJob.getJobId(), dynamicTabletJob);
+        dynamicTabletJobs.put(dynamicTabletJob.getJobId(), dynamicTabletJob);
     }
 
     public void replayRemoveDynamicTabletJob(long dynamicTabletJobId) {
-        if (jobs.remove(dynamicTabletJobId) == null) {
+        if (dynamicTabletJobs.remove(dynamicTabletJobId) == null) {
             // Should not happen, just add a warnning log
             LOG.warn("Failed to find dynamic tablet job {} when replaying remove dynamic tablet job",
                     dynamicTabletJobId);
@@ -94,12 +101,35 @@ public class DynamicTabletJobMgr extends FrontendDaemon {
 
     @Override
     protected void runAfterCatalogReady() {
-        runJobs();
+        runDynamicTabletJobs();
     }
 
-    private void runJobs() {
-        for (Iterator<Map.Entry<Long, DynamicTabletJob>> it = jobs.entrySet().iterator(); it.hasNext(); /* */) {
-            DynamicTabletJob job = it.next().getValue();
+    private void checkDynamicTabletJob(DynamicTabletJob dynamicTabletJob) throws StarRocksException {
+        if (dynamicTabletJob.getJobState() != DynamicTabletJob.JobState.PENDING) {
+            throw new StarRocksException("Dynamic tablet job state is not pending. " + dynamicTabletJob);
+        }
+
+        long totalParallelTablets = dynamicTabletJob.getParallelTablets();
+        for (DynamicTabletJob job : dynamicTabletJobs.values()) {
+            if (job.isDone()) {
+                continue;
+            }
+
+            if (job.getDbId() == dynamicTabletJob.getDbId() && job.getTableId() == dynamicTabletJob.getTableId()) {
+                throw new StarRocksException("Dynamic tablet job is not done. " + job);
+            }
+            totalParallelTablets += job.getParallelTablets();
+        }
+
+        if (totalParallelTablets > Config.dynamic_tablet_max_parallel_tablets) {
+            throw new StarRocksException("Total parallel tablets exceed dynamic_tablet_max_parallel_tablets: "
+                    + Config.dynamic_tablet_max_parallel_tablets);
+        }
+    }
+
+    private void runDynamicTabletJobs() {
+        for (var iterator = dynamicTabletJobs.entrySet().iterator(); iterator.hasNext(); /* */) {
+            DynamicTabletJob job = iterator.next().getValue();
             // Job is not done, run it
             if (!job.isDone()) {
                 job.run();
@@ -108,7 +138,7 @@ public class DynamicTabletJobMgr extends FrontendDaemon {
 
             // Job is done, remove expired job
             if (job.isExpired()) {
-                it.remove();
+                iterator.remove();
                 GlobalStateMgr.getCurrentState().getEditLog().logRemoveDynamicTabletJob(job.getJobId());
                 LOG.info("Removed expired dynamic tablet job. {}", job);
             }
@@ -123,6 +153,6 @@ public class DynamicTabletJobMgr extends FrontendDaemon {
 
     public void load(SRMetaBlockReader reader) throws SRMetaBlockEOFException, IOException, SRMetaBlockException {
         DynamicTabletJobMgr dynamicTabletJobMgr = reader.readJson(DynamicTabletJobMgr.class);
-        jobs.putAll(dynamicTabletJobMgr.jobs);
+        dynamicTabletJobs.putAll(dynamicTabletJobMgr.dynamicTabletJobs);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTabletUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTabletUtils.java
@@ -14,29 +14,18 @@
 
 package com.starrocks.alter.dynamictablet;
 
-import com.starrocks.catalog.Tablet;
+public class DynamicTabletUtils {
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+    public static boolean isPowerOfTwo(long n) {
+        return n > 1 && (n & (n - 1)) == 0;
+    }
 
-/*
- * DynamicTablets is the base class of DynamicTablets and MergingTablets.
- * DynamicTablets saves the old and new tablets during tablet splitting or merging for a materialized index
- */
-public interface DynamicTablets {
-
-    Map<Long, SplittingTablet> getSplittingTablets();
-
-    List<MergingTablet> getMergingTablets();
-
-    Set<Long> getOldTabletIds();
-
-    List<Tablet> getNewTablets();
-
-    long getParallelTablets();
-
-    boolean isEmpty();
-
-    List<Long> calcNewVirtualBuckets(List<Long> oldVirtualBuckets);
+    public static int calcSplitCount(long dataSize, long splitSize) {
+        int splitCount = 1;
+        while (dataSize > splitCount) {
+            splitCount *= 2;
+            dataSize /= splitCount;
+        }
+        return splitCount;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/MaterializedIndexContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/MaterializedIndexContext.java
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.dynamictablet;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.MaterializedIndex;
+
+/*
+ * MaterializedIndexContext saves the context during tablet splitting or merging for a materialized index
+ */
+public class MaterializedIndexContext {
+
+    @SerializedName(value = "materializedIndex")
+    protected final MaterializedIndex materializedIndex;
+
+    @SerializedName(value = "dynamicTablets")
+    protected final DynamicTablets dynamicTablets;
+
+    public MaterializedIndexContext(MaterializedIndex materializedIndex, DynamicTablets dynamicTablets) {
+        this.materializedIndex = materializedIndex;
+        this.dynamicTablets = dynamicTablets;
+    }
+
+    public MaterializedIndex getMaterializedIndex() {
+        return materializedIndex;
+    }
+
+    public DynamicTablets getDynamicTablets() {
+        return dynamicTablets;
+    }
+
+    public long getParallelTablets() {
+        return dynamicTablets.getParallelTablets();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/MergingTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/MergingTablet.java
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.dynamictablet;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Tablet;
+
+import java.util.List;
+
+/*
+ * MergingTablet saves the old tablet ids and the new tablet during tablets merging
+ */
+public class MergingTablet implements DynamicTablet {
+
+    @SerializedName(value = "oldTabletIds")
+    protected final List<Long> oldTabletIds;
+
+    @SerializedName(value = "newTablet")
+    protected final Tablet newTablet;
+
+    public MergingTablet(List<Long> oldTabletIds, Tablet newTablet) {
+        // Old tablet size is usaully 2, but we allow a power of 2
+        Preconditions.checkState(DynamicTabletUtils.isPowerOfTwo(oldTabletIds.size()),
+                "Old tablet size must be a power of 2, actual: " + oldTabletIds.size());
+
+        this.oldTabletIds = oldTabletIds;
+        this.newTablet = newTablet;
+    }
+
+    public List<Long> getOldTabletIds() {
+        return oldTabletIds;
+    }
+
+    public Tablet getNewTablet() {
+        return newTablet;
+    }
+
+    @Override
+    public SplittingTablet getSplittingTablet() {
+        return null;
+    }
+
+    @Override
+    public MergingTablet getMergingTablet() {
+        return this;
+    }
+
+    @Override
+    public long getParallelTablets() {
+        return oldTabletIds.size();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/PhysicalPartitionContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/PhysicalPartitionContext.java
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.dynamictablet;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Map;
+
+/*
+ * PhysicalPartitionContext saves the context during tablet splitting or merging for a physical partition
+ */
+public class PhysicalPartitionContext {
+
+    @SerializedName(value = "commitVersion")
+    protected long commitVersion;
+
+    @SerializedName(value = "indexContexts")
+    protected final Map<Long, MaterializedIndexContext> indexContexts;
+
+    public PhysicalPartitionContext(Map<Long, MaterializedIndexContext> indexContexts) {
+        this.indexContexts = indexContexts;
+    }
+
+    public long getCommitVersion() {
+        return commitVersion;
+    }
+
+    public void setCommitVersion(long commitVersion) {
+        this.commitVersion = commitVersion;
+    }
+
+    public Map<Long, MaterializedIndexContext> getIndexContexts() {
+        return indexContexts;
+    }
+
+    public long getParallelTablets() {
+        long parallelTablets = 0;
+        for (MaterializedIndexContext indexContext : indexContexts.values()) {
+            parallelTablets += indexContext.getParallelTablets();
+        }
+        return parallelTablets;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplitTabletJob.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.dynamictablet;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+
+public class SplitTabletJob extends DynamicTabletJob {
+    private static final Logger LOG = LogManager.getLogger(SplitTabletJob.class);
+
+    public SplitTabletJob(long jobId, long dbId, long tableId,
+            Map<Long, PhysicalPartitionContext> physicalPartitionContexts) {
+        super(jobId, JobType.SPLIT_TABLET, dbId, tableId, physicalPartitionContexts);
+    }
+
+    // Begin and commit the split transaction
+    @Override
+    protected void runPendingJob() {
+
+    }
+
+    // Wait for previous version published, than publish the split transaction
+    @Override
+    protected void runPreparingJob() {
+
+    }
+
+    // Wait for the publish finished, than replace old tablets with new tablets
+    @Override
+    protected void runRunningJob() {
+
+    }
+
+    // Wait for all previous transactions finished, than delete old tablets
+    @Override
+    protected void runCleaningJob() {
+
+    }
+
+    // Clear new tablets
+    @Override
+    protected void runAbortingJob() {
+
+    }
+
+    // Can abort only when job state is PENDING
+    @Override
+    protected boolean canAbort() {
+        return jobState == JobState.PENDING;
+    }
+
+    @Override
+    public void replay() {
+
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplitTabletJobFactory.java
@@ -1,0 +1,323 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.dynamictablet;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo.DistributionInfoType;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndex.IndexExtState;
+import com.starrocks.catalog.MaterializedIndex.IndexState;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.Config;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.SplitTabletClause;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+/*
+ * SplitTabletJobFactory is for creating SplitTabletJob.
+ */
+public class SplitTabletJobFactory implements DynamicTabletJobFactory {
+    private static final Logger LOG = LogManager.getLogger(SplitTabletJobFactory.class);
+
+    private final Database db;
+
+    private final OlapTable table;
+
+    private final SplitTabletClause splitTabletClause;
+
+    public SplitTabletJobFactory(Database db, OlapTable table, SplitTabletClause splitTabletClause) {
+        this.db = db;
+        this.table = table;
+        this.splitTabletClause = splitTabletClause;
+    }
+
+    /*
+     * Create a dynamic tablet job and return it.
+     * Dynamic tablets are created for all related materialized indexes.
+     * New shareds are created for new tablets.
+     */
+    @Override
+    public DynamicTabletJob createDynamicTabletJob() throws StarRocksException {
+        if (!table.isCloudNativeTableOrMaterializedView()) {
+            throw new StarRocksException("Unsupported table type " + table.getType()
+                    + " in table " + db.getFullName() + '.' + table.getName());
+        }
+
+        if (table.getDefaultDistributionInfo().getType() != DistributionInfoType.HASH) {
+            throw new StarRocksException("Unsupported distribution type " + table.getDefaultDistributionInfo().getType()
+                    + " in table " + db.getFullName() + '.' + table.getName());
+        }
+
+        Map<Long, PhysicalPartitionContext> physicalPartitionContexts = createPhysicalPartitionContexts();
+        if (physicalPartitionContexts.isEmpty()) {
+            throw new StarRocksException("No tablets need to split in table "
+                    + db.getFullName() + '.' + table.getName());
+        }
+
+        createNewShards(physicalPartitionContexts);
+
+        long jobId = GlobalStateMgr.getCurrentState().getNextId();
+        return new SplitTabletJob(jobId, db.getId(), table.getId(), physicalPartitionContexts);
+    }
+
+    /*
+     * Create dynamic tablets for all related materialized indexes
+     */
+    private Map<Long, PhysicalPartitionContext> createPhysicalPartitionContexts() throws StarRocksException {
+        Preconditions.checkState(splitTabletClause.getPartitionNames() == null ||
+                splitTabletClause.getTabletList() == null);
+
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        Map<Long, PhysicalPartitionContext> physicalPartitionContexts = new HashMap<>();
+        Map<Long, Long> oldIndexIdToNewIndexId = new HashMap<>();
+
+        Locker locker = new Locker();
+        locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+        try {
+            if (splitTabletClause.getTabletList() != null) {
+                Map<PhysicalPartition, Map<MaterializedIndex, Collection<Tablet>>> tablets = getTabletsByTabletIds(
+                        splitTabletClause.getTabletList().getTabletIds());
+
+                for (var physicalPartitionEntry : tablets.entrySet()) {
+                    PhysicalPartition physicalPartition = physicalPartitionEntry.getKey();
+
+                    Map<Long, MaterializedIndexContext> indexContexts = new HashMap<>();
+                    for (var indexEntry : physicalPartitionEntry.getValue().entrySet()) {
+                        MaterializedIndex index = indexEntry.getKey();
+
+                        Map<Long, SplittingTablet> splittingTablets = new HashMap<>();
+                        for (Tablet tablet : indexEntry.getValue()) {
+                            int newTabletCount = 0;
+                            if (splitTabletClause.getDynamicTabletSplitSize() <= 0) {
+                                long splitCount = -splitTabletClause.getDynamicTabletSplitSize();
+                                if (splitCount > Config.dynamic_tablet_max_split_count
+                                        || !DynamicTabletUtils.isPowerOfTwo(splitCount)) {
+                                    throw new StarRocksException("Invalid dynamic_tablet_split_size: "
+                                            + splitTabletClause.getDynamicTabletSplitSize());
+                                }
+
+                                newTabletCount = (int) splitCount;
+                            } else {
+                                newTabletCount = DynamicTabletUtils.calcSplitCount(tablet.getDataSize(true),
+                                        splitTabletClause.getDynamicTabletSplitSize());
+                            }
+
+                            if (newTabletCount <= 1) {
+                                continue;
+                            }
+
+                            SplittingTablet splittingTablet = createSplittingTablet(tablet.getId(), newTabletCount);
+                            splittingTablets.put(splittingTablet.getOldTabletId(), splittingTablet);
+                        }
+
+                        if (splittingTablets.isEmpty()) {
+                            continue;
+                        }
+
+                        long newIndexId = oldIndexIdToNewIndexId.computeIfAbsent(index.getId(),
+                                k -> globalStateMgr.getNextId());
+
+                        indexContexts.put(index.getId(),
+                                new MaterializedIndexContext(
+                                        new MaterializedIndex(newIndexId, IndexState.NORMAL, index.getShardGroupId()),
+                                        new SplittingTablets(splittingTablets)));
+                    }
+
+                    if (indexContexts.isEmpty()) {
+                        continue;
+                    }
+
+                    physicalPartitionContexts.put(physicalPartition.getId(),
+                            new PhysicalPartitionContext(indexContexts));
+                }
+            } else {
+                Collection<PhysicalPartition> physicalPartitions = null;
+                if (splitTabletClause.getPartitionNames() == null) {
+                    physicalPartitions = table.getPhysicalPartitions();
+                } else {
+                    physicalPartitions = new ArrayList<>();
+                    for (String partitonName : splitTabletClause.getPartitionNames().getPartitionNames()) {
+                        Partition partition = table.getPartition(partitonName);
+                        if (partition == null) {
+                            throw new StarRocksException("Cannot find partition " + partitonName
+                                    + " in table " + db.getFullName() + '.' + table.getName());
+                        }
+                        physicalPartitions.addAll(partition.getSubPartitions());
+                    }
+                }
+
+                for (PhysicalPartition physicalPartition : physicalPartitions) {
+
+                    Map<Long, MaterializedIndexContext> indexContexts = new HashMap<>();
+                    for (MaterializedIndex index : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
+
+                        Map<Long, SplittingTablet> splittingTablets = new HashMap<>();
+                        for (Tablet tablet : index.getTablets()) {
+                            Preconditions.checkState(splitTabletClause.getDynamicTabletSplitSize() > 0,
+                                    "Invalid dynamic_tablet_split_size: "
+                                            + splitTabletClause.getDynamicTabletSplitSize());
+
+                            int newTabletCount = DynamicTabletUtils.calcSplitCount(tablet.getDataSize(true),
+                                    splitTabletClause.getDynamicTabletSplitSize());
+
+                            if (newTabletCount <= 1) {
+                                continue;
+                            }
+
+                            SplittingTablet splittingTablet = createSplittingTablet(tablet.getId(), newTabletCount);
+                            splittingTablets.put(splittingTablet.getOldTabletId(), splittingTablet);
+                        }
+
+                        if (splittingTablets.isEmpty()) {
+                            continue;
+                        }
+
+                        long newIndexId = oldIndexIdToNewIndexId.computeIfAbsent(index.getId(),
+                                k -> globalStateMgr.getNextId());
+
+                        indexContexts.put(index.getId(),
+                                new MaterializedIndexContext(
+                                        new MaterializedIndex(newIndexId, IndexState.NORMAL, index.getShardGroupId()),
+                                        new SplittingTablets(splittingTablets)));
+                    }
+
+                    if (indexContexts.isEmpty()) {
+                        continue;
+                    }
+
+                    physicalPartitionContexts.put(physicalPartition.getId(),
+                            new PhysicalPartitionContext(indexContexts));
+                }
+            }
+        } finally {
+            locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+        }
+
+        return physicalPartitionContexts;
+    }
+
+    private Map<PhysicalPartition, Map<MaterializedIndex, Collection<Tablet>>> getTabletsByTabletIds(
+            List<Long> tabletIds) throws StarRocksException {
+        Map<PhysicalPartition, Map<MaterializedIndex, Collection<Tablet>>> tablets = new HashMap<>();
+
+        List<TabletMeta> tabletMetas = GlobalStateMgr.getCurrentState().getTabletInvertedIndex()
+                .getTabletMetaList(tabletIds);
+        for (int i = 0; i < tabletMetas.size(); ++i) {
+            long tabletId = tabletIds.get(i);
+            TabletMeta tabletMeta = tabletMetas.get(i);
+            if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META ||
+                    tabletMeta.getTableId() != table.getId()) {
+                throw new StarRocksException("Cannot find tablet " + tabletId
+                        + " in inverted index in table " + db.getFullName() + '.' + table.getName());
+            }
+
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(
+                    tabletMeta.getPhysicalPartitionId());
+            if (physicalPartition == null) {
+                throw new StarRocksException(
+                        "Cannot find physical partition " + tabletMeta.getPhysicalPartitionId()
+                                + " in table " + db.getFullName() + '.' + table.getName());
+            }
+
+            MaterializedIndex index = physicalPartition.getIndex(tabletMeta.getIndexId());
+            if (index == null) {
+                throw new StarRocksException("Cannot find materialized index " + tabletMeta.getIndexId()
+                        + " in physical partition " + physicalPartition.getId()
+                        + " in table " + db.getFullName() + '.' + table.getName());
+            }
+            if (index.getState() != IndexState.NORMAL) {
+                throw new StarRocksException("Not a normal state materialized index " + tabletMeta.getIndexId()
+                        + " in physical partition " + physicalPartition.getId()
+                        + " in table " + db.getFullName() + '.' + table.getName());
+            }
+
+            Tablet tablet = index.getTablet(tabletId);
+            if (tablet == null) {
+                throw new StarRocksException("Cannot find tablet " + tabletId
+                        + " in materialized index " + tabletMeta.getIndexId()
+                        + " in physical partition " + physicalPartition.getId()
+                        + " in table " + db.getFullName() + '.' + table.getName());
+            }
+
+            tablets.computeIfAbsent(physicalPartition, k -> new HashMap<>())
+                    .computeIfAbsent(index, k -> new HashSet<>())
+                    .add(tablet);
+        }
+
+        return tablets;
+    }
+
+    private void createNewShards(Map<Long, PhysicalPartitionContext> physicalPartitionContexts)
+            throws StarRocksException {
+        for (var physicalPartitionEntry : physicalPartitionContexts.entrySet()) {
+            Long physicalPartitionId = physicalPartitionEntry.getKey();
+            PhysicalPartitionContext physicalPartitionContext = physicalPartitionEntry.getValue();
+
+            for (var indexEntry : physicalPartitionContext.getIndexContexts().entrySet()) {
+                Long indexId = indexEntry.getKey();
+                MaterializedIndexContext indexContext = indexEntry.getValue();
+
+                Map<Long, List<Long>> oldToNewTabletIds = new HashMap<>();
+                for (var tabletEntry : indexContext.getDynamicTablets().getSplittingTablets().entrySet()) {
+                    List<Tablet> newTablets = tabletEntry.getValue().getNewTablets();
+                    List<Long> newTabletIds = new ArrayList<>(newTablets.size());
+                    for (Tablet tablet : newTablets) {
+                        newTabletIds.add(tablet.getId());
+                    }
+                    oldToNewTabletIds.put(tabletEntry.getKey(), newTabletIds);
+                }
+
+                Map<String, String> properties = new HashMap<>();
+                properties.put(LakeTablet.PROPERTY_KEY_TABLE_ID, Long.toString(table.getId()));
+                properties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
+                properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(indexId));
+
+                GlobalStateMgr.getCurrentState().getStarOSAgent().createShards(oldToNewTabletIds,
+                        table.getPartitionFilePathInfo(physicalPartitionId),
+                        table.getPartitionFileCacheInfo(physicalPartitionId),
+                        indexContext.getMaterializedIndex().getShardGroupId(),
+                        properties, WarehouseManager.DEFAULT_RESOURCE);
+            }
+        }
+    }
+
+    private static SplittingTablet createSplittingTablet(long oldTabletId, int newTabletCount) {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        List<Tablet> newTablets = new ArrayList<>(newTabletCount);
+        for (int j = 0; j < newTabletCount; ++j) {
+            newTablets.add(new LakeTablet(globalStateMgr.getNextId()));
+        }
+        return new SplittingTablet(oldTabletId, newTablets);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplittingTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplittingTablet.java
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.dynamictablet;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Tablet;
+
+import java.util.List;
+
+/*
+ * SplittingTablet saves the old tablet id and the new tablets during a tablet splitting
+ */
+public class SplittingTablet implements DynamicTablet {
+
+    @SerializedName(value = "oldTabletId")
+    protected final Long oldTabletId;
+
+    @SerializedName(value = "newTablets")
+    protected final List<Tablet> newTablets;
+
+    public SplittingTablet(Long oldTabletId, List<Tablet> newTablets) {
+        // New tablet size is usaully 2, but we allow a power of 2
+        Preconditions.checkState(DynamicTabletUtils.isPowerOfTwo(newTablets.size()),
+                "New tablet size must be a power of 2, actual: " + newTablets.size());
+
+        this.oldTabletId = oldTabletId;
+        this.newTablets = newTablets;
+    }
+
+    public Long getOldTabletId() {
+        return oldTabletId;
+    }
+
+    public List<Tablet> getNewTablets() {
+        return newTablets;
+    }
+
+    @Override
+    public SplittingTablet getSplittingTablet() {
+        return this;
+    }
+
+    @Override
+    public MergingTablet getMergingTablet() {
+        return null;
+    }
+
+    @Override
+    public long getParallelTablets() {
+        return newTablets.size();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
@@ -62,5 +62,4 @@ public abstract class Tablet extends MetaObject implements Writable {
     public String toString() {
         return "id=" + id;
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3776,6 +3776,18 @@ public class Config extends ConfigBase {
     public static long dynamic_tablet_max_parallel_tablets = 10 * 1024;
 
     /**
+     * Tablets with size larger than this value will be considered to split.
+     */
+    @ConfField(mutable = true, comment = "Tablets with size larger than this value will be considered to split.")
+    public static long dynamic_tablet_split_size = 4 * 1024 * 1024 * 1024;
+
+    /**
+     * The max number of new tablets that an old tablet can be split into.
+     */
+    @ConfField(mutable = true, comment = "The max number of new tablets that an old tablet can be split into.")
+    public static int dynamic_tablet_max_split_count = 1024;
+
+    /**
      * Whether to enable tracing historical nodes when cluster scale
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -260,6 +260,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_COMPACTION_STRATEGY = "compaction_strategy";
 
+    public static final String PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE = "dynamic_tablet_split_size";
+
     /**
      * Matches location labels like : ["*", "a:*", "bcd_123:*", "123bcd_:val_123", "  a :  b  "],
      * leading and trailing space of key and value will be ignored.

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -71,8 +71,13 @@ import com.starrocks.alter.OnlineOptimizeJobV2;
 import com.starrocks.alter.OptimizeJobV2;
 import com.starrocks.alter.RollupJobV2;
 import com.starrocks.alter.SchemaChangeJobV2;
+import com.starrocks.alter.dynamictablet.DynamicTablet;
+import com.starrocks.alter.dynamictablet.DynamicTabletJob;
 import com.starrocks.alter.dynamictablet.DynamicTablets;
+import com.starrocks.alter.dynamictablet.MergingTablet;
 import com.starrocks.alter.dynamictablet.MergingTablets;
+import com.starrocks.alter.dynamictablet.SplitTabletJob;
+import com.starrocks.alter.dynamictablet.SplittingTablet;
 import com.starrocks.alter.dynamictablet.SplittingTablets;
 import com.starrocks.authentication.FileGroupProvider;
 import com.starrocks.authentication.GroupProvider;
@@ -432,6 +437,15 @@ public class GsonUtils {
             RuntimeTypeAdapterFactory.of(ComputeResource.class, "clazz")
                     .registerSubtype(WarehouseComputeResource.class, "WarehouseComputeResource", true);
 
+    public static final RuntimeTypeAdapterFactory<DynamicTabletJob> DYNAMIC_TABLET_JOB_TYPE_RUNTIME_ADAPTER_FACTORY = 
+            RuntimeTypeAdapterFactory.of(DynamicTabletJob.class, "clazz")
+                    .registerSubtype(SplitTabletJob.class, "SplitTabletJob");
+
+    public static final RuntimeTypeAdapterFactory<DynamicTablet> DYNAMIC_TABLET_RUNTIME_TYPE_ADAPTER_FACTORY = 
+            RuntimeTypeAdapterFactory.of(DynamicTablet.class, "clazz")
+                    .registerSubtype(SplittingTablet.class, "SplittingTablet")
+                    .registerSubtype(MergingTablet.class, "MergingTablet");
+
     public static final RuntimeTypeAdapterFactory<DynamicTablets> DYNAMIC_TABLETS_RUNTIME_TYPE_ADAPTER_FACTORY = 
             RuntimeTypeAdapterFactory.of(DynamicTablets.class, "clazz")
                     .registerSubtype(SplittingTablets.class, "SplittingTablets")
@@ -499,6 +513,8 @@ public class GsonUtils {
             .registerTypeAdapterFactory(ANALYZE_STATUS_RUNTIME_TYPE_ADAPTER_FACTORY)
             .registerTypeAdapterFactory(ANALYZE_JOB_RUNTIME_TYPE_ADAPTER_FACTORY)
             .registerTypeAdapterFactory(COMPUTE_RESOURCE_RUNTIME_TYPE_ADAPTER_FACTORY)
+            .registerTypeAdapterFactory(DYNAMIC_TABLET_JOB_TYPE_RUNTIME_ADAPTER_FACTORY)
+            .registerTypeAdapterFactory(DYNAMIC_TABLET_RUNTIME_TYPE_ADAPTER_FACTORY)
             .registerTypeAdapterFactory(DYNAMIC_TABLETS_RUNTIME_TYPE_ADAPTER_FACTORY)
             .registerTypeAdapter(LocalDateTime.class, LOCAL_DATE_TIME_TYPE_SERIALIZER)
             .registerTypeAdapter(LocalDateTime.class, LOCAL_DATE_TIME_TYPE_DESERIALIZER)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -50,6 +50,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.NotImplementedException;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.DynamicPartitionUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
@@ -1226,6 +1227,13 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
         if (!table.isCloudNativeTableOrMaterializedView()) {
             throw new SemanticException("Split tablet only support cloud native tables");
         }
+
+        try {
+            clause.analyze();
+        } catch (StarRocksException e) {
+            throw new SemanticException(e.getMessage());
+        }
+
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TabletList.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TabletList.java
@@ -32,6 +32,10 @@ public class TabletList implements ParseNode {
 
     private final NodePosition pos;
 
+    public TabletList(List<Long> tabletIds) {
+        this(tabletIds, NodePosition.ZERO);
+    }
+
     public TabletList(List<Long> tabletIds, NodePosition pos) {
         this.tabletIds = tabletIds;
         this.pos = pos;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/MergingTabletsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/MergingTabletsTest.java
@@ -18,195 +18,200 @@ import com.starrocks.catalog.LocalTablet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 public class MergingTabletsTest {
     @Test
     public void testCalcNewVirtualBuckets() {
-        MergingTablets mergingTablets = new MergingTablets();
-        Assertions.assertTrue(mergingTablets.isEmpty());
-        Assertions.assertTrue(mergingTablets.getMergingTablets().isEmpty());
+        {
+            MergingTablets mergingTablets = new MergingTablets(Collections.emptyList());
+            Assertions.assertTrue(mergingTablets.isEmpty());
+            Assertions.assertTrue(mergingTablets.getMergingTablets().isEmpty());
+            Assertions.assertNull(mergingTablets.getSplittingTablets());
+        }
 
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> mergingTablets.addSplittingTablet(0, null));
-        Assertions.assertNull(mergingTablets.getSplittingTablets());
+        {
+            MergingTablets mergingTablets = new MergingTablets(List.of(
+                    new MergingTablet(
+                            List.of(101L, 102L),
+                            new LocalTablet(1)),
+                    new MergingTablet(
+                            List.of(201L, 202L),
+                            new LocalTablet(2))));
 
-        mergingTablets.addMergingTablet(
-                List.of(101L, 102L),
-                new LocalTablet(1));
-        mergingTablets.addMergingTablet(
-                List.of(201L, 202L),
-                new LocalTablet(2));
-        Assertions.assertFalse(mergingTablets.isEmpty());
+            Assertions.assertFalse(mergingTablets.isEmpty());
 
-        Assertions.assertEquals(List.of(1L, 2L, 3L, 4L, 5L),
-                mergingTablets.calcNewVirtualBuckets(List.of(
-                        101L, 201L, 3L, 4L, 5L,
-                        102L, 202L, 3L, 4L, 5L)));
+            Assertions.assertEquals(List.of(1L, 2L, 3L, 4L, 5L),
+                    mergingTablets.calcNewVirtualBuckets(List.of(
+                            101L, 201L, 3L, 4L, 5L,
+                            102L, 202L, 3L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(
-                1L, 2L, 301L, 4L, 5L,
-                1L, 2L, 302L, 4L, 5L),
-                mergingTablets.calcNewVirtualBuckets(
-                        List.of(101L, 201L, 301L, 4L, 5L,
-                                102L, 202L, 302L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    1L, 2L, 301L, 4L, 5L,
+                    1L, 2L, 302L, 4L, 5L),
+                    mergingTablets.calcNewVirtualBuckets(
+                            List.of(101L, 201L, 301L, 4L, 5L,
+                                    102L, 202L, 302L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(
-                1L, 2L, 301L, 4L, 5L,
-                1L, 2L, 302L, 4L, 5L,
-                1L, 2L, 303L, 4L, 5L,
-                1L, 2L, 304L, 4L, 5L),
-                mergingTablets.calcNewVirtualBuckets(
-                        List.of(101L, 201L, 301L, 4L, 5L,
-                                102L, 202L, 302L, 4L, 5L,
-                                101L, 201L, 303L, 4L, 5L,
-                                102L, 202L, 304L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    1L, 2L, 301L, 4L, 5L,
+                    1L, 2L, 302L, 4L, 5L,
+                    1L, 2L, 303L, 4L, 5L,
+                    1L, 2L, 304L, 4L, 5L),
+                    mergingTablets.calcNewVirtualBuckets(
+                            List.of(101L, 201L, 301L, 4L, 5L,
+                                    102L, 202L, 302L, 4L, 5L,
+                                    101L, 201L, 303L, 4L, 5L,
+                                    102L, 202L, 304L, 4L, 5L)));
+        }
 
-        mergingTablets.clear();
-        Assertions.assertTrue(mergingTablets.isEmpty());
+        {
+            MergingTablets mergingTablets = new MergingTablets(List.of(
+                    new MergingTablet(
+                            List.of(201L, 202L, 203L, 204L),
+                            new LocalTablet(2)),
+                    new MergingTablet(
+                            List.of(301L, 302L),
+                            new LocalTablet(3))));
 
-        mergingTablets.addMergingTablet(
-                List.of(201L, 202L, 203L, 204L),
-                new LocalTablet(2));
-        mergingTablets.addMergingTablet(
-                List.of(301L, 302L),
-                new LocalTablet(3));
+            Assertions.assertEquals(List.of(1L, 2L, 3L, 4L, 5L),
+                    mergingTablets.calcNewVirtualBuckets(List.of(
+                            1L, 201L, 301L, 4L, 5L,
+                            1L, 202L, 302L, 4L, 5L,
+                            1L, 203L, 301L, 4L, 5L,
+                            1L, 204L, 302L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(1L, 2L, 3L, 4L, 5L),
-                mergingTablets.calcNewVirtualBuckets(List.of(
-                        1L, 201L, 301L, 4L, 5L,
-                        1L, 202L, 302L, 4L, 5L,
-                        1L, 203L, 301L, 4L, 5L,
-                        1L, 204L, 302L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    101L, 2L, 3L, 4L, 5L,
+                    102L, 2L, 3L, 4L, 5L),
+                    mergingTablets.calcNewVirtualBuckets(
+                            List.of(101L, 201L, 301L, 4L, 5L,
+                                    102L, 202L, 302L, 4L, 5L,
+                                    101L, 203L, 301L, 4L, 5L,
+                                    102L, 204L, 302L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(
-                101L, 2L, 3L, 4L, 5L,
-                102L, 2L, 3L, 4L, 5L),
-                mergingTablets.calcNewVirtualBuckets(
-                        List.of(101L, 201L, 301L, 4L, 5L,
-                                102L, 202L, 302L, 4L, 5L,
-                                101L, 203L, 301L, 4L, 5L,
-                                102L, 204L, 302L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    101L, 2L, 3L, 4L, 5L,
+                    102L, 2L, 3L, 4L, 5L,
+                    103L, 2L, 3L, 4L, 5L,
+                    104L, 2L, 3L, 4L, 5L),
+                    mergingTablets.calcNewVirtualBuckets(
+                            List.of(101L, 201L, 301L, 4L, 5L,
+                                    102L, 202L, 302L, 4L, 5L,
+                                    103L, 203L, 301L, 4L, 5L,
+                                    104L, 204L, 302L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(
-                101L, 2L, 3L, 4L, 5L,
-                102L, 2L, 3L, 4L, 5L,
-                103L, 2L, 3L, 4L, 5L,
-                104L, 2L, 3L, 4L, 5L),
-                mergingTablets.calcNewVirtualBuckets(
-                        List.of(101L, 201L, 301L, 4L, 5L,
-                                102L, 202L, 302L, 4L, 5L,
-                                103L, 203L, 301L, 4L, 5L,
-                                104L, 204L, 302L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    101L, 2L, 3L, 4L, 5L,
+                    102L, 2L, 3L, 4L, 5L,
+                    103L, 2L, 3L, 4L, 5L,
+                    104L, 2L, 3L, 4L, 5L,
+                    105L, 2L, 3L, 4L, 5L,
+                    106L, 2L, 3L, 4L, 5L,
+                    107L, 2L, 3L, 4L, 5L,
+                    108L, 2L, 3L, 4L, 5L),
+                    mergingTablets.calcNewVirtualBuckets(
+                            List.of(101L, 201L, 301L, 4L, 5L,
+                                    102L, 202L, 302L, 4L, 5L,
+                                    103L, 203L, 301L, 4L, 5L,
+                                    104L, 204L, 302L, 4L, 5L,
+                                    105L, 201L, 301L, 4L, 5L,
+                                    106L, 202L, 302L, 4L, 5L,
+                                    107L, 203L, 301L, 4L, 5L,
+                                    108L, 204L, 302L, 4L, 5L)));
+        }
 
-        Assertions.assertEquals(List.of(
-                101L, 2L, 3L, 4L, 5L,
-                102L, 2L, 3L, 4L, 5L,
-                103L, 2L, 3L, 4L, 5L,
-                104L, 2L, 3L, 4L, 5L,
-                105L, 2L, 3L, 4L, 5L,
-                106L, 2L, 3L, 4L, 5L,
-                107L, 2L, 3L, 4L, 5L,
-                108L, 2L, 3L, 4L, 5L),
-                mergingTablets.calcNewVirtualBuckets(
-                        List.of(101L, 201L, 301L, 4L, 5L,
-                                102L, 202L, 302L, 4L, 5L,
-                                103L, 203L, 301L, 4L, 5L,
-                                104L, 204L, 302L, 4L, 5L,
-                                105L, 201L, 301L, 4L, 5L,
-                                106L, 202L, 302L, 4L, 5L,
-                                107L, 203L, 301L, 4L, 5L,
-                                108L, 204L, 302L, 4L, 5L)));
+        {
+            MergingTablets mergingTablets = new MergingTablets(List.of(
+                    new MergingTablet(
+                            List.of(10101L, 10102L, 10103L, 10104L),
+                            new LocalTablet(101)),
+                    new MergingTablet(
+                            List.of(201L, 202L, 203L, 204L),
+                            new LocalTablet(2))));
 
-        mergingTablets.clear();
-        Assertions.assertTrue(mergingTablets.isEmpty());
+            Assertions.assertEquals(List.of(
+                    101L, 2L, 3L, 4L, 5L,
+                    102L, 2L, 3L, 4L, 5L),
+                    mergingTablets.calcNewVirtualBuckets(List.of(
+                            10101L, 201L, 3L, 4L, 5L,
+                            102L, 202L, 3L, 4L, 5L,
+                            10102L, 203L, 3L, 4L, 5L,
+                            102L, 204L, 3L, 4L, 5L,
+                            10103L, 201L, 3L, 4L, 5L,
+                            102L, 202L, 3L, 4L, 5L,
+                            10104L, 203L, 3L, 4L, 5L,
+                            102L, 204L, 3L, 4L, 5L)));
 
-        mergingTablets.addMergingTablet(
-                List.of(10101L, 10102L, 10103L, 10104L),
-                new LocalTablet(101));
-        mergingTablets.addMergingTablet(
-                List.of(201L, 202L, 203L, 204L),
-                new LocalTablet(2));
+            Assertions.assertEquals(List.of(
+                    101L, 2L, 301L, 4L, 5L,
+                    102L, 2L, 302L, 4L, 5L,
+                    101L, 2L, 303L, 4L, 5L,
+                    102L, 2L, 304L, 4L, 5L),
+                    mergingTablets.calcNewVirtualBuckets(List.of(
+                            10101L, 201L, 301L, 4L, 5L,
+                            102L, 202L, 302L, 4L, 5L,
+                            10102L, 203L, 303L, 4L, 5L,
+                            102L, 204L, 304L, 4L, 5L,
+                            10103L, 201L, 301L, 4L, 5L,
+                            102L, 202L, 302L, 4L, 5L,
+                            10104L, 203L, 303L, 4L, 5L,
+                            102L, 204L, 304L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(
-                101L, 2L, 3L, 4L, 5L,
-                102L, 2L, 3L, 4L, 5L),
-                mergingTablets.calcNewVirtualBuckets(List.of(
-                        10101L, 201L, 3L, 4L, 5L,
-                        102L, 202L, 3L, 4L, 5L,
-                        10102L, 203L, 3L, 4L, 5L,
-                        102L, 204L, 3L, 4L, 5L,
-                        10103L, 201L, 3L, 4L, 5L,
-                        102L, 202L, 3L, 4L, 5L,
-                        10104L, 203L, 3L, 4L, 5L,
-                        102L, 204L, 3L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    101L, 2L, 301L, 4L, 5L,
+                    102L, 2L, 302L, 4L, 5L,
+                    101L, 2L, 303L, 4L, 5L,
+                    102L, 2L, 304L, 4L, 5L,
+                    101L, 2L, 305L, 4L, 5L,
+                    102L, 2L, 306L, 4L, 5L,
+                    101L, 2L, 307L, 4L, 5L,
+                    102L, 2L, 308L, 4L, 5L),
+                    mergingTablets.calcNewVirtualBuckets(List.of(
+                            10101L, 201L, 301L, 4L, 5L,
+                            102L, 202L, 302L, 4L, 5L,
+                            10102L, 203L, 303L, 4L, 5L,
+                            102L, 204L, 304L, 4L, 5L,
+                            10103L, 201L, 305L, 4L, 5L,
+                            102L, 202L, 306L, 4L, 5L,
+                            10104L, 203L, 307L, 4L, 5L,
+                            102L, 204L, 308L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(
-                101L, 2L, 301L, 4L, 5L,
-                102L, 2L, 302L, 4L, 5L,
-                101L, 2L, 303L, 4L, 5L,
-                102L, 2L, 304L, 4L, 5L),
-                mergingTablets.calcNewVirtualBuckets(List.of(
-                        10101L, 201L, 301L, 4L, 5L,
-                        102L, 202L, 302L, 4L, 5L,
-                        10102L, 203L, 303L, 4L, 5L,
-                        102L, 204L, 304L, 4L, 5L,
-                        10103L, 201L, 301L, 4L, 5L,
-                        102L, 202L, 302L, 4L, 5L,
-                        10104L, 203L, 303L, 4L, 5L,
-                        102L, 204L, 304L, 4L, 5L)));
-
-        Assertions.assertEquals(List.of(
-                101L, 2L, 301L, 4L, 5L,
-                102L, 2L, 302L, 4L, 5L,
-                101L, 2L, 303L, 4L, 5L,
-                102L, 2L, 304L, 4L, 5L,
-                101L, 2L, 305L, 4L, 5L,
-                102L, 2L, 306L, 4L, 5L,
-                101L, 2L, 307L, 4L, 5L,
-                102L, 2L, 308L, 4L, 5L),
-                mergingTablets.calcNewVirtualBuckets(List.of(
-                        10101L, 201L, 301L, 4L, 5L,
-                        102L, 202L, 302L, 4L, 5L,
-                        10102L, 203L, 303L, 4L, 5L,
-                        102L, 204L, 304L, 4L, 5L,
-                        10103L, 201L, 305L, 4L, 5L,
-                        102L, 202L, 306L, 4L, 5L,
-                        10104L, 203L, 307L, 4L, 5L,
-                        102L, 204L, 308L, 4L, 5L)));
-
-        Assertions.assertEquals(List.of(
-                101L, 2L, 301L, 4L, 5L,
-                102L, 2L, 302L, 4L, 5L,
-                101L, 2L, 303L, 4L, 5L,
-                102L, 2L, 304L, 4L, 5L,
-                101L, 2L, 305L, 4L, 5L,
-                102L, 2L, 306L, 4L, 5L,
-                101L, 2L, 307L, 4L, 5L,
-                102L, 2L, 308L, 4L, 5L,
-                101L, 2L, 309L, 4L, 5L,
-                102L, 2L, 310L, 4L, 5L,
-                101L, 2L, 311L, 4L, 5L,
-                102L, 2L, 312L, 4L, 5L,
-                101L, 2L, 313L, 4L, 5L,
-                102L, 2L, 314L, 4L, 5L,
-                101L, 2L, 315L, 4L, 5L,
-                102L, 2L, 316L, 4L, 5L),
-                mergingTablets.calcNewVirtualBuckets(List.of(
-                        10101L, 201L, 301L, 4L, 5L,
-                        102L, 202L, 302L, 4L, 5L,
-                        10102L, 203L, 303L, 4L, 5L,
-                        102L, 204L, 304L, 4L, 5L,
-                        10103L, 201L, 305L, 4L, 5L,
-                        102L, 202L, 306L, 4L, 5L,
-                        10104L, 203L, 307L, 4L, 5L,
-                        102L, 204L, 308L, 4L, 5L,
-                        10101L, 201L, 309L, 4L, 5L,
-                        102L, 202L, 310L, 4L, 5L,
-                        10102L, 203L, 311L, 4L, 5L,
-                        102L, 204L, 312L, 4L, 5L,
-                        10103L, 201L, 313L, 4L, 5L,
-                        102L, 202L, 314L, 4L, 5L,
-                        10104L, 203L, 315L, 4L, 5L,
-                        102L, 204L, 316L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    101L, 2L, 301L, 4L, 5L,
+                    102L, 2L, 302L, 4L, 5L,
+                    101L, 2L, 303L, 4L, 5L,
+                    102L, 2L, 304L, 4L, 5L,
+                    101L, 2L, 305L, 4L, 5L,
+                    102L, 2L, 306L, 4L, 5L,
+                    101L, 2L, 307L, 4L, 5L,
+                    102L, 2L, 308L, 4L, 5L,
+                    101L, 2L, 309L, 4L, 5L,
+                    102L, 2L, 310L, 4L, 5L,
+                    101L, 2L, 311L, 4L, 5L,
+                    102L, 2L, 312L, 4L, 5L,
+                    101L, 2L, 313L, 4L, 5L,
+                    102L, 2L, 314L, 4L, 5L,
+                    101L, 2L, 315L, 4L, 5L,
+                    102L, 2L, 316L, 4L, 5L),
+                    mergingTablets.calcNewVirtualBuckets(List.of(
+                            10101L, 201L, 301L, 4L, 5L,
+                            102L, 202L, 302L, 4L, 5L,
+                            10102L, 203L, 303L, 4L, 5L,
+                            102L, 204L, 304L, 4L, 5L,
+                            10103L, 201L, 305L, 4L, 5L,
+                            102L, 202L, 306L, 4L, 5L,
+                            10104L, 203L, 307L, 4L, 5L,
+                            102L, 204L, 308L, 4L, 5L,
+                            10101L, 201L, 309L, 4L, 5L,
+                            102L, 202L, 310L, 4L, 5L,
+                            10102L, 203L, 311L, 4L, 5L,
+                            102L, 204L, 312L, 4L, 5L,
+                            10103L, 201L, 313L, 4L, 5L,
+                            102L, 202L, 314L, 4L, 5L,
+                            10104L, 203L, 315L, 4L, 5L,
+                            102L, 204L, 316L, 4L, 5L)));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/SplitTabletJobFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/SplitTabletJobFactoryTest.java
@@ -1,0 +1,95 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.dynamictablet;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.SplitTabletClause;
+import com.starrocks.sql.ast.TabletList;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class SplitTabletJobFactoryTest {
+    protected static ConnectContext connectContext;
+    protected static StarRocksAssert starRocksAssert;
+    private static Database db;
+    private static OlapTable table;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        starRocksAssert.withDatabase("test").useDatabase("test");
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+
+        String sql = "create table test_table (key1 int, key2 varchar(10))\n" +
+                "distributed by hash(key1) buckets 1\n" +
+                "properties('replication_num' = '1'); ";
+        starRocksAssert.withTable(sql);
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "test_table");
+    }
+
+    @Test
+    public void testCreateDynamicTabletJob() throws Exception {
+        {
+            Map<String, String> properties = Map.of(PropertyAnalyzer.PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE, "-1");
+            SplitTabletClause clause = new SplitTabletClause(null, null, properties);
+            clause.analyze();
+
+            DynamicTabletJobFactory factory = new SplitTabletJobFactory(db, table, clause);
+            Assertions.assertThrows(IllegalStateException.class, () -> factory.createDynamicTabletJob());
+        }
+
+        {
+            Map<String, String> properties = Map.of(PropertyAnalyzer.PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE, "1");
+            SplitTabletClause clause = new SplitTabletClause(null, null, properties);
+            clause.analyze();
+
+            DynamicTabletJobFactory factory = new SplitTabletJobFactory(db, table, clause);
+            Assertions.assertThrows(StarRocksException.class, () -> factory.createDynamicTabletJob());
+        }
+
+        {
+            PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+            MaterializedIndex materializedIndex = physicalPartition.getBaseIndex();
+            long tabletId = materializedIndex.getTablets().get(0).getId();
+            TabletList tabletList = new TabletList(List.of(tabletId));
+
+            Map<String, String> properties = Map.of(PropertyAnalyzer.PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE, "-2");
+            SplitTabletClause clause = new SplitTabletClause(null, tabletList, properties);
+            clause.analyze();
+
+            DynamicTabletJobFactory factory = new SplitTabletJobFactory(db, table, clause);
+            DynamicTabletJob dynamicTabletJob = factory.createDynamicTabletJob();
+            Assertions.assertNotNull(dynamicTabletJob);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/SplittingTabletsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/SplittingTabletsTest.java
@@ -18,202 +18,207 @@ import com.starrocks.catalog.LocalTablet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class SplittingTabletsTest {
     @Test
     public void testCalcNewVirtualBuckets() {
-        SplittingTablets splittingTablets = new SplittingTablets();
-        Assertions.assertTrue(splittingTablets.isEmpty());
-        Assertions.assertTrue(splittingTablets.getSplittingTablets().isEmpty());
+        {
+            SplittingTablets splittingTablets = new SplittingTablets(Collections.emptyMap());
+            Assertions.assertTrue(splittingTablets.isEmpty());
+            Assertions.assertTrue(splittingTablets.getSplittingTablets().isEmpty());
+            Assertions.assertNull(splittingTablets.getMergingTablets());
+        }
 
-        Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> splittingTablets.addMergingTablet(null, null));
-        Assertions.assertNull(splittingTablets.getMergingTablets());
+        {
+            SplittingTablets splittingTablets = new SplittingTablets(Map.of(
+                    1L, new SplittingTablet(1L,
+                            List.of(new LocalTablet(101),
+                                    new LocalTablet(102))),
+                    2L, new SplittingTablet(2L,
+                            List.of(new LocalTablet(201),
+                                    new LocalTablet(202)))));
 
-        splittingTablets.addSplittingTablet(1,
-                List.of(new LocalTablet(101),
-                        new LocalTablet(102)));
-        splittingTablets.addSplittingTablet(2,
-                List.of(new LocalTablet(201),
-                        new LocalTablet(202)));
-        Assertions.assertFalse(splittingTablets.isEmpty());
+            Assertions.assertFalse(splittingTablets.isEmpty());
 
-        Assertions.assertEquals(List.of(
-                101L, 201L, 3L, 4L, 5L,
-                102L, 202L, 3L, 4L, 5L),
-                splittingTablets.calcNewVirtualBuckets(List.of(1L, 2L, 3L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    101L, 201L, 3L, 4L, 5L,
+                    102L, 202L, 3L, 4L, 5L),
+                    splittingTablets.calcNewVirtualBuckets(List.of(1L, 2L, 3L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(
-                101L, 201L, 301L, 4L, 5L,
-                102L, 202L, 302L, 4L, 5L),
-                splittingTablets.calcNewVirtualBuckets(
-                        List.of(1L, 2L, 301L, 4L, 5L,
-                                1L, 2L, 302L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    101L, 201L, 301L, 4L, 5L,
+                    102L, 202L, 302L, 4L, 5L),
+                    splittingTablets.calcNewVirtualBuckets(
+                            List.of(1L, 2L, 301L, 4L, 5L,
+                                    1L, 2L, 302L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(
-                101L, 201L, 301L, 4L, 5L,
-                102L, 202L, 302L, 4L, 5L,
-                101L, 201L, 303L, 4L, 5L,
-                102L, 202L, 304L, 4L, 5L),
-                splittingTablets.calcNewVirtualBuckets(
-                        List.of(1L, 2L, 301L, 4L, 5L,
-                                1L, 2L, 302L, 4L, 5L,
-                                1L, 2L, 303L, 4L, 5L,
-                                1L, 2L, 304L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    101L, 201L, 301L, 4L, 5L,
+                    102L, 202L, 302L, 4L, 5L,
+                    101L, 201L, 303L, 4L, 5L,
+                    102L, 202L, 304L, 4L, 5L),
+                    splittingTablets.calcNewVirtualBuckets(
+                            List.of(1L, 2L, 301L, 4L, 5L,
+                                    1L, 2L, 302L, 4L, 5L,
+                                    1L, 2L, 303L, 4L, 5L,
+                                    1L, 2L, 304L, 4L, 5L)));
+        }
 
-        splittingTablets.clear();
-        Assertions.assertTrue(splittingTablets.isEmpty());
+        {
+            SplittingTablets splittingTablets = new SplittingTablets(Map.of(
+                    2L, new SplittingTablet(2L,
+                            List.of(new LocalTablet(201),
+                                    new LocalTablet(202),
+                                    new LocalTablet(203),
+                                    new LocalTablet(204))),
+                    3L, new SplittingTablet(3L,
+                            List.of(new LocalTablet(301),
+                                    new LocalTablet(302)))));
 
-        splittingTablets.addSplittingTablet(2,
-                List.of(new LocalTablet(201),
-                        new LocalTablet(202),
-                        new LocalTablet(203),
-                        new LocalTablet(204)));
-        splittingTablets.addSplittingTablet(3,
-                List.of(new LocalTablet(301),
-                        new LocalTablet(302)));
+            Assertions.assertEquals(List.of(
+                    1L, 201L, 301L, 4L, 5L,
+                    1L, 202L, 302L, 4L, 5L,
+                    1L, 203L, 301L, 4L, 5L,
+                    1L, 204L, 302L, 4L, 5L),
+                    splittingTablets.calcNewVirtualBuckets(List.of(1L, 2L, 3L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(
-                1L, 201L, 301L, 4L, 5L,
-                1L, 202L, 302L, 4L, 5L,
-                1L, 203L, 301L, 4L, 5L,
-                1L, 204L, 302L, 4L, 5L),
-                splittingTablets.calcNewVirtualBuckets(List.of(1L, 2L, 3L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    101L, 201L, 301L, 4L, 5L,
+                    102L, 202L, 302L, 4L, 5L,
+                    101L, 203L, 301L, 4L, 5L,
+                    102L, 204L, 302L, 4L, 5L),
+                    splittingTablets.calcNewVirtualBuckets(
+                            List.of(101L, 2L, 3L, 4L, 5L,
+                                    102L, 2L, 3L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(
-                101L, 201L, 301L, 4L, 5L,
-                102L, 202L, 302L, 4L, 5L,
-                101L, 203L, 301L, 4L, 5L,
-                102L, 204L, 302L, 4L, 5L),
-                splittingTablets.calcNewVirtualBuckets(
-                        List.of(101L, 2L, 3L, 4L, 5L,
-                                102L, 2L, 3L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    101L, 201L, 301L, 4L, 5L,
+                    102L, 202L, 302L, 4L, 5L,
+                    103L, 203L, 301L, 4L, 5L,
+                    104L, 204L, 302L, 4L, 5L),
+                    splittingTablets.calcNewVirtualBuckets(
+                            List.of(101L, 2L, 3L, 4L, 5L,
+                                    102L, 2L, 3L, 4L, 5L,
+                                    103L, 2L, 3L, 4L, 5L,
+                                    104L, 2L, 3L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(
-                101L, 201L, 301L, 4L, 5L,
-                102L, 202L, 302L, 4L, 5L,
-                103L, 203L, 301L, 4L, 5L,
-                104L, 204L, 302L, 4L, 5L),
-                splittingTablets.calcNewVirtualBuckets(
-                        List.of(101L, 2L, 3L, 4L, 5L,
-                                102L, 2L, 3L, 4L, 5L,
-                                103L, 2L, 3L, 4L, 5L,
-                                104L, 2L, 3L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    101L, 201L, 301L, 4L, 5L,
+                    102L, 202L, 302L, 4L, 5L,
+                    103L, 203L, 301L, 4L, 5L,
+                    104L, 204L, 302L, 4L, 5L,
+                    105L, 201L, 301L, 4L, 5L,
+                    106L, 202L, 302L, 4L, 5L,
+                    107L, 203L, 301L, 4L, 5L,
+                    108L, 204L, 302L, 4L, 5L),
+                    splittingTablets.calcNewVirtualBuckets(
+                            List.of(101L, 2L, 3L, 4L, 5L,
+                                    102L, 2L, 3L, 4L, 5L,
+                                    103L, 2L, 3L, 4L, 5L,
+                                    104L, 2L, 3L, 4L, 5L,
+                                    105L, 2L, 3L, 4L, 5L,
+                                    106L, 2L, 3L, 4L, 5L,
+                                    107L, 2L, 3L, 4L, 5L,
+                                    108L, 2L, 3L, 4L, 5L)));
+        }
 
-        Assertions.assertEquals(List.of(
-                101L, 201L, 301L, 4L, 5L,
-                102L, 202L, 302L, 4L, 5L,
-                103L, 203L, 301L, 4L, 5L,
-                104L, 204L, 302L, 4L, 5L,
-                105L, 201L, 301L, 4L, 5L,
-                106L, 202L, 302L, 4L, 5L,
-                107L, 203L, 301L, 4L, 5L,
-                108L, 204L, 302L, 4L, 5L),
-                splittingTablets.calcNewVirtualBuckets(
-                        List.of(101L, 2L, 3L, 4L, 5L,
-                                102L, 2L, 3L, 4L, 5L,
-                                103L, 2L, 3L, 4L, 5L,
-                                104L, 2L, 3L, 4L, 5L,
-                                105L, 2L, 3L, 4L, 5L,
-                                106L, 2L, 3L, 4L, 5L,
-                                107L, 2L, 3L, 4L, 5L,
-                                108L, 2L, 3L, 4L, 5L)));
+        {
+            SplittingTablets splittingTablets = new SplittingTablets(Map.of(
+                    101L, new SplittingTablet(101L,
+                            List.of(new LocalTablet(10101),
+                                    new LocalTablet(10102),
+                                    new LocalTablet(10103),
+                                    new LocalTablet(10104))),
+                    2L, new SplittingTablet(2L,
+                            List.of(new LocalTablet(201),
+                                    new LocalTablet(202),
+                                    new LocalTablet(203),
+                                    new LocalTablet(204)))));
 
-        splittingTablets.clear();
-        Assertions.assertTrue(splittingTablets.isEmpty());
+            Assertions.assertEquals(List.of(
+                    10101L, 201L, 3L, 4L, 5L,
+                    102L, 202L, 3L, 4L, 5L,
+                    10102L, 203L, 3L, 4L, 5L,
+                    102L, 204L, 3L, 4L, 5L,
+                    10103L, 201L, 3L, 4L, 5L,
+                    102L, 202L, 3L, 4L, 5L,
+                    10104L, 203L, 3L, 4L, 5L,
+                    102L, 204L, 3L, 4L, 5L),
+                    splittingTablets.calcNewVirtualBuckets(List.of(
+                            101L, 2L, 3L, 4L, 5L,
+                            102L, 2L, 3L, 4L, 5L)));
 
-        splittingTablets.addSplittingTablet(101,
-                List.of(new LocalTablet(10101),
-                        new LocalTablet(10102),
-                        new LocalTablet(10103),
-                        new LocalTablet(10104)));
-        splittingTablets.addSplittingTablet(2,
-                List.of(new LocalTablet(201),
-                        new LocalTablet(202),
-                        new LocalTablet(203),
-                        new LocalTablet(204)));
+            Assertions.assertEquals(List.of(
+                    10101L, 201L, 301L, 4L, 5L,
+                    102L, 202L, 302L, 4L, 5L,
+                    10102L, 203L, 303L, 4L, 5L,
+                    102L, 204L, 304L, 4L, 5L,
+                    10103L, 201L, 301L, 4L, 5L,
+                    102L, 202L, 302L, 4L, 5L,
+                    10104L, 203L, 303L, 4L, 5L,
+                    102L, 204L, 304L, 4L, 5L),
+                    splittingTablets.calcNewVirtualBuckets(List.of(
+                            101L, 2L, 301L, 4L, 5L,
+                            102L, 2L, 302L, 4L, 5L,
+                            101L, 2L, 303L, 4L, 5L,
+                            102L, 2L, 304L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(
-                10101L, 201L, 3L, 4L, 5L,
-                102L, 202L, 3L, 4L, 5L,
-                10102L, 203L, 3L, 4L, 5L,
-                102L, 204L, 3L, 4L, 5L,
-                10103L, 201L, 3L, 4L, 5L,
-                102L, 202L, 3L, 4L, 5L,
-                10104L, 203L, 3L, 4L, 5L,
-                102L, 204L, 3L, 4L, 5L),
-                splittingTablets.calcNewVirtualBuckets(List.of(
-                        101L, 2L, 3L, 4L, 5L,
-                        102L, 2L, 3L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    10101L, 201L, 301L, 4L, 5L,
+                    102L, 202L, 302L, 4L, 5L,
+                    10102L, 203L, 303L, 4L, 5L,
+                    102L, 204L, 304L, 4L, 5L,
+                    10103L, 201L, 305L, 4L, 5L,
+                    102L, 202L, 306L, 4L, 5L,
+                    10104L, 203L, 307L, 4L, 5L,
+                    102L, 204L, 308L, 4L, 5L),
+                    splittingTablets.calcNewVirtualBuckets(List.of(
+                            101L, 2L, 301L, 4L, 5L,
+                            102L, 2L, 302L, 4L, 5L,
+                            101L, 2L, 303L, 4L, 5L,
+                            102L, 2L, 304L, 4L, 5L,
+                            101L, 2L, 305L, 4L, 5L,
+                            102L, 2L, 306L, 4L, 5L,
+                            101L, 2L, 307L, 4L, 5L,
+                            102L, 2L, 308L, 4L, 5L)));
 
-        Assertions.assertEquals(List.of(
-                10101L, 201L, 301L, 4L, 5L,
-                102L, 202L, 302L, 4L, 5L,
-                10102L, 203L, 303L, 4L, 5L,
-                102L, 204L, 304L, 4L, 5L,
-                10103L, 201L, 301L, 4L, 5L,
-                102L, 202L, 302L, 4L, 5L,
-                10104L, 203L, 303L, 4L, 5L,
-                102L, 204L, 304L, 4L, 5L),
-                splittingTablets.calcNewVirtualBuckets(List.of(
-                        101L, 2L, 301L, 4L, 5L,
-                        102L, 2L, 302L, 4L, 5L,
-                        101L, 2L, 303L, 4L, 5L,
-                        102L, 2L, 304L, 4L, 5L)));
-
-        Assertions.assertEquals(List.of(
-                10101L, 201L, 301L, 4L, 5L,
-                102L, 202L, 302L, 4L, 5L,
-                10102L, 203L, 303L, 4L, 5L,
-                102L, 204L, 304L, 4L, 5L,
-                10103L, 201L, 305L, 4L, 5L,
-                102L, 202L, 306L, 4L, 5L,
-                10104L, 203L, 307L, 4L, 5L,
-                102L, 204L, 308L, 4L, 5L),
-                splittingTablets.calcNewVirtualBuckets(List.of(
-                        101L, 2L, 301L, 4L, 5L,
-                        102L, 2L, 302L, 4L, 5L,
-                        101L, 2L, 303L, 4L, 5L,
-                        102L, 2L, 304L, 4L, 5L,
-                        101L, 2L, 305L, 4L, 5L,
-                        102L, 2L, 306L, 4L, 5L,
-                        101L, 2L, 307L, 4L, 5L,
-                        102L, 2L, 308L, 4L, 5L)));
-
-        Assertions.assertEquals(List.of(
-                10101L, 201L, 301L, 4L, 5L,
-                102L, 202L, 302L, 4L, 5L,
-                10102L, 203L, 303L, 4L, 5L,
-                102L, 204L, 304L, 4L, 5L,
-                10103L, 201L, 305L, 4L, 5L,
-                102L, 202L, 306L, 4L, 5L,
-                10104L, 203L, 307L, 4L, 5L,
-                102L, 204L, 308L, 4L, 5L,
-                10101L, 201L, 309L, 4L, 5L,
-                102L, 202L, 310L, 4L, 5L,
-                10102L, 203L, 311L, 4L, 5L,
-                102L, 204L, 312L, 4L, 5L,
-                10103L, 201L, 313L, 4L, 5L,
-                102L, 202L, 314L, 4L, 5L,
-                10104L, 203L, 315L, 4L, 5L,
-                102L, 204L, 316L, 4L, 5L),
-                splittingTablets.calcNewVirtualBuckets(List.of(
-                        101L, 2L, 301L, 4L, 5L,
-                        102L, 2L, 302L, 4L, 5L,
-                        101L, 2L, 303L, 4L, 5L,
-                        102L, 2L, 304L, 4L, 5L,
-                        101L, 2L, 305L, 4L, 5L,
-                        102L, 2L, 306L, 4L, 5L,
-                        101L, 2L, 307L, 4L, 5L,
-                        102L, 2L, 308L, 4L, 5L,
-                        101L, 2L, 309L, 4L, 5L,
-                        102L, 2L, 310L, 4L, 5L,
-                        101L, 2L, 311L, 4L, 5L,
-                        102L, 2L, 312L, 4L, 5L,
-                        101L, 2L, 313L, 4L, 5L,
-                        102L, 2L, 314L, 4L, 5L,
-                        101L, 2L, 315L, 4L, 5L,
-                        102L, 2L, 316L, 4L, 5L)));
+            Assertions.assertEquals(List.of(
+                    10101L, 201L, 301L, 4L, 5L,
+                    102L, 202L, 302L, 4L, 5L,
+                    10102L, 203L, 303L, 4L, 5L,
+                    102L, 204L, 304L, 4L, 5L,
+                    10103L, 201L, 305L, 4L, 5L,
+                    102L, 202L, 306L, 4L, 5L,
+                    10104L, 203L, 307L, 4L, 5L,
+                    102L, 204L, 308L, 4L, 5L,
+                    10101L, 201L, 309L, 4L, 5L,
+                    102L, 202L, 310L, 4L, 5L,
+                    10102L, 203L, 311L, 4L, 5L,
+                    102L, 204L, 312L, 4L, 5L,
+                    10103L, 201L, 313L, 4L, 5L,
+                    102L, 202L, 314L, 4L, 5L,
+                    10104L, 203L, 315L, 4L, 5L,
+                    102L, 204L, 316L, 4L, 5L),
+                    splittingTablets.calcNewVirtualBuckets(List.of(
+                            101L, 2L, 301L, 4L, 5L,
+                            102L, 2L, 302L, 4L, 5L,
+                            101L, 2L, 303L, 4L, 5L,
+                            102L, 2L, 304L, 4L, 5L,
+                            101L, 2L, 305L, 4L, 5L,
+                            102L, 2L, 306L, 4L, 5L,
+                            101L, 2L, 307L, 4L, 5L,
+                            102L, 2L, 308L, 4L, 5L,
+                            101L, 2L, 309L, 4L, 5L,
+                            102L, 2L, 310L, 4L, 5L,
+                            101L, 2L, 311L, 4L, 5L,
+                            102L, 2L, 312L, 4L, 5L,
+                            101L, 2L, 313L, 4L, 5L,
+                            102L, 2L, 314L, 4L, 5L,
+                            101L, 2L, 315L, 4L, 5L,
+                            102L, 2L, 316L, 4L, 5L)));
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
To initiate a split tablet job, when need a split tablet job factory to create split tablet job.
This pr Implement split tablet job factory to create split tablet job.
Split tablet job factory is responsible for the following:
1. Create dynamic tablet for tablets to be split.
2. Create new shards for new tablets.
3. If all ok, create split tablet job.

## What I'm doing:
 Implement split tablet job factory for dynamic tablet splitting and merging.

Fixes https://github.com/StarRocks/starrocks/issues/59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
