### PR TITLE
[BugFix] Fix parquet column name case sensitive when inserting from files()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -503,8 +503,10 @@ public class InsertAnalyzer {
                     continue;
                 }
 
-                newCol.setName(selectColumnName);
-                newFileTableColumns.put(selectColumnName, newCol);
+                // file table function table should use original column name because BE is case-sensitive when reading columns.
+                String origColumnName = oldCol.getName();
+                newCol.setName(origColumnName);
+                newFileTableColumns.put(origColumnName, newCol);
             }
 
             List<Column> newFileTableSchema = fileTable.getFullSchema().stream()

--- a/test/sql/test_files/R/test_parquet_column_name_case_insensitive
+++ b/test/sql/test_files/R/test_parquet_column_name_case_insensitive
@@ -1,0 +1,90 @@
+-- name: test_parquet_column_name_case_insensitive
+
+create database db_${uuid0};
+use db_${uuid0};
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/parquet_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+
+insert into files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+select cast(1 as bigint) as K1;
+-- result:
+-- !result
+
+desc files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+K1	bigint	YES
+-- !result
+
+
+select k1 from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+1
+-- !result
+
+select K1 from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+1
+-- !result
+
+
+create table t1 (k1 int);
+-- result:
+-- !result
+
+insert into t1
+select k1 from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+
+select * from t1;
+-- result:
+1
+-- !result
+
+truncate table t1;
+-- result:
+-- !result
+
+insert into t1
+select K1 from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+
+select * from t1;
+-- result:
+1
+-- !result
+
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null

--- a/test/sql/test_files/T/test_parquet_column_name_case_insensitive
+++ b/test/sql/test_files/T/test_parquet_column_name_case_insensitive
@@ -1,0 +1,61 @@
+-- name: test_parquet_column_name_case_insensitive
+
+create database db_${uuid0};
+use db_${uuid0};
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/parquet_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+-- insert files
+insert into files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+select cast(1 as bigint) as K1;
+
+desc files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
+-- test select
+select k1 from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
+select K1 from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
+-- test insert
+create table t1 (k1 int);
+
+insert into t1
+select k1 from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+select * from t1;
+truncate table t1;
+
+insert into t1
+select K1 from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+select * from t1;
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null


### PR DESCRIPTION
## Why I'm doing:

```
mysql> desc files("path" = "s3://bucket/*", "format" = "parquet");
+-------+---------+------+
| Field | Type    | Null |
+-------+---------+------+
| K1    | bigint  | YES  |
+-------+---------+------+
1 row in set (0.02 sec)

mysql> desc t1;
+-------+------+------+------+---------+-------+
| Field | Type | Null | Key  | Default | Extra |
+-------+------+------+------+---------+-------+
| k1    | int  | YES  | true | NULL    |       |
+-------+------+------+------+---------+-------+
1 row in set (0.01 sec)

mysql> insert into t1 select k1 from files("path" = "s3://bucket/*", "format" = "parquet");
ERROR 5609 (22000): Column: k1 is not found in file: s3://bucket/x.parquet: Consider setting 'fill_mismatch_column_with' = 'null' property: BE:10004
```

## What I'm doing:

file table function table should use original column name because BE is case-sensitive when reading columns.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
