### PR TITLE
[BugFix] Fix inconsistent implementations in url_extract_parameter

### DIFF
--- a/be/src/util/url_parser.cpp
+++ b/be/src/util/url_parser.cpp
@@ -74,14 +74,17 @@ bool UrlParser::parse_url(const Slice& url, UrlPart part, Slice* result) {
     std::string_view url_view = url;
     Slice trimmed_url = trim(url_view);
 
+    std::string_view protocol_end;
+
     // All parts require checking for the _s_protocol.
     int32_t protocol_pos = _s_protocol_search.search(trimmed_url);
     if (protocol_pos < 0) {
-        return false;
+        protocol_pos = 0;
+        protocol_end = trimmed_url;
+    } else {
+        // Positioned to first char after '://'.
+        protocol_end = std::string_view(trimmed_url).substr(protocol_pos + _s_protocol.size);
     }
-
-    // Positioned to first char after '://'.
-    auto protocol_end = std::string_view(trimmed_url).substr(protocol_pos + _s_protocol.size);
 
     switch (part) {
     case AUTHORITY: {

--- a/test/sql/test_url_extract_parameter/R/test_url_extract_parameter
+++ b/test/sql/test_url_extract_parameter/R/test_url_extract_parameter
@@ -330,3 +330,24 @@ select (case only_null when true then url_extract_parameter('https://starrocks.c
 -- result:
 1
 -- !result
+create table t_url_extract_parameter(c0 varchar(200), c1 varchar(200))
+        DUPLICATE KEY(c0)
+        DISTRIBUTED BY HASH(c0)
+        BUCKETS 1
+        PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+insert into t_url_extract_parameter values ('http://host:80/123?k=1&v=1', 'k'), ('/123?k=1&v=1', 'v'), ('', 'k'), ('','');
+-- result:
+-- !result
+select c0, c1, url_extract_parameter(c0, c1) from t_url_extract_parameter order by 1,2;
+-- result:
+		None
+	k	None
+/123?k=1&v=1	v	1
+http://host:80/123?k=1&v=1	k	1
+-- !result
+select url_extract_parameter('http://host:80/123?k=1&v=1', 'k'), url_extract_parameter('/123?k=1&v=1', 'v'), url_extract_parameter('', 'k'), url_extract_parameter('','');
+-- result:
+1	1	None	None
+-- !result

--- a/test/sql/test_url_extract_parameter/T/test_url_extract_parameter
+++ b/test/sql/test_url_extract_parameter/T/test_url_extract_parameter
@@ -109,3 +109,12 @@ select (case only_null when true then url_extract_parameter(url, param_key) is N
 select (case only_null when true then url_extract_parameter('https://starrocks.com/doc?k0=10&k1=%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%22%25%2D%2E%3C%3E%5C%5E%5F%60%7B%7C%7D%7E&k2', param_key) is NULL else url_extract_parameter('https://starrocks.com/doc?k0=10&k1=%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%22%25%2D%2E%3C%3E%5C%5E%5F%60%7B%7C%7D%7E&k2', param_key) = expect end) as result from t0 where id = 17;
 select (case only_null when true then url_extract_parameter(url, 'k1') is NULL else url_extract_parameter(url, 'k1') = expect end) as result from t0 where id = 17;
 select (case only_null when true then url_extract_parameter('https://starrocks.com/doc?k0=10&k1=%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%22%25%2D%2E%3C%3E%5C%5E%5F%60%7B%7C%7D%7E&k2', 'k1') is NULL else url_extract_parameter('https://starrocks.com/doc?k0=10&k1=%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%22%25%2D%2E%3C%3E%5C%5E%5F%60%7B%7C%7D%7E&k2', 'k1') = expect end) as result from t0 where id = 17;
+
+create table t_url_extract_parameter(c0 varchar(200), c1 varchar(200))
+        DUPLICATE KEY(c0)
+        DISTRIBUTED BY HASH(c0)
+        BUCKETS 1
+        PROPERTIES('replication_num'='1');
+insert into t_url_extract_parameter values ('http://host:80/123?k=1&v=1', 'k'), ('/123?k=1&v=1', 'v'), ('', 'k'), ('','');
+select c0, c1, url_extract_parameter(c0, c1) from t_url_extract_parameter order by 1,2;
+select url_extract_parameter('http://host:80/123?k=1&v=1', 'k'), url_extract_parameter('/123?k=1&v=1', 'v'), url_extract_parameter('', 'k'), url_extract_parameter('','');


### PR DESCRIPTION
## Why I'm doing:

BE needs to treat the relative URL as a legal URL.

## What I'm doing:

Fixes #60446

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
