### PR TITLE
[BugFix] Fix the JDBC connection issue that the actual number of JDBC connections may exceed the `jdbc_connection_pool_size` limit.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCConnector.java
@@ -54,6 +54,14 @@ public class JDBCConnector implements Connector {
         if (this.properties.get(JDBCResource.CHECK_SUM) == null) {
             computeDriverChecksum();
         }
+
+        // Try to create jdbc metadata, if failed, it will be created later when `getMetadata`.
+        try {
+            metadata = new JDBCMetadata(properties, catalogName);
+        } catch (Exception e) {
+            metadata = null;
+            LOG.error("Failed to create jdbc metadata on [catalog : {}]", catalogName, e);
+        }
     }
 
     private void validate(String propertyKey) {


### PR DESCRIPTION
## Why I'm doing:
Now we lazily create the JDBC metadata instance only when getting metadata, while the `getMetadata` is not thread safe, which may cause multiple metadata instances are created In high concurrency scenarios if the metadata has never been created before.

Because each metadata contains a jdbc thread pool, resulting the total JDBC connections exceed the `jdbc_connection_pool_size` limit.

## What I'm doing:
As the `getMetadata` is a high frequency operation, so we still keep this function lock-free. And init the metadata when JDBC connector is constructed, to avoid multiple metadata instances are created later when getting metadata.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
