### PR TITLE
[BugFix] Fix NPE while missing setting globalStateMgr in `ConnectContext`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -35,6 +35,7 @@
 package com.starrocks.qe;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -218,8 +219,6 @@ public class ConnectContext {
     // Cache thread info for this connection.
     protected ThreadInfo threadInfo;
 
-    // GlobalStateMgr: put globalStateMgr here is convenient for unit test,
-    // because globalStateMgr is singleton, hard to mock
     protected GlobalStateMgr globalStateMgr;
     protected boolean isSend;
 
@@ -350,13 +349,15 @@ public class ConnectContext {
     }
 
     public ConnectContext(StreamConnection connection) {
+        // `globalStateMgr` is used in many cases, so we should explicitly make sure it is not null
+        globalStateMgr = GlobalStateMgr.getCurrentState();
         closed = false;
         state = new QueryState();
         returnRows = 0;
         serverCapability = MysqlCapability.DEFAULT_CAPABILITY;
         isKilled = false;
         serializer = MysqlSerializer.newInstance();
-        sessionVariable = GlobalStateMgr.getCurrentState().getVariableMgr().newSessionVariable();
+        sessionVariable = globalStateMgr.getVariableMgr().newSessionVariable();
         userVariables = new ConcurrentHashMap<>();
         command = MysqlCommand.COM_SLEEP;
         queryDetail = null;
@@ -460,6 +461,7 @@ public class ConnectContext {
     }
 
     public void setGlobalStateMgr(GlobalStateMgr globalStateMgr) {
+        Preconditions.checkState(globalStateMgr != null);
         this.globalStateMgr = globalStateMgr;
     }
 
@@ -491,9 +493,9 @@ public class ConnectContext {
         try {
             Set<Long> defaultRoleIds;
             if (GlobalVariable.isActivateAllRolesOnLogin()) {
-                defaultRoleIds = GlobalStateMgr.getCurrentState().getAuthorizationMgr().getRoleIdsByUser(user);
+                defaultRoleIds = globalStateMgr.getAuthorizationMgr().getRoleIdsByUser(user);
             } else {
-                defaultRoleIds = GlobalStateMgr.getCurrentState().getAuthorizationMgr().getDefaultRoleIdsByUser(user);
+                defaultRoleIds = globalStateMgr.getAuthorizationMgr().getDefaultRoleIdsByUser(user);
             }
             this.currentRoleIds = defaultRoleIds;
         } catch (PrivilegeException e) {
@@ -564,8 +566,8 @@ public class ConnectContext {
     }
 
     public void modifySystemVariable(SystemVariable setVar, boolean onlySetSessionVar) throws DdlException {
-        GlobalStateMgr.getCurrentState().getVariableMgr().setSystemVariable(sessionVariable, setVar, onlySetSessionVar);
-        if (!SetType.GLOBAL.equals(setVar.getType()) && GlobalStateMgr.getCurrentState().getVariableMgr()
+        globalStateMgr.getVariableMgr().setSystemVariable(sessionVariable, setVar, onlySetSessionVar);
+        if (!SetType.GLOBAL.equals(setVar.getType()) && globalStateMgr.getVariableMgr()
                 .shouldForwardToLeader(setVar.getVariable())) {
             modifiedSessionVariables.put(setVar.getVariable(), setVar);
         }
@@ -661,7 +663,7 @@ public class ConnectContext {
     }
 
     public void resetSessionVariable() {
-        this.sessionVariable = GlobalStateMgr.getCurrentState().getVariableMgr().newSessionVariable();
+        this.sessionVariable = globalStateMgr.getVariableMgr().newSessionVariable();
         modifiedSessionVariables.clear();
     }
 
@@ -1341,7 +1343,7 @@ public class ConnectContext {
     // Change current catalog of this session, and reset current database.
     // We can support "use 'catalog <catalog_name>'" from mysql client or "use catalog <catalog_name>" from jdbc.
     public void changeCatalog(String newCatalogName) throws DdlException {
-        CatalogMgr catalogMgr = GlobalStateMgr.getCurrentState().getCatalogMgr();
+        CatalogMgr catalogMgr = globalStateMgr.getCatalogMgr();
         if (!catalogMgr.catalogExists(newCatalogName)) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_CATALOG_ERROR, newCatalogName);
         }
@@ -1362,8 +1364,8 @@ public class ConnectContext {
     // For "CATALOG.DB", we change the current catalog database.
     // For "DB", we keep the current catalog and change the current database.
     public void changeCatalogDb(String identifier) throws DdlException {
-        CatalogMgr catalogMgr = GlobalStateMgr.getCurrentState().getCatalogMgr();
-        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        CatalogMgr catalogMgr = globalStateMgr.getCatalogMgr();
+        MetadataMgr metadataMgr = globalStateMgr.getMetadataMgr();
 
         String dbName;
 
@@ -1414,7 +1416,7 @@ public class ConnectContext {
         if (sessionId == null) {
             return;
         }
-        if (!GlobalStateMgr.getCurrentState().getTemporaryTableMgr().sessionExists(sessionId)) {
+        if (!globalStateMgr.getTemporaryTableMgr().sessionExists(sessionId)) {
             return;
         }
         LOG.debug("clean temporary table on session {}", sessionId);
@@ -1437,10 +1439,10 @@ public class ConnectContext {
             // set session variables
             Map<String, String> sessionVariables = userProperty.getSessionVariables();
             for (Map.Entry<String, String> entry : sessionVariables.entrySet()) {
-                String currentValue = GlobalStateMgr.getCurrentState().getVariableMgr().getValue(
+                String currentValue = globalStateMgr.getVariableMgr().getValue(
                         sessionVariable, new VariableExpr(entry.getKey()));
                 if (!currentValue.equalsIgnoreCase(
-                        GlobalStateMgr.getCurrentState().getVariableMgr().getDefaultValue(entry.getKey()))) {
+                        globalStateMgr.getVariableMgr().getDefaultValue(entry.getKey()))) {
                     // If the current session variable is not default value, we should respect it.
                     continue;
                 }
@@ -1450,7 +1452,7 @@ public class ConnectContext {
 
             // set catalog and database
             boolean dbHasBeenSetByUser = !getCurrentCatalog().equals(
-                    GlobalStateMgr.getCurrentState().getVariableMgr().getDefaultValue(SessionVariable.CATALOG))
+                    globalStateMgr.getVariableMgr().getDefaultValue(SessionVariable.CATALOG))
                     || !getDatabase().isEmpty();
             if (!dbHasBeenSetByUser) {
                 String catalog = userProperty.getCatalog();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
@@ -167,8 +167,6 @@ public class ConnectContextTest {
         Assertions.assertEquals(new TUniqueId(100, 200), ctx.getExecutionId());
 
         // GlobalStateMgr
-        Assertions.assertNull(ctx.getGlobalStateMgr());
-        ctx.setGlobalStateMgr(globalStateMgr);
         Assertions.assertNotNull(ctx.getGlobalStateMgr());
 
         // clean up
@@ -453,5 +451,23 @@ public class ConnectContextTest {
         ComputeResource resource = WarehouseComputeResource.of(1L);
         ctx.setCurrentComputeResource(resource);
         Assertions.assertEquals(resource, ctx.getCurrentComputeResourceNoAcquire());
+    }
+
+    @Test
+    public void testConnectContextNoGlobalStateMgrNPE() {
+        ConnectContext connectContext = ConnectContext.get();
+        if (connectContext == null) {
+            connectContext = new ConnectContext();
+            // not set globalStateMgr
+            connectContext.setThreadLocalInfo();
+        }
+        // ConnectContext.get() should have non-nullable globalStateMgr even if forget to manually create the context
+        // without setting globalStateMgr explicitly
+        Assertions.assertNotNull(ConnectContext.get().getGlobalStateMgr());
+
+        connectContext = ConnectContext.get();
+        // set globalStateMgr explicitly
+        connectContext.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        Assertions.assertNotNull(ConnectContext.get().getGlobalStateMgr());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExecuteAsStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExecuteAsStmtTest.java
@@ -27,8 +27,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.parser.AstBuilder;
 import com.starrocks.sql.parser.SqlParser;
 import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +49,10 @@ public class ExecuteAsStmtTest {
 
     @BeforeEach
     public void setUp() throws PrivilegeException {
-        new Expectations(globalStateMgr) {
+
+        SqlParser sqlParser = new SqlParser(AstBuilder.getInstance());
+        Analyzer analyzer = new Analyzer(Analyzer.AnalyzerVisitor.getInstance());
+        new Expectations() {
             {
                 GlobalStateMgr.getCurrentState().getAuthenticationMgr();
                 minTimes = 0;
@@ -63,25 +64,15 @@ public class ExecuteAsStmtTest {
             }
         };
 
-        new Expectations(ctx) {
+        new Expectations() {
             {
-                ctx.getGlobalStateMgr();
+                globalStateMgr.getSqlParser();
                 minTimes = 0;
-                result = globalStateMgr;
-            }
-        };
+                result = sqlParser;
 
-        SqlParser sqlParser = new SqlParser(AstBuilder.getInstance());
-        Analyzer analyzer = new Analyzer(Analyzer.AnalyzerVisitor.getInstance());
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            public SqlParser getSqlParser() {
-                return sqlParser;
-            }
-
-            @Mock
-            public Analyzer getAnalyzer() {
-                return analyzer;
+                globalStateMgr.getAnalyzer();
+                minTimes = 0;
+                result = analyzer;
             }
         };
     }
@@ -107,6 +98,7 @@ public class ExecuteAsStmtTest {
                 minTimes = 0;
             }
         };
+        ctx.setGlobalStateMgr(globalStateMgr);
 
         ExecuteAsStmt stmt = (ExecuteAsStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "execute as user1 with no revert", 1).get(0);


### PR DESCRIPTION
## Why I'm doing:

`ConnectContext` with current implementation is easily miss used. An example to produce NPE is as following:

1. Someone needs to use `ConnectContext`, but it has no aware of wether he should set that `globalStateMgr`first (In fact, he's right, he shouldn't care about this)
```java
        ConnectContext connectContext = ConnectContext.get();
        if (connectContext == null) {
            connectContext = new ConnectContext();
            // not set globalStateMgr property
            connectContext.setThreadLocalInfo();
        }
```

2. But after that, in some other place within same thread, code like following will produce NPE:
```java
ConnectContext.get().setCurrentWarehouseId(xxx);
```

Because `setCurrentWarehouseId()`'s implementation depends on `globalStateMgr` property in `ConnectConext`

## What I'm doing:

Make sure `globalStateMgr` is set in constructor of `ConnectConext` class, as many method in `ConnectConext` now depends on it.

Fixes #60879 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
