### PR TITLE
[BugFix] incorrect expression in zonemap filters

### DIFF
--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -545,7 +545,7 @@ StatusOr<ColumnPredicate*> StructColumnReader::_try_to_rewrite_subfield_expr(
     subfield_output->insert(subfield_output->end(), subfields[0].begin(), subfields[0].end());
 
     // check subfield expr has only one child, and it's a SlotRef
-    if (subfield_expr->children().size() != 1 && !subfield_expr->get_child(0)->is_slotref()) {
+    if (subfield_expr->children().size() != 1 || !subfield_expr->get_child(0)->is_slotref()) {
         return Status::InternalError("Invalid pattern for predicate");
     }
 


### PR DESCRIPTION
regression introduced in #53967

available in 3.5, backported to 3.4
3.3 doesn't have bug 

`!(expr1 && expr2)` have to be transformed into `!expr1 || !expr2`
not like it happens in pr `!expr1 && !expr2`

otherwise we will use incorrect expression a top of scalar column

## Why I'm doing:

in #53967 we introduce zonemap filtering for struct column
but it contain bug 

failed query
```
select x
from y
where x.field1[1].field2
```

```cpp
    // check subfield expr has only one child, and it's a SlotRef
    if (subfield_expr->children().size() != 1 && !subfield_expr->get_child(0)->is_slotref()) {
        return Status::InternalError("Invalid pattern for predicate");
    }
```

`subfield_expr->children().size() != 1`  - `false`
`!subfield_expr->get_child(0)->is_slotref()` - `true`, because it will be array access

whole expression also `false` and execution continued
now we expect, because we want 

```
// Rewrite ColumnExprPredicate which contains subfield expr and put subfield path into subfield_output
// For example, WHERE col.a.b.c > 5, a.b.c is subfields, we will rewrite it to c > 5
```
but still have `[1].field2`

## What I'm doing:

fix expression logic

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
