### PR TITLE
[BugFix] Executable segments generated by JIT are not released when it is evicted from JIT cache

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1557,10 +1557,15 @@ CONF_mInt32(olap_string_max_length, "1048576");
 // Skip get from pk index when light pk compaction publish is enabled
 CONF_mBool(enable_light_pk_compaction_publish, "true");
 
+// jit LRU object cache size for total 32 shards, it will be an auto value if it < 0
+// mem_limit = system memory or process memory limit if set.
+// if mem_limit < 16 GB, disable JIT.
+// else it  = min(mem_limit*0.01, 4MB);
+CONF_mInt64(jit_lru_object_cache_size, "0");
 // jit LRU cache size for total 32 shards, it will be an auto value if it <=0:
 // mem_limit = system memory or process memory limit if set.
 // if mem_limit < 16 GB, disable JIT.
-// else it = min(mem_limit*0.01, 1GB)
+// else it = min(mem_limit*0.01, 4MB)
 CONF_mInt64(jit_lru_cache_size, "0");
 
 CONF_mInt64(arrow_io_coalesce_read_max_buffer_size, "8388608");

--- a/be/src/exprs/jit/jit_expr.h
+++ b/be/src/exprs/jit/jit_expr.h
@@ -36,7 +36,7 @@ public:
 
     Expr* clone(ObjectPool* pool) const override { return JITExpr::create(pool, _expr); }
 
-    bool is_jit_compiled() { return _jit_function != nullptr; }
+    bool is_jit_compiled() { return _jit_callable != nullptr; }
 
     void set_uncompilable_children(RuntimeState* state);
 
@@ -54,8 +54,7 @@ private:
     // The original expression.
     Expr* _expr;
     bool _is_prepared = false;
-    JITScalarFunction _jit_function = nullptr;
-    std::unique_ptr<JitObjectCache> _jit_obj_cache;
+    JITCallablePtr _jit_callable;
 };
 
 } // namespace starrocks

--- a/be/src/http/CMakeLists.txt
+++ b/be/src/http/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(Webserver STATIC
   action/update_config_action.cpp
   action/runtime_filter_cache_action.cpp
   action/query_cache_action.cpp
+  action/jit_cache_action.cpp
   action/datacache_action.cpp
   action/pipeline_blocking_drivers_action.cpp
   action/lake/dump_tablet_metadata_action.cpp

--- a/be/src/http/action/jit_cache_action.cpp
+++ b/be/src/http/action/jit_cache_action.cpp
@@ -1,0 +1,149 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http/action/jit_cache_action.h"
+
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/stringbuffer.h>
+
+#include <string>
+
+#include "common/logging.h"
+#include "exprs/jit/jit_engine.h"
+#include "gutil/strings/substitute.h"
+#include "http/http_channel.h"
+#include "http/http_headers.h"
+#include "http/http_request.h"
+#include "http/http_status.h"
+
+namespace starrocks {
+
+const static std::string HEADER_JSON = "application/json";
+const static std::string ACTION_KEY = "action";
+const static std::string ACTION_STAT = "stat";
+const static std::string ACTION_INVALIDATE_ALL = "invalidate_all";
+
+void JITCacheAction::handle(HttpRequest* req) {
+    VLOG_ROW << req->debug_string();
+    const auto& action = req->param(ACTION_KEY);
+    if (req->method() == HttpMethod::GET) {
+        if (action == ACTION_STAT) {
+            _handle_stat(req);
+        } else {
+            _handle_error(req, strings::Substitute("Not support GET method: '$0'", req->uri()));
+        }
+    } else if (req->method() == HttpMethod::PUT) {
+        if (action == ACTION_INVALIDATE_ALL) {
+            _handle_invalidate_all(req);
+        } else {
+            _handle_error(req, strings::Substitute("Not support PUT method: '$0'", req->uri()));
+        }
+    } else {
+        _handle_error(req,
+                      strings::Substitute("Not support $0 method: '$1'", to_method_desc(req->method()), req->uri()));
+    }
+}
+void JITCacheAction::_handle(HttpRequest* req, const std::function<void(rapidjson::Document&)>& func) {
+    rapidjson::Document root;
+    root.SetObject();
+    func(root);
+    rapidjson::StringBuffer strbuf;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(strbuf);
+    root.Accept(writer);
+    req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.c_str());
+    HttpChannel::send_reply(req, HttpStatus::OK, strbuf.GetString());
+}
+void JITCacheAction::_handle_stat(HttpRequest* req) {
+    auto* jit_engine = JITEngine::get_instance();
+    _handle(req, [=](rapidjson::Document& root) {
+        auto& allocator = root.GetAllocator();
+
+        if (jit_engine == nullptr) {
+            root.AddMember("error", rapidjson::StringRef("JITEngine is nullptr"), allocator);
+            return;
+        }
+        auto* object_cache = jit_engine->get_object_cache();
+        auto* callable_cache = jit_engine->get_callable_cache();
+        rapidjson::Value object_cache_obj(rapidjson::kObjectType);
+        if (object_cache == nullptr) {
+            object_cache_obj.AddMember("error", rapidjson::StringRef("JITObjectCache is nullptr"), allocator);
+        } else {
+            object_cache_obj.AddMember("capacity", rapidjson::Value(object_cache->get_capacity()), allocator);
+            object_cache_obj.AddMember("usage", rapidjson::Value(object_cache->get_memory_usage()), allocator);
+            auto usage_ratio = double(object_cache->get_memory_usage()) /
+                               double(object_cache->get_capacity() == 0 ? 1 : object_cache->get_capacity());
+            object_cache_obj.AddMember("usage_ratio", rapidjson::Value(usage_ratio), allocator);
+            object_cache_obj.AddMember("lookup_count", rapidjson::Value(object_cache->get_lookup_count()), allocator);
+            object_cache_obj.AddMember("hit_count", rapidjson::Value(object_cache->get_hit_count()), allocator);
+            auto hit_ratio = double(object_cache->get_hit_count()) /
+                             double(object_cache->get_lookup_count() == 0 ? 1 : object_cache->get_lookup_count());
+            object_cache_obj.AddMember("hit_ratio", rapidjson::Value(hit_ratio), allocator);
+        }
+        root.AddMember("object_cache", object_cache_obj, allocator);
+
+        rapidjson::Value callable_cache_obj(rapidjson::kObjectType);
+        if (callable_cache == nullptr) {
+            callable_cache_obj.AddMember("error", rapidjson::StringRef("JITCallableCache is nullptr"), allocator);
+        } else {
+            callable_cache_obj.AddMember("capacity", rapidjson::Value(callable_cache->get_capacity()), allocator);
+            callable_cache_obj.AddMember("usage", rapidjson::Value(callable_cache->get_memory_usage()), allocator);
+            auto usage_ratio = double(callable_cache->get_memory_usage()) /
+                               double(callable_cache->get_capacity() == 0 ? 1 : callable_cache->get_capacity());
+            callable_cache_obj.AddMember("usage_ratio", rapidjson::Value(usage_ratio), allocator);
+            callable_cache_obj.AddMember("lookup_count", rapidjson::Value(callable_cache->get_lookup_count()),
+                                         allocator);
+            callable_cache_obj.AddMember("hit_count", rapidjson::Value(callable_cache->get_hit_count()), allocator);
+            auto hit_ratio = double(callable_cache->get_hit_count()) /
+                             double(callable_cache->get_lookup_count() == 0 ? 1 : callable_cache->get_lookup_count());
+            callable_cache_obj.AddMember("hit_ratio", rapidjson::Value(hit_ratio), allocator);
+        }
+        root.AddMember("callable_cache", callable_cache_obj, allocator);
+    });
+}
+
+void JITCacheAction::_handle_invalidate_all(HttpRequest* req) {
+    auto* jit_engine = JITEngine::get_instance();
+    _handle(req, [&](rapidjson::Document& root) {
+        auto& allocator = root.GetAllocator();
+        if (jit_engine == nullptr) {
+            root.AddMember("error", rapidjson::StringRef("JITEngine is nullptr"), allocator);
+            return;
+        }
+        auto* object_cache = jit_engine->get_object_cache();
+        auto* callable_cache = jit_engine->get_callable_cache();
+        auto invalidate = [](Cache* cache) {
+            auto old_capacity = cache->get_capacity();
+            // set capacity of cache to zero, the cache shall prune all cache entries.
+            cache->set_capacity(0);
+            cache->set_capacity(old_capacity);
+        };
+        if (object_cache != nullptr) {
+            invalidate(object_cache);
+        }
+        if (callable_cache != nullptr) {
+            invalidate(callable_cache);
+        }
+        root.AddMember("status", rapidjson::StringRef("OK"), allocator);
+    });
+}
+
+void JITCacheAction::_handle_error(HttpRequest* req, const std::string& err_msg) {
+    _handle(req, [err_msg](rapidjson::Document& root) {
+        auto& allocator = root.GetAllocator();
+        root.AddMember("error", rapidjson::Value(err_msg.c_str(), err_msg.size()), allocator);
+    });
+}
+
+} // namespace starrocks

--- a/be/src/http/action/jit_cache_action.h
+++ b/be/src/http/action/jit_cache_action.h
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/rapidjson.h>
+#include <rapidjson/stringbuffer.h>
+
+#include <functional>
+#include <mutex>
+#include <unordered_map>
+
+#include "http/http_handler.h"
+#include "runtime/exec_env.h"
+
+namespace starrocks {
+
+class JITCacheAction : public HttpHandler {
+public:
+    explicit JITCacheAction() {}
+    ~JITCacheAction() override = default;
+
+    void handle(HttpRequest* req) override;
+
+private:
+    void _handle(HttpRequest* req, const std::function<void(rapidjson::Document& root)>& func);
+    void _handle_stat(HttpRequest* req);
+    void _handle_invalidate_all(HttpRequest* req);
+    void _handle_error(HttpRequest* req, const std::string& error_msg);
+};
+
+} // namespace starrocks

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -43,6 +43,7 @@
 #include "http/action/datacache_action.h"
 #include "http/action/greplog_action.h"
 #include "http/action/health_action.h"
+#include "http/action/jit_cache_action.h"
 #include "http/action/lake/dump_tablet_metadata_action.h"
 #include "http/action/memory_metrics_action.h"
 #include "http/action/meta_action.h"
@@ -262,6 +263,11 @@ Status HttpServiceBE::start() {
     _ev_http_server->register_handler(HttpMethod::GET, "/api/query_cache/{action}", query_cache_action);
     _ev_http_server->register_handler(HttpMethod::PUT, "/api/query_cache/{action}", query_cache_action);
     _http_handlers.emplace_back(query_cache_action);
+
+    auto* jit_cache_action = new JITCacheAction();
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/jit_cache/{action}", jit_cache_action);
+    _ev_http_server->register_handler(HttpMethod::PUT, "/api/jit_cache/{action}", jit_cache_action);
+    _http_handlers.emplace_back(jit_cache_action);
 
     auto* datacache_action = new DataCacheAction(_cache_env->local_cache());
     _ev_http_server->register_handler(HttpMethod::GET, "/api/datacache/{action}", datacache_action);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -144,7 +144,7 @@ set(EXEC_FILES
         ./exprs/function_helper_test.cpp
         ./exprs/in_predicate_test.cpp
         ./exprs/is_null_predicate_test.cpp
-        ./exprs/jit_func_cache_test.cpp
+        ./exprs/jit_cache_test.cpp
         ./exprs/json_functions_test.cpp
         ./exprs/flat_json_functions_test.cpp
         ./exprs/lambda_array_expr_test.cpp


### PR DESCRIPTION
## Why I'm doing:
The JIT cache design is flawed, primarily because it confuses the two distinct stages:
1. Compile: IR → Object
2. Link: Object → StandardSegments (executable memory)

In reality, two separate caches are needed:
1. An Object cache — LLVM provides API support for this.
2. A StandardSegments (executable memory) cache — LLVM does not encourage this, but it can be worked around.

There is a fundamental misunderstanding of the purpose of the ObjectCache. Its role is to avoid recompiling IR to Object — not to cache executable segments. However, many developers mistakenly treat it as a cache for executable memory and create a separate ObjectCache for each JIT expression. The correct design should treat this as a global table.

As for JITLinkingMemoryManager, which manages executable segments:
This component should not be global, but has incorrectly been made global. In fact, its lifecycle should be managed by the second cache — the one responsible for executable memory. JITLinkingMemoryManager's derived class InProcessMemoryManager is used in link-time, it never releases executable segments when InProcessMemoryManager goes out its scope. 

## What I'm doing:
1. Use object cache and callable cache to save compiling result(object) and linking result(executable segments) respectively.
2. Introduce a subclass of InProcessMemoryManager, which named CustomizedInProcessMemoryManager, it can release executable segments when it goes out of scope.
3. refactor JITEngine.

**Test Result**

Use query format based on ssb
```
SELECT SUM(
    CASE 
        WHEN x < {param1} THEN x / 1000000 + 0 * x
        WHEN x < {param2} THEN x / 2000000 + 1 * x
        WHEN x < {param3} THEN x / 3000000 + 2 * x
        WHEN x < 400000   THEN x / 4000000 + 3 * x
        WHEN x < 500000   THEN x / 5000000 + 4 * x
        WHEN x < 600000   THEN x / 6000000 + 5 * x
        WHEN x < 700000   THEN x / 7000000 + 6 * x
        WHEN x < 800000   THEN x / 8000000 + 7 * x
        WHEN x < 900000   THEN x / 9000000 + 8 * x
        WHEN x < 1000000  THEN x / 10000000 + 9 * x
        ELSE 10
    END
) 
FROM (
    SELECT lo_partkey AS x FROM lineorder
    UNION ALL
    SELECT lo_partkey AS x FROM lineorder
    UNION ALL
    SELECT lo_partkey AS x FROM lineorder
) A;
```

{params1} ranges from 1000 ~ 1010
{params2} ranges from 2000 ~ 2010
{params3} ranges from 3000 ~ 3020

use different combinations of params1, params2 and params3 to generate 2000 queries, which queries would be JITed into different executable segments. 

Then set capacity of JIT cache to be 1048576 bytes(jit_lru_cache_size = 1048576),  so it can keep 256 pages, 8 pages for each shard of JIT cache.

in the previous version,  readonly executable private(r-xp)mapped pages are 4001,  it exceeds 256 pages so far.
in the current version, readonly executable private mapped pages are 95, it is below 256 pages.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
