### PR TITLE
[BugFix] Fix a bug that agg_state_if will not handle the streaming aggregation cases

### DIFF
--- a/test/sql/test_agg_state/R/test_agg_filter.sql
+++ b/test/sql/test_agg_state/R/test_agg_filter.sql
@@ -86,6 +86,30 @@ set sql_dialect='StarRocks';
 -- result:
 -- !result
 
+SELECT  /*+ SET_VAR (streaming_preaggregation_mode = 'force_streaming') */
+AVG(amount) FILTER (WHERE product = 'A') AS avg_amount_a,
+COUNT(*) FILTER (WHERE quantity > 15) AS count_large_quantity,
+MAX(amount) FILTER (WHERE product = 'B') AS max_amount_b,
+MIN(amount) FILTER (WHERE amount > 100) AS min_amount_large,
+SUM(amount) FILTER (WHERE product = 'C') AS sum_amount_c,
+ARRAY_AGG(product) FILTER (WHERE quantity < 20) AS products,
+ARRAY_AGG(DISTINCT product) FILTER (WHERE quantity < 20) AS distinct_products1,
+ARRAY_AGG_DISTINCT(product) FILTER (WHERE quantity < 20) AS distinct_products2,
+COUNT(amount) AS count_amount,
+COUNT(*) FILTER (WHERE amount > (SELECT AVG(amount) FROM sales)) AS count_above_avg,
+SUM(amount) FILTER (WHERE product IN (SELECT product FROM products WHERE category = 'Electronics')) AS sum_electronics
+FROM sales
+group by id
+order by id;
+-- result:
+100.00000000	0	None	None	None	["A"]	["A"]	["A"]	1	0	None
+None	1	150.00	150.00	None	[null]	[null]	[null]	1	0	None
+200.00000000	0	None	200.00	None	["A"]	["A"]	["A"]	1	0	None
+None	1	250.00	250.00	None	[null]	[null]	[null]	1	0	None
+None	1	None	300.00	300.00	[null]	[null]	[null]	1	1	None
+None	1	None	500.00	None	[null]	[null]	[null]	1	1	500.00
+-- !result
+
 drop table sales;
 -- result:
 -- !result

--- a/test/sql/test_agg_state/T/test_agg_filter.sql
+++ b/test/sql/test_agg_state/T/test_agg_filter.sql
@@ -63,6 +63,22 @@ order by id;
 
 set sql_dialect='StarRocks';
 
+SELECT /*+ SET_VAR (streaming_preaggregation_mode = 'force_streaming') */
+AVG(amount) FILTER (WHERE product = 'A') AS avg_amount_a,
+COUNT(*) FILTER (WHERE quantity > 15) AS count_large_quantity,
+MAX(amount) FILTER (WHERE product = 'B') AS max_amount_b,
+MIN(amount) FILTER (WHERE amount > 100) AS min_amount_large,
+SUM(amount) FILTER (WHERE product = 'C') AS sum_amount_c,
+ARRAY_AGG(product) FILTER (WHERE quantity < 20) AS products,
+ARRAY_AGG(DISTINCT product) FILTER (WHERE quantity < 20) AS distinct_products1,
+ARRAY_AGG_DISTINCT(product) FILTER (WHERE quantity < 20) AS distinct_products2,
+COUNT(amount) AS count_amount,
+COUNT(*) FILTER (WHERE amount > (SELECT AVG(amount) FROM sales)) AS count_above_avg,
+SUM(amount) FILTER (WHERE product IN (SELECT product FROM products WHERE category = 'Electronics')) AS sum_electronics
+FROM sales
+group by id
+order by id;
+
 drop table sales;
 drop table products;
 


### PR DESCRIPTION
[BugFix] Fix a bug that agg_state_if will not handle the streaming aggregation cases
## Why I'm doing:
Currently when the aggregation are using streaming mode the agg_state_if will be not applied because we did not do the filter in `convert_to_serialize_format` method in `agg_state_if.h`.
Then the result will be wrong.
## What I'm doing:
Reuse the `update_help` to do filter. After that the result will be correct. 
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
