### PR TITLE
[BugFix] efficiently handle error string truncating

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -896,13 +896,15 @@ void OlapTableSink::_print_varchar_error_msg(RuntimeState* state, const Slice& s
     if (state->has_reached_max_error_msg_num()) {
         return;
     }
-    std::string error_str = str.to_string();
-    if (error_str.length() > 100) {
-        error_str = error_str.substr(0, 100);
+    std::string error_str;
+    if (str.get_size() > 100) {
+        error_str.assign(str.get_data(), 100);
         error_str.append("...");
+    } else {
+        error_str = str.to_string();
     }
     std::string error_msg = strings::Substitute("String '$0'(length=$1) is too long. The max length of '$2' is $3",
-                                                error_str, str.size, desc->col_name(), desc->type().len);
+                                                error_str, str.get_size(), desc->col_name(), desc->type().len);
 #if BE_TEST
     LOG(INFO) << error_msg;
 #else


### PR DESCRIPTION
* truncate the string before convert to a std::string

## Why I'm doing:

```
W0713 17:45:07.945505 41413 mem_hook.cpp:90] large memory alloc, query_id:78472d5d-414e-ebb9-3edf-18733d316fb4 instance: 00000000-0000-0000-0000-000000000000 acquire:4294955590 bytes, stack:
    @          0x2f9d0f2  malloc
    @          0x915b765  operator new()
    @          0x373a583  std::__cxx11::basic_string<>::_M_construct<>()
    @          0x373b014  starrocks::stream_load::OlapTableSink::_print_varchar_error_msg()
    @          0x373fa75  starrocks::stream_load::OlapTableSink::_validate_data()
    @          0x374782a  starrocks::stream_load::OlapTableSink::send_chunk()
    @          0x2f5a50b  starrocks::PlanFragmentExecutor::_open_internal_vectorized()
    @          0x2f5cd81  starrocks::PlanFragmentExecutor::open()
    @          0x2ed4ceb  starrocks::FragmentExecState::execute()
    @          0x2edb5a8  starrocks::FragmentMgr::exec_actual()
    @          0x30542cc  starrocks::ThreadPool::dispatch_thread()
    @          0x304d0ea  starrocks::Thread::supervise_thread()
    @     0x2b3316651ea5  start_thread
    @     0x2b331728c96d  __clone
    @              (nil)  (unknown)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
