### PR TITLE
[BugFix] set hit_count in vector index metrics

### DIFF
--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -715,7 +715,7 @@ void SystemMetrics::_update_vector_index_cache_metrics() {
     auto dynamic_lookup_count = lookup_count - _vector_index_cache_metrics->_previous_lookup_count;
     auto dynamic_hit_count = hit_count - _vector_index_cache_metrics->_previous_hit_count;
     auto dynamic_hit_ratio =
-            (dynamic_lookup_count == 0) ? 0.0 : double(dynamic_lookup_count) / double(dynamic_hit_count);
+            (dynamic_lookup_count == 0) ? 0.0 : double(dynamic_hit_count) / double(dynamic_lookup_count);
     _vector_index_cache_metrics->vector_index_cache_capacity.set_value(capacity);
     _vector_index_cache_metrics->vector_index_cache_usage.set_value(usage);
     _vector_index_cache_metrics->vector_index_cache_usage_ratio.set_value(usage_ratio);

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -695,7 +695,6 @@ void SystemMetrics::_install_vector_index_cache_metrics(MetricRegistry* registry
 }
 
 void SystemMetrics::_update_vector_index_cache_metrics() {
-    auto hit_count = 0;
 #ifdef WITH_TENANN
     auto* index_cache = tenann::IndexCache::GetGlobalInstance();
     if (UNLIKELY(index_cache == nullptr)) {
@@ -704,10 +703,12 @@ void SystemMetrics::_update_vector_index_cache_metrics() {
     auto capacity = index_cache->capacity();
     auto usage = index_cache->memory_usage();
     auto lookup_count = index_cache->lookup_count();
+    auto hit_count = index_cache->hit_count();
 #else
     auto capacity = 0;
     auto usage = 0;
     auto lookup_count = 0;
+    auto hit_count = 0;
 #endif
     auto usage_ratio = (capacity == 0L) ? 0.0 : double(usage) / double(capacity);
     auto hit_ratio = (lookup_count == 0L) ? 0.0 : double(hit_count) / double(lookup_count);


### PR DESCRIPTION
## Why I'm doing:
The `vector_index_cache_hit_count` metric is always zero because `hit_count` is never populated from the `tenann` index cache. Its value never changes from zero.

Additionally, the operands for `dynamic_hit_ratio` are backwards.

## What I'm doing:
If the `tenann` index is used, `hit_count` is populated from the index.

The operands of `dynamic_hit_ratio` are swapped.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
