### PR TITLE
[UT] Fix LakePublishBatchTest failure

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.proto.PublishLogVersionBatchRequest;
@@ -98,6 +99,7 @@ public class LakePublishBatchTest {
 
     @BeforeAll
     public static void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
         enable_batch_publish_version = Config.lake_enable_batch_publish_version;
         batch_publish_min_version_num = Config.lake_batch_publish_min_version_num;
         alterSchedulerIntervalMs = Config.alter_scheduler_interval_millisecond;
@@ -154,6 +156,7 @@ public class LakePublishBatchTest {
         Config.lake_enable_batch_publish_version = enable_batch_publish_version;
         Config.lake_batch_publish_min_version_num = batch_publish_min_version_num;
         Config.alter_scheduler_interval_millisecond = alterSchedulerIntervalMs;
+        FeConstants.runningUnitTest = false;
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Why I'm doing:
```
LakePublishBatchTest.testBatchPublishShadowIndex

Cannot read field "status" because "response" is null
java.lang.NullPointerException: Cannot read field "status" because "response" is null
	at com.starrocks.lake.vacuum.AutovacuumDaemon.vacuumPartitionImpl(AutovacuumDaemon.java:277)
	at com.starrocks.lake.vacuum.AutovacuumDaemon.vacuumPartition(AutovacuumDaemon.java:166)
	at com.starrocks.lake.vacuum.AutovacuumDaemon.lambda$vacuumTable$1(AutovacuumDaemon.java:159)
	at org.apache.hadoop.util.SemaphoredDelegatingExecutor$RunnableWithPermitRelease.run(SemaphoredDelegatingExecutor.java:225)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
