### PR TITLE
[BugFix] erase partition from partiton_map when partiton_ids is empty

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -762,4 +762,17 @@ void OlapTablePartitionParam::_compute_hashes(const Chunk* chunk, std::vector<ui
     }
 }
 
+Status OlapTablePartitionParam::test_add_partitions(OlapTablePartition* partition) {
+    _partitions[partition->id] = partition;
+    std::vector<int64_t> part_ids{partition->id};
+    if (partition->in_keys.empty()) {
+        _partitions_map[&(partition->end_key)] = part_ids;
+    } else {
+        for (auto& in_key : partition->in_keys) {
+            _partitions_map[&in_key] = part_ids;
+        }
+    }
+    return Status::OK();
+}
+
 } // namespace starrocks

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -575,7 +575,7 @@ Status OlapTablePartitionParam::remove_partitions(const std::vector<int64_t>& pa
                 auto& part_ids = _partitions_map[&in_key];
                 part_ids.erase(std::remove(part_ids.begin(), part_ids.end(), id), part_ids.end());
                 if (part_ids.empty()) {
-                    _partitions_map.erase(&part->end_key);
+                    _partitions_map.erase(&in_key);
                 }
             }
         }

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -567,10 +567,16 @@ Status OlapTablePartitionParam::remove_partitions(const std::vector<int64_t>& pa
         if (part->in_keys.empty()) {
             auto& part_ids = _partitions_map[&part->end_key];
             part_ids.erase(std::remove(part_ids.begin(), part_ids.end(), id), part_ids.end());
+            if (part_ids.empty()) {
+                _partitions_map.erase(&part->end_key);
+            }
         } else {
             for (auto& in_key : part->in_keys) {
                 auto& part_ids = _partitions_map[&in_key];
                 part_ids.erase(std::remove(part_ids.begin(), part_ids.end(), id), part_ids.end());
+                if (part_ids.empty()) {
+                    _partitions_map.erase(&part->end_key);
+                }
             }
         }
 

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -270,6 +270,8 @@ public:
 
     const TOlapTablePartitionParam& param() const { return _t_param; }
 
+    Status test_add_partitions(OlapTablePartition* partition);
+
 private:
     /**
      * @brief  find tablets with range partition table

--- a/be/test/exec/tablet_info_test.cpp
+++ b/be/test/exec/tablet_info_test.cpp
@@ -195,4 +195,42 @@ TEST_F(OlapTablePartitionParamTest, NodesInfo) {
     }
 }
 
+TEST_F(OlapTablePartitionParamTest, removePartition) {
+    Columns columns;
+    for (size_t i = 0; i < 2; i++) {
+        auto column = FixedLengthColumn<int32_t>::create();
+        for (int j = 0; j < 5; j++) {
+            column->append(j);
+        }
+        columns.emplace_back(column);
+    }
+    ChunkRow row1(&columns, 0);
+    ChunkRow row2(&columns, 1);
+    ChunkRow row3(&columns, 2);
+
+    OlapTablePartition partition1;
+    partition1.id = 10;
+
+    OlapTablePartition partition2;
+    partition2.id = 11;
+    partition2.end_key = row1;
+
+    OlapTablePartition partition3;
+    partition3.id = 12;
+    partition3.in_keys.push_back(row2);
+
+    TDescriptorTable t_desc_tbl;
+    auto t_schema = get_schema(&t_desc_tbl);
+    std::shared_ptr<OlapTableSchemaParam> schema(new OlapTableSchemaParam());
+    TOlapTablePartitionParam t_partition_param;
+    OlapTablePartitionParam part(schema, t_partition_param);
+
+    ASSERT_TRUE(part.test_add_partitions(&partition1).ok());
+    ASSERT_TRUE(part.remove_partitions({10}).ok());
+
+    ASSERT_TRUE(part.test_add_partitions(&partition2).ok());
+    ASSERT_TRUE(part.test_add_partitions(&partition3).ok());
+    ASSERT_TRUE(part.remove_partitions({11, 12}).ok());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
SIGFPE with the following stack trace.
```
*** Aborted at 1752213367 (unix time) try "date -d @1752213367" if you are using GNU date ***
PC: @          0x40e0704 starrocks::OlapTablePartitionParam::_find_tablets_with_range_partition(starrocks::Chunk*, std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column> > >, std::vector<starrocks::OlapTablePartition*, std::allocator<starPW^K^S
*** SIGFPE (@0x40e0704) received by PID 123653 (TID 0x154d6a496640) from PID 68028164; stack trace: ***
    @     0x15523ca8ef38 __pthread_once_slow
    @          0x7dbe140 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x15523da2b9b9 os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x15523da31c7a JVM_handle_linux_signal
    @     0x15523da23a4c signalHandler(int, siginfo_t*, void*)
    @     0x15523ca3e730 (/usr/lib64/libc.so.6+0x3e72f)
    @          0x40e0704 starrocks::OlapTablePartitionParam::_find_tablets_with_range_partition(starrocks::Chunk*, std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column> > >, std::vector<starrocks::OlapTablePartition*, std::allocator<starPW^K^S
    @          0x40e2eb9 starrocks::OlapTablePartitionParam::find_tablets(starrocks::Chunk*, std::vector<starrocks::OlapTablePartition*, std::allocator<starrocks::OlapTablePartition*> >*, std::vector<unsigned int, std::allocator<unsigned int> >*, std::vector<unsigned char, std::alPW^K^S
    @          0x40f71ae starrocks::OlapTableSink::_send_chunk(starrocks::RuntimeState*, starrocks::Chunk*, bool)
    @          0x40f7898 starrocks::OlapTableSink::send_chunk_nonblocking(starrocks::RuntimeState*, starrocks::Chunk*)
    @          0x4460cc7 starrocks::pipeline::OlapTableSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0x44f04e4 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x47b35f3 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x398b053 starrocks::ThreadPool::dispatch_thread()
    @          0x3983296 starrocks::Thread::supervise_thread(void*)
    @     0x15523ca89d22 start_thread
```

## What I'm doing:
when we remove physical partition id from `_partition_map` and physical partition set is empty, we should remove the element from `_partition_map`


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
