### PR TITLE
[Enhancement] Fix mv view rewrite with external tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
@@ -17,7 +17,6 @@ package com.starrocks.sql.optimizer;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
-import com.starrocks.catalog.Table.TableType;
 import com.starrocks.qe.ConnectContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,8 +49,7 @@ public class MvPlanContextBuilder {
             Optional.ofNullable(doGetOptimizePlan(() -> mvOptimizer.optimize(mv, connectContext), isThrowException))
                     .map(results::add);
 
-            // TODO: Only add context with view when view rewrite is set on.
-            if (mv.getBaseTableTypes().stream().anyMatch(type -> type == TableType.VIEW)) {
+            if (mv.getBaseTables().stream().anyMatch(table -> table.isView())) {
                 Optional.ofNullable(doGetOptimizePlan(() -> mvOptimizer.optimize(mv, connectContext, false, true),
                                 isThrowException))
                         .map(results::add);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -263,22 +263,22 @@ public class MvRewritePreprocessor {
         if (!connectContext.getSessionVariable().isEnableViewBasedMvRewrite()) {
             return;
         }
-        List<LogicalViewScanOperator> viewScans = Lists.newArrayList();
-        // process equivalent operator，construct logical plan with view
-        OptExpression logicalPlanWithView = extractLogicalPlanWithView(logicOperatorTree, viewScans);
-        if (queryMaterializationContext != null && queryMaterializationContext.getValidCandidateMVs().isEmpty()) {
+        if (queryMaterializationContext == null || queryMaterializationContext.getValidCandidateMVs().isEmpty()) {
             return;
         }
-
-        if (viewScans.isEmpty()) {
+        final List<LogicalViewScanOperator> logicalViewScanOperators = Lists.newArrayList();
+        // process equivalent operator，construct logical plan with view
+        final OptExpression logicalPlanWithViewInline = extractLogicalPlanWithView(logicOperatorTree,
+                logicalViewScanOperators);
+        if (CollectionUtils.isEmpty(logicalViewScanOperators)) {
             // means there is no plan with view
             return;
         }
         // optimize logical plan with view
-        OptExpression optimizedPlan = MvUtils.optimizeViewPlan(
-                logicalPlanWithView, connectContext, requiredColumns, columnRefFactory);
-        queryMaterializationContext.setQueryOptPlanWithView(optimizedPlan);
-        queryMaterializationContext.setQueryViewScanOps(viewScans);
+        OptExpression optViewScanExpressions = MvUtils.optimizeViewPlan(
+                logicalPlanWithViewInline, connectContext, requiredColumns, columnRefFactory);
+        queryMaterializationContext.setQueryOptPlanWithView(optViewScanExpressions);
+        queryMaterializationContext.setQueryViewScanOps(logicalViewScanOperators);
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
@@ -21,7 +21,9 @@ import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.OptimizerOptions;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import org.apache.commons.collections4.CollectionUtils;
 
 public class MvRewriteStrategy {
     public static final MvRewriteStrategy DEFAULT = new MvRewriteStrategy();
@@ -105,9 +107,11 @@ public class MvRewriteStrategy {
         }
 
         private boolean isEnableRBOViewBasedRewrite() {
-            return optimizerContext.getQueryMaterializationContext() != null
-                    && optimizerContext.getQueryMaterializationContext().getQueryOptPlanWithView() != null
+            QueryMaterializationContext queryMaterializationContext = optimizerContext.getQueryMaterializationContext();
+            return queryMaterializationContext != null
                     && sessionVariable.isEnableViewBasedMvRewrite()
+                    && queryMaterializationContext.getQueryOptPlanWithView() != null
+                    && CollectionUtils.isNotEmpty(queryMaterializationContext.getQueryViewScanOps())
                     && !sessionVariable.isEnableCBOViewBasedMvRewrite();
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -2074,7 +2074,7 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
         String plan = getFragmentPlan(query1);
         PlanTestBase.assertContains(plan, "test_mv1");
         List<MvPlanContext> mvPlanContexts =
-                CachingMvPlanContextBuilder.getInstance().getOrLoadPlanContext(connectContext.getSessionVariable(), mv);
+                CachingMvPlanContextBuilder.getInstance().getOrLoadPlanContext(mv, 3000);
         // mv's plan contexts should contain 2 entries:
         // - one is for view with inlined
         // - one is for view scan operator
@@ -2097,7 +2097,7 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
         String query2 = "select * from test_mv1 where id > 100 limit 1;";
         String plan2 = getFragmentPlan(query2);
         PlanTestBase.assertContains(plan2, "test_mv2");
-        mvPlanContexts = CachingMvPlanContextBuilder.getInstance().getOrLoadPlanContext(connectContext.getSessionVariable(), mv2);
+        mvPlanContexts = CachingMvPlanContextBuilder.getInstance().getOrLoadPlanContext(mv2, 3000);
         Assertions.assertTrue(mvPlanContexts.size() == 1);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -14,14 +14,17 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.Partition;
 import com.starrocks.common.Config;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.utframe.UtFrameUtils;
@@ -2034,7 +2037,6 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
 
     @Test
     public void testRefBaseTablePartitionWithTransform() throws Exception {
-        final String mvName = "test_mv1";
         final String sql = "CREATE MATERIALIZED VIEW test_mv1\n" +
                 "PARTITION BY date_trunc('month', ts)\n" +
                 "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
@@ -2048,5 +2050,54 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
                         connectContext);
         MaterializedViewAnalyzer.analyze(stmt, starRocksAssert.getCtx());
         Assertions.assertTrue(stmt.isRefBaseTablePartitionWithTransform());
+    }
+
+    @Test
+    public void testRewriteWithIcebergView1() throws Exception {
+        starRocksAssert.withView("CREATE VIEW iceberg_view1 AS " +
+                "SELECT id, data, ts FROM `iceberg0`.`partitioned_transforms_db`.`t0_month` order by id, ts;");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test_mv1\n" +
+                "PARTITION BY date_trunc('month', ts)\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS SELECT * from iceberg_view1;");
+        MaterializedView mv = getMv("test", "test_mv1");
+        refreshMaterializedView("test", "test_mv1");
+        List<BaseTableInfo> baseTableInfos = mv.getBaseTableInfos();
+        Assertions.assertEquals(2, baseTableInfos.size());
+        List<BaseTableInfo> baseTableInfosWithoutView = mv.getBaseTableInfosWithoutView();
+        Assertions.assertEquals(1, baseTableInfosWithoutView.size());
+
+        String query1 = "select * from iceberg_view1 limit 1;";
+        String plan = getFragmentPlan(query1);
+        PlanTestBase.assertContains(plan, "test_mv1");
+        List<MvPlanContext> mvPlanContexts =
+                CachingMvPlanContextBuilder.getInstance().getOrLoadPlanContext(connectContext.getSessionVariable(), mv);
+        // mv's plan contexts should contain 2 entries:
+        // - one is for view with inlined
+        // - one is for view scan operator
+        Assertions.assertTrue(mvPlanContexts.size() == 2);
+
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test_mv2\n" +
+                "PARTITION BY date_trunc('month', ts)\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS SELECT * from test_mv1 where id > 100;");
+        MaterializedView mv2 = getMv("test", "test_mv2");
+        refreshMaterializedView("test", "test_mv2");
+        List<BaseTableInfo> baseTableInfos2 = mv2.getBaseTableInfos();
+        Assertions.assertEquals(1, baseTableInfos2.size());
+        List<BaseTableInfo> baseTableInfosWithoutView2 = mv2.getBaseTableInfosWithoutView();
+        Assertions.assertEquals(1, baseTableInfosWithoutView2.size());
+
+        String query2 = "select * from test_mv1 where id > 100 limit 1;";
+        String plan2 = getFragmentPlan(query2);
+        PlanTestBase.assertContains(plan2, "test_mv2");
+        mvPlanContexts = CachingMvPlanContextBuilder.getInstance().getOrLoadPlanContext(connectContext.getSessionVariable(), mv2);
+        Assertions.assertTrue(mvPlanContexts.size() == 1);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -867,7 +867,7 @@ public class MvRewriteHiveTest extends MVTestBase {
         String plan = getFragmentPlan(query1);
         PlanTestBase.assertContains(plan, "test_mv1");
         List<MvPlanContext> mvPlanContexts =
-                CachingMvPlanContextBuilder.getInstance().getOrLoadPlanContext(connectContext.getSessionVariable(), mv);
+                CachingMvPlanContextBuilder.getInstance().getOrLoadPlanContext(mv, 3000);
         // mv's plan contexts should contain 2 entries:
         // - one is for view with inlined
         // - one is for view scan operator
@@ -896,7 +896,7 @@ public class MvRewriteHiveTest extends MVTestBase {
         String plan = getFragmentPlan(query1);
         PlanTestBase.assertContains(plan, "test_mv1");
         List<MvPlanContext> mvPlanContexts =
-                CachingMvPlanContextBuilder.getInstance().getOrLoadPlanContext(connectContext.getSessionVariable(), mv);
+                CachingMvPlanContextBuilder.getInstance().getOrLoadPlanContext(mv, 3000);
         // mv's plan contexts should contain 2 entries:
         // - one is for view with inlined
         // - one is for view scan operator

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -16,9 +16,12 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.common.FeConstants;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
@@ -843,5 +846,60 @@ public class MvRewriteHiveTest extends MVTestBase {
                 }
             });
         });
+    }
+
+    @Test
+    public void testRewriteWithHiveView1() throws Exception {
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test_mv1`\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS select * from hive0.tpch.customer_view;");
+        MaterializedView mv = getMv("test", "test_mv1");
+        refreshMaterializedView("test", "test_mv1");
+        List<BaseTableInfo> baseTableInfos = mv.getBaseTableInfos();
+        Assertions.assertEquals(2, baseTableInfos.size());
+        List<BaseTableInfo> baseTableInfosWithoutView = mv.getBaseTableInfosWithoutView();
+        Assertions.assertEquals(1, baseTableInfosWithoutView.size());
+
+        String query1 = "select * from hive0.tpch.customer_view limit 1;";
+        String plan = getFragmentPlan(query1);
+        PlanTestBase.assertContains(plan, "test_mv1");
+        List<MvPlanContext> mvPlanContexts =
+                CachingMvPlanContextBuilder.getInstance().getOrLoadPlanContext(connectContext.getSessionVariable(), mv);
+        // mv's plan contexts should contain 2 entries:
+        // - one is for view with inlined
+        // - one is for view scan operator
+        Assertions.assertTrue(mvPlanContexts.size() == 2);
+    }
+
+    @Test
+    public void testRewriteWithHiveView2() throws Exception {
+        // view contains non spjg operators, only can be rewritten by view-rewrite
+        starRocksAssert.withView("CREATE VIEW `customer_view1` AS\n" +
+                "SELECT * FROM `hive0`.`tpch`.`customer` WHERE c_mktsegment = 'BUILDING' ORDER BY c_custkey limit 10;");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test_mv1`\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS select * from customer_view1;");
+        MaterializedView mv = getMv("test", "test_mv1");
+        refreshMaterializedView("test", "test_mv1");
+        List<BaseTableInfo> baseTableInfos = mv.getBaseTableInfos();
+        Assertions.assertEquals(2, baseTableInfos.size());
+        List<BaseTableInfo> baseTableInfosWithoutView = mv.getBaseTableInfosWithoutView();
+        Assertions.assertEquals(1, baseTableInfosWithoutView.size());
+
+        String query1 = "select * from customer_view1 limit 1;";
+        String plan = getFragmentPlan(query1);
+        PlanTestBase.assertContains(plan, "test_mv1");
+        List<MvPlanContext> mvPlanContexts =
+                CachingMvPlanContextBuilder.getInstance().getOrLoadPlanContext(connectContext.getSessionVariable(), mv);
+        // mv's plan contexts should contain 2 entries:
+        // - one is for view with inlined
+        // - one is for view scan operator
+        Assertions.assertTrue(mvPlanContexts.size() == 2);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

I found two potential bugs and one enhancement for MV View Rewrite as below:
1. (Bug)Original view  rewrite can be only used for olap view, but cannot be applied to iceberg/hive views in [MvPlanContextBuilder.java](https://github.com/StarRocks/starrocks/pull/61037/files#diff-ad5a26b4ff02014dc773a76201fc27ae3b27845b608a1f99f2d4090b685beec8)
```
            if (mv.getBaseTableTypes().stream().anyMatch(type -> type == TableType.VIEW)) {
            }
```
2. (Bug)In some cases, refresh a mv with `view` may fail since mv's baseTableInfos treat `view` as base table which may cause potential bugs:
```
Refresh mv dwd_theme_infectious_disease_preposition failed after 1/0 times, error-msg : java.lang.NullPointerException: traits not supported: VIEW
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:921)
        at com.starrocks.connector.ConnectorPartitionTraits.build(ConnectorPartitionTraits.java:94)
        at com.starrocks.connector.ConnectorPartitionTraits.buildWithoutCache(ConnectorPartitionTraits.java:134)
        at com.starrocks.connector.ConnectorPartitionTraits.buildWithCache(ConnectorPartitionTraits.java:105)
        at com.starrocks.connector.ConnectorPartitionTraits.build(ConnectorPartitionTraits.java:130)
        at com.starrocks.connector.PartitionUtil.getPartitionColumns(PartitionUtil.java:268)
        at com.starrocks.catalog.MaterializedView.getBaseTablePartitionColumnMapImpl(MaterializedView.java:1712)
        at com.starrocks.catalog.MaterializedView.getRefBaseTablePartitionColumns(MaterializedView.java:1664)
        at com.starrocks.sql.common.ListPartitionDiffer.syncBaseTablePartitionInfos(ListPartitionDiffer.java:237)
        at com.starrocks.sql.common.ListPartitionDiffer.computeListPartitionDiff(ListPartitionDiffer.java:280)
        at com.starrocks.scheduler.mv.MVPCTRefreshListPartitioner.syncAddOrDropPartitions(MVPCTRefreshListPartitioner.java:84)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.syncPartitions(PartitionBasedMvRefreshProcessor.java:1064)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:417)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:373)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:332)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:200)
        at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:285)
        at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:6」
```
3.(Enhancement) If view rewrite is sucessful, no need to try non-view rewrite again to avoid mv rewrite time costing.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
