### PR TITLE
[Enhancement] Add future timeout for MVPrepareRelatedMVs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1840,8 +1840,10 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      */
     public String getQueryRewriteStatus() {
         // since check mv valid to rewrite query is a heavy operation, we only check it when it's in the plan cache.
-        final MVPlanValidationResult result = MvRewritePreprocessor.isMVValidToRewriteQuery(ConnectContext.get(),
-                this, false, Sets.newHashSet(), true);
+        ConnectContext context = ConnectContext.get() == null ? ConnectContext.build() : ConnectContext.get();
+        final MVPlanValidationResult result = MvRewritePreprocessor.isMVValidToRewriteQuery(context,
+                this, Sets.newHashSet(), false, true,
+                context.getSessionVariable().getOptimizerExecuteTimeout());
         switch (result.getStatus()) {
             case VALID:
                 return "VALID";

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -23,6 +23,8 @@ import com.starrocks.catalog.mv.MVTimelinessListPartitionArbiter;
 import com.starrocks.catalog.mv.MVTimelinessNonPartitionArbiter;
 import com.starrocks.catalog.mv.MVTimelinessRangePartitionArbiter;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.sql.common.PCell;
 import com.starrocks.sql.common.UnsupportedException;
@@ -86,7 +88,7 @@ public class MvRefreshArbiter {
         logMVPrepare(mv, "MV refresh arbiter start to get partition names to refresh, query rewrite mode: {}",
                 mvConsistencyRewriteMode);
         MVTimelinessArbiter timelinessArbiter = buildMVTimelinessArbiter(mv, isQueryRewrite);
-        try {
+        try (Timer ignored = Tracers.watchScope("MVTimelinessUpdateInfo")) {
             return timelinessArbiter.getMVTimelinessUpdateInfo(mvConsistencyRewriteMode);
         } catch (AnalysisException e) {
             logMVPrepare(mv, "Failed to get mv timeliness info: {}", DebugUtil.getStackTrace(e));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -28,6 +28,8 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.sql.common.PCell;
 import com.starrocks.sql.common.PartitionDiff;
 import com.starrocks.sql.common.PartitionDiffResult;
@@ -262,9 +264,12 @@ public abstract class MVTimelinessArbiter {
             return MvUpdateInfo.fullRefresh(mv);
         }
 
-        PartitionDiff diff = getChangedPartitionDiff(mv, refBaseTablePartitionMap);
-        if (diff == null) {
-            return null;
+        PartitionDiff diff;
+        try (Timer ignored = Tracers.watchScope("MVTimelinessGetChangedPartitionDiff")) {
+            diff = getChangedPartitionDiff(mv, refBaseTablePartitionMap);
+            if (diff == null) {
+                return null;
+            }
         }
         Map<String, PCell> adds = diff.getAdds();
         MvUpdateInfo mvUpdateInfo = MvUpdateInfo.partialRefresh(mv, TableProperty.QueryRewriteConsistencyMode.LOOSE);
@@ -273,8 +278,12 @@ public abstract class MVTimelinessArbiter {
                     mvUpdateInfo.getMvToRefreshPartitionNames().add(mvPartitionName));
         }
         addEmptyPartitionsToRefresh(mvUpdateInfo);
-        collectBaseTableUpdatePartitionNamesInLoose(mvUpdateInfo);
-        collectMVToBaseTablePartitionNames(refBaseTablePartitionMap, diff, mvUpdateInfo);
+        try (Timer ignored = Tracers.watchScope("MVTimelinessCollectBaseTableUpdatePartitionNames")) {
+            collectBaseTableUpdatePartitionNamesInLoose(mvUpdateInfo);
+        }
+        try (Timer ignored = Tracers.watchScope("MVTimelinessCollectMVToBaseTablePartitionNames")) {
+            collectMVToBaseTablePartitionNames(refBaseTablePartitionMap, diff, mvUpdateInfo);
+        }
         return mvUpdateInfo;
     }
 
@@ -320,10 +329,13 @@ public abstract class MVTimelinessArbiter {
             return MvUpdateInfo.fullRefresh(mv);
         }
 
-        PartitionDiff diff = getChangedPartitionDiff(mv, refBaseTablePartitionMap);
-        if (diff == null) {
-            logMVPrepare(mv, "Materialized view compute partition difference with base table failed");
-            return null;
+        PartitionDiff diff;
+        try (Timer ignored = Tracers.watchScope("MVTimelinessGetChangedPartitionDiff")) {
+            diff = getChangedPartitionDiff(mv, refBaseTablePartitionMap);
+            if (diff == null) {
+                logMVPrepare(mv, "Materialized view compute partition difference with base table failed");
+                return null;
+            }
         }
         Map<String, PCell> adds = diff.getAdds();
         MvUpdateInfo mvUpdateInfo = MvUpdateInfo.partialRefresh(mv, TableProperty.QueryRewriteConsistencyMode.FORCE_MV);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -265,7 +265,7 @@ public abstract class MVTimelinessArbiter {
         }
 
         PartitionDiff diff;
-        try (Timer ignored = Tracers.watchScope("MVTimelinessGetChangedPartitionDiff")) {
+        try (Timer ignored = Tracers.watchScope("GetChangedPartitionDiff")) {
             diff = getChangedPartitionDiff(mv, refBaseTablePartitionMap);
             if (diff == null) {
                 return null;
@@ -278,10 +278,10 @@ public abstract class MVTimelinessArbiter {
                     mvUpdateInfo.getMvToRefreshPartitionNames().add(mvPartitionName));
         }
         addEmptyPartitionsToRefresh(mvUpdateInfo);
-        try (Timer ignored = Tracers.watchScope("MVTimelinessCollectBaseTableUpdatePartitionNames")) {
+        try (Timer ignored = Tracers.watchScope("CollectBaseTableUpdatePartitionNames")) {
             collectBaseTableUpdatePartitionNamesInLoose(mvUpdateInfo);
         }
-        try (Timer ignored = Tracers.watchScope("MVTimelinessCollectMVToBaseTablePartitionNames")) {
+        try (Timer ignored = Tracers.watchScope("CollectMVToBaseTablePartitionNames")) {
             collectMVToBaseTablePartitionNames(refBaseTablePartitionMap, diff, mvUpdateInfo);
         }
         return mvUpdateInfo;
@@ -330,7 +330,7 @@ public abstract class MVTimelinessArbiter {
         }
 
         PartitionDiff diff;
-        try (Timer ignored = Tracers.watchScope("MVTimelinessGetChangedPartitionDiff")) {
+        try (Timer ignored = Tracers.watchScope("GetChangedPartitionDiff")) {
             diff = getChangedPartitionDiff(mv, refBaseTablePartitionMap);
             if (diff == null) {
                 logMVPrepare(mv, "Materialized view compute partition difference with base table failed");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
@@ -23,6 +23,8 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.sql.common.ListPartitionDiffer;
 import com.starrocks.sql.common.PCell;
 import com.starrocks.sql.common.PartitionDiff;
@@ -65,23 +67,34 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
 
         // update mv's to refresh partitions based on base table's partition changes
         MvUpdateInfo mvTimelinessInfo = MvUpdateInfo.partialRefresh(mv, TableProperty.QueryRewriteConsistencyMode.CHECKED);
-        Map<Table, Set<String>> baseChangedPartitionNames = collectBaseTableUpdatePartitionNames(refBaseTablePartitionColumns,
-                mvTimelinessInfo);
+        Map<Table, Set<String>> baseChangedPartitionNames;
+        try (Timer ignored = Tracers.watchScope("MVTimelinessCollectBaseTableUpdatePartitionNames")) {
+            baseChangedPartitionNames = collectBaseTableUpdatePartitionNames(refBaseTablePartitionColumns,
+                    mvTimelinessInfo);
+        }
 
         // collect base table's partition infos
-        Map<Table, Map<String, PCell>> refBaseTablePartitionMap = syncBaseTablePartitions(mv);
-        if (refBaseTablePartitionMap == null) {
-            logMVPrepare(mv, "Sync base table partition infos failed");
-            return MvUpdateInfo.fullRefresh(mv);
+        Map<Table, Map<String, PCell>> refBaseTablePartitionMap;
+        try (Timer ignored = Tracers.watchScope("MVTimelinessSyncBaseTablePartitions")) {
+            refBaseTablePartitionMap = syncBaseTablePartitions(mv);
+            if (refBaseTablePartitionMap == null) {
+                logMVPrepare(mv, "Sync base table partition infos failed");
+                return MvUpdateInfo.fullRefresh(mv);
+            }
         }
         // If base table is materialized view, add partition name to cell mapping into base table partition mapping,
         // otherwise base table(mv) may lose partition names of the real base table changed partitions.
-        collectExtraBaseTableChangedPartitions(mvTimelinessInfo.getBaseTableUpdateInfos(), refBaseTablePartitionMap);
+        try (Timer ignored = Tracers.watchScope("MVTimelinessCollectExtraBaseTableChangedPartitions")) {
+            collectExtraBaseTableChangedPartitions(mvTimelinessInfo.getBaseTableUpdateInfos(), refBaseTablePartitionMap);
+        }
 
-        PartitionDiff diff = getChangedPartitionDiff(mv, refBaseTablePartitionMap);
-        if (diff == null) {
-            logMVPrepare(mv, "Partitioned mv compute list diff failed");
-            return MvUpdateInfo.fullRefresh(mv);
+        PartitionDiff diff;
+        try (Timer ignored = Tracers.watchScope("MVTimelinessGetChangedPartitionDiff")) {
+            diff = getChangedPartitionDiff(mv, refBaseTablePartitionMap);
+            if (diff == null) {
+                logMVPrepare(mv, "Partitioned mv compute list diff failed");
+                return MvUpdateInfo.fullRefresh(mv);
+            }
         }
 
         // update into mv's to refresh partitions
@@ -99,10 +112,14 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
                 .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
         mvTimelinessInfo.addMVPartitionNameToCellMap(mvPartitionNameToCell);
 
-        Map<Table, Map<String, Set<String>>> baseToMvNameRef =
-                differ.generateBaseRefMap(refBaseTablePartitionMap, mvPartitionNameToListMap);
-        Map<String, Map<Table, Set<String>>> mvToBaseNameRef =
-                differ.generateMvRefMap(mvPartitionNameToListMap, refBaseTablePartitionMap);
+        Map<Table, Map<String, Set<String>>> baseToMvNameRef;
+        try (Timer ignored = Tracers.watchScope("MVTimelinessGenerateBaseRefMap")) {
+            baseToMvNameRef = differ.generateBaseRefMap(refBaseTablePartitionMap, mvPartitionNameToListMap);
+        }
+        Map<String, Map<Table, Set<String>>> mvToBaseNameRef;
+        try (Timer ignored = Tracers.watchScope("MVTimelinessGenerateMvRefMap")) {
+            mvToBaseNameRef = differ.generateMvRefMap(mvPartitionNameToListMap, refBaseTablePartitionMap);
+        }
         mvTimelinessInfo.getBasePartToMvPartNames().putAll(baseToMvNameRef);
         mvTimelinessInfo.getMvPartToBasePartNames().putAll(mvToBaseNameRef);
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
@@ -68,14 +68,14 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
         // update mv's to refresh partitions based on base table's partition changes
         MvUpdateInfo mvTimelinessInfo = MvUpdateInfo.partialRefresh(mv, TableProperty.QueryRewriteConsistencyMode.CHECKED);
         Map<Table, Set<String>> baseChangedPartitionNames;
-        try (Timer ignored = Tracers.watchScope("MVTimelinessCollectBaseTableUpdatePartitionNames")) {
+        try (Timer ignored = Tracers.watchScope("CollectBaseTableUpdatePartitionNames")) {
             baseChangedPartitionNames = collectBaseTableUpdatePartitionNames(refBaseTablePartitionColumns,
                     mvTimelinessInfo);
         }
 
         // collect base table's partition infos
         Map<Table, Map<String, PCell>> refBaseTablePartitionMap;
-        try (Timer ignored = Tracers.watchScope("MVTimelinessSyncBaseTablePartitions")) {
+        try (Timer ignored = Tracers.watchScope("SyncBaseTablePartitions")) {
             refBaseTablePartitionMap = syncBaseTablePartitions(mv);
             if (refBaseTablePartitionMap == null) {
                 logMVPrepare(mv, "Sync base table partition infos failed");
@@ -84,12 +84,12 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
         }
         // If base table is materialized view, add partition name to cell mapping into base table partition mapping,
         // otherwise base table(mv) may lose partition names of the real base table changed partitions.
-        try (Timer ignored = Tracers.watchScope("MVTimelinessCollectExtraBaseTableChangedPartitions")) {
+        try (Timer ignored = Tracers.watchScope("CollectExtraBaseTableChangedPartitions")) {
             collectExtraBaseTableChangedPartitions(mvTimelinessInfo.getBaseTableUpdateInfos(), refBaseTablePartitionMap);
         }
 
         PartitionDiff diff;
-        try (Timer ignored = Tracers.watchScope("MVTimelinessGetChangedPartitionDiff")) {
+        try (Timer ignored = Tracers.watchScope("GetChangedPartitionDiff")) {
             diff = getChangedPartitionDiff(mv, refBaseTablePartitionMap);
             if (diff == null) {
                 logMVPrepare(mv, "Partitioned mv compute list diff failed");
@@ -113,11 +113,11 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
         mvTimelinessInfo.addMVPartitionNameToCellMap(mvPartitionNameToCell);
 
         Map<Table, Map<String, Set<String>>> baseToMvNameRef;
-        try (Timer ignored = Tracers.watchScope("MVTimelinessGenerateBaseRefMap")) {
+        try (Timer ignored = Tracers.watchScope("GenerateBaseRefMap")) {
             baseToMvNameRef = differ.generateBaseRefMap(refBaseTablePartitionMap, mvPartitionNameToListMap);
         }
         Map<String, Map<Table, Set<String>>> mvToBaseNameRef;
-        try (Timer ignored = Tracers.watchScope("MVTimelinessGenerateMvRefMap")) {
+        try (Timer ignored = Tracers.watchScope("GenerateMvRefMap")) {
             mvToBaseNameRef = differ.generateMvRefMap(mvPartitionNameToListMap, refBaseTablePartitionMap);
         }
         mvTimelinessInfo.getBasePartToMvPartNames().putAll(baseToMvNameRef);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
@@ -25,6 +25,8 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.scheduler.TableWithPartitions;
 import com.starrocks.sql.common.PCell;
 import com.starrocks.sql.common.PartitionDiff;
@@ -76,29 +78,41 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
         MvUpdateInfo mvTimelinessInfo = MvUpdateInfo.partialRefresh(mv,
                 TableProperty.QueryRewriteConsistencyMode.CHECKED);
         // collect & update mv's to refresh partitions based on base table's partition changes
-        Map<Table, Set<String>> baseChangedPartitionNames = collectBaseTableUpdatePartitionNames(refBaseTablePartitionColumns,
-                mvTimelinessInfo);
+        Map<Table, Set<String>> baseChangedPartitionNames;
+        try (Timer ignored = Tracers.watchScope("MVTimelinessCollectBaseTableUpdatePartitionNames")) {
+            baseChangedPartitionNames = collectBaseTableUpdatePartitionNames(refBaseTablePartitionColumns,
+                    mvTimelinessInfo);
+        }
 
         // collect all ref base table's partition range map
         Optional<Expr> partitionExprOpt = mv.getRangePartitionFirstExpr();
         Preconditions.checkArgument(partitionExprOpt.isPresent(),
                 "Materialized view %s has no partition expr.", mv.getName());
         Expr partitionExpr = partitionExprOpt.get();
-        Map<Table, Map<String, PCell>> basePartitionNameToRangeMap = syncBaseTablePartitions(mv);
-        if (basePartitionNameToRangeMap == null) {
-            logMVPrepare(mv, "Sync base table partition infos failed");
-            return MvUpdateInfo.fullRefresh(mv);
+        Map<Table, Map<String, PCell>> basePartitionNameToRangeMap;
+
+        try (Timer ignored = Tracers.watchScope("MVTimelinessSyncBaseTablePartitions")) {
+            basePartitionNameToRangeMap = syncBaseTablePartitions(mv);
+            if (basePartitionNameToRangeMap == null) {
+                logMVPrepare(mv, "Sync base table partition infos failed");
+                return MvUpdateInfo.fullRefresh(mv);
+            }
         }
 
         // If base table is materialized view, add partition name to cell mapping into base table partition mapping,
         // otherwise base table(mv) may lose partition names of the real base table changed partitions.
-        collectExtraBaseTableChangedPartitions(mvTimelinessInfo.getBaseTableUpdateInfos(), basePartitionNameToRangeMap);
+        try (Timer ignored = Tracers.watchScope("MVTimelinessCollectExtraBaseTableChangedPartitions")) {
+            collectExtraBaseTableChangedPartitions(mvTimelinessInfo.getBaseTableUpdateInfos(), basePartitionNameToRangeMap);
+        }
 
         // There may be a performance issue here, because it will fetch all partitions of base tables and mv partitions.
-        PartitionDiff diff = getChangedPartitionDiff(mv, basePartitionNameToRangeMap);
-        if (diff == null) {
-            throw new AnalysisException(String.format("Compute partition difference of mv %s with base table failed.",
-                    mv.getName()));
+        PartitionDiff diff;
+        try (Timer ignored = Tracers.watchScope("MVTimelinessGetChangedPartitionDiff")) {
+            diff = getChangedPartitionDiff(mv, basePartitionNameToRangeMap);
+            if (diff == null) {
+                throw new AnalysisException(String.format("Compute partition difference of mv %s with base table failed.",
+                        mv.getName()));
+            }
         }
 
         // no needs to refresh the deleted partitions, because the deleted partitions are not in the mv's partition map.
@@ -116,10 +130,14 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
         // add mv partition name to range map into timeline info to be used if it's a sub mv of nested mv
         mvTimelinessInfo.addMVPartitionNameToCellMap(mvPartitionToCells);
 
-        Map<Table, Map<String, Set<String>>> baseToMvNameRef =
-                differ.generateBaseRefMap(basePartitionNameToRangeMap, mvPartitionToCells);
-        Map<String, Map<Table, Set<String>>> mvToBaseNameRef =
-                differ.generateMvRefMap(mvPartitionToCells, basePartitionNameToRangeMap);
+        Map<Table, Map<String, Set<String>>> baseToMvNameRef;
+        try (Timer ignored = Tracers.watchScope("MVTimelinessGenerateBaseRefMap")) {
+            baseToMvNameRef = differ.generateBaseRefMap(basePartitionNameToRangeMap, mvPartitionToCells);
+        }
+        Map<String, Map<Table, Set<String>>> mvToBaseNameRef;
+        try (Timer ignored = Tracers.watchScope("MVTimelinessGenerateMvRefMap")) {
+            mvToBaseNameRef = differ.generateMvRefMap(mvPartitionToCells, basePartitionNameToRangeMap);
+        }
         mvTimelinessInfo.getBasePartToMvPartNames().putAll(baseToMvNameRef);
         mvTimelinessInfo.getMvPartToBasePartNames().putAll(mvToBaseNameRef);
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
@@ -79,7 +79,7 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
                 TableProperty.QueryRewriteConsistencyMode.CHECKED);
         // collect & update mv's to refresh partitions based on base table's partition changes
         Map<Table, Set<String>> baseChangedPartitionNames;
-        try (Timer ignored = Tracers.watchScope("MVTimelinessCollectBaseTableUpdatePartitionNames")) {
+        try (Timer ignored = Tracers.watchScope("CollectBaseTableUpdatePartitionNames")) {
             baseChangedPartitionNames = collectBaseTableUpdatePartitionNames(refBaseTablePartitionColumns,
                     mvTimelinessInfo);
         }
@@ -91,7 +91,7 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
         Expr partitionExpr = partitionExprOpt.get();
         Map<Table, Map<String, PCell>> basePartitionNameToRangeMap;
 
-        try (Timer ignored = Tracers.watchScope("MVTimelinessSyncBaseTablePartitions")) {
+        try (Timer ignored = Tracers.watchScope("SyncBaseTablePartitions")) {
             basePartitionNameToRangeMap = syncBaseTablePartitions(mv);
             if (basePartitionNameToRangeMap == null) {
                 logMVPrepare(mv, "Sync base table partition infos failed");
@@ -101,13 +101,13 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
 
         // If base table is materialized view, add partition name to cell mapping into base table partition mapping,
         // otherwise base table(mv) may lose partition names of the real base table changed partitions.
-        try (Timer ignored = Tracers.watchScope("MVTimelinessCollectExtraBaseTableChangedPartitions")) {
+        try (Timer ignored = Tracers.watchScope("CollectExtraBaseTableChangedPartitions")) {
             collectExtraBaseTableChangedPartitions(mvTimelinessInfo.getBaseTableUpdateInfos(), basePartitionNameToRangeMap);
         }
 
         // There may be a performance issue here, because it will fetch all partitions of base tables and mv partitions.
         PartitionDiff diff;
-        try (Timer ignored = Tracers.watchScope("MVTimelinessGetChangedPartitionDiff")) {
+        try (Timer ignored = Tracers.watchScope("GetChangedPartitionDiff")) {
             diff = getChangedPartitionDiff(mv, basePartitionNameToRangeMap);
             if (diff == null) {
                 throw new AnalysisException(String.format("Compute partition difference of mv %s with base table failed.",
@@ -131,11 +131,11 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
         mvTimelinessInfo.addMVPartitionNameToCellMap(mvPartitionToCells);
 
         Map<Table, Map<String, Set<String>>> baseToMvNameRef;
-        try (Timer ignored = Tracers.watchScope("MVTimelinessGenerateBaseRefMap")) {
+        try (Timer ignored = Tracers.watchScope("GenerateBaseRefMap")) {
             baseToMvNameRef = differ.generateBaseRefMap(basePartitionNameToRangeMap, mvPartitionToCells);
         }
         Map<String, Map<Table, Set<String>>> mvToBaseNameRef;
-        try (Timer ignored = Tracers.watchScope("MVTimelinessGenerateMvRefMap")) {
+        try (Timer ignored = Tracers.watchScope("GenerateMvRefMap")) {
             mvToBaseNameRef = differ.generateMvRefMap(mvPartitionToCells, basePartitionNameToRangeMap);
         }
         mvTimelinessInfo.getBasePartToMvPartNames().putAll(baseToMvNameRef);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -27,6 +27,8 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.LogUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.UUIDUtil;
@@ -314,8 +316,12 @@ public class TaskRun implements Comparable<TaskRun> {
 
         // prepare to execute task run, move it here so that we can catch the exception and set the status
         processor.prepare(taskRunContext);
+
         // process task run
-        Constants.TaskRunState taskRunState = processor.processTaskRun(taskRunContext);
+        Constants.TaskRunState taskRunState;
+        try (Timer ignored = Tracers.watchScope("TaskRunProcess")) {
+            taskRunState = processor.processTaskRun(taskRunContext);
+        }
 
         QueryState queryState = runCtx.getState();
         LOG.info("[QueryId:{}] finished to execute task run, task_id:{}, query_state:{}",
@@ -331,7 +337,7 @@ public class TaskRun implements Comparable<TaskRun> {
         }
 
         // post prosess task run
-        try {
+        try (Timer ignored = Tracers.watchScope("TaskRunPostProcess")) {
             processor.postTaskRun(taskRunContext);
         } catch (Exception e) {
             LOG.warn("Failed to post task run, task_id: {}, task_run_id: {}, error: {}",

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -329,6 +329,14 @@ public class TaskRun implements Comparable<TaskRun> {
             status.setErrorCode(errorCode);
             return Constants.TaskRunState.FAILED;
         }
+
+        // post prosess task run
+        try {
+            processor.postTaskRun(taskRunContext);
+        } catch (Exception e) {
+            LOG.warn("Failed to post task run, task_id: {}, task_run_id: {}, error: {}",
+                    taskId, taskRunId, e.getMessage());
+        }
         return taskRunState;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -189,12 +189,13 @@ public class CachingMvPlanContextBuilder {
     private List<MvPlanContext> getMvPlanCacheFromFuture(SessionVariable sessionVariable,
                                                          MaterializedView mv,
                                                          CompletableFuture<List<MvPlanContext>> future) {
-        long optimizeTimeout = sessionVariable == null ? SessionVariable.DEFAULT_SESSION_VARIABLE.getOptimizerExecuteTimeout() :
-                sessionVariable.getOptimizerExecuteTimeout();
+        long optimizeTimeout = sessionVariable == null ?
+                SessionVariable.DEFAULT_SESSION_VARIABLE.getOptimizerExecuteTimeout()
+                : sessionVariable.getOptimizerExecuteTimeout() / 2;
         List<MvPlanContext> result;
         long startTime = System.currentTimeMillis();
         try {
-            result = future.get(optimizeTimeout, TimeUnit.SECONDS);
+            result = future.get(optimizeTimeout, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
             LOG.warn("get mv plan cache timeout: {}", mv.getName());
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -385,9 +385,10 @@ public class MvRewritePreprocessor {
             OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), "inactive");
             return null;
         }
-
+        // NOTE: To avoid building plan for every mv cost too much time, we should only get plan
+        // when the mv is in the plan cache.
         List<MvPlanContext> mvPlanContexts = CachingMvPlanContextBuilder.getInstance()
-                .getPlanContext(connectContext.getSessionVariable(), mv);
+                .getPlanContextIfPresent(connectContext.getSessionVariable(), mv);
         if (CollectionUtils.isEmpty(mvPlanContexts)) {
             OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), "invalid query plan");
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -719,8 +719,12 @@ public class MvRewritePreprocessor {
         if (!checkMvPartitionNamesToRefresh(connectContext, mv, partitionNamesToRefresh, mvPlanContext)) {
             return null;
         }
-        logMVPrepare(tracers, mv, "MV' partitions to refresh: {}/{}", partitionNamesToRefresh.size(),
-                MvUtils.shrinkToSize(partitionNamesToRefresh, Config.max_mv_task_run_meta_message_values_length));
+        if (partitionNamesToRefresh.isEmpty()) {
+            logMVPrepare(tracers, connectContext, mv, "MV {} has no partitions to refresh", mv.getName());
+        } else {
+            logMVPrepare(tracers, mv, "MV' partitions to refresh: {}/{}", partitionNamesToRefresh.size(),
+                    MvUtils.shrinkToSize(partitionNamesToRefresh, Config.max_mv_task_run_meta_message_values_length));
+        }
 
         MaterializationContext materializationContext = buildMaterializationContext(context, mv, mvPlanContext,
                 mvUpdateInfo, queryTables, mvWithPlanContext.getLevel());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -201,59 +201,57 @@ public class MvRewritePreprocessor {
         SessionVariable sessionVariable = connectContext.getSessionVariable();
         logMVPrepare(connectContext, "Query input tables: {}", queryTables);
 
-        // enable or not
-        logMVPrepare(connectContext, "---------------------------------");
-        logMVPrepare(connectContext, "Materialized View Enable/Disable Params: ");
-        logMVPrepare(connectContext, "  enable_experimental_mv: {}", Config.enable_experimental_mv);
-        logMVPrepare(connectContext, "  enable_materialized_view_rewrite: {}",
-                sessionVariable.isEnableMaterializedViewRewrite());
-        logMVPrepare(connectContext, "  enable_view_based_mv_rewrite: {}",
-                sessionVariable.isEnableViewBasedMvRewrite());
-        logMVPrepare(connectContext, "  enable_materialized_view_union_rewrite: {}",
-                sessionVariable.isEnableMaterializedViewUnionRewrite());
-        logMVPrepare(connectContext, "  enable_materialized_view_view_delta_rewrite: {}",
-                sessionVariable.isEnableMaterializedViewViewDeltaRewrite());
-        logMVPrepare(connectContext, "  enable_materialized_view_single_table_view_delta_rewrite: {}",
-                sessionVariable.isEnableMaterializedViewSingleTableViewDeltaRewrite());
-        logMVPrepare(connectContext, "  enable_materialized_view_plan_cache: {}",
-                sessionVariable.isEnableMaterializedViewPlanCache());
-        logMVPrepare(connectContext, "  mv_auto_analyze_async: {}",
-                Config.mv_auto_analyze_async);
-        logMVPrepare(connectContext, "  enable_mv_automatic_active_check: {}",
-                Config.enable_mv_automatic_active_check);
-        logMVPrepare(connectContext, "  enable_sync_materialized_view_rewrite: {}",
-                sessionVariable.isEnableSyncMaterializedViewRewrite());
-        logMVPrepare(connectContext, "  enable_view_based_mv_rewrite: {}",
-                sessionVariable.isEnableViewBasedMvRewrite());
-        logMVPrepare(connectContext, "  enable_materialized_view_text_match_rewrite: {}",
-                sessionVariable.isEnableMaterializedViewTextMatchRewrite());
-        logMVPrepare(connectContext, "  enable_materialized_view_multi_stages_rewrite: {}",
-                sessionVariable.isEnableMaterializedViewMultiStagesRewrite());
+        // Get all MV related session variables
+        List<Pair<String, Object>> mvSessionVariables = Lists.newArrayList(
+                Pair.create("enable_materialized_view_rewrite", sessionVariable.isEnableMaterializedViewRewrite()),
+                Pair.create("enable_view_based_mv_rewrite", sessionVariable.isEnableViewBasedMvRewrite()),
+                Pair.create("enable_materialized_view_union_rewrite", sessionVariable.isEnableMaterializedViewUnionRewrite()),
+                Pair.create("enable_materialized_view_view_delta_rewrite",
+                        sessionVariable.isEnableMaterializedViewViewDeltaRewrite()),
+                Pair.create("enable_materialized_view_plan_cache", sessionVariable.isEnableMaterializedViewPlanCache()),
+                Pair.create("enable_sync_materialized_view_rewrite", sessionVariable.isEnableSyncMaterializedViewRewrite()),
+                Pair.create("enable_materialized_view_text_match_rewrite",
+                        sessionVariable.isEnableMaterializedViewTextMatchRewrite()),
+                Pair.create("enable_materialized_view_multi_stages_rewrite",
+                        sessionVariable.isEnableMaterializedViewMultiStagesRewrite()),
+                Pair.create("optimizer_materialized_view_timelimit",
+                        sessionVariable.getOptimizerMaterializedViewTimeLimitMillis()),
+                Pair.create("materialized_view_join_same_table_permutation_limit",
+                        sessionVariable.getMaterializedViewJoinSameTablePermutationLimit()),
+                Pair.create("analyze_mv", sessionVariable.getAnalyzeForMV()),
+                Pair.create("query_excluding_mv_names", sessionVariable.getQueryExcludingMVNames()),
+                Pair.create("query_including_mv_names", sessionVariable.getQueryIncludingMVNames()),
+                Pair.create("cbo_materialized_view_rewrite_rule_output_limit",
+                        sessionVariable.getCboMaterializedViewRewriteRuleOutputLimit()),
+                Pair.create("cbo_materialized_view_rewrite_candidate_limit",
+                        sessionVariable.getCboMaterializedViewRewriteCandidateLimit()),
+                Pair.create("cbo_materialized_view_rewrite_related_mvs_limit",
+                        sessionVariable.getCboMaterializedViewRewriteRelatedMVsLimit()),
+                Pair.create("materialized_view_rewrite_mode", sessionVariable.getMaterializedViewRewriteMode())
+        );
 
-        // limit
-        logMVPrepare(connectContext, "---------------------------------");
-        logMVPrepare(connectContext, "Materialized View Limit Params: ");
-        logMVPrepare(connectContext, "  optimizer_materialized_view_timelimit: {}",
-                sessionVariable.getOptimizerMaterializedViewTimeLimitMillis());
-        logMVPrepare(connectContext, "  materialized_view_join_same_table_permutation_limit: {}",
-                sessionVariable.getMaterializedViewJoinSameTablePermutationLimit());
-        logMVPrepare(connectContext, "  skip_whole_phase_lock_mv_limit: {}",
-                Config.skip_whole_phase_lock_mv_limit);
+        // Get all MV related config variables
+        List<Pair<String, Object>> mvConfigVariables = Lists.newArrayList(
+                Pair.create("enable_experimental_mv", Config.enable_experimental_mv),
+                Pair.create("mv_auto_analyze_async", Config.mv_auto_analyze_async),
+                Pair.create("enable_mv_automatic_active_check", Config.enable_mv_automatic_active_check),
+                Pair.create("skip_whole_phase_lock_mv_limit", Config.skip_whole_phase_lock_mv_limit),
+                Pair.create("enable_materialized_view_concurrent_prepare", Config.enable_materialized_view_concurrent_prepare)
+        );
 
-        // config
+        // Log session variables
         logMVPrepare(connectContext, "---------------------------------");
-        logMVPrepare(connectContext, "Materialized View Config Params: ");
-        logMVPrepare(connectContext, "  analyze_mv: {}", sessionVariable.getAnalyzeForMV());
-        logMVPrepare(connectContext, "  query_excluding_mv_names: {}", sessionVariable.getQueryExcludingMVNames());
-        logMVPrepare(connectContext, "  query_including_mv_names: {}", sessionVariable.getQueryIncludingMVNames());
-        logMVPrepare(connectContext, "  cbo_materialized_view_rewrite_rule_output_limit: {}",
-                sessionVariable.getCboMaterializedViewRewriteRuleOutputLimit());
-        logMVPrepare(connectContext, "  cbo_materialized_view_rewrite_candidate_limit: {}",
-                sessionVariable.getCboMaterializedViewRewriteCandidateLimit());
-        logMVPrepare(connectContext, "  cbo_materialized_view_rewrite_related_mvs_limit: {}",
-                sessionVariable.getCboMaterializedViewRewriteRelatedMVsLimit());
-        logMVPrepare(connectContext, "  materialized_view_rewrite_mode: {}",
-                sessionVariable.getMaterializedViewRewriteMode());
+        logMVPrepare(connectContext, "Materialized View Session Variables:");
+        for (Pair<String, Object> variable : mvSessionVariables) {
+            logMVPrepare(connectContext, "  {}: {}", variable.first, variable.second);
+        }
+
+        // Log config variables
+        logMVPrepare(connectContext, "---------------------------------");
+        logMVPrepare(connectContext, "Materialized View Config Variables:");
+        for (Pair<String, Object> variable : mvConfigVariables) {
+            logMVPrepare(connectContext, "  {}: {}", variable.first, variable.second);
+        }
         logMVPrepare(connectContext, "---------------------------------");
     }
 
@@ -736,6 +734,15 @@ public class MvRewritePreprocessor {
         return null;
     }
 
+    private long getMvPrepareTimeoutMs(int mvCount) {
+        long defaultTimeout = connectContext.getSessionVariable().getOptimizerExecuteTimeout() / 2;
+        if (mvCount == 0) {
+            return defaultTimeout;
+        }
+        // Ensure at least 1 second per MV, but not more than the total timeout
+        return Math.max(1000, defaultTimeout / mvCount);
+    }
+
     /**
      * Process MVs with individual timeouts to allow continuation even if some timeout.
      * Each MV gets a timeout of total_timeout / number_of_mvs to ensure fair distribution.
@@ -751,12 +758,9 @@ public class MvRewritePreprocessor {
         if (mvInfos.isEmpty()) {
             return;
         }
-
-        // Calculate individual timeout for each MV
-        long totalTimeoutMs = Config.mv_refresh_default_planner_optimize_timeout;
-        long individualTimeoutMs = Math.max(1000, totalTimeoutMs / mvInfos.size()); // Minimum 1 second per MV
-        
-        LOG.info("Processing {} MVs with individual timeout of {} ms each", mvInfos.size(), individualTimeoutMs);
+        long individualTimeoutMs = getMvPrepareTimeoutMs(mvInfos.size());
+        logMVPrepare(connectContext, "Processing {} MVs with individual timeout of {} ms each", mvInfos.size(),
+                individualTimeoutMs);
         
         List<CompletableFuture<Void>> futures = Lists.newArrayListWithExpectedSize(mvInfos.size());
         List<String> timeoutMvNames = Lists.newArrayList();
@@ -803,15 +807,8 @@ public class MvRewritePreprocessor {
         
         // Log summary
         int successCount = mvInfos.size() - timeoutMvNames.size() - failedMvNames.size();
-        LOG.info("MV preparation summary: {} successful, {} timeout, {} failed out of {} total",
+        logMVPrepare(connectContext, "MV preparation summary: {} successful, {} timeout, {} failed out of {} total",
                 successCount, timeoutMvNames.size(), failedMvNames.size(), mvInfos.size());
-        
-        if (!timeoutMvNames.isEmpty()) {
-            LOG.warn("MVs that timed out: {}", timeoutMvNames);
-        }
-        if (!failedMvNames.isEmpty()) {
-            LOG.warn("MVs that failed: {}", failedMvNames);
-        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -4545,7 +4545,8 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 starRocksAssert.showCreateTable("show create table mv_enable"));
         starRocksAssert.refreshMV("refresh materialized view mv_enable with sync mode");
         MaterializedView mv = starRocksAssert.getMv("test", "mv_enable");
-        MVPlanValidationResult valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, true, null, false);
+        MVPlanValidationResult valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv,
+                null, true, false, connectContext.getSessionVariable().getOptimizerExecuteTimeout());
         Assertions.assertTrue(valid.getStatus().isValid());
 
         starRocksAssert.ddl("alter materialized view mv_enable set('enable_query_rewrite'='false') ");
@@ -4564,7 +4565,8 @@ public class CreateMaterializedViewTest extends MVTestBase {
                         "`t1`.`c_1_12`\n" +
                         "FROM `test`.`t1`;",
                 starRocksAssert.showCreateTable("show create table mv_enable"));
-        valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, true, null, false);
+        valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, null,
+                true, false, connectContext.getSessionVariable().getOptimizerExecuteTimeout());
         Assertions.assertFalse(valid.getStatus().isValid());
         Assertions.assertEquals("enable_query_rewrite=FALSE", valid.getReason());
         starRocksAssert.dropMaterializedView("mv_enable");

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManyJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManyJoinTest.java
@@ -95,6 +95,7 @@ public class MaterializedViewManyJoinTest extends MaterializedViewTestBase {
         connectContext.getSessionVariable().setEnableMaterializedViewTextMatchRewrite(false);
         connectContext.getSessionVariable().setCboMaterializedViewRewriteCandidateLimit(3);
         connectContext.getSessionVariable().setCboMaterializedViewRewriteRuleOutputLimit(3);
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
         List<Arguments> arguments = generateManyJoinArguments();
         for (Arguments argument : arguments) {
             String name = (String) argument.get()[0];
@@ -138,7 +139,7 @@ public class MaterializedViewManyJoinTest extends MaterializedViewTestBase {
     public void testManyJoins(String name, String query, boolean expectHitMv) throws Exception {
         Stopwatch watch = Stopwatch.createStarted();
         // Make sure it's not empty
-        String plan = getFragmentPlan(query);
+        String plan = getFragmentPlan(query, "MV");
         PlanTestBase.assertContains(plan, "OlapScanNode");
         if (expectHitMv) {
             PlanTestBase.assertContains(plan, "MaterializedView: true");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -707,7 +707,7 @@ public class MvRewritePreprocessorTest extends MVTestBase {
         starRocksAssert.withMaterializedView(sql, (obj) -> {
             String mvName = (String) obj;
             MaterializedView mv = getMv(DB_NAME, mvName);
-            CachingMvPlanContextBuilder.getInstance().invalidateAstFromCache(mv);
+            CachingMvPlanContextBuilder.getInstance().evictMaterializedViewCache(mv);
             String status = mv.getQueryRewriteStatus();
             Assertions.assertTrue(status.equalsIgnoreCase("UNKNOWN: MV plan is not in cache, valid check is unknown"));
         });


### PR DESCRIPTION
## Why I'm doing:
`MVPrepareRelatedMVs[1] 1m25s` costs too much time and needs a limit for this stage.
```
  Planner:
     - -- Parser[1] 0
     - -- Total[1] 1m25s
     -     -- Analyzer[1] 0
     -         -- Lock[1] 0
     -         -- AnalyzeDatabase[1] 0
     -         -- AnalyzeTemporaryTable[1] 0
     -         -- AnalyzeTable[1] 0
     -     -- Transformer[1] 0
     -     -- Optimizer[1] 1m25s
     -         -- MVPreprocess[1] 1m25s
     -             -- MVChooseCandidates[1] 0
     -             -- MVGenerateMvPlan[1] 0
     -             -- MVPrepareRelatedMVs[1] 1m25s
     -             -- MVProcessWithView[1] 0
     -         -- MVTextRewrite[1] 0
     -         -- RuleBaseOptimize[1] 245ms
     -         -- CostBaseOptimize[1] 23ms
     -         -- PhysicalRewrite[1] 1ms
     -         -- DynamicRewrite[1] 0
     -         -- PlanValidate[1] 0
     -             -- InputDependenciesChecker[1] 0
     -             -- TypeChecker[1] 0
     -             -- CTEUniqueChecker[1] 0
     -             -- ColumnReuseChecker[1] 0
     -     -- ExecPlanBuild[1] 17ms
     - -- Pending[1] 0
     - -- Prepare[1] 0
     - -- Deploy[1] 4ms
     -     -- DeployLockInternalTime[1] 4ms
     -         -- DeploySerializeConcurrencyTime[2] 0
     -         -- DeployStageByStageTime[6] 0
     -         -- DeployWaitTime[6] 3ms
     -             -- DeployAsyncSendTime[2] 0
     - DeployDataSize: 3276
```
## What I'm doing:
- Always add a timeout limit for MVPrepareRelatedMVs/MVPrepareRelatedMVs which each mv prepare time should not occupy query_optimizer_execute_timeout / valid_mv_size;
- After this pr, mv rewrite only can use mv's plan from cache other than getting plans in mv rewrite stage which may occupy a lot of time.
- Add more time trace for mv prepare stage to find more slow points later.


After this pr, we can trace more detail costs for mv rewrite in `MVPrepareRelatedMVs` stage:
```
mysql> trace times select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 where k2 > '2020-10-23 12:12:00' group by k1, date_trunc('day', k2) order by 1;
+-------------------------------------------------------------------------+
| Explain String                                                          |
+-------------------------------------------------------------------------+
|  0ms|-- Parser[1] 0                                                     |
|  1ms|-- Total[1] 19ms                                                   |
|  1ms|    -- Analyzer[1] 0                                               |
|  1ms|        -- Lock[1] 0                                               |
|  1ms|        -- AnalyzeDatabase[1] 0                                    |
|  1ms|        -- AnalyzeTemporaryTable[1] 0                              |
|  1ms|        -- AnalyzeTable[1] 0                                       |
|  2ms|    -- Transformer[1] 0                                            |
|  3ms|    -- Optimizer[1] 16ms                                           |
|  3ms|        -- MVPreprocess[1] 4ms                                     |
|  3ms|            -- MVChooseCandidates[1] 0                             |
|  3ms|            -- MVGenerateMvPlan[1] 0                               |
|  3ms|            -- MVPrepareRelatedMVs[1] 4ms                          |
|  3ms|                -- MVTimelinessUpdateInfo[4] 2ms                   |
|  3ms|                    -- CollectBaseTableUpdatePartitionNames[4] 0   |
|  3ms|                    -- SyncBaseTablePartitions[4] 0                |
|  3ms|                    -- CollectExtraBaseTableChangedPartitions[4] 0 |
|  3ms|                    -- GetChangedPartitionDiff[4] 0                |
|  4ms|                    -- GenerateBaseRefMap[4] 0                     |
|  4ms|                    -- GenerateMvRefMap[4] 0                       |
|  7ms|            -- MVProcessWithView[1] 0                              |
|  8ms|        -- MVTextRewrite[1] 0                                      |
|  8ms|        -- RuleBaseOptimize[1] 8ms                                 |
| 16ms|        -- CostBaseOptimize[1] 1ms                                 |
| 18ms|        -- PhysicalRewrite[1] 0                                    |
| 18ms|        -- DynamicRewrite[1] 0                                     |
| 19ms|        -- PlanValidate[1] 0                                       |
| 19ms|            -- InputDependenciesChecker[1] 0                       |
| 19ms|            -- TypeChecker[1] 0                                    |
| 19ms|            -- CTEUniqueChecker[1] 0                               |
| 19ms|            -- ColumnReuseChecker[1] 0                             |
| 19ms|    -- ExecPlanBuild[1] 1ms                                        |
| Tracer Cost: 126us                                                      |
+-------------------------------------------------------------------------+
33 rows in set (0.02 sec)

```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
