### PR TITLE
[BugFix] handle invalid column of ColumnUsage

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -483,7 +483,7 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
     }
 
     public Column getColumnByUniqueId(long uniqueId) {
-        return fullSchema.stream().filter(c -> c.getUniqueId() == uniqueId).findFirst().get();
+        return fullSchema.stream().filter(c -> c.getUniqueId() == uniqueId).findFirst().orElse(null);
     }
 
     public boolean containColumn(String columnName) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnStatsUsageSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnStatsUsageSystemTable.java
@@ -139,9 +139,9 @@ public class ColumnStatsUsageSystemTable extends SystemTable {
         Optional<Pair<TableName, ColumnId>> names = columnFullId.toNames();
         List<ScalarOperator> result = Lists.newArrayList();
         result.add(ConstantOperator.createVarchar(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME));
-        result.add(ConstantOperator.createVarchar(names.map(x -> x.first.getDb()).orElse(null)));
-        result.add(ConstantOperator.createVarchar(names.map(x -> x.first.getTbl()).orElse(null)));
-        result.add(ConstantOperator.createVarchar(names.map(x -> x.second.getId()).orElse(null)));
+        result.add(ConstantOperator.createNullableObject(names.map(x -> x.first.getDb()).orElse(null), Type.VARCHAR));
+        result.add(ConstantOperator.createNullableObject(names.map(x -> x.first.getTbl()).orElse(null), Type.VARCHAR));
+        result.add(ConstantOperator.createNullableObject(names.map(x -> x.second.getId()).orElse(null), Type.VARCHAR));
         result.add(ConstantOperator.createVarchar(columnUsage.getUseCaseString()));
         result.add(ConstantOperator.createDatetime(columnUsage.getLastUsed()));
         result.add(ConstantOperator.createDatetime(columnUsage.getCreated()));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ColumnFullId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ColumnFullId.java
@@ -61,7 +61,7 @@ public class ColumnFullId {
         Optional<Database> database = meta.mayGetDb(dbId);
         Optional<Table> table = meta.mayGetTable(dbId, tableId);
         Optional<Column> column = table.flatMap(x -> Optional.ofNullable(x.getColumnByUniqueId(columnUniqueId)));
-        if (database.isEmpty() || table.isEmpty()) {
+        if (database.isEmpty() || table.isEmpty() || column.isEmpty()) {
             return Optional.empty();
         }
         return Optional.of(Pair.create(new TableName(database.get().getOriginName(), table.get().getName()),
@@ -83,6 +83,16 @@ public class ColumnFullId {
     @Override
     public int hashCode() {
         return Objects.hash(dbId, tableId, columnUniqueId);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("ColumnFullId{");
+        sb.append("dbId=").append(dbId);
+        sb.append(", tableId=").append(tableId);
+        sb.append(", columnUniqueId=").append(columnUniqueId);
+        sb.append('}');
+        return sb.toString();
     }
 
     public long getDbId() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ColumnUsage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ColumnUsage.java
@@ -30,6 +30,8 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import org.apache.commons.lang3.EnumUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -39,6 +41,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class ColumnUsage implements GsonPostProcessable {
+
+    private static final Logger LOG = LogManager.getLogger(ColumnUsage.class);
 
     @SerializedName("columnId")
     private ColumnFullId columnId;
@@ -91,9 +95,8 @@ public class ColumnUsage implements GsonPostProcessable {
         return tableName;
     }
 
-    public String getOlapColumnName(OlapTable olap) {
-        return Preconditions.checkNotNull(olap.getColumnByUniqueId(columnId.getColumnUniqueId()),
-                this + " not exists").getName();
+    public Optional<String> getOlapColumnName(OlapTable olap) {
+        return Optional.ofNullable(olap.getColumnByUniqueId(columnId.getColumnUniqueId())).map(Column::getName);
     }
 
     public EnumSet<UseCase> getUseCases() {
@@ -176,6 +179,8 @@ public class ColumnUsage implements GsonPostProcessable {
         Optional<Pair<TableName, ColumnId>> names = getColumnFullId().toNames();
         if (names.isPresent()) {
             setTableName(names.get().first);
+        } else {
+            LOG.warn("unable to find column: {}", this);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

When deserializing `ColumnUsage`, the process attempts to locate the column name using `columnUniqueId`. However, in certain scenarios—such as when the column has been dropped or is temporary—it may fail to find the column. In such cases, the error should be ignored.

Fixes https://github.com/StarRocks/StarRocksTest/issues/10004

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
