### PR TITLE
[BugFix] Fix dictionary inconsistency in shared-data mode

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -118,11 +118,23 @@ private:
             }
         }
 
-        void add_finished_tablet(int64_t tablet_id) {
+        void add_finished_tablet(int64_t tablet_id, const DeltaWriter* delta_writer) {
             std::lock_guard l(_mtx);
             auto info = _response->add_tablet_vec();
             info->set_tablet_id(tablet_id);
             info->set_schema_hash(0); // required field
+            const auto* dict_valid_info = delta_writer->global_dict_columns_valid_info();
+            const auto* writer_global_dicts = delta_writer->global_dict_map();
+            if (dict_valid_info == nullptr) return;
+            for (const auto& item : *dict_valid_info) {
+                if (item.second && writer_global_dicts != nullptr &&
+                    writer_global_dicts->find(item.first) != writer_global_dicts->end()) {
+                    info->add_valid_dict_cache_columns(item.first);
+                    info->add_valid_dict_collected_version(writer_global_dicts->at(item.first).version);
+                } else {
+                    info->add_invalid_dict_cache_columns(item.first);
+                }
+            }
         }
 
         // NOT thread-safe
@@ -498,12 +510,12 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
                     count_down_latch.count_down();
                     continue;
                 }
-                dw->finish(_finish_mode, [&, id = tablet_id](StatusOr<TxnLogPtr> res) {
+                dw->finish(_finish_mode, [&, id = tablet_id, self = dw.get()](StatusOr<TxnLogPtr> res) {
                     if (!res.ok()) {
                         context->update_status(res.status());
                         LOG(ERROR) << "Fail to finish tablet " << id << ": " << res.status();
                     } else {
-                        context->add_finished_tablet(id);
+                        context->add_finished_tablet(id, self->delta_writer());
                         VLOG(5) << "Finished tablet " << id;
                     }
                     if (_finish_mode == lake::DeltaWriterFinishMode::kDontWriteTxnLog) {
@@ -735,6 +747,7 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
                                               .set_load_id(params.id())
                                               .set_profile(_profile)
                                               .set_bundle_writable_file_context(bundle_writable_file_context)
+                                              .set_global_dicts(&_global_dicts)
                                               .build());
         _delta_writers.emplace(tablet.tablet_id(), std::move(writer));
         tablet_ids.emplace_back(tablet.tablet_id());

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -400,6 +400,10 @@ DeltaWriter* AsyncDeltaWriter::delta_writer() {
     return _impl->delta_writer();
 }
 
+const DictColumnsValidMap* AsyncDeltaWriter::global_dict_columns_valid_info() const {
+    return _impl->delta_writer()->global_dict_columns_valid_info();
+}
+
 StatusOr<AsyncDeltaWriterBuilder::AsyncDeltaWriterPtr> AsyncDeltaWriterBuilder::build() {
     ASSIGN_OR_RETURN(auto writer, DeltaWriterBuilder()
                                           .set_tablet_manager(_tablet_mgr)
@@ -418,6 +422,7 @@ StatusOr<AsyncDeltaWriterBuilder::AsyncDeltaWriterPtr> AsyncDeltaWriterBuilder::
                                           .set_load_id(_load_id)
                                           .set_profile(_profile)
                                           .set_bundle_writable_file_context(_bundle_writable_file_context)
+                                          .set_global_dicts(_global_dicts)
                                           .build());
     auto impl = new AsyncDeltaWriterImpl(std::move(writer));
     return std::make_unique<AsyncDeltaWriter>(impl);

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -22,6 +22,7 @@
 #include "common/statusor.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "gutil/macros.h"
+#include "runtime/global_dict/types_fwd_decl.h"
 #include "storage/lake/delta_writer_finish_mode.h"
 #include "util/runtime_profile.h"
 
@@ -115,6 +116,8 @@ public:
     [[nodiscard]] int64_t last_write_ts() const;
 
     DeltaWriter* delta_writer();
+
+    const DictColumnsValidMap* global_dict_columns_valid_info() const;
 
 private:
     AsyncDeltaWriterImpl* _impl;
@@ -210,6 +213,11 @@ public:
         return *this;
     }
 
+    AsyncDeltaWriterBuilder& set_global_dicts(GlobalDictByNameMaps* global_dicts) {
+        _global_dicts = global_dicts;
+        return *this;
+    }
+
     StatusOr<AsyncDeltaWriterPtr> build();
 
 private:
@@ -229,6 +237,7 @@ private:
     PUniqueId _load_id;
     RuntimeProfile* _profile{nullptr};
     BundleWritableFileContext* _bundle_writable_file_context{nullptr};
+    GlobalDictByNameMaps* _global_dicts = nullptr;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -21,6 +21,7 @@
 #include "common/statusor.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "gutil/macros.h"
+#include "runtime/global_dict/types_fwd_decl.h"
 #include "storage/lake/delta_writer_finish_mode.h"
 #include "storage/memtable_flush_executor.h"
 #include "util/runtime_profile.h"
@@ -159,6 +160,9 @@ public:
 
     bool has_spill_block() const;
 
+    const DictColumnsValidMap* global_dict_columns_valid_info() const;
+    const GlobalDictByNameMaps* global_dict_map() const;
+
 private:
     DeltaWriterImpl* _impl;
 };
@@ -257,6 +261,11 @@ public:
         return *this;
     }
 
+    DeltaWriterBuilder& set_global_dicts(GlobalDictByNameMaps* global_dicts) {
+        _global_dicts = global_dicts;
+        return *this;
+    }
+
     StatusOr<DeltaWriterPtr> build();
 
 private:
@@ -277,6 +286,7 @@ private:
     PUniqueId _load_id;
     RuntimeProfile* _profile{nullptr};
     BundleWritableFileContext* _bundle_writable_file_context{nullptr};
+    GlobalDictByNameMaps* _global_dicts = nullptr;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -94,7 +94,6 @@ Status HorizontalGeneralTabletWriter::reset_segment_writer(bool eos) {
     SegmentWriterOptions opts;
     opts.is_compaction = _is_compaction;
     opts.global_dicts = _global_dicts;
-    // opts.global_dicts =
     WritableFileOptions wopts;
     if (config::enable_transparent_data_encryption) {
         ASSIGN_OR_RETURN(auto pair, KeyCache::instance().create_encryption_meta_pair_using_current_kek());

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -34,9 +34,11 @@ namespace starrocks::lake {
 HorizontalGeneralTabletWriter::HorizontalGeneralTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                                              std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
                                                              bool is_compaction, ThreadPool* flush_pool,
-                                                             BundleWritableFileContext* bundle_file_context)
+                                                             BundleWritableFileContext* bundle_file_context,
+                                                             GlobalDictByNameMaps* global_dicts)
         : TabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id, is_compaction, flush_pool),
-          _bundle_file_context(bundle_file_context) {}
+          _bundle_file_context(bundle_file_context),
+          _global_dicts(global_dicts) {}
 
 HorizontalGeneralTabletWriter::~HorizontalGeneralTabletWriter() = default;
 
@@ -91,6 +93,8 @@ Status HorizontalGeneralTabletWriter::reset_segment_writer(bool eos) {
     auto name = gen_segment_filename(_txn_id);
     SegmentWriterOptions opts;
     opts.is_compaction = _is_compaction;
+    opts.global_dicts = _global_dicts;
+    // opts.global_dicts =
     WritableFileOptions wopts;
     if (config::enable_transparent_data_encryption) {
         ASSIGN_OR_RETURN(auto pair, KeyCache::instance().create_encryption_meta_pair_using_current_kek());
@@ -142,6 +146,18 @@ Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
             segment->set_path(segment_path);
             segment->set_encryption_meta(_seg_writer->encryption_meta());
         }
+        const auto& seg_global_dict_columns_valid_info = _seg_writer->global_dict_columns_valid_info();
+        for (const auto& it : seg_global_dict_columns_valid_info) {
+            if (!it.second) {
+                _global_dict_columns_valid_info[it.first] = false;
+            } else {
+                if (const auto& iter = _global_dict_columns_valid_info.find(it.first);
+                    iter == _global_dict_columns_valid_info.end()) {
+                    _global_dict_columns_valid_info[it.first] = true;
+                }
+            }
+        }
+
         _seg_writer.reset();
     }
     return Status::OK();

--- a/be/src/storage/lake/general_tablet_writer.h
+++ b/be/src/storage/lake/general_tablet_writer.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "gutil/macros.h"
+#include "runtime/global_dict/types_fwd_decl.h"
 #include "storage/lake/tablet_writer.h"
 
 namespace starrocks {
@@ -36,7 +37,8 @@ public:
     explicit HorizontalGeneralTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                            std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
                                            bool is_compaction, ThreadPool* flush_pool = nullptr,
-                                           BundleWritableFileContext* bundle_file_context = nullptr);
+                                           BundleWritableFileContext* bundle_file_context = nullptr,
+                                           GlobalDictByNameMaps* global_dicts = nullptr);
 
     ~HorizontalGeneralTabletWriter() override;
 
@@ -81,6 +83,7 @@ protected:
 
     std::unique_ptr<SegmentWriter> _seg_writer;
     BundleWritableFileContext* _bundle_file_context = nullptr;
+    GlobalDictByNameMaps* _global_dicts = nullptr;
 };
 
 class VerticalGeneralTabletWriter : public TabletWriter {

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -32,9 +32,10 @@ namespace starrocks::lake {
 HorizontalPkTabletWriter::HorizontalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                                    std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
                                                    ThreadPool* flush_pool, bool is_compaction,
-                                                   BundleWritableFileContext* bundle_file_context)
+                                                   BundleWritableFileContext* bundle_file_context,
+                                                   GlobalDictByNameMaps* global_dicts)
         : HorizontalGeneralTabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id, is_compaction, flush_pool,
-                                        bundle_file_context),
+                                        bundle_file_context, global_dicts),
           _rowset_txn_meta(std::make_unique<RowsetTxnMetaPB>()) {
     if (is_compaction) {
         auto rows_mapper_filename = lake_rows_mapper_filename(tablet_id, txn_id);

--- a/be/src/storage/lake/pk_tablet_writer.h
+++ b/be/src/storage/lake/pk_tablet_writer.h
@@ -15,10 +15,10 @@
 #pragma once
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gutil/macros.h"
+#include "runtime/global_dict/types_fwd_decl.h"
 #include "storage/lake/general_tablet_writer.h"
 
 namespace starrocks {
@@ -34,7 +34,8 @@ public:
     explicit HorizontalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                       std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
                                       ThreadPool* flush_pool, bool is_compaction,
-                                      BundleWritableFileContext* bundle_file_context = nullptr);
+                                      BundleWritableFileContext* bundle_file_context = nullptr,
+                                      GlobalDictByNameMaps* _global_dicts = nullptr);
 
     ~HorizontalPkTabletWriter() override;
 

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -21,6 +21,7 @@
 #include "fs/fs.h" // FileInfo
 #include "gen_cpp/data.pb.h"
 #include "gen_cpp/lake_types.pb.h"
+#include "runtime/global_dict/types_fwd_decl.h"
 #include "storage/lake/location_provider.h"
 #include "storage/tablet_schema.h"
 
@@ -140,6 +141,8 @@ public:
 
     const OlapWriterStatistics& stats() const { return _stats; }
 
+    const DictColumnsValidMap& global_dict_columns_valid_info() const { return _global_dict_columns_valid_info; }
+
 protected:
     TabletManager* _tablet_mgr;
     int64_t _tablet_id;
@@ -157,6 +160,7 @@ protected:
     OlapWriterStatistics _stats;
 
     bool _is_compaction = false;
+    DictColumnsValidMap _global_dict_columns_valid_info;
 };
 
 } // namespace lake

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
@@ -495,7 +496,7 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                             .setOp(newOlapScan)
                             .setInputs(Lists.newArrayList())
                             .setLogicalProperty(rewriteLogicProperty(optExpression.getLogicalProperty(),
-                            context.stringColumnIdToDictColumnIds))
+                                    context.stringColumnIdToDictColumnIds))
                             .setStatistics(optExpression.getStatistics())
                             .setCost(optExpression.getCost());
                     return visitProjectionAfter(builder.build(), context);
@@ -947,7 +948,8 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                 }
 
                 ColumnStatistic columnStatistic =
-                        GlobalStateMgr.getCurrentState().getStatisticStorage().getColumnStatistic(table, column.getName());
+                        GlobalStateMgr.getCurrentState().getStatisticStorage()
+                                .getColumnStatistic(table, column.getName());
                 // Condition 2: the varchar column is low cardinality string column
                 if (!FeConstants.USE_MOCK_DICT_MANAGER && (columnStatistic.isUnknown() ||
                         columnStatistic.getDistinctValuesCount() > CacheDictManager.LOW_CARDINALITY_THRESHOLD)) {
@@ -1015,7 +1017,8 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                 .setInputs(Lists.newArrayList(childExpr))
                 .setStatistics(childExpr.get(0).getStatistics())
                 .setCost(childExpr.get(0).getCost())
-                .setLogicalProperty(DecodeVisitor.rewriteLogicProperty(decodeProperty, decodeOperator.getDictIdToStringsId()));
+                .setLogicalProperty(
+                        DecodeVisitor.rewriteLogicProperty(decodeProperty, decodeOperator.getDictIdToStringsId()));
         context.clear();
         return builder.build();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -926,9 +926,8 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
 
         for (PhysicalOlapScanOperator scanOperator : scanOperators) {
             OlapTable table = (OlapTable) scanOperator.getTable();
-            long version = table.getPartitions().stream().flatMap(
-                            partition -> partition.getSubPartitions().stream().map(PhysicalPartition::getVisibleVersionTime))
-                    .max(Long::compareTo).orElse(0L);
+            long version = table.getPartitions().stream().flatMap(p -> p.getSubPartitions().stream()).map(
+                    PhysicalPartition::getVisibleVersionTime).max(Long::compareTo).orElse(0L);
 
             if ((table.getKeysType().equals(KeysType.PRIMARY_KEYS))) {
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -926,7 +926,8 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
 
         for (PhysicalOlapScanOperator scanOperator : scanOperators) {
             OlapTable table = (OlapTable) scanOperator.getTable();
-            long version = table.getPartitions().stream().map(p -> p.getDefaultPhysicalPartition().getVisibleVersionTime())
+            long version = table.getPartitions().stream().flatMap(
+                            partition -> partition.getSubPartitions().stream().map(PhysicalPartition::getVisibleVersionTime))
                     .max(Long::compareTo).orElse(0L);
 
             if ((table.getKeysType().equals(KeysType.PRIMARY_KEYS))) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -614,9 +614,8 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
     public DecodeInfo visitPhysicalOlapScan(OptExpression optExpression, DecodeInfo context) {
         PhysicalOlapScanOperator scan = optExpression.getOp().cast();
         OlapTable table = (OlapTable) scan.getTable();
-        long version = table.getPartitions().stream().flatMap(
-                            partition -> partition.getSubPartitions().stream().map(PhysicalPartition::getVisibleVersionTime))
-                    .max(Long::compareTo).orElse(0L);
+        long version = table.getPartitions().stream().flatMap(p -> p.getSubPartitions().stream()).map(
+                PhysicalPartition::getVisibleVersionTime).max(Long::compareTo).orElse(0L);
 
         if (table.hasForbiddenGlobalDict()) {
             return DecodeInfo.EMPTY;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.FeConstants;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -614,8 +614,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
     public DecodeInfo visitPhysicalOlapScan(OptExpression optExpression, DecodeInfo context) {
         PhysicalOlapScanOperator scan = optExpression.getOp().cast();
         OlapTable table = (OlapTable) scan.getTable();
-        long version = table.getPartitions().stream().map(p -> p.getDefaultPhysicalPartition().getVisibleVersionTime())
-                .max(Long::compareTo).orElse(0L);
+        long version = table.getPartitions().stream().flatMap(
+                            partition -> partition.getSubPartitions().stream().map(PhysicalPartition::getVisibleVersionTime))
+                    .max(Long::compareTo).orElse(0L);
 
         if (table.hasForbiddenGlobalDict()) {
             return DecodeInfo.EMPTY;


### PR DESCRIPTION
## Why I'm doing:

1. In a randomly distributed table, the default partition's version time is immutable.
2. Under shared-data, after loading data , the dictionary is not updated correctly for version or expired

These two issues can lead to inconsistent dictionaries in shared-data mode.

## What I'm doing:

we should run case: test_continuous_insert in shared-data mode.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
