### PR TITLE
[Enhancement] Optimizing partition statistics lock competition.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.statistics;
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -402,7 +403,8 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
     /**
      *
      */
-    private Map<String, PartitionStats> getColumnNDVForPartitions(Table table, List<String> columns) {
+    @VisibleForTesting
+    public Map<String, PartitionStats> getColumnNDVForPartitions(Table table, List<String> columns) {
 
         List<ColumnStatsCacheKey> cacheKeys = columns.stream()
                 .map(column -> new ColumnStatsCacheKey(table.getId(), column)).toList();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
@@ -56,6 +56,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class CachedStatisticStorageTest {
     public static ConnectContext connectContext;
@@ -384,6 +385,17 @@ public class CachedStatisticStorageTest {
             {
                 partitionStatistics.getAll((Iterable<? extends ColumnStatsCacheKey>) any);
                 result = CompletableFuture.failedFuture(new Exception("test"));
+                minTimes = 0;
+            }
+        };
+        partitionStatsMap =
+                cachedStatisticStorage.getColumnNDVForPartitions(table, ImmutableList.of("c1"));
+        Assertions.assertEquals(0, partitionStatsMap.size());
+
+        new Expectations() {
+            {
+                partitionStatistics.getAll((Iterable<? extends ColumnStatsCacheKey>) any);
+                result = CompletableFuture.failedFuture(new TimeoutException("test"));
                 minTimes = 0;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
@@ -354,51 +354,45 @@ public class CachedStatisticStorageTest {
                 minTimes = 0;
             }
         };
-
         Map<String, PartitionStats> partitionStatsMap =
                 cachedStatisticStorage.getColumnNDVForPartitions(table, ImmutableList.of("c1"));
         Assertions.assertEquals(0, partitionStatsMap.size());
 
-        new Expectations() {
-            {
-                partitionStatistics.getAll((Iterable<? extends ColumnStatsCacheKey>) any);
-                result = new CompletableFuture<>();
-                minTimes = 0;
+
+        new MockUp<CompletableFuture<Map<ColumnStatsCacheKey, Optional<PartitionStats>>>>() {
+            @Mock
+            public Map<ColumnStatsCacheKey, Optional<PartitionStats>> get(long timeout, TimeUnit unit) throws
+                    InterruptedException, ExecutionException, TimeoutException {
+                throw new InterruptedException("test");
             }
         };
+
         partitionStatsMap =
                 cachedStatisticStorage.getColumnNDVForPartitions(table, ImmutableList.of("c1"));
         Assertions.assertEquals(0, partitionStatsMap.size());
 
-        new Expectations() {
-            {
-                partitionStatistics.getAll((Iterable<? extends ColumnStatsCacheKey>) any);
-                result = CompletableFuture.failedFuture(new InterruptedException("test"));
-                minTimes = 0;
+
+        new MockUp<CompletableFuture<Map<ColumnStatsCacheKey, Optional<PartitionStats>>>>() {
+            @Mock
+            public Map<ColumnStatsCacheKey, Optional<PartitionStats>> get(long timeout, TimeUnit unit) throws
+                    InterruptedException, ExecutionException, TimeoutException {
+                throw new ExecutionException("test", new Exception());
             }
         };
+
         partitionStatsMap =
                 cachedStatisticStorage.getColumnNDVForPartitions(table, ImmutableList.of("c1"));
         Assertions.assertEquals(0, partitionStatsMap.size());
 
-        new Expectations() {
-            {
-                partitionStatistics.getAll((Iterable<? extends ColumnStatsCacheKey>) any);
-                result = CompletableFuture.failedFuture(new Exception("test"));
-                minTimes = 0;
-            }
-        };
-        partitionStatsMap =
-                cachedStatisticStorage.getColumnNDVForPartitions(table, ImmutableList.of("c1"));
-        Assertions.assertEquals(0, partitionStatsMap.size());
 
-        new Expectations() {
-            {
-                partitionStatistics.getAll((Iterable<? extends ColumnStatsCacheKey>) any);
-                result = CompletableFuture.failedFuture(new TimeoutException("test"));
-                minTimes = 0;
+        new MockUp<CompletableFuture<Map<ColumnStatsCacheKey, Optional<PartitionStats>>>>() {
+            @Mock
+            public Map<ColumnStatsCacheKey, Optional<PartitionStats>> get(long timeout, TimeUnit unit) throws
+                    InterruptedException, ExecutionException, TimeoutException {
+                throw new TimeoutException("test");
             }
         };
+
         partitionStatsMap =
                 cachedStatisticStorage.getColumnNDVForPartitions(table, ImmutableList.of("c1"));
         Assertions.assertEquals(0, partitionStatsMap.size());


### PR DESCRIPTION
## Why I'm doing:
Partition statistics uses synchronized access to Caffeine, resulting in holding DB locks for long periods of time.
## What I'm doing:

Fixes #61042
Modifying partition statistics to use asynchronous access to Caffeine.
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
