### PR TITLE
[Refactor] Add WALApplier interface to apply in-memory change after WAL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -1281,6 +1281,15 @@ public class EditLog {
     }
 
     /**
+     * Apply the in-memory change in WALApplier.
+     */
+    public void logEdit(short op, Writable writable, WALApplier applier) {
+        JournalTask task = submitLog(op, writable, -1);
+        waitInfinity(task);
+        applier.apply(writable);
+    }
+
+    /**
      * submit log in queue and return immediately
      */
     private JournalTask submitLog(short op, Writable writable, long maxWaitIntervalMs) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/WALApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/WALApplier.java
@@ -1,0 +1,22 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.starrocks.common.io.Writable;
+
+public interface WALApplier {
+
+    void apply(Writable wal);
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
