### PR TITLE
[Enhancement] Enable enable_materialized_view_agg_pushdown_rewrite by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -581,9 +581,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String MATERIALIZED_VIEW_UNION_REWRITE_MODE = "materialized_view_union_rewrite_mode";
     public static final String ENABLE_MATERIALIZED_VIEW_TRANSPARENT_UNION_REWRITE =
             "enable_materialized_view_transparent_union_rewrite";
+
     public static final String ENABLE_MATERIALIZED_VIEW_REWRITE_PARTITION_COMPENSATE =
             "enable_materialized_view_rewrite_partition_compensate";
-    public static final String ENABLE_MATERIALIZED_VIEW_AGG_PUSHDOWN_REWRITE = "enable_materialized_view_agg_pushdown_rewrite";
+    public static final String ENABLE_MATERIALIZED_VIEW_AGG_PUSHDOWN_REWRITE
+            = "enable_materialized_view_agg_pushdown_rewrite";
+    public static final String ENABLE_MATERIALIZED_VIEW_AGG_PUSHDOWN_REWRITE_V2 =
+            "enable_materialized_view_agg_pushdown_rewrite_v2";
     public static final String ENABLE_MATERIALIZED_VIEW_TIMESERIES_AGG_PUSHDOWN_REWRITE =
             "enable_materialized_view_timeseries_agg_pushdown_rewrite";
 
@@ -2185,8 +2189,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     /**
      * Whether to support to rewrite query with materialized view by using aggregate pushdown.
      */
-    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_AGG_PUSHDOWN_REWRITE)
-    private boolean enableMaterializedViewPushDownRewrite = false;
+    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_AGG_PUSHDOWN_REWRITE_V2, alias = ENABLE_MATERIALIZED_VIEW_AGG_PUSHDOWN_REWRITE,
+            show = ENABLE_MATERIALIZED_VIEW_AGG_PUSHDOWN_REWRITE)
+    private boolean enableMaterializedViewPushDownRewrite = true;
 
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_TIMESERIES_AGG_PUSHDOWN_REWRITE)
     private boolean enableMaterializedViewTimeSeriesPushDownRewrite = true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -58,7 +58,7 @@ public class MVColumnPruner {
         }
     }
 
-    public OptExpression doPruneColumns(OptExpression optExpression) {
+    private OptExpression doPruneColumns(OptExpression optExpression) {
         // TODO: remove this check after we support more operators.
         Projection projection = optExpression.getOp().getProjection();
         // OptExpression after mv rewrite must have projection.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
-import com.starrocks.sql.common.UnsupportedException;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.Utils;
@@ -248,7 +247,8 @@ public class MVColumnPruner {
         }
 
         public OptExpression visit(OptExpression optExpression, Void context) {
-            throw UnsupportedException.unsupportedException(String.format("ColumnPruner does not support:%s", optExpression));
+            Operator operator = optExpression.getOp();
+            return OptExpression.create(operator, visitChildren(optExpression));
         }
 
         private List<OptExpression> visitChildren(OptExpression optExpression) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCDSTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCDSTest.java
@@ -14,12 +14,29 @@
 
 package com.starrocks.planner;
 
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.Optimizer;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.OptimizerFactory;
+import com.starrocks.sql.optimizer.OptimizerOptions;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVPartitionPruner;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import com.starrocks.sql.optimizer.transformer.LogicalPlan;
+import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.plan.TPCDSPlanTestBase;
 import com.starrocks.sql.plan.TPCDSTestUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
 
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class MaterializedViewTPCDSTest extends MaterializedViewTestBase {
@@ -28,6 +45,28 @@ public class MaterializedViewTPCDSTest extends MaterializedViewTestBase {
         MaterializedViewTestBase.beforeClass();
         TPCDSTestUtil.prepareTables(starRocksAssert);
         starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
+    }
+
+    @Test
+    public void testMVPartitionPruner() {
+        Map<String, String> sqlMap = TPCDSPlanTestBase.getSqlMap();
+        for (String sql : sqlMap.values()) {
+            StatementBase mvStmt = MVTestBase.getAnalyzedPlan(sql, connectContext);
+            QueryRelation query = ((QueryStatement) mvStmt).getQueryRelation();
+            ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+            LogicalPlan logicalPlan =
+                    new RelationTransformer(columnRefFactory, connectContext).transformWithSelectLimit(query);
+            OptimizerContext optimizerContext =
+                    OptimizerFactory.initContext(connectContext, columnRefFactory, OptimizerOptions.newRuleBaseOpt());
+            Optimizer optimizer = OptimizerFactory.create(optimizerContext);
+            OptExpression optExpression = optimizer.optimize(
+                    logicalPlan.getRoot(),
+                    new PhysicalPropertySet(),
+                    new ColumnRefSet(logicalPlan.getOutputColumn()));
+            MVPartitionPruner mvPartitionPruner = new MVPartitionPruner(
+                    optimizerContext, null);
+            mvPartitionPruner.prunePartition(optExpression);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCDSTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCDSTest.java
@@ -25,6 +25,7 @@ import com.starrocks.sql.optimizer.OptimizerOptions;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVColumnPruner;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVPartitionPruner;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
@@ -48,7 +49,7 @@ public class MaterializedViewTPCDSTest extends MaterializedViewTestBase {
     }
 
     @Test
-    public void testMVPartitionPruner() {
+    public void testMVPartitionPrunerAndColumnPruner() {
         Map<String, String> sqlMap = TPCDSPlanTestBase.getSqlMap();
         for (String sql : sqlMap.values()) {
             StatementBase mvStmt = MVTestBase.getAnalyzedPlan(sql, connectContext);
@@ -65,7 +66,11 @@ public class MaterializedViewTPCDSTest extends MaterializedViewTestBase {
                     new ColumnRefSet(logicalPlan.getOutputColumn()));
             MVPartitionPruner mvPartitionPruner = new MVPartitionPruner(
                     optimizerContext, null);
+            // partition pruner
             mvPartitionPruner.prunePartition(optExpression);
+
+            // column pruner
+            new MVColumnPruner().pruneColumns(optExpression, optExpression.getOutputColumns());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -108,7 +108,7 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
                         " where t1.d in ('2023-08-01')\n" +
                         " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
-            PlanTestBase.assertNotContains(plan, "test_mv1");
+            PlanTestBase.assertContains(plan, "test_mv1");
         }
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q10.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q10.sql
@@ -33,9 +33,22 @@ order by
 [result]
 TOP-N (order by [[39: sum DESC NULLS LAST]])
     TOP-N (order by [[39: sum DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{39: sum=sum(39: sum)}] group by [[1: c_custkey, 2: c_name, 6: c_acctbal, 5: c_phone, 35: n_name, 3: c_address, 8: c_comment]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{142: sum=sum(142: sum)}] group by [[1: c_custkey, 2: c_name, 6: c_acctbal, 5: c_phone, 35: n_name, 3: c_address, 8: c_comment]] having [null]
             EXCHANGE SHUFFLE[1, 2, 6, 5, 35, 3, 8]
-                AGGREGATE ([LOCAL] aggregate [{39: sum=sum(38: expr)}] group by [[1: c_custkey, 2: c_name, 6: c_acctbal, 5: c_phone, 35: n_name, 3: c_address, 8: c_comment]] having [null]
-                    SCAN (mv[lineitem_mv] columns[60: c_address, 61: c_acctbal, 62: c_comment, 64: c_name, 66: c_phone, 74: l_returnflag, 79: o_custkey, 80: o_orderdate, 93: l_saleprice, 99: n_name2] predicate[80: o_orderdate >= 1994-05-01 AND 80: o_orderdate < 1994-08-01 AND 74: l_returnflag = R])
+                AGGREGATE ([LOCAL] aggregate [{142: sum=sum(140: sum)}] group by [[1: c_custkey, 2: c_name, 6: c_acctbal, 5: c_phone, 35: n_name, 3: c_address, 8: c_comment]] having [null]
+                    INNER JOIN (join-predicate [4: c_nationkey = 34: n_nationkey] post-join-predicate [null])
+                        INNER JOIN (join-predicate [1: c_custkey = 10: o_custkey] post-join-predicate [null])
+                            EXCHANGE SHUFFLE[1]
+                                HIVE SCAN (columns{1,2,3,4,5,6,8} predicate[1: c_custkey IS NOT NULL])
+                            EXCHANGE SHUFFLE[10]
+                                INNER JOIN (join-predicate [9: o_orderkey = 18: l_orderkey] post-join-predicate [null])
+                                    HIVE SCAN (columns{9,10,13} predicate[13: o_orderdate >= 1994-05-01 AND 13: o_orderdate < 1994-08-01])
+                                    EXCHANGE BROADCAST
+                                        AGGREGATE ([GLOBAL] aggregate [{141: sum=sum(141: sum)}] group by [[116: l_orderkey]] having [null]
+                                            EXCHANGE SHUFFLE[116]
+                                                AGGREGATE ([LOCAL] aggregate [{141: sum=sum(126: sum_disc_price)}] group by [[116: l_orderkey]] having [null]
+                                                    SCAN (mv[lineitem_agg_mv1] columns[116: l_orderkey, 118: l_returnflag, 126: sum_disc_price] predicate[118: l_returnflag = R])
+                        EXCHANGE BROADCAST
+                            HIVE SCAN (columns{34,35} predicate[34: n_nationkey IS NOT NULL])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q3.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q3.sql
@@ -24,9 +24,19 @@ order by
 [result]
 TOP-N (order by [[35: sum DESC NULLS LAST, 13: o_orderdate ASC NULLS FIRST]])
     TOP-N (order by [[35: sum DESC NULLS LAST, 13: o_orderdate ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[18: l_orderkey, 13: o_orderdate, 16: o_shippriority]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{123: sum=sum(123: sum)}] group by [[18: l_orderkey, 13: o_orderdate, 16: o_shippriority]] having [null]
             EXCHANGE SHUFFLE[18, 13, 16]
-                AGGREGATE ([LOCAL] aggregate [{35: sum=sum(34: expr)}] group by [[18: l_orderkey, 13: o_orderdate, 16: o_shippriority]] having [null]
-                    SCAN (mv[lineitem_mv] columns[44: c_mktsegment, 51: l_orderkey, 56: l_shipdate, 61: o_orderdate, 64: o_shippriority, 74: l_saleprice] predicate[61: o_orderdate < 1995-03-11 AND 56: l_shipdate > 1995-03-11 AND 44: c_mktsegment = HOUSEHOLD])
+                AGGREGATE ([LOCAL] aggregate [{123: sum=sum(121: sum)}] group by [[18: l_orderkey, 13: o_orderdate, 16: o_shippriority]] having [null]
+                    INNER JOIN (join-predicate [10: o_custkey = 1: c_custkey] post-join-predicate [null])
+                        EXCHANGE SHUFFLE[10]
+                            INNER JOIN (join-predicate [9: o_orderkey = 18: l_orderkey] post-join-predicate [null])
+                                HIVE SCAN (columns{9,10,13,16} predicate[13: o_orderdate < 1995-03-11])
+                                EXCHANGE BROADCAST
+                                    AGGREGATE ([GLOBAL] aggregate [{122: sum=sum(122: sum)}] group by [[100: l_orderkey]] having [null]
+                                        EXCHANGE SHUFFLE[100]
+                                            AGGREGATE ([LOCAL] aggregate [{122: sum=sum(110: sum_disc_price)}] group by [[100: l_orderkey]] having [null]
+                                                SCAN (mv[lineitem_agg_mv1] columns[100: l_orderkey, 101: l_shipdate, 110: sum_disc_price] predicate[101: l_shipdate > 1995-03-11])
+                        EXCHANGE SHUFFLE[1]
+                            HIVE SCAN (columns{1,7} predicate[7: c_mktsegment = HOUSEHOLD])
 [end]
 


### PR DESCRIPTION
## Why I'm doing:
`enable_materialized_view_agg_pushdown_rewrite` can be used for multi sceces: https://docs.starrocks.io/docs/using_starrocks/async_mv/use_cases/query_rewrite_with_materialized_views/#aggregation-pushdown

We can enable it by default after multi versions which is introduced in v3.3.0


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
