### PR TITLE
[UT] Fix broken stringCastBitmapFailed0 test

### DIFF
--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -1067,9 +1067,8 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapFailed0) {
 
     {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
-
         // right cast
-        auto v = BitmapColumn::static_pointer_cast(ptr);
+        auto v = NullableColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1105,7 +1104,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapFailed1) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
-        auto v = BitmapColumn::static_pointer_cast(ptr);
+        auto v = NullableColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1177,7 +1176,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapSingleFailed) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
-        auto v = BitmapColumn::static_pointer_cast(ptr);
+        auto v = NullableColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1252,7 +1251,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapSetFailed) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
-        auto v = BitmapColumn::static_pointer_cast(ptr);
+        auto v = NullableColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1331,7 +1330,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapMapFailed) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
-        auto v = BitmapColumn::static_pointer_cast(ptr);
+        auto v = NullableColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {


### PR DESCRIPTION
## Why I'm doing:
For fail-cast cases, results are all nulls,  use `NullableColumn` instead.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
