### PR TITLE
[BugFix] fix cache might not be used when upgraded from 3.3

### DIFF
--- a/be/src/cache/datacache_utils.h
+++ b/be/src/cache/datacache_utils.h
@@ -17,6 +17,7 @@
 #include "cache/cache_metrics.h"
 #include "cache/local_cache_engine.h"
 #include "gen_cpp/DataCache_types.h"
+#include "storage/options.h"
 
 namespace starrocks {
 
@@ -42,6 +43,12 @@ public:
     static Status change_disk_path(const std::string& old_disk_path, const std::string& new_disk_path);
 
     static dev_t disk_device_id(const std::string& disk_path);
+
+#ifdef USE_STAROS
+    // for each dir in `store_paths`, get each corresponding dir in `starlet_cache_dir`
+    static StatusOr<std::vector<std::string>> get_corresponding_starlet_cache_dir(
+            const std::vector<StorePath>& store_paths, const std::string& starlet_cache_dir);
+#endif
 };
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

if user set `starlet_cache_dir` in 3.3, the cache will not be used when upgraded to 3.4+

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
