### PR TITLE
[BugFix] Fix aggregate publish bug with lake rollup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -682,8 +682,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
             OlapTable table = getTableOrThrow(db, tableId);
             boolean useAggregatePublish = table.isFileBundling();
-            AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
             for (long partitionId : physicalPartitionIdToRollupIndex.keySet()) {
+                AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(partitionId);
                 Preconditions.checkState(physicalPartition != null, partitionId);
                 List<MaterializedIndex> allMaterializedIndex = physicalPartition
@@ -723,9 +723,10 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                     Utils.createSubRequestForAggregatePublish(allOtherPartitionTablets, Lists.newArrayList(originTxnInfo), 
                             commitVersion - 1, commitVersion, null, computeResource, request);
                 }
-            }
-            if (useAggregatePublish) {
-                Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null);
+
+                if (useAggregatePublish) {
+                    Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null);
+                }
             }
             return true;
         } catch (Exception e) {


### PR DESCRIPTION
## Why I'm doing:
If table enable `file_bundling`, all tables under the same partition should be publish at the same time. But the tablet under different partitions should be published separately.

When creating a `LakeRollup`, the tablets under different partitions maybe published at the same time.
## What I'm doing:
Fix the bug

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
