### PR TITLE
[Refactor] Use tablet id instead of lake tablet in warehouse manager

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -39,7 +39,6 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.LakeTableHelper;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
 import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.TxnInfoPB;
@@ -203,7 +202,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                     long rollupTabletId = rollupTablet.getId();
                     ComputeNode computeNode = null;
                     try {
-                        computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, (LakeTablet) rollupTablet);
+                        computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, rollupTabletId);
                     } catch (ErrorReportException e) {
                         // computeNode is null
                     }
@@ -323,7 +322,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
 
                     ComputeNode computeNode = null;
                     try {
-                        computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, (LakeTablet) rollupTablet);
+                        computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, rollupTabletId);
                     } catch (ErrorReportException e) {
                         // computeNode is null
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -34,7 +34,6 @@ import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeTable;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
 import com.starrocks.mv.MVRepairHandler.PartitionRepairInfo;
 import com.starrocks.proto.TxnInfoPB;
@@ -350,7 +349,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
 
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         for (Tablet tablet : tablets) {
-            Long backendId = warehouseManager.getAliveComputeNodeId(computeResource, (LakeTablet) tablet);
+            Long backendId = warehouseManager.getAliveComputeNodeId(computeResource, tablet.getId());
             if (backendId == null) {
                 throw new AlterCancelException("no alive node");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -56,7 +56,6 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.journal.JournalTask;
 import com.starrocks.lake.LakeTableHelper;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.gson.GsonUtils;
@@ -416,7 +415,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                     for (Tablet shadowTablet : shadowIdx.getTablets()) {
                         long shadowTabletId = shadowTablet.getId();
                         ComputeNode computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource,
-                                (LakeTablet) shadowTablet);
+                                shadowTabletId);
                         if (computeNode == null) {
                             //todo: fix the error message.
                             throw new AlterCancelException("No alive backend");
@@ -650,7 +649,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
 
                     for (Tablet shadowTablet : shadowIdx.getTablets()) {
                         ComputeNode computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource,
-                                (LakeTablet) shadowTablet);
+                                shadowTablet.getId());
                         if (computeNode == null) {
                             throw new AlterCancelException("No alive backend");
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -372,7 +372,7 @@ public class TabletStatMgr extends FrontendDaemon {
             final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
             Map<ComputeNode, List<TabletInfo>> beToTabletInfos = new HashMap<>();
             for (Tablet tablet : tablets.values()) {
-                ComputeNode node = warehouseManager.getComputeNodeAssignedToTablet(computeResource, (LakeTablet) tablet);
+                ComputeNode node = warehouseManager.getComputeNodeAssignedToTablet(computeResource, tablet.getId());
                 if (node == null) {
                     LOG.warn("Stop sending tablet stat task for partition {} because no alive node", debugName());
                     return;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/TabletView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/TabletView.java
@@ -46,10 +46,9 @@ public class TabletView {
         tvo.setBackendIds(tablet.getBackendIds());
 
         if (tablet instanceof LakeTablet) {
-            LakeTablet lakeTablet = (LakeTablet) tablet;
             // TODO(ComputeResource): support more better compute resource acquiring.
             Long computeNodeId = GlobalStateMgr.getCurrentState().getWarehouseMgr()
-                    .getAliveComputeNodeId(DEFAULT_RESOURCE, lakeTablet);
+                    .getAliveComputeNodeId(DEFAULT_RESOURCE, tablet.getId());
             tvo.setPrimaryComputeNodeId(computeNodeId);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
@@ -126,7 +126,7 @@ public class LakeTablet extends Tablet {
 
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         try {
-            List<Long> ids = warehouseManager.getAllComputeNodeIdsAssignToTablet(computeResource, this);
+            List<Long> ids = warehouseManager.getAllComputeNodeIdsAssignToTablet(computeResource, getId());
             if (ids == null) {
                 return Sets.newHashSet();
             } else {
@@ -159,7 +159,7 @@ public class LakeTablet extends Tablet {
                                      long visibleVersion, long localBeId, int schemaHash,
                                      ComputeResource computeResource) {
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-        List<Long> computeNodeIds = warehouseManager.getAllComputeNodeIdsAssignToTablet(computeResource, this);
+        List<Long> computeNodeIds = warehouseManager.getAllComputeNodeIdsAssignToTablet(computeResource, getId());
         if (computeNodeIds == null) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -90,7 +90,7 @@ public class Utils {
                 for (MaterializedIndex index : physicalPartition.getMaterializedIndices(indexState)) {
                     for (Tablet tablet : index.getTablets()) {
                         ComputeNode computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource,
-                                (LakeTablet) tablet);
+                                tablet.getId());
                         if (computeNode == null) {
                             throw new NoAliveBackendException("no alive backend");
                         }
@@ -130,11 +130,11 @@ public class Utils {
 
         List<Long> rebuildPindexTabletIds = new ArrayList<>();
         for (Tablet tablet : tablets) {
-            ComputeNode computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, (LakeTablet) tablet);
+            ComputeNode computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, tablet.getId());
             if (computeNode == null) {
                 LOG.warn("No alive node in warehouse for handle publish version request, try to use background warehouse");
                 computeResource = warehouseManager.getBackgroundComputeResource();
-                computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, (LakeTablet) tablet);
+                computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, tablet.getId());
                 if (computeNode == null) {
                     throw new NoAliveBackendException("No alive node for handle publish version request in background warehouse");
                 }
@@ -205,7 +205,7 @@ public class Utils {
                                          Map<ComputeNode, List<Long>> nodeToTablets,
                                          List<Long> rebuildPindexTabletIds, long baseVersion) {
         for (Tablet tablet : tablets) {
-            ComputeNode computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, (LakeTablet) tablet);
+            ComputeNode computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, tablet.getId());
             if (computeNode == null) {
                 LOG.warn("No alive node in warehouse for handle publish version request, try to use background warehouse");
                 return false;
@@ -380,11 +380,11 @@ public class Utils {
         }
 
         for (Tablet tablet : tablets) {
-            ComputeNode computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, (LakeTablet) tablet);
+            ComputeNode computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, tablet.getId());
             if (computeNode == null) {
                 LOG.warn("no alive node in warehouse for handle publish log version request, try to use background warehouse");
                 computeResource = warehouseManager.getBackgroundComputeResource();
-                computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, (LakeTablet) tablet);
+                computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, tablet.getId());
                 if (computeNode == null) {
                     throw new NoAliveBackendException("No alive node for handle publish version request in background warehouse");
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeBackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeBackupJob.java
@@ -28,7 +28,6 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.io.Text;
 import com.starrocks.lake.LakeTable;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.proto.LockTabletMetadataRequest;
 import com.starrocks.proto.LockTabletMetadataResponse;
@@ -113,7 +112,7 @@ public class LakeBackupJob extends BackupJob {
         try {
             // TODO(ComputeResource): support more better compute resource acquiring.
             ComputeNode computeNode = GlobalStateMgr.getCurrentState().getWarehouseMgr()
-                    .getComputeNodeAssignedToTablet(WarehouseManager.DEFAULT_RESOURCE, (LakeTablet) tablet);
+                    .getComputeNodeAssignedToTablet(WarehouseManager.DEFAULT_RESOURCE, tablet.getId());
             LakeTableSnapshotInfo snapshotInfo = new LakeTableSnapshotInfo(dbId,
                     tbl.getId(), partition.getId(), index.getId(), tablet.getId(),
                     computeNode.getId(), schemaHash, visibleVersion);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -131,7 +131,7 @@ public class LakeRestoreJob extends RestoreJob {
                 MaterializedIndex index = part.getDefaultPhysicalPartition().getIndex(idChain.getIdxId());
                 tablet = (LakeTablet) index.getTablet(idChain.getTabletId());
                 Long computeNodeId = GlobalStateMgr.getCurrentState().getWarehouseMgr()
-                        .getAliveComputeNodeId(WarehouseManager.DEFAULT_RESOURCE, tablet);
+                        .getAliveComputeNodeId(WarehouseManager.DEFAULT_RESOURCE, tablet.getId());
                 Preconditions.checkArgument(computeNodeId != null,
                         "No alive backend or compute node in %s warehouse", WarehouseManager.DEFAULT_RESOURCE);
                 LakeTableSnapshotInfo info = new LakeTableSnapshotInfo(db.getId(), idChain.getTblId(),

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -33,7 +33,6 @@ import com.starrocks.common.util.Daemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeAggregator;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.proto.AggregateCompactRequest;
 import com.starrocks.proto.CompactRequest;
 import com.starrocks.proto.ComputeNodePB;
@@ -461,7 +460,7 @@ public class CompactionScheduler extends Daemon {
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         for (MaterializedIndex index : visibleIndexes) {
             for (Tablet tablet : index.getTablets()) {
-                ComputeNode computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, (LakeTablet) tablet);
+                ComputeNode computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, tablet.getId());
                 if (computeNode == null) {
                     beToTablets.clear();
                     return beToTablets;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -216,7 +216,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
                     pickNode = LakeAggregator.chooseAggregatorNode(computeResource);
                 }
             } else {
-                pickNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, lakeTablet);
+                pickNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, lakeTablet.getId());
             }
 
             if (pickNode == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -568,7 +568,7 @@ public class SparkLoadJob extends BulkLoadJob {
                                 } else {
                                     // lake tablet
                                     ComputeNode backend = warehouseManager.getComputeNodeAssignedToTablet(computeResource,
-                                            (LakeTablet) tablet);
+                                            tablet.getId());
                                     if (backend == null) {
                                         LOG.warn("replica {} not exists", ((LakeTablet) tablet).getShardId());
                                         continue;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -804,7 +804,7 @@ public class OlapTableSink extends DataSink {
                     Tablet tablet = index.getTablets().get(idx);
                     if (table.isCloudNativeTableOrMaterializedView()) {
                         long computeNodeId =
-                                warehouseManager.getComputeNodeAssignedToTablet(computeResource, (LakeTablet) tablet).getId();
+                                warehouseManager.getComputeNodeAssignedToTablet(computeResource, tablet.getId()).getId();
                         locationParam.addToTablets(new TTabletLocation(tablet.getId(), Lists.newArrayList(computeNodeId)));
                     } else {
                         // we should ensure the replica backend is alive

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -23,7 +23,6 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.io.Writable;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.persist.DropWarehouseLog;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.WarehouseInternalOpLog;
@@ -296,7 +295,7 @@ public class WarehouseManager implements Writable {
         return computeResourceProvider.getAliveComputeNodes(computeResource);
     }
 
-    public Long getComputeNodeId(ComputeResource computeResource, LakeTablet tablet) {
+    public Long getComputeNodeId(ComputeResource computeResource, long tabletId) {
         // check warehouse exists
         if (!warehouseExists(computeResource.getWarehouseId())) {
             throw ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE,
@@ -304,13 +303,13 @@ public class WarehouseManager implements Writable {
         }
         try {
             return GlobalStateMgr.getCurrentState().getStarOSAgent()
-                    .getPrimaryComputeNodeIdByShard(tablet.getShardId(), computeResource.getWorkerGroupId());
+                    .getPrimaryComputeNodeIdByShard(tabletId, computeResource.getWorkerGroupId());
         } catch (StarRocksException e) {
             return null;
         }
     }
 
-    public Long getAliveComputeNodeId(ComputeResource computeResource, LakeTablet tablet) {
+    public Long getAliveComputeNodeId(ComputeResource computeResource, long tabletId) {
         // check warehouse exists
         if (!warehouseExists(computeResource.getWarehouseId())) {
             throw ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE,
@@ -318,7 +317,7 @@ public class WarehouseManager implements Writable {
         }
         try {
             List<Long> nodeIds = GlobalStateMgr.getCurrentState().getStarOSAgent()
-                    .getAllNodeIdsByShard(tablet.getShardId(), computeResource.getWorkerGroupId());
+                    .getAllNodeIdsByShard(tabletId, computeResource.getWorkerGroupId());
             Long nodeId = nodeIds
                     .stream()
                     .filter(id -> GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkBackendAlive(id) ||
@@ -331,7 +330,7 @@ public class WarehouseManager implements Writable {
         }
     }
 
-    public List<Long> getAllComputeNodeIdsAssignToTablet(ComputeResource computeResource, LakeTablet tablet) {
+    public List<Long> getAllComputeNodeIdsAssignToTablet(ComputeResource computeResource, long tabletId) {
         // check warehouse exists
         if (!warehouseExists(computeResource.getWarehouseId())) {
             throw ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE,
@@ -339,19 +338,19 @@ public class WarehouseManager implements Writable {
         }
         try {
             return GlobalStateMgr.getCurrentState().getStarOSAgent()
-                    .getAllNodeIdsByShard(tablet.getShardId(), computeResource.getWorkerGroupId());
+                    .getAllNodeIdsByShard(tabletId, computeResource.getWorkerGroupId());
         } catch (StarRocksException e) {
             return null;
         }
     }
 
-    public ComputeNode getComputeNodeAssignedToTablet(ComputeResource computeResource, LakeTablet tablet) {
+    public ComputeNode getComputeNodeAssignedToTablet(ComputeResource computeResource, long tabletId) {
         // check warehouse exists
         if (!warehouseExists(computeResource.getWarehouseId())) {
             throw ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE,
                     String.format("id: %d", computeResource.getWarehouseId()));
         }
-        Long computeNodeId = getAliveComputeNodeId(computeResource, tablet);
+        Long computeNodeId = getAliveComputeNodeId(computeResource, tabletId);
         if (computeNodeId == null) {
             Warehouse warehouse = idToWh.get(computeResource.getWarehouseId());
             throw ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE,

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -114,7 +114,6 @@ import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.http.rest.WarehouseInfosBuilder;
 import com.starrocks.journal.CheckpointException;
 import com.starrocks.journal.CheckpointWorker;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
 import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.leader.CheckpointController;
@@ -2140,7 +2139,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     try {
                         // use default warehouse nodes
                         ComputeNode computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource,
-                                (LakeTablet) tablet);
+                                tablet.getId());
                         tablets.add(new TTabletLocation(tablet.getId(), Collections.singletonList(computeNode.getId())));
                     } catch (Exception exception) {
                         throw new StarRocksException("Check if any backend is down or not. tablet_id: " + tablet.getId());
@@ -2423,10 +2422,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     .getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
                 if (olapTable.isCloudNativeTable()) {
                     for (Tablet tablet : index.getTablets()) {
-                        LakeTablet cloudNativeTablet = (LakeTablet) tablet;
                         try {
                             // use default warehouse nodes
-                            Long computeNodeId = warehouseManager.getAliveComputeNodeId(computeResource, cloudNativeTablet);
+                            Long computeNodeId = warehouseManager.getAliveComputeNodeId(computeResource, tablet.getId());
                             if (computeNodeId == null) {
                                 errorStatus.setError_msgs(Lists.newArrayList(
                                         "No alive compute node found for tablet. Check if any backend is down or not. tablet_id: "

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -30,7 +30,6 @@ import com.starrocks.common.TimeoutException;
 import com.starrocks.common.util.ThreadUtil;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.journal.LeaderTransferException;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
@@ -256,7 +255,7 @@ public class TabletTaskExecutor {
         for (Tablet tablet : index.getTablets()) {
             List<Long> nodeIdsOfReplicas = new ArrayList<>();
             if (isCloudNativeTable) {
-                long nodeId = warehouseManager.getComputeNodeAssignedToTablet(computeResource, (LakeTablet) tablet).getId();
+                long nodeId = warehouseManager.getComputeNodeAssignedToTablet(computeResource, tablet.getId()).getId();
                 nodeIdsOfReplicas.add(nodeId);
             } else {
                 for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/LakeTabletsProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/LakeTabletsProcNodeTest.java
@@ -84,10 +84,10 @@ public class LakeTabletsProcNodeTest {
                 GlobalStateMgr.getCurrentState().getWarehouseMgr();
                 result = agent;
 
-                agent.getAllComputeNodeIdsAssignToTablet((ComputeResource) any, (LakeTablet) tablet1);
+                agent.getAllComputeNodeIdsAssignToTablet((ComputeResource) any, tablet1.getId());
                 result = Lists.newArrayList(10000, 10001);
 
-                agent.getAllComputeNodeIdsAssignToTablet((ComputeResource) any, (LakeTablet) tablet2);
+                agent.getAllComputeNodeIdsAssignToTablet((ComputeResource) any, tablet2.getId());
                 result = Lists.newArrayList(10001, 10002);
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
@@ -222,13 +222,13 @@ public class TablePartitionActionTest extends StarRocksHttpTestCase {
                 result = Sets.newHashSet(testBackendId1);
 
                 GlobalStateMgr.getCurrentState().getWarehouseMgr()
-                        .getComputeNodeId((ComputeResource) any, (LakeTablet) any);
+                        .getComputeNodeId((ComputeResource) any, anyLong);
 
                 minTimes = 0;
                 result = testBackendId1;
 
                 GlobalStateMgr.getCurrentState().getWarehouseMgr()
-                        .getAliveComputeNodeId((ComputeResource) any, (LakeTablet) any);
+                        .getAliveComputeNodeId((ComputeResource) any, anyLong);
 
                 minTimes = 0;
                 result = testBackendId1;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.Future;
 
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -118,7 +119,7 @@ public class VacuumTest {
         
 
         when(warehouseManager.getBackgroundWarehouse()).thenReturn(mock(Warehouse.class));
-        when(warehouseManager.getComputeNodeAssignedToTablet((ComputeResource) any(), any(LakeTablet.class)))
+        when(warehouseManager.getComputeNodeAssignedToTablet((ComputeResource) any(), anyLong()))
                 .thenReturn(computeNode);
 
         when(computeNode.getHost()).thenReturn("localhost");

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -75,9 +75,9 @@ public class WarehouseManagerTest {
         ExceptionChecker.expectThrowsWithMsg(ErrorReportException.class, "Warehouse id: 1 not exist.",
                 () -> mgr.getAllComputeNodeIds(WarehouseComputeResource.of(1L)));
         ExceptionChecker.expectThrowsWithMsg(ErrorReportException.class, "Warehouse id: 1 not exist.",
-                () -> mgr.getComputeNodeId(WarehouseComputeResource.of(1L), null));
+                () -> mgr.getComputeNodeId(WarehouseComputeResource.of(1L), 0));
         ExceptionChecker.expectThrowsWithMsg(ErrorReportException.class, "Warehouse id: 1 not exist.",
-                () -> mgr.getAliveComputeNodeId(WarehouseComputeResource.of(1L), null));
+                () -> mgr.getAliveComputeNodeId(WarehouseComputeResource.of(1L), 0));
     }
 
     @Test
@@ -136,7 +136,7 @@ public class WarehouseManagerTest {
         Assertions.assertEquals(1, nodes.size());
 
         LakeTablet tablet = new LakeTablet(1L);
-        Long nodeId = mgr.getAliveComputeNodeId(WarehouseManager.DEFAULT_RESOURCE, tablet);
+        Long nodeId = mgr.getAliveComputeNodeId(WarehouseManager.DEFAULT_RESOURCE, tablet.getId());
         Assertions.assertNull(nodeId);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplCreatePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplCreatePartitionTest.java
@@ -19,7 +19,6 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -102,7 +101,7 @@ public class FrontendServiceImplCreatePartitionTest {
         new MockUp<WarehouseManager>() {
             int count = 0;
             @Mock
-            public Long getAliveComputeNodeId(ComputeResource computeResource, LakeTablet tablet) {
+            public Long getAliveComputeNodeId(ComputeResource computeResource, long tabletId) {
                 if (count < 1) {
                     count++;
                     return 50001L;

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
@@ -24,7 +24,6 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.lake.LakeAggregator;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -141,7 +140,7 @@ public class LakeAggregatePublishTest {
         
             WarehouseManager mockManager = mock(WarehouseManager.class);
             when(mockManager.warehouseExists(anyLong())).thenReturn(true);
-            when(mockManager.getComputeNodeAssignedToTablet(any(), any(LakeTablet.class)))
+            when(mockManager.getComputeNodeAssignedToTablet(any(), anyLong()))
                     .thenReturn(null);
             when(mockManager.getBackgroundWarehouse()).thenReturn(new DefaultWarehouse(100, "test"));
             warehouseMgrField.set(GlobalStateMgr.getCurrentState(), mockManager);

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedWarehouseManager.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedWarehouseManager.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.warehouse.DefaultWarehouse;
@@ -110,17 +109,17 @@ public class MockedWarehouseManager extends WarehouseManager {
     }
 
     @Override
-    public Long getComputeNodeId(ComputeResource computeResource, LakeTablet tablet) {
+    public Long getComputeNodeId(ComputeResource computeResource, long tabletId) {
         return computeNodeId;
     }
 
     @Override
-    public Long getAliveComputeNodeId(ComputeResource computeResource, LakeTablet tablet) {
+    public Long getAliveComputeNodeId(ComputeResource computeResource, long tabletId) {
         return computeNodeId;
     }
 
     @Override
-    public List<Long> getAllComputeNodeIdsAssignToTablet(ComputeResource computeResource, LakeTablet tablet) {
+    public List<Long> getAllComputeNodeIdsAssignToTablet(ComputeResource computeResource, long tabletId) {
         return computeNodeIdSetAssignedToTablet;
     }
 
@@ -130,7 +129,7 @@ public class MockedWarehouseManager extends WarehouseManager {
 
 
     @Override
-    public ComputeNode getComputeNodeAssignedToTablet(ComputeResource computeResource, LakeTablet tablet) {
+    public ComputeNode getComputeNodeAssignedToTablet(ComputeResource computeResource, long tabletId) {
         if (computeNodeSetAssignedToTablet.isEmpty()) {
             return null;
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/warehouse/WarehouseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/warehouse/WarehouseTest.java
@@ -17,7 +17,6 @@ package com.starrocks.warehouse;
 import com.staros.proto.ShardInfo;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorReportException;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
@@ -56,17 +55,17 @@ public class WarehouseTest {
 
         new MockUp<WarehouseManager>() {
             @Mock
-            public Long getComputeNodeId(ComputeResource computeResource, LakeTablet tablet) {
+            public Long getComputeNodeId(ComputeResource computeResource, long tabletId) {
                 return null;
             }
 
             @Mock
-            public Long getAliveComputeNodeId(ComputeResource computeResource, LakeTablet tablet) {
+            public Long getAliveComputeNodeId(ComputeResource computeResource, long tabletId) {
                 return null;
             }
         };
         try {
-            warehouseManager.getComputeNodeAssignedToTablet(WarehouseManager.DEFAULT_RESOURCE, new LakeTablet(0));
+            warehouseManager.getComputeNodeAssignedToTablet(WarehouseManager.DEFAULT_RESOURCE, 0);
             Assertions.fail();
         } catch (ErrorReportException e) {
             Assertions.assertTrue(e.getMessage().contains("No alive backend or compute node in warehouse"));


### PR DESCRIPTION
## Why I'm doing:
Warehouse manager uses lake tablet as arguments in several functions, actually it only needs tablet id.

## What I'm doing:
Refactor code to use tablet id instead of lake tablet in warehouse manager.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
