### PR TITLE
[BugFix] Add more protects for mv aggregate push down

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -406,9 +406,9 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             materializedView.getTableProperty().setMvQueryRewriteSwitch(queryRewriteSwitch);
             if (!materializedView.isEnableRewrite()) {
                 // invalidate caches for mv rewrite when disable mv rewrite.
-                CachingMvPlanContextBuilder.getInstance().updateMvPlanContextCache(materializedView, false);
+                CachingMvPlanContextBuilder.getInstance().evictMaterializedViewCache(materializedView);
             } else {
-                CachingMvPlanContextBuilder.getInstance().putAstIfAbsent(materializedView);
+                CachingMvPlanContextBuilder.getInstance().cacheMaterializedView(materializedView);
             }
             isChanged = true;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -634,7 +634,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         this.active = true;
         this.inactiveReason = null;
         // reset mv rewrite cache when it is active again
-        CachingMvPlanContextBuilder.getInstance().updateMvPlanContextCache(this, true);
+        CachingMvPlanContextBuilder.getInstance().cacheMaterializedView(this);
     }
 
     public synchronized void setInactiveAndReason(String reason) {
@@ -643,7 +643,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         this.inactiveReason = reason;
         // reset cached variables
         resetMetadataCache();
-        CachingMvPlanContextBuilder.getInstance().updateMvPlanContextCache(this, false);
+        CachingMvPlanContextBuilder.getInstance().evictMaterializedViewCache(this);
     }
 
     /**
@@ -1029,7 +1029,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         MaterializedViewMetricsRegistry.getInstance().remove(mvId);
 
         // 1. Remove from plan cache
-        CachingMvPlanContextBuilder.getInstance().updateMvPlanContextCache(this, false);
+        CachingMvPlanContextBuilder.getInstance().evictMaterializedViewCache(this);
 
         // 2. Remove from base tables
         List<BaseTableInfo> baseTableInfos = getBaseTableInfos();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -16,9 +16,7 @@ package com.starrocks.planner;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.plan.MockTpchStatisticStorage;
 import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.jupiter.api.BeforeAll;
@@ -59,9 +57,9 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
         // And OneTabletExecutorVisitor#visitLogicalTableScan will deduce `supportOneTabletOpt` because this test
         // case has no tablets left after mv rewrite.
         connectContext.getSessionVariable().setEnableForceRuleBasedMvRewrite(false);
-        QueryDebugOptions queryDebugOptions = new QueryDebugOptions();
-        queryDebugOptions.setEnableQueryTraceLog(true);
-        connectContext.getSessionVariable().setQueryDebugOptions(queryDebugOptions.toString());
+        //QueryDebugOptions queryDebugOptions = new QueryDebugOptions();
+        //queryDebugOptions.setEnableQueryTraceLog(true);
+        //connectContext.getSessionVariable().setQueryDebugOptions(queryDebugOptions.toString());
     }
 
     @ParameterizedTest(name = "Tpch.{0}")
@@ -84,7 +82,6 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
 
     @Test
     public void testQuery13WithAggPushdown() throws Exception {
-        FeConstants.USE_MOCK_DICT_MANAGER = true;
         connectContext.getSessionVariable().setEnableMaterializedViewPushDownRewrite(true);
         String plan = getVerboseExplain("select  c_count,  count(*) as custdist from " +
                 "(select c_custkey,count(o_orderkey) as c_count from  customer left outer join orders " +
@@ -95,5 +92,6 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
         assertCContains(plan, "  0:OlapScanNode\n" +
                 "     table: customer, rollup: customer\n" +
                 "     preAggregation: on");
+        connectContext.getSessionVariable().setEnableMaterializedViewPushDownRewrite(false);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Fix a bug after #60976.

MV Agg push down may generate wrong plans, eg : query as below,  `count(o_orderkey)` shuld not be pushed down into `customer` table side:
```
 select  c_count,  count(*) as custdist from (select c_custkey,count(o_orderkey) as c_count from customer left outer join orders on c_custkey = o_custkey and o_comment not like '%special%requests%' group by  c_custkey) as c_orders group by  c_count order by custdist desc, c_count desc;
```

## What I'm doing:
- Add more protects for mv aggregate push down
- Add more tests for alter mv with `enable_query_rewrite` property.

Fixes https://github.com/StarRocks/StarRocksTest/issues/10020

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
