### PR TITLE
[BugFix] Fix MaterializedView gsonPostProcess result

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -666,11 +666,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
         waitForSchemaChangeAlterJobFinish(job.get());
 
         Assertions.assertEquals(QueryState.MysqlStateType.OK, connectContext.getState().getStateType());
-    }
 
-    @Test
-    public void testShowMVWithIndex() throws Exception {
-        testAlterMVWithIndex();
         String showCreateSql = "show create materialized view test.index_mv_to_check;";
         ShowCreateTableStmt showCreateTableStmt =
                     (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateSql, connectContext);
@@ -1116,5 +1112,52 @@ public class MaterializedViewTest extends StarRocksTestBase {
         Assertions.assertEquals(2, baseMv.getRelatedMaterializedViews().size());
         Assertions.assertTrue(baseMv.getRelatedMaterializedViews().contains(mv1.getMvId()));
         Assertions.assertTrue(baseMv.getRelatedMaterializedViews().contains(mv2.getMvId()));
+    }
+
+    @Test
+    public void testGsonPrePostProcess() throws Exception {
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE base_table\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withMaterializedView("CREATE MATERIALIZED VIEW base_mv\n" +
+                        "PARTITION BY k1\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "REFRESH manual\n" +
+                        "as select k1,k2,v1 from base_table;")
+                .withMaterializedView("CREATE MATERIALIZED VIEW mv1\n" +
+                        "PARTITION BY k1\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "REFRESH manual\n" +
+                        "as select k1,k2,v1 from base_mv;")
+                .withMaterializedView("CREATE MATERIALIZED VIEW mv2\n" +
+                        "PARTITION BY k1\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "REFRESH manual\n" +
+                        "as select k1,k2,v1 from base_mv;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView baseMv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "base_mv"));
+        Assertions.assertTrue(baseMv.getPartitionExprMaps().size() == 1);
+        baseMv.gsonPreProcess();
+        baseMv.gsonPostProcess();
+        Assertions.assertTrue(baseMv.getPartitionExprMaps().size() == 1);
+
+        MaterializedView mv1 = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "mv1"));
+        Assertions.assertTrue(mv1.getPartitionExprMaps().size() == 1);
+        baseMv.gsonPreProcess();
+        baseMv.gsonPostProcess();
+        Assertions.assertTrue(mv1.getPartitionExprMaps().size() == 1);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
MV rewrite will fail if there are multi FEs.

`partitionExprMaps` was initialized twice, because they are associated with partition columns, in some cases its wrong size will cause unexpected results.
```
   partitionExprMaps = Maps.newLinkedHashMap();
        if (serializedPartitionRefTableExprs != null) {
            for (ExpressionSerializedObject expressionSql : serializedPartitionRefTableExprs) {
                Expr partitionExpr = parsePartitionExpr(expressionSql.getExpressionSql());
                if (partitionExpr == null) {
                    LOG.warn("parse partition expr failed, sql: {}", expressionSql.getExpressionSql());
                    continue;
                }
                partitionRefTableExprs.add(partitionExpr);
                // for compatibility
                SlotRef partitionSlotRef = getMvPartitionSlotRef(partitionExpr);
                partitionExprMaps.put(partitionExpr, partitionSlotRef);
            }
        }

        // for multi ref base tables, recover from serializedPartitionExprMaps
        if (serializedPartitionExprMaps != null) {
            for (Map.Entry<ExpressionSerializedObject, ExpressionSerializedObject> entry :
                    serializedPartitionExprMaps.entrySet()) {
                if (entry.getKey() != null && entry.getValue() != null) {
                    Expr partitionExpr = parsePartitionExpr(entry.getKey().getExpressionSql());
                    if (partitionExpr == null) {
                        LOG.warn("parse partition expr failed, sql: {}", entry.getKey().getExpressionSql());
                        continue;
                    }
                    SlotRef partitionSlotRef = getMvPartitionSlotRef(partitionExpr);
                    partitionExprMaps.put(partitionExpr, partitionSlotRef);
                }
            }
        }
```
## What I'm doing:
`partitionExprMaps` should not be initialized twice, otherwise  mv's partition columns may be wrong.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
