### PR TITLE
[BugFix] Fix txn log not exist when batch publish for shared-data arch

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -505,7 +505,9 @@ public class PublishVersionDaemon extends FrontendDaemon {
         final List<Long> versions = publishVersionData.getCommitVersions();
         final List<TxnInfoPB> txnInfos = publishVersionData.getTxnInfos();
 
-        Map<Long, Set<Tablet>> shadowTabletsMap = new HashMap<>();
+        //  Record which transactions can be published in a batch for each shadow index.
+        //  The mapping is shadow index id -> ShadowIndexTxnBatch
+        Map<Long, ShadowIndexTxnBatch> shadowIndexTxnBatches = null;
         Set<Tablet> normalTablets = null;
 
         Locker locker = new Locker();
@@ -538,18 +540,22 @@ public class PublishVersionDaemon extends FrontendDaemon {
                 computeResource = txnState.getComputeResource();
                 List<MaterializedIndex> indexes = txnState.getPartitionLoadedTblIndexes(table.getId(), partition);
                 for (MaterializedIndex index : indexes) {
-                    if (!index.visibleForTransaction(txnState.getTransactionId())) {
-                        LOG.info("Ignored index {} for transaction {}", table.getIndexNameById(index.getId()),
-                                txnState.getTransactionId());
-                        continue;
-                    }
                     if (index.getState() == MaterializedIndex.IndexState.SHADOW) {
-                        if (shadowTabletsMap.containsKey(versions.get(i))) {
-                            shadowTabletsMap.get(versions.get(i)).addAll(index.getTablets());
-                        } else {
-                            Set<Tablet> tabletsNew = new HashSet<>(index.getTablets());
-                            shadowTabletsMap.put(versions.get(i), tabletsNew);
+                        // sanity check. should not happen
+                        if (!index.visibleForTransaction(txnState.getTransactionId())) {
+                            LOG.error("Shadow index is included in the transaction but not visible, " +
+                                    "partitionId: {}, partitionName: {}, txnId: {} indexId: {}, indexName: {}",
+                                    partition.getId(), partition.getName(), txnState.getTransactionId(),
+                                    index.getId(), table.getIndexNameById(index.getId()));
+                            return false;
                         }
+                        if (shadowIndexTxnBatches == null) {
+                            shadowIndexTxnBatches = new HashMap<>();
+                        }
+                        ShadowIndexTxnBatch txnBatch =
+                                shadowIndexTxnBatches.computeIfAbsent(index.getId(),
+                                        id -> new ShadowIndexTxnBatch(index.getTablets()));
+                        txnBatch.txnIds.add(txnState.getTransactionId());
                     } else {
                         normalTablets = (normalTablets == null) ? Sets.newHashSet() : normalTablets;
                         normalTablets.addAll(index.getTablets());
@@ -564,13 +570,30 @@ public class PublishVersionDaemon extends FrontendDaemon {
         long endVersion = versions.get(versions.size() - 1);
 
         try {
-            for (Map.Entry<Long, Set<Tablet>> item : shadowTabletsMap.entrySet()) {
-                int index = versions.indexOf(item.getKey());
-                List<Tablet> publishShadowTablets = new ArrayList<>(item.getValue());
-                Utils.publishLogVersionBatch(publishShadowTablets,
-                        txnInfos.subList(index, txnInfos.size()),
-                        versions.subList(index, versions.size()),
-                        computeResource);
+            if (shadowIndexTxnBatches != null) {
+                for (ShadowIndexTxnBatch txnBatch : shadowIndexTxnBatches.values()) {
+                    List<Tablet> shadowIndexTablets = txnBatch.tablets;
+                    if (shadowIndexTablets.isEmpty()) {
+                        continue;
+                    }
+                    List<TxnInfoPB> txnInfoList;
+                    List<Long> versionList;
+                    if (txnBatch.txnIds.size() == transactionStates.size()) {
+                        txnInfoList = txnInfos;
+                        versionList = versions;
+                    } else {
+                        txnInfoList = new ArrayList<>(txnBatch.txnIds.size());
+                        versionList = new ArrayList<>(txnBatch.txnIds.size());
+                        for (int i = 0; i < transactionStates.size(); i++) {
+                            TransactionState txnState = transactionStates.get(i);
+                            if (txnBatch.txnIds.contains(txnState.getTransactionId())) {
+                                txnInfoList.add(txnInfos.get(i));
+                                versionList.add(versions.get(i));
+                            }
+                        }
+                    }
+                    Utils.publishLogVersionBatch(shadowIndexTablets, txnInfoList, versionList, computeResource);
+                }
             }
             if (CollectionUtils.isNotEmpty(normalTablets)) {
                 Map<Long, Double> compactionScores = new HashMap<>();
@@ -880,6 +903,18 @@ public class PublishVersionDaemon extends FrontendDaemon {
             LOG.error("Fail to publish partition {} of txn {}: {}", partitionCommitInfo.getPhysicalPartitionId(),
                     txnId, e.getMessage());
             return false;
+        }
+    }
+
+    // Transactions that can be published in a batch for a partition of a shadow index
+    private static class ShadowIndexTxnBatch {
+        // the txn ids that include the shadow index
+        Set<Long> txnIds = new HashSet<>();
+        // the tablets in one partition of the shadow index
+        List<Tablet> tablets = new ArrayList<>();
+
+        public ShadowIndexTxnBatch(List<Tablet> tablets) {
+            this.tablets.addAll(tablets);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -543,11 +543,11 @@ public class PublishVersionDaemon extends FrontendDaemon {
                     if (index.getState() == MaterializedIndex.IndexState.SHADOW) {
                         // sanity check. should not happen
                         if (!index.visibleForTransaction(txnState.getTransactionId())) {
-                            LOG.error("Shadow index is included in the transaction but not visible, " +
-                                    "partitionId: {}, partitionName: {}, txnId: {} indexId: {}, indexName: {}",
+                            LOG.warn("Ignore shadow index included in the transaction but not visible, " +
+                                    "partitionId: {}, partitionName: {}, txnId: {}, indexId: {}, indexName: {}",
                                     partition.getId(), partition.getName(), txnState.getTransactionId(),
                                     index.getId(), table.getIndexNameById(index.getId()));
-                            return false;
+                            continue;
                         }
                         if (shadowIndexTxnBatches == null) {
                             shadowIndexTxnBatches = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -576,12 +576,9 @@ public class PublishVersionDaemon extends FrontendDaemon {
                     if (shadowIndexTablets.isEmpty()) {
                         continue;
                     }
-                    List<TxnInfoPB> txnInfoList;
-                    List<Long> versionList;
-                    if (txnBatch.txnIds.size() == transactionStates.size()) {
-                        txnInfoList = txnInfos;
-                        versionList = versions;
-                    } else {
+                    List<TxnInfoPB> txnInfoList = txnInfos;
+                    List<Long> versionList = versions;
+                    if (txnBatch.txnIds.size() != transactionStates.size()) {
                         txnInfoList = new ArrayList<>(txnBatch.txnIds.size());
                         versionList = new ArrayList<>(txnBatch.txnIds.size());
                         for (int i = 0; i < transactionStates.size(); i++) {

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -143,6 +143,7 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -553,7 +554,11 @@ public class MockedBackend {
         }
     }
 
-    private static class MockLakeService implements LakeService {
+    public static class MockLakeService implements LakeService {
+
+        private final ConcurrentLinkedQueue<PublishLogVersionBatchRequest> publishLogVersionBatchRequests =
+                new ConcurrentLinkedQueue<>();
+
         @Override
         public Future<PublishVersionResponse> publishVersion(PublishVersionRequest request) {
             return CompletableFuture.completedFuture(null);
@@ -606,7 +611,12 @@ public class MockedBackend {
 
         @Override
         public Future<PublishLogVersionResponse> publishLogVersionBatch(PublishLogVersionBatchRequest request) {
+            publishLogVersionBatchRequests.add(request);
             return CompletableFuture.completedFuture(null);
+        }
+
+        public PublishLogVersionBatchRequest pollPublishLogVersionBatchRequests() {
+            return publishLogVersionBatchRequests.poll();
         }
 
         @Override


### PR DESCRIPTION
## Why I'm doing:
In shared-data architecture, concurrent execution of a batch publish and a schema change can lead to a publish failure, with the corresponding exception being txn log not found
```
Fail to publish log version: Not found: starlet err Object s3://starrocks-qa-test-cloud-data/daily/fe_InstanceId/f9a9c798-f208-48f1-a056-4ae85a26e385/db11101/11219/13574/log/000000000005B4D4_000000000000AF28.log does not exist
```
Scenario that Triggers the Issue:
* The initial table has only a normal index, one partition (partition 0), and one tablet (Tablet 1).
* An import transaction, TXN 1, is initiated. This import involves partition 0 and only contains Tablet 1.
* A schema change is initiated to add a bloom filter. This creates a shadow index and a corresponding Tablet 2 for Tablet 1. The process then enters the WAITING_TXN state, waiting for TXN 1 to complete.
* Another import transaction, TXN 2, is initiated. This import involves partition 0 and contains both Tablet 1 and Tablet 2.
* TXN 2 commits first, creating version 1. A .log file for TXN 2 exists on both Tablet 1 and Tablet 2.
* TXN 1 commits later, creating version 2. A .log file for TXN 1 exists only on Tablet 1.
* A batch publish is performed for TXN 1 and TXN 2. However, due to a logic error in the code, a task to publish TXN 1 is also sent to Tablet 2. Because TXN 1 does not involve Tablet 2, Tablet 2 cannot find the corresponding .log file, and the publish operation fails.

<img width="1781" height="505" alt="image" src="https://github.com/user-attachments/assets/10594c17-f8c9-4422-a216-fc8e3c663574" />


## What I'm doing:

The core issue is the lack of differentiation between ​normal indexes​ and ​shadow indexes ( https://github.com/StarRocks/starrocks/blob/branch-3.5.2/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java#L532)
* When all transactions include the same partition, batch publishing can be performed for these transactions.
* While partition inclusion guarantees all transactions cover tablets of the normal index, due to the special mechanism of schema changes, ​there's no guarantee​ that all transactions include tablets of the shadow index (as illustrated above).
* When processing shadow indexes, the code selects transactions to publish from the txnInfos list using the ​same logic​ as for normal indexes. This logic assumes that if the first transaction in a batch contains shadow index tablets, ​subsequent transactions must also contain them. If a later transaction misses a tablet, its publish task fails with a "transaction log not found" error when pushed to that tablet.
<img width="1373" height="433" alt="image" src="https://github.com/user-attachments/assets/be1e8382-e8f1-4058-a13f-bd93be92a7a8" />


The solution is to ​individually check each transaction​ for the presence of a shadow index. ​It cannot be assumed​ that just because the previous committed transaction had a shadow index, ​all subsequent transactions must necessarily have one too.​​

Fixes https://github.com/StarRocks/StarRocksTest/issues/9986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
