### PR TITLE
[BugFix] Fix array column cloning durign array comparison

### DIFF
--- a/be/src/exec/sorting/compare_column.cpp
+++ b/be/src/exec/sorting/compare_column.cpp
@@ -157,11 +157,8 @@ public:
 
     Status do_visit(const ArrayColumn& column) {
         // Convert the datum to a array column
-        auto rhs_column = column.elements().clone_empty();
-        auto& datum_array = _rhs_value.get_array();
-        for (auto& x : datum_array) {
-            rhs_column->append_datum(x);
-        }
+        auto rhs_column = column.clone_empty();
+        rhs_column->append_datum(_rhs_value);
         auto cmp = [&](int lhs_index) {
             return column.compare_at(lhs_index, 0, *rhs_column, _null_first) * _sort_order;
         };

--- a/be/test/exec/sorting_test.cpp
+++ b/be/test/exec/sorting_test.cpp
@@ -587,8 +587,6 @@ TEST(SortingTest, compare) {
     // any type
     std::vector<TypeDescriptor> type_lists;
     for (auto type : {TYPE_INT, TYPE_JSON, TYPE_VARCHAR}) {
-        TypeDescriptor desc(TYPE_ARRAY);
-        desc.children.emplace_back(type);
         type_lists.emplace_back(type);
     }
     for (auto type : {TYPE_INT, TYPE_JSON, TYPE_VARCHAR}) {

--- a/be/test/exec/sorting_test.cpp
+++ b/be/test/exec/sorting_test.cpp
@@ -21,6 +21,7 @@
 #include <utility>
 
 #include "column/chunk.h"
+#include "column/column.h"
 #include "column/column_helper.h"
 #include "column/vectorized_fwd.h"
 #include "exec/sorting/merge.h"
@@ -33,6 +34,7 @@
 #include "runtime/runtime_state.h"
 #include "runtime/types.h"
 #include "testutil/assert.h"
+#include "types/logical_type.h"
 #include "util/defer_op.h"
 
 namespace starrocks {
@@ -578,6 +580,30 @@ TEST(MergePathTest, test1) {
                 }
             }
         }
+    }
+}
+
+TEST(SortingTest, compare) {
+    // any type
+    std::vector<TypeDescriptor> type_lists;
+    for (auto type : {TYPE_INT, TYPE_JSON, TYPE_VARCHAR}) {
+        TypeDescriptor desc(TYPE_ARRAY);
+        desc.children.emplace_back(type);
+        type_lists.emplace_back(type);
+    }
+    for (auto type : {TYPE_INT, TYPE_JSON, TYPE_VARCHAR}) {
+        TypeDescriptor desc(TYPE_ARRAY);
+        desc.children.emplace_back(type);
+        type_lists.emplace_back(desc);
+    }
+
+    for (size_t i = 0; i < type_lists.size(); ++i) {
+        auto column = ColumnHelper::create_column(type_lists[i], false);
+        column->append_default();
+        auto rhs_col = column->clone();
+        Datum rhs_value = rhs_col->get(0);
+        CompareVector vector(1);
+        EXPECT_EQ(1, compare_column(column, vector, rhs_value, SortDesc(1, 1)));
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Changing the way how column is cloned for comparison. 
Currently in master we:
- get the elements column of array and making it's empty copy
- get all contents of datum (array)
- add it to elements column
- In the end instead of ArrayColumn we have Column<NullColumn<FixedLengthColumn>>

Instead now I:
- create an empty copy of array column
- copy content of datum array into the new column

Fixes [#61029](https://github.com/StarRocks/starrocks/issues/61029)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
