### PR TITLE
[BugFix]Fix transaction stream load can not find the coordinator node.(backport #60154)

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -2484,6 +2484,24 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: The time interval at which finished transactions are cleaned up. Unit: second. We recommend that you specify a short time interval to ensure that finished transactions can be cleaned up in a timely manner.
 - Introduced in: -
 
+##### transaction_stream_load_coordinator_cache_capacity
+
+- Default: 4096
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The capacity of the cache that stores the mapping from transaction label to coordinator node.
+- Introduced in: -
+
+##### transaction_stream_load_coordinator_cache_expire_seconds
+
+- Default: 900
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: The time to keep the coordinator mapping in the cache before it's evicted(TTL).
+- Introduced in: -
+
 ### Storage
 
 ##### default_replication_num

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -1733,6 +1733,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: 完了したトランザクションがクリーンアップされる時間間隔。単位: 秒。完了したトランザクションがタイムリーにクリーンアップされるように、短い時間間隔を指定することをお勧めします。
 - 導入バージョン: -
 
+##### transaction_stream_load_coordinator_cache_capacity
+
+- デフォルト：4096
+- タイプ：Int
+- 単位：-
+- 変更可能：是
+- 説明：ストレージトランザクションタグからcoordinatorノードへのマッピングのキャッシュ容量を設定します。
+- 導入バージョン：-
+
+##### transaction_stream_load_coordinator_cache_expire_seconds
+
+- デフォルト：900
+- タイプ：Int
+- 単位：-
+- 変更可能：是
+- 説明：トランザクションタグとcoordinatorノードのマッピング関係がキャッシュ内に保持される生存時間（TTL）。
+- 導入バージョン：-
+
 ### ストレージ
 
 ##### default_replication_num

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -2476,6 +2476,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：已结束事务的清理间隔。建议清理间隔尽量短，从而确保已完成的事务能够及时清理掉。
 - 引入版本：-
 
+##### transaction_stream_load_coordinator_cache_capacity
+
+- 默认值：4096
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：存储事务标签到coordinator节点映射的缓存容量。
+- 引入版本：-
+
+##### transaction_stream_load_coordinator_cache_expire_seconds
+
+- 默认值：900
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：事务标签与coordinator节点映射关系在缓存中的存活时间(TTL)。
+- 引入版本：-
+
 ### 存储
 
 ##### default_replication_num

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1058,6 +1058,13 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int max_stream_load_timeout_second = 259200; // 3days
 
+    @ConfField(mutable = true, comment = "The capacity of " +
+            "the cache that stores the mapping from transaction label to coordinator node.")
+    public static int transaction_stream_load_coordinator_cache_capacity = 4096;
+
+    @ConfField(mutable = true, comment = "The time to keep the coordinator mapping in the cache before it's evicted.")
+    public static int transaction_stream_load_coordinator_cache_expire_seconds = 900;
+
     /**
      * Max stream load load batch size
      */

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpMetricRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpMetricRegistry.java
@@ -81,6 +81,15 @@ public class HttpMetricRegistry {
     /** A histogram metric. The latency in milliseconds to handle rollback operations. */
     public static final String TXN_STREAM_LOAD_ROLLBACK_LATENCY_MS = "txn_stream_load_rollback_latency_ms";
 
+    /** A counter metric. The cumulative count of cache hits since initialization */
+    public static final String TXN_STREAM_LOAD_CACHE_HIT_NUM = "txn_stream_load_cache_hit_num";
+
+    /** A counter metric. The cumulative count of cache misses since initialization */
+    public static final String TXN_STREAM_LOAD_CACHE_MISS_NUM = "txn_stream_load_cache_miss_num";
+
+    /** A counter metric. The cumulative count of cache evictions since initialization */
+    public static final String TXN_STREAM_LOAD_CACHE_EVICTION_NUM = "txn_stream_load_cache_eviction_num";
+
     // ================= Metric maps =================
 
     private final Map<String, CounterMetric<?>> counterMetrics = new ConcurrentHashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -37,6 +37,7 @@ package com.starrocks.http.rest;
 import com.codahale.metrics.Histogram;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.LabelAlreadyUsedException;
@@ -57,6 +58,7 @@ import com.starrocks.http.rest.transaction.TransactionOperationParams.Body;
 import com.starrocks.http.rest.transaction.TransactionOperationParams.Channel;
 import com.starrocks.http.rest.transaction.TransactionWithChannelHandler;
 import com.starrocks.http.rest.transaction.TransactionWithoutChannelHandler;
+import com.starrocks.metric.GaugeMetric;
 import com.starrocks.metric.LongCounterMetric;
 import com.starrocks.metric.Metric;
 import com.starrocks.server.GlobalStateMgr;
@@ -72,16 +74,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.Function;
 
 import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_BEGIN_LATENCY_MS;
 import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_BEGIN_NUM;
+import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_CACHE_EVICTION_NUM;
+import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_CACHE_HIT_NUM;
+import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_CACHE_MISS_NUM;
 import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_COMMIT_LATENCY_MS;
 import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_COMMIT_NUM;
 import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_LOAD_LATENCY_MS;
@@ -112,18 +112,18 @@ public class TransactionLoadAction extends RestBaseAction {
     // Map operation name to metrics
     private final Map<TransactionOperation, OpMetrics> opMetricsMap = new HashMap<>();
 
-    private final ReadWriteLock txnNodeMapAccessLock = new ReentrantReadWriteLock();
-    private final Map<String, Long> txnNodeMap = new LinkedHashMap<>(512, 0.75f, true) {
-        @Override
-        protected boolean removeEldestEntry(Map.Entry<String, Long> eldest) {
-            return size() > (GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalBackendNumber() +
-                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalComputeNodeNumber()) * 512;
-        }
-    };
+    // Manage coordinators for transaction stream load
+    private final TransactionLoadCoordinatorMgr coordinatorMgr;
 
     public TransactionLoadAction(ActionController controller) {
         super(controller);
+        this.coordinatorMgr = new TransactionLoadCoordinatorMgr();
         initMetrics();
+    }
+
+    @VisibleForTesting
+    public TransactionLoadCoordinatorMgr getCoordinatorMgr() {
+        return coordinatorMgr;
     }
 
     @Override
@@ -164,12 +164,39 @@ public class TransactionLoadAction extends RestBaseAction {
         metricRegistry.registerCounter(txnStreamLoadRollbackNum);
         Histogram rollbackLatency = metricRegistry.registerHistogram(TXN_STREAM_LOAD_ROLLBACK_LATENCY_MS);
         opMetricsMap.put(TXN_ROLLBACK, OpMetrics.of(txnStreamLoadRollbackNum, rollbackLatency));
+
+        GaugeMetric<Long> txnStreamLoadCacheHitNum = new GaugeMetric<>(TXN_STREAM_LOAD_CACHE_HIT_NUM, Metric.MetricUnit.NOUNIT,
+                "The cumulative count of cache hits for requested items in the transaction stream.") {
+            @Override
+            public Long getValue() {
+                return coordinatorMgr.getCacheHitCount();
+            }
+        };
+        metricRegistry.registerGauge(txnStreamLoadCacheHitNum);
+
+        GaugeMetric<Long> txnStreamLoadCacheMissNum = new GaugeMetric<>(TXN_STREAM_LOAD_CACHE_MISS_NUM, Metric.MetricUnit.NOUNIT,
+                "The cumulative count of cache misses for requested items in the transaction stream.") {
+            @Override
+            public Long getValue() {
+                return coordinatorMgr.getCacheMissCount();
+            }
+        };
+        metricRegistry.registerGauge(txnStreamLoadCacheMissNum);
+
+        GaugeMetric<Long> txnStreamLoadCacheEvictionNum = new GaugeMetric<>(TXN_STREAM_LOAD_CACHE_EVICTION_NUM,
+                Metric.MetricUnit.NOUNIT,
+                "The cumulative count of cache evictions for requested items in the transaction stream.") {
+            @Override
+            public Long getValue() {
+                return coordinatorMgr.getCacheEvictionCount();
+            }
+        };
+        metricRegistry.registerGauge(txnStreamLoadCacheEvictionNum);
     }
 
-    public int txnNodeMapSize() {
-        return accessTxnNodeMapWithReadLock(Map::size);
+    public long coordinatorMgrSize() {
+        return coordinatorMgr.size();
     }
-
     public static TransactionLoadAction getAction() {
         return ac;
     }
@@ -231,14 +258,10 @@ public class TransactionLoadAction extends RestBaseAction {
         // redirect transaction op to BE
         TNetworkAddress redirectAddress = result.getRedirectAddress();
         if (null == redirectAddress) {
-            Long nodeId = getNodeId(txnOperation, label, txnOperationParams.getWarehouseName());
-            ComputeNode node = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(nodeId);
-            if (node == null) {
-                node = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNode(nodeId);
-                if (node == null) {
-                    throw new StarRocksException("Node " + nodeId + " is not alive");
-                }
-            }
+            // TODO This must be a transaction stream load. Should refactor the code to make it clearer.
+            ComputeNode node = TXN_BEGIN.equals(txnOperation) ?
+                    coordinatorMgr.allocate(label, txnOperationParams.getWarehouseName()) :
+                    coordinatorMgr.get(label, txnOperationParams.getDbName());
 
             redirectAddress = new TNetworkAddress(node.getHost(), node.getHttpPort());
         }
@@ -250,61 +273,46 @@ public class TransactionLoadAction extends RestBaseAction {
 
     private TransactionOperationHandler getTxnOperationHandler(TransactionOperationParams params) throws
             StarRocksException {
+        // parallel transaction stream load must include channel parameters, so it must be
+        // parallel transaction stream load if channel exists, otherwise it is not.
         if (params.getChannel().notNull()) {
             return new TransactionWithChannelHandler(params);
         }
 
-        TransactionOperation txnOperation = params.getTxnOperation();
         LoadJobSourceType sourceType = params.getSourceType();
-        if ((TXN_BEGIN.equals(txnOperation) || TXN_LOAD.equals(txnOperation)) && null == sourceType) {
-            return new TransactionWithoutChannelHandler(params);
-        }
+        // There can be several cases where sourceType is not specified (null) in the request:
+        // 1. The operation is BEGIN or LOAD. This is only allowed for transaction stream load for backward compatibility.
+        // 2. The operation is COMMIT, PREPARE, or ROLLBACK. It can be transaction stream load or bypass writer. Need to
+        // get the source type from transaction state.
+        if (sourceType == null) {
+            // if the operation is BEGIN or LOAD, it must be a transaction stream load.
+            TransactionOperation txnOperation = params.getTxnOperation();
+            if (TXN_BEGIN.equals(txnOperation) || TXN_LOAD.equals(txnOperation)) {
+                return new TransactionWithoutChannelHandler(params);
+            }
 
-        String label = params.getLabel();
-        if (accessTxnNodeMapWithReadLock(txnNodeMap -> txnNodeMap.containsKey(label))) {
-            /*
-             * The Bypass Write scenario will not redirect the request to BE definitely,
-             * so if txnNodeMap contains the label, this must not be a Bypass Write scenario.
-             */
-            return new TransactionWithoutChannelHandler(params);
-        }
+            String label = params.getLabel();
+            // A fast path to distinguish whether it is a transaction stream load.
+            // The label will be cached in coordinatorMgr, so if it still exists
+            // in cache, it must be a transaction stream load.
+            if (coordinatorMgr.existInCache(label)) {
+                return new TransactionWithoutChannelHandler(params);
+            }
 
-        if (null == sourceType) {
+            // judge the source type by transaction state
             String dbName = params.getDbName();
             Database db = Optional.ofNullable(GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName))
                     .orElseThrow(() -> new StarRocksException(String.format("Database[%s] does not exist.", dbName)));
-
             TransactionState txnState = GlobalStateMgr.getCurrentState()
                     .getGlobalTransactionMgr().getLabelTransactionState(db.getId(), label);
             if (null == txnState) {
-                throw new StarRocksException(String.format("No transaction found by label %s", label));
+                throw new StarRocksException(String.format("No transaction found with db[%s] and label[%s]", dbName, label));
             }
             sourceType = txnState.getSourceType();
         }
 
         return LoadJobSourceType.BYPASS_WRITE.equals(sourceType)
                 ? new BypassWriteTransactionHandler(params) : new TransactionWithoutChannelHandler(params);
-    }
-
-    private Long getNodeId(TransactionOperation txnOperation, String label, String warehouseName) throws StarRocksException {
-        Long nodeId;
-        // save label->be hashmap when begin transaction, so that subsequent operator can send to same BE
-        if (TXN_BEGIN.equals(txnOperation)) {
-            List<Long> nodeIds = LoadAction.selectNodes(warehouseName);
-            Long chosenNodeId = nodeIds.get(0);
-            nodeId = chosenNodeId;
-            // txnNodeMap is LRU cache, it atomic remove unused entry
-            accessTxnNodeMapWithWriteLock(txnNodeMap -> txnNodeMap.put(label, chosenNodeId));
-        } else {
-            nodeId = accessTxnNodeMapWithReadLock(txnNodeMap -> txnNodeMap.get(label));
-        }
-
-        if (nodeId == null) {
-            throw new StarRocksException(String.format(
-                    "Transaction with op[%s] and label[%s] has no node.", txnOperation.getValue(), label));
-        }
-
-        return nodeId;
     }
 
     /**
@@ -406,24 +414,6 @@ public class TransactionLoadAction extends RestBaseAction {
             return jobSourceType;
         } catch (NumberFormatException e) {
             throw new StarRocksException("Invalid source type: " + sourceType);
-        }
-    }
-
-    private <T> T accessTxnNodeMapWithReadLock(Function<Map<String, Long>, T> function) {
-        txnNodeMapAccessLock.readLock().lock();
-        try {
-            return function.apply(txnNodeMap);
-        } finally {
-            txnNodeMapAccessLock.readLock().unlock();
-        }
-    }
-
-    private <T> T accessTxnNodeMapWithWriteLock(Function<Map<String, Long>, T> function) {
-        txnNodeMapAccessLock.writeLock().lock();
-        try {
-            return function.apply(txnNodeMap);
-        } finally {
-            txnNodeMapAccessLock.writeLock().unlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadCoordinatorMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadCoordinatorMgr.java
@@ -1,0 +1,231 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.catalog.Database;
+import com.starrocks.common.Config;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.transaction.TransactionState;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manages the allocation and retrieval of coordinator nodes for transaction stream load.
+ * <p>
+ * This class maintains a cache that maps transaction labels to the node IDs of their coordinators,
+ * allowing for efficient lookup and management of coordinators during the lifecycle of a transaction
+ * stream load. By leveraging this cache, the system can avoid querying the transaction state for every
+ * request, which reduces the lock contention on the transaction manager.
+ */
+public class TransactionLoadCoordinatorMgr {
+
+    private static final Logger LOG = LogManager.getLogger(TransactionLoadCoordinatorMgr.class);
+
+    /**
+     * A cache that stores the mapping from transaction label to coordinator node ID.
+     * The cache's capacity and expiration time are dynamically adjustable based on
+     * configuration changes.
+     */
+    private final Cache<String, Long> cache;
+
+    public TransactionLoadCoordinatorMgr() {
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(Config.transaction_stream_load_coordinator_cache_capacity)
+                .expireAfterAccess(Config.transaction_stream_load_coordinator_cache_expire_seconds, TimeUnit.SECONDS)
+                .evictionListener((key, value, cause) ->
+                        LOG.debug("Evict load, label {}, nodeId: {}, cause: {}", key, value, cause))
+                .recordStats()
+                .build();
+        GlobalStateMgr.getCurrentState().getConfigRefreshDaemon().registerListener(this::updateCacheCapacity);
+        GlobalStateMgr.getCurrentState().getConfigRefreshDaemon().registerListener(this::updateCacheExpireTime);
+    }
+
+    /**
+     * Updates the cache's maximum capacity if the configuration value has changed.
+     * This method is called when the related configuration is refreshed.
+     */
+    private void updateCacheCapacity() {
+        cache.policy().eviction().ifPresent(eviction -> {
+            long oldCapacity = eviction.getMaximum();
+            long newCapacity = Config.transaction_stream_load_coordinator_cache_capacity;
+            if (oldCapacity != newCapacity) {
+                eviction.setMaximum(newCapacity);
+                LOG.info("Update cache capacity, old: {}, new: {}", oldCapacity, newCapacity);
+            }
+        });
+    }
+
+    /**
+     * The cumulative number of times requested items were found in the cache.
+     */
+    public long getCacheHitCount() {
+        return cache.stats().hitCount();
+    }
+
+    /**
+     * The cumulative number of times requested items were not found in the cache.
+     */
+    public long getCacheMissCount() {
+        return cache.stats().missCount();
+    }
+
+    /**
+     * The cumulative number of entries evicted from the cache.
+     */
+    public long getCacheEvictionCount() {
+        return cache.stats().evictionCount();
+    }
+
+    /**
+     * Updates the cache's expiration time if the configuration value has changed.
+     * This method is called when the related configuration is refreshed.
+     */
+    private void updateCacheExpireTime() {
+        cache.policy().expireAfterAccess().ifPresent(expire -> {
+            long oldExpire = expire.getExpiresAfter(TimeUnit.SECONDS);
+            long newExpire = Config.transaction_stream_load_coordinator_cache_expire_seconds;
+            if (oldExpire != newExpire) {
+                expire.setExpiresAfter(newExpire, TimeUnit.SECONDS);
+                LOG.info("Update cache expire time, old: {}, new: {}", oldExpire, newExpire);
+            }
+        });
+    }
+
+    /**
+     * Allocates a coordinator node for a given transaction label and warehouse name.
+     * The selected node is cached for future retrievals.
+     *
+     * @param label         the transaction label
+     * @param warehouseName the name of the warehouse
+     * @return the allocated {@link ComputeNode}
+     * @throws StarRocksException if allocation fails or no suitable node is found
+     */
+    public @NonNull ComputeNode allocate(String label, String warehouseName) throws StarRocksException {
+        List<Long> nodeIds = LoadAction.selectNodes(warehouseName);
+        Long chosenNodeId = nodeIds.get(0);
+        ComputeNode node = getNodeFromId(chosenNodeId);
+        cache.put(label, chosenNodeId);
+        return node;
+    }
+
+    /**
+     * Retrieves the coordinator node for a given transaction label and database name.
+     * If the label is not present in the cache, attempts to retrieve the node from the transaction state.
+     *
+     * @param label  the transaction label
+     * @param dbName the database name
+     * @return the corresponding {@link ComputeNode}
+     * @throws StarRocksException if the node cannot be found
+     */
+    public @NonNull ComputeNode get(String label, String dbName) throws StarRocksException {
+        Long nodeId = cache.getIfPresent(label);
+        return nodeId != null ? getNodeFromId(nodeId) : getNodeFromTransactionState(label, dbName);
+    }
+
+    /**
+     * Remove key form cache. It is only used in test cases
+     *
+     * @param label  the transaction label
+     */
+    @VisibleForTesting
+    public void remove(String label) {
+        cache.invalidate(label);
+    }
+
+    /**
+     * Calculate the length of the cache. It is only used in test cases
+     */
+    @VisibleForTesting
+    public long size() {
+        return cache.estimatedSize();
+    }
+
+    /**
+     * It is only used in test cases
+     */
+    @VisibleForTesting
+    public void put(String key, Long value) {
+        cache.put(key, value);
+    }
+
+    /**
+     * Checks if a transaction label exists in the cache.
+     *
+     * @param label the transaction label
+     * @return true if the label exists in the cache, false otherwise
+     */
+    public boolean existInCache(String label) {
+        return cache.getIfPresent(label) != null;
+    }
+
+    /**
+     * Retrieves a {@link ComputeNode} by its node ID.
+     *
+     * @param nodeId the ID of the node
+     * @return the corresponding {@link ComputeNode}
+     * @throws StarRocksException if the node cannot be found
+     */
+    @VisibleForTesting
+    public @NonNull ComputeNode getNodeFromId(Long nodeId) throws StarRocksException {
+        ComputeNode node = GlobalStateMgr.getCurrentState().getNodeMgr()
+                .getClusterInfo().getBackendOrComputeNode(nodeId);
+        if (node == null) {
+            throw new StarRocksException(String.format("Can't find node id %s. You can check the cluster " +
+                    "to see whether the node exists ", nodeId));
+        }
+        return node;
+    }
+
+    /**
+     * Retrieves a {@link ComputeNode} from the transaction state using the label and database name.
+     *
+     * @param label  the transaction label
+     * @param dbName the database name
+     * @return the corresponding {@link ComputeNode}
+     * @throws StarRocksException if the transaction or node cannot be found
+     */
+    private @NonNull ComputeNode getNodeFromTransactionState(String label, String dbName) throws StarRocksException {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbName);
+        if (db == null) {
+            throw new StarRocksException(String.format("Can't find db[%s] for label[%s]. The db may be dropped.", dbName, label));
+        }
+
+        TransactionState state = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().
+                getLabelTransactionState(db.getId(), label);
+        if (state == null) {
+            throw new StarRocksException(String.format("Can't find the transaction with db [%s] and label[%s]." +
+                    " The possible reasons: 1. FE leader is started or switched; " +
+                    "2. The transaction timeouts and is cleaned.", dbName, label));
+        }
+
+        TransactionState.TxnCoordinator txnCoordinator = state.getCoordinator();
+        if (!TransactionState.TxnSourceType.BE.equals(txnCoordinator.sourceType)) {
+            throw new StarRocksException(String.format("The source type for transaction stream load " +
+                            "with db [%s] and label[%s] should be %s, but is %s.",
+                    dbName, label, TransactionState.TxnSourceType.BE, txnCoordinator.sourceType));
+        }
+        return getNodeFromId(txnCoordinator.getBackendId());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -160,7 +160,7 @@ public class StreamLoadMgr implements MemoryTrackable {
     // for sync stream load task
     public void beginLoadTaskFromBackend(String dbName, String tableName, String label, TUniqueId requestId,
                                          String user, String clientIp, long timeoutMillis,
-                                         TransactionResult resp, boolean isRoutineLoad, long warehouseId) throws
+                                         TransactionResult resp, boolean isRoutineLoad, long warehouseId, long backendId) throws
             StarRocksException {
         StreamLoadTask task = null;
         Database db = checkDbName(dbName);
@@ -174,7 +174,7 @@ public class StreamLoadMgr implements MemoryTrackable {
             LOG.info(new LogBuilder(LogKey.STREAM_LOAD_TASK, task.getId())
                     .add("msg", "create load task").build());
 
-            task.beginTxnFromBackend(requestId, clientIp, resp);
+            task.beginTxnFromBackend(requestId, clientIp, backendId, resp);
             addLoadTask(task);
         } finally {
             writeUnlock();

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -286,8 +286,8 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         return endTimeMs();
     }
 
-    public void beginTxnFromBackend(TUniqueId requestId, String clientIp, TransactionResult resp) {
-        beginTxn(0, 1, requestId, new TxnCoordinator(TransactionState.TxnSourceType.BE, clientIp), resp);
+    public void beginTxnFromBackend(TUniqueId requestId, String clientIp, long backendId, TransactionResult resp) {
+        beginTxn(0, 1, requestId, TxnCoordinator.fromBackend(clientIp, backendId), resp);
     }
 
     public void beginTxnFromFrontend(int channelId, int channelNum, TransactionResult resp) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1226,8 +1226,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         long timeoutSecond = request.isSetTimeout() ? request.getTimeout() : Config.stream_load_default_timeout_second;
         MetricRepo.COUNTER_LOAD_ADD.increase(1L);
 
+        long backendId = request.isSetBackend_id() ? request.getBackend_id() : -1;
         long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
-        if (request.isSetBackend_id()) {
+        if (backendId > 0) {
             SystemInfoService systemInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
             warehouseId = Utils.getWarehouseIdByNodeId(systemInfo, request.getBackend_id())
                     .orElse(WarehouseManager.DEFAULT_WAREHOUSE_ID);
@@ -1241,7 +1242,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         TransactionResult resp = new TransactionResult();
         StreamLoadMgr streamLoadManager = GlobalStateMgr.getCurrentState().getStreamLoadMgr();
         streamLoadManager.beginLoadTaskFromBackend(dbName, table.getName(), request.getLabel(), request.getRequest_id(),
-                request.getUser(), clientIp, timeoutSecond * 1000, resp, false, warehouseId);
+                request.getUser(), clientIp, timeoutSecond * 1000, resp, false, warehouseId, backendId);
         if (!resp.stateOK()) {
             LOG.warn(resp.msg);
             throw resp.getException();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -163,6 +163,15 @@ public class TransactionState implements Writable, GsonPreProcessable {
         public TxnSourceType sourceType;
         @SerializedName("ip")
         public String ip;
+        // The id of the coordinator backend. Only valid if sourceType is BE.
+        // Currently, it's only used to record which backend to redirect for
+        // transaction stream load when the transaction is still in PREPARE.
+        // Do not persist it as the PREPARE transaction also does not persist,
+        // and it will not be used after the transaction is prepared, committed
+        // or aborted. We can not do redirection based on 'ip' because there may
+        // be multiple backends on the same physical node, so the ip is not unique
+        // among backends, but backend id is unique.
+        private long backendId = -1;
 
         public TxnCoordinator() {
         }
@@ -175,6 +184,16 @@ public class TransactionState implements Writable, GsonPreProcessable {
         public static TxnCoordinator fromThisFE() {
             return new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE,
                     FrontendOptions.getLocalHostAddress());
+        }
+
+        public static TxnCoordinator fromBackend(String ip, long backendId) {
+            TxnCoordinator coordinator = new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, ip);
+            coordinator.backendId = backendId;
+            return coordinator;
+        }
+
+        public long getBackendId() {
+            return backendId;
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -85,7 +85,6 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
-import junit.framework.AssertionFailedError;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -99,6 +98,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.opentest4j.AssertionFailedError;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -124,6 +124,8 @@ public abstract class StarRocksHttpTestCase {
 
     public static final String DB_NAME = "testDb";
     public static final String TABLE_NAME = "testTbl";
+    public static final String TABLE_NAME2 = "testTbl2";
+
 
     protected static final String ES_TABLE_NAME = "es_table";
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -16,16 +16,21 @@ package com.starrocks.http;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.http.rest.ActionStatus;
 import com.starrocks.http.rest.TransactionLoadAction;
+import com.starrocks.http.rest.TransactionLoadCoordinatorMgr;
 import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.http.rest.transaction.TransactionOperation;
 import com.starrocks.load.streamload.StreamLoadMgr;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.server.RunMode;
 import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.transaction.BeginTransactionException;
 import com.starrocks.transaction.GlobalTransactionMgr;
@@ -65,7 +70,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -179,7 +183,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
             }
 
-            assertTrue(TransactionLoadAction.getAction().txnNodeMapSize() <= 2048);
+            assertTrue(TransactionLoadAction.getAction().coordinatorMgrSize() <= 2048);
         }
     }
 
@@ -307,6 +311,149 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
             }
         }
     }
+
+    @Test
+    public void transactionLoadCoordinatorMgrWithoutChannelTest() throws Exception {
+
+        String label = RandomStringUtils.randomAlphanumeric(32);
+        Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
+            reqBuilder.addHeader(DB_KEY, DB_NAME);
+            reqBuilder.addHeader(TABLE_KEY, TABLE_NAME2);
+            reqBuilder.addHeader(LABEL_KEY, label);
+        });
+        try (Response response = networkClient.newCall(request).execute()) {
+            Map<String, Object> body = parseResponseBody(response);
+            assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+            assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("mock redirect to BE"));
+        }
+
+        ComputeNode node = TransactionLoadAction.getAction().getCoordinatorMgr().get(label, DB_NAME);
+        assertEquals(node.getId(), 1234);
+
+        request = newRequest(TransactionOperation.TXN_PREPARE, (uriBuilder, reqBuilder) -> {
+            reqBuilder.addHeader(DB_KEY, DB_NAME);
+            reqBuilder.addHeader(TABLE_KEY, TABLE_NAME2);
+            reqBuilder.addHeader(LABEL_KEY, label);
+        });
+        try (Response response = networkClient.newCall(request).execute()) {
+            Map<String, Object> body = parseResponseBody(response);
+            assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+            assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("mock redirect to BE"));
+        }
+    }
+
+    @Test
+    public void transactionLoadCoordinatorMgrMultiBeOnSameNodeWithoutChannelTest() throws Exception {
+
+        String label = RandomStringUtils.randomAlphanumeric(32);
+        Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
+            reqBuilder.addHeader(DB_KEY, DB_NAME);
+            reqBuilder.addHeader(TABLE_KEY, TABLE_NAME2);
+            reqBuilder.addHeader(LABEL_KEY, label);
+        });
+        try (Response response = networkClient.newCall(request).execute()) {
+            Map<String, Object> body = parseResponseBody(response);
+            assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+            assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("mock redirect to BE"));
+        }
+
+        ComputeNode node = TransactionLoadAction.getAction().getCoordinatorMgr().get(label, DB_NAME);
+        assertEquals(node.getId(), 1234);
+
+
+        if (RunMode.isSharedDataMode()) {
+            ComputeNode computeNode = new ComputeNode(12345, "localhost", 8041);
+            computeNode.setBePort(9300);
+            computeNode.setAlive(true);
+            computeNode.setHttpPort(TEST_HTTP_PORT);
+            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addComputeNode(computeNode);
+        } else {
+            Backend backend4 = new Backend(12345, "localhost", 8041);
+            backend4.setBePort(9300);
+            backend4.setAlive(true);
+            backend4.setHttpPort(TEST_HTTP_PORT);
+            backend4.setDisks(new ImmutableMap.Builder<String, DiskInfo>().put("1", new DiskInfo("")).build());
+            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addBackend(backend4);
+        }
+
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                times = 2;
+                result = newTxnStateWithCoordinator(-1, label,
+                        LoadJobSourceType.BACKEND_STREAMING, TransactionStatus.UNKNOWN, "localhost", 1234);
+            }
+        };
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Database getDb(String name) {
+                return new Database(testDbId, DB_NAME);
+            }
+        };
+
+
+        TransactionLoadAction.getAction().getCoordinatorMgr().remove(label);
+        request = newRequest(TransactionOperation.TXN_PREPARE, (uriBuilder, reqBuilder) -> {
+            reqBuilder.addHeader(DB_KEY, DB_NAME);
+            reqBuilder.addHeader(TABLE_KEY, TABLE_NAME2);
+            reqBuilder.addHeader(LABEL_KEY, label);
+        });
+        try (Response response = networkClient.newCall(request).execute()) {
+            Map<String, Object> body = parseResponseBody(response);
+            assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+            assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("mock redirect to BE"));
+        }
+
+    }
+
+    @Test
+    public void transactionLoadCoordinatorMgrOneBeOnNodeWithoutChannelTest() throws Exception {
+
+        String label = RandomStringUtils.randomAlphanumeric(32);
+        Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
+            reqBuilder.addHeader(DB_KEY, DB_NAME);
+            reqBuilder.addHeader(TABLE_KEY, TABLE_NAME2);
+            reqBuilder.addHeader(LABEL_KEY, label);
+        });
+        try (Response response = networkClient.newCall(request).execute()) {
+            Map<String, Object> body = parseResponseBody(response);
+            assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+            assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("mock redirect to BE"));
+        }
+
+        ComputeNode node = TransactionLoadAction.getAction().getCoordinatorMgr().get(label, DB_NAME);
+        assertEquals(node.getId(), 1234);
+
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                times = 2;
+                returns(newTxnStateWithCoordinator(-1, label, LoadJobSourceType.BACKEND_STREAMING,
+                        TransactionStatus.UNKNOWN, "localhost", 1234), null);
+            }
+        };
+
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Database getDb(String name) {
+                return new Database(testDbId, DB_NAME);
+            }
+        };
+
+        TransactionLoadAction.getAction().getCoordinatorMgr().remove(label);
+        request = newRequest(TransactionOperation.TXN_PREPARE, (uriBuilder, reqBuilder) -> {
+            reqBuilder.addHeader(DB_KEY, DB_NAME);
+            reqBuilder.addHeader(TABLE_KEY, TABLE_NAME2);
+            reqBuilder.addHeader(LABEL_KEY, label);
+        });
+        try (Response response = networkClient.newCall(request).execute()) {
+            Map<String, Object> body = parseResponseBody(response);
+            assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+            assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("Can't find the transaction with db"));
+        }
+
+    }
+
 
     @Test
     public void beginTransactionWithoutChannelInfoTest() throws Exception {
@@ -569,7 +716,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
     @Test
     public void prepareTransactionWithoutChannelInfoTest() throws Exception {
         String label = RandomStringUtils.randomAlphanumeric(32);
-        setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+        setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
             private static final long serialVersionUID = -4276328107866085321L;
 
             {
@@ -779,7 +926,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 }
             };
 
-            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
                 private static final long serialVersionUID = 5890524883711716645L;
 
                 {
@@ -809,7 +956,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 }
             };
 
-            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
                 private static final long serialVersionUID = -4276328107866085321L;
 
                 {
@@ -839,7 +986,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 }
             };
 
-            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
                 private static final long serialVersionUID = 8612091611347668755L;
 
                 {
@@ -869,7 +1016,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 }
             };
 
-            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
                 private static final long serialVersionUID = 3214813746415023231L;
 
                 {
@@ -903,7 +1050,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 }
             };
 
-            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
                 private static final long serialVersionUID = 6893430743492341004L;
 
                 {
@@ -937,7 +1084,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 }
             };
 
-            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
                 private static final long serialVersionUID = 8165080593735535441L;
 
                 {
@@ -1246,7 +1393,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 }
             };
 
-            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
                 private static final long serialVersionUID = 5890524883711716645L;
 
                 {
@@ -1276,7 +1423,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 }
             };
 
-            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
                 private static final long serialVersionUID = -4276328107866085321L;
 
                 {
@@ -1306,7 +1453,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 }
             };
 
-            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
                 private static final long serialVersionUID = -5731416357248595041L;
 
                 {
@@ -1336,7 +1483,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 }
             };
 
-            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
                 private static final long serialVersionUID = -6655156575562250213L;
 
                 {
@@ -1370,7 +1517,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 }
             };
 
-            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
                 private static final long serialVersionUID = -891006164191904128L;
 
                 {
@@ -1403,7 +1550,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 }
             };
 
-            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
                 private static final long serialVersionUID = 4824168412840558066L;
 
                 {
@@ -1627,7 +1774,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
     @Test
     public void loadTransactionWithoutChannelInfoTest() throws Exception {
         String label = RandomStringUtils.randomAlphanumeric(32);
-        setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+        setField(TransactionLoadAction.getAction(), "coordinatorMgr", new TransactionLoadCoordinatorMgr() {
             private static final long serialVersionUID = -4276328107866085321L;
 
             {
@@ -1700,6 +1847,25 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 null,
                 sourceType,
                 new TxnCoordinator(TxnSourceType.FE, "127.0.0.1"),
+                -1,
+                20000L
+        );
+        txnState.setTransactionStatus(txnStatus);
+        return txnState;
+    }
+
+    public static TransactionState newTxnStateWithCoordinator(long txnId,
+                                                              String label,
+                                                              LoadJobSourceType sourceType,
+                                                              TransactionStatus txnStatus, String ip, long backendId) {
+        TransactionState txnState = new TransactionState(
+                testDbId,
+                new ArrayList<>(0),
+                txnId,
+                label,
+                null,
+                sourceType,
+                TxnCoordinator.fromBackend(ip, backendId),
                 -1,
                 20000L
         );

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadCoordinatorMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadCoordinatorMgrTest.java
@@ -1,0 +1,181 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DiskInfo;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.http.rest.TransactionLoadCoordinatorMgr;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionStatus;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static com.starrocks.http.TransactionLoadActionTest.newTxnStateWithCoordinator;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestMethodOrder(MethodName.class)
+public class TransactionLoadCoordinatorMgrTest {
+    private static long testDbId = 100L;
+    private static String DB_NAME = "testDb";
+    @Mocked
+    private GlobalTransactionMgr globalTransactionMgr;
+    private GlobalStateMgr globalStateMgr;
+    private Database db;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
+        db = new Database(testDbId, DB_NAME);
+        NodeMgr nodeMgr = new NodeMgr();
+        SystemInfoService systemInfoService = new SystemInfoService();
+        LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
+        new Expectations(globalStateMgr) {
+            {
+                globalStateMgr.getLocalMetastore();
+                minTimes = 0;
+                result = localMetastore;
+
+                globalStateMgr.getNodeMgr();
+                minTimes = 0;
+                result = nodeMgr;
+            }
+        };
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+            }
+        };
+
+        new Expectations(nodeMgr) {
+            {
+                nodeMgr.getClusterInfo();
+                minTimes = 0;
+                result = systemInfoService;
+            }
+        };
+
+        // init default warehouse
+        globalStateMgr.getWarehouseMgr().initDefaultWarehouse();
+        Backend backend1 = new Backend(1234, "localhost", 8040);
+        backend1.setBePort(9300);
+        backend1.setAlive(true);
+        backend1.setHttpPort(9301);
+        backend1.setDisks(new ImmutableMap.Builder<String, DiskInfo>().put("1", new DiskInfo("")).build());
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addBackend(backend1);
+    }
+
+    @Test
+    public void transactionLoadCoordinatorMgrTest() throws Exception {
+        String label = "label_transactionLoadLabelCacheTest";
+
+        new Expectations(globalStateMgr) {
+            {
+
+                globalStateMgr.getLocalMetastore().getDb(DB_NAME);
+                minTimes = 0;
+                result = db;
+
+                globalStateMgr.getLocalMetastore().getDb(anyString);
+                minTimes = 0;
+                result = null;
+            }
+        };
+
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                times = 1;
+                result = newTxnStateWithCoordinator(-1, label, TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                        TransactionStatus.UNKNOWN, "localhost", 1234);
+            }
+        };
+
+        TransactionLoadCoordinatorMgr cache = new TransactionLoadCoordinatorMgr();
+        long value = 1234L;
+        cache.put(label, value);
+        assertEquals(value, cache.get(label, DB_NAME).getId());
+        cache.remove(label);
+        assertEquals(value, cache.get(label, DB_NAME).getId());
+
+        try {
+            cache.get(label, "empty_db");
+        } catch (StarRocksException e) {
+            Assertions.assertTrue(e.getMessage().contains("Can't find db[empty_db] " +
+                    "for label[label_transactionLoadLabelCacheTest]. The db may be dropped."));
+        }
+    }
+
+    @Test
+    public void multiThreadWriteTransactionLoadCoordinatorMgrTest() throws Exception {
+        TransactionLoadCoordinatorMgr cache = new TransactionLoadCoordinatorMgr();
+        ExecutorService executor = Executors.newFixedThreadPool(5);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int i = 0; i < 5; i++) {
+            final int threadId = i;
+            final long value = (long) i;
+            futures.add(executor.submit(() -> {
+                String label = "label_" + threadId;
+                cache.put(label, value);
+            }));
+        }
+
+        for (Future<?> future : futures) {
+            future.get();
+        }
+        executor.shutdown();
+
+        new MockUp<TransactionLoadCoordinatorMgr>() {
+            @Mock
+            public @NonNull ComputeNode getNodeFromId(Long nodeId) {
+                return new ComputeNode(nodeId, "", 0);
+            }
+        };
+
+        for (int i = 0; i < 5; i++) {
+            String label = "label_" + i;
+            long expectedValue = (long) i;
+            assertEquals(expectedValue, cache.get(label, "").getId());
+        }
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/ShowStreamLoadTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/ShowStreamLoadTest.java
@@ -77,10 +77,10 @@ public class ShowStreamLoadTest {
         String labelName = "label_stream_load";
         TransactionResult resp = new TransactionResult();
         streamLoadManager.beginLoadTaskFromBackend(dbName, tableName, labelName, null, "", "", timeoutMillis, resp, false,
-                WarehouseManager.DEFAULT_WAREHOUSE_ID);
+                WarehouseManager.DEFAULT_WAREHOUSE_ID, 10003);
         labelName = "label_routine_load";
         streamLoadManager.beginLoadTaskFromBackend(dbName, tableName, labelName, null, "", "", timeoutMillis, resp, true,
-                WarehouseManager.DEFAULT_WAREHOUSE_ID);
+                WarehouseManager.DEFAULT_WAREHOUSE_ID, 10003);
 
         String sql = "show all stream load";
         ShowStreamLoadStmt showStreamLoadStmt = (ShowStreamLoadStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
@@ -296,7 +296,7 @@ public class StreamLoadManagerTest {
 
         TransactionResult resp = new TransactionResult();
         streamLoadManager.beginLoadTaskFromBackend(
-                dbName, tableName, labelName, null, "", "", timeoutMillis, resp, false, warehouseId);
+                dbName, tableName, labelName, null, "", "", timeoutMillis, resp, false, warehouseId, 10001);
 
         Map<String, StreamLoadTask> idToStreamLoadTask =
                 Deencapsulation.getField(streamLoadManager, "idToStreamLoadTask");


### PR DESCRIPTION
## Why I'm doing:
TransactionLoadAction class txnNodeMap field is not thread-safe, accessTxnNodeMapWithReadLock will concurrently update the Eldest Entry when holding a readLock, leading to data race. This can lead to memory leaks https://github.com/StarRocks/starrocks/issues/59436 and cache invalidation https://github.com/StarRocks/starrocks/issues/60155
## What I'm doing:

Refactor the code to use caffeine instead of LinkedHashMap.
If the cache is invalid, get the backendId corresponding to the label from TransactionState.
Fixes https://github.com/StarRocks/starrocks/issues/60155
Fixes https://github.com/StarRocks/starrocks/issues/59436

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
