### PR TITLE
[BugFix] Add shard group id into cluster snapshot info for GC control

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -245,6 +245,13 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                       shardGroupId);
             return false;
         }
+
+        if (GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isShardGroupIdInClusterSnapshotInfo(
+                dbId, tableId, partitionId, shardGroupId)) {
+            LOG.debug("shard group {} can not be delete shard for now, because it exists in cluster snapshot info",
+                      shardGroupId);
+            return false;
+        }
         return true;
     }
 
@@ -507,6 +514,13 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                                       .getClusterSnapshotMgr().isMaterializedIndexInClusterSnapshotInfo(
                                             db.getId(), table.getId(), physicalPartition.getParentId(),
                                                 physicalPartition.getId(), materializedIndex.getId())) {
+                        continue;
+                    }
+
+                    if (GlobalStateMgr.getCurrentState()
+                                      .getClusterSnapshotMgr().isShardGroupIdInClusterSnapshotInfo(
+                                            db.getId(), table.getId(), physicalPartition.getParentId(),
+                                                physicalPartition.getId(), materializedIndex.getShardGroupId())) {
                         continue;
                     }
                     // collect shard in starmgr but not in fe

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotInfo.java
@@ -68,6 +68,34 @@ public class ClusterSnapshotInfo {
         return false;
     }
 
+    public boolean containsShardGroupId(long dbId, long tableId, long partId, long physicalPartId, long shardGroupId) {
+        PhysicalPartitionSnapshotInfo physicalPartInfo = getPhysicalPartitionInfo(dbId, tableId, partId, physicalPartId);
+        if (physicalPartInfo == null) {
+            return false;
+        }
+
+        for (MaterializedIndexSnapshotInfo indexInfo : physicalPartInfo.indexInfos.values()) {
+            if (indexInfo.shardGroupId == shardGroupId) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean containsShardGroupId(long dbId, long tableId, long partId, long shardGroupId) {
+        PartitionSnapshotInfo partInfo = getPartitionInfo(dbId, tableId, partId);
+        if (partInfo == null) {
+            return false;
+        }
+
+        for (PhysicalPartitionSnapshotInfo physicalPartInfo : partInfo.physicalPartInfos.values()) {
+            if (containsShardGroupId(dbId, tableId, partId, physicalPartInfo.physicalPartitionId, shardGroupId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private DatabaseSnapshotInfo getDbInfo(long dbId) {
         return dbInfos.get(dbId);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -353,6 +353,17 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         return false;
     }
 
+    // keep this interface and do not remove it
+    public boolean isShardGroupIdInClusterSnapshotInfo(long dbId, long tableId, long partId, long shardGroupId) {
+        return false;
+    }
+
+    // keep this interface and do not remove it
+    public boolean isShardGroupIdInClusterSnapshotInfo(
+                   long dbId, long tableId, long partId, long physicalPartId, long shardGroupId) {
+        return false;
+    }
+
     public void start() {
         if (RunMode.isSharedDataMode() && clusterSnapshotCheckpointScheduler == null) {
             clusterSnapshotCheckpointScheduler = new ClusterSnapshotCheckpointScheduler(

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/MaterializedIndexSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/MaterializedIndexSnapshotInfo.java
@@ -19,8 +19,11 @@ import com.google.gson.annotations.SerializedName;
 public class MaterializedIndexSnapshotInfo {
     @SerializedName(value = "indexId")
     public final long indexId;
+    @SerializedName(value = "shardGroupId")
+    public final long shardGroupId;
 
-    public MaterializedIndexSnapshotInfo(long indexId) {
+    public MaterializedIndexSnapshotInfo(long indexId, long shardGroupId) {
         this.indexId = indexId;
+        this.shardGroupId = shardGroupId;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/SnapshotInfoHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/SnapshotInfoHelper.java
@@ -71,6 +71,6 @@ public class SnapshotInfoHelper {
     }
 
     public static MaterializedIndexSnapshotInfo buildMaterializedIndexSnapshotInfo(MaterializedIndex index) {
-        return new MaterializedIndexSnapshotInfo(index.getId());
+        return new MaterializedIndexSnapshotInfo(index.getId(), index.getShardGroupId());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotInfoTest.java
@@ -100,6 +100,24 @@ public class ClusterSnapshotInfoTest {
                     Assertions.assertTrue(!clusterSnapshotInfo.containsMaterializedIndex(dbTest.getId(), olapTable.getId(),
                                                                                      part.getParentId(), part.getId(),
                                                                                      index.getId() + 1L));
+
+                    Assertions.assertTrue(clusterSnapshotInfo.containsShardGroupId(dbTest.getId(), olapTable.getId(),
+                                                                                   part.getParentId(), index.getShardGroupId()));
+                    Assertions.assertTrue(clusterSnapshotInfo.containsShardGroupId(dbTest.getId(), olapTable.getId(),
+                                                                                   part.getParentId(), part.getId(),
+                                                                                   index.getShardGroupId()));
+                    Assertions.assertTrue(!clusterSnapshotInfo.containsShardGroupId(dbTest.getId(), olapTable.getId(),
+                                                                                    part.getParentId() + 666L,
+                                                                                    index.getShardGroupId()));
+                    Assertions.assertTrue(!clusterSnapshotInfo.containsShardGroupId(dbTest.getId(), olapTable.getId(),
+                                                                                    part.getParentId(), part.getId() + 666L,
+                                                                                    index.getShardGroupId()));
+                    Assertions.assertTrue(!clusterSnapshotInfo.containsShardGroupId(dbTest.getId(), olapTable.getId(),
+                                                                                    part.getParentId(), part.getId(),
+                                                                                    index.getShardGroupId() + 666L));
+                    Assertions.assertTrue(!clusterSnapshotInfo.containsShardGroupId(dbTest.getId(), olapTable.getId(),
+                                                                                    part.getParentId(),
+                                                                                    index.getShardGroupId() + 666L));
                 }
             }
         }


### PR DESCRIPTION
## Why I'm doing:
When sr gc shard in starMgrMetaSyncer, it will remove all shard which found in starMgr but not in FE for the same shard group. But in the previous impl, we just check the materialized index id but not the shard group id which will lead the starMgrMetaSyncer delete the data incorrectly.

## What I'm doing:
Introduce shard group id into cluster snapshot info and check it in starMgrMetaSyncer.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
