### PR TITLE
[Enhancement] Add balance type in cluster balance proc result

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -1232,12 +1232,22 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         return System.currentTimeMillis() - lastSchedTime > taskTimeoutMs;
     }
 
+    private String getTabletScheduleStatus() {
+        String status = FeConstants.NULL_STRING;
+        if (type == Type.BALANCE && balanceType != null) {
+            status = balanceType.name();
+        } else if (tabletHealthStatus != null) {
+            status = tabletHealthStatus.name();
+        }
+        return status;
+    }
+
     public List<String> getBrief() {
         List<String> result = Lists.newArrayList();
         result.add(String.valueOf(tabletId));
         result.add(type.name());
         result.add(storageMedium == null ? FeConstants.NULL_STRING : storageMedium.name());
-        result.add(tabletHealthStatus == null ? FeConstants.NULL_STRING : tabletHealthStatus.name());
+        result.add(getTabletScheduleStatus());
         result.add(state.name());
         result.add(origPriority.name());
         result.add(dynamicPriority.name());
@@ -1333,8 +1343,8 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("tablet id: ").append(tabletId).append(", status: ").append(tabletHealthStatus.name());
-        sb.append(", state: ").append(state.name()).append(", type: ").append(type.name());
+        sb.append("tablet id: ").append(tabletId).append(", type: ").append(type.name());
+        sb.append(", status: ").append(getTabletScheduleStatus()).append(", state: ").append(state.name());
         if (srcReplica != null) {
             sb.append(". from backend: ").append(srcReplica.getBackendId());
             sb.append(", src path hash: ").append(srcPathHash);

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
@@ -282,7 +282,25 @@ public class TabletSchedCtxTest {
             Assertions.assertTrue(false);
         }
         Assertions.assertEquals(be1.getId(), ctx.getDestBackendId());
-
     }
 
+    @Test
+    public void testGetBrief() {
+        TabletSchedCtx ctx = new TabletSchedCtx(Type.REPAIR, 1, 2, 3, 4, 1000, System.currentTimeMillis());
+        ctx.setOrigPriority(Priority.NORMAL);
+        ctx.setTabletStatus(LocalTablet.TabletHealthStatus.VERSION_INCOMPLETE);
+        List<String> results = ctx.getBrief();
+        Assertions.assertEquals(25, results.size());
+        Assertions.assertEquals("1000", results.get(0));
+        Assertions.assertEquals("REPAIR", results.get(1));
+        Assertions.assertEquals("VERSION_INCOMPLETE", results.get(3));
+
+        ctx = new TabletSchedCtx(Type.BALANCE, 1, 2, 3, 4, 1001, System.currentTimeMillis());
+        ctx.setOrigPriority(Priority.NORMAL);
+        ctx.setBalanceType(DiskAndTabletLoadReBalancer.BalanceType.TABLET_BETWEEN_BACKENDS);
+        results = ctx.getBrief();
+        Assertions.assertEquals("1001", results.get(0));
+        Assertions.assertEquals("BALANCE", results.get(1));
+        Assertions.assertEquals("TABLET_BETWEEN_BACKENDS", results.get(3));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
The `Status` is `HEALTHY` when `Type` is `BALANCE`.
We want to know the balance type.

```
mysql> show proc "/cluster_balance/history_tablets"\G
*************************** 223. row ***************************
      TabletId: 15032
          Type: BALANCE
        Medium: HDD
        **Status: HEALTHY**
         State: FINISHED
      OrigPrio: LOW
      DynmPrio: LOW
         SrcBe: 10002
       SrcPath: 5294856446334472594
        DestBe: 10003
      DestPath: -1120861476078339545
       Timeout: 180000
        Create: 2025-07-18 17:21:31
      LstSched: 2025-07-18 17:21:32
      LstVisit: 2025-07-18 17:21:32
      Finished: 2025-07-18 17:21:32
          Rate: NULL
   FailedSched: 0
 FailedRunning: 0
    LstAdjPrio: NULL
    VisibleVer: 2
VisibleVerHash: 0
        CmtVer: 2
    CmtVerHash: 0
        ErrMsg:
```

## What I'm doing:
Add balance type in cluster balance pending/running/history tablets.

Replace `HEALTHY` with balance type when `Type` is `BALANCE`.
```
mysql> show proc "/cluster_balance/history_tablets"\G
*************************** 223. row ***************************
      TabletId: 15032
          Type: BALANCE
        Medium: HDD
        **Status: CLUSTER_TABLET**
         State: FINISHED
      OrigPrio: LOW
      DynmPrio: LOW
         SrcBe: 10002
       SrcPath: 5294856446334472594
        DestBe: 10003
      DestPath: -1120861476078339545
       Timeout: 180000
        Create: 2025-07-18 17:21:31
      LstSched: 2025-07-18 17:21:32
      LstVisit: 2025-07-18 17:21:32
      Finished: 2025-07-18 17:21:32
          Rate: NULL
   FailedSched: 0
 FailedRunning: 0
    LstAdjPrio: NULL
    VisibleVer: 2
VisibleVerHash: 0
        CmtVer: 2
    CmtVerHash: 0
        ErrMsg:
```

Fixes #61340

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
