### PR TITLE
[UT] Fix unstable ut in ConnectProcessorTest

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -637,7 +637,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         request.setSql("select 1");
         request.setIsInternalStmt(true);
         request.setModified_variables_sql("set query_timeout = 10");
-        request.setCurrent_user_ident(new TUserIdentity());
+        request.setCurrent_user_ident(new TUserIdentity().setUsername("root").setHost("127.0.0.1"));
         request.setQueryId(UUIDUtil.genTUniqueId());
         request.setSession_id(UUID.randomUUID().toString());
         request.setIsLastStmt(true);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Fix NPE
```
    <error message="Cannot invoke &quot;String.hashCode()&quot; because &quot;this.user&quot; is null" type="java.lang.NullPointerException"><![CDATA[java.lang.NullPointerException: Cannot invoke "String.hashCode()" because "this.user" is null
        at com.starrocks.sql.ast.UserIdentity.hashCode(UserIdentity.java:204)
        at com.starrocks.authorization.AuthorizationMgr.getUserPrivilegeCollectionUnlocked(AuthorizationMgr.java:1135)
        at com.starrocks.authorization.AuthorizationMgr.getDefaultRoleIdsByUser(AuthorizationMgr.java:1588)
        at com.starrocks.qe.ConnectContext.setCurrentRoleIds(ConnectContext.java:511)
        at com.starrocks.qe.ConnectContext.setAuthInfoFromThrift(ConnectContext.java:537)
        at com.starrocks.qe.ConnectProcessor.proxyExecute(ConnectProcessor.java:785)
        at com.starrocks.qe.ConnectProcessorTest.testProxyExecute(ConnectProcessorTest.java:666)

```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
