### PR TITLE
[Refactor] Refactor the historical node manager interfaces based on compute resource instead of the combination of warehouse id and worker group id.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/HistoricalNodeProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/HistoricalNodeProcNode.java
@@ -15,13 +15,13 @@
 package com.starrocks.common.proc;
 
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Pair;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.HistoricalNodeMgr;
 import com.starrocks.system.HistoricalNodeSet;
 import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,16 +45,16 @@ public class HistoricalNodeProcNode implements ProcNodeInterface {
         result.setNames(TITLES);
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         HistoricalNodeMgr historicalNodeMgr = globalStateMgr.getHistoricalNodeMgr();
-        ConcurrentHashMap<Pair<Long, Long>, HistoricalNodeSet> resourceToNodeSet = historicalNodeMgr.getAllHistoricalNodeSet();
-        for (Pair<Long, Long> resourceId : resourceToNodeSet.keySet()) {
-            HistoricalNodeSet nodeSet = resourceToNodeSet.get(resourceId);
-            Warehouse warehouse = warehouseManager.getWarehouse(resourceId.first);
+        ConcurrentHashMap<ComputeResource, HistoricalNodeSet> resourceToNodeSet = historicalNodeMgr.getAllHistoricalNodeSet();
+        for (ComputeResource computeResource : resourceToNodeSet.keySet()) {
+            HistoricalNodeSet nodeSet = resourceToNodeSet.get(computeResource);
+            Warehouse warehouse = warehouseManager.getWarehouseAllowNull(computeResource.getWarehouseId());
             if (nodeSet == null || warehouse == null) {
                 continue;
             }
             List<String> row = new ArrayList<>();
             row.add(warehouse.getName());
-            row.add(resourceId.second.toString());
+            row.add(String.valueOf(computeResource.getWorkerGroupId()));
             row.add(nodeSet.getHistoricalBackendIds().toString());
             row.add(nodeSet.getHistoricalComputeNodeIds().toString());
             row.add(TimeUtils.longToTimeString(nodeSet.getLastUpdateTime()));

--- a/fe/fe-core/src/main/java/com/starrocks/persist/UpdateHistoricalNodeLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/UpdateHistoricalNodeLog.java
@@ -16,6 +16,7 @@ package com.starrocks.persist;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Writable;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 
 import java.util.List;
 
@@ -23,11 +24,8 @@ public class UpdateHistoricalNodeLog implements Writable {
     @SerializedName(value = "warehouse")
     private String warehouse;
 
-    @SerializedName(value = "warehouseId")
-    private long warehouseId;
-
-    @SerializedName(value = "workerGroupId")
-    private long workerGroupId;
+    @SerializedName("computeResource")
+    private ComputeResource computeResource;
 
     @SerializedName(value = "updateTime")
     private long updateTime;
@@ -38,10 +36,9 @@ public class UpdateHistoricalNodeLog implements Writable {
     @SerializedName(value = "computeNodeIds")
     private List<Long> computeNodeIds;
 
-    public UpdateHistoricalNodeLog(long warehouseId, long workerGroupId, long updateTime, List<Long> backendIds,
+    public UpdateHistoricalNodeLog(ComputeResource computeResource, long updateTime, List<Long> backendIds,
                                    List<Long> computeNodeIds) {
-        this.warehouseId = warehouseId;
-        this.workerGroupId = workerGroupId;
+        this.computeResource = computeResource;
         this.updateTime = updateTime;
         this.backendIds = backendIds;
         this.computeNodeIds = computeNodeIds;
@@ -51,12 +48,8 @@ public class UpdateHistoricalNodeLog implements Writable {
         return warehouse;
     }
 
-    public long getWarehouseId() {
-        return warehouseId;
-    }
-
-    public long getWorkerGroupId() {
-        return workerGroupId;
+    public ComputeResource getComputeResource() {
+        return computeResource;
     }
 
     public long getUpdateTime() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -191,8 +191,7 @@ public class HDFSBackendSelector implements BackendSelector {
         HistoricalNodeMgr historicalNodeMgr = GlobalStateMgr.getCurrentState().getHistoricalNodeMgr();
         ComputeResource computeResource = workerProvider.getComputeResource();
 
-        long lastUpdateTime = historicalNodeMgr.getLastUpdateTime(computeResource.getWarehouseId(),
-                computeResource.getWorkerGroupId());
+        long lastUpdateTime = historicalNodeMgr.getLastUpdateTime(computeResource);
         long currentTime = System.currentTimeMillis();
         if (currentTime - lastUpdateTime > cacheSharingWorkPeriod * 1000) {
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/CandidateWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/CandidateWorkerProvider.java
@@ -139,8 +139,7 @@ public class CandidateWorkerProvider extends DefaultWorkerProvider implements Wo
             HistoricalNodeMgr historicalNodeMgr,
             ComputeResource computeResource) {
         ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
-        ImmutableList<Long> backendIds = historicalNodeMgr.getHistoricalBackendIds(computeResource.getWarehouseId(),
-                computeResource.getWorkerGroupId());
+        ImmutableList<Long> backendIds = historicalNodeMgr.getHistoricalBackendIds(computeResource);
         for (long nodeId : backendIds) {
             ComputeNode backend = systemInfoService.getBackendOrComputeNode(nodeId);
             if (backend != null) {
@@ -155,8 +154,7 @@ public class CandidateWorkerProvider extends DefaultWorkerProvider implements Wo
             HistoricalNodeMgr historicalNodeMgr,
             ComputeResource computeResource) {
         ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
-        ImmutableList<Long> computeNodeIds = historicalNodeMgr.getHistoricalComputeNodeIds(computeResource.getWarehouseId(),
-                computeResource.getWorkerGroupId());
+        ImmutableList<Long> computeNodeIds = historicalNodeMgr.getHistoricalComputeNodeIds(computeResource);
         for (long nodeId : computeNodeIds) {
             ComputeNode computeNode = systemInfoService.getBackendOrComputeNode(nodeId);
             if (computeNode != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/HistoricalNodeProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/HistoricalNodeProcNodeTest.java
@@ -19,6 +19,8 @@ import com.starrocks.lake.StarOSAgent;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.HistoricalNodeMgr;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.ComputeResourceProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,15 +37,18 @@ public class HistoricalNodeProcNodeTest {
 
         HistoricalNodeMgr historicalNodeMgr = GlobalStateMgr.getCurrentState().getHistoricalNodeMgr();
 
-        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
-        long workerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
+        ComputeResourceProvider computeResourceProvider = warehouseManager.getComputeResourceProvider();
+        ComputeResource computeResource = computeResourceProvider.ofComputeResource(
+                WarehouseManager.DEFAULT_WAREHOUSE_ID, StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+
+
         List<Long> computeNodeIds = Arrays.asList(201L, 202L);
         long updateTime = System.currentTimeMillis();
-        historicalNodeMgr.updateHistoricalComputeNodeIds(warehouseId, workerGroupId, computeNodeIds, updateTime);
+        historicalNodeMgr.updateHistoricalComputeNodeIds(computeResource, computeNodeIds, updateTime);
 
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouseId, workerGroupId).size(),
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(computeResource).size(),
                 computeNodeIds.size());
-        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(warehouseId, workerGroupId), updateTime);
+        Assertions.assertEquals(historicalNodeMgr.getLastUpdateTime(computeResource), updateTime);
         Assertions.assertEquals(historicalNodeMgr.getAllHistoricalNodeSet().size(), 1);
     }
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
@@ -32,6 +32,8 @@ import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TScanRangeParams;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.ComputeResourceProvider;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
@@ -425,9 +427,14 @@ public class HDFSBackendSelectorTest {
 
         ImmutableMap.Entry<Long, ComputeNode> candidateNode = computeNodes.entrySet().asList().get(0);
         List<Long> candidateNodeIds = Collections.singletonList(candidateNode.getKey());
+
+        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        ComputeResourceProvider computeResourceProvider = warehouseManager.getComputeResourceProvider();
+        ComputeResource computeResource = computeResourceProvider.ofComputeResource(
+                WarehouseManager.DEFAULT_WAREHOUSE_ID, StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+
         HistoricalNodeMgr historicalNodeMgr = GlobalStateMgr.getCurrentState().getHistoricalNodeMgr();
-        historicalNodeMgr.updateHistoricalComputeNodeIds(WarehouseManager.DEFAULT_WAREHOUSE_ID,
-                StarOSAgent.DEFAULT_WORKER_GROUP_ID, candidateNodeIds, System.currentTimeMillis());
+        historicalNodeMgr.updateHistoricalComputeNodeIds(computeResource, candidateNodeIds, System.currentTimeMillis());
 
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
         systemInfoService.addComputeNode(candidateNode.getValue());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/CandidateWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/CandidateWorkerProviderTest.java
@@ -24,6 +24,8 @@ import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.HistoricalNodeMgr;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.ComputeResourceProvider;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
@@ -72,12 +74,13 @@ public class CandidateWorkerProviderTest {
         HistoricalNodeMgr historicalNodeMgr = GlobalStateMgr.getCurrentState().getHistoricalNodeMgr();
 
         String warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
-        //List<Long> computeNodeIds = Arrays.asList(201L, 202L);
         long updateTime = System.currentTimeMillis();
-        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
-        long workerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
-        historicalNodeMgr.updateHistoricalBackendIds(warehouseId, workerGroupId, id2Backend.keySet().asList(), updateTime);
-        historicalNodeMgr.updateHistoricalComputeNodeIds(warehouseId, workerGroupId, id2ComputeNode.keySet().asList(),
+
+        ComputeResourceProvider computeResourceProvider = warehouseManager.getComputeResourceProvider();
+        ComputeResource computeResource = computeResourceProvider.ofComputeResource(
+                WarehouseManager.DEFAULT_WAREHOUSE_ID, StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+        historicalNodeMgr.updateHistoricalBackendIds(computeResource, id2Backend.keySet().asList(), updateTime);
+        historicalNodeMgr.updateHistoricalComputeNodeIds(computeResource, id2ComputeNode.keySet().asList(),
                 updateTime);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
@@ -31,6 +31,7 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.ModifyBackendClause;
 import com.starrocks.warehouse.cngroup.CRAcquireContext;
 import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.ComputeResourceProvider;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -289,6 +290,8 @@ public class SystemInfoServiceTest {
         };
 
         HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
+        WarehouseManager warehouseManager = new WarehouseManager();
+        warehouseManager.initDefaultWarehouse();
 
         new Expectations() {
             {
@@ -297,20 +300,24 @@ public class SystemInfoServiceTest {
 
                 globalStateMgr.getHistoricalNodeMgr();
                 result = historicalNodeMgr;
+
+                globalStateMgr.getWarehouseMgr();
+                result = warehouseManager;
             }
         };
+
+        ComputeResourceProvider computeResourceProvider = warehouseManager.getComputeResourceProvider();
+        ComputeResource computeResource = computeResourceProvider.ofComputeResource(
+                WarehouseManager.DEFAULT_WAREHOUSE_ID, StarOSAgent.DEFAULT_WORKER_GROUP_ID);
 
         List<Long> backendIds = Arrays.asList(101L, 102L);
         List<Long> computeNodeIds = Arrays.asList(201L, 202L, 203L);
         long updateTime = System.currentTimeMillis();
-        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
-        long workerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
-        UpdateHistoricalNodeLog log = new UpdateHistoricalNodeLog(warehouseId, workerGroupId, updateTime, backendIds,
-                computeNodeIds);
+        UpdateHistoricalNodeLog log = new UpdateHistoricalNodeLog(computeResource, updateTime, backendIds, computeNodeIds);
 
         service.replayUpdateHistoricalNode(log);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(warehouseId, workerGroupId).size(), 2);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouseId, workerGroupId).size(), 3);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(computeResource).size(), 2);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(computeResource).size(), 3);
     }
 
     @Test
@@ -330,6 +337,9 @@ public class SystemInfoServiceTest {
         };
 
         HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
+        WarehouseManager warehouseManager = new WarehouseManager();
+        warehouseManager.initDefaultWarehouse();
+
         new Expectations() {
             {
                 GlobalStateMgr.getCurrentState();
@@ -337,20 +347,24 @@ public class SystemInfoServiceTest {
 
                 globalStateMgr.getHistoricalNodeMgr();
                 result = historicalNodeMgr;
+
+                globalStateMgr.getWarehouseMgr();
+                result = warehouseManager;
             }
         };
+
+        ComputeResourceProvider computeResourceProvider = warehouseManager.getComputeResourceProvider();
+        ComputeResource computeResource = computeResourceProvider.ofComputeResource(
+                WarehouseManager.DEFAULT_WAREHOUSE_ID, StarOSAgent.DEFAULT_WORKER_GROUP_ID);
 
         List<Long> backendIds = Arrays.asList(101L, 102L);
         List<Long> computeNodeIds = Arrays.asList(201L, 202L, 203L);
         long updateTime = System.currentTimeMillis();
-        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
-        long workerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
-        UpdateHistoricalNodeLog log = new UpdateHistoricalNodeLog(warehouseId, workerGroupId, updateTime, backendIds,
-                computeNodeIds);
+        UpdateHistoricalNodeLog log = new UpdateHistoricalNodeLog(null, updateTime, backendIds, computeNodeIds);
 
         service.replayUpdateHistoricalNode(log);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(warehouseId, workerGroupId).size(), 2);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouseId, workerGroupId).size(), 3);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(computeResource).size(), 2);
+        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(computeResource).size(), 3);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Now we use the `warehouseId` and `workerGroupId` in historical node manager interfaces to visit historical node information. However, this breaks down the ComputeResource concept, and we should be compute resource oriented design and implementation. It means that all the interfaces should be interacted as ComputeResource whenever there is a warehouseId + workerGroupId in the parameter list. 

## What I'm doing:
* Refactor the historical node manager interfaces based on compute resource instead of the combination of warehouse id and worker group id.
* Catch some exceptions related to historical node management to avoid affecting the main logic.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3