### PR TITLE
[BugFix] Fix MVPartitionPruner bugs with LogicalViewScanOperator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
@@ -127,6 +127,8 @@ public class MVPartitionPruner {
                         (LogicalScanOperator) builder.withOperator(scanOperator).build();
                 result = OptExternalPartitionPruner.prunePartitions(optimizerContext,
                         copiedScanOperator);
+            } else {
+                result = optExpression.getOp().cast();
             }
             if (result != null) {
                 result.setOpRuleBit(OP_PARTITION_PRUNED);

--- a/test/sql/test_materialized_view/R/test_materialized_view_agg_pushdown_rewrite2
+++ b/test/sql/test_materialized_view/R/test_materialized_view_agg_pushdown_rewrite2
@@ -1,0 +1,113 @@
+-- name: test_materialized_view_agg_pushdown_rewrite2
+CREATE TABLE t1 (
+  c1   DATETIME,
+  c2   DATETIME,
+  c3   DATE,
+  c4   VARCHAR(16),
+  c5   INT,
+  c6   INT,
+  c7   INT,
+  c8   VARCHAR(64),
+  c9   VARCHAR(32),
+  c10  DOUBLE,
+  c11  DOUBLE,
+  c12  DOUBLE
+) PARTITION BY (c3);
+-- result:
+-- !result
+INSERT INTO t1 VALUES
+('2025-01-01 08:10:00', '2025-01-01 08:00:00', 20250101, 'w3ggmt', 16379, 5, 5, 'ABC123', 'booked', 15.50, 3.2, 1.5),
+('2025-01-01 09:15:00', '2025-01-01 09:00:00', 20250101, 'w3ggng', 14625, 5, 5, 'XYZ789', 'booked', 20.00, 5.0, 2.0),
+('2025-01-01 10:25:00', '2025-01-01 10:00:00', 20250101, 'w3ggqp', 14544, 5, 5, 'LMN456', 'booked', 12.00, 2.5, 1.2);
+-- result:
+-- !result
+CREATE TABLE t2 (
+  c1  BIGINT,
+  c2  VARCHAR(256),
+  c3  VARCHAR(64),
+  c4  BIGINT,
+  c5  BIGINT,
+  c6  BIGINT,
+  c7  VARCHAR(256),
+  c8  VARCHAR(64),
+  c9  VARCHAR(64),
+  c10 VARCHAR(256),
+  c11 VARCHAR(256),
+  c12 VARCHAR(256),
+  c13 VARCHAR(256),
+  c14 VARCHAR(256),
+  c15 VARCHAR(256),
+  c16 VARCHAR(256),
+  c17 VARCHAR(256),
+  c18 ARRAY<VARCHAR(64)>,
+  c19 ARRAY<INT>
+);
+-- result:
+-- !result
+INSERT INTO t2 VALUES (
+  1001, 'Area A', 'district', 2, 5, 101, 'City X', 'business', 'GF001', 'generic',
+  'Country A', 'Territory X', 'Region Y', 'City Z', 'Subcity Q', 'District P', 'Area L',
+  ['w3ggmt', 'w3ggng', 'w3ggqp'], [2001, 2002, 2003]
+);
+-- result:
+-- !result
+CREATE VIEW v1 AS
+SELECT
+  geohash AS c1,
+  MAX(CASE WHEN x.c3 = 'SubCity' THEN x.c1 END) AS c2,
+  MAX(CASE WHEN x.c3 = 'SubCity' THEN x.c2 END) AS c3,
+  MAX(CASE WHEN x.c3 = 'District' THEN x.c1 END) AS c4,
+  MAX(CASE WHEN x.c3 = 'District' THEN x.c2 END) AS c5,
+  MAX(CASE WHEN x.c3 = 'Area' THEN x.c1 END) AS c6,
+  MAX(CASE WHEN x.c3 = 'Area' THEN x.c2 END) AS c7
+FROM (
+  SELECT
+    t2.c6, t2.c3, t2.c1, t2.c2, t2.c10, geohash
+  FROM t2
+  CROSS JOIN UNNEST(t2.c18) AS t0(geohash)
+) x
+GROUP BY geohash;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1
+DISTRIBUTED BY RANDOM
+REFRESH MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT
+  c1 AS c1_key,
+  MAX(c3) AS c_subcity,
+  MAX(c5) AS c_district,
+  MAX(c7) AS c_area
+FROM v1
+GROUP BY 1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv2
+PARTITION BY (c3)
+DISTRIBUTED BY HASH (c4)
+REFRESH MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT
+  DATE_TRUNC('day', c1) AS c1_day,
+  DATE_TRUNC('hour', c1) AS c1_hour,
+  c3, c4, c5, c6, c7,
+  SUM(c12) AS sum_surge,
+  SUM(c11) AS sum_distance,
+  SUM(c10) AS sum_fare,
+  COUNT(c12) AS count_surge
+FROM t1
+GROUP BY 1,2,3,4,5,6,7;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT z.c_district AS c_district_name, CAST(SUM(x.c10) AS DOUBLE) / CAST(SUM(x.c11) AS DOUBLE) AS fare_per_km FROM t1 x LEFT JOIN (SELECT c1, MAX(c5) AS c_district FROM v1 GROUP BY c1) z ON CAST(z.c1 AS VARCHAR) = CAST(x.c4 AS VARCHAR) GROUP BY 1 ORDER BY 1;", "mv1", "mv2")
+-- result:
+True
+-- !result
+SELECT z.c_district AS c_district_name, CAST(SUM(x.c10) AS DOUBLE) / CAST(SUM(x.c11) AS DOUBLE) AS fare_per_km FROM t1 x LEFT JOIN (SELECT c1, MAX(c5) AS c_district FROM v1 GROUP BY c1) z ON CAST(z.c1 AS VARCHAR) = CAST(x.c4 AS VARCHAR) GROUP BY 1 ORDER BY 1;
+-- result:
+None	4.4392523364485985
+-- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_agg_pushdown_rewrite2
+++ b/test/sql/test_materialized_view/T/test_materialized_view_agg_pushdown_rewrite2
@@ -1,0 +1,106 @@
+-- name: test_materialized_view_agg_pushdown_rewrite2
+
+CREATE TABLE t1 (
+  c1   DATETIME,
+  c2   DATETIME,
+  c3   DATE,
+  c4   VARCHAR(16),
+  c5   INT,
+  c6   INT,
+  c7   INT,
+  c8   VARCHAR(64),
+  c9   VARCHAR(32),
+  c10  DOUBLE,
+  c11  DOUBLE,
+  c12  DOUBLE
+) PARTITION BY (c3);
+
+INSERT INTO t1 VALUES
+('2025-01-01 08:10:00', '2025-01-01 08:00:00', 20250101, 'w3ggmt', 16379, 5, 5, 'ABC123', 'booked', 15.50, 3.2, 1.5),
+('2025-01-01 09:15:00', '2025-01-01 09:00:00', 20250101, 'w3ggng', 14625, 5, 5, 'XYZ789', 'booked', 20.00, 5.0, 2.0),
+('2025-01-01 10:25:00', '2025-01-01 10:00:00', 20250101, 'w3ggqp', 14544, 5, 5, 'LMN456', 'booked', 12.00, 2.5, 1.2);
+
+CREATE TABLE t2 (
+  c1  BIGINT,
+  c2  VARCHAR(256),
+  c3  VARCHAR(64),
+  c4  BIGINT,
+  c5  BIGINT,
+  c6  BIGINT,
+  c7  VARCHAR(256),
+  c8  VARCHAR(64),
+  c9  VARCHAR(64),
+  c10 VARCHAR(256),
+  c11 VARCHAR(256),
+  c12 VARCHAR(256),
+  c13 VARCHAR(256),
+  c14 VARCHAR(256),
+  c15 VARCHAR(256),
+  c16 VARCHAR(256),
+  c17 VARCHAR(256),
+  c18 ARRAY<VARCHAR(64)>,
+  c19 ARRAY<INT>
+);
+
+INSERT INTO t2 VALUES (
+  1001, 'Area A', 'district', 2, 5, 101, 'City X', 'business', 'GF001', 'generic',
+  'Country A', 'Territory X', 'Region Y', 'City Z', 'Subcity Q', 'District P', 'Area L',
+  ['w3ggmt', 'w3ggng', 'w3ggqp'], [2001, 2002, 2003]
+);
+
+-- View over dimension table t2
+CREATE VIEW v1 AS
+SELECT
+  geohash AS c1,
+  MAX(CASE WHEN x.c3 = 'SubCity' THEN x.c1 END) AS c2,
+  MAX(CASE WHEN x.c3 = 'SubCity' THEN x.c2 END) AS c3,
+  MAX(CASE WHEN x.c3 = 'District' THEN x.c1 END) AS c4,
+  MAX(CASE WHEN x.c3 = 'District' THEN x.c2 END) AS c5,
+  MAX(CASE WHEN x.c3 = 'Area' THEN x.c1 END) AS c6,
+  MAX(CASE WHEN x.c3 = 'Area' THEN x.c2 END) AS c7
+FROM (
+  SELECT
+    t2.c6, t2.c3, t2.c1, t2.c2, t2.c10, geohash
+  FROM t2
+  CROSS JOIN UNNEST(t2.c18) AS t0(geohash)
+) x
+GROUP BY geohash;
+
+-- Materialized view over view v1
+CREATE MATERIALIZED VIEW mv1
+DISTRIBUTED BY RANDOM
+REFRESH MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT
+  c1 AS c1_key,
+  MAX(c3) AS c_subcity,
+  MAX(c5) AS c_district,
+  MAX(c7) AS c_area
+FROM v1
+GROUP BY 1;
+
+-- Materialized view over t1
+CREATE MATERIALIZED VIEW mv2
+PARTITION BY (c3)
+DISTRIBUTED BY HASH (c4)
+REFRESH MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT
+  DATE_TRUNC('day', c1) AS c1_day,
+  DATE_TRUNC('hour', c1) AS c1_hour,
+  c3, c4, c5, c6, c7,
+  SUM(c12) AS sum_surge,
+  SUM(c11) AS sum_distance,
+  SUM(c10) AS sum_fare,
+  COUNT(c12) AS count_surge
+FROM t1
+GROUP BY 1,2,3,4,5,6,7;
+
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+
+function: print_hit_materialized_view("SELECT z.c_district AS c_district_name, CAST(SUM(x.c10) AS DOUBLE) / CAST(SUM(x.c11) AS DOUBLE) AS fare_per_km FROM t1 x LEFT JOIN (SELECT c1, MAX(c5) AS c_district FROM v1 GROUP BY c1) z ON CAST(z.c1 AS VARCHAR) = CAST(x.c4 AS VARCHAR) GROUP BY 1 ORDER BY 1;", "mv1", "mv2")
+-- Aggregated join query
+SELECT z.c_district AS c_district_name, CAST(SUM(x.c10) AS DOUBLE) / CAST(SUM(x.c11) AS DOUBLE) AS fare_per_km FROM t1 x LEFT JOIN (SELECT c1, MAX(c5) AS c_district FROM v1 GROUP BY c1) z ON CAST(z.c1 AS VARCHAR) = CAST(x.c4 AS VARCHAR) GROUP BY 1 ORDER BY 1;


### PR DESCRIPTION
## Why I'm doing:
When `enable_materialized_view_agg_pushdown_rewrite` and `enable_view_based_rewrite` are enabled together, MV rewrite may generated `LogicalViewScanOperator` in plan, but `MVPartitionPruner` cannot handle it:

```
751ms|    [MV TRACE] [REWRITE TF_MV_AGGREGATE_JOIN_PUSH_DOWN_RULE] [InMemo:false] mv rewrite exception, exception message:java.lang.NullPointerException
"	at com.starrocks.sql.optimizer.base.LogicalProperty.derive(LogicalProperty.java:100)"
"	at com.starrocks.sql.optimizer.ExpressionContext.deriveLogicalProperty(ExpressionContext.java:160)"
"	at com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.deriveLogicalProperty(MvUtils.java:1241)"
"	at com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.deriveLogicalProperty(MvUtils.java:1237)"
"	at com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.deriveLogicalProperty(MvUtils.java:1237)"
"	at com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.deriveLogicalProperty(MvUtils.java:1237)"
"	at com.starrocks.sql.optimizer.rule.transformation.materialization.rule.BaseMaterializedViewRewriteRule.doTransform(BaseMaterializedViewRewriteRule.java:229)"
"	at com.starrocks.sql.optimizer.rule.transformation.materialization.rule.BaseMaterializedViewRewriteRule.doTransform(BaseMaterializedViewRewriteRule.java:162)"
"	at com.starrocks.sql.optimizer.rule.transformation.materialization.rule.BaseMaterializedViewRewriteRule.transform(BaseMaterializedViewRewriteRule.java:100)"
"	at com.starrocks.sql.optimizer.task.RewriteTreeTask.applyRules(RewriteTreeTask.java:88)"
"	at com.starrocks.sql.optimizer.task.RewriteTreeTask.rewrite(RewriteTreeTask.java:69)"
"	at com.starrocks.sql.optimizer.task.RewriteTreeTask.rewrite(RewriteTreeTask.java:72)"
"	at com.starrocks.sql.optimizer.task.RewriteTreeTask.execute(RewriteTreeTask.java:58)"
"	at com.starrocks.sql.optimizer.task.SeriallyTaskScheduler.executeTasks(SeriallyTaskScheduler.java:65)"
"	at com.starrocks.sql.optimizer.Optimizer.ruleRewriteIterative(Optimizer.java:1072)"
"	at com.starrocks.sql.optimizer.Optimizer.viewBasedMvRuleRewrite(Optimizer.java:773)"
"	at com.starrocks.sql.optimizer.Optimizer.doRuleBasedMaterializedViewRewrite(Optimizer.java:480)"
"	at com.starrocks.sql.optimizer.Optimizer.ruleBasedMaterializedViewRewriteStage1(Optimizer.java:507)"
"	at com.starrocks.sql.optimizer.Optimizer.logicalRuleRewrite(Optimizer.java:600)"
"	at com.starrocks.sql.optimizer.Optimizer.rewriteAndValidatePlan(Optimizer.java:803)"
"	at com.starrocks.sql.optimizer.Optimizer.optimizeByCost(Optimizer.java:266)"
"	at com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:214)"
"	at com.starrocks.sql.StatementPlanner.createQueryPlan(StatementPlanner.java:300)"
"	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:143)"
"	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:104)"
"	at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:606)"
"	at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:392)"
"	at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:592)"
"	at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:930)"
"	at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:71)"
"	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)"
"	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)"
"	at java.base/java.lang.Thread.run(Thread.java:829)"
```
or
```
java.lang.NullPointerException: Cannot invoke "com.starrocks.analysis.Expr.getType()" because "expr" is null
        at com.starrocks.sql.plan.ScalarOperatorToExpr$Formatter.hackTypeNull(ScalarOperatorToExpr.java:148) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.ScalarOperatorToExpr$Formatter.visitVariableReference(ScalarOperatorToExpr.java:172) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.ScalarOperatorToExpr$Formatter.visitVariableReference(ScalarOperatorToExpr.java:135) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator.accept(ColumnRefOperator.java:131) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.ScalarOperatorToExpr.buildExecExpression(ScalarOperatorToExpr.java:107) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder.lambda$createOutputFragment$1(PlanFragmentBuilder.java:346) ~[starrocks-fe.jar:?]
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder.createOutputFragment(PlanFragmentBuilder.java:348) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder.createPhysicalPlan(PlanFragmentBuilder.java:262) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:400) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:154) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:108) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:621) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:427) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:637) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:986) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:71) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]

```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
