### PR TITLE
[Feature] Use original virtual buckets when creating shadow materialized index in schema change and rollup job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableRollupJobBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableRollupJobBuilder.java
@@ -32,7 +32,10 @@ import com.starrocks.thrift.TStorageMedium;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class OlapTableRollupJobBuilder extends AlterJobV2Builder {
     private static final Logger LOG = LogManager.getLogger(OlapTableRollupJobBuilder.class);
@@ -69,6 +72,7 @@ public class OlapTableRollupJobBuilder extends AlterJobV2Builder {
                 MaterializedIndex baseIndex = physicalPartition.getIndex(baseIndexId);
                 TabletMeta mvTabletMeta = new TabletMeta(dbId, olapTable.getId(),
                         physicalPartitionId, rollupIndexId, mvSchemaHash, medium);
+                Map<Long, Long> tabletIdMap = new HashMap<>();
                 for (Tablet baseTablet : baseIndex.getTablets()) {
                     long baseTabletId = baseTablet.getId();
                     long mvTabletId = globalStateMgr.getNextId();
@@ -79,6 +83,7 @@ public class OlapTableRollupJobBuilder extends AlterJobV2Builder {
                     addedTablets.add(newTablet);
 
                     mvJob.addTabletIdMap(physicalPartitionId, mvTabletId, baseTabletId);
+                    tabletIdMap.put(baseTabletId, mvTabletId);
 
                     List<Replica> baseReplicas = ((LocalTablet) baseTablet).getImmutableReplicas();
 
@@ -122,6 +127,10 @@ public class OlapTableRollupJobBuilder extends AlterJobV2Builder {
                         throw new DdlException("tablet " + baseTabletId + " has few healthy replica: " + healthyReplicaNum);
                     }
                 } // end for baseTablets
+
+                List<Long> virtualBuckets = new ArrayList<>(baseIndex.getVirtualBuckets());
+                virtualBuckets.replaceAll(tabletId -> tabletIdMap.get(tabletId));
+                mvIndex.setVirtualBuckets(virtualBuckets);
 
                 mvJob.addMVIndex(physicalPartitionId, mvIndex);
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -201,6 +201,10 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         return virtualBuckets;
     }
 
+    public void setVirtualBuckets(List<Long> virtualBuckets) {
+        this.virtualBuckets = virtualBuckets;
+    }
+
     public List<Tablet> getTablets() {
         return tablets;
     }


### PR DESCRIPTION
## Why I'm doing:
When creating shadow materialized index in schema change and rollup job, the virtual buckets of the shadow materialized index should be the same as the original materialized index.

## What I'm doing:
Use original virtual buckets when creating shadow materialized index in schema change and rollup job.

Fixes https://github.com/StarRocks/starrocks/issues/59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
