### PR TITLE
[BugFix] Fix the `maxInstantTime` used to filter Hudi files when getting latest merged file slices.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -45,6 +45,8 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -298,7 +300,8 @@ public class HudiTable extends Table {
         }
 
         if (tableType == HudiTableType.MOR) {
-            tHudiTable.setInstant_time(lastInstant == null ? "" : lastInstant.getCompletionTime());
+            tHudiTable.setInstant_time(lastInstant == null ? "" :
+                    Collections.max(Arrays.asList(lastInstant.requestedTime(), lastInstant.getCompletionTime())));
         }
 
         tHudiTable.setHive_column_names(hudiProperties.get(HUDI_TABLE_COLUMN_NAMES));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
@@ -43,6 +43,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -117,8 +119,10 @@ public class HudiRemoteFileIO implements RemoteFileIO {
                 return resultPartitions.put(pathKey, fileDescs).build();
             }
 
+            String maxInstanceTime = Collections.max(
+                    Arrays.asList(scanContext.hudiLastInstant.requestedTime(), scanContext.hudiLastInstant.getCompletionTime()));
             Iterator<FileSlice> hoodieFileSliceIterator = scanContext.hudiFsView
-                    .getLatestMergedFileSlicesBeforeOrOn(partitionName, scanContext.hudiLastInstant.getCompletionTime())
+                    .getLatestMergedFileSlicesBeforeOrOn(partitionName, maxInstanceTime)
                     .iterator();
             while (hoodieFileSliceIterator.hasNext()) {
                 FileSlice fileSlice = hoodieFileSliceIterator.next();


### PR DESCRIPTION
## Why I'm doing:
After upgrade to Hudi 1.0.2, we use the instant completion time instead of old timestamp as the `maxInstantTime` to filter Hudi files when getting latest merged file slices.

However, in some unusual cases, the completion time acquired by HoodieTableMetaClient can be less than the requested time, which may be caused by the clock synchronization problem. At this time, if we still use the completion time as the `maxInstantTime`, many valid files will be filtered and return wrong result.

## What I'm doing:
Choose the max value of instant requested time and completion time as the`maxInstantTime` , to filter Hudi files when getting latest merged file slices.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
