### PR TITLE
[BugFix] make scan behavior consistent on shared-data and shared-nothing

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -348,8 +348,8 @@ Status LakeDataSource::init_tablet_reader(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(get_tablet(_scan_range));
     RETURN_IF_ERROR(init_global_dicts(&_params));
     RETURN_IF_ERROR(init_unused_output_columns(thrift_lake_scan_node.unused_output_column_name));
-    RETURN_IF_ERROR(init_scanner_columns(scanner_columns, reader_columns));
     RETURN_IF_ERROR(init_reader_params(_scanner_ranges));
+    RETURN_IF_ERROR(init_scanner_columns(scanner_columns, reader_columns));
 
     if (_split_context != nullptr) {
         auto split_context = down_cast<const pipeline::LakeSplitContext*>(_split_context);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Introduced by ##60462.

During the initialization of OlapChunkSource and LakeDataSource, there are two functions that are called in an inconsistent order, which can sometimes cause them to select different segment iterators, resulting in inconsistent behavior.

<img width="956" height="386" alt="image" src="https://github.com/user-attachments/assets/c7e322df-6fca-4345-a82e-a1d4eba1bb56" />

<img width="893" height="272" alt="image" src="https://github.com/user-attachments/assets/031616e9-7c6a-4d7f-9a11-50546ee0b720" />


Fixes https://github.com/StarRocks/StarRocksTest/issues/10002

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
