### PR TITLE
[Enhancement] Support parquet version in files unload

### DIFF
--- a/be/src/formats/parquet/parquet_file_writer.h
+++ b/be/src/formats/parquet/parquet_file_writer.h
@@ -95,9 +95,11 @@ struct ParquetWriterOptions : FileWriterOptions {
     std::string time_zone = TimezoneUtils::default_time_zone;
     bool use_legacy_decimal_encoding = false;
     bool use_int96_timestamp_encoding = false;
+    ::parquet::ParquetVersion::type version = ::parquet::ParquetVersion::PARQUET_2_6;
 
     inline static std::string USE_LEGACY_DECIMAL_ENCODING = "use_legacy_decimal_encoding";
     inline static std::string USE_INT96_TIMESTAMP_ENCODING = "use_int96_timestamp_encoding";
+    inline static std::string VERSION = "version";
 };
 
 class ParquetFileWriter final : public FileWriter {

--- a/be/src/runtime/table_function_table_sink.cpp
+++ b/be/src/runtime/table_function_table_sink.cpp
@@ -114,6 +114,9 @@ Status TableFunctionTableSink::decompose_to_pipeline(pipeline::OpFactories prev_
         sink_ctx->options[formats::ParquetWriterOptions::USE_LEGACY_DECIMAL_ENCODING] = "true";
         sink_ctx->options[formats::ParquetWriterOptions::USE_INT96_TIMESTAMP_ENCODING] = "true";
     }
+    if (target_table.__isset.parquet_options && target_table.parquet_options.__isset.version) {
+        sink_ctx->options[formats::ParquetWriterOptions::VERSION] = target_table.parquet_options.version;
+    }
 
     auto connector = connector::ConnectorManager::default_instance()->get(connector::Connector::FILE);
     auto sink_provider = connector->create_data_sink_provider();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -337,4 +337,25 @@ public class TableFunctionTableTest {
                 "Delimiter cannot be empty or null",
                 () -> new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable()));
     }
+
+    @Test
+    public void testParquetVersion() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("path", "file://path");
+        properties.put("format", "parquet");
+
+        // normal
+        TableFunctionTable table = new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable());
+        Assertions.assertEquals("2.6", Deencapsulation.getField(table, "parquetVersion"));
+
+        properties.put("parquet.version", "1.0");
+        table = new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable());
+        Assertions.assertEquals("1.0", Deencapsulation.getField(table, "parquetVersion"));
+
+        // abnormal
+        properties.put("parquet.version", "2.0");
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                "Invalid parquet.version: '2.0'. Expected values should be 2.4, 2.6, 1.0",
+                () -> new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable()));
+    }
 }

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -77,13 +77,6 @@ enum TResultSinkFormatType {
     OTHERS
 }
 
-struct TParquetOptions {
-    // parquet row group max size in bytes
-    1: optional i64 parquet_max_group_bytes
-    2: optional Types.TCompressionType compression_type
-    3: optional bool use_dict
-}
-
 struct TResultFileSinkOptions {
     1: required string file_path
     2: required PlanNodes.TFileFormatType file_format
@@ -99,7 +92,7 @@ struct TResultFileSinkOptions {
     9: optional i32 hdfs_write_buffer_size_kb = 0
     // properties from hdfs-site.xml, core-site.xml and load_properties
     10: optional PlanNodes.THdfsProperties hdfs_properties
-    11: optional TParquetOptions parquet_options
+    11: optional Types.TParquetOptions parquet_options
     12: optional list<string> file_column_names
 }
 

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -488,6 +488,7 @@ struct TTableFunctionTable {
     9: optional string csv_column_seperator
 
     10: optional bool parquet_use_legacy_encoding
+    11: optional Types.TParquetOptions parquet_options
 }
 
 struct TIcebergSchemaField {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -617,3 +617,12 @@ enum TNodeType {
     Backend = 0,
     Compute = 1
 }
+
+struct TParquetOptions {
+    // parquet row group max size in bytes
+    1: optional i64 parquet_max_group_bytes
+    2: optional TCompressionType compression_type
+    3: optional bool use_dict
+    // for files table function
+    4: optional string version
+}

--- a/test/sql/test_sink/R/test_files_sink_parquet_version
+++ b/test/sql/test_sink/R/test_files_sink_parquet_version
@@ -1,0 +1,81 @@
+-- name: test_files_sink_parquet_version
+
+create database db_${uuid0};
+use db_${uuid0};
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+insert into files(
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/",
+    "format" = "parquet",
+    "parquet.version" = "2.6",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+select 1 as int_col, "abc" as string_col, cast("123.456" as decimal(16,3)) as decimal_col, cast("2025-07-11" as date) as date_col;
+-- result:
+-- !result
+
+select * from files(
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+1	abc	123.456	2025-07-11
+-- !result
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/ > /dev/null
+
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+insert into files(
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/",
+    "format" = "parquet",
+    "parquet.version" = "2.4",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+select 1 as int_col, "abc" as string_col, cast("123.456" as decimal(16,3)) as decimal_col, cast("2025-07-11" as date) as date_col;
+-- result:
+-- !result
+
+select * from files(
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+1	abc	123.456	2025-07-11
+-- !result
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/ > /dev/null
+
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+insert into files(
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/",
+    "format" = "parquet",
+    "parquet.version" = "1.0",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+select 1 as int_col, "abc" as string_col, cast("123.456" as decimal(16,3)) as decimal_col, cast("2025-07-11" as date) as date_col;
+-- result:
+-- !result
+
+select * from files(
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+1	abc	123.456	2025-07-11
+-- !result
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/ > /dev/null

--- a/test/sql/test_sink/T/test_files_sink_parquet_version
+++ b/test/sql/test_sink/T/test_files_sink_parquet_version
@@ -1,0 +1,69 @@
+-- name: test_files_sink_parquet_version
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- version 2.6
+shell: ossutil64 mkdir oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+insert into files(
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/",
+    "format" = "parquet",
+    "parquet.version" = "2.6",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+select 1 as int_col, "abc" as string_col, cast("123.456" as decimal(16,3)) as decimal_col, cast("2025-07-11" as date) as date_col;
+
+select * from files(
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/ > /dev/null
+
+
+-- version 2.4
+shell: ossutil64 mkdir oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+insert into files(
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/",
+    "format" = "parquet",
+    "parquet.version" = "2.4",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+select 1 as int_col, "abc" as string_col, cast("123.456" as decimal(16,3)) as decimal_col, cast("2025-07-11" as date) as date_col;
+
+select * from files(
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/ > /dev/null
+
+
+-- version 1.0
+shell: ossutil64 mkdir oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+insert into files(
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/",
+    "format" = "parquet",
+    "parquet.version" = "1.0",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+select 1 as int_col, "abc" as string_col, cast("123.456" as decimal(16,3)) as decimal_col, cast("2025-07-11" as date) as date_col;
+
+select * from files(
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink_parquet_version/${uuid0}/ > /dev/null


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Parquet files written with version 2.6 may not be readable in all parquet implementations, so support parquet version 1.0 in files unload to maximize file compatibility.

The default version is 2.6, same as before.
Supports version 1.0, 2.4 and 2.6.

```
insert into files("path" = "s3://bucket/path/", "format" = "parquet", "parquet.version" = "1.0") 
select * from table
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
