### PR TITLE
[Feature] Https support for FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -184,7 +184,7 @@ public class StarRocksFE {
             // 4. ArrowFlightSqlService for Arrow Flight SQL Server
             QeService qeService = new QeService(Config.query_port, ExecuteEnv.getInstance().getScheduler());
             FrontendThriftServer frontendThriftServer = new FrontendThriftServer(Config.rpc_port);
-            HttpServer httpServer = new HttpServer(Config.http_port);
+            HttpServer httpServer = new HttpServer(Config.enable_https ? Config.https_port : Config.http_port);
             Optional<HttpServer> httpsServer = Optional.ofNullable(
                     Config.enable_https ? new HttpServer(Config.https_port, true) : null);
             ArrowFlightSqlService arrowFlightSqlService = new ArrowFlightSqlService(Config.arrow_flight_port);

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -729,6 +729,18 @@ public class Config extends ConfigBase {
     public static boolean enable_https = false;
 
     /**
+     * format of the keystore, JKS by default
+     */
+    @ConfField
+    public static String ssl_keystore_type = "JKS";
+
+    /**
+     * format of the truststore, JKS by default
+     */
+    @ConfField
+    public static String ssl_truststore_type = "JKS";
+
+    /**
      * Configs for query queue v2.
      * The configs {@code query_queue_v2_xxx} are effective only when {@code enable_query_queue_v2} is true.
      * @see com.starrocks.qe.scheduler.slot.QueryQueueOptions

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/FrontendsProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/FrontendsProcNode.java
@@ -108,7 +108,7 @@ public class FrontendsProcNode implements ProcNodeInterface {
             info.add(fe.getHost());
 
             info.add(Integer.toString(fe.getEditLogPort()));
-            info.add(Integer.toString(Config.http_port));
+            info.add(Integer.toString(Config.enable_https ? Config.https_port : Config.http_port));
 
             if (fe.getHost().equals(globalStateMgr.getNodeMgr().getSelfNode().first)) {
                 info.add(Integer.toString(Config.query_port));

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/HttpSSLContextLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/HttpSSLContextLoader.java
@@ -39,7 +39,7 @@ public class HttpSSLContextLoader {
     }
 
     private static SslContext createSSLContext() throws Exception {
-        KeyStore keyStore = KeyStore.getInstance("JKS");
+        KeyStore keyStore = KeyStore.getInstance(Config.ssl_keystore_type);
         try (InputStream keyStoreIS = new FileInputStream(Config.ssl_keystore_location)) {
             if (Strings.isNullOrEmpty(Config.ssl_keystore_password)) {
                 throw new IllegalArgumentException("The SSL keystore password cannot be null or empty.");

--- a/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
@@ -270,7 +270,9 @@ public class CheckpointController extends FrontendDaemon {
             throw new IOException(errMessage);
         }
         File dir = new File(imageDir);
-        String url = "http://" + NetUtils.getHostPortInAccessibleFormat(frontend.getHost(), Config.http_port) +
+        int port = Config.enable_https ? Config.https_port : Config.http_port;
+        String scheme = Config.enable_https ? "https://" : "http://";
+        String url = scheme + NetUtils.getHostPortInAccessibleFormat(frontend.getHost(), port) +
                 "/image?version=" + journalId
                 + "&subdir=" + subDir
                 + "&image_format_version=" + imageFormatVersion;
@@ -407,7 +409,9 @@ public class CheckpointController extends FrontendDaemon {
 
             boolean pushSuccess = true;
             ImageFormatVersion formatVersion = belongToGlobalStateMgr ? ImageFormatVersion.v2 : ImageFormatVersion.v1;
-            String url = "http://" + NetUtils.getHostPortInAccessibleFormat(frontend.getHost(), Config.http_port)
+            int port = Config.enable_https ? Config.https_port : Config.http_port;
+            String scheme = Config.enable_https ? "https://" : "http://";
+            String url = scheme + NetUtils.getHostPortInAccessibleFormat(frontend.getHost(), port)
                     + "/put?version=" + imageVersion
                     + "&port=" + Config.http_port
                     + "&subdir=" + subDir
@@ -438,7 +442,8 @@ public class CheckpointController extends FrontendDaemon {
         long minReplayedJournalId = Long.MAX_VALUE;
         for (Frontend fe : GlobalStateMgr.getServingState().getNodeMgr().getOtherFrontends()) {
             String host = fe.getHost();
-            int port = Config.http_port;
+            int port = Config.enable_https ? Config.https_port : Config.http_port;
+            String scheme = Config.enable_https ? "https://" : "http://";
             URL idURL;
             HttpURLConnection conn = null;
             try {
@@ -448,7 +453,8 @@ public class CheckpointController extends FrontendDaemon {
                  * any non-master node's current replayed journal id. otherwise,
                  * this lagging node can never get the deleted journal.
                  */
-                idURL = new URL("http://" + NetUtils.getHostPortInAccessibleFormat(host, port) + "/journal_id?prefix=" + journal.getPrefix());
+                idURL = new URL(scheme + NetUtils.getHostPortInAccessibleFormat(host, port)
+                        + "/journal_id?prefix=" + journal.getPrefix());
                 conn = (HttpURLConnection) idURL.openConnection();
                 conn.setConnectTimeout(CONNECT_TIMEOUT_SECOND * 1000);
                 conn.setReadTimeout(READ_TIMEOUT_SECOND * 1000);

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLContextLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLContextLoader.java
@@ -44,7 +44,7 @@ public class SSLContextLoader {
     }
 
     private static SSLContext createSSLContext() throws Exception {
-        KeyStore keyStore = KeyStore.getInstance("JKS");
+        KeyStore keyStore = KeyStore.getInstance(Config.ssl_keystore_type);
         try (InputStream keyStoreIS = new FileInputStream(Config.ssl_keystore_location)) {
             keyStore.load(keyStoreIS, Config.ssl_keystore_password.toCharArray());
         }
@@ -62,7 +62,7 @@ public class SSLContextLoader {
     }
 
     private static TrustManager[] createTrustManagers(String filepath, String keystorePassword) throws Exception {
-        KeyStore trustStore = KeyStore.getInstance("JKS");
+        KeyStore trustStore = KeyStore.getInstance(Config.ssl_truststore_type);
         try (InputStream trustStoreIS = new FileInputStream(filepath)) {
             trustStore.load(trustStoreIS, keystorePassword.toCharArray());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -367,8 +367,10 @@ public class HeartbeatMgr extends FrontendDaemon {
                 }
             }
 
-            String accessibleHostPort = NetUtils.getHostPortInAccessibleFormat(fe.getHost(), Config.http_port);
-            String url = "http://" + accessibleHostPort
+            int port = Config.enable_https ? Config.https_port : Config.http_port;
+            String accessibleHostPort = NetUtils.getHostPortInAccessibleFormat(fe.getHost(), port);
+            String scheme = Config.enable_https ? "https://" : "http://";
+            String url = scheme + accessibleHostPort
                     + "/api/bootstrap?cluster_id=" + clusterId + "&token=" + token;
             try {
                 String resultStr = Util.getResultForUrl(url, null,


### PR DESCRIPTION
## Why I'm doing:

- Use load balancer or proxy at your site or cloud environment to terminate TLS/HTTPS.
- Secure the server directly. This requires you to obtain a valid certificate and add it to the FE configuration.

This PR is adding support for second alternative mentioned above.

To enable HTTPS, below configurations must be set

1. `enable_https`: Controls whether to enable https or not, default is false
2. `https_port`: Controls the https port, default is 8443
3. `ssl_keystore_type`: Keystore type, JKS default
4. `ssl_keystore_location`: The keystrore file path
5. `ssl_keystore_password`: the password of keystore file
6. `ssl_key_password`: the password of private key

For testing, you can create certs using keytool, remember to add both IPs and Hostname as SAN

```
keytool -genkeypair \
   -alias starrocks-local-cert \
   -keyalg RSA \
   -keysize 2048 \
   -validity 365 \
   -keystore keystore.jks \
   -storepass password \
   -keypass password \
   -storetype JKS \
   -dname "CN=localhost, OU=MyOrg, O=MyCompany, L=MyCity, ST=MyState, C=US" \
   -ext SAN=dns:fe1,dns:fe2,dns:localhost,ip:127.0.0.1,ip:172.25.0.10,ip:172.25.0.11,ip:172.25.0.12
  ``` 
  
  And 
  
  Create trust-store
  
  ```
 keytool -export -alias starrocks-local-cert -keystore keystore.jks -file server.crt -storepass password
keytool -import -alias starrocks-local-cert -file server.crt  -storetype JKS -keystore truststore.jks -storepass password -noprompt
```

And use trust store as JVM params - required for self signed certs

```
-Djavax.net.ssl.trustStore=/opt/starrocks/fe/conf/truststore.jks -Djavax.net.ssl.trustStorePassword=password -Djavax.net.ssl.trustStoreType=JKS
```


## What I'm doing:

Fixes #56393

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3