### PR TITLE
[BugFix] Change KEYWORD to WORD to comply with MySQL's standard definition

### DIFF
--- a/be/src/exec/schema_scanner/schema_keywords_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_keywords_scanner.cpp
@@ -25,7 +25,7 @@ namespace starrocks {
 
 SchemaScanner::ColumnDesc SchemaKeywordsScanner::_s_columns[] = {
         //   name,       type,          size,     is_null
-        {"KEYWORD", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
+        {"WORD", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
         {"RESERVED", TypeDescriptor::from_logical_type(TYPE_BOOLEAN), sizeof(bool), false},
 };
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/KeywordsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/KeywordsSystemTable.java
@@ -31,7 +31,7 @@ public class KeywordsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("KEYWORD", ScalarType.createVarchar(128))
+                        .column("WORD", ScalarType.createVarchar(128))
                         .column("RESERVED", ScalarType.createType(PrimitiveType.BOOLEAN))
                         .build(),
                 TSchemaTableType.SCH_KEYWORDS);

--- a/test/sql/test_information_schema/R/test_keywords
+++ b/test/sql/test_information_schema/R/test_keywords
@@ -6,10 +6,10 @@ USE db_${uuid0};
 -- result:
 -- !result
 
-SELECT * FROM information_schema.keywords ORDER BY keyword ASC;
+SELECT * FROM information_schema.keywords ORDER BY word ASC;
 -- result:
 -- !result
--- KEYWORD  | RESERVED
+-- WORD  | RESERVED
 -- ---------|---------
 -- DELETE   | true
 -- INDEX    | true
@@ -21,41 +21,41 @@ SELECT * FROM information_schema.keywords ORDER BY keyword ASC;
 -- USER     | false
 -- VIEW     | true
 
-SELECT * FROM information_schema.keywords WHERE RESERVED = true ORDER BY keyword ASC;
+SELECT * FROM information_schema.keywords WHERE RESERVED = true ORDER BY word ASC;
 -- result:
 -- !result
 
-SELECT * FROM information_schema.keywords WHERE RESERVED = false ORDER BY keyword ASC;
+SELECT * FROM information_schema.keywords WHERE RESERVED = false ORDER BY word ASC;
 -- result:
 -- !result
 
-SELECT * FROM information_schema.keywords ORDER BY keyword ASC LIMIT 3 OFFSET 2;
+SELECT * FROM information_schema.keywords ORDER BY word ASC LIMIT 3 OFFSET 2;
 -- result:
 -- !result
 
-SELECT * FROM information_schema.keywords WHERE keyword LIKE 'S%' ORDER BY keyword ASC;
+SELECT * FROM information_schema.keywords WHERE word LIKE 'S%' ORDER BY word ASC;
 -- result:
 -- !result
 
-SELECT * FROM information_schema.keywords WHERE keyword IN ('SELECT', 'USER', 'TABLE') ORDER BY keyword ASC;
+SELECT * FROM information_schema.keywords WHERE word IN ('SELECT', 'USER', 'TABLE') ORDER BY word ASC;
 -- result:
 -- !result
 
-SELECT * FROM information_schema.keywords ORDER BY RESERVED DESC, keyword ASC;
+SELECT * FROM information_schema.keywords ORDER BY RESERVED DESC, word ASC;
 -- result:
 -- !result
 
 ADMIN SET FRONTEND CONFIG("max_get_partitions_meta_result_count" = "1");
 -- result:
 -- !result
-SELECT * FROM information_schema.keywords ORDER BY keyword ASC;
+SELECT * FROM information_schema.keywords ORDER BY word ASC;
 -- result:
 -- !result
 ADMIN SET FRONTEND CONFIG("max_get_partitions_meta_result_count" = "100000");
 -- result:
 -- !result
 
-SELECT * FROM information_schema.keywords WHERE keyword = 'NON_EXISTENT_KEYWORD';
+SELECT * FROM information_schema.keywords WHERE word = 'NON_EXISTENT_KEYWORD';
 -- result:
 -- !result
 

--- a/test/sql/test_information_schema/T/test_keywords
+++ b/test/sql/test_information_schema/T/test_keywords
@@ -1,15 +1,15 @@
 -- name: test_keywords_system_table
 CREATE DATABASE db_${uuid0};
 USE db_${uuid0};
-SELECT * FROM information_schema.keywords ORDER BY keyword ASC;
-SELECT * FROM information_schema.keywords WHERE RESERVED = true ORDER BY keyword ASC;
-SELECT * FROM information_schema.keywords WHERE RESERVED = false ORDER BY keyword ASC;
-SELECT * FROM information_schema.keywords ORDER BY keyword ASC LIMIT 3 OFFSET 2;
-SELECT * FROM information_schema.keywords WHERE keyword LIKE 'S%' ORDER BY keyword ASC;
-SELECT * FROM information_schema.keywords WHERE keyword IN ('SELECT', 'USER', 'TABLE') ORDER BY keyword ASC;
-SELECT * FROM information_schema.keywords ORDER BY RESERVED DESC, keyword ASC;
+SELECT * FROM information_schema.keywords ORDER BY word ASC;
+SELECT * FROM information_schema.keywords WHERE RESERVED = true ORDER BY word ASC;
+SELECT * FROM information_schema.keywords WHERE RESERVED = false ORDER BY word ASC;
+SELECT * FROM information_schema.keywords ORDER BY word ASC LIMIT 3 OFFSET 2;
+SELECT * FROM information_schema.keywords WHERE word LIKE 'S%' ORDER BY word ASC;
+SELECT * FROM information_schema.keywords WHERE word IN ('SELECT', 'USER', 'TABLE') ORDER BY word ASC;
+SELECT * FROM information_schema.keywords ORDER BY RESERVED DESC, word ASC;
 ADMIN SET FRONTEND CONFIG("max_get_partitions_meta_result_count" = "1");
-SELECT * FROM information_schema.keywords ORDER BY keyword ASC;
+SELECT * FROM information_schema.keywords ORDER BY word ASC;
 ADMIN SET FRONTEND CONFIG("max_get_partitions_meta_result_count" = "100000");
 DROP USER IF EXISTS test_user;
 CREATE USER test_user IDENTIFIED BY 'password';


### PR DESCRIPTION
## Why I'm doing:
Change KEYWORD to WORD to comply with MySQL's standard definition. https://dev.mysql.com/doc/refman/8.0/en/information-schema-keywords-table.html

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
