### PR TITLE
[Enhancement] Optimize information_schema tables/views schema scan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
@@ -13,23 +13,48 @@
 // limitations under the License.
 package com.starrocks.catalog.system.information;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.service.InformationSchemaDataSource;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.thrift.TAuthInfo;
+import com.starrocks.thrift.TGetTablesInfoRequest;
+import com.starrocks.thrift.TGetTablesInfoResponse;
 import com.starrocks.thrift.TSchemaTableType;
+import com.starrocks.thrift.TTableInfo;
+import com.starrocks.thrift.TUserIdentity;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TException;
+import org.apache.thrift.meta_data.FieldValueMetaData;
 
-import static com.starrocks.catalog.system.SystemTable.FN_REFLEN;
-import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
-import static com.starrocks.catalog.system.SystemTable.builder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
-public class TablesSystemTable {
+public class TablesSystemTable extends SystemTable {
     public static final int MY_CS_NAME_SIZE = 32;
     private static final String NAME = "tables";
 
-    public static SystemTable create(String catalogName) {
-        return new SystemTable(catalogName, SystemId.TABLES_ID, NAME, Table.TableType.SCHEMA, builder()
+    private static final Logger LOG = LogManager.getLogger(TablesSystemTable.class);
+
+    public TablesSystemTable(String catalogName) {
+        super(catalogName, SystemId.TABLES_ID, NAME, Table.TableType.SCHEMA, builder()
                 .column("TABLE_CATALOG", ScalarType.createVarchar(FN_REFLEN))
                 .column("TABLE_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
                 .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
@@ -52,5 +77,98 @@ public class TablesSystemTable {
                 .column("CREATE_OPTIONS", ScalarType.createVarchar(255))
                 .column("TABLE_COMMENT", ScalarType.createVarchar(2048))
                 .build(), TSchemaTableType.SCH_TABLES);
+    }
+
+    public static SystemTable create(String catalogName) {
+        return new TablesSystemTable(catalogName);
+    }
+
+    private static final Set<String> SUPPORTED_EQUAL_COLUMNS =
+            Collections.unmodifiableSet(new TreeSet<>(String.CASE_INSENSITIVE_ORDER) {
+                {
+                    add("TABLE_SCHEMA");
+                    add("TABLE_NAME");
+                }
+            });
+
+    @Override
+    public boolean supportFeEvaluation(ScalarOperator predicate) {
+        final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        if (conjuncts.isEmpty()) {
+            return true;
+        }
+        if (!isEmptyOrOnlyEqualConstantOps(conjuncts)) {
+            return false;
+        }
+        return isSupportedEqualPredicateColumn(conjuncts, SUPPORTED_EQUAL_COLUMNS);
+    }
+
+    public static List<ScalarOperator> infoToScalar(SystemTable systemTable,
+                                                    TTableInfo tableInfo) {
+        List<ScalarOperator> result = Lists.newArrayList();
+        for (Column column : systemTable.getBaseSchema()) {
+            String name = column.getName().toLowerCase();
+            TTableInfo._Fields field = TTableInfo._Fields.findByName(name);
+            Preconditions.checkArgument(field != null, "Unknown field: " + name);
+            FieldValueMetaData meta = TTableInfo.metaDataMap.get(field).valueMetaData;
+            Object obj = tableInfo.getFieldValue(field);
+            Type valueType = thriftToScalarType(meta.type);
+            if (valueType.isStringType() && obj == null) {
+                obj = ""; // Convert null string to empty string
+            }
+            ConstantOperator scalar = ConstantOperator.createNullableObject(obj, valueType);
+            try {
+                scalar = mayCast(scalar, column.getType());
+            } catch (Exception e) {
+                LOG.debug("Failed to cast scalar operator for column: {}, value: {}, type: {}",
+                        column.getName(), obj, valueType, e);
+                scalar = ConstantOperator.createNull(column.getType());
+            }
+            result.add(scalar);
+        }
+        return result;
+    }
+
+    @Override
+    public List<List<ScalarOperator>> evaluate(ScalarOperator predicate) {
+        final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        ConnectContext context = Preconditions.checkNotNull(ConnectContext.get(), "not a valid connection");
+        TUserIdentity userIdentity = context.getCurrentUserIdentity().toThrift();
+        TGetTablesInfoRequest params = new TGetTablesInfoRequest();
+        TAuthInfo authInfo = new TAuthInfo();
+        authInfo.setCurrent_user_ident(userIdentity);
+        authInfo.setPattern(context.getDatabase());
+        for (ScalarOperator conjunct : conjuncts) {
+            BinaryPredicateOperator binary = (BinaryPredicateOperator) conjunct;
+            ColumnRefOperator columnRef = binary.getChild(0).cast();
+            String name = columnRef.getName();
+            ConstantOperator value = binary.getChild(1).cast();
+            switch (name.toUpperCase()) {
+                case "TABLE_NAME":
+                    params.setTable_name(value.getVarchar());
+                    break;
+                case "TABLE_SCHEMA":
+                    authInfo.setPattern(value.getVarchar());
+                    break;
+                default:
+                    throw new NotImplementedException("unsupported column: " + name);
+            }
+        }
+        params.setAuth_info(authInfo);
+
+        try {
+            TGetTablesInfoResponse result = query(params);
+            return result.getTables_infos().stream()
+                    .map(t -> infoToScalar(this, t))
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            LOG.warn("Failed to query materialized views", e);
+            // Return empty result if query failed
+            return Lists.newArrayList();
+        }
+    }
+
+    public static TGetTablesInfoResponse query(TGetTablesInfoRequest request) throws TException {
+        return InformationSchemaDataSource.generateTablesInfoResponse(request);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
@@ -137,7 +137,7 @@ public class TablesSystemTable extends SystemTable {
         TGetTablesInfoRequest params = new TGetTablesInfoRequest();
         TAuthInfo authInfo = new TAuthInfo();
         authInfo.setCurrent_user_ident(userIdentity);
-        authInfo.setPattern(context.getDatabase());
+        authInfo.setCatalog_name(this.getCatalogName());
         for (ScalarOperator conjunct : conjuncts) {
             BinaryPredicateOperator binary = (BinaryPredicateOperator) conjunct;
             ColumnRefOperator columnRef = binary.getChild(0).cast();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog.system.information;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
@@ -138,6 +139,9 @@ public class TablesSystemTable extends SystemTable {
         TAuthInfo authInfo = new TAuthInfo();
         authInfo.setCurrent_user_ident(userIdentity);
         authInfo.setCatalog_name(this.getCatalogName());
+        if (InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME.equalsIgnoreCase(this.getCatalogName())) {
+            authInfo.setPattern(context.getDatabase());
+        }
         for (ScalarOperator conjunct : conjuncts) {
             BinaryPredicateOperator binary = (BinaryPredicateOperator) conjunct;
             ColumnRefOperator columnRef = binary.getChild(0).cast();
@@ -162,7 +166,7 @@ public class TablesSystemTable extends SystemTable {
                     .map(t -> infoToScalar(this, t))
                     .collect(Collectors.toList());
         } catch (Exception e) {
-            LOG.warn("Failed to query materialized views", e);
+            LOG.warn("Failed to query tables ", e);
             // Return empty result if query failed
             return Lists.newArrayList();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
@@ -147,7 +147,7 @@ public class ViewsSystemTable extends SystemTable {
                     .map(t -> infoToScalar(this, t, params.db))
                     .collect(Collectors.toList());
         } catch (Exception e) {
-            LOG.warn("Failed to query materialized views", e);
+            LOG.warn("Failed to query views ", e);
             // Return empty result if query failed
             return Lists.newArrayList();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
@@ -13,20 +13,65 @@
 // limitations under the License.
 package com.starrocks.catalog.system.information;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.TableName;
+import com.starrocks.authentication.AuthenticationMgr;
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.authorization.PrivilegeBuiltinConstants;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
+import com.starrocks.catalog.View;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.common.CaseSensibility;
+import com.starrocks.common.PatternMatcher;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.thrift.TGetTablesParams;
+import com.starrocks.thrift.TListTableStatusResult;
 import com.starrocks.thrift.TSchemaTableType;
+import com.starrocks.thrift.TTableStatus;
+import com.starrocks.thrift.TTableType;
+import com.starrocks.thrift.TUserIdentity;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.parquet.Strings;
+import org.apache.thrift.TException;
+import org.apache.thrift.meta_data.FieldValueMetaData;
 
-import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
-import static com.starrocks.catalog.system.SystemTable.builder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
-public class ViewsSystemTable {
+import static com.starrocks.thrift.TTableType.VIEW;
+
+public class ViewsSystemTable extends SystemTable {
     public static final String NAME = "views";
 
-    public static SystemTable create(String catalogName) {
-        return new SystemTable(
+    private static final Logger LOG = LogManager.getLogger(ViewsSystemTable.class);
+
+    public ViewsSystemTable(String catalogName) {
+        super(
                 catalogName,
                 SystemId.VIEWS_ID,
                 NAME,
@@ -45,5 +90,228 @@ public class ViewsSystemTable {
                         .column("CHARACTER_SET_CLIENT", ScalarType.createVarchar(32))
                         .column("COLLATION_CONNECTION", ScalarType.createVarchar(32))
                         .build(), TSchemaTableType.SCH_VIEWS);
+    }
+
+    public static SystemTable create(String catalogName) {
+        return new ViewsSystemTable(catalogName);
+    }
+
+    private static final Set<String> SUPPORTED_EQUAL_COLUMNS =
+            Collections.unmodifiableSet(new TreeSet<>(String.CASE_INSENSITIVE_ORDER) {
+                {
+                    add("TABLE_SCHEMA");
+                    add("TABLE_NAME");
+                }
+            });
+
+    @Override
+    public boolean supportFeEvaluation(ScalarOperator predicate) {
+        final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        if (conjuncts.isEmpty()) {
+            return true;
+        }
+        if (!isEmptyOrOnlyEqualConstantOps(conjuncts)) {
+            return false;
+        }
+        return isSupportedEqualPredicateColumn(conjuncts, SUPPORTED_EQUAL_COLUMNS);
+    }
+
+    public List<List<ScalarOperator>> evaluate(ScalarOperator predicate) {
+        final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        ConnectContext context = Preconditions.checkNotNull(ConnectContext.get(), "not a valid connection");
+        TUserIdentity userIdentity = context.getCurrentUserIdentity().toThrift();
+        TGetTablesParams params = new TGetTablesParams();
+        params.setCurrent_user_ident(userIdentity);
+        params.setDb(context.getDatabase());
+        params.setType(VIEW);
+        for (ScalarOperator conjunct : conjuncts) {
+            BinaryPredicateOperator binary = (BinaryPredicateOperator) conjunct;
+            ColumnRefOperator columnRef = binary.getChild(0).cast();
+            String name = columnRef.getName();
+            ConstantOperator value = binary.getChild(1).cast();
+            switch (name.toUpperCase()) {
+                case "TABLE_NAME":
+                    params.setTable_name(value.getVarchar());
+                    break;
+                case "TABLE_SCHEMA":
+                    params.setDb(value.getVarchar());
+                    break;
+                default:
+                    throw new NotImplementedException("unsupported column: " + name);
+            }
+        }
+
+        try {
+            TListTableStatusResult result = query(params, context);
+            return result.getTables().stream()
+                    .map(t -> infoToScalar(this, t, params.db))
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            LOG.warn("Failed to query materialized views", e);
+            // Return empty result if query failed
+            return Lists.newArrayList();
+        }
+    }
+
+    private static final Map<String, String> ALIAS_MAP = ImmutableMap.of(
+            "view_definition", "ddl_sql",
+            "table_name", "name"
+    );
+
+    private static final Map<String, String> CONSTANT_MAP = ImmutableMap.of(
+            "table_catalog", "def",
+            "check_option", "NONE",
+            "is_updatable", "NO",
+            "definer", "",
+            "security_type", "",
+            "character_set_client", "utf8",
+            "collation_connection", "utf8_general_ci"
+    );
+
+    public static List<ScalarOperator> infoToScalar(SystemTable systemTable,
+                                                    TTableStatus status,
+                                                    String dbName) {
+        List<ScalarOperator> result = Lists.newArrayList();
+        for (Column column : systemTable.getBaseSchema()) {
+            String name = column.getName().toLowerCase();
+            if (CONSTANT_MAP.containsKey(name)) {
+                // For some columns, we return a constant value
+                Object obj = CONSTANT_MAP.get(name);
+                Type valueType = column.getType();
+                if (valueType.isStringType() && obj == null) {
+                    obj = ""; // Convert null string to empty string
+                }
+                ConstantOperator scalar = ConstantOperator.createNullableObject(obj, valueType);
+                result.add(scalar);
+                continue;
+            }
+            if ("table_schema".equals(name)) {
+                // For TABLE_SCHEMA, we return the database name
+                ConstantOperator scalar = ConstantOperator.createNullableObject(dbName, column.getType());
+                result.add(scalar);
+                continue;
+            }
+            if (ALIAS_MAP.containsKey(name)) {
+                name = ALIAS_MAP.get(name);
+            }
+            TTableStatus._Fields field = TTableStatus._Fields.findByName(name);
+            Preconditions.checkArgument(field != null, "Unknown field: " + name);
+            FieldValueMetaData meta = TTableStatus.metaDataMap.get(field).valueMetaData;
+            Object obj = status.getFieldValue(field);
+            Type valueType = thriftToScalarType(meta.type);
+            if (valueType.isStringType() && obj == null) {
+                obj = ""; // Convert null string to empty string
+            }
+            ConstantOperator scalar = ConstantOperator.createNullableObject(obj, valueType);
+            try {
+                scalar = mayCast(scalar, column.getType());
+            } catch (Exception e) {
+                LOG.debug("Failed to cast scalar operator for column: {}, value: {}, type: {}",
+                        column.getName(), obj, valueType, e);
+                scalar = ConstantOperator.createNull(column.getType());
+            }
+            result.add(scalar);
+        }
+        return result;
+    }
+
+    public static TListTableStatusResult query(TGetTablesParams params,
+                                               ConnectContext context) throws TException {
+        LOG.debug("get list table request: {}", params);
+        TListTableStatusResult result = new TListTableStatusResult();
+        List<TTableStatus> tablesResult = Lists.newArrayList();
+        result.setTables(tablesResult);
+        PatternMatcher matcher = null;
+        boolean caseSensitive = CaseSensibility.TABLE.getCaseSensibility();
+        if (params.isSetPattern()) {
+            try {
+                matcher = PatternMatcher.createMysqlPattern(params.getPattern(), caseSensitive);
+            } catch (SemanticException e) {
+                throw new TException("Pattern is in bad format " + params.getPattern());
+            }
+        }
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(params.db);
+        long limit = params.isSetLimit() ? params.getLimit() : -1;
+        UserIdentity currentUser;
+        if (params.isSetCurrent_user_ident()) {
+            currentUser = UserIdentity.fromThrift(params.current_user_ident);
+        } else {
+            currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
+        }
+        String tableNameParam = params.isSetTable_name() ? params.getTable_name() : null;
+        if (db != null) {
+            Locker locker = new Locker();
+            locker.lockDatabase(db.getId(), LockType.READ);
+            try {
+                boolean listingViews = params.isSetType() && TTableType.VIEW.equals(params.getType());
+                List<Table> tables = listingViews ? db.getViews() :
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
+                OUTER:
+                for (Table table : tables) {
+                    try {
+                        context.setCurrentUserIdentity(currentUser);
+                        context.setCurrentRoleIds(currentUser);
+                        Authorizer.checkAnyActionOnTableLikeObject(context, params.db, table);
+                    } catch (AccessDeniedException e) {
+                        continue;
+                    }
+
+                    if (!PatternMatcher.matchPattern(params.getPattern(), table.getName(), matcher, caseSensitive)) {
+                        continue;
+                    }
+                    if (!Strings.isNullOrEmpty(tableNameParam) &&
+                            !table.getName().equalsIgnoreCase(tableNameParam)) {
+                        continue;
+                    }
+
+                    TTableStatus status = new TTableStatus();
+                    status.setName(table.getName());
+                    status.setType(table.getMysqlType());
+                    status.setEngine(table.getEngine());
+                    status.setComment(table.getComment());
+                    status.setCreate_time(table.getCreateTime());
+                    status.setLast_check_time(table.getLastCheckTime());
+                    if (listingViews) {
+                        View view = (View) table;
+                        String ddlSql = view.getInlineViewDef();
+
+                        ConnectContext connectContext = ConnectContext.buildInner();
+                        connectContext.setQualifiedUser(AuthenticationMgr.ROOT_USER);
+                        connectContext.setCurrentUserIdentity(UserIdentity.ROOT);
+                        connectContext.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+
+                        try {
+                            List<TableName> allTables = view.getTableRefs();
+                            for (TableName tableName : allTables) {
+                                Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                        .getTable(db.getFullName(), tableName.getTbl());
+                                if (tbl != null) {
+                                    try {
+                                        context.setCurrentUserIdentity(currentUser);
+                                        context.setCurrentRoleIds(currentUser);
+                                        Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), tbl);
+                                    } catch (AccessDeniedException e) {
+                                        continue OUTER;
+                                    }
+                                }
+                            }
+                        } catch (SemanticException e) {
+                            // ignore semantic exception because view maybe invalid
+                        }
+                        status.setDdl_sql(ddlSql);
+                    }
+
+                    tablesResult.add(status);
+                    // if user set limit, then only return limit size result
+                    if (limit > 0 && tablesResult.size() >= limit) {
+                        break;
+                    }
+                }
+            } finally {
+                locker.unLockDatabase(db.getId(), LockType.READ);
+            }
+        }
+        return result;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -49,9 +49,7 @@ import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.analysis.TupleId;
 import com.starrocks.authentication.AuthenticationException;
 import com.starrocks.authentication.AuthenticationHandler;
-import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.authorization.AccessDeniedException;
-import com.starrocks.authorization.PrivilegeBuiltinConstants;
 import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
@@ -72,12 +70,13 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
-import com.starrocks.catalog.View;
 import com.starrocks.catalog.system.information.AnalyzeStatusSystemTable;
 import com.starrocks.catalog.system.information.ColumnStatsUsageSystemTable;
 import com.starrocks.catalog.system.information.MaterializedViewsSystemTable;
+import com.starrocks.catalog.system.information.TablesSystemTable;
 import com.starrocks.catalog.system.information.TaskRunsSystemTable;
 import com.starrocks.catalog.system.information.TasksSystemTable;
+import com.starrocks.catalog.system.information.ViewsSystemTable;
 import com.starrocks.catalog.system.sys.GrantsTo;
 import com.starrocks.catalog.system.sys.RoleEdges;
 import com.starrocks.catalog.system.sys.SysFeLocks;
@@ -344,8 +343,6 @@ import com.starrocks.thrift.TStreamLoadPutResult;
 import com.starrocks.thrift.TTablePrivDesc;
 import com.starrocks.thrift.TTableReplicationRequest;
 import com.starrocks.thrift.TTableReplicationResponse;
-import com.starrocks.thrift.TTableStatus;
-import com.starrocks.thrift.TTableType;
 import com.starrocks.thrift.TTabletLocation;
 import com.starrocks.thrift.TTaskInfo;
 import com.starrocks.thrift.TTrackingLoadInfo;
@@ -536,99 +533,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
     @Override
     public TListTableStatusResult listTableStatus(TGetTablesParams params) throws TException {
-        LOG.debug("get list table request: {}", params);
-        TListTableStatusResult result = new TListTableStatusResult();
-        List<TTableStatus> tablesResult = Lists.newArrayList();
-        result.setTables(tablesResult);
-        PatternMatcher matcher = null;
-        boolean caseSensitive = CaseSensibility.TABLE.getCaseSensibility();
-        if (params.isSetPattern()) {
-            try {
-                matcher = PatternMatcher.createMysqlPattern(params.getPattern(), caseSensitive);
-            } catch (SemanticException e) {
-                throw new TException("Pattern is in bad format " + params.getPattern());
-            }
-        }
-
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(params.db);
-        long limit = params.isSetLimit() ? params.getLimit() : -1;
-        UserIdentity currentUser;
-        if (params.isSetCurrent_user_ident()) {
-            currentUser = UserIdentity.fromThrift(params.current_user_ident);
-        } else {
-            currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
-        }
-        if (db != null) {
-            Locker locker = new Locker();
-            locker.lockDatabase(db.getId(), LockType.READ);
-            try {
-                boolean listingViews = params.isSetType() && TTableType.VIEW.equals(params.getType());
-                List<Table> tables = listingViews ? db.getViews() :
-                        GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
-                OUTER:
-                for (Table table : tables) {
-                    try {
-                        ConnectContext context = new ConnectContext();
-                        context.setCurrentUserIdentity(currentUser);
-                        context.setCurrentRoleIds(currentUser);
-                        Authorizer.checkAnyActionOnTableLikeObject(context, params.db, table);
-                    } catch (AccessDeniedException e) {
-                        continue;
-                    }
-
-                    if (!PatternMatcher.matchPattern(params.getPattern(), table.getName(), matcher, caseSensitive)) {
-                        continue;
-                    }
-
-                    TTableStatus status = new TTableStatus();
-                    status.setName(table.getName());
-                    status.setType(table.getMysqlType());
-                    status.setEngine(table.getEngine());
-                    status.setComment(table.getComment());
-                    status.setCreate_time(table.getCreateTime());
-                    status.setLast_check_time(table.getLastCheckTime());
-                    if (listingViews) {
-                        View view = (View) table;
-                        String ddlSql = view.getInlineViewDef();
-
-                        ConnectContext connectContext = ConnectContext.buildInner();
-                        connectContext.setQualifiedUser(AuthenticationMgr.ROOT_USER);
-                        connectContext.setCurrentUserIdentity(UserIdentity.ROOT);
-                        connectContext.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
-
-                        try {
-                            List<TableName> allTables = view.getTableRefs();
-                            for (TableName tableName : allTables) {
-                                Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                        .getTable(db.getFullName(), tableName.getTbl());
-                                if (tbl != null) {
-                                    try {
-                                        ConnectContext context = new ConnectContext();
-                                        context.setCurrentUserIdentity(currentUser);
-                                        context.setCurrentRoleIds(currentUser);
-                                        Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), tbl);
-                                    } catch (AccessDeniedException e) {
-                                        continue OUTER;
-                                    }
-                                }
-                            }
-                        } catch (SemanticException e) {
-                            // ignore semantic exception because view maybe invalid
-                        }
-                        status.setDdl_sql(ddlSql);
-                    }
-
-                    tablesResult.add(status);
-                    // if user set limit, then only return limit size result
-                    if (limit > 0 && tablesResult.size() >= limit) {
-                        break;
-                    }
-                }
-            } finally {
-                locker.unLockDatabase(db.getId(), LockType.READ);
-            }
-        }
-        return result;
+        ConnectContext context = new ConnectContext();
+        return ViewsSystemTable.query(params, context);
     }
 
     @Override
@@ -2560,7 +2466,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
     @Override
     public TGetTablesInfoResponse getTablesInfo(TGetTablesInfoRequest request) throws TException {
-        return InformationSchemaDataSource.generateTablesInfoResponse(request);
+        return TablesSystemTable.query(request);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTimeSeriesRewriteWithOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTimeSeriesRewriteWithOlapTest.java
@@ -429,7 +429,8 @@ public class MvTimeSeriesRewriteWithOlapTest extends MVTestBase {
             aggFuncs.add(mvAggFunc);
         }
 
-        int repeatTimes = 4;
+        int repeatTimes = 2;
+        int idx = 0;
         for (String aggFunc : aggFuncs) {
             if (aggFunc.contains("bitmap_union")) {
                 continue;
@@ -439,25 +440,26 @@ public class MvTimeSeriesRewriteWithOlapTest extends MVTestBase {
                 repeatAggs.add(String.format("%s as agg%s", aggFunc, i));
             }
             String agg = Joiner.on(", ").join(repeatAggs);
-            starRocksAssert.withMaterializedView(String.format("create MATERIALIZED VIEW test_mv1\n" +
+            String mvName = String.format("test_mv%d", idx++);
+            starRocksAssert.withMaterializedView(String.format("create MATERIALIZED VIEW %s\n" +
                     "PARTITION BY (dt)\n" +
                     "DISTRIBUTED BY RANDOM\n" +
                     "as select date_trunc('day', k1) as dt, %s " +
-                    "from t0 group by date_trunc('day', k1);", agg));
+                    "from t0 group by date_trunc('day', k1);", mvName, agg));
             {
                 String query = String.format("select %s from t0 where k1 >= '2024-01-01 01:00:00'", agg);
                 String plan = getFragmentPlan(query);
-                PlanTestBase.assertContains(plan, "     TABLE: test_mv1");
+                PlanTestBase.assertContains(plan, String.format("     TABLE: %s", mvName));
                 PlanTestBase.assertContains(plan, "     TABLE: t0");
             }
             {
                 String query = String.format("select date_trunc('day', k1), %s from t0 " +
                         "where k1 >= '2024-01-01 01:00:00' group by date_trunc('day', k1)", agg);
                 String plan = getFragmentPlan(query);
-                PlanTestBase.assertContains(plan, "     TABLE: test_mv1");
+                PlanTestBase.assertContains(plan, String.format("     TABLE: %s", mvName));
                 PlanTestBase.assertContains(plan, "     TABLE: t0");
             }
-            starRocksAssert.dropMaterializedView("test_mv1");
+            starRocksAssert.dropMaterializedView(mvName);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
Like #59379, we can optimize information_schema tables/views schema scan into FE optimizer constant evaluation in some cases to avoid heavy rpc between BE and FEs.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
