### PR TITLE
[Refactor] Split JoinFunc to KeyConstructor and HashMapMethod

### DIFF
--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -24,6 +24,7 @@
 #include "exec/hash_join_node.h"
 #include "serde/column_array_serde.h"
 #include "simd/simd.h"
+#include "types/logical_type_infra.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks {
@@ -73,19 +74,19 @@ void HashTableProbeState::consider_probe_time_locality() {
     ++probe_chunks;
 }
 
-void SerializedJoinBuildFunc::prepare(RuntimeState* state, JoinHashTableItems* table_items) {
-    table_items->bucket_size = JoinHashMapHelper::calc_bucket_size(table_items->row_count + 1);
-    table_items->first.resize(table_items->bucket_size, 0);
-    table_items->next.resize(table_items->row_count + 1, 0);
+// ------------------------------------------------------------------------------------
+// KeyConstructor
+// ------------------------------------------------------------------------------------
+
+void BuildKeyConstructorForSerialized::prepare(RuntimeState* state, JoinHashTableItems* table_items) {
     table_items->build_slice.resize(table_items->row_count + 1);
     table_items->build_pool = std::make_unique<MemPool>();
 }
 
-void SerializedJoinBuildFunc::construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                                   HashTableProbeState* probe_state) {
-    uint32_t row_count = table_items->row_count;
+void BuildKeyConstructorForSerialized::build_key(RuntimeState* state, JoinHashTableItems* table_items) {
+    const uint32_t row_count = table_items->row_count;
 
-    // prepare columns
+    // Prepare data and null columns.
     Columns data_columns;
     NullColumns null_columns;
 
@@ -103,80 +104,40 @@ void SerializedJoinBuildFunc::construct_hash_table(RuntimeState* state, JoinHash
         }
     }
 
-    // calc serialize size
+    // Calc serialize size.
     size_t serialize_size = 0;
     for (const auto& data_column : data_columns) {
         serialize_size += serde::ColumnArraySerde::max_serialized_size(*data_column);
     }
     uint8_t* ptr = table_items->build_pool->allocate(serialize_size);
 
-    // serialize and build hash table
-    uint32_t quo = row_count / state->chunk_size();
-    uint32_t rem = row_count % state->chunk_size();
-
-    if (!null_columns.empty()) {
-        for (size_t i = 0; i < quo; i++) {
-            _build_nullable_columns(table_items, probe_state, data_columns, null_columns, 1 + state->chunk_size() * i,
-                                    state->chunk_size(), &ptr);
+    // Serialize to key columns and build key is_nulls.
+    if (null_columns.empty()) {
+        for (uint32_t i = 1; i < 1 + row_count; i++) {
+            table_items->build_slice[i] = JoinHashMapHelper::get_hash_key(data_columns, i, ptr);
+            ptr += table_items->build_slice[i].size;
         }
-        _build_nullable_columns(table_items, probe_state, data_columns, null_columns, 1 + state->chunk_size() * quo,
-                                rem, &ptr);
     } else {
-        for (size_t i = 0; i < quo; i++) {
-            _build_columns(table_items, probe_state, data_columns, 1 + state->chunk_size() * i, state->chunk_size(),
-                           &ptr);
+        table_items->build_key_nulls.resize(row_count + 1);
+        auto* dest_is_nulls = table_items->build_key_nulls.data();
+        std::memcpy(dest_is_nulls, null_columns[0]->get_data().data(), (row_count + 1) * sizeof(NullColumn::ValueType));
+        for (uint32_t i = 1; i < null_columns.size(); i++) {
+            for (uint32_t j = 1; j < 1 + row_count; j++) {
+                dest_is_nulls[j] |= null_columns[i]->get_data()[j];
+            }
         }
-        _build_columns(table_items, probe_state, data_columns, 1 + state->chunk_size() * quo, rem, &ptr);
-    }
-    table_items->calculate_ht_info(serialize_size);
-}
 
-void SerializedJoinBuildFunc::_build_columns(JoinHashTableItems* table_items, HashTableProbeState* probe_state,
-                                             const Columns& data_columns, uint32_t start, uint32_t count,
-                                             uint8_t** ptr) {
-    for (size_t i = 0; i < count; i++) {
-        table_items->build_slice[start + i] = JoinHashMapHelper::get_hash_key(data_columns, start + i, *ptr);
-        probe_state->buckets[i] = JoinHashMapHelper::calc_bucket_num<Slice>(
-                table_items->build_slice[start + i], table_items->bucket_size, table_items->log_bucket_size);
-        *ptr += table_items->build_slice[start + i].size;
-    }
-
-    for (size_t i = 0; i < count; i++) {
-        table_items->next[start + i] = table_items->first[probe_state->buckets[i]];
-        table_items->first[probe_state->buckets[i]] = start + i;
-    }
-}
-
-void SerializedJoinBuildFunc::_build_nullable_columns(JoinHashTableItems* table_items, HashTableProbeState* probe_state,
-                                                      const Columns& data_columns, const NullColumns& null_columns,
-                                                      uint32_t start, uint32_t count, uint8_t** ptr) {
-    for (uint32_t i = 0; i < count; i++) {
-        probe_state->is_nulls[i] = null_columns[0]->get_data()[start + i];
-    }
-    for (uint32_t i = 1; i < null_columns.size(); i++) {
-        for (uint32_t j = 0; j < count; j++) {
-            probe_state->is_nulls[j] |= null_columns[i]->get_data()[start + j];
-        }
-    }
-
-    for (size_t i = 0; i < count; i++) {
-        if (probe_state->is_nulls[i] == 0) {
-            table_items->build_slice[start + i] = JoinHashMapHelper::get_hash_key(data_columns, start + i, *ptr);
-            probe_state->buckets[i] = JoinHashMapHelper::calc_bucket_num<Slice>(
-                    table_items->build_slice[start + i], table_items->bucket_size, table_items->log_bucket_size);
-            *ptr += table_items->build_slice[start + i].size;
-        }
-    }
-
-    for (size_t i = 0; i < count; i++) {
-        if (probe_state->is_nulls[i] == 0) {
-            table_items->next[start + i] = table_items->first[probe_state->buckets[i]];
-            table_items->first[probe_state->buckets[i]] = start + i;
+        for (uint32_t i = 1; i < 1 + row_count; i++) {
+            if (dest_is_nulls[i] == 0) {
+                table_items->build_slice[i] = JoinHashMapHelper::get_hash_key(data_columns, i, ptr);
+                ptr += table_items->build_slice[i].size;
+            }
         }
     }
 }
 
-void SerializedJoinProbeFunc::lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state) {
+void ProbeKeyConstructorForSerialized::build_key(const JoinHashTableItems& table_items,
+                                                 HashTableProbeState* probe_state) {
     probe_state->probe_pool->clear();
 
     // prepare columns
@@ -213,31 +174,25 @@ void SerializedJoinProbeFunc::lookup_init(const JoinHashTableItems& table_items,
     } else {
         _probe_column(table_items, probe_state, data_columns, ptr);
     }
-    probe_state->consider_probe_time_locality();
 }
 
-void SerializedJoinProbeFunc::_probe_column(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
-                                            const Columns& data_columns, uint8_t* ptr) {
-    uint32_t row_count = probe_state->probe_row_count;
-
+void ProbeKeyConstructorForSerialized::_probe_column(const JoinHashTableItems& table_items,
+                                                     HashTableProbeState* probe_state, const Columns& data_columns,
+                                                     uint8_t* ptr) {
+    const uint32_t row_count = probe_state->probe_row_count;
     for (uint32_t i = 0; i < row_count; i++) {
         probe_state->probe_slice[i] = JoinHashMapHelper::get_hash_key(data_columns, i, ptr);
-        probe_state->buckets[i] = JoinHashMapHelper::calc_bucket_num<Slice>(
-                probe_state->probe_slice[i], table_items.bucket_size, table_items.log_bucket_size);
         ptr += probe_state->probe_slice[i].size;
     }
 
     probe_state->null_array = nullptr;
-
-    for (uint32_t i = 0; i < row_count; i++) {
-        probe_state->next[i] = table_items.first[probe_state->buckets[i]];
-    }
 }
 
-void SerializedJoinProbeFunc::_probe_nullable_column(const JoinHashTableItems& table_items,
-                                                     HashTableProbeState* probe_state, const Columns& data_columns,
-                                                     const NullColumns& null_columns, uint8_t* ptr) {
-    uint32_t row_count = probe_state->probe_row_count;
+void ProbeKeyConstructorForSerialized::_probe_nullable_column(const JoinHashTableItems& table_items,
+                                                              HashTableProbeState* probe_state,
+                                                              const Columns& data_columns,
+                                                              const NullColumns& null_columns, uint8_t* ptr) {
+    const uint32_t row_count = probe_state->probe_row_count;
 
     for (uint32_t i = 0; i < row_count; i++) {
         probe_state->is_nulls[i] = null_columns[0]->get_data()[i];
@@ -248,7 +203,6 @@ void SerializedJoinProbeFunc::_probe_nullable_column(const JoinHashTableItems& t
         }
     }
 
-    probe_state->null_array = &null_columns[0]->get_data();
     for (uint32_t i = 0; i < row_count; i++) {
         if (probe_state->is_nulls[i] == 0) {
             probe_state->probe_slice[i] = JoinHashMapHelper::get_hash_key(data_columns, i, ptr);
@@ -256,28 +210,258 @@ void SerializedJoinProbeFunc::_probe_nullable_column(const JoinHashTableItems& t
         }
     }
 
-    for (uint32_t i = 0; i < row_count; i++) {
-        if (probe_state->is_nulls[i] == 0) {
-            probe_state->buckets[i] = JoinHashMapHelper::calc_bucket_num<Slice>(
-                    probe_state->probe_slice[i], table_items.bucket_size, table_items.log_bucket_size);
-            probe_state->next[i] = table_items.first[probe_state->buckets[i]];
-        } else {
-            probe_state->next[i] = 0;
-        }
-    }
+    probe_state->null_array = &probe_state->is_nulls;
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_index_output(ChunkPtr* chunk) {
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_index_output(ChunkPtr* chunk) {
     _probe_state->probe_index.resize((*chunk)->num_rows());
     (*chunk)->append_column(_probe_state->probe_index_column, Chunk::HASH_JOIN_PROBE_INDEX_SLOT_ID);
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_build_index_output(ChunkPtr* chunk) {
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_build_index_output(ChunkPtr* chunk) {
     _probe_state->build_index.resize(_probe_state->count);
     (*chunk)->append_column(_probe_state->build_index_column, Chunk::HASH_JOIN_BUILD_INDEX_SLOT_ID);
 }
+
+// ------------------------------------------------------------------------------------
+// JoinHashMapSelector
+// ------------------------------------------------------------------------------------
+
+class JoinHashMapResolver {
+public:
+    JoinHashMapResolver();
+    static JoinHashMapResolver& instance();
+
+    StatusOr<JoinHashMapType> get_unary_type(JoinKeyConstructor key_builder_type, LogicalType key_type,
+                                             JoinHashMapMethodType hash_map_method_type);
+
+private:
+    phmap::flat_hash_map<std::tuple<JoinKeyConstructor, LogicalType, JoinHashMapMethodType>, JoinHashMapType> _types;
+};
+
+JoinHashMapResolver::JoinHashMapResolver() {
+#define ADD_TYPE(KEY_BUILDER_TYPE, LOGICAL_TYPE, METHOD_TYPE, MAP_TYPE)                                              \
+    _types.emplace(                                                                                                  \
+            std::make_tuple(JoinKeyConstructor::KEY_BUILDER_TYPE, LOGICAL_TYPE, JoinHashMapMethodType::METHOD_TYPE), \
+            JoinHashMapType::MAP_TYPE);
+
+    ADD_TYPE(ONE_KEY, TYPE_BOOLEAN, DIRECT_MAPPING, keyboolean);
+    ADD_TYPE(ONE_KEY, TYPE_TINYINT, DIRECT_MAPPING, key8);
+    ADD_TYPE(ONE_KEY, TYPE_SMALLINT, DIRECT_MAPPING, key16);
+
+    ADD_TYPE(ONE_KEY, TYPE_INT, BUCKET_CHAINED, key32);
+    ADD_TYPE(ONE_KEY, TYPE_BIGINT, BUCKET_CHAINED, key64);
+    ADD_TYPE(ONE_KEY, TYPE_LARGEINT, BUCKET_CHAINED, key128);
+    ADD_TYPE(ONE_KEY, TYPE_FLOAT, BUCKET_CHAINED, keyfloat);
+    ADD_TYPE(ONE_KEY, TYPE_DOUBLE, BUCKET_CHAINED, keydouble);
+    ADD_TYPE(ONE_KEY, TYPE_DATE, BUCKET_CHAINED, keydate);
+    ADD_TYPE(ONE_KEY, TYPE_DATETIME, BUCKET_CHAINED, keydatetime);
+    ADD_TYPE(ONE_KEY, TYPE_DECIMALV2, BUCKET_CHAINED, keydecimal);
+    ADD_TYPE(ONE_KEY, TYPE_DECIMAL32, BUCKET_CHAINED, keydecimal32);
+    ADD_TYPE(ONE_KEY, TYPE_DECIMAL64, BUCKET_CHAINED, keydecimal64);
+    ADD_TYPE(ONE_KEY, TYPE_DECIMAL128, BUCKET_CHAINED, keydecimal128);
+    ADD_TYPE(ONE_KEY, TYPE_VARCHAR, BUCKET_CHAINED, keystring);
+
+    ADD_TYPE(SERIALIZED_FIXED_SIZE, TYPE_INT, BUCKET_CHAINED, fixed32);
+    ADD_TYPE(SERIALIZED_FIXED_SIZE, TYPE_BIGINT, BUCKET_CHAINED, fixed64);
+    ADD_TYPE(SERIALIZED_FIXED_SIZE, TYPE_LARGEINT, BUCKET_CHAINED, fixed128);
+
+    ADD_TYPE(SERIALIZED, TYPE_VARCHAR, BUCKET_CHAINED, slice);
+#undef ADD_TYPE
+}
+
+JoinHashMapResolver& JoinHashMapResolver::instance() {
+    static JoinHashMapResolver resolver;
+    return resolver;
+}
+
+StatusOr<JoinHashMapType> JoinHashMapResolver::get_unary_type(JoinKeyConstructor key_builder_type, LogicalType key_type,
+                                                              JoinHashMapMethodType hash_map_method_type) {
+    if (const auto it = _types.find(std::make_tuple(key_builder_type, key_type, hash_map_method_type));
+        it != _types.end()) {
+        return it->second;
+    }
+    return Status::InternalError(strings::Substitute(
+            "Unsupported join hash map type: key_builder_type={}, key_type={}, hash_map_method_type={}",
+            static_cast<int>(key_builder_type), key_type, static_cast<int>(hash_map_method_type)));
+}
+
+class JoinHashMapSelector {
+public:
+    static StatusOr<JoinHashMapType> construct_key_and_determine_hash_map(RuntimeState* state,
+                                                                          JoinHashTableItems* table_items);
+
+private:
+    static size_t _get_size_of_fixed_and_contiguous_type(LogicalType data_type);
+    static std::pair<JoinKeyConstructor, LogicalType> _determine_key_constructor(JoinHashTableItems* table_items);
+    static void _construct_key(RuntimeState* state, JoinHashTableItems* table_items,
+                               JoinKeyConstructor key_builder_type, LogicalType key_type);
+    static JoinHashMapMethodType _determine_hash_map_method(JoinKeyConstructor key_builder_type, LogicalType key_type);
+};
+
+StatusOr<JoinHashMapType> JoinHashMapSelector::construct_key_and_determine_hash_map(RuntimeState* state,
+                                                                                    JoinHashTableItems* table_items) {
+    if (table_items->row_count == 0) {
+        return JoinHashMapType::empty;
+    }
+
+    const auto [key_builder_type, key_type] = _determine_key_constructor(table_items);
+    _construct_key(state, table_items, key_builder_type, key_type);
+
+    const auto method_type = _determine_hash_map_method(key_builder_type, key_type);
+    return JoinHashMapResolver::instance().get_unary_type(key_builder_type, key_type, method_type);
+}
+
+template <class Functor, class Ret, class... Args>
+static auto logical_type_dispatch_join(LogicalType ltype, Ret default_value, Functor fun, Args... args) {
+#define _TYPE_DISPATCH_CASE(type) \
+    case type:                    \
+        return fun.template operator()<type>(args...);
+
+    switch (ltype) {
+        _TYPE_DISPATCH_CASE(TYPE_TINYINT)
+        _TYPE_DISPATCH_CASE(TYPE_SMALLINT)
+        _TYPE_DISPATCH_CASE(TYPE_INT)
+        _TYPE_DISPATCH_CASE(TYPE_BIGINT)
+        _TYPE_DISPATCH_CASE(TYPE_LARGEINT)
+        // float will be convert to double, so current can't reach here
+        _TYPE_DISPATCH_CASE(TYPE_FLOAT)
+        _TYPE_DISPATCH_CASE(TYPE_DOUBLE)
+        _TYPE_DISPATCH_CASE(TYPE_DECIMALV2)
+        _TYPE_DISPATCH_CASE(TYPE_DECIMAL32)
+        _TYPE_DISPATCH_CASE(TYPE_DECIMAL64)
+        _TYPE_DISPATCH_CASE(TYPE_DECIMAL128)
+        _TYPE_DISPATCH_CASE(TYPE_BOOLEAN)
+        // date will be convert to datetime, so current can't reach here
+        _TYPE_DISPATCH_CASE(TYPE_DATE)
+        _TYPE_DISPATCH_CASE(TYPE_DATETIME)
+        _TYPE_DISPATCH_CASE(TYPE_CHAR)
+        _TYPE_DISPATCH_CASE(TYPE_VARCHAR)
+    default:
+        return default_value;
+    }
+
+#undef _TYPE_DISPATCH_CASE
+}
+
+size_t JoinHashMapSelector::_get_size_of_fixed_and_contiguous_type(const LogicalType data_type) {
+    switch (data_type) {
+    case LogicalType::TYPE_BOOLEAN:
+        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_BOOLEAN>::CppType);
+    case LogicalType::TYPE_TINYINT:
+        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_TINYINT>::CppType);
+    case LogicalType::TYPE_SMALLINT:
+        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_SMALLINT>::CppType);
+    case LogicalType::TYPE_INT:
+        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_INT>::CppType);
+    case LogicalType::TYPE_BIGINT:
+        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_BIGINT>::CppType);
+    case LogicalType::TYPE_FLOAT:
+        // float will be convert to double, so current can't reach here
+        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_FLOAT>::CppType);
+    case LogicalType::TYPE_DOUBLE:
+        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_DOUBLE>::CppType);
+    case LogicalType::TYPE_DATE:
+        // date will be convert to datetime, so current can't reach here
+        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_DATE>::CppType);
+    case LogicalType::TYPE_DATETIME:
+        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_DATETIME>::CppType);
+    default:
+        return 0;
+    }
+}
+
+std::pair<JoinKeyConstructor, LogicalType> JoinHashMapSelector::_determine_key_constructor(
+        JoinHashTableItems* table_items) {
+    const size_t num_keys = table_items->join_keys.size();
+    DCHECK_GT(num_keys, 0);
+
+    for (size_t i = 0; i < num_keys; i++) {
+        if (!table_items->key_columns[i]->has_null()) {
+            table_items->join_keys[i].is_null_safe_equal = false;
+        }
+    }
+
+    if (num_keys == 1 && !table_items->join_keys[0].is_null_safe_equal) {
+        return logical_type_dispatch_join(
+                table_items->join_keys[0].type->type,
+                std::make_pair(JoinKeyConstructor::SERIALIZED, LogicalType::TYPE_VARCHAR),
+                [&]<LogicalType LT>() { return std::make_pair(JoinKeyConstructor::ONE_KEY, LT); });
+    }
+
+    size_t total_size_in_byte = 0;
+    for (const auto& join_key : table_items->join_keys) {
+        if (join_key.is_null_safe_equal) {
+            total_size_in_byte += 1;
+        }
+        size_t s = _get_size_of_fixed_and_contiguous_type(join_key.type->type);
+        if (s > 0) {
+            total_size_in_byte += s;
+        } else {
+            return {JoinKeyConstructor::SERIALIZED, LogicalType::TYPE_VARCHAR};
+        }
+    }
+
+    if (total_size_in_byte <= 4) {
+        return {JoinKeyConstructor::SERIALIZED_FIXED_SIZE, LogicalType::TYPE_INT};
+    }
+    if (total_size_in_byte <= 8) {
+        return {JoinKeyConstructor::SERIALIZED_FIXED_SIZE, LogicalType::TYPE_BIGINT};
+    }
+    if (total_size_in_byte <= 16) {
+        return {JoinKeyConstructor::SERIALIZED_FIXED_SIZE, LogicalType::TYPE_LARGEINT};
+    }
+
+    return {JoinKeyConstructor::SERIALIZED, LogicalType::TYPE_VARCHAR};
+}
+
+void JoinHashMapSelector::_construct_key(RuntimeState* state, JoinHashTableItems* table_items,
+                                         JoinKeyConstructor key_builder_type, LogicalType key_type) {
+    auto process = [&]<typename JoinKeyConstructor>() {
+        JoinKeyConstructor().prepare(state, table_items);
+        JoinKeyConstructor().build_key(state, table_items);
+    };
+
+    switch (key_builder_type) {
+    case JoinKeyConstructor::ONE_KEY:
+        logical_type_dispatch_join(key_type, std::nullopt, [&]<LogicalType LT>() {
+            DCHECK_NE(LT, LogicalType::TYPE_CHAR);
+            process.operator()<BuildKeyConstructorForOneKey<LT>>();
+            return std::nullopt;
+        });
+        break;
+    case JoinKeyConstructor::SERIALIZED_FIXED_SIZE:
+        if (key_type == LogicalType::TYPE_INT) {
+            process.operator()<BuildKeyConstructorForSerializedFixedSize<LogicalType::TYPE_INT>>();
+        } else if (key_type == LogicalType::TYPE_BIGINT) {
+            process.operator()<BuildKeyConstructorForSerializedFixedSize<LogicalType::TYPE_BIGINT>>();
+        } else if (key_type == LogicalType::TYPE_LARGEINT) {
+            process.operator()<BuildKeyConstructorForSerializedFixedSize<LogicalType::TYPE_LARGEINT>>();
+        } else {
+            DCHECK(false) << "Unsupported key type for fixed size serialized join build func: " << key_type;
+        }
+        break;
+    case JoinKeyConstructor::SERIALIZED:
+    default:
+        process.operator()<BuildKeyConstructorForSerialized>();
+    }
+}
+
+JoinHashMapMethodType JoinHashMapSelector::_determine_hash_map_method(JoinKeyConstructor key_builder_type,
+                                                                      LogicalType key_type) {
+    if (key_builder_type == JoinKeyConstructor::ONE_KEY &&
+        (key_type == LogicalType::TYPE_BOOLEAN || key_type == LogicalType::TYPE_TINYINT ||
+         key_type == LogicalType::TYPE_SMALLINT)) {
+        return JoinHashMapMethodType::DIRECT_MAPPING;
+    }
+    return JoinHashMapMethodType::BUCKET_CHAINED;
+}
+
+// ------------------------------------------------------------------------------------
+// JoinHashTable
+// ------------------------------------------------------------------------------------
 
 JoinHashTable JoinHashTable::clone_readable_table() {
     JoinHashTable ht;
@@ -541,7 +725,8 @@ Status JoinHashTable::build(RuntimeState* state) {
 
     RETURN_IF_ERROR(_upgrade_key_columns_if_overflow());
 
-    _hash_map_type = _choose_join_hash_map();
+    ASSIGN_OR_RETURN(_hash_map_type,
+                     JoinHashMapSelector::construct_key_and_determine_hash_map(state, _table_items.get()));
 
     switch (_hash_map_type) {
 #define M(NAME)                                                                                                       \
@@ -561,7 +746,6 @@ Status JoinHashTable::build(RuntimeState* state) {
 }
 
 void JoinHashTable::reset_probe_state(starrocks::RuntimeState* state) {
-    _hash_map_type = _choose_join_hash_map();
     switch (_hash_map_type) {
 #define M(NAME)                                                                                                       \
     case JoinHashMapType::NAME:                                                                                       \
@@ -734,114 +918,6 @@ Status JoinHashTable::_upgrade_key_columns_if_overflow() {
     return Status::OK();
 }
 
-JoinHashMapType JoinHashTable::_choose_join_hash_map() {
-    if (_table_items->row_count == 0) {
-        return JoinHashMapType::empty;
-    }
-
-    size_t size = _table_items->join_keys.size();
-    DCHECK_GT(size, 0);
-
-    for (size_t i = 0; i < size; i++) {
-        if (!_table_items->key_columns[i]->has_null()) {
-            _table_items->join_keys[i].is_null_safe_equal = false;
-        }
-    }
-
-    if (size == 1 && !_table_items->join_keys[0].is_null_safe_equal) {
-        switch (_table_items->join_keys[0].type->type) {
-        case LogicalType::TYPE_BOOLEAN:
-            return JoinHashMapType::keyboolean;
-        case LogicalType::TYPE_TINYINT:
-            return JoinHashMapType::key8;
-        case LogicalType::TYPE_SMALLINT:
-            return JoinHashMapType::key16;
-        case LogicalType::TYPE_INT:
-            return JoinHashMapType::key32;
-        case LogicalType::TYPE_BIGINT:
-            return JoinHashMapType::key64;
-        case LogicalType::TYPE_LARGEINT:
-            return JoinHashMapType::key128;
-        case LogicalType::TYPE_FLOAT:
-            // float will be convert to double, so current can't reach here
-            return JoinHashMapType::keyfloat;
-        case LogicalType::TYPE_DOUBLE:
-            return JoinHashMapType::keydouble;
-        case LogicalType::TYPE_VARCHAR:
-        case LogicalType::TYPE_CHAR:
-            return JoinHashMapType::keystring;
-        case LogicalType::TYPE_DATE:
-            // date will be convert to datetime, so current can't reach here
-            return JoinHashMapType::keydate;
-        case LogicalType::TYPE_DATETIME:
-            return JoinHashMapType::keydatetime;
-        case LogicalType::TYPE_DECIMALV2:
-            return JoinHashMapType::keydecimal;
-        case LogicalType::TYPE_DECIMAL32:
-            return JoinHashMapType::keydecimal32;
-        case LogicalType::TYPE_DECIMAL64:
-            return JoinHashMapType::keydecimal64;
-        case LogicalType::TYPE_DECIMAL128:
-            return JoinHashMapType::keydecimal128;
-        default:
-            return JoinHashMapType::slice;
-        }
-    }
-
-    size_t total_size_in_byte = 0;
-
-    for (auto& join_key : _table_items->join_keys) {
-        if (join_key.is_null_safe_equal) {
-            total_size_in_byte += 1;
-        }
-        size_t s = _get_size_of_fixed_and_contiguous_type(join_key.type->type);
-        if (s > 0) {
-            total_size_in_byte += s;
-        } else {
-            return JoinHashMapType::slice;
-        }
-    }
-
-    if (total_size_in_byte <= 4) {
-        return JoinHashMapType::fixed32;
-    }
-    if (total_size_in_byte <= 8) {
-        return JoinHashMapType::fixed64;
-    }
-    if (total_size_in_byte <= 16) {
-        return JoinHashMapType::fixed128;
-    }
-
-    return JoinHashMapType::slice;
-}
-
-size_t JoinHashTable::_get_size_of_fixed_and_contiguous_type(LogicalType data_type) {
-    switch (data_type) {
-    case LogicalType::TYPE_BOOLEAN:
-        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_BOOLEAN>::CppType);
-    case LogicalType::TYPE_TINYINT:
-        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_TINYINT>::CppType);
-    case LogicalType::TYPE_SMALLINT:
-        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_SMALLINT>::CppType);
-    case LogicalType::TYPE_INT:
-        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_INT>::CppType);
-    case LogicalType::TYPE_BIGINT:
-        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_BIGINT>::CppType);
-    case LogicalType::TYPE_FLOAT:
-        // float will be convert to double, so current can't reach here
-        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_FLOAT>::CppType);
-    case LogicalType::TYPE_DOUBLE:
-        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_DOUBLE>::CppType);
-    case LogicalType::TYPE_DATE:
-        // date will be convert to datetime, so current can't reach here
-        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_DATE>::CppType);
-    case LogicalType::TYPE_DATETIME:
-        return sizeof(RunTimeTypeTraits<LogicalType::TYPE_DATETIME>::CppType);
-    default:
-        return 0;
-    }
-}
-
 void JoinHashTable::_remove_duplicate_index_for_left_outer_join(Filter* filter) {
     size_t row_count = filter->size();
 
@@ -968,4 +1044,5 @@ template class JoinHashMapForSerializedKey(TYPE_VARCHAR);
 template class JoinHashMapForFixedSizeKey(TYPE_INT);
 template class JoinHashMapForFixedSizeKey(TYPE_BIGINT);
 template class JoinHashMapForFixedSizeKey(TYPE_LARGEINT);
+
 } // namespace starrocks

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -1,4 +1,4 @@
-; // Copyright 2021-present StarRocks, Inc. All rights reserved.
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -451,6 +451,9 @@ public:
 
     static void prepare(RuntimeState* state, JoinHashTableItems* table_items) {}
     static void build_key(RuntimeState* state, JoinHashTableItems* table_items) {}
+    static size_t get_key_column_bytes(const JoinHashTableItems& table_items) {
+        return table_items.key_columns[0]->byte_size();
+    }
     static const Buffer<CppType>& get_key_data(const JoinHashTableItems& table_items);
     static const Buffer<uint8_t>* get_is_nulls(const JoinHashTableItems& table_items);
 };
@@ -464,6 +467,9 @@ public:
     static void prepare(RuntimeState* state, JoinHashTableItems* table_items);
     static void build_key(RuntimeState* state, JoinHashTableItems* table_items);
 
+    static size_t get_key_column_bytes(const JoinHashTableItems& table_items) {
+        return table_items.build_key_column->byte_size();
+    }
     static const Buffer<CppType>& get_key_data(const JoinHashTableItems& table_items) {
         return ColumnHelper::as_raw_column<const ColumnType>(table_items.build_key_column)->get_data();
     }
@@ -477,6 +483,9 @@ public:
     static void prepare(RuntimeState* state, JoinHashTableItems* table_items);
     static void build_key(RuntimeState* state, JoinHashTableItems* table_items);
 
+    static size_t get_key_column_bytes(const JoinHashTableItems& table_items) {
+        return table_items.build_pool->total_allocated_bytes();
+    }
     static const Buffer<Slice>& get_key_data(const JoinHashTableItems& table_items) { return table_items.build_slice; }
     static const Buffer<uint8_t>* get_is_nulls(const JoinHashTableItems& table_items) {
         return table_items.build_key_nulls.empty() ? nullptr : &table_items.build_key_nulls;

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -1,4 +1,4 @@
-// Copyright 2021-present StarRocks, Inc. All rights reserved.
+; // Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +38,10 @@
 namespace starrocks {
 
 class ColumnRef;
+
+// ------------------------------------------------------------------------------------
+// Utils
+// ------------------------------------------------------------------------------------
 
 #define APPLY_FOR_JOIN_VARIANTS(M) \
     M(empty)                       \
@@ -84,6 +88,14 @@ enum class JoinHashMapType {
     fixed128 // 16 bytes
 };
 
+enum class JoinKeyConstructor {
+    ONE_KEY,
+    SERIALIZED_FIXED_SIZE,
+    SERIALIZED,
+};
+
+enum class JoinHashMapMethodType { BUCKET_CHAINED, DIRECT_MAPPING };
+
 enum class JoinMatchFlag { NORMAL, ALL_NOT_MATCH, ALL_MATCH_ONE, MOST_MATCH_ONE };
 
 struct JoinKeyDesc {
@@ -113,8 +125,11 @@ struct JoinHashTableItems {
     // about the bucket-chained hash table of this kind.
     Buffer<uint32_t> first;
     Buffer<uint32_t> next;
+
     Buffer<Slice> build_slice;
     ColumnPtr build_key_column = nullptr;
+    Buffer<uint8_t> build_key_nulls;
+
     uint32_t bucket_size = 0;
     uint32_t log_bucket_size = 0;
     uint32_t row_count = 0; // real row count
@@ -226,7 +241,7 @@ struct HashTableProbeState {
 
         using promise_type = ProbePromise;
         ProbeCoroutine(std::coroutine_handle<ProbePromise> h) : handle(h) {}
-        ~ProbeCoroutine() {}
+        ~ProbeCoroutine() = default;
         std::coroutine_handle<ProbePromise> handle;
         operator std::coroutine_handle<promise_type>() const { return std::move(handle); }
     };
@@ -306,6 +321,10 @@ struct HashTableParam {
     RuntimeProfile::Counter* output_probe_column_timer = nullptr;
     RuntimeProfile::Counter* probe_counter = nullptr;
 };
+
+// ------------------------------------------------------------------------------------
+// JoinHashMapHelper
+// ------------------------------------------------------------------------------------
 
 template <class T, size_t Size = sizeof(T)>
 struct JoinKeyHash {
@@ -406,95 +425,77 @@ public:
     }
 };
 
+// ------------------------------------------------------------------------------------
+// KeyConstructor
+// ------------------------------------------------------------------------------------
+
+// The JoinHashMap uses the following three template classes:
+// - BuildKeyConstructor and ProbeKeyConstructor are employed to construct join keys from the input builder and prober data segments.
+// - JoinHashMapMethod facilitates the creation and probing of the hash map structure.
+//
+// The BuildKeyConstructor, ProbeKeyConstructor, and JoinHashMapMethod use `prepare` or `prepare_build` methods to allocate required memory structures.
+//
+// There are two phases:
+// - Building Phase:
+//   - Invoke `BuildKeyConstructor::build_key` to generate the builder join key,
+//     then `JoinHashMapMethod::construct_hash_table` to construct the hash map.
+// - Probing Phase:
+//   - Invoke `ProbeKeyConstructor::build_key` to assemble the prober join key,
+//     then `JoinHashMapMethod::lookup_init` to initialize the chained buckets for each row.
+
 template <LogicalType LT>
-class JoinBuildFunc {
+class BuildKeyConstructorForOneKey {
 public:
     using CppType = typename RunTimeTypeTraits<LT>::CppType;
     using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
 
-    static void prepare(RuntimeState* runtime, JoinHashTableItems* table_items);
+    static void prepare(RuntimeState* state, JoinHashTableItems* table_items) {}
+    static void build_key(RuntimeState* state, JoinHashTableItems* table_items) {}
     static const Buffer<CppType>& get_key_data(const JoinHashTableItems& table_items);
-    static void construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                     HashTableProbeState* probe_state);
+    static const Buffer<uint8_t>* get_is_nulls(const JoinHashTableItems& table_items);
 };
 
 template <LogicalType LT>
-class DirectMappingJoinBuildFunc {
-public:
-    using CppType = typename RunTimeTypeTraits<LT>::CppType;
-    using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
-
-    static void prepare(RuntimeState* runtime, JoinHashTableItems* table_items);
-    static const Buffer<CppType>& get_key_data(const JoinHashTableItems& table_items);
-    static void construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                     HashTableProbeState* probe_state);
-};
-
-template <LogicalType LT>
-class FixedSizeJoinBuildFunc {
+class BuildKeyConstructorForSerializedFixedSize {
 public:
     using CppType = typename RunTimeTypeTraits<LT>::CppType;
     using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
 
     static void prepare(RuntimeState* state, JoinHashTableItems* table_items);
+    static void build_key(RuntimeState* state, JoinHashTableItems* table_items);
 
     static const Buffer<CppType>& get_key_data(const JoinHashTableItems& table_items) {
         return ColumnHelper::as_raw_column<const ColumnType>(table_items.build_key_column)->get_data();
     }
-    static void construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                     HashTableProbeState* probe_state);
-
-private:
-    static void _build_columns(JoinHashTableItems* table_items, HashTableProbeState* probe_state,
-                               const Columns& data_columns, uint32_t start, uint32_t count);
-
-    static void _build_nullable_columns(JoinHashTableItems* table_items, HashTableProbeState* probe_state,
-                                        const Columns& data_columns, const NullColumns& null_columns, uint32_t start,
-                                        uint32_t count);
+    static const Buffer<uint8_t>* get_is_nulls(const JoinHashTableItems& table_items) {
+        return table_items.build_key_nulls.empty() ? nullptr : &table_items.build_key_nulls;
+    }
 };
 
-class SerializedJoinBuildFunc {
+class BuildKeyConstructorForSerialized {
 public:
     static void prepare(RuntimeState* state, JoinHashTableItems* table_items);
+    static void build_key(RuntimeState* state, JoinHashTableItems* table_items);
+
     static const Buffer<Slice>& get_key_data(const JoinHashTableItems& table_items) { return table_items.build_slice; }
-    static void construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                     HashTableProbeState* probe_state);
-
-private:
-    static void _build_columns(JoinHashTableItems* table_items, HashTableProbeState* probe_state,
-                               const Columns& data_columns, uint32_t start, uint32_t count, uint8_t** ptr);
-
-    static void _build_nullable_columns(JoinHashTableItems* table_items, HashTableProbeState* probe_state,
-                                        const Columns& data_columns, const NullColumns& null_columns, uint32_t start,
-                                        uint32_t count, uint8_t** ptr);
+    static const Buffer<uint8_t>* get_is_nulls(const JoinHashTableItems& table_items) {
+        return table_items.build_key_nulls.empty() ? nullptr : &table_items.build_key_nulls;
+    }
 };
 
 template <LogicalType LT>
-class JoinProbeFunc {
+class ProbeKeyConstructorForOneKey {
 public:
     using CppType = typename RunTimeTypeTraits<LT>::CppType;
     using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
 
     static void prepare(RuntimeState* state, HashTableProbeState* probe_state) {}
-    static void lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
+    static void build_key(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
     static const Buffer<CppType>& get_key_data(const HashTableProbeState& probe_state);
-    static bool equal(const CppType& x, const CppType& y) { return x == y; }
 };
 
 template <LogicalType LT>
-class DirectMappingJoinProbeFunc {
-public:
-    using CppType = typename RunTimeTypeTraits<LT>::CppType;
-    using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
-
-    static void prepare(RuntimeState* state, HashTableProbeState* probe_state) {}
-    static void lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
-    static const Buffer<CppType>& get_key_data(const HashTableProbeState& probe_state);
-    static bool equal(const CppType& x, const CppType& y) { return true; }
-};
-
-template <LogicalType LT>
-class FixedSizeJoinProbeFunc {
+class ProbeKeyConstructorForSerializedFixedSize {
 public:
     using CppType = typename RunTimeTypeTraits<LT>::CppType;
     using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
@@ -504,35 +505,24 @@ public:
         probe_state->probe_key_column = ColumnType::create(state->chunk_size());
     }
 
-    // serialize and calculate hash values for probe keys.
-    static void lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
+    static void build_key(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
 
     static const Buffer<CppType>& get_key_data(const HashTableProbeState& probe_state) {
         return ColumnHelper::as_raw_column<ColumnType>(probe_state.probe_key_column)->get_data();
     }
-
-    static bool equal(const CppType& x, const CppType& y) { return x == y; }
-
-private:
-    static void _probe_column(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
-                              const Columns& data_columns);
-    static void _probe_nullable_column(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
-                                       const Columns& data_columns, const NullColumns& null_columns);
 };
 
-class SerializedJoinProbeFunc {
+class ProbeKeyConstructorForSerialized {
 public:
-    static const Buffer<Slice>& get_key_data(const HashTableProbeState& probe_state) { return probe_state.probe_slice; }
-
     static void prepare(RuntimeState* state, HashTableProbeState* probe_state) {
+        probe_state->is_nulls.resize(state->chunk_size());
         probe_state->probe_pool = std::make_unique<MemPool>();
         probe_state->probe_slice.resize(state->chunk_size());
-        probe_state->is_nulls.resize(state->chunk_size());
     }
 
-    static void lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
+    static void build_key(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
 
-    static bool equal(const Slice& x, const Slice& y) { return x == y; }
+    static const Buffer<Slice>& get_key_data(const HashTableProbeState& probe_state) { return probe_state.probe_slice; }
 
 private:
     static void _probe_column(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
@@ -540,6 +530,46 @@ private:
     static void _probe_nullable_column(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
                                        const Columns& data_columns, const NullColumns& null_columns, uint8_t* ptr);
 };
+
+// ------------------------------------------------------------------------------------
+// HashMapMethod
+// ------------------------------------------------------------------------------------
+
+template <LogicalType LT>
+class BucketChainedJoinHashMap {
+public:
+    using CppType = typename RunTimeTypeTraits<LT>::CppType;
+    using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
+
+    static void build_prepare(RuntimeState* state, JoinHashTableItems* table_items);
+    static void construct_hash_table(JoinHashTableItems* table_items, const Buffer<CppType>& keys,
+                                     const Buffer<uint8_t>* is_nulls);
+
+    static void lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
+                            const Buffer<CppType>& keys, const Buffer<uint8_t>* is_nulls);
+
+    static bool equal(const CppType& x, const CppType& y) { return x == y; }
+};
+
+template <LogicalType LT>
+class DirectMappingJoinHashMap {
+public:
+    using CppType = typename RunTimeTypeTraits<LT>::CppType;
+    using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
+
+    static void build_prepare(RuntimeState* state, JoinHashTableItems* table_items);
+    static void construct_hash_table(JoinHashTableItems* table_items, const Buffer<CppType>& keys,
+                                     const Buffer<uint8_t>* is_nulls);
+
+    static void lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
+                            const Buffer<CppType>& keys, const Buffer<uint8_t>* is_nulls);
+
+    static bool equal(const CppType& x, const CppType& y) { return true; }
+};
+
+// ------------------------------------------------------------------------------------
+// JoinHashMapForEmpty
+// ------------------------------------------------------------------------------------
 
 // When hash table is empty, specific its implemention.
 // TODO: Merge with JoinHashMap?
@@ -673,7 +703,11 @@ private:
     HashTableProbeState* _probe_state = nullptr;
 };
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+// ------------------------------------------------------------------------------------
+// JoinHashMap
+// ------------------------------------------------------------------------------------
+
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 class JoinHashMap {
 public:
     using CppType = typename RunTimeTypeTraits<LT>::CppType;
@@ -789,22 +823,16 @@ private:
     template <bool first_probe>
     void _probe_from_ht_for_left_semi_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                const Buffer<CppType>& probe_data);
-    HashTableProbeState::ProbeCoroutine _probe_from_ht_for_left_semi_join_with_other_conjunct(
-            RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
 
     // for null aware anti join with other join conjunct
     template <bool first_probe>
     void _probe_from_ht_for_null_aware_anti_join_with_other_conjunct(RuntimeState* state,
                                                                      const Buffer<CppType>& build_data,
                                                                      const Buffer<CppType>& probe_data);
-    HashTableProbeState::ProbeCoroutine _probe_from_ht_for_null_aware_anti_join_with_other_conjunct(
-            RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
 
     // for one key right outer join with other conjunct
     template <bool first_probe>
     void _probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct(
-            RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
-    HashTableProbeState::ProbeCoroutine _probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct(
             RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
 
     // for one key full outer join with other join conjunct
@@ -812,17 +840,24 @@ private:
     void _probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct(RuntimeState* state,
                                                                                      const Buffer<CppType>& build_data,
                                                                                      const Buffer<CppType>& probe_data);
-    HashTableProbeState::ProbeCoroutine _probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct(
-            RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
 
     JoinHashTableItems* _table_items = nullptr;
     HashTableProbeState* _probe_state = nullptr;
 };
 
-#define JoinHashMapForOneKey(LT) JoinHashMap<LT, JoinBuildFunc<LT>, JoinProbeFunc<LT>>
-#define JoinHashMapForDirectMapping(LT) JoinHashMap<LT, DirectMappingJoinBuildFunc<LT>, DirectMappingJoinProbeFunc<LT>>
-#define JoinHashMapForFixedSizeKey(LT) JoinHashMap<LT, FixedSizeJoinBuildFunc<LT>, FixedSizeJoinProbeFunc<LT>>
-#define JoinHashMapForSerializedKey(LT) JoinHashMap<LT, SerializedJoinBuildFunc, SerializedJoinProbeFunc>
+#define JoinHashMapForOneKey(LT) \
+    JoinHashMap<LT, BuildKeyConstructorForOneKey<LT>, ProbeKeyConstructorForOneKey<LT>, BucketChainedJoinHashMap<LT>>
+#define JoinHashMapForDirectMapping(LT) \
+    JoinHashMap<LT, BuildKeyConstructorForOneKey<LT>, ProbeKeyConstructorForOneKey<LT>, DirectMappingJoinHashMap<LT>>
+#define JoinHashMapForFixedSizeKey(LT)                                                                            \
+    JoinHashMap<LT, BuildKeyConstructorForSerializedFixedSize<LT>, ProbeKeyConstructorForSerializedFixedSize<LT>, \
+                BucketChainedJoinHashMap<LT>>
+#define JoinHashMapForSerializedKey(LT) \
+    JoinHashMap<LT, BuildKeyConstructorForSerialized, ProbeKeyConstructorForSerialized, BucketChainedJoinHashMap<LT>>
+
+// ------------------------------------------------------------------------------------
+// JoinHashTable
+// ------------------------------------------------------------------------------------
 
 class JoinHashTable {
 public:
@@ -877,9 +912,6 @@ private:
     void _init_build_column(const HashTableParam& param);
     void _init_join_keys();
 
-    JoinHashMapType _choose_join_hash_map();
-    static size_t _get_size_of_fixed_and_contiguous_type(LogicalType data_type);
-
     Status _upgrade_key_columns_if_overflow();
 
     void _remove_duplicate_index_for_left_outer_join(Filter* filter);
@@ -916,10 +948,12 @@ private:
     std::shared_ptr<JoinHashTableItems> _table_items;
     std::unique_ptr<HashTableProbeState> _probe_state = std::make_unique<HashTableProbeState>();
 };
+
 } // namespace starrocks
 
 #ifndef JOIN_HASH_MAP_TPP
 #include "exec/join_hash_map.tpp"
+
 #endif
 
 #undef JOIN_HASH_MAP_H

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -88,7 +88,7 @@ enum class JoinHashMapType {
     fixed128 // 16 bytes
 };
 
-enum class JoinKeyConstructor {
+enum class JoinKeyConstructorType {
     ONE_KEY,
     SERIALIZED_FIXED_SIZE,
     SERIALIZED,

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -25,17 +25,13 @@
 #endif
 
 namespace starrocks {
-template <LogicalType LT>
-void JoinBuildFunc<LT>::prepare(RuntimeState* runtime, JoinHashTableItems* table_items) {
-    table_items->bucket_size = JoinHashMapHelper::calc_bucket_size(table_items->row_count + 1);
-    table_items->log_bucket_size = __builtin_ctz(table_items->bucket_size);
-    table_items->first.resize(table_items->bucket_size, 0);
-    table_items->next.resize(table_items->row_count + 1, 0);
-}
+
+// ------------------------------------------------------------------------------------
+// KeyConstructor
+// ------------------------------------------------------------------------------------
 
 template <LogicalType LT>
-const Buffer<typename JoinBuildFunc<LT>::CppType>& JoinBuildFunc<LT>::get_key_data(
-        const JoinHashTableItems& table_items) {
+auto BuildKeyConstructorForOneKey<LT>::get_key_data(const JoinHashTableItems& table_items) -> const Buffer<CppType>& {
     ColumnPtr data_column;
     if (table_items.key_columns[0]->is_nullable()) {
         auto* null_column = ColumnHelper::as_raw_column<NullableColumn>(table_items.key_columns[0]);
@@ -56,102 +52,25 @@ const Buffer<typename JoinBuildFunc<LT>::CppType>& JoinBuildFunc<LT>::get_key_da
 }
 
 template <LogicalType LT>
-void JoinBuildFunc<LT>::construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                             HashTableProbeState* probe_state) {
-    auto& data = get_key_data(*table_items);
-    if (table_items->key_columns[0]->is_nullable() && table_items->key_columns[0]->has_null()) {
-        auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(table_items->key_columns[0]);
-        const auto& null_array = nullable_column->null_column()->get_data();
-        for (size_t i = 1; i < table_items->row_count + 1; i++) {
-            if (null_array[i] == 0) {
-                const uint32_t bucket_num = JoinHashMapHelper::calc_bucket_num<CppType>(
-                        data[i], table_items->bucket_size, table_items->log_bucket_size);
-                table_items->next[i] = table_items->first[bucket_num];
-                table_items->first[bucket_num] = i;
-            }
-        }
+const Buffer<uint8_t>* BuildKeyConstructorForOneKey<LT>::get_is_nulls(const JoinHashTableItems& table_items) {
+    if (table_items.key_columns[0]->is_nullable() && table_items.key_columns[0]->has_null()) {
+        auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(table_items.key_columns[0]);
+        return &nullable_column->null_column()->get_data();
     } else {
-        auto* __restrict next = table_items->next.data();
-        for (size_t i = 1; i < table_items->row_count + 1; i++) {
-            const uint32_t bucket_num = JoinHashMapHelper::calc_bucket_num<CppType>(data[i], table_items->bucket_size,
-                                                                                    table_items->log_bucket_size);
-            // Use `next` stores `bucket_num` temporarily.
-            next[i] = bucket_num;
-        }
-
-        auto* __restrict first = table_items->first.data();
-        for (size_t i = 1; i < table_items->row_count + 1; i++) {
-            const uint32_t bucket_num = next[i];
-            next[i] = first[bucket_num];
-            first[bucket_num] = i;
-        }
+        return nullptr;
     }
-
-    table_items->calculate_ht_info(table_items->key_columns[0]->byte_size());
 }
 
 template <LogicalType LT>
-void DirectMappingJoinBuildFunc<LT>::prepare(RuntimeState* runtime, JoinHashTableItems* table_items) {
-    static constexpr size_t BUCKET_SIZE =
-            (int64_t)(RunTimeTypeLimits<LT>::max_value()) - (int64_t)(RunTimeTypeLimits<LT>::min_value()) + 1L;
-    table_items->bucket_size = BUCKET_SIZE;
-    table_items->log_bucket_size = __builtin_ctz(table_items->bucket_size);
-    table_items->first.resize(table_items->bucket_size, 0);
-    table_items->next.resize(table_items->row_count + 1, 0);
-}
-
-template <LogicalType LT>
-const Buffer<typename DirectMappingJoinBuildFunc<LT>::CppType>& DirectMappingJoinBuildFunc<LT>::get_key_data(
-        const JoinHashTableItems& table_items) {
-    if (table_items.key_columns[0]->is_nullable()) {
-        auto* null_column = ColumnHelper::as_raw_column<NullableColumn>(table_items.key_columns[0]);
-        return ColumnHelper::as_raw_column<ColumnType>(null_column->data_column())->get_data();
-    }
-
-    return ColumnHelper::as_raw_column<ColumnType>(table_items.key_columns[0])->get_data();
-}
-
-template <LogicalType LT>
-void DirectMappingJoinBuildFunc<LT>::construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                                          HashTableProbeState* probe_state) {
-    static constexpr CppType MIN_VALUE = RunTimeTypeLimits<LT>::min_value();
-
-    auto& data = get_key_data(*table_items);
-    if (table_items->key_columns[0]->is_nullable()) {
-        auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(table_items->key_columns[0]);
-        auto& null_array = nullable_column->null_column()->get_data();
-        for (size_t i = 1; i < table_items->row_count + 1; i++) {
-            if (null_array[i] == 0) {
-                size_t buckets = data[i] - MIN_VALUE;
-                table_items->next[i] = table_items->first[buckets];
-                table_items->first[buckets] = i;
-            }
-        }
-    } else {
-        for (size_t i = 1; i < table_items->row_count + 1; i++) {
-            size_t buckets = data[i] - MIN_VALUE;
-            table_items->next[i] = table_items->first[buckets];
-            table_items->first[buckets] = i;
-        }
-    }
-    table_items->calculate_ht_info(table_items->key_columns[0]->byte_size());
-}
-
-template <LogicalType LT>
-void FixedSizeJoinBuildFunc<LT>::prepare(RuntimeState* state, JoinHashTableItems* table_items) {
-    table_items->bucket_size = JoinHashMapHelper::calc_bucket_size(table_items->row_count + 1);
-    table_items->log_bucket_size = __builtin_ctz(table_items->bucket_size);
-    table_items->first.resize(table_items->bucket_size, 0);
-    table_items->next.resize(table_items->row_count + 1, 0);
+void BuildKeyConstructorForSerializedFixedSize<LT>::prepare(RuntimeState* state, JoinHashTableItems* table_items) {
     table_items->build_key_column = ColumnType::create(table_items->row_count + 1);
 }
 
 template <LogicalType LT>
-void FixedSizeJoinBuildFunc<LT>::construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                                      HashTableProbeState* probe_state) {
-    uint32_t row_count = table_items->row_count;
+void BuildKeyConstructorForSerializedFixedSize<LT>::build_key(RuntimeState* state, JoinHashTableItems* table_items) {
+    const uint32_t row_count = table_items->row_count;
 
-    // prepare columns
+    // Prepare data and null columns.
     Columns data_columns;
     NullColumns null_columns;
     for (size_t i = 0; i < table_items->key_columns.size(); i++) {
@@ -167,150 +86,36 @@ void FixedSizeJoinBuildFunc<LT>::construct_hash_table(RuntimeState* state, JoinH
             data_columns.emplace_back(table_items->key_columns[i]);
         }
     }
-
-    // serialize and build hash table
-    uint32_t quo = row_count / state->chunk_size();
-    uint32_t rem = row_count % state->chunk_size();
-
+    // Serialize to key columns.
+    JoinHashMapHelper::serialize_fixed_size_key_column<LT>(data_columns, table_items->build_key_column.get(), 1,
+                                                           row_count);
+    // Build key is_nulls.
     if (!null_columns.empty()) {
-        for (size_t i = 0; i < quo; i++) {
-            _build_nullable_columns(table_items, probe_state, data_columns, null_columns, 1 + state->chunk_size() * i,
-                                    state->chunk_size());
-        }
-        _build_nullable_columns(table_items, probe_state, data_columns, null_columns, 1 + state->chunk_size() * quo,
-                                rem);
-    } else {
-        for (size_t i = 0; i < quo; i++) {
-            _build_columns(table_items, probe_state, data_columns, 1 + state->chunk_size() * i, state->chunk_size());
-        }
-        _build_columns(table_items, probe_state, data_columns, 1 + state->chunk_size() * quo, rem);
-    }
-    table_items->calculate_ht_info(table_items->build_key_column->byte_size());
-}
-
-template <LogicalType LT>
-void FixedSizeJoinBuildFunc<LT>::_build_columns(JoinHashTableItems* table_items, HashTableProbeState* probe_state,
-                                                const Columns& data_columns, uint32_t start, uint32_t count) {
-    JoinHashMapHelper::serialize_fixed_size_key_column<LT>(data_columns, table_items->build_key_column.get(), start,
-                                                           count);
-
-    const auto& data = get_key_data(*table_items);
-    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items->bucket_size, table_items->log_bucket_size,
-                                                 &probe_state->buckets, start, count);
-
-    for (uint32_t i = 0; i < count; i++) {
-        table_items->next[start + i] = table_items->first[probe_state->buckets[i]];
-        table_items->first[probe_state->buckets[i]] = start + i;
-    }
-}
-
-template <LogicalType LT>
-void FixedSizeJoinBuildFunc<LT>::_build_nullable_columns(JoinHashTableItems* table_items,
-                                                         HashTableProbeState* probe_state, const Columns& data_columns,
-                                                         const NullColumns& null_columns, uint32_t start,
-                                                         uint32_t count) {
-    for (uint32_t i = 0; i < count; i++) {
-        probe_state->is_nulls[i] = null_columns[0]->get_data()[start + i];
-    }
-    for (uint32_t i = 1; i < null_columns.size(); i++) {
-        for (uint32_t j = 0; j < count; j++) {
-            probe_state->is_nulls[j] |= null_columns[i]->get_data()[start + j];
-        }
-    }
-
-    JoinHashMapHelper::serialize_fixed_size_key_column<LT>(data_columns, table_items->build_key_column.get(), start,
-                                                           count);
-    const auto& data = get_key_data(*table_items);
-    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items->bucket_size, table_items->log_bucket_size,
-                                                 &probe_state->buckets, start, count);
-
-    for (size_t i = 0; i < count; i++) {
-        if (probe_state->is_nulls[i] == 0) {
-            table_items->next[start + i] = table_items->first[probe_state->buckets[i]];
-            table_items->first[probe_state->buckets[i]] = start + i;
+        table_items->build_key_nulls.resize(row_count + 1);
+        auto* dest_is_nulls = table_items->build_key_nulls.data();
+        std::memcpy(dest_is_nulls, null_columns[0]->get_data().data(), (row_count + 1) * sizeof(NullColumn::ValueType));
+        for (uint32_t i = 1; i < null_columns.size(); i++) {
+            for (uint32_t j = 1; j < 1 + row_count; j++) {
+                dest_is_nulls[j] |= null_columns[i]->get_data()[j];
+            }
         }
     }
 }
 
 template <LogicalType LT>
-void DirectMappingJoinProbeFunc<LT>::lookup_init(const JoinHashTableItems& table_items,
+void ProbeKeyConstructorForOneKey<LT>::build_key(const JoinHashTableItems& table_items,
                                                  HashTableProbeState* probe_state) {
-    static constexpr CppType MIN_VALUE = RunTimeTypeLimits<LT>::min_value();
-    size_t probe_row_count = probe_state->probe_row_count;
-    auto& data = get_key_data(*probe_state);
-    probe_state->active_coroutines = 0; // the ht data is not large, so disable it always.
-
-    if ((*probe_state->key_columns)[0]->is_nullable()) {
-        auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>((*probe_state->key_columns)[0]);
-
-        if (nullable_column->has_null()) {
-            auto& null_array = nullable_column->null_column()->get_data();
-            for (size_t i = 0; i < probe_row_count; i++) {
-                if (null_array[i] == 0) {
-                    probe_state->next[i] = table_items.first[data[i] - MIN_VALUE];
-                } else {
-                    probe_state->next[i] = 0;
-                }
-            }
-            probe_state->null_array = &null_array;
-        } else {
-            for (size_t i = 0; i < probe_row_count; i++) {
-                probe_state->next[i] = table_items.first[data[i] - MIN_VALUE];
-            }
-            probe_state->null_array = nullptr;
-        }
-        return;
-    }
-
-    for (size_t i = 0; i < probe_row_count; i++) {
-        probe_state->next[i] = table_items.first[data[i] - MIN_VALUE];
-    }
-    probe_state->null_array = nullptr;
-}
-
-template <LogicalType LT>
-const Buffer<typename DirectMappingJoinProbeFunc<LT>::CppType>& DirectMappingJoinProbeFunc<LT>::get_key_data(
-        const HashTableProbeState& probe_state) {
-    if ((*probe_state.key_columns)[0]->is_nullable()) {
-        auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>((*probe_state.key_columns)[0]);
-        return ColumnHelper::as_raw_column<ColumnType>(nullable_column->data_column())->get_data();
-    }
-
-    return ColumnHelper::as_raw_column<ColumnType>((*probe_state.key_columns)[0])->get_data();
-}
-
-template <LogicalType LT>
-void JoinProbeFunc<LT>::lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state) {
-    const size_t probe_row_count = probe_state->probe_row_count;
-    auto& data = get_key_data(*probe_state);
-    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items.bucket_size, table_items.log_bucket_size,
-                                                 &probe_state->buckets, 0, data.size());
-
-    const auto* firsts = table_items.first.data();
-    const auto* buckets = probe_state->buckets.data();
-    auto* nexts = probe_state->next.data();
-
-    if ((*probe_state->key_columns)[0]->is_nullable()) {
+    const auto& key_column = (*probe_state->key_columns)[0];
+    if (key_column->is_nullable() && key_column->has_null()) {
         const auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>((*probe_state->key_columns)[0]);
-        if (nullable_column->has_null()) {
-            const auto* is_nulls = nullable_column->null_column()->get_data().data();
-            SIMDGather::gather(nexts, firsts, buckets, is_nulls, probe_row_count);
-
-            probe_state->null_array = &nullable_column->null_column()->get_data();
-            probe_state->consider_probe_time_locality();
-            return;
-        }
+        probe_state->null_array = &nullable_column->null_column()->get_data();
+    } else {
+        probe_state->null_array = nullptr;
     }
-
-    SIMDGather::gather(nexts, firsts, buckets, probe_row_count);
-
-    probe_state->null_array = nullptr;
-    probe_state->consider_probe_time_locality();
 }
 
 template <LogicalType LT>
-const Buffer<typename JoinProbeFunc<LT>::CppType>& JoinProbeFunc<LT>::get_key_data(
-        const HashTableProbeState& probe_state) {
+auto ProbeKeyConstructorForOneKey<LT>::get_key_data(const HashTableProbeState& probe_state) -> const Buffer<CppType>& {
     if ((*probe_state.key_columns)[0]->is_nullable()) {
         auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>((*probe_state.key_columns)[0]);
         return ColumnHelper::as_raw_column<ColumnType>(nullable_column->data_column())->get_data();
@@ -320,8 +125,9 @@ const Buffer<typename JoinProbeFunc<LT>::CppType>& JoinProbeFunc<LT>::get_key_da
 }
 
 template <LogicalType LT>
-void FixedSizeJoinProbeFunc<LT>::lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state) {
-    // prepare columns
+void ProbeKeyConstructorForSerializedFixedSize<LT>::build_key(const JoinHashTableItems& table_items,
+                                                              HashTableProbeState* probe_state) {
+    // Prepare columns.
     Columns data_columns;
     NullColumns null_columns;
 
@@ -345,69 +151,192 @@ void FixedSizeJoinProbeFunc<LT>::lookup_init(const JoinHashTableItems& table_ite
         }
     }
 
-    // serialize and init search
-    if (!null_columns.empty()) {
-        _probe_nullable_column(table_items, probe_state, data_columns, null_columns);
+    // Build key and is_nulls.
+    const uint32_t row_count = probe_state->probe_row_count;
+    JoinHashMapHelper::serialize_fixed_size_key_column<LT>(data_columns, probe_state->probe_key_column.get(), 0,
+                                                           row_count);
+
+    if (null_columns.empty()) {
+        probe_state->null_array = nullptr;
     } else {
-        _probe_column(table_items, probe_state, data_columns);
+        for (uint32_t i = 0; i < row_count; i++) {
+            probe_state->is_nulls[i] = null_columns[0]->get_data()[i];
+        }
+        for (uint32_t i = 1; i < null_columns.size(); i++) {
+            for (uint32_t j = 0; j < row_count; j++) {
+                probe_state->is_nulls[j] |= null_columns[i]->get_data()[j];
+            }
+        }
+
+        probe_state->null_array = &probe_state->is_nulls;
     }
-    probe_state->consider_probe_time_locality();
+}
+
+// ------------------------------------------------------------------------------------
+// HashMapMethod
+// ------------------------------------------------------------------------------------
+
+template <LogicalType LT>
+void BucketChainedJoinHashMap<LT>::build_prepare(RuntimeState* state, JoinHashTableItems* table_items) {
+    table_items->bucket_size = JoinHashMapHelper::calc_bucket_size(table_items->row_count + 1);
+    table_items->log_bucket_size = __builtin_ctz(table_items->bucket_size);
+    table_items->first.resize(table_items->bucket_size, 0);
+    table_items->next.resize(table_items->row_count + 1, 0);
 }
 
 template <LogicalType LT>
-void FixedSizeJoinProbeFunc<LT>::_probe_column(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
-                                               const Columns& data_columns) {
-    uint32_t row_count = probe_state->probe_row_count;
+void BucketChainedJoinHashMap<LT>::construct_hash_table(JoinHashTableItems* table_items, const Buffer<CppType>& keys,
+                                                        const Buffer<uint8_t>* is_nulls) {
+    const auto num_rows = 1 + table_items->row_count;
 
-    JoinHashMapHelper::serialize_fixed_size_key_column<LT>(data_columns, probe_state->probe_key_column.get(), 0,
-                                                           row_count);
-    const auto& data = get_key_data(*probe_state);
-    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items.bucket_size, table_items.log_bucket_size,
-                                                 &probe_state->buckets, 0, row_count);
-    probe_state->null_array = nullptr;
-    for (uint32_t i = 0; i < row_count; i++) {
-        probe_state->next[i] = table_items.first[probe_state->buckets[i]];
+    if (is_nulls == nullptr) {
+        auto* __restrict next = table_items->next.data();
+        for (uint32_t i = 1; i < num_rows; i++) {
+            // Use `next` stores `bucket_num` temporarily.
+            next[i] = JoinHashMapHelper::calc_bucket_num<CppType>(keys[i], table_items->bucket_size,
+                                                                  table_items->log_bucket_size);
+        }
+
+        auto* __restrict first = table_items->first.data();
+        for (uint32_t i = 1; i < num_rows; i++) {
+            const uint32_t bucket_num = next[i];
+            next[i] = first[bucket_num];
+            first[bucket_num] = i;
+        }
+    } else {
+        const auto* __restrict is_nulls_data = is_nulls->data();
+        auto need_calc_bucket_num = [&](const uint32_t index) {
+            if constexpr (!std::is_same_v<CppType, Slice>) {
+                return true;
+            } else {
+                return is_nulls_data[index] == 0;
+            }
+        };
+
+        auto* __restrict next = table_items->next.data();
+        for (uint32_t i = 0; i < num_rows; i++) {
+            // Use `next` stores `bucket_num` temporarily.
+            if (need_calc_bucket_num(i)) {
+                next[i] = JoinHashMapHelper::calc_bucket_num<CppType>(keys[i], table_items->bucket_size,
+                                                                      table_items->log_bucket_size);
+            }
+        }
+
+        auto* __restrict first = table_items->first.data();
+        for (uint32_t i = 0; i < num_rows; i++) {
+            if (is_nulls_data[i] == 0) {
+                const uint32_t bucket_num = next[i];
+                next[i] = first[bucket_num];
+                first[bucket_num] = i;
+            } else {
+                next[i] = 0;
+            }
+        }
     }
 }
 
 template <LogicalType LT>
-void FixedSizeJoinProbeFunc<LT>::_probe_nullable_column(const JoinHashTableItems& table_items,
-                                                        HashTableProbeState* probe_state, const Columns& data_columns,
-                                                        const NullColumns& null_columns) {
-    uint32_t row_count = probe_state->probe_row_count;
+void BucketChainedJoinHashMap<LT>::lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
+                                               const Buffer<CppType>& keys, const Buffer<uint8_t>* is_nulls) {
+    const uint32_t row_count = probe_state->probe_row_count;
+    const auto* firsts = table_items.first.data();
+    const auto* buckets = probe_state->buckets.data();
+    auto* nexts = probe_state->next.data();
 
-    for (uint32_t i = 0; i < row_count; i++) {
-        probe_state->is_nulls[i] = null_columns[0]->get_data()[i];
-    }
-    for (uint32_t i = 1; i < null_columns.size(); i++) {
-        for (uint32_t j = 0; j < row_count; j++) {
-            probe_state->is_nulls[j] |= null_columns[i]->get_data()[j];
+    if (is_nulls == nullptr) {
+        for (uint32_t i = 0; i < row_count; i++) {
+            probe_state->buckets[i] = JoinHashMapHelper::calc_bucket_num<CppType>(keys[i], table_items.bucket_size,
+                                                                                  table_items.log_bucket_size);
         }
+        SIMDGather::gather(nexts, firsts, buckets, row_count);
+    } else {
+        const auto* is_nulls_data = is_nulls->data();
+        auto need_calc_bucket_num = [&](const uint32_t index) {
+            if constexpr (!std::is_same_v<CppType, Slice>) {
+                return true;
+            } else {
+                return is_nulls_data[index] == 0;
+            }
+        };
+        for (uint32_t i = 0; i < row_count; i++) {
+            if (need_calc_bucket_num(i)) {
+                probe_state->buckets[i] = JoinHashMapHelper::calc_bucket_num<CppType>(keys[i], table_items.bucket_size,
+                                                                                      table_items.log_bucket_size);
+            }
+        }
+        SIMDGather::gather(nexts, firsts, buckets, is_nulls_data, row_count);
     }
-    probe_state->null_array = &null_columns[0]->get_data();
+}
 
-    JoinHashMapHelper::serialize_fixed_size_key_column<LT>(data_columns, probe_state->probe_key_column.get(), 0,
-                                                           row_count);
-    const auto& data = get_key_data(*probe_state);
-    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items.bucket_size, table_items.log_bucket_size,
-                                                 &probe_state->buckets, 0, row_count);
+template <LogicalType LT>
+void DirectMappingJoinHashMap<LT>::build_prepare(RuntimeState* state, JoinHashTableItems* table_items) {
+    static constexpr size_t BUCKET_SIZE = static_cast<int64_t>(RunTimeTypeLimits<LT>::max_value()) -
+                                          static_cast<int64_t>(RunTimeTypeLimits<LT>::min_value()) + 1L;
+    table_items->bucket_size = BUCKET_SIZE;
+    table_items->log_bucket_size = __builtin_ctz(table_items->bucket_size);
+    table_items->first.resize(table_items->bucket_size, 0);
+    table_items->next.resize(table_items->row_count + 1, 0);
+}
 
-    for (uint32_t i = 0; i < row_count; i++) {
-        if (probe_state->is_nulls[i] == 0) {
-            probe_state->next[i] = table_items.first[probe_state->buckets[i]];
-        } else {
-            probe_state->next[i] = 0;
+template <LogicalType LT>
+void DirectMappingJoinHashMap<LT>::construct_hash_table(JoinHashTableItems* table_items, const Buffer<CppType>& keys,
+                                                        const Buffer<uint8_t>* is_nulls) {
+    static constexpr CppType MIN_VALUE = RunTimeTypeLimits<LT>::min_value();
+
+    const auto num_rows = 1 + table_items->row_count;
+    if (is_nulls == nullptr) {
+        for (uint32_t i = 1; i < num_rows; i++) {
+            const size_t bucket_num = keys[i] - MIN_VALUE;
+            table_items->next[i] = table_items->first[bucket_num];
+            table_items->first[bucket_num] = i;
+        }
+    } else {
+        const auto* is_nulls_data = is_nulls->data();
+        for (uint32_t i = 1; i < num_rows; i++) {
+            if (is_nulls_data[i] == 0) {
+                const size_t bucket_num = keys[i] - MIN_VALUE;
+                table_items->next[i] = table_items->first[bucket_num];
+                table_items->first[bucket_num] = i;
+            }
         }
     }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::build_prepare(RuntimeState* state) {
-    BuildFunc().prepare(state, _table_items);
+template <LogicalType LT>
+void DirectMappingJoinHashMap<LT>::lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
+                                               const Buffer<CppType>& keys, const Buffer<uint8_t>* is_nulls) {
+    probe_state->active_coroutines = 0; // the ht data is not large, so disable it always.
+
+    static constexpr CppType MIN_VALUE = RunTimeTypeLimits<LT>::min_value();
+    const size_t probe_row_count = probe_state->probe_row_count;
+
+    if (is_nulls == nullptr) {
+        for (size_t i = 0; i < probe_row_count; i++) {
+            probe_state->next[i] = table_items.first[keys[i] - MIN_VALUE];
+        }
+    } else {
+        const auto* is_nulls_data = is_nulls->data();
+        for (size_t i = 0; i < probe_row_count; i++) {
+            if (is_nulls_data[i] == 0) {
+                probe_state->next[i] = table_items.first[keys[i] - MIN_VALUE];
+            } else {
+                probe_state->next[i] = 0;
+            }
+        }
+    }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe_prepare(RuntimeState* state) {
+// ------------------------------------------------------------------------------------
+// JoinHashMap
+// ------------------------------------------------------------------------------------
+
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::build_prepare(RuntimeState* state) {
+    HashMapMethod().build_prepare(state, _table_items);
+}
+
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::probe_prepare(RuntimeState* state) {
     size_t chunk_size = state->chunk_size();
     _probe_state->build_index.resize(chunk_size + 8);
     _probe_state->probe_index.resize(chunk_size + 8);
@@ -422,17 +351,19 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe_prepare(RuntimeState* state) {
         _probe_state->build_match_index[0] = 1;
     }
 
-    ProbeFunc().prepare(state, _probe_state);
+    ProbeKeyConstructor().prepare(state, _probe_state);
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::build(RuntimeState* state) {
-    BuildFunc().construct_hash_table(state, _table_items, _probe_state);
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::build(RuntimeState* state) {
+    const auto& keys = BuildKeyConstructor().get_key_data(*_table_items);
+    const auto* is_nulls = BuildKeyConstructor().get_is_nulls(*_table_items);
+    HashMapMethod().construct_hash_table(_table_items, keys, is_nulls);
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Columns& key_columns,
-                                                  ChunkPtr* probe_chunk, ChunkPtr* chunk, bool* has_remain) {
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::probe(
+        RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk, bool* has_remain) {
     _probe_state->key_columns = &key_columns;
     {
         SCOPED_TIMER(_probe_state->search_ht_timer);
@@ -503,8 +434,10 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
     }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* has_remain) {
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::probe_remain(RuntimeState* state,
+                                                                                            ChunkPtr* chunk,
+                                                                                            bool* has_remain) {
     _search_ht_remain(state);
     if (_probe_state->count <= 0) {
         *has_remain = false;
@@ -529,9 +462,10 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe_remain(RuntimeState* state, Ch
     }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool is_lazy>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_output(ChunkPtr* probe_chunk, ChunkPtr* chunk) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_output(ChunkPtr* probe_chunk,
+                                                                                             ChunkPtr* chunk) {
     bool to_nullable = _table_items->left_to_nullable;
 
     for (size_t i = 0; i < _table_items->probe_column_count; i++) {
@@ -549,10 +483,11 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_output(ChunkPtr* probe_chunk,
     }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool is_remain>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::lazy_output(RuntimeState* state, ChunkPtr* probe_chunk,
-                                                        ChunkPtr* result_chunk) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::lazy_output(RuntimeState* state,
+                                                                                           ChunkPtr* probe_chunk,
+                                                                                           ChunkPtr* result_chunk) {
     if ((*result_chunk)->num_rows() < _probe_state->count) {
         _probe_state->match_flag = JoinMatchFlag::NORMAL;
         _probe_state->count = (*result_chunk)->num_rows();
@@ -604,9 +539,10 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::lazy_output(RuntimeState* state, Chu
     _probe_state->count = 0;
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool is_lazy>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_null_output(ChunkPtr* chunk, size_t count) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_null_output(ChunkPtr* chunk,
+                                                                                                  size_t count) {
     for (size_t i = 0; i < _table_items->probe_column_count; i++) {
         HashTableSlotDescriptor hash_table_slot = _table_items->probe_slots[i];
         SlotDescriptor* slot = hash_table_slot.slot;
@@ -619,9 +555,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_null_output(ChunkPtr* chunk, 
     }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool is_lazy>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_build_output(ChunkPtr* chunk) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_build_output(ChunkPtr* chunk) {
     bool to_nullable = _table_items->right_to_nullable;
     for (size_t i = 0; i < _table_items->build_column_count; i++) {
         HashTableSlotDescriptor hash_table_slot = _table_items->build_slots[i];
@@ -639,8 +575,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_build_output(ChunkPtr* chunk) {
     }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_build_default_output(ChunkPtr* chunk, size_t count) {
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_build_default_output(ChunkPtr* chunk,
+                                                                                                     size_t count) {
     for (size_t i = 0; i < _table_items->build_column_count; i++) {
         auto hash_tablet_slot = _table_items->build_slots[i];
         SlotDescriptor* slot = hash_tablet_slot.slot;
@@ -652,9 +589,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_build_default_output(ChunkPtr* chun
     }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_copy_probe_column(ColumnPtr* src_column, ChunkPtr* chunk,
-                                                               const SlotDescriptor* slot, bool to_nullable) {
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_copy_probe_column(
+        ColumnPtr* src_column, ChunkPtr* chunk, const SlotDescriptor* slot, bool to_nullable) {
     if (_probe_state->match_flag == JoinMatchFlag::ALL_MATCH_ONE) {
         if (to_nullable) {
             ColumnPtr dest_column =
@@ -680,9 +617,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_copy_probe_column(ColumnPtr* src_co
     }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_copy_probe_nullable_column(ColumnPtr* src_column, ChunkPtr* chunk,
-                                                                        const SlotDescriptor* slot) {
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_copy_probe_nullable_column(
+        ColumnPtr* src_column, ChunkPtr* chunk, const SlotDescriptor* slot) {
     if (_probe_state->match_flag == JoinMatchFlag::ALL_MATCH_ONE) {
         (*chunk)->append_column(*src_column, slot->id());
     } else if (_probe_state->match_flag == JoinMatchFlag::MOST_MATCH_ONE) {
@@ -695,9 +632,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_copy_probe_nullable_column(ColumnPt
     }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_copy_build_column(const ColumnPtr& src_column, ChunkPtr* chunk,
-                                                               const SlotDescriptor* slot, bool to_nullable) {
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_copy_build_column(
+        const ColumnPtr& src_column, ChunkPtr* chunk, const SlotDescriptor* slot, bool to_nullable) {
     if (to_nullable) {
         auto data_column = src_column->clone_empty();
         data_column->append_selective(*src_column, _probe_state->build_index.data(), 0, _probe_state->count);
@@ -722,9 +659,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_copy_build_column(const ColumnPtr& 
     }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_copy_build_nullable_column(const ColumnPtr& src_column, ChunkPtr* chunk,
-                                                                        const SlotDescriptor* slot) {
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_copy_build_nullable_column(
+        const ColumnPtr& src_column, ChunkPtr* chunk, const SlotDescriptor* slot) {
     const uint32_t num_rows = _probe_state->count;
     const auto* build_index = _probe_state->build_index.data();
 
@@ -751,8 +688,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_copy_build_nullable_column(const Co
     (*chunk)->append_column(std::move(dest_column), slot->id());
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht(RuntimeState* state, ChunkPtr* probe_chunk) {
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_search_ht(RuntimeState* state,
+                                                                                          ChunkPtr* probe_chunk) {
     if (_table_items->enable_late_materialization) {
         _probe_state->probe_index.resize(state->chunk_size() + 8);
         _probe_state->build_index.resize(state->chunk_size() + 8);
@@ -764,20 +702,23 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht(RuntimeState* state, Chun
         if (state->query_options().interleaving_group_size > 0 && !_table_items->ht_cache_miss_serious()) {
             _probe_state->active_coroutines = 0;
         }
-        ProbeFunc().lookup_init(*_table_items, _probe_state);
 
-        auto& build_data = BuildFunc().get_key_data(*_table_items);
-        auto& probe_data = ProbeFunc().get_key_data(*_probe_state);
+        ProbeKeyConstructor().build_key(*_table_items, _probe_state);
+
+        auto& build_data = BuildKeyConstructor().get_key_data(*_table_items);
+        auto& probe_data = ProbeKeyConstructor().get_key_data(*_probe_state);
+        HashMapMethod().lookup_init(*_table_items, _probe_state, probe_data, _probe_state->null_array);
+
         _search_ht_impl<true>(state, build_data, probe_data);
     } else {
-        auto& build_data = BuildFunc().get_key_data(*_table_items);
-        auto& probe_data = ProbeFunc().get_key_data(*_probe_state);
+        auto& build_data = BuildKeyConstructor().get_key_data(*_table_items);
+        auto& probe_data = ProbeKeyConstructor().get_key_data(*_probe_state);
         _search_ht_impl<false>(state, build_data, probe_data);
     }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_remain(RuntimeState* state) {
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_search_ht_remain(RuntimeState* state) {
     if (!_probe_state->has_remain) {
         size_t zero_count = SIMD::count_zero(_probe_state->build_match_index);
         if (zero_count <= 0) {
@@ -841,10 +782,10 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_remain(RuntimeState* stat
         X<first_probe>(state, build_data, data);                                                                     \
     }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_impl(RuntimeState* state, const Buffer<CppType>& build_data,
-                                                            const Buffer<CppType>& data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_search_ht_impl(
+        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& data) {
     if (!_table_items->with_other_conjunct) {
         switch (_table_items->join_type) {
         case TJoinOp::LEFT_OUTER_JOIN:
@@ -1021,10 +962,10 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_impl(RuntimeState* state,
 
 /// TODO (fzh): calculate hash distribution, skew or not.
 // NOTE: coroutine only SIMD code of SSE but not AVX
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_coroutine(RuntimeState* state, const Buffer<CppType>& build_data,
-                                                             const Buffer<CppType>& probe_data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_coroutine(
+        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     _probe_state->match_flag = JoinMatchFlag::NORMAL;
     _probe_state->match_count = 0;
     _probe_state->cur_row_match_count = 0;
@@ -1050,10 +991,10 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_coroutine(RuntimeState* state
     }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data,
-                                                           const Buffer<CppType>& probe_data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht(
+        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     if (_table_items->is_collision_free_and_unique) {
         _do_probe_from_ht<first_probe, true>(state, build_data, probe_data);
     } else {
@@ -1061,10 +1002,10 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht(RuntimeState* state, 
     }
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe, bool is_collision_free_and_unique>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_do_probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data,
-                                                              const Buffer<CppType>& probe_data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_do_probe_from_ht(
+        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     _probe_state->match_flag = JoinMatchFlag::NORMAL;
     size_t match_count = 0;
     bool one_to_many = false;
@@ -1099,7 +1040,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_do_probe_from_ht(RuntimeState* stat
         }
 
         do {
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = build_index;
                 match_count++;
@@ -1142,9 +1083,11 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_do_probe_from_ht(RuntimeState* stat
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht(
-        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor,
+                                                HashMapMethod>::_probe_from_ht(RuntimeState* state,
+                                                                               const Buffer<CppType>& build_data,
+                                                                               const Buffer<CppType>& probe_data) {
     for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
          i = _probe_state->cur_probe_index++) {
         _probe_state->probe_match_filter[i] = 0;
@@ -1153,7 +1096,7 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
         if (build_index != 0) {
             do {
                 PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-                if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+                if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                     COWAIT_IF_CHUNK_FULL()
                     _probe_state->probe_index[_probe_state->match_count] = i;
                     _probe_state->build_index[_probe_state->match_count] = build_index;
@@ -1183,8 +1126,9 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join(
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+HashTableProbeState::ProbeCoroutine
+JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_left_outer_join(
         RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
          i = _probe_state->cur_probe_index++) {
@@ -1192,7 +1136,7 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
         size_t build_index = _probe_state->next[i];
         while (build_index != 0) {
             PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                 COWAIT_IF_CHUNK_FULL()
                 _probe_state->probe_index[_probe_state->match_count] = i;
                 _probe_state->build_index[_probe_state->match_count] = build_index;
@@ -1226,11 +1170,10 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join(RuntimeState* state,
-                                                                               const Buffer<CppType>& build_data,
-                                                                               const Buffer<CppType>& probe_data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_left_outer_join(
+        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     _probe_state->match_flag = JoinMatchFlag::NORMAL;
     size_t match_count = 0;
     bool one_to_many = false;
@@ -1257,7 +1200,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join(R
             RETURN_IF_CHUNK_FULL()
         } else {
             while (build_index != 0) {
-                if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+                if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                     _probe_state->probe_index[match_count] = i;
                     _probe_state->build_index[match_count] = build_index;
                     match_count++;
@@ -1289,8 +1232,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join(R
     }
     PROBE_OVER()
 }
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join(
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+HashTableProbeState::ProbeCoroutine
+JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_left_semi_join(
         RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
          i = _probe_state->cur_probe_index++) {
@@ -1301,7 +1245,7 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
 
         while (build_index != 0) {
             PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->probe_index[_probe_state->match_count] = i;
                 _probe_state->match_count++;
                 break;
@@ -1318,11 +1262,10 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join(RuntimeState* state,
-                                                                              const Buffer<CppType>& build_data,
-                                                                              const Buffer<CppType>& probe_data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_left_semi_join(
+        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
     size_t probe_row_count = _probe_state->probe_row_count;
     for (size_t i = 0; i < probe_row_count; i++) {
@@ -1332,7 +1275,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join(Ru
         }
 
         while (index != 0) {
-            if (ProbeFunc().equal(build_data[index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 match_count++;
                 break;
@@ -1344,11 +1287,10 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join(Ru
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join(RuntimeState* state,
-                                                                              const Buffer<CppType>& build_data,
-                                                                              const Buffer<CppType>& probe_data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_left_anti_join(
+        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
 
     size_t probe_row_count = _probe_state->probe_row_count;
@@ -1369,7 +1311,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join(Ru
 
             bool found = false;
             while (index != 0) {
-                if (ProbeFunc().equal(build_data[index], probe_data[i])) {
+                if (HashMapMethod().equal(build_data[index], probe_data[i])) {
                     found = true;
                     break;
                 }
@@ -1390,7 +1332,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join(Ru
             }
             bool found = false;
             while (index != 0) {
-                if (ProbeFunc().equal(build_data[index], probe_data[i])) {
+                if (HashMapMethod().equal(build_data[index], probe_data[i])) {
                     found = true;
                     break;
                 }
@@ -1406,8 +1348,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join(Ru
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join(
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+HashTableProbeState::ProbeCoroutine
+JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_left_anti_join(
         RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     DCHECK_LT(0, _table_items->row_count);
     if (_table_items->join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN && _probe_state->null_array != nullptr) {
@@ -1428,7 +1371,7 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
             bool found = false;
             while (build_index != 0) {
                 PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-                if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+                if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                     found = true;
                     break;
                 }
@@ -1451,7 +1394,7 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
             bool found = false;
             while (build_index != 0) {
                 PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-                if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+                if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                     found = true;
                     break;
                 }
@@ -1472,11 +1415,10 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_join(RuntimeState* state,
-                                                                                const Buffer<CppType>& build_data,
-                                                                                const Buffer<CppType>& probe_data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_right_outer_join(
+        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
     size_t i = _probe_state->cur_probe_index;
 
@@ -1497,7 +1439,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_join(
         }
 
         while (build_index != 0) {
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = build_index;
                 _probe_state->build_match_index[build_index] = 1;
@@ -1513,8 +1455,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_join(
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_join(
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+HashTableProbeState::ProbeCoroutine
+JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_right_outer_join(
         RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
          i = _probe_state->cur_probe_index++) {
@@ -1525,7 +1468,7 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
 
         while (build_index != 0) {
             PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                 COWAIT_IF_CHUNK_FULL()
                 _probe_state->probe_index[_probe_state->match_count] = i;
                 _probe_state->build_index[_probe_state->match_count] = build_index;
@@ -1545,11 +1488,10 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_semi_join(RuntimeState* state,
-                                                                               const Buffer<CppType>& build_data,
-                                                                               const Buffer<CppType>& probe_data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_right_semi_join(
+        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
     size_t i = _probe_state->cur_probe_index;
 
@@ -1566,7 +1508,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_semi_join(R
         }
 
         while (build_index != 0) {
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                 if (_probe_state->build_match_index[build_index] == 0) {
                     _probe_state->build_index[match_count] = build_index;
                     _probe_state->build_match_index[build_index] = 1;
@@ -1582,8 +1524,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_semi_join(R
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_semi_join(
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+HashTableProbeState::ProbeCoroutine
+JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_right_semi_join(
         RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
          i = _probe_state->cur_probe_index++) {
@@ -1594,7 +1537,7 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
 
         while (build_index != 0) {
             PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                 if (_probe_state->build_match_index[build_index] == 0) {
                     COWAIT_IF_CHUNK_FULL()
                     _probe_state->build_index[_probe_state->match_count] = build_index;
@@ -1614,11 +1557,10 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_anti_join(RuntimeState* state,
-                                                                               const Buffer<CppType>& build_data,
-                                                                               const Buffer<CppType>& probe_data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_right_anti_join(
+        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t probe_row_count = _probe_state->probe_row_count;
     for (size_t i = 0; i < probe_row_count; i++) {
         size_t index = _probe_state->next[i];
@@ -1627,7 +1569,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_anti_join(R
         }
 
         while (index != 0) {
-            if (ProbeFunc().equal(build_data[index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[index], probe_data[i])) {
                 _probe_state->build_match_index[index] = 1;
             }
             index = _table_items->next[index];
@@ -1636,8 +1578,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_anti_join(R
     _probe_state->count = 0;
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_anti_join(
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+HashTableProbeState::ProbeCoroutine
+JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_right_anti_join(
         RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
          i = _probe_state->cur_probe_index++) {
@@ -1648,7 +1591,7 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
 
         while (build_index != 0) {
             PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->build_match_index[build_index] = 1;
             }
             build_index = _table_items->next[build_index];
@@ -1657,11 +1600,10 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
     _probe_state->count = 0;
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_full_outer_join(RuntimeState* state,
-                                                                               const Buffer<CppType>& build_data,
-                                                                               const Buffer<CppType>& probe_data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_full_outer_join(
+        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
     size_t i = _probe_state->cur_probe_index;
 
@@ -1688,7 +1630,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_full_outer_join(R
             RETURN_IF_CHUNK_FULL()
         } else {
             while (build_index != 0) {
-                if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+                if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                     _probe_state->probe_index[match_count] = i;
                     _probe_state->build_index[match_count] = build_index;
                     _probe_state->build_match_index[build_index] = 1;
@@ -1713,8 +1655,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_full_outer_join(R
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_full_outer_join(
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
+HashTableProbeState::ProbeCoroutine
+JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_probe_from_ht_for_full_outer_join(
         RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
          i = _probe_state->cur_probe_index++) {
@@ -1722,7 +1665,7 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
         int cur_row_match_count = 0;
         while (build_index != 0) {
             PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                 COWAIT_IF_CHUNK_FULL()
                 _probe_state->probe_index[_probe_state->match_count] = i;
                 _probe_state->build_index[_probe_state->match_count] = build_index;
@@ -1748,10 +1691,11 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join_with_other_conjunct(
-        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::
+        _probe_from_ht_for_left_semi_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
+                                                              const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
 
     size_t i = _probe_state->cur_probe_index;
@@ -1777,7 +1721,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join_wi
         }
 
         while (build_index != 0) {
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = build_index;
                 match_count++;
@@ -1791,41 +1735,12 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join_wi
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine
-JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join_with_other_conjunct(
-        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
-    for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
-         i = _probe_state->cur_probe_index++) {
-        size_t build_index = _probe_state->next[i];
-        if (build_index == 0) {
-            continue;
-        }
-
-        while (build_index != 0) {
-            PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
-                COWAIT_IF_CHUNK_FULL()
-                _probe_state->probe_index[_probe_state->match_count] = i;
-                _probe_state->build_index[_probe_state->match_count] = build_index;
-                _probe_state->match_count++;
-            }
-            build_index = _table_items->next[build_index];
-        }
-    }
-
-    if (--_probe_state->active_coroutines > 0) {
-        co_return;
-    }
-    // only the last coroutine does
-    auto match_count = _probe_state->match_count;
-    PROBE_OVER()
-}
-
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_join_with_other_conjunct(
-        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::
+        _probe_from_ht_for_null_aware_anti_join_with_other_conjunct(RuntimeState* state,
+                                                                    const Buffer<CppType>& build_data,
+                                                                    const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
 
     size_t i = _probe_state->cur_probe_index;
@@ -1870,7 +1785,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
         _probe_state->cur_nullaware_build_index = _table_items->row_count + 1;
 
         while (build_index != 0) {
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = build_index;
                 _probe_state->probe_match_index[i]++;
@@ -1895,9 +1810,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::
         _probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct(
                 RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
@@ -1913,7 +1828,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::
         }
 
         while (build_index != 0) {
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+            if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = build_index;
                 match_count++;
@@ -1927,10 +1842,12 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::
     PROBE_OVER()
 }
 
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
+template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
 template <bool first_probe>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct(
-        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
+void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::
+        _probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct(RuntimeState* state,
+                                                                                    const Buffer<CppType>& build_data,
+                                                                                    const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
 
     size_t i = _probe_state->cur_probe_index;
@@ -1960,7 +1877,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_left_a
             RETURN_IF_CHUNK_FULL()
         } else {
             while (build_index != 0) {
-                if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
+                if (HashMapMethod().equal(build_data[build_index], probe_data[i])) {
                     _probe_state->probe_index[match_count] = i;
                     _probe_state->build_index[match_count] = build_index;
                     _probe_state->probe_match_index[i]++;
@@ -1985,6 +1902,10 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_left_a
     PROBE_OVER()
 }
 
+// ------------------------------------------------------------------------------------
+// JoinHashTable
+// ------------------------------------------------------------------------------------
+
 template <bool is_remain>
 Status JoinHashTable::lazy_output(RuntimeState* state, ChunkPtr* probe_chunk, ChunkPtr* result_chunk) {
     switch (_hash_map_type) {
@@ -2004,4 +1925,5 @@ Status JoinHashTable::lazy_output(RuntimeState* state, ChunkPtr* probe_chunk, Ch
 }
 
 #undef JOIN_HASH_MAP_TPP
+
 } // namespace starrocks

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -359,6 +359,7 @@ void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::b
     const auto& keys = BuildKeyConstructor().get_key_data(*_table_items);
     const auto* is_nulls = BuildKeyConstructor().get_is_nulls(*_table_items);
     HashMapMethod().construct_hash_table(_table_items, keys, is_nulls);
+    _table_items->calculate_ht_info(BuildKeyConstructor().get_key_column_bytes(*_table_items));
 }
 
 template <LogicalType LT, class BuildKeyConstructor, class ProbeKeyConstructor, typename HashMapMethod>
@@ -708,6 +709,7 @@ void JoinHashMap<LT, BuildKeyConstructor, ProbeKeyConstructor, HashMapMethod>::_
         auto& build_data = BuildKeyConstructor().get_key_data(*_table_items);
         auto& probe_data = ProbeKeyConstructor().get_key_data(*_probe_state);
         HashMapMethod().lookup_init(*_table_items, _probe_state, probe_data, _probe_state->null_array);
+        _probe_state->consider_probe_time_locality();
 
         _search_ht_impl<true>(state, build_data, probe_data);
     } else {

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -1143,10 +1143,20 @@ TEST_F(JoinHashMapTest, JoinBuildProbeFunc) {
     Columns probe_columns{probe_column};
     probe_state.key_columns = &probe_columns;
 
-    JoinBuildFunc<LogicalType::TYPE_INT>::prepare(nullptr, &table_items);
-    JoinProbeFunc<LogicalType::TYPE_INT>::prepare(_runtime_state.get(), &probe_state);
-    JoinBuildFunc<LogicalType::TYPE_INT>::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
-    JoinProbeFunc<LogicalType::TYPE_INT>::lookup_init(table_items, &probe_state);
+    using BuildKeyConstructor = BuildKeyConstructorForOneKey<LogicalType::TYPE_INT>;
+    using ProbeKeyConstructor = ProbeKeyConstructorForOneKey<LogicalType::TYPE_INT>;
+    using JoinHashMapMethod = BucketChainedJoinHashMap<LogicalType::TYPE_INT>;
+
+    BuildKeyConstructor::prepare(nullptr, &table_items);
+    BuildKeyConstructor::build_key(nullptr, &table_items);
+    JoinHashMapMethod::build_prepare(nullptr, &table_items);
+    JoinHashMapMethod::construct_hash_table(&table_items, BuildKeyConstructor::get_key_data(table_items),
+                                            BuildKeyConstructor::get_is_nulls(table_items));
+
+    ProbeKeyConstructor::prepare(nullptr, &probe_state);
+    ProbeKeyConstructor::build_key(table_items, &probe_state);
+    JoinHashMapMethod::lookup_init(table_items, &probe_state, ProbeKeyConstructor().get_key_data(probe_state),
+                                   probe_state.null_array);
 
     for (size_t i = 0; i < 10; i++) {
         size_t found_count = 0;
@@ -1183,10 +1193,20 @@ TEST_F(JoinHashMapTest, JoinBuildProbeFuncNullable) {
     Columns probe_columns{probe_column};
     probe_state.key_columns = &probe_columns;
 
-    JoinBuildFunc<TYPE_INT>::prepare(nullptr, &table_items);
-    JoinProbeFunc<TYPE_INT>::prepare(_runtime_state.get(), &probe_state);
-    JoinBuildFunc<TYPE_INT>::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
-    JoinProbeFunc<TYPE_INT>::lookup_init(table_items, &probe_state);
+    using BuildKeyConstructor = BuildKeyConstructorForOneKey<LogicalType::TYPE_INT>;
+    using ProbeKeyConstructor = ProbeKeyConstructorForOneKey<LogicalType::TYPE_INT>;
+    using JoinHashMapMethod = BucketChainedJoinHashMap<LogicalType::TYPE_INT>;
+
+    BuildKeyConstructor::prepare(nullptr, &table_items);
+    BuildKeyConstructor::build_key(nullptr, &table_items);
+    JoinHashMapMethod::build_prepare(nullptr, &table_items);
+    JoinHashMapMethod::construct_hash_table(&table_items, BuildKeyConstructor::get_key_data(table_items),
+                                            BuildKeyConstructor::get_is_nulls(table_items));
+
+    ProbeKeyConstructor::prepare(nullptr, &probe_state);
+    ProbeKeyConstructor::build_key(table_items, &probe_state);
+    JoinHashMapMethod::lookup_init(table_items, &probe_state, ProbeKeyConstructor().get_key_data(probe_state),
+                                   probe_state.null_array);
 
     for (size_t i = 0; i < 10; i++) {
         size_t found_count = 0;
@@ -1346,10 +1366,20 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildProbeFunc) {
     Columns probe_columns{probe_column1, probe_column2};
     probe_state.key_columns = &probe_columns;
 
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::prepare(_runtime_state.get(), &table_items);
-    FixedSizeJoinProbeFunc<TYPE_BIGINT>::prepare(_runtime_state.get(), &probe_state);
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
-    FixedSizeJoinProbeFunc<TYPE_BIGINT>::lookup_init(table_items, &probe_state);
+    using BuildKeyConstructor = BuildKeyConstructorForSerializedFixedSize<LogicalType::TYPE_BIGINT>;
+    using ProbeKeyConstructor = ProbeKeyConstructorForSerializedFixedSize<LogicalType::TYPE_BIGINT>;
+    using JoinHashMapMethod = BucketChainedJoinHashMap<LogicalType::TYPE_BIGINT>;
+
+    BuildKeyConstructor::prepare(_runtime_state.get(), &table_items);
+    BuildKeyConstructor::build_key(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::build_prepare(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::construct_hash_table(&table_items, BuildKeyConstructor::get_key_data(table_items),
+                                            BuildKeyConstructor::get_is_nulls(table_items));
+
+    ProbeKeyConstructor::prepare(_runtime_state.get(), &probe_state);
+    ProbeKeyConstructor::build_key(table_items, &probe_state);
+    JoinHashMapMethod::lookup_init(table_items, &probe_state, ProbeKeyConstructor().get_key_data(probe_state),
+                                   probe_state.null_array);
 
     for (size_t i = 0; i < 10; i++) {
         size_t found_count = 0;
@@ -1396,10 +1426,20 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildProbeFuncNullable) {
     Columns probe_columns{probe_column1, probe_column2};
     probe_state.key_columns = &probe_columns;
 
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::prepare(_runtime_state.get(), &table_items);
-    FixedSizeJoinProbeFunc<TYPE_BIGINT>::prepare(_runtime_state.get(), &probe_state);
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
-    FixedSizeJoinProbeFunc<TYPE_BIGINT>::lookup_init(table_items, &probe_state);
+    using BuildKeyConstructor = BuildKeyConstructorForSerializedFixedSize<LogicalType::TYPE_BIGINT>;
+    using ProbeKeyConstructor = ProbeKeyConstructorForSerializedFixedSize<LogicalType::TYPE_BIGINT>;
+    using JoinHashMapMethod = BucketChainedJoinHashMap<LogicalType::TYPE_BIGINT>;
+
+    BuildKeyConstructor::prepare(_runtime_state.get(), &table_items);
+    BuildKeyConstructor::build_key(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::build_prepare(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::construct_hash_table(&table_items, BuildKeyConstructor::get_key_data(table_items),
+                                            BuildKeyConstructor::get_is_nulls(table_items));
+
+    ProbeKeyConstructor::prepare(_runtime_state.get(), &probe_state);
+    ProbeKeyConstructor::build_key(table_items, &probe_state);
+    JoinHashMapMethod::lookup_init(table_items, &probe_state, ProbeKeyConstructor().get_key_data(probe_state),
+                                   probe_state.null_array);
 
     for (size_t i = 0; i < 10; i++) {
         size_t found_count = 0;
@@ -1453,10 +1493,20 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFunc) {
     probe_state.key_columns = &probe_columns;
     Buffer<uint8_t> buffer(1024);
 
-    SerializedJoinBuildFunc::prepare(_runtime_state.get(), &table_items);
-    SerializedJoinProbeFunc::prepare(_runtime_state.get(), &probe_state);
-    SerializedJoinBuildFunc::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
-    SerializedJoinProbeFunc::lookup_init(table_items, &probe_state);
+    using BuildKeyConstructor = BuildKeyConstructorForSerialized;
+    using ProbeKeyConstructor = ProbeKeyConstructorForSerialized;
+    using JoinHashMapMethod = BucketChainedJoinHashMap<LogicalType::TYPE_VARCHAR>;
+
+    BuildKeyConstructor::prepare(_runtime_state.get(), &table_items);
+    BuildKeyConstructor::build_key(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::build_prepare(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::construct_hash_table(&table_items, BuildKeyConstructor::get_key_data(table_items),
+                                            BuildKeyConstructor::get_is_nulls(table_items));
+
+    ProbeKeyConstructor::prepare(_runtime_state.get(), &probe_state);
+    ProbeKeyConstructor::build_key(table_items, &probe_state);
+    JoinHashMapMethod::lookup_init(table_items, &probe_state, ProbeKeyConstructor().get_key_data(probe_state),
+                                   probe_state.null_array);
 
     for (size_t i = 0; i < 10; i++) {
         size_t found_count = 0;
@@ -1507,10 +1557,20 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFuncNullable) {
     probe_state.key_columns = &probe_columns;
     Buffer<uint8_t> buffer(1024);
 
-    SerializedJoinBuildFunc::prepare(_runtime_state.get(), &table_items);
-    SerializedJoinProbeFunc::prepare(_runtime_state.get(), &probe_state);
-    SerializedJoinBuildFunc::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
-    SerializedJoinProbeFunc::lookup_init(table_items, &probe_state);
+    using BuildKeyConstructor = BuildKeyConstructorForSerialized;
+    using ProbeKeyConstructor = ProbeKeyConstructorForSerialized;
+    using JoinHashMapMethod = BucketChainedJoinHashMap<LogicalType::TYPE_VARCHAR>;
+
+    BuildKeyConstructor::prepare(_runtime_state.get(), &table_items);
+    BuildKeyConstructor::build_key(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::build_prepare(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::construct_hash_table(&table_items, BuildKeyConstructor::get_key_data(table_items),
+                                            BuildKeyConstructor::get_is_nulls(table_items));
+
+    ProbeKeyConstructor::prepare(_runtime_state.get(), &probe_state);
+    ProbeKeyConstructor::build_key(table_items, &probe_state);
+    JoinHashMapMethod::lookup_init(table_items, &probe_state, ProbeKeyConstructor().get_key_data(probe_state),
+                                   probe_state.null_array);
 
     Columns probe_data_columns;
     probe_data_columns.emplace_back(
@@ -2166,7 +2226,7 @@ TEST_F(JoinHashMapTest, SerializeJoinHashTable) {
 }
 
 // NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, FixedSizeJoinBuildFuncForNotNullableColumn) {
+TEST_F(JoinHashMapTest, BuildKeyConstructorForSerializedFixedSizeForNotNullableColumn) {
     JoinHashTableItems table_items;
     HashTableProbeState probe_state;
     uint32_t build_row_count = 9000;
@@ -2190,8 +2250,14 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildFuncForNotNullableColumn) {
     table_items.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
 
     // Construct Hash Table
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::prepare(_runtime_state.get(), &table_items);
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
+    using BuildKeyConstructor = BuildKeyConstructorForSerializedFixedSize<LogicalType::TYPE_BIGINT>;
+    using JoinHashMapMethod = BucketChainedJoinHashMap<LogicalType::TYPE_BIGINT>;
+
+    BuildKeyConstructor::prepare(_runtime_state.get(), &table_items);
+    BuildKeyConstructor::build_key(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::build_prepare(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::construct_hash_table(&table_items, BuildKeyConstructor::get_key_data(table_items),
+                                            BuildKeyConstructor::get_is_nulls(table_items));
 
     // Check
     check_build_index(table_items.first, table_items.next, build_row_count);
@@ -2199,7 +2265,7 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildFuncForNotNullableColumn) {
 }
 
 // NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, FixedSizeJoinBuildFuncForNullableColumn) {
+TEST_F(JoinHashMapTest, BuildKeyConstructorForSerializedFixedSizeForNullableColumn) {
     JoinHashTableItems table_items;
     HashTableProbeState probe_state;
     uint32_t build_row_count = 9000;
@@ -2225,8 +2291,14 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildFuncForNullableColumn) {
     table_items.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
 
     // Construct Hash Table
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::prepare(_runtime_state.get(), &table_items);
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
+    using BuildKeyConstructor = BuildKeyConstructorForSerializedFixedSize<LogicalType::TYPE_BIGINT>;
+    using JoinHashMapMethod = BucketChainedJoinHashMap<LogicalType::TYPE_BIGINT>;
+
+    BuildKeyConstructor::prepare(_runtime_state.get(), &table_items);
+    BuildKeyConstructor::build_key(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::build_prepare(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::construct_hash_table(&table_items, BuildKeyConstructor::get_key_data(table_items),
+                                            BuildKeyConstructor::get_is_nulls(table_items));
 
     // Check
     check_build_index(table_items.first, table_items.next, build_row_count);
@@ -2234,7 +2306,7 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildFuncForNullableColumn) {
 }
 
 // NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, FixedSizeJoinBuildFuncForPartialNullableColumn) {
+TEST_F(JoinHashMapTest, BuildKeyConstructorForSerializedFixedSizeForPartialNullableColumn) {
     JoinHashTableItems table_items;
     HashTableProbeState probe_state;
     uint32_t build_row_count = 9000;
@@ -2260,8 +2332,14 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildFuncForPartialNullableColumn) {
     table_items.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
 
     // Construct Hash Table
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::prepare(_runtime_state.get(), &table_items);
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
+    using BuildKeyConstructor = BuildKeyConstructorForSerializedFixedSize<LogicalType::TYPE_BIGINT>;
+    using JoinHashMapMethod = BucketChainedJoinHashMap<LogicalType::TYPE_BIGINT>;
+
+    BuildKeyConstructor::prepare(_runtime_state.get(), &table_items);
+    BuildKeyConstructor::build_key(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::build_prepare(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::construct_hash_table(&table_items, BuildKeyConstructor::get_key_data(table_items),
+                                            BuildKeyConstructor::get_is_nulls(table_items));
 
     // Check
     auto nulls = create_bools(build_row_count, 4);
@@ -2270,7 +2348,7 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildFuncForPartialNullableColumn) {
 }
 
 // NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, SerializedJoinBuildFuncForNotNullableColumn) {
+TEST_F(JoinHashMapTest, BuildKeyConstructorForSerializedForNotNullableColumn) {
     JoinHashTableItems table_items;
     HashTableProbeState probe_state;
     uint32_t build_row_count = 9000;
@@ -2294,8 +2372,14 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildFuncForNotNullableColumn) {
     table_items.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
 
     // Construct Hash Table
-    SerializedJoinBuildFunc::prepare(_runtime_state.get(), &table_items);
-    SerializedJoinBuildFunc::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
+    using BuildKeyConstructor = BuildKeyConstructorForSerialized;
+    using JoinHashMapMethod = BucketChainedJoinHashMap<LogicalType::TYPE_VARCHAR>;
+
+    BuildKeyConstructor::prepare(_runtime_state.get(), &table_items);
+    BuildKeyConstructor::build_key(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::build_prepare(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::construct_hash_table(&table_items, BuildKeyConstructor::get_key_data(table_items),
+                                            BuildKeyConstructor::get_is_nulls(table_items));
 
     // Check
     check_build_index(table_items.first, table_items.next, build_row_count);
@@ -2303,7 +2387,7 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildFuncForNotNullableColumn) {
 }
 
 // NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, SerializedJoinBuildFuncForNullableColumn) {
+TEST_F(JoinHashMapTest, BuildKeyConstructorForSerializedForNullableColumn) {
     JoinHashTableItems table_items;
     HashTableProbeState probe_state;
     uint32_t build_row_count = 9000;
@@ -2329,8 +2413,14 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildFuncForNullableColumn) {
     table_items.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
 
     // Construct Hash Table
-    SerializedJoinBuildFunc::prepare(_runtime_state.get(), &table_items);
-    SerializedJoinBuildFunc::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
+    using BuildKeyConstructor = BuildKeyConstructorForSerialized;
+    using JoinHashMapMethod = BucketChainedJoinHashMap<LogicalType::TYPE_VARCHAR>;
+
+    BuildKeyConstructor::prepare(_runtime_state.get(), &table_items);
+    BuildKeyConstructor::build_key(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::build_prepare(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::construct_hash_table(&table_items, BuildKeyConstructor::get_key_data(table_items),
+                                            BuildKeyConstructor::get_is_nulls(table_items));
 
     // Check
     check_build_index(table_items.first, table_items.next, build_row_count);
@@ -2338,7 +2428,7 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildFuncForNullableColumn) {
 }
 
 // NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, SerializedJoinBuildFuncForPartialNullColumn) {
+TEST_F(JoinHashMapTest, BuildKeyConstructorForSerializedForPartialNullColumn) {
     JoinHashTableItems table_items;
     HashTableProbeState probe_state;
     uint32_t build_row_count = 9000;
@@ -2364,8 +2454,14 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildFuncForPartialNullColumn) {
     table_items.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
 
     // Construct Hash Table
-    SerializedJoinBuildFunc::prepare(_runtime_state.get(), &table_items);
-    SerializedJoinBuildFunc::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
+    using BuildKeyConstructor = BuildKeyConstructorForSerialized;
+    using JoinHashMapMethod = BucketChainedJoinHashMap<LogicalType::TYPE_VARCHAR>;
+
+    BuildKeyConstructor::prepare(_runtime_state.get(), &table_items);
+    BuildKeyConstructor::build_key(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::build_prepare(_runtime_state.get(), &table_items);
+    JoinHashMapMethod::construct_hash_table(&table_items, BuildKeyConstructor::get_key_data(table_items),
+                                            BuildKeyConstructor::get_is_nulls(table_items));
 
     // Check
     auto nulls = create_bools(build_row_count, 4);

--- a/test/sql/test_join/R/test_join_direct_mapping
+++ b/test/sql/test_join/R/test_join_direct_mapping
@@ -1,0 +1,576 @@
+-- name: test_join_direct_mapping
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_bool boolean,
+    c_bool_null boolean NULL,
+    c_tinyint tinyint,
+    c_tinyint_null tinyint NULL,
+    c_smallint smallint,
+    c_smallint_null smallint NULL,
+    c_int int,
+    c_int_null int NULL,
+    c_bigint bigint,
+    c_bigint_null bigint NULL,
+    c_float float,
+    c_float_null float NULL,
+    c_double double,
+    c_double_null double NULL,
+    c_date date,
+    c_date_null date NULL,
+    c_datetime datetime,
+    c_datetime_null datetime NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 
+select
+    idx,
+
+    idx % 2 = 0,
+    if (idx % 7 = 0, idx % 2 = 0, null),
+
+    idx % 128,
+    if (idx % 12 = 0, idx % 128, null),
+
+    idx % 32768,
+    if (idx % 13 = 0, idx % 32768, null),
+
+    idx % 2147483648,
+    if (idx % 14 = 0, idx % 2147483648, null),
+
+    idx,
+    if (idx % 15 = 0, idx, null),
+
+    idx,
+    if (idx % 16 = 0, idx, null),
+
+    idx,
+    if (idx % 16 = 0, idx, null),
+
+    date_add('2023-01-01', idx % 365),
+    if (idx % 17 = 0, date_add('2023-01-01', idx % 365), null),
+
+    date_add('2023-01-01 00:00:00', idx % 365 * 24 * 3600 + idx % 86400),
+    if (idx % 18 = 0, date_add('2023-01-01 00:00:00', idx % 365 * 24 * 3600 + idx % 86400), null)
+from __row_util;
+-- result:
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 join w1 t2 using(c_bool_null);
+-- result:
+1279999	1279999	1279999
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 left outer join w1 t2 using(c_bool_null);
+-- result:
+2377142	1279999	1279999
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.c_bool_null)
+from t1 left semi join w1 t2 using(c_bool_null);
+-- result:
+182857	182857
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.c_bool_null)
+from t1 left anti join w1 t2 using(c_bool_null);
+-- result:
+1097143	0
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 right outer join w1 t2 using(c_bool_null);
+-- result:
+1280084	1279999	1279999
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t2.c_bool_null)
+from t1 right semi join w1 t2 using(c_bool_null);
+-- result:
+14	14
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t2.c_bool_null)
+from t1 right anti join w1 t2 using(c_bool_null);
+-- result:
+85	0
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 full join w1 t2 using(c_bool_null);
+-- result:
+2377227	1279999	1279999
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 join w1 t2 using(c_bool_null);
+-- result:
+639996	639996	639996
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 left outer join w1 t2 using(c_bool_null);
+-- result:
+1828568	731425	639996
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t1.c_bool_null)
+from t1 left semi join w1 t2 using(c_bool_null);
+-- result:
+91428	91428
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t1.c_bool_null)
+from t1 left anti join w1 t2 using(c_bool_null);
+-- result:
+1188572	91429
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 right outer join w1 t2 using(c_bool_null);
+-- result:
+639996	639996	639996
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t2.c_bool_null)
+from t1 right semi join w1 t2 using(c_bool_null);
+-- result:
+7	7
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t2.c_bool_null)
+from t1 right anti join w1 t2 using(c_bool_null);
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 full join w1 t2 using(c_bool_null);
+-- result:
+1828568	731425	639996
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 join w1 t2 using(c_bool_null);
+-- result:
+0	0	0
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 left outer join w1 t2 using(c_bool_null);
+-- result:
+1280000	182857	0
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t1.c_bool_null)
+from t1 left semi join w1 t2 using(c_bool_null);
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t1.c_bool_null)
+from t1 left anti join w1 t2 using(c_bool_null);
+-- result:
+1280000	182857
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 right outer join w1 t2 using(c_bool_null);
+-- result:
+0	0	0
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t2.c_bool_null)
+from t1 right semi join w1 t2 using(c_bool_null);
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t2.c_bool_null)
+from t1 right anti join w1 t2 using(c_bool_null);
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 full join w1 t2 using(c_bool_null);
+-- result:
+1280000	182857	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 join w1 t2 using(c_bool_null) where (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+91429	91429	91429
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 left outer join w1 t2 using(c_bool_null) where (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+91429	91429	91429
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_bool_null)
+from t1 left semi join w1 t2 on t1.c_bool_null = t2.c_bool_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+91429	91429
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_bool_null)
+from t1 left anti join w1 t2 on t1.c_bool_null = t2.c_bool_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+1188571	91428
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 right outer join w1 t2 on t1.c_bool_null = t2.c_bool_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+91437	91429	91429
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t2.c_bool_null)
+from t1 right semi join w1 t2 on t1.c_bool_null = t2.c_bool_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+1	1
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t2.c_bool_null)
+from t1 right anti join w1 t2 on t1.c_bool_null = t2.c_bool_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+8	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 full join w1 t2 using(c_bool_null) where (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+91429	91429	91429
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 join w1 t2 using(c_tinyint_null);
+-- result:
+80002	80002	80002
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 left outer join w1 t2 using(c_tinyint_null);
+-- result:
+1280000	106666	80002
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t1.c_tinyint_null)
+from t1 left semi join w1 t2 using(c_tinyint_null);
+-- result:
+80002	80002
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t1.c_tinyint_null)
+from t1 left anti join w1 t2 using(c_tinyint_null);
+-- result:
+1199998	26664
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 right outer join w1 t2 using(c_tinyint_null);
+-- result:
+80002	80002	80002
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t2.c_tinyint_null)
+from t1 right semi join w1 t2 using(c_tinyint_null);
+-- result:
+24	24
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t2.c_tinyint_null)
+from t1 right anti join w1 t2 using(c_tinyint_null);
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 full join w1 t2 using(c_tinyint_null);
+-- result:
+1280000	106666	80002
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 join w1 t2 using(c_tinyint_null);
+-- result:
+0	0	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 left outer join w1 t2 using(c_tinyint_null);
+-- result:
+1280000	106666	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t1.c_tinyint_null)
+from t1 left semi join w1 t2 using(c_tinyint_null);
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t1.c_tinyint_null)
+from t1 left anti join w1 t2 using(c_tinyint_null);
+-- result:
+1280000	106666
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 right outer join w1 t2 using(c_tinyint_null);
+-- result:
+0	0	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t2.c_tinyint_null)
+from t1 right semi join w1 t2 using(c_tinyint_null);
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t2.c_tinyint_null)
+from t1 right anti join w1 t2 using(c_tinyint_null);
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 full join w1 t2 using(c_tinyint_null);
+-- result:
+1280000	106666	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 join w1 t2 using(c_tinyint_null) where (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+0	0	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 left outer join w1 t2 using(c_tinyint_null) where (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+0	0	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_tinyint_null)
+from t1 left semi join w1 t2 on t1.c_tinyint_null = t2.c_tinyint_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_tinyint_null)
+from t1 left anti join w1 t2 on t1.c_tinyint_null = t2.c_tinyint_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+1280000	106666
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 right outer join w1 t2 on t1.c_tinyint_null = t2.c_tinyint_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+9	0	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t2.c_tinyint_null)
+from t1 right semi join w1 t2 on t1.c_tinyint_null = t2.c_tinyint_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t2.c_tinyint_null)
+from t1 right anti join w1 t2 on t1.c_tinyint_null = t2.c_tinyint_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+9	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 full join w1 t2 using(c_tinyint_null) where (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+0	0	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 join w1 t2 using(c_smallint_null);
+-- result:
+44	44	44
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 left outer join w1 t2 using(c_smallint_null);
+-- result:
+1280000	98461	44
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t1.c_smallint_null)
+from t1 left semi join w1 t2 using(c_smallint_null);
+-- result:
+44	44
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t1.c_smallint_null)
+from t1 left anti join w1 t2 using(c_smallint_null);
+-- result:
+1279956	98417
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 right outer join w1 t2 using(c_smallint_null);
+-- result:
+44	44	44
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t2.c_smallint_null)
+from t1 right semi join w1 t2 using(c_smallint_null);
+-- result:
+11	11
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t2.c_smallint_null)
+from t1 right anti join w1 t2 using(c_smallint_null);
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 full join w1 t2 using(c_smallint_null);
+-- result:
+1280000	98461	44
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 join w1 t2 using(c_smallint_null);
+-- result:
+0	0	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 left outer join w1 t2 using(c_smallint_null);
+-- result:
+1280000	98461	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t1.c_smallint_null)
+from t1 left semi join w1 t2 using(c_smallint_null);
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t1.c_smallint_null)
+from t1 left anti join w1 t2 using(c_smallint_null);
+-- result:
+1280000	98461
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 right outer join w1 t2 using(c_smallint_null);
+-- result:
+0	0	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t2.c_smallint_null)
+from t1 right semi join w1 t2 using(c_smallint_null);
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t2.c_smallint_null)
+from t1 right anti join w1 t2 using(c_smallint_null);
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 full join w1 t2 using(c_smallint_null);
+-- result:
+1280000	98461	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 join w1 t2 using(c_smallint_null) where (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+0	0	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 left outer join w1 t2 using(c_smallint_null) where (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+0	0	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_smallint_null)
+from t1 left semi join w1 t2 on t1.c_smallint_null = t2.c_smallint_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_smallint_null)
+from t1 left anti join w1 t2 on t1.c_smallint_null = t2.c_smallint_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+1280000	98461
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 right outer join w1 t2 on t1.c_smallint_null = t2.c_smallint_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+9	0	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t2.c_smallint_null)
+from t1 right semi join w1 t2 on t1.c_smallint_null = t2.c_smallint_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+0	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t2.c_smallint_null)
+from t1 right anti join w1 t2 on t1.c_smallint_null = t2.c_smallint_null and (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+9	0
+-- !result
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 full join w1 t2 using(c_smallint_null) where (t1.k1 + t2.k1) % 7 = 0;
+-- result:
+0	0	0
+-- !result

--- a/test/sql/test_join/R/test_join_fixed_size
+++ b/test/sql/test_join/R/test_join_fixed_size
@@ -115,6 +115,11 @@ from t1 join t1 t2 on t1.c_bool_null <=> t2.c_bool_null and t1.c_tinyint_null <=
 216093
 -- !result
 select count(1)
+from t1 full join t1 t2 on t1.c_bool_null <=> t2.c_bool_null and t1.c_tinyint_null <=> t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null;
+-- result:
+2579171
+-- !result
+select count(1)
 from t1 join t1 t2 on t1.c_bool_null = t2.c_bool_null and t1.c_tinyint_null = t2.c_tinyint_null and t1.c_int = t2.c_int;
 -- result:
 15238
@@ -165,6 +170,11 @@ from t1 join t1 t2 on t1.c_bool_null <=> t2.c_bool_null and t1.c_tinyint_null = 
 8205
 -- !result
 select count(1)
+from t1 full join t1 t2 on t1.c_bool_null <=> t2.c_bool_null and t1.c_tinyint_null = t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null and t1.c_int = t2.c_int;
+-- result:
+2551795
+-- !result
+select count(1)
 from t1 join t1 t2 on t1.c_double = t2.c_double and t1.c_int = t2.c_int;
 -- result:
 1280000
@@ -188,4 +198,14 @@ select count(1)
 from t1 join t1 t2 on t1.c_bigint_null = t2.c_bigint_null and t1.c_int = t2.c_int;
 -- result:
 85333
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_bigint_null = t2.c_bigint_null and t1.c_int = t2.c_int and t1.c_double = t2.c_double;
+-- result:
+85333
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_datetime = t2.c_datetime and cast(t1.c_int as string) = cast(t2.c_int as string);
+-- result:
+118291
 -- !result

--- a/test/sql/test_join/R/test_join_fixed_size
+++ b/test/sql/test_join/R/test_join_fixed_size
@@ -1,0 +1,191 @@
+-- name: test_join_fixed_size
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_bool boolean,
+    c_bool_null boolean NULL,
+    c_tinyint tinyint,
+    c_tinyint_null tinyint NULL,
+    c_smallint smallint,
+    c_smallint_null smallint NULL,
+    c_int int,
+    c_int_null int NULL,
+    c_bigint bigint,
+    c_bigint_null bigint NULL,
+    c_float float,
+    c_float_null float NULL,
+    c_double double,
+    c_double_null double NULL,
+    c_date date,
+    c_date_null date NULL,
+    c_datetime datetime,
+    c_datetime_null datetime NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 
+select
+    idx,
+
+    idx % 2 = 0,
+    if (idx % 7 = 0, idx % 2 = 0, null),
+
+    idx % 128,
+    if (idx % 12 = 0, idx % 128, null),
+
+    idx % 32768,
+    if (idx % 13 = 0, idx % 32768, null),
+
+    idx % 2147483648,
+    if (idx % 14 = 0, idx % 2147483648, null),
+
+    idx,
+    if (idx % 15 = 0, idx, null),
+
+    idx,
+    if (idx % 16 = 0, idx, null),
+
+    idx,
+    if (idx % 16 = 0, idx, null),
+
+    date_add('2023-01-01', idx % 365),
+    if (idx % 17 = 0, date_add('2023-01-01', idx % 365), null),
+
+    date_add('2023-01-01 00:00:00', idx % 365 * 24 * 3600 + idx % 86400),
+    if (idx % 18 = 0, date_add('2023-01-01 00:00:00', idx % 365 * 24 * 3600 + idx % 86400), null)
+from __row_util;
+-- result:
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_tinyint_null = t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null;
+-- result:
+8231
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_bool_null = t2.c_bool_null and t1.c_tinyint_null = t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null;
+-- result:
+1172
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_smallint_null = t2.c_smallint_null and t1.c_smallint_null + 1 = t2.c_smallint_null + 1;
+-- result:
+296011
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_bool_null <=> t2.c_bool_null and t1.c_tinyint_null <=> t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null;
+-- result:
+216093
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_bool_null = t2.c_bool_null and t1.c_tinyint_null = t2.c_tinyint_null and t1.c_int = t2.c_int;
+-- result:
+15238
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_bool_null = t2.c_bool_null and t1.c_tinyint_null = t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null and t1.c_int = t2.c_int;
+-- result:
+1172
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_bool = t2.c_bool and t1.c_tinyint = t2.c_tinyint and t1.c_smallint = t2.c_smallint and t1.c_int = t2.c_int;
+-- result:
+1280000
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_int_null = t2.c_int_null and t1.c_int = t2.c_int;
+-- result:
+91428
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_int + 1 = t2.c_int + 1 and t1.c_int = t2.c_int;
+-- result:
+1280000
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_int + 1 = t2.c_int + 2 and t1.c_int = t2.c_int;
+-- result:
+0
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_float = t2.c_float and t1.c_int = t2.c_int;
+-- result:
+1280000
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_date = t2.c_date and t1.c_int = t2.c_int;
+-- result:
+1280000
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_datetime = t2.c_datetime and t1.c_int = t2.c_int;
+-- result:
+118291
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_bool_null <=> t2.c_bool_null and t1.c_tinyint_null = t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null and t1.c_int = t2.c_int;
+-- result:
+8205
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_double = t2.c_double and t1.c_int = t2.c_int;
+-- result:
+1280000
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_double_null = t2.c_double_null and t1.c_int = t2.c_int;
+-- result:
+80000
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_float_null <=> t2.c_float_null and t1.c_int = t2.c_int;
+-- result:
+1280000
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_bigint = t2.c_bigint and t1.c_int = t2.c_int;
+-- result:
+1280000
+-- !result
+select count(1)
+from t1 join t1 t2 on t1.c_bigint_null = t2.c_bigint_null and t1.c_int = t2.c_int;
+-- result:
+85333
+-- !result

--- a/test/sql/test_join/R/test_join_one_key
+++ b/test/sql/test_join/R/test_join_one_key
@@ -1,0 +1,576 @@
+-- name: test_join_one_key
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_bool boolean,
+    c_bool_null boolean NULL,
+    c_tinyint tinyint,
+    c_tinyint_null tinyint NULL,
+    c_smallint smallint,
+    c_smallint_null smallint NULL,
+    c_int int,
+    c_int_null int NULL,
+    c_bigint bigint,
+    c_bigint_null bigint NULL,
+    c_largeint bigint,
+    c_largeint_null bigint NULL,
+    c_float float,
+    c_float_null float NULL,
+    c_double double,
+    c_double_null double NULL,
+    c_decimalv2 DECIMAL,
+    c_decimalv2_null DECIMAL NULL,
+    c_decimal32 DECIMAL(9),
+    c_decimal32_null DECIMAL(9) NULL,
+    c_decimal64 DECIMAL(18),
+    c_decimal64_null DECIMAL(18) NULL,
+    c_decimal128 DECIMAL(38),
+    c_decimal128_null DECIMAL(38) NULL,
+    c_date date,
+    c_date_null date NULL,
+    c_datetime datetime,
+    c_datetime_null datetime NULL,
+    c_char char(100),
+    c_char_null char(100) NULL,
+    c_varchar varchar(100),
+    c_varchar_null varchar(100) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 
+select
+    idx,
+
+    idx % 2 = 0, -- c_bool
+    if (idx % 7 = 0, idx % 2 = 0, null),
+
+    idx % 128, -- c_tinyint
+    if (idx % 12 = 0, idx % 128, null),
+
+    idx % 32768, -- c_smallint
+    if (idx % 13 = 0, idx % 32768, null),
+
+    idx / 2, -- c_int
+    if (idx % 14 = 0, idx, null),
+
+    idx / 2, -- c_bigint
+    if (idx % 15 = 0, idx, null),
+
+    idx / 2, -- c_largeint
+    if (idx % 16 = 0, idx, null),
+
+    idx / 2, -- c_float
+    if (idx % 17 = 0, idx, null),
+
+    idx / 2, -- c_double
+    if (idx % 18 = 0, idx, null),
+
+    idx / 2, -- c_decimalv2
+    if (idx % 23 = 0, idx, null),
+
+    idx / 2, -- c_decimal32
+    if (idx % 24 = 0,idx, null),
+
+    idx / 2, -- c_decimal64
+    if (idx % 25 = 0, idx, null),
+
+    idx / 2, -- c_decimal128
+    if (idx % 26 = 0, idx, null),
+
+    date_add('2023-01-01', idx / 2), -- c_date
+    if (idx % 19 = 0, date_add('2023-01-01', idx), null),
+
+    date_add('2023-01-01 00:00:00', idx / 2), -- c_datetime
+    if (idx % 20 = 0, date_add('2023-01-01 00:00:00', idx), null),
+
+    concat('char_', idx / 2), -- c_char
+    if (idx % 21 = 0, concat('char_', idx), null),
+
+    concat('varchar_', idx / 2), -- c_varchar
+    if (idx % 22 = 0, concat('varchar_', idx), null)
+
+from __row_util;
+-- result:
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.k1), count(t1.c_bool_null)
+from t1 join w1 t2 using(c_bool_null);
+-- result:
+1279999	1279999	1279999
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.k1), count(t1.c_bool_null)
+from t1 full join w1 t2 using(c_bool_null);
+-- result:
+2377227	2377142	1279999
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.k1), count(t1.c_bool_null)
+from t1 left semi join w1 t2 using(c_bool_null);
+-- result:
+182857	182857	182857
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.k1), count(t1.c_tinyint_null)
+from t1 join w1 t2 using(c_tinyint_null);
+-- result:
+26672	26672	26672
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.k1), count(t1.c_tinyint_null)
+from t1 full join w1 t2 using(c_tinyint_null);
+-- result:
+1280091	1280000	106666
+-- !result
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.k1), count(t1.c_tinyint_null)
+from t1 left semi join w1 t2 using(c_tinyint_null);
+-- result:
+26672	26672	26672
+-- !result
+with w1 as (select * from t1 where k1 < 10000)
+select count(1), count(t1.k1), count(t1.c_smallint_null)
+from t1 join w1 t2 using(c_smallint_null);
+-- result:
+2464	2464	2464
+-- !result
+with w1 as (select * from t1 where k1 < 10000)
+select count(1), count(t1.k1), count(t1.c_smallint_null)
+from t1 full join w1 t2 using(c_smallint_null);
+-- result:
+1289230	1280000	98461
+-- !result
+with w1 as (select * from t1 where k1 < 10000)
+select count(1), count(t1.k1), count(t1.c_smallint_null)
+from t1 left semi join w1 t2 using(c_smallint_null);
+-- result:
+2464	2464	2464
+-- !result
+select count(1), count(t1.k1), count(t1.c_int)
+from t1 join t1 t2 using(c_int);
+-- result:
+2559998	2559998	2559998
+-- !result
+select count(1), count(t1.k1), count(t1.c_int)
+from t1 full join t1 t2 using(c_int);
+-- result:
+2559998	2559998	2559998
+-- !result
+select count(1), count(t1.k1), count(t1.c_int)
+from t1 left semi join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_int_null)
+from t1 join t1 t2 using(c_int_null);
+-- result:
+91428	91428	91428
+-- !result
+select count(1), count(t1.k1), count(t1.c_int_null)
+from t1 full join t1 t2 using(c_int_null);
+-- result:
+2468572	1280000	91428
+-- !result
+select count(1), count(t1.k1), count(t1.c_int_null)
+from t1 left semi join t1 t2 using(c_int_null);
+-- result:
+91428	91428	91428
+-- !result
+select count(1), count(t1.k1), count(t1.c_bigint)
+from t1 join t1 t2 using(c_bigint);
+-- result:
+2559998	2559998	2559998
+-- !result
+select count(1), count(t1.k1), count(t1.c_bigint)
+from t1 full join t1 t2 using(c_bigint);
+-- result:
+2559998	2559998	2559998
+-- !result
+select count(1), count(t1.k1), count(t1.c_bigint)
+from t1 left semi join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_bigint_null)
+from t1 join t1 t2 using(c_bigint_null);
+-- result:
+85333	85333	85333
+-- !result
+select count(1), count(t1.k1), count(t1.c_bigint_null)
+from t1 full join t1 t2 using(c_bigint_null);
+-- result:
+2474667	1280000	85333
+-- !result
+select count(1), count(t1.k1), count(t1.c_bigint_null)
+from t1 left semi join t1 t2 using(c_bigint_null);
+-- result:
+85333	85333	85333
+-- !result
+select count(1), count(t1.k1), count(t1.c_largeint)
+from t1 join t1 t2 using(c_largeint);
+-- result:
+2559998	2559998	2559998
+-- !result
+select count(1), count(t1.k1), count(t1.c_largeint)
+from t1 full join t1 t2 using(c_largeint);
+-- result:
+2559998	2559998	2559998
+-- !result
+select count(1), count(t1.k1), count(t1.c_largeint)
+from t1 left semi join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_largeint_null)
+from t1 join t1 t2 using(c_largeint_null);
+-- result:
+80000	80000	80000
+-- !result
+select count(1), count(t1.k1), count(t1.c_largeint_null)
+from t1 full join t1 t2 using(c_largeint_null);
+-- result:
+2480000	1280000	80000
+-- !result
+select count(1), count(t1.k1), count(t1.c_largeint_null)
+from t1 left semi join t1 t2 using(c_largeint_null);
+-- result:
+80000	80000	80000
+-- !result
+select count(1), count(t1.k1), count(t1.c_float)
+from t1 join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_float)
+from t1 full join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_float)
+from t1 left semi join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_float_null)
+from t1 join t1 t2 using(c_float_null);
+-- result:
+75294	75294	75294
+-- !result
+select count(1), count(t1.k1), count(t1.c_float_null)
+from t1 full join t1 t2 using(c_float_null);
+-- result:
+2484706	1280000	75294
+-- !result
+select count(1), count(t1.k1), count(t1.c_float_null)
+from t1 left semi join t1 t2 using(c_float_null);
+-- result:
+75294	75294	75294
+-- !result
+select count(1), count(t1.k1), count(t1.c_double)
+from t1 join t1 t2 using(c_double);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_double)
+from t1 full join t1 t2 using(c_double);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_double)
+from t1 left semi join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_double_null)
+from t1 join t1 t2 using(c_double_null);
+-- result:
+71111	71111	71111
+-- !result
+select count(1), count(t1.k1), count(t1.c_double_null)
+from t1 full join t1 t2 using(c_double_null);
+-- result:
+2488889	1280000	71111
+-- !result
+select count(1), count(t1.k1), count(t1.c_double_null)
+from t1 left semi join t1 t2 using(c_double_null);
+-- result:
+71111	71111	71111
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimalv2)
+from t1 join t1 t2 using(c_decimalv2);
+-- result:
+2560000	2560000	2560000
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimalv2)
+from t1 full join t1 t2 using(c_decimalv2);
+-- result:
+2560000	2560000	2560000
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimalv2)
+from t1 left semi join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimalv2_null)
+from t1 join t1 t2 using(c_decimalv2_null);
+-- result:
+55652	55652	55652
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimalv2_null)
+from t1 full join t1 t2 using(c_decimalv2_null);
+-- result:
+2504348	1280000	55652
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimalv2_null)
+from t1 left semi join t1 t2 using(c_decimalv2_null);
+-- result:
+55652	55652	55652
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal32)
+from t1 join t1 t2 using(c_decimal32);
+-- result:
+2560000	2560000	2560000
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal32)
+from t1 full join t1 t2 using(c_decimal32);
+-- result:
+2560000	2560000	2560000
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal32)
+from t1 left semi join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal32_null)
+from t1 join t1 t2 using(c_decimal32_null);
+-- result:
+53333	53333	53333
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal32_null)
+from t1 full join t1 t2 using(c_decimal32_null);
+-- result:
+2506667	1280000	53333
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal32_null)
+from t1 left semi join t1 t2 using(c_decimal32_null);
+-- result:
+53333	53333	53333
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal64)
+from t1 join t1 t2 using(c_decimal64);
+-- result:
+2560000	2560000	2560000
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal64)
+from t1 full join t1 t2 using(c_decimal64);
+-- result:
+2560000	2560000	2560000
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal64)
+from t1 left semi join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal64_null)
+from t1 join t1 t2 using(c_decimal64_null);
+-- result:
+51200	51200	51200
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal64_null)
+from t1 full join t1 t2 using(c_decimal64_null);
+-- result:
+2508800	1280000	51200
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal64_null)
+from t1 left semi join t1 t2 using(c_decimal64_null);
+-- result:
+51200	51200	51200
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal128)
+from t1 join t1 t2 using(c_decimal128);
+-- result:
+2560000	2560000	2560000
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal128)
+from t1 full join t1 t2 using(c_decimal128);
+-- result:
+2560000	2560000	2560000
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal128)
+from t1 left semi join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal128_null)
+from t1 join t1 t2 using(c_decimal128_null);
+-- result:
+49230	49230	49230
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal128_null)
+from t1 full join t1 t2 using(c_decimal128_null);
+-- result:
+2510770	1280000	49230
+-- !result
+select count(1), count(t1.k1), count(t1.c_decimal128_null)
+from t1 left semi join t1 t2 using(c_decimal128_null);
+-- result:
+49230	49230	49230
+-- !result
+select count(1), count(t1.k1), count(t1.c_date)
+from t1 join t1 t2 using(c_date);
+-- result:
+2559998	2559998	2559998
+-- !result
+select count(1), count(t1.k1), count(t1.c_date)
+from t1 full join t1 t2 using(c_date);
+-- result:
+2559998	2559998	2559998
+-- !result
+select count(1), count(t1.k1), count(t1.c_date)
+from t1 left semi join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_date_null)
+from t1 join t1 t2 using(c_date_null);
+-- result:
+67368	67368	67368
+-- !result
+select count(1), count(t1.k1), count(t1.c_date_null)
+from t1 full join t1 t2 using(c_date_null);
+-- result:
+2492632	1280000	67368
+-- !result
+select count(1), count(t1.k1), count(t1.c_date_null)
+from t1 left semi join t1 t2 using(c_date_null);
+-- result:
+67368	67368	67368
+-- !result
+select count(1), count(t1.k1), count(t1.c_datetime)
+from t1 join t1 t2 using(c_datetime);
+-- result:
+2559998	2559998	2559998
+-- !result
+select count(1), count(t1.k1), count(t1.c_datetime)
+from t1 full join t1 t2 using(c_datetime);
+-- result:
+2559998	2559998	2559998
+-- !result
+select count(1), count(t1.k1), count(t1.c_datetime)
+from t1 left semi join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_datetime_null)
+from t1 join t1 t2 using(c_datetime_null);
+-- result:
+64000	64000	64000
+-- !result
+select count(1), count(t1.k1), count(t1.c_datetime_null)
+from t1 full join t1 t2 using(c_datetime_null);
+-- result:
+2496000	1280000	64000
+-- !result
+select count(1), count(t1.k1), count(t1.c_datetime_null)
+from t1 left semi join t1 t2 using(c_datetime_null);
+-- result:
+64000	64000	64000
+-- !result
+select count(1), count(t1.k1), count(t1.c_char)
+from t1 join t1 t2 using(c_char);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_char)
+from t1 full join t1 t2 using(c_char);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_char)
+from t1 left semi join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_char_null)
+from t1 join t1 t2 using(c_char_null);
+-- result:
+60952	60952	60952
+-- !result
+select count(1), count(t1.k1), count(t1.c_char_null)
+from t1 full join t1 t2 using(c_char_null);
+-- result:
+2499048	1280000	60952
+-- !result
+select count(1), count(t1.k1), count(t1.c_char_null)
+from t1 left semi join t1 t2 using(c_char_null);
+-- result:
+60952	60952	60952
+-- !result
+select count(1), count(t1.k1), count(t1.c_varchar)
+from t1 join t1 t2 using(c_varchar);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_varchar)
+from t1 full join t1 t2 using(c_varchar);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_varchar)
+from t1 left semi join t1 t2 using(c_float);
+-- result:
+1280000	1280000	1280000
+-- !result
+select count(1), count(t1.k1), count(t1.c_varchar_null)
+from t1 join t1 t2 using(c_varchar_null);
+-- result:
+58181	58181	58181
+-- !result
+select count(1), count(t1.k1), count(t1.c_varchar_null)
+from t1 full join t1 t2 using(c_varchar_null);
+-- result:
+2501819	1280000	58181
+-- !result
+select count(1), count(t1.k1), count(t1.c_varchar_null)
+from t1 left semi join t1 t2 using(c_varchar_null);
+-- result:
+58181	58181	58181
+-- !result

--- a/test/sql/test_join/T/test_join_direct_mapping
+++ b/test/sql/test_join/T/test_join_direct_mapping
@@ -1,0 +1,420 @@
+-- name: test_join_direct_mapping
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_bool boolean,
+    c_bool_null boolean NULL,
+    c_tinyint tinyint,
+    c_tinyint_null tinyint NULL,
+    c_smallint smallint,
+    c_smallint_null smallint NULL,
+    c_int int,
+    c_int_null int NULL,
+    c_bigint bigint,
+    c_bigint_null bigint NULL,
+    c_float float,
+    c_float_null float NULL,
+    c_double double,
+    c_double_null double NULL,
+    c_date date,
+    c_date_null date NULL,
+    c_datetime datetime,
+    c_datetime_null datetime NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t1 
+select
+    idx,
+
+    idx % 2 = 0,
+    if (idx % 7 = 0, idx % 2 = 0, null),
+
+    idx % 128,
+    if (idx % 12 = 0, idx % 128, null),
+
+    idx % 32768,
+    if (idx % 13 = 0, idx % 32768, null),
+
+    idx % 2147483648,
+    if (idx % 14 = 0, idx % 2147483648, null),
+
+    idx,
+    if (idx % 15 = 0, idx, null),
+
+    idx,
+    if (idx % 16 = 0, idx, null),
+
+    idx,
+    if (idx % 16 = 0, idx, null),
+
+    date_add('2023-01-01', idx % 365),
+    if (idx % 17 = 0, date_add('2023-01-01', idx % 365), null),
+
+    date_add('2023-01-01 00:00:00', idx % 365 * 24 * 3600 + idx % 86400),
+    if (idx % 18 = 0, date_add('2023-01-01 00:00:00', idx % 365 * 24 * 3600 + idx % 86400), null)
+from __row_util;
+
+-- bool, right table has true, false, null.
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 left outer join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.c_bool_null)
+from t1 left semi join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.c_bool_null)
+from t1 left anti join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 right outer join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t2.c_bool_null)
+from t1 right semi join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t2.c_bool_null)
+from t1 right anti join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 full join w1 t2 using(c_bool_null);
+
+-- bool, right table has true
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 left outer join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t1.c_bool_null)
+from t1 left semi join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t1.c_bool_null)
+from t1 left anti join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 right outer join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t2.c_bool_null)
+from t1 right semi join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t2.c_bool_null)
+from t1 right anti join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 full join w1 t2 using(c_bool_null);
+
+-- bool, right table has null
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 left outer join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t1.c_bool_null)
+from t1 left semi join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t1.c_bool_null)
+from t1 left anti join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 right outer join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t2.c_bool_null)
+from t1 right semi join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t2.c_bool_null)
+from t1 right anti join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100 and c_bool_null is null and c_bool_null = true)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 full join w1 t2 using(c_bool_null);
+
+-- bool, has other conjuncts
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 join w1 t2 using(c_bool_null) where (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 left outer join w1 t2 using(c_bool_null) where (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_bool_null)
+from t1 left semi join w1 t2 on t1.c_bool_null = t2.c_bool_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_bool_null)
+from t1 left anti join w1 t2 on t1.c_bool_null = t2.c_bool_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 right outer join w1 t2 on t1.c_bool_null = t2.c_bool_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t2.c_bool_null)
+from t1 right semi join w1 t2 on t1.c_bool_null = t2.c_bool_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t2.c_bool_null)
+from t1 right anti join w1 t2 on t1.c_bool_null = t2.c_bool_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_bool_null), count(t2.c_bool_null)
+from t1 full join w1 t2 using(c_bool_null) where (t1.k1 + t2.k1) % 7 = 0;
+
+
+-- tinyint
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 left outer join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t1.c_tinyint_null)
+from t1 left semi join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t1.c_tinyint_null)
+from t1 left anti join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 right outer join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t2.c_tinyint_null)
+from t1 right semi join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t2.c_tinyint_null)
+from t1 right anti join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 full join w1 t2 using(c_tinyint_null);
+
+-- tinyint, right table only has null
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 left outer join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t1.c_tinyint_null)
+from t1 left semi join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t1.c_tinyint_null)
+from t1 left anti join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 right outer join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t2.c_tinyint_null)
+from t1 right semi join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t2.c_tinyint_null)
+from t1 right anti join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_tinyint_null % 2 = 0 and c_tinyint_null is null)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 full join w1 t2 using(c_tinyint_null);
+
+-- tinyint, has other conjuncts
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 join w1 t2 using(c_tinyint_null) where (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 left outer join w1 t2 using(c_tinyint_null) where (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_tinyint_null)
+from t1 left semi join w1 t2 on t1.c_tinyint_null = t2.c_tinyint_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_tinyint_null)
+from t1 left anti join w1 t2 on t1.c_tinyint_null = t2.c_tinyint_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 right outer join w1 t2 on t1.c_tinyint_null = t2.c_tinyint_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t2.c_tinyint_null)
+from t1 right semi join w1 t2 on t1.c_tinyint_null = t2.c_tinyint_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t2.c_tinyint_null)
+from t1 right anti join w1 t2 on t1.c_tinyint_null = t2.c_tinyint_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_tinyint_null), count(t2.c_tinyint_null)
+from t1 full join w1 t2 using(c_tinyint_null) where (t1.k1 + t2.k1) % 7 = 0;
+
+
+-- smallint
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 left outer join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t1.c_smallint_null)
+from t1 left semi join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t1.c_smallint_null)
+from t1 left anti join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 right outer join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t2.c_smallint_null)
+from t1 right semi join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t2.c_smallint_null)
+from t1 right anti join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 full join w1 t2 using(c_smallint_null);
+
+-- smallint, right table only has null
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 left outer join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t1.c_smallint_null)
+from t1 left semi join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t1.c_smallint_null)
+from t1 left anti join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 right outer join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t2.c_smallint_null)
+from t1 right semi join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t2.c_smallint_null)
+from t1 right anti join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 300 and c_smallint_null % 2 = 0 and c_smallint_null is null)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 full join w1 t2 using(c_smallint_null);
+
+-- smallint, has other conjuncts
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 join w1 t2 using(c_smallint_null) where (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 left outer join w1 t2 using(c_smallint_null) where (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_smallint_null)
+from t1 left semi join w1 t2 on t1.c_smallint_null = t2.c_smallint_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_smallint_null)
+from t1 left anti join w1 t2 on t1.c_smallint_null = t2.c_smallint_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 right outer join w1 t2 on t1.c_smallint_null = t2.c_smallint_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t2.c_smallint_null)
+from t1 right semi join w1 t2 on t1.c_smallint_null = t2.c_smallint_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t2.c_smallint_null)
+from t1 right anti join w1 t2 on t1.c_smallint_null = t2.c_smallint_null and (t1.k1 + t2.k1) % 7 = 0;
+
+with w1 as (select * from t1 where k1 < 10)
+select count(1), count(t1.c_smallint_null), count(t2.c_smallint_null)
+from t1 full join w1 t2 using(c_smallint_null) where (t1.k1 + t2.k1) % 7 = 0;
+

--- a/test/sql/test_join/T/test_join_fixed_size
+++ b/test/sql/test_join/T/test_join_fixed_size
@@ -101,6 +101,8 @@ from t1 join t1 t2 on t1.c_smallint_null = t2.c_smallint_null and t1.c_smallint_
 -- fixed size 8 bytes
 select count(1)
 from t1 join t1 t2 on t1.c_bool_null <=> t2.c_bool_null and t1.c_tinyint_null <=> t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null;
+select count(1)
+from t1 full join t1 t2 on t1.c_bool_null <=> t2.c_bool_null and t1.c_tinyint_null <=> t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null;
 
 select count(1)
 from t1 join t1 t2 on t1.c_bool_null = t2.c_bool_null and t1.c_tinyint_null = t2.c_tinyint_null and t1.c_int = t2.c_int;
@@ -133,6 +135,8 @@ from t1 join t1 t2 on t1.c_datetime = t2.c_datetime and t1.c_int = t2.c_int;
 -- fixed size 16 bytes
 select count(1)
 from t1 join t1 t2 on t1.c_bool_null <=> t2.c_bool_null and t1.c_tinyint_null = t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null and t1.c_int = t2.c_int;
+select count(1)
+from t1 full join t1 t2 on t1.c_bool_null <=> t2.c_bool_null and t1.c_tinyint_null = t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null and t1.c_int = t2.c_int;
 
 select count(1)
 from t1 join t1 t2 on t1.c_double = t2.c_double and t1.c_int = t2.c_int;
@@ -148,3 +152,11 @@ from t1 join t1 t2 on t1.c_bigint = t2.c_bigint and t1.c_int = t2.c_int;
 
 select count(1)
 from t1 join t1 t2 on t1.c_bigint_null = t2.c_bigint_null and t1.c_int = t2.c_int;
+
+-- non-fixed size
+
+select count(1)
+from t1 join t1 t2 on t1.c_bigint_null = t2.c_bigint_null and t1.c_int = t2.c_int and t1.c_double = t2.c_double;
+
+select count(1)
+from t1 join t1 t2 on t1.c_datetime = t2.c_datetime and cast(t1.c_int as string) = cast(t2.c_int as string);

--- a/test/sql/test_join/T/test_join_fixed_size
+++ b/test/sql/test_join/T/test_join_fixed_size
@@ -1,0 +1,150 @@
+
+-- name: test_join_fixed_size
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_bool boolean,
+    c_bool_null boolean NULL,
+    c_tinyint tinyint,
+    c_tinyint_null tinyint NULL,
+    c_smallint smallint,
+    c_smallint_null smallint NULL,
+    c_int int,
+    c_int_null int NULL,
+    c_bigint bigint,
+    c_bigint_null bigint NULL,
+    c_float float,
+    c_float_null float NULL,
+    c_double double,
+    c_double_null double NULL,
+    c_date date,
+    c_date_null date NULL,
+    c_datetime datetime,
+    c_datetime_null datetime NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t1 
+select
+    idx,
+
+    idx % 2 = 0,
+    if (idx % 7 = 0, idx % 2 = 0, null),
+
+    idx % 128,
+    if (idx % 12 = 0, idx % 128, null),
+
+    idx % 32768,
+    if (idx % 13 = 0, idx % 32768, null),
+
+    idx % 2147483648,
+    if (idx % 14 = 0, idx % 2147483648, null),
+
+    idx,
+    if (idx % 15 = 0, idx, null),
+
+    idx,
+    if (idx % 16 = 0, idx, null),
+
+    idx,
+    if (idx % 16 = 0, idx, null),
+
+    date_add('2023-01-01', idx % 365),
+    if (idx % 17 = 0, date_add('2023-01-01', idx % 365), null),
+
+    date_add('2023-01-01 00:00:00', idx % 365 * 24 * 3600 + idx % 86400),
+    if (idx % 18 = 0, date_add('2023-01-01 00:00:00', idx % 365 * 24 * 3600 + idx % 86400), null)
+from __row_util;
+
+
+-- fixed size 4 bytes
+select count(1)
+from t1 join t1 t2 on t1.c_tinyint_null = t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null;
+
+select count(1)
+from t1 join t1 t2 on t1.c_bool_null = t2.c_bool_null and t1.c_tinyint_null = t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null;
+
+select count(1)
+from t1 join t1 t2 on t1.c_smallint_null = t2.c_smallint_null and t1.c_smallint_null + 1 = t2.c_smallint_null + 1;
+
+-- fixed size 8 bytes
+select count(1)
+from t1 join t1 t2 on t1.c_bool_null <=> t2.c_bool_null and t1.c_tinyint_null <=> t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null;
+
+select count(1)
+from t1 join t1 t2 on t1.c_bool_null = t2.c_bool_null and t1.c_tinyint_null = t2.c_tinyint_null and t1.c_int = t2.c_int;
+
+select count(1)
+from t1 join t1 t2 on t1.c_bool_null = t2.c_bool_null and t1.c_tinyint_null = t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null and t1.c_int = t2.c_int;
+
+select count(1)
+from t1 join t1 t2 on t1.c_bool = t2.c_bool and t1.c_tinyint = t2.c_tinyint and t1.c_smallint = t2.c_smallint and t1.c_int = t2.c_int;
+
+select count(1)
+from t1 join t1 t2 on t1.c_int_null = t2.c_int_null and t1.c_int = t2.c_int;
+
+select count(1)
+from t1 join t1 t2 on t1.c_int + 1 = t2.c_int + 1 and t1.c_int = t2.c_int;
+
+select count(1)
+from t1 join t1 t2 on t1.c_int + 1 = t2.c_int + 2 and t1.c_int = t2.c_int;
+
+select count(1)
+from t1 join t1 t2 on t1.c_float = t2.c_float and t1.c_int = t2.c_int;
+
+select count(1)
+from t1 join t1 t2 on t1.c_date = t2.c_date and t1.c_int = t2.c_int;
+
+select count(1)
+from t1 join t1 t2 on t1.c_datetime = t2.c_datetime and t1.c_int = t2.c_int;
+
+
+-- fixed size 16 bytes
+select count(1)
+from t1 join t1 t2 on t1.c_bool_null <=> t2.c_bool_null and t1.c_tinyint_null = t2.c_tinyint_null and t1.c_smallint_null = t2.c_smallint_null and t1.c_int = t2.c_int;
+
+select count(1)
+from t1 join t1 t2 on t1.c_double = t2.c_double and t1.c_int = t2.c_int;
+
+select count(1)
+from t1 join t1 t2 on t1.c_double_null = t2.c_double_null and t1.c_int = t2.c_int;
+
+select count(1)
+from t1 join t1 t2 on t1.c_float_null <=> t2.c_float_null and t1.c_int = t2.c_int;
+
+select count(1)
+from t1 join t1 t2 on t1.c_bigint = t2.c_bigint and t1.c_int = t2.c_int;
+
+select count(1)
+from t1 join t1 t2 on t1.c_bigint_null = t2.c_bigint_null and t1.c_int = t2.c_int;

--- a/test/sql/test_join/T/test_join_one_key
+++ b/test/sql/test_join/T/test_join_one_key
@@ -1,0 +1,410 @@
+-- name: test_join_one_key
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_bool boolean,
+    c_bool_null boolean NULL,
+    c_tinyint tinyint,
+    c_tinyint_null tinyint NULL,
+    c_smallint smallint,
+    c_smallint_null smallint NULL,
+    c_int int,
+    c_int_null int NULL,
+    c_bigint bigint,
+    c_bigint_null bigint NULL,
+    c_largeint bigint,
+    c_largeint_null bigint NULL,
+    c_float float,
+    c_float_null float NULL,
+    c_double double,
+    c_double_null double NULL,
+    c_decimalv2 DECIMAL,
+    c_decimalv2_null DECIMAL NULL,
+    c_decimal32 DECIMAL(9),
+    c_decimal32_null DECIMAL(9) NULL,
+    c_decimal64 DECIMAL(18),
+    c_decimal64_null DECIMAL(18) NULL,
+    c_decimal128 DECIMAL(38),
+    c_decimal128_null DECIMAL(38) NULL,
+    c_date date,
+    c_date_null date NULL,
+    c_datetime datetime,
+    c_datetime_null datetime NULL,
+    c_char char(100),
+    c_char_null char(100) NULL,
+    c_varchar varchar(100),
+    c_varchar_null varchar(100) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t1 
+select
+    idx,
+
+    idx % 2 = 0, -- c_bool
+    if (idx % 7 = 0, idx % 2 = 0, null),
+
+    idx % 128, -- c_tinyint
+    if (idx % 12 = 0, idx % 128, null),
+
+    idx % 32768, -- c_smallint
+    if (idx % 13 = 0, idx % 32768, null),
+
+    idx / 2, -- c_int
+    if (idx % 14 = 0, idx, null),
+
+    idx / 2, -- c_bigint
+    if (idx % 15 = 0, idx, null),
+
+    idx / 2, -- c_largeint
+    if (idx % 16 = 0, idx, null),
+
+    idx / 2, -- c_float
+    if (idx % 17 = 0, idx, null),
+
+    idx / 2, -- c_double
+    if (idx % 18 = 0, idx, null),
+
+    idx / 2, -- c_decimalv2
+    if (idx % 23 = 0, idx, null),
+
+    idx / 2, -- c_decimal32
+    if (idx % 24 = 0,idx, null),
+
+    idx / 2, -- c_decimal64
+    if (idx % 25 = 0, idx, null),
+
+    idx / 2, -- c_decimal128
+    if (idx % 26 = 0, idx, null),
+
+    date_add('2023-01-01', idx / 2), -- c_date
+    if (idx % 19 = 0, date_add('2023-01-01', idx), null),
+
+    date_add('2023-01-01 00:00:00', idx / 2), -- c_datetime
+    if (idx % 20 = 0, date_add('2023-01-01 00:00:00', idx), null),
+
+    concat('char_', idx / 2), -- c_char
+    if (idx % 21 = 0, concat('char_', idx), null),
+
+    concat('varchar_', idx / 2), -- c_varchar
+    if (idx % 22 = 0, concat('varchar_', idx), null)
+
+from __row_util;
+
+-- c_bool_null
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.k1), count(t1.c_bool_null)
+from t1 join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.k1), count(t1.c_bool_null)
+from t1 full join w1 t2 using(c_bool_null);
+
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.k1), count(t1.c_bool_null)
+from t1 left semi join w1 t2 using(c_bool_null);
+
+-- c_tinyint_null
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.k1), count(t1.c_tinyint_null)
+from t1 join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.k1), count(t1.c_tinyint_null)
+from t1 full join w1 t2 using(c_tinyint_null);
+
+with w1 as (select * from t1 where k1 < 100)
+select count(1), count(t1.k1), count(t1.c_tinyint_null)
+from t1 left semi join w1 t2 using(c_tinyint_null);
+
+-- c_smallint_null
+with w1 as (select * from t1 where k1 < 10000)
+select count(1), count(t1.k1), count(t1.c_smallint_null)
+from t1 join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 10000)
+select count(1), count(t1.k1), count(t1.c_smallint_null)
+from t1 full join w1 t2 using(c_smallint_null);
+
+with w1 as (select * from t1 where k1 < 10000)
+select count(1), count(t1.k1), count(t1.c_smallint_null)
+from t1 left semi join w1 t2 using(c_smallint_null);
+
+-- c_int
+select count(1), count(t1.k1), count(t1.c_int)
+from t1 join t1 t2 using(c_int);
+
+select count(1), count(t1.k1), count(t1.c_int)
+from t1 full join t1 t2 using(c_int);
+
+select count(1), count(t1.k1), count(t1.c_int)
+from t1 left semi join t1 t2 using(c_float);
+
+-- c_int_null
+select count(1), count(t1.k1), count(t1.c_int_null)
+from t1 join t1 t2 using(c_int_null);
+
+select count(1), count(t1.k1), count(t1.c_int_null)
+from t1 full join t1 t2 using(c_int_null);
+
+select count(1), count(t1.k1), count(t1.c_int_null)
+from t1 left semi join t1 t2 using(c_int_null);
+-- c_bigint
+select count(1), count(t1.k1), count(t1.c_bigint)
+from t1 join t1 t2 using(c_bigint);
+
+select count(1), count(t1.k1), count(t1.c_bigint)
+from t1 full join t1 t2 using(c_bigint);
+
+select count(1), count(t1.k1), count(t1.c_bigint)
+from t1 left semi join t1 t2 using(c_float);
+
+-- c_bigint_null
+select count(1), count(t1.k1), count(t1.c_bigint_null)
+from t1 join t1 t2 using(c_bigint_null);
+
+select count(1), count(t1.k1), count(t1.c_bigint_null)
+from t1 full join t1 t2 using(c_bigint_null);
+
+select count(1), count(t1.k1), count(t1.c_bigint_null)
+from t1 left semi join t1 t2 using(c_bigint_null);
+-- c_largeint
+select count(1), count(t1.k1), count(t1.c_largeint)
+from t1 join t1 t2 using(c_largeint);
+
+select count(1), count(t1.k1), count(t1.c_largeint)
+from t1 full join t1 t2 using(c_largeint);
+
+select count(1), count(t1.k1), count(t1.c_largeint)
+from t1 left semi join t1 t2 using(c_float);
+
+-- c_largeint_null
+select count(1), count(t1.k1), count(t1.c_largeint_null)
+from t1 join t1 t2 using(c_largeint_null);
+
+select count(1), count(t1.k1), count(t1.c_largeint_null)
+from t1 full join t1 t2 using(c_largeint_null);
+
+select count(1), count(t1.k1), count(t1.c_largeint_null)
+from t1 left semi join t1 t2 using(c_largeint_null);
+-- c_float
+select count(1), count(t1.k1), count(t1.c_float)
+from t1 join t1 t2 using(c_float);
+
+select count(1), count(t1.k1), count(t1.c_float)
+from t1 full join t1 t2 using(c_float);
+
+select count(1), count(t1.k1), count(t1.c_float)
+from t1 left semi join t1 t2 using(c_float);
+
+-- c_float_null
+select count(1), count(t1.k1), count(t1.c_float_null)
+from t1 join t1 t2 using(c_float_null);
+
+select count(1), count(t1.k1), count(t1.c_float_null)
+from t1 full join t1 t2 using(c_float_null);
+
+select count(1), count(t1.k1), count(t1.c_float_null)
+from t1 left semi join t1 t2 using(c_float_null);
+-- c_double
+select count(1), count(t1.k1), count(t1.c_double)
+from t1 join t1 t2 using(c_double);
+
+select count(1), count(t1.k1), count(t1.c_double)
+from t1 full join t1 t2 using(c_double);
+
+select count(1), count(t1.k1), count(t1.c_double)
+from t1 left semi join t1 t2 using(c_float);
+
+-- c_double_null
+select count(1), count(t1.k1), count(t1.c_double_null)
+from t1 join t1 t2 using(c_double_null);
+
+select count(1), count(t1.k1), count(t1.c_double_null)
+from t1 full join t1 t2 using(c_double_null);
+
+select count(1), count(t1.k1), count(t1.c_double_null)
+from t1 left semi join t1 t2 using(c_double_null);
+-- c_decimalv2
+select count(1), count(t1.k1), count(t1.c_decimalv2)
+from t1 join t1 t2 using(c_decimalv2);
+
+select count(1), count(t1.k1), count(t1.c_decimalv2)
+from t1 full join t1 t2 using(c_decimalv2);
+
+select count(1), count(t1.k1), count(t1.c_decimalv2)
+from t1 left semi join t1 t2 using(c_float);
+
+-- c_decimalv2_null
+select count(1), count(t1.k1), count(t1.c_decimalv2_null)
+from t1 join t1 t2 using(c_decimalv2_null);
+
+select count(1), count(t1.k1), count(t1.c_decimalv2_null)
+from t1 full join t1 t2 using(c_decimalv2_null);
+
+select count(1), count(t1.k1), count(t1.c_decimalv2_null)
+from t1 left semi join t1 t2 using(c_decimalv2_null);
+-- c_decimal32
+select count(1), count(t1.k1), count(t1.c_decimal32)
+from t1 join t1 t2 using(c_decimal32);
+
+select count(1), count(t1.k1), count(t1.c_decimal32)
+from t1 full join t1 t2 using(c_decimal32);
+
+select count(1), count(t1.k1), count(t1.c_decimal32)
+from t1 left semi join t1 t2 using(c_float);
+
+-- c_decimal32_null
+select count(1), count(t1.k1), count(t1.c_decimal32_null)
+from t1 join t1 t2 using(c_decimal32_null);
+
+select count(1), count(t1.k1), count(t1.c_decimal32_null)
+from t1 full join t1 t2 using(c_decimal32_null);
+
+select count(1), count(t1.k1), count(t1.c_decimal32_null)
+from t1 left semi join t1 t2 using(c_decimal32_null);
+-- c_decimal64
+select count(1), count(t1.k1), count(t1.c_decimal64)
+from t1 join t1 t2 using(c_decimal64);
+
+select count(1), count(t1.k1), count(t1.c_decimal64)
+from t1 full join t1 t2 using(c_decimal64);
+
+select count(1), count(t1.k1), count(t1.c_decimal64)
+from t1 left semi join t1 t2 using(c_float);
+
+-- c_decimal64_null
+select count(1), count(t1.k1), count(t1.c_decimal64_null)
+from t1 join t1 t2 using(c_decimal64_null);
+
+select count(1), count(t1.k1), count(t1.c_decimal64_null)
+from t1 full join t1 t2 using(c_decimal64_null);
+
+select count(1), count(t1.k1), count(t1.c_decimal64_null)
+from t1 left semi join t1 t2 using(c_decimal64_null);
+-- c_decimal128
+select count(1), count(t1.k1), count(t1.c_decimal128)
+from t1 join t1 t2 using(c_decimal128);
+
+select count(1), count(t1.k1), count(t1.c_decimal128)
+from t1 full join t1 t2 using(c_decimal128);
+
+select count(1), count(t1.k1), count(t1.c_decimal128)
+from t1 left semi join t1 t2 using(c_float);
+
+-- c_decimal128_null
+select count(1), count(t1.k1), count(t1.c_decimal128_null)
+from t1 join t1 t2 using(c_decimal128_null);
+
+select count(1), count(t1.k1), count(t1.c_decimal128_null)
+from t1 full join t1 t2 using(c_decimal128_null);
+
+select count(1), count(t1.k1), count(t1.c_decimal128_null)
+from t1 left semi join t1 t2 using(c_decimal128_null);
+-- c_date
+select count(1), count(t1.k1), count(t1.c_date)
+from t1 join t1 t2 using(c_date);
+
+select count(1), count(t1.k1), count(t1.c_date)
+from t1 full join t1 t2 using(c_date);
+
+select count(1), count(t1.k1), count(t1.c_date)
+from t1 left semi join t1 t2 using(c_float);
+
+-- c_date_null
+select count(1), count(t1.k1), count(t1.c_date_null)
+from t1 join t1 t2 using(c_date_null);
+
+select count(1), count(t1.k1), count(t1.c_date_null)
+from t1 full join t1 t2 using(c_date_null);
+
+select count(1), count(t1.k1), count(t1.c_date_null)
+from t1 left semi join t1 t2 using(c_date_null);
+-- c_datetime
+select count(1), count(t1.k1), count(t1.c_datetime)
+from t1 join t1 t2 using(c_datetime);
+
+select count(1), count(t1.k1), count(t1.c_datetime)
+from t1 full join t1 t2 using(c_datetime);
+
+select count(1), count(t1.k1), count(t1.c_datetime)
+from t1 left semi join t1 t2 using(c_float);
+
+-- c_datetime_null
+select count(1), count(t1.k1), count(t1.c_datetime_null)
+from t1 join t1 t2 using(c_datetime_null);
+
+select count(1), count(t1.k1), count(t1.c_datetime_null)
+from t1 full join t1 t2 using(c_datetime_null);
+
+select count(1), count(t1.k1), count(t1.c_datetime_null)
+from t1 left semi join t1 t2 using(c_datetime_null);
+-- c_char
+select count(1), count(t1.k1), count(t1.c_char)
+from t1 join t1 t2 using(c_char);
+
+select count(1), count(t1.k1), count(t1.c_char)
+from t1 full join t1 t2 using(c_char);
+
+select count(1), count(t1.k1), count(t1.c_char)
+from t1 left semi join t1 t2 using(c_float);
+
+-- c_char_null
+select count(1), count(t1.k1), count(t1.c_char_null)
+from t1 join t1 t2 using(c_char_null);
+
+select count(1), count(t1.k1), count(t1.c_char_null)
+from t1 full join t1 t2 using(c_char_null);
+
+select count(1), count(t1.k1), count(t1.c_char_null)
+from t1 left semi join t1 t2 using(c_char_null);
+-- c_varchar
+select count(1), count(t1.k1), count(t1.c_varchar)
+from t1 join t1 t2 using(c_varchar);
+
+select count(1), count(t1.k1), count(t1.c_varchar)
+from t1 full join t1 t2 using(c_varchar);
+
+select count(1), count(t1.k1), count(t1.c_varchar)
+from t1 left semi join t1 t2 using(c_float);
+
+-- c_varchar_null
+select count(1), count(t1.k1), count(t1.c_varchar_null)
+from t1 join t1 t2 using(c_varchar_null);
+
+select count(1), count(t1.k1), count(t1.c_varchar_null)
+from t1 full join t1 t2 using(c_varchar_null);
+
+select count(1), count(t1.k1), count(t1.c_varchar_null)
+from t1 left semi join t1 t2 using(c_varchar_null);


### PR DESCRIPTION
## Why I'm doing:

### Split JoinFunc to KeyConstructor and HashMapMethod

<img width="2084" height="630" alt="QQ_1752631461657" src="https://github.com/user-attachments/assets/418230e2-bddc-4d86-a4d8-9660f9d8937c" />



Currently, there are four implementations of `JoinBuildFunc` and `JoinProbeFunc`. These actually represent two distinct dimensions.

- **Different methods for constructing join keys**:
  - `JoinBuildFunc`, `JoinProbeFunc`: For single-column join keys.
  - `FixedSizeJoinBuildFunc`, `FixedSizeJoinProbeFunc`: For multi-column join keys, serialized into fixed-length `INT`, `BIGINT`, or `LARGEINT`.
  - `SerializedJoinBuildFunc`, `SerializedJoinProbeFunc`: For multi-column join keys, serialized into strings.
  
- **Different hash map implementations**:
  - `JoinBuildFunc`, `FixedSizeJoinBuildFunc`, `SerializedJoinBuildFunc`: Implement a bucket-chained hash map.
  - `DirectMappingJoinBuildFunc`, `DirectMappingJoinProbeFunc`: Use a direct-mapped hash table via `value - min_value`. Their approach to constructing join keys is functionally similar to `JoinBuildFunc` and `JoinProbeFunc`.

To facilitate adding different join hash map implementations without concern for join key construction methods, we split `JoinFunc` into `KeyConstructor` and `HashMapMethod`.
- `BuildKeyConstructor` and `ProbeKeyConstructor` are employed to construct join keys from the input builder and prober data segments.
- `JoinHashMapMethod` facilitates the creation and probing of the hash map structure.

### Constructing the builder join keys is moved earlier

Additionally, we move the process of constructing the builder join keys *before* determining the type of join hash map. This is because, in the future, we will need to analyze data characteristics of the builder join keys (such as max value, min value, NDV) to decide which join hash map to use.

This change introduces a requirement: `BuildKeyConstructorForSerializedFixedSize` and `BuildKeyConstructorForSerialized` must use a new field, `TableItems::build_key_nulls`, to record whether each row of the join key is null. Previously, since join key construction and hash map building occurred within the same function, this information did not need to be stored. This will use more memory.

## What I'm doing:



Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
