### PR TITLE
[Enhancement] share file io in iceberg metadata scanner

### DIFF
--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/SerializableTable.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/SerializableTable.java
@@ -61,11 +61,13 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class SerializableTable implements Table, Serializable, HasTableOperations {
 
     private final String name;
     private final String location;
+    private final UUID uuid;
     private final String metadataFileLocation;
     private final Map<String, String> properties;
     private final String schemaAsJson;
@@ -85,6 +87,7 @@ public class SerializableTable implements Table, Serializable, HasTableOperation
     public SerializableTable(Table table, FileIO fileIO) {
         this.name = table.name();
         this.location = table.location();
+        this.uuid = table.uuid();
         this.metadataFileLocation = metadataFileLocation(table);
         this.properties = SerializableMap.copyOf(table.properties());
         this.schemaAsJson = SchemaParser.toJson(table.schema());
@@ -152,6 +155,11 @@ public class SerializableTable implements Table, Serializable, HasTableOperation
     @Override
     public Map<String, String> properties() {
         return properties;
+    }
+
+    @Override
+    public UUID uuid() {
+        return uuid;
     }
 
     @Override

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/AbstractIcebergMetadataScanner.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/AbstractIcebergMetadataScanner.java
@@ -20,6 +20,7 @@ import com.starrocks.jni.connector.ScannerHelper;
 import com.starrocks.jni.connector.SelectedFields;
 import com.starrocks.utils.loader.ThreadContextClassLoader;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.io.FileIO;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -41,7 +42,10 @@ public abstract class AbstractIcebergMetadataScanner extends ConnectorScanner {
     private final int fetchSize;
     protected final ClassLoader classLoader;
     protected Table table;
+    protected FileIO fileIO;
     protected String timezone;
+
+    private static final TableFileIOCache TABLE_FILE_IO_CACHE = new TableFileIOCache(3600, 1000);
 
     public AbstractIcebergMetadataScanner(int fetchSize, Map<String, String> params) {
         this.fetchSize = fetchSize;
@@ -58,6 +62,7 @@ public abstract class AbstractIcebergMetadataScanner extends ConnectorScanner {
     public void open() throws IOException {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             this.table = deserializeFromBase64(serializedTable);
+            this.fileIO = TABLE_FILE_IO_CACHE.get(table);
             parseRequiredTypes();
             initOffHeapTableWriter(requiredTypes, requiredFields, fetchSize);
             doOpen();

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/AbstractIcebergMetadataScanner.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/AbstractIcebergMetadataScanner.java
@@ -45,7 +45,9 @@ public abstract class AbstractIcebergMetadataScanner extends ConnectorScanner {
     protected FileIO fileIO;
     protected String timezone;
 
-    private static final TableFileIOCache TABLE_FILE_IO_CACHE = new TableFileIOCache(3600, 1000);
+    // expire after 600 seconds long enough for most credential expiration
+    // max 1000 entries large enough for most use cases
+    private static final TableFileIOCache TABLE_FILE_IO_CACHE = new TableFileIOCache(600, 1000);
 
     public AbstractIcebergMetadataScanner(int fetchSize, Map<String, String> params) {
         this.fetchSize = fetchSize;

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergFilesTableScanner.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergFilesTableScanner.java
@@ -94,13 +94,13 @@ public class IcebergFilesTableScanner extends AbstractIcebergMetadataScanner {
         List<String> scanColumns;
         if (manifestFile.content() == ManifestContent.DATA) {
             scanColumns = loadColumnStats ? SCAN_WITH_STATS_COLUMNS : SCAN_COLUMNS;
-            reader = ManifestFiles.read(manifestFile, table.io(), specs)
+            reader = ManifestFiles.read(manifestFile, fileIO, specs)
                     .select(scanColumns)
                     .caseSensitive(false)
                     .iterator();
         } else {
             scanColumns = loadColumnStats ? DELETE_SCAN_WITH_STATS_COLUMNS : DELETE_SCAN_COLUMNS;
-            reader = ManifestFiles.readDeleteManifest(manifestFile, table.io(), specs)
+            reader = ManifestFiles.readDeleteManifest(manifestFile, fileIO, specs)
                     .select(scanColumns)
                     .caseSensitive(false)
                     .iterator();

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergManifestsTableScanner.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergManifestsTableScanner.java
@@ -71,7 +71,7 @@ public class IcebergManifestsTableScanner extends AbstractIcebergMetadataScanner
     @Override
     protected void initReader() {
         if (table.currentSnapshot() != null) {
-            reader = table.currentSnapshot().allManifests(table.io()).iterator();
+            reader = table.currentSnapshot().allManifests(fileIO).iterator();
         }
     }
 

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergMetadataScanner.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergMetadataScanner.java
@@ -146,14 +146,14 @@ public class IcebergMetadataScanner extends AbstractIcebergMetadataScanner {
         List<String> scanColumns;
         if (manifestFile.content() == ManifestContent.DATA) {
             scanColumns = loadColumnStats ? SCAN_WITH_STATS_COLUMNS : SCAN_COLUMNS;
-            reader = ManifestFiles.read(manifestFile, table.io(), specs)
+            reader = ManifestFiles.read(manifestFile, fileIO, specs)
                     .select(scanColumns)
                     .filterRows(predicate)
                     .caseSensitive(false)
                     .iterator();
         } else {
             scanColumns = loadColumnStats ? DELETE_SCAN_WITH_STATS_COLUMNS : DELETE_SCAN_COLUMNS;
-            reader = ManifestFiles.readDeleteManifest(manifestFile, table.io(), specs)
+            reader = ManifestFiles.readDeleteManifest(manifestFile, fileIO, specs)
                     .select(scanColumns)
                     .filterRows(predicate)
                     .caseSensitive(false)

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionsTableScanner.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionsTableScanner.java
@@ -102,12 +102,12 @@ public class IcebergPartitionsTableScanner extends AbstractIcebergMetadataScanne
     protected void initReader() {
         Map<Integer, PartitionSpec> specs = table.specs();
         if (manifestFile.content() == ManifestContent.DATA) {
-            reader = ManifestFiles.read(manifestFile, table.io(), specs)
+            reader = ManifestFiles.read(manifestFile, fileIO, specs)
                     .select(SCAN_COLUMNS)
                     .caseSensitive(false)
                     .iterator();
         } else {
-            reader = ManifestFiles.readDeleteManifest(manifestFile, table.io(), specs)
+            reader = ManifestFiles.readDeleteManifest(manifestFile, fileIO, specs)
                     .select(SCAN_COLUMNS)
                     .caseSensitive(false)
                     .iterator();

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/TableFileIOCache.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/TableFileIOCache.java
@@ -25,8 +25,12 @@ public class TableFileIOCache {
     private final Cache<String, FileIO> cache;
 
     public TableFileIOCache(long expireSeconds, long capacity) {
+        // note: reason why not use expireAfterAccess is that
+        // fileio could be bound to credentials, and credentials could be expired.
+        // some fileio implementations may not handle this well
+        // so for safety, we use expireAfterWrite
         this.cache = CacheBuilder.newBuilder()
-                .expireAfterAccess(expireSeconds, TimeUnit.SECONDS)
+                .expireAfterWrite(expireSeconds, TimeUnit.SECONDS)
                 .maximumSize(capacity)
                 .build();
     }

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/TableFileIOCache.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/TableFileIOCache.java
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.io.FileIO;
+
+import java.util.concurrent.TimeUnit;
+
+public class TableFileIOCache {
+    private final Cache<String, FileIO> cache;
+
+    public TableFileIOCache(long expireSeconds, long capacity) {
+        this.cache = CacheBuilder.newBuilder()
+                .expireAfterAccess(expireSeconds, TimeUnit.SECONDS)
+                .maximumSize(capacity)
+                .build();
+    }
+
+    public FileIO get(Table table) {
+        String cacheKey = generateCacheKey(table);
+        FileIO fileIO = cache.getIfPresent(cacheKey);
+        if (fileIO == null) {
+            fileIO = table.io();
+            cache.put(cacheKey, fileIO);
+        }
+        return fileIO;
+    }
+
+    private static String generateCacheKey(Table table) {
+        return table.name() + "_" + table.uuid();
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

We came across such excpetion when querying a huge iceberg table

```
Caused by: software.amazon.awssdk.core.exception.SdkClientException: Failed to load credentials from IMDS.
        at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:111)
        at software.amazon.awssdk.core.exception.SdkClientException.create(SdkClientException.java:47)
       ...
        at software.amazon.awssdk.services.s3.DefaultS3Client.getObject(DefaultS3Client.java:5848)
        at org.apache.iceberg.aws.s3.S3InputStream.openStream(S3InputStream.java:240)
        at org.apache.iceberg.aws.s3.S3InputStream.openStream(S3InputStream.java:225)
        at org.apache.iceberg.aws.s3.S3InputStream.positionStream(S3InputStream.java:221)
        at org.apache.iceberg.aws.s3.S3InputStream.read(S3InputStream.java:143)
        at org.apache.iceberg.avro.AvroIO$AvroInputStreamAdapter.read(AvroIO.java:117)
        at org.apache.avro.file.DataFileReader.openReader(DataFileReader.java:66)
        at org.apache.iceberg.avro.AvroIterable.newFileReader(AvroIterable.java:102)
        at org.apache.iceberg.avro.AvroIterable.iterator(AvroIterable.java:77)
        at org.apache.iceberg.io.CloseableIterable$7$1.<init>(CloseableIterable.java:188)
        at org.apache.iceberg.io.CloseableIterable$7.iterator(CloseableIterable.java:187)
        at org.apache.iceberg.io.CloseableIterable.lambda$filter$0(CloseableIterable.java:109)
        at org.apache.iceberg.io.CloseableIterable$2.iterator(CloseableIterable.java:72)
        at org.apache.iceberg.io.CloseableIterable.lambda$filter$1(CloseableIterable.java:136)
        at org.apache.iceberg.io.CloseableIterable$2.iterator(CloseableIterable.java:72)
        at org.apache.iceberg.io.CloseableIterable$7$1.<init>(CloseableIterable.java:188)
        at org.apache.iceberg.io.CloseableIterable$7.iterator(CloseableIterable.java:187)
        at org.apache.iceberg.ManifestReader.iterator(ManifestReader.java:305)
        at com.starrocks.connector.iceberg.IcebergMetadataScanner.initReader(IcebergMetadataScanner.java:153)
        at com.starrocks.connector.iceberg.AbstractIcebergMetadataScanner.open(AbstractIcebergMetadataScanner.java:64)
Caused by: software.amazon.awssdk.core.exception.SdkClientException: Failed to load credentials from metadata service.
        at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:111)
        at software.amazon.awssdk.auth.credentials.internal.HttpCredentialsLoader.loadCredentials(HttpCredentialsLoader.java:82)
        at software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider.refreshCredentials(InstanceProfileCredentialsProvider.java:155)
        ... 67 more
Caused by: java.net.SocketTimeoutException: connect timed out
        at java.base/java.net.PlainSocketImpl.socketConnect(Native Method)
        at java.base/java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:412)
        at java.base/java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:255)
        at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:237)
        at java.base/java.net.Socket.connect(Socket.java:609)
        at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:177)
        at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:509)
        at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:604)
        at java.base/sun.net.www.http.HttpClient.<init>(HttpClient.java:277)
        at java.base/sun.net.www.http.HttpClient.New(HttpClient.java:376)
        at java.base/sun.net.www.http.HttpClient.New(HttpClient.java:397)
        at java.base/sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:1268)
        at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1247)
        at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1096)
        at java.base/sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:1030)
        at software.amazon.awssdk.regions.internal.util.ConnectionUtils.connectToEndpoint(ConnectionUtils.java:54)
        at software.amazon.awssdk.regions.internal.util.ConnectionUtils.connectToEndpoint(ConnectionUtils.java:60)
        at software.amazon.awssdk.regions.util.HttpResourcesUtils.readResource(HttpResourcesUtils.java:112)
        at software.amazon.awssdk.regions.util.HttpResourcesUtils.readResource(HttpResourcesUtils.java:91)
        at software.amazon.awssdk.auth.credentials.internal.HttpCredentialsLoader.loadCredentials(HttpCredentialsLoader.java:60)
```

and my hypothesis is that, every be scanner has to connect IMDS for credentials, so quickly IMDS service will be overloaded. 

## What I'm doing:

To solev this problem, we can share FILEIO across scanner.  So after each file io has get credential, it deos not need to connect IMDS any more.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
