### PR TITLE
[BugFix] Fix partition creation failure when partition values differ but names are case-insensitively equal

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1434,14 +1434,7 @@ public class AnalyzerUtils {
                 if (!partitionColNames.contains(partitionName)) {
                     List<List<String>> partitionItems = Collections.singletonList(partitionValue);
                     PListCell cell = new PListCell(partitionItems);
-                    // If the partition name already exists and their partition values are different, change the partition name.
-                    if (tablePartitions.containsKey(partitionName) && !tablePartitions.get(partitionName).equals(cell)) {
-                        partitionName = calculateUniquePartitionName(partitionName, tablePartitions);
-                        if (tablePartitions.containsKey(partitionName)) {
-                            throw new AnalysisException(String.format("partition name %s already exists in table " +
-                                    "%s.", partitionName, olapTable.getName()));
-                        }
-                    }
+                    partitionName = calculateUniquePartitionName(partitionName, cell, tablePartitions);
                     MultiItemListPartitionDesc multiItemListPartitionDesc = new MultiItemListPartitionDesc(true,
                             partitionName, partitionItems, partitionProperties);
                     multiItemListPartitionDesc.setSystem(true);
@@ -1464,19 +1457,21 @@ public class AnalyzerUtils {
     /**
      * Calculate the unique partition name for list partition.
      */
-    private static String calculateUniquePartitionName(String partitionName,
-                                                       Map<String, PListCell> tablePartitions) {
-        // ensure partition name is unique with case-insensitive
-        int diff = partitionName.hashCode();
-        String newPartitionName = partitionName + "_" + Integer.toHexString(diff);
-        if (tablePartitions.containsKey(newPartitionName)) {
-            int i = 0;
-            do {
-                diff += 1;
-                newPartitionName = partitionName + "_" + Integer.toHexString(diff);
-            } while (i++ < 100 && tablePartitions.containsKey(newPartitionName));
+    private static String calculateUniquePartitionName(String partitionName, PListCell cell,
+                                                       Map<String, PListCell> tablePartitions) throws AnalysisException {
+        String orignialPartitionName = partitionName;
+        int i = 0;
+        // If the partition name already exists and their partition values are different, change the partition name.
+        while (tablePartitions.containsKey(partitionName) && !tablePartitions.get(partitionName).equals(cell)) {
+            // ensure partition name is unique with case-insensitive
+            int diff = orignialPartitionName.hashCode();
+            partitionName = orignialPartitionName + "_" + Integer.toHexString(diff + i);
+            if (++i > 100) {
+                // throw exception
+                throw new AnalysisException("Failed to calculate unique partition name after multiple attempts.");
+            }
         }
-        return newPartitionName;
+        return partitionName;
     }
 
     @VisibleForTesting


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/54278 introduced logic to compare partitionValue when partitionName is the same. If the partitionValue differs, a new partitionName is generated. This change is meant to address the issue where different cases (e.g., uppercase/lowercase) could result in the same partitionName.

Assuming we already have p1 -> v1 (partitionName -> Value), the first time p1 -> v2 appears, p1 will be renamed to p1_0 -> v2. However, the second time p1 -> v2 appears, it will be renamed to p1_1 instead of p1_0. This results in the same partitionValue being assigned to different partitionNames, which leads to an error in subsequent checks due to Duplicate Values.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
