### PR TITLE
[Enhancement] add a rule to rewrite from_unixtime function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -89,6 +89,7 @@ public class FunctionSet {
     public static final String FROM_UNIXTIME = "from_unixtime";
     public static final String FROM_UNIXTIME_MS = "from_unixtime_ms";
     public static final String HOUR = "hour";
+    public static final String HOUR_FROM_UNIXTIME = "hour_from_unixtime";
     public static final String MINUTE = "minute";
     public static final String MONTH = "month";
     public static final String MONTHNAME = "monthname";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -393,6 +393,8 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
             return simplifiedCoalesce(call);
         } else if (FunctionSet.JSON_QUERY.equalsIgnoreCase(call.getFnName())) {
             return simplifiedJsonQuery(call);
+        } else if (FunctionSet.HOUR.equalsIgnoreCase(call.getFnName())) {
+            return simplifiedHourFromUnixTime(call);
         }
         return call;
     }
@@ -572,5 +574,40 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
         String mergePath = path1 + (StringUtils.isBlank(path2) ? "" : "." + path2);
         return new CallOperator(child.getFnName(), call.getType(), Lists.newArrayList(child.getChild(0),
                 ConstantOperator.createVarchar(mergePath)), child.getFunction());
+    }
+
+    // Simplify hour(from_unixtime(ts)) to hour_from_unixtime(ts)
+    private static ScalarOperator simplifiedHourFromUnixTime(CallOperator call) {
+        if (call.getChildren().size() != 1) {
+            return call;
+        }
+
+        ScalarOperator child = call.getChild(0);
+        if (!(child instanceof CallOperator)) {
+            return call;
+        }
+
+        CallOperator childCall = (CallOperator) child;
+        if (!FunctionSet.FROM_UNIXTIME.equalsIgnoreCase(childCall.getFnName())) {
+            return call;
+        }
+
+        // Create hour_from_unixtime function call
+        Type[] argTypes = childCall.getChildren().stream().map(ScalarOperator::getType).toArray(Type[]::new);
+        Function fn =
+                Expr.getBuiltinFunction(FunctionSet.HOUR_FROM_UNIXTIME, argTypes, Function.CompareMode.IS_IDENTICAL);
+
+        if (fn == null) {
+            return call;
+        }
+
+        if (childCall.getChildren().stream().anyMatch(s -> s.getType().isDecimalV3())) {
+            Function decimalFn = ScalarFunction.createVectorizedBuiltin(fn.getId(), fn.getFunctionName().getFunction(),
+                    Arrays.stream(argTypes).collect(Collectors.toList()), fn.hasVarArgs(), call.getType());
+            decimalFn.setCouldApplyDictOptimize(fn.isCouldApplyDictOptimize());
+            return new CallOperator(FunctionSet.HOUR_FROM_UNIXTIME, call.getType(), childCall.getChildren(), decimalFn);
+        }
+
+        return new CallOperator(FunctionSet.HOUR_FROM_UNIXTIME, call.getType(), childCall.getChildren(), fn);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -601,13 +601,6 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
             return call;
         }
 
-        if (childCall.getChildren().stream().anyMatch(s -> s.getType().isDecimalV3())) {
-            Function decimalFn = ScalarFunction.createVectorizedBuiltin(fn.getId(), fn.getFunctionName().getFunction(),
-                    Arrays.stream(argTypes).collect(Collectors.toList()), fn.hasVarArgs(), call.getType());
-            decimalFn.setCouldApplyDictOptimize(fn.isCouldApplyDictOptimize());
-            return new CallOperator(FunctionSet.HOUR_FROM_UNIXTIME, call.getType(), childCall.getChildren(), decimalFn);
-        }
-
         return new CallOperator(FunctionSet.HOUR_FROM_UNIXTIME, call.getType(), childCall.getChildren(), fn);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Following #60331, the `hour(from_unixtime(ts))` function can be updated to `hour_from_unixtime(ts)` for improved performance.



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
