### PR TITLE
[Enhancement] Use RangeDirectMapping to optimize hash join

### DIFF
--- a/be/src/exec/hash_join_components.h
+++ b/be/src/exec/hash_join_components.h
@@ -116,7 +116,7 @@ public:
     virtual size_t get_output_probe_column_count() const = 0;
     virtual size_t get_output_build_column_count() const = 0;
 
-    virtual void get_build_info(size_t* bucket_size, float* avg_keys_per_bucket) = 0;
+    virtual void get_build_info(size_t* bucket_size, float* avg_keys_per_bucket, std::string* hash_map_type) = 0;
 
     virtual void visitHt(const std::function<void(JoinHashTable*)>& visitor) = 0;
 
@@ -157,9 +157,10 @@ public:
 
     int64_t ht_mem_usage() const override { return _ht.mem_usage(); }
 
-    void get_build_info(size_t* bucket_size, float* avg_keys_per_bucket) override {
+    void get_build_info(size_t* bucket_size, float* avg_keys_per_bucket, std::string* hash_map_type) override {
         *bucket_size = _ht.get_bucket_size();
         *avg_keys_per_bucket = _ht.get_keys_per_bucket();
+        *hash_map_type = _ht.get_hash_map_type();
     }
 
     size_t get_output_probe_column_count() const override { return _ht.get_output_probe_column_count(); }

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -161,6 +161,7 @@ struct HashJoinBuildMetrics {
     RuntimeProfile::Counter* hash_table_memory_usage = nullptr;
     RuntimeProfile::Counter* partial_runtime_bloom_filter_bytes = nullptr;
     RuntimeProfile::Counter* partition_nums = nullptr;
+    std::string* hash_map_type_info = nullptr;
 
     void prepare(RuntimeProfile* runtime_profile);
 };

--- a/be/src/exec/join/join_hash_map.cpp
+++ b/be/src/exec/join/join_hash_map.cpp
@@ -41,7 +41,12 @@ public:
 private:
     static size_t _get_size_of_fixed_and_contiguous_type(LogicalType data_type);
     static JoinKeyConstructorUnaryType _determine_key_constructor(JoinHashTableItems* table_items);
-    static JoinHashMapMethodUnaryType _determine_hash_map_method(JoinKeyConstructorUnaryType key_constructor_type);
+    static JoinHashMapMethodUnaryType _determine_hash_map_method(RuntimeState* state, JoinHashTableItems* table_items,
+                                                                 JoinKeyConstructorUnaryType key_constructor_type);
+    // @return: <can_use, JoinHashMapMethodUnaryType>, where `JoinHashMapMethodUnaryType` is effective only when `can_use` is true.
+    template <LogicalType LT>
+    static std::pair<bool, JoinHashMapMethodUnaryType> _try_use_range_direct_mapping(RuntimeState* state,
+                                                                                     JoinHashTableItems* table_items);
 };
 
 std::tuple<JoinKeyConstructorUnaryType, JoinHashMapMethodUnaryType>
@@ -55,7 +60,7 @@ JoinHashMapSelector::construct_key_and_determine_hash_map(RuntimeState* state, J
         KeyConstructor().build_key(state, table_items);
     });
 
-    const auto method_type = _determine_hash_map_method(key_constructor_type);
+    const auto method_type = _determine_hash_map_method(state, table_items, key_constructor_type);
     return {key_constructor_type, method_type};
 }
 
@@ -132,15 +137,87 @@ JoinKeyConstructorUnaryType JoinHashMapSelector::_determine_key_constructor(Join
 }
 
 JoinHashMapMethodUnaryType JoinHashMapSelector::_determine_hash_map_method(
-        JoinKeyConstructorUnaryType key_constructor_type) {
+        RuntimeState* state, JoinHashTableItems* table_items, JoinKeyConstructorUnaryType key_constructor_type) {
     return dispatch_join_key_constructor_unary(key_constructor_type, [&]<JoinKeyConstructorUnaryType CUT>() {
         static constexpr auto LT = JoinKeyConstructorUnaryTypeTraits<CUT>::logical_type;
+        static constexpr auto CT = JoinKeyConstructorUnaryTypeTraits<CUT>::key_constructor_type;
+
         if constexpr (LT == TYPE_BOOLEAN || LT == TYPE_TINYINT || LT == TYPE_SMALLINT) {
             return JoinHashMapMethodTypeTraits<JoinHashMapMethodType::DIRECT_MAPPING, LT>::unary_type;
         } else {
+            if constexpr (CT == JoinKeyConstructorType::ONE_KEY && (LT == TYPE_INT || LT == TYPE_BIGINT)) {
+                const auto [can_use, hash_map_type] = _try_use_range_direct_mapping<LT>(state, table_items);
+                if (can_use) {
+                    return hash_map_type;
+                }
+            }
+
             return JoinHashMapMethodTypeTraits<JoinHashMapMethodType::BUCKET_CHAINED, LT>::unary_type;
         }
     });
+}
+
+template <LogicalType LT>
+std::pair<bool, JoinHashMapMethodUnaryType> JoinHashMapSelector::_try_use_range_direct_mapping(
+        RuntimeState* state, JoinHashTableItems* table_items) {
+    if (!state->enable_hash_join_range_direct_mapping_opt()) {
+        return {false, JoinHashMapMethodUnaryType::BUCKET_CHAINED_INT};
+    }
+
+    using KeyConstructor = typename JoinKeyConstructorTypeTraits<JoinKeyConstructorType::ONE_KEY, LT>::BuildType;
+    const auto* keys = KeyConstructor().get_key_data(*table_items).data();
+    const size_t num_rows = table_items->row_count + 1;
+    const int64_t min_value = *std::min_element(keys + 1, keys + num_rows);
+    const int64_t max_value = *std::max_element(keys + 1, keys + num_rows);
+
+    // `max_value - min_value + 1` will be overflow.
+    if (min_value == std::numeric_limits<int64_t>::min() && max_value == std::numeric_limits<int64_t>::max()) {
+        return {false, JoinHashMapMethodUnaryType::BUCKET_CHAINED_INT};
+    }
+
+    const uint64_t value_interval = static_cast<uint64_t>(max_value) - min_value + 1;
+    if (value_interval >= std::numeric_limits<uint32_t>::max()) {
+        return {false, JoinHashMapMethodUnaryType::BUCKET_CHAINED_INT};
+    }
+
+    table_items->min_value = min_value;
+    table_items->max_value = max_value;
+
+    const uint64_t row_count = table_items->row_count;
+    const uint64_t bucket_size = JoinHashMapHelper::calc_bucket_size(table_items->row_count + 1);
+    static const size_t HALF_L3_CACHE_SIZE = [] {
+        static constexpr size_t DEFAULT_L3_CACHE_SIZE = 32 * 1024 * 1024;
+        const auto& cache_sizes = CpuInfo::get_cache_sizes();
+        const auto l3_cache = cache_sizes[CpuInfo::L3_CACHE] ? cache_sizes[CpuInfo::L3_CACHE] : DEFAULT_L3_CACHE_SIZE;
+        return l3_cache / 2;
+    }();
+    static const size_t L2_CACHE_SIZE = CpuInfo::get_l2_cache_size();
+
+    if ((table_items->join_type == TJoinOp::LEFT_ANTI_JOIN || table_items->join_type == TJoinOp::LEFT_SEMI_JOIN) &&
+        !table_items->with_other_conjunct) {
+        const uint64_t memory_usage = (value_interval + 7) / 8;
+        // one bit vs. 8 bytes(`first` and `next`)
+        if (memory_usage <= bucket_size * 64 || memory_usage <= HALF_L3_CACHE_SIZE) {
+            return {true, JoinHashMapMethodTypeTraits<JoinHashMapMethodType::RANGE_DIRECT_MAPPING_SET, LT>::unary_type};
+        }
+    } else {
+        if (value_interval <= bucket_size || value_interval <= L2_CACHE_SIZE) {
+            return {true, JoinHashMapMethodTypeTraits<JoinHashMapMethodType::RANGE_DIRECT_MAPPING, LT>::unary_type};
+        }
+
+        // BUCKET_CHAINE:
+        // - The size of `table_items.first` is `bucket_size`.
+        // - Assuming we can use 10% more memory than `BUCKET_CHAINED`, so the total is `(bucket_size + bucket_size / 10) * 4`.
+        // DENSE_RANGE_DIRECT_MAPPING`:
+        // - Each value index uses 2 bits, so totally uses `value_interval / 4` bytes.
+        // - The size of `table_items.first` only needs `row_count`.
+        if (value_interval / 4 + row_count * 4 <= (bucket_size + bucket_size / 10) * 4) {
+            return {true,
+                    JoinHashMapMethodTypeTraits<JoinHashMapMethodType::DENSE_RANGE_DIRECT_MAPPING, LT>::unary_type};
+        }
+    }
+
+    return {false, JoinHashMapMethodUnaryType::BUCKET_CHAINED_INT};
 }
 
 // ------------------------------------------------------------------------------------
@@ -198,15 +275,15 @@ float JoinHashTable::get_keys_per_bucket() const {
 }
 
 std::string JoinHashTable::get_hash_map_type() const {
-    return dispatch_join_key_constructor_unary(_key_constructor_type, [&]<JoinKeyConstructorUnaryType CUT>() {
-        return dispatch_join_hash_map_method_unary(_hash_map_method_type, [&]<JoinHashMapMethodUnaryType MUT>() {
-            static constexpr auto LT = JoinKeyConstructorUnaryTypeTraits<CUT>::logical_type;
-            static constexpr auto CT = JoinKeyConstructorUnaryTypeTraits<CUT>::key_constructor_type;
-            static constexpr auto MT = JoinHashMapMethodUnaryTypeTraits<MUT>::hash_map_method_type;
-            return fmt::format("{}-{}-", join_key_constructor_type_to_string(CT),
-                               join_hash_map_method_type_to_string(MT), logical_type_to_string(LT));
-        });
-    });
+    return dispatch_join_hash_map(
+            _key_constructor_type, _hash_map_method_type,
+            [&]<JoinKeyConstructorUnaryType CUT, JoinHashMapMethodUnaryType MUT>() {
+                static constexpr auto LT = JoinKeyConstructorUnaryTypeTraits<CUT>::logical_type;
+                static constexpr auto CT = JoinKeyConstructorUnaryTypeTraits<CUT>::key_constructor_type;
+                static constexpr auto MT = JoinHashMapMethodUnaryTypeTraits<MUT>::map_method_type;
+                return fmt::format("{}-{}-{}", join_key_constructor_type_to_string(CT),
+                                   join_hash_map_method_type_to_string(MT), logical_type_to_string(LT));
+            });
 }
 
 void JoinHashTable::close() {
@@ -452,12 +529,7 @@ Status JoinHashTable::build(RuntimeState* state) {
                 return Status::OK();
             }
         };
-        RETURN_IF_ERROR(
-                dispatch_join_key_constructor_unary(_key_constructor_type, [&]<JoinKeyConstructorUnaryType CUT>() {
-                    return dispatch_join_hash_map_method_unary(
-                            _hash_map_method_type,
-                            [&]<JoinHashMapMethodUnaryType MUT>() { return create_hash_map.operator()<CUT, MUT>(); });
-                }));
+        RETURN_IF_ERROR(dispatch_join_hash_map(_key_constructor_type, _hash_map_method_type, create_hash_map));
     }
     visit([&](auto& hash_map) {
         hash_map->build_prepare(state);

--- a/be/src/exec/join/join_hash_map.cpp
+++ b/be/src/exec/join/join_hash_map.cpp
@@ -197,6 +197,18 @@ float JoinHashTable::get_keys_per_bucket() const {
     return _table_items->get_keys_per_bucket();
 }
 
+std::string JoinHashTable::get_hash_map_type() const {
+    return dispatch_join_key_constructor_unary(_key_constructor_type, [&]<JoinKeyConstructorUnaryType CUT>() {
+        return dispatch_join_hash_map_method_unary(_hash_map_method_type, [&]<JoinHashMapMethodUnaryType MUT>() {
+            static constexpr auto LT = JoinKeyConstructorUnaryTypeTraits<CUT>::logical_type;
+            static constexpr auto CT = JoinKeyConstructorUnaryTypeTraits<CUT>::key_constructor_type;
+            static constexpr auto MT = JoinHashMapMethodUnaryTypeTraits<MUT>::hash_map_method_type;
+            return fmt::format("{}-{}-", join_key_constructor_type_to_string(CT),
+                               join_hash_map_method_type_to_string(MT), logical_type_to_string(LT));
+        });
+    });
+}
+
 void JoinHashTable::close() {
     _table_items.reset();
     _probe_state.reset();

--- a/be/src/exec/join/join_hash_map.cpp
+++ b/be/src/exec/join/join_hash_map.cpp
@@ -275,6 +275,14 @@ float JoinHashTable::get_keys_per_bucket() const {
 }
 
 std::string JoinHashTable::get_hash_map_type() const {
+    if (const bool has_not_built = visit([&](const auto& map) { return map == nullptr; }); has_not_built) {
+        return "NONE";
+    }
+
+    if (_is_empty_map) {
+        return "EMPTY";
+    }
+
     return dispatch_join_hash_map(
             _key_constructor_type, _hash_map_method_type,
             [&]<JoinKeyConstructorUnaryType CUT, JoinHashMapMethodUnaryType MUT>() {

--- a/be/src/exec/join/join_hash_map.h
+++ b/be/src/exec/join/join_hash_map.h
@@ -457,7 +457,7 @@ private:
                          std::unique_ptr<JoinHashMapForFixedSizeKeyDenseRangeDirectMapping(TYPE_INT)>,
                          std::unique_ptr<JoinHashMapForFixedSizeKeyDenseRangeDirectMapping(TYPE_BIGINT)>>;
 
-    bool _is_empty_map = false;
+    bool _is_empty_map = true;
     JoinKeyConstructorUnaryType _key_constructor_type;
     JoinHashMapMethodUnaryType _hash_map_method_type;
     JoinHashMapVariant _hash_map;

--- a/be/src/exec/join/join_hash_map.h
+++ b/be/src/exec/join/join_hash_map.h
@@ -231,14 +231,12 @@ private:
     void _search_ht(RuntimeState* state, ChunkPtr* probe_chunk);
     void _search_ht_remain(RuntimeState* state);
 
-    template <bool first_probe>
+    template <bool first_probe, bool is_collision_free_and_unique>
     void _search_ht_impl(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& data);
 
     // for one key inner join
-    template <bool first_probe>
-    void _probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
     template <bool first_probe, bool is_collision_free_and_unique>
-    void _do_probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
+    void _probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
 
     HashTableProbeState::ProbeCoroutine _probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data,
                                                        const Buffer<CppType>& probe_data);
@@ -247,14 +245,16 @@ private:
     void _probe_coroutine(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
 
     // for one key left outer join
-    template <bool first_probe>
+    template <bool first_probe, bool is_collision_free_and_unique>
     void _probe_from_ht_for_left_outer_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                             const Buffer<CppType>& probe_data);
     HashTableProbeState::ProbeCoroutine _probe_from_ht_for_left_outer_join(RuntimeState* state,
                                                                            const Buffer<CppType>& build_data,
                                                                            const Buffer<CppType>& probe_data);
+    bool _contains_probe_row(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data,
+                             uint32_t probe_index);
     // for one key left semi join
-    template <bool first_probe>
+    template <bool first_probe, bool is_collision_free_and_unique>
     void _probe_from_ht_for_left_semi_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                            const Buffer<CppType>& probe_data);
 
@@ -262,7 +262,7 @@ private:
                                                                           const Buffer<CppType>& build_data,
                                                                           const Buffer<CppType>& probe_data);
     // for one key left anti join
-    template <bool first_probe>
+    template <bool first_probe, bool is_collision_free_and_unique>
     void _probe_from_ht_for_left_anti_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                            const Buffer<CppType>& probe_data);
     HashTableProbeState::ProbeCoroutine _probe_from_ht_for_left_anti_join(RuntimeState* state,
@@ -270,7 +270,7 @@ private:
                                                                           const Buffer<CppType>& probe_data);
 
     // for one key right outer join
-    template <bool first_probe>
+    template <bool first_probe, bool is_collision_free_and_unique>
     void _probe_from_ht_for_right_outer_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                              const Buffer<CppType>& probe_data);
     HashTableProbeState::ProbeCoroutine _probe_from_ht_for_right_outer_join(RuntimeState* state,
@@ -278,7 +278,7 @@ private:
                                                                             const Buffer<CppType>& probe_data);
 
     // for one key right semi join
-    template <bool first_probe>
+    template <bool first_probe, bool is_collision_free_and_unique>
     void _probe_from_ht_for_right_semi_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                             const Buffer<CppType>& probe_data);
     HashTableProbeState::ProbeCoroutine _probe_from_ht_for_right_semi_join(RuntimeState* state,
@@ -286,7 +286,7 @@ private:
                                                                            const Buffer<CppType>& probe_data);
 
     // for one key right anti join
-    template <bool first_probe>
+    template <bool first_probe, bool is_collision_free_and_unique>
     void _probe_from_ht_for_right_anti_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                             const Buffer<CppType>& probe_data);
     HashTableProbeState::ProbeCoroutine _probe_from_ht_for_right_anti_join(RuntimeState* state,
@@ -294,7 +294,7 @@ private:
                                                                            const Buffer<CppType>& probe_data);
 
     // for one key full outer join
-    template <bool first_probe>
+    template <bool first_probe, bool is_collision_free_and_unique>
     void _probe_from_ht_for_full_outer_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                             const Buffer<CppType>& probe_data);
     HashTableProbeState::ProbeCoroutine _probe_from_ht_for_full_outer_join(RuntimeState* state,
@@ -302,23 +302,23 @@ private:
                                                                            const Buffer<CppType>& probe_data);
 
     // for left semi join with other join conjunct
-    template <bool first_probe>
+    template <bool first_probe, bool is_collision_free_and_unique>
     void _probe_from_ht_for_left_semi_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                const Buffer<CppType>& probe_data);
 
     // for null aware anti join with other join conjunct
-    template <bool first_probe>
+    template <bool first_probe, bool is_collision_free_and_unique>
     void _probe_from_ht_for_null_aware_anti_join_with_other_conjunct(RuntimeState* state,
                                                                      const Buffer<CppType>& build_data,
                                                                      const Buffer<CppType>& probe_data);
 
     // for one key right outer join with other conjunct
-    template <bool first_probe>
+    template <bool first_probe, bool is_collision_free_and_unique>
     void _probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct(
             RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
 
     // for one key full outer join with other join conjunct
-    template <bool first_probe>
+    template <bool first_probe, bool is_collision_free_and_unique>
     void _probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct(RuntimeState* state,
                                                                                      const Buffer<CppType>& build_data,
                                                                                      const Buffer<CppType>& probe_data);
@@ -334,6 +334,18 @@ private:
     JoinHashMap<LT, JoinKeyConstructorType::SERIALIZED_FIXED_SIZE, JoinHashMapMethodType::BUCKET_CHAINED>
 #define JoinHashMapForSerializedKey(LT) \
     JoinHashMap<LT, JoinKeyConstructorType::SERIALIZED, JoinHashMapMethodType::BUCKET_CHAINED>
+#define JoinHashMapForOneKeyRangeDirectMapping(LT) \
+    JoinHashMap<LT, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::RANGE_DIRECT_MAPPING>
+#define JoinHashSetForOneKeyRangeDirectMapping(LT) \
+    JoinHashMap<LT, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::RANGE_DIRECT_MAPPING_SET>
+#define JoinHashMapForOneKeyDenseRangeDirectMapping(LT) \
+    JoinHashMap<LT, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::DENSE_RANGE_DIRECT_MAPPING>
+#define JoinHashMapForFixedSizeKeyRangeDirectMapping(LT) \
+    JoinHashMap<LT, JoinKeyConstructorType::SERIALIZED_FIXED_SIZE, JoinHashMapMethodType::RANGE_DIRECT_MAPPING>
+#define JoinHashSetForFixedSizeKeyRangeDirectMapping(LT) \
+    JoinHashMap<LT, JoinKeyConstructorType::SERIALIZED_FIXED_SIZE, JoinHashMapMethodType::RANGE_DIRECT_MAPPING_SET>
+#define JoinHashMapForFixedSizeKeyDenseRangeDirectMapping(LT) \
+    JoinHashMap<LT, JoinKeyConstructorType::SERIALIZED_FIXED_SIZE, JoinHashMapMethodType::DENSE_RANGE_DIRECT_MAPPING>
 
 // ------------------------------------------------------------------------------------
 // JoinHashTable
@@ -408,26 +420,42 @@ private:
     void _remove_duplicate_index_for_right_anti_join(Filter* filter);
     void _remove_duplicate_index_for_full_outer_join(Filter* filter);
 
-    using JoinHashMapVariant = std::variant<std::unique_ptr<JoinHashMapForEmpty>, //
-                                            std::unique_ptr<JoinHashMapForDirectMapping(TYPE_BOOLEAN)>,
-                                            std::unique_ptr<JoinHashMapForDirectMapping(TYPE_TINYINT)>,
-                                            std::unique_ptr<JoinHashMapForDirectMapping(TYPE_SMALLINT)>,
-                                            std::unique_ptr<JoinHashMapForOneKey(TYPE_INT)>, //
-                                            std::unique_ptr<JoinHashMapForOneKey(TYPE_BIGINT)>,
-                                            std::unique_ptr<JoinHashMapForOneKey(TYPE_LARGEINT)>, //
-                                            std::unique_ptr<JoinHashMapForOneKey(TYPE_FLOAT)>,
-                                            std::unique_ptr<JoinHashMapForOneKey(TYPE_DOUBLE)>, //
-                                            std::unique_ptr<JoinHashMapForOneKey(TYPE_VARCHAR)>,
-                                            std::unique_ptr<JoinHashMapForOneKey(TYPE_DATE)>, //
-                                            std::unique_ptr<JoinHashMapForOneKey(TYPE_DATETIME)>,
-                                            std::unique_ptr<JoinHashMapForOneKey(TYPE_DECIMALV2)>,
-                                            std::unique_ptr<JoinHashMapForOneKey(TYPE_DECIMAL32)>,
-                                            std::unique_ptr<JoinHashMapForOneKey(TYPE_DECIMAL64)>,
-                                            std::unique_ptr<JoinHashMapForOneKey(TYPE_DECIMAL128)>,
-                                            std::unique_ptr<JoinHashMapForSerializedKey(TYPE_VARCHAR)>,
-                                            std::unique_ptr<JoinHashMapForFixedSizeKey(TYPE_INT)>,
-                                            std::unique_ptr<JoinHashMapForFixedSizeKey(TYPE_BIGINT)>,
-                                            std::unique_ptr<JoinHashMapForFixedSizeKey(TYPE_LARGEINT)>>;
+    using JoinHashMapVariant =
+            std::variant<std::unique_ptr<JoinHashMapForEmpty>, //
+                         std::unique_ptr<JoinHashMapForDirectMapping(TYPE_BOOLEAN)>,
+                         std::unique_ptr<JoinHashMapForDirectMapping(TYPE_TINYINT)>,
+                         std::unique_ptr<JoinHashMapForDirectMapping(TYPE_SMALLINT)>,
+
+                         std::unique_ptr<JoinHashMapForOneKey(TYPE_INT)>, //
+                         std::unique_ptr<JoinHashMapForOneKey(TYPE_BIGINT)>,
+                         std::unique_ptr<JoinHashMapForOneKey(TYPE_LARGEINT)>, //
+                         std::unique_ptr<JoinHashMapForOneKey(TYPE_FLOAT)>,
+                         std::unique_ptr<JoinHashMapForOneKey(TYPE_DOUBLE)>, //
+                         std::unique_ptr<JoinHashMapForOneKey(TYPE_VARCHAR)>,
+                         std::unique_ptr<JoinHashMapForOneKey(TYPE_DATE)>, //
+                         std::unique_ptr<JoinHashMapForOneKey(TYPE_DATETIME)>,
+                         std::unique_ptr<JoinHashMapForOneKey(TYPE_DECIMALV2)>,
+                         std::unique_ptr<JoinHashMapForOneKey(TYPE_DECIMAL32)>,
+                         std::unique_ptr<JoinHashMapForOneKey(TYPE_DECIMAL64)>,
+                         std::unique_ptr<JoinHashMapForOneKey(TYPE_DECIMAL128)>,
+
+                         std::unique_ptr<JoinHashMapForSerializedKey(TYPE_VARCHAR)>,
+                         std::unique_ptr<JoinHashMapForFixedSizeKey(TYPE_INT)>,
+                         std::unique_ptr<JoinHashMapForFixedSizeKey(TYPE_BIGINT)>,
+                         std::unique_ptr<JoinHashMapForFixedSizeKey(TYPE_LARGEINT)>,
+
+                         std::unique_ptr<JoinHashMapForOneKeyRangeDirectMapping(TYPE_INT)>,
+                         std::unique_ptr<JoinHashMapForOneKeyRangeDirectMapping(TYPE_BIGINT)>,
+                         std::unique_ptr<JoinHashSetForOneKeyRangeDirectMapping(TYPE_INT)>,
+                         std::unique_ptr<JoinHashSetForOneKeyRangeDirectMapping(TYPE_BIGINT)>,
+                         std::unique_ptr<JoinHashMapForOneKeyDenseRangeDirectMapping(TYPE_INT)>,
+                         std::unique_ptr<JoinHashMapForOneKeyDenseRangeDirectMapping(TYPE_BIGINT)>,
+                         std::unique_ptr<JoinHashMapForFixedSizeKeyRangeDirectMapping(TYPE_INT)>,
+                         std::unique_ptr<JoinHashMapForFixedSizeKeyRangeDirectMapping(TYPE_BIGINT)>,
+                         std::unique_ptr<JoinHashSetForFixedSizeKeyRangeDirectMapping(TYPE_INT)>,
+                         std::unique_ptr<JoinHashSetForFixedSizeKeyRangeDirectMapping(TYPE_BIGINT)>,
+                         std::unique_ptr<JoinHashMapForFixedSizeKeyDenseRangeDirectMapping(TYPE_INT)>,
+                         std::unique_ptr<JoinHashMapForFixedSizeKeyDenseRangeDirectMapping(TYPE_BIGINT)>>;
 
     bool _is_empty_map = false;
     JoinKeyConstructorUnaryType _key_constructor_type;

--- a/be/src/exec/join/join_hash_map.h
+++ b/be/src/exec/join/join_hash_map.h
@@ -382,6 +382,7 @@ public:
     size_t get_output_build_column_count() const { return _table_items->output_build_column_count; }
     size_t get_bucket_size() const { return _table_items->bucket_size; }
     float get_keys_per_bucket() const;
+    std::string get_hash_map_type() const;
     void remove_duplicate_index(Filter* filter);
     JoinHashTableItems* table_items() const { return _table_items.get(); }
 

--- a/be/src/exec/join/join_hash_map_method.h
+++ b/be/src/exec/join/join_hash_map_method.h
@@ -19,6 +19,37 @@
 
 namespace starrocks {
 
+// The `first` and `next` together form a bucket-chained linked list.
+//   - `first` stores the first element of the list,
+//   - and `next` stores the next element in the list.
+//
+// `BucketChainedJoinHashMap` maps to a position in `first` using a hash function.
+//
+// The following diagram illustrates the structure of `BucketChainedJoinHashMap`:
+//
+// build keys                       first       next
+//                                  ┌───┐       ┌───┐
+//                                  │   │       │   │◄───┐
+//                                  │   │       │   │◄┐  │
+//                                  ├───┤       ├───┤ │  │
+//                                  │   ├─┐     │   │ │  │
+//                         ┌───────►│   │ │     │   │ │  │
+//                         │        ├───┤ │     ├───┤ │  │
+//              ┌────────┐ │        │   │ │     │   ├─┘  │
+//  ┌──────┐    │        │ │        │   │ │     │   │◄─┐ │
+//  │ key  ├───►│  Hash  ├─┘        ├───┤ │     ├───┤  │ │
+//  └──────┘    │        │          │   │ │     │   │  │ │
+//              └────────┘          │   │ │     │   │  │ │
+//                                  ├───┤ │     ├───┤  │ │
+//                                  │   │ └────►│   │  │ │
+//                                  │   │       │   ├──┘ │
+//                                  ├───┤       ├───┤    │
+//                                  │   │       │   │    │
+//                                  │   │       │   │    │
+//                                  ├───┤       ├───┤    │
+//                                  │   │       │   │    │
+//                                  │   ├──────►│   ├────┘
+//                                  └───┘       └───┘
 template <LogicalType LT>
 class BucketChainedJoinHashMap {
 public:
@@ -35,8 +66,157 @@ public:
     static bool equal(const CppType& x, const CppType& y) { return x == y; }
 };
 
+// The bucket-chained linked list formed by first` and `next` is the same as that of `BucketChainedJoinHashMap`.
+//
+// `DirectMappingJoinHashMap` maps to a position in `first` using `key-MIN_VALUE`.
+//
+// The following diagram illustrates the structure of `DirectMappingJoinHashMap`:
+//
+// build keys               first       next
+//                          ┌───┐       ┌───┐
+//                          │   │       │   │◄───┐
+//                          │   │       │   │◄┐  │
+//                          ├───┤       ├───┤ │  │
+//          key-MIN_VALUE   │   ├─┐     │   │ │  │
+//                 ┌───────►│   │ │     │   │ │  │
+// ┌──────┐        │        ├───┤ │     ├───┤ │  │
+// │ key  │────────┘        │   │ │     │   ├─┘  │
+// └──────┘                 │   │ │     │   │◄─┐ │
+//                          ├───┤ │     ├───┤  │ │
+//                          │   │ │     │   │  │ │
+//                          │   │ │     │   │  │ │
+//                          ├───┤ │     ├───┤  │ │
+//                          │   │ └────►│   │  │ │
+//                          │   │       │   ├──┘ │
+//                          ├───┤       ├───┤    │
+//                          │   │       │   │    │
+//                          │   │       │   │    │
+//                          ├───┤       ├───┤    │
+//                          │   │       │   │    │
+//                          │   ├──────►│   ├────┘
+//                          └───┘       └───┘
 template <LogicalType LT>
 class DirectMappingJoinHashMap {
+public:
+    using CppType = typename RunTimeTypeTraits<LT>::CppType;
+    using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
+
+    static void build_prepare(RuntimeState* state, JoinHashTableItems* table_items);
+    static void construct_hash_table(JoinHashTableItems* table_items, const Buffer<CppType>& keys,
+                                     const Buffer<uint8_t>* is_nulls);
+
+    static void lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
+                            const Buffer<CppType>& keys, const Buffer<uint8_t>* is_nulls);
+
+    static bool equal(const CppType& x, const CppType& y) { return true; }
+};
+
+// The bucket-chained linked list formed by first` and `next` is the same as that of `BucketChainedJoinHashMap`.
+//
+// `RangeDirectMappingJoinHashMap` maps to a position in `first` using `key-min_value`, where `min_value` is the
+// minimum value of all the builder's keys.
+// Therefore, the probing key needs to be checked whether it is in the range of [min_value, max_value] during probing.
+//
+// The following diagram illustrates the structure of `DirectMappingJoinHashMap`:
+//
+// build keys               first       next
+//                          ┌───┐       ┌───┐
+//                          │   │       │   │◄───┐
+//                          │   │       │   │◄┐  │
+//                          ├───┤       ├───┤ │  │
+//          key-min_value   │   ├─┐     │   │ │  │
+//                 ┌───────►│   │ │     │   │ │  │
+// ┌──────┐        │        ├───┤ │     ├───┤ │  │
+// │ key  ├────────┘        │   │ │     │   ├─┘  │
+// └──────┘                 │   │ │     │   │◄─┐ │
+//                          ├───┤ │     ├───┤  │ │
+//                          │   │ │     │   │  │ │
+//                          │   │ │     │   │  │ │
+//                          ├───┤ │     ├───┤  │ │
+//                          │   │ └────►│   │  │ │
+//                          │   │       │   ├──┘ │
+//                          ├───┤       ├───┤    │
+//                          │   │       │   │    │
+//                          │   │       │   │    │
+//                          ├───┤       ├───┤    │
+//                          │   │       │   │    │
+//                          │   ├──────►│   ├────┘
+//                          └───┘       └───┘
+
+template <LogicalType LT>
+class RangeDirectMappingJoinHashMap {
+public:
+    using CppType = typename RunTimeTypeTraits<LT>::CppType;
+    using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
+
+    static void build_prepare(RuntimeState* state, JoinHashTableItems* table_items);
+    static void construct_hash_table(JoinHashTableItems* table_items, const Buffer<CppType>& keys,
+                                     const Buffer<uint8_t>* is_nulls);
+
+    static void lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
+                            const Buffer<CppType>& keys, const Buffer<uint8_t>* is_nulls);
+
+    static bool equal(const CppType& x, const CppType& y) { return true; }
+};
+
+// `RangeDirectMappingJoinHashSet` is used for LEFT_SEMI/LEFT_ANTI JOIN scenarios where no additional JOIN ON conditions
+// exist, while `RangeDirectMappingJoinHashMap` is employed for all other cases.
+// `RangeDirectMappingJoinHashSet` uses only one bit to store each `value - min_value`.
+template <LogicalType LT>
+class RangeDirectMappingJoinHashSet {
+public:
+    using CppType = typename RunTimeTypeTraits<LT>::CppType;
+    using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
+
+    static void build_prepare(RuntimeState* state, JoinHashTableItems* table_items);
+    static void construct_hash_table(JoinHashTableItems* table_items, const Buffer<CppType>& keys,
+                                     const Buffer<uint8_t>* is_nulls);
+
+    static void lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
+                            const Buffer<CppType>& keys, const Buffer<uint8_t>* is_nulls);
+
+    static bool equal(const CppType& x, const CppType& y) { return true; }
+};
+
+// The bucket-chained linked list formed by first` and `next` is the same as that of `BucketChainedJoinHashMap`.
+//
+// As for a key, the position in `first` is obtained through the following steps:
+// 1. Calculate `bucket = key - min_value`
+// 2. Compress the `bucket` using dense groups to obtain the `dense bucket`.
+//
+// Using dense groups, the size of `first` is squeezed down to `row_count`, meaning empty first positions are discarded.
+// Each dense group stores information for 32 first positions, represented using 64 bits (start_index: 32 bits, bitset: 32 bits).
+// Thus, a single value_interval position is represented with 2 bits (64 bits / 32 = 2 bits).
+// - start_index: Indicates the starting position of this dense group within the dense first array.
+// - bitset: Uses 32 bits to represent which of the 32 positions in this dense group are non-empty.
+//
+// The following diagram illustrates the structure of `DenseRangeDirectMappingJoinHashMap`:
+//
+// build keys              dense groups       first       next
+//                         ┌───────────┐      ┌───┐       ┌───┐
+//                         │start_index┼─┐    │   │       │ 0 │◄───┐
+//                         │bitset     │ │    │   │       │   │◄┐  │
+//                         ├───────────┤ │    ├───┤       ├───┤ │  │
+//                         │           │ │    │   │─┐     │   │ │  │
+//                         │           │ └───►│   │ │     │   │ │  │
+//                         ├───────────┤      ├───┤ │     ├───┤ │  │
+//                         │           │      │   │ │     │   │─┘  │
+//  ┌──────┐key-min_value  │           │      │   │ │     │   │◄─┐ │
+//  │ key  ├─────────────► ├───────────┤      ├───┤ │     ├───┤  │ │
+//  └──────┘               │           │      │   │ │     │   │  │ │
+//                         │           │      │   │ │     │   │  │ │
+//                         ├───────────┤      ├───┤ │     ├───┤  │ │
+//                         │           │      │   │ └────►│   │  │ │
+//                         │           │      │   │       │   │──┘ │
+//                         ├───────────┤      ├───┤       ├───┤    │
+//                         │           │      │   │       │   │    │
+//                         │           │      │   │       │   │    │
+//                         ├───────────┤      ├───┤       ├───┤    │
+//                         │           │      │   │       │   │    │
+//                         │           │      │   │──────►│   │────┘
+//                         └───────────┘      └───┘       └───┘
+template <LogicalType LT>
+class DenseRangeDirectMappingJoinHashMap {
 public:
     using CppType = typename RunTimeTypeTraits<LT>::CppType;
     using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -432,6 +432,11 @@ public:
         return column_view_concat_bytes_limit() > 0 || column_view_concat_rows_limit() > 0;
     }
 
+    bool enable_hash_join_range_direct_mapping_opt() const {
+        return _query_options.__isset.enable_hash_join_range_direct_mapping_opt &&
+               _query_options.enable_hash_join_range_direct_mapping_opt;
+    }
+
     const std::vector<TTabletCommitInfo>& tablet_commit_infos() const { return _tablet_commit_infos; }
 
     std::vector<TTabletCommitInfo>& tablet_commit_infos() { return _tablet_commit_infos; }

--- a/be/src/util/bit_util.h
+++ b/be/src/util/bit_util.h
@@ -92,6 +92,14 @@ public:
         }
     }
 
+    static inline int count_one_bits(uint32_t x) {
+#ifdef __POPCNT__
+        return __builtin_popcount(x);
+#else
+        return Bits::CountOnes(x);
+#endif
+    }
+
     // Returns the 'num_bits' least-significant bits of 'v'.
     static inline uint64_t trailing_bits(uint64_t v, int num_bits) {
         if (UNLIKELY(num_bits == 0)) {

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -408,7 +408,7 @@ void RuntimeProfile::add_info_string(const std::string& key, const std::string& 
     }
 }
 
-const std::string* RuntimeProfile::get_info_string(const std::string& key) {
+std::string* RuntimeProfile::get_info_string(const std::string& key) {
     std::lock_guard<std::mutex> l(_info_strings_lock);
     auto it = _info_strings.find(key);
 

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -490,7 +490,7 @@ public:
 
     // Returns a pointer to the info string value for 'key'.  Returns NULL if
     // the key does not exist.
-    const std::string* get_info_string(const std::string& key);
+    std::string* get_info_string(const std::string& key);
 
     // Copy all the string infos from src profile
     void copy_all_info_strings_from(RuntimeProfile* src_profile);

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -1605,7 +1605,7 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFuncNullable) {
         probe_state.build_index.assign(4096 + 8, 0);                                                           \
         probe_state.probe_match_index.assign(4096 + 8, 0);                                                     \
         if (group == 0) {                                                                                      \
-            join_hash_map->FUNC<FIRST>(_runtime_state.get(), build_data, probe_data);                          \
+            join_hash_map->FUNC<FIRST, false>(_runtime_state.get(), build_data, probe_data);                   \
         } else {                                                                                               \
             probe_state.handles.clear();                                                                       \
             for (int i = 0; i < group; ++i) {                                                                  \
@@ -1618,7 +1618,7 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFuncNullable) {
 
 #define DO_TEST_PROBE_MID(FUNC)                                                                           \
     if (group == 0) {                                                                                     \
-        join_hash_map->FUNC<false>(_runtime_state.get(), build_data, probe_data);                         \
+        join_hash_map->FUNC<false, false>(_runtime_state.get(), build_data, probe_data);                  \
     } else {                                                                                              \
         join_hash_map->_probe_coroutine<false>(_runtime_state.get(), build_data, probe_data);             \
         sort_results_from_coroutine(probe_state.probe_index, probe_state.build_index, probe_state.count); \
@@ -1877,7 +1877,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmpty) {
     this->prepare_probe_data(&probe_data, probe_row_count);
 
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct<true>(
+    join_hash_map->_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct<true, false>(
             _runtime_state.get(), build_data, probe_data);
     this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count);
     this->check_match_index(probe_state.probe_match_index, 0, config::vector_chunk_size, match_count);
@@ -1899,7 +1899,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmptyMore) {
     this->prepare_probe_data(&probe_data, probe_row_count);
 
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct<true>(
+    join_hash_map->_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct<true, false>(
             _runtime_state.get(), build_data, probe_data);
     std::vector<std::pair<uint32_t, uint32_t>> results;
     ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
@@ -1908,7 +1908,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmptyMore) {
         results.push_back(std::make_pair(probe_state.probe_index[i], probe_state.build_index[i]));
     }
 
-    join_hash_map->_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct<false>(
+    join_hash_map->_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct<false, false>(
             _runtime_state.get(), build_data, probe_data);
     ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
     ASSERT_FALSE(probe_state.has_remain);
@@ -1957,13 +1957,13 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunct) {
 
         // first probe
         auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-        join_hash_map->_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<true>(
+        join_hash_map->_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<true, false>(
                 _runtime_state.get(), build_data, probe_data);
         this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count);
 
         // second probe
         join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-        join_hash_map->_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<false>(
+        join_hash_map->_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<false, false>(
                 _runtime_state.get(), build_data, probe_data);
         this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 1, match_count, probe_row_count);
     }
@@ -1985,7 +1985,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunctMore) {
         this->prepare_probe_data(&probe_data, probe_row_count);
 
         auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-        join_hash_map->_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<true>(
+        join_hash_map->_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<true, false>(
                 _runtime_state.get(), build_data, probe_data);
         std::vector<std::pair<uint32_t, uint32_t>> results;
         ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
@@ -1994,7 +1994,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunctMore) {
             results.push_back(std::make_pair(probe_state.probe_index[i], probe_state.build_index[i]));
         }
 
-        join_hash_map->_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<false>(
+        join_hash_map->_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<false, false>(
                 _runtime_state.get(), build_data, probe_data);
         ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
         ASSERT_FALSE(probe_state.has_remain);
@@ -2873,8 +2873,8 @@ TEST_F(JoinHashMapTest, NullAwareAntiJoinTest) {
     this->prepare_probe_data(&probe_data, probe_row_count);
 
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht_for_null_aware_anti_join_with_other_conjunct<true>(_runtime_state.get(), build_data,
-                                                                                     probe_data);
+    join_hash_map->_probe_from_ht_for_null_aware_anti_join_with_other_conjunct<true, false>(_runtime_state.get(),
+                                                                                            build_data, probe_data);
 
     // null in probe table match all build table rows
     ASSERT_EQ(probe_state.probe_match_index[0], build_row_count);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -446,6 +446,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_JOIN_RUNTIME_FILTER_PUSH_DOWN = "enable_join_runtime_filter_push_down";
     public static final String ENABLE_JOIN_RUNTIME_BITSET_FILTER = "enable_join_runtime_bitset_filter";
 
+    public static final String ENABLE_HASH_JOIN_RANGE_DIRECT_MAPPING_OPT = "enable_hash_join_range_direct_mapping_opt";
+
     public static final String ENABLE_PIPELINE_LEVEL_MULTI_PARTITIONED_RF =
             "enable_pipeline_level_multi_partitioned_rf";
 
@@ -1593,6 +1595,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enableJoinRuntimeFilterPushDown = true;
     @VariableMgr.VarAttr(name = ENABLE_JOIN_RUNTIME_BITSET_FILTER, flag = VariableMgr.INVISIBLE)
     private boolean enableJoinRuntimeBitsetFilter = true;
+
+    @VarAttr(name = ENABLE_HASH_JOIN_RANGE_DIRECT_MAPPING_OPT)
+    private boolean enableHashJoinRangeDirectMappingOpt = true;
 
     @VarAttr(name = ENABLE_PIPELINE_LEVEL_MULTI_PARTITIONED_RF)
     private boolean enablePipelineLevelMultiPartitionedRf = false;
@@ -5283,6 +5288,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setEnable_parquet_reader_page_index(enableParquetReaderPageIndex);
         tResult.setColumn_view_concat_rows_limit(columnViewConcatRowsLimit);
         tResult.setColumn_view_concat_bytes_limit(columnViewConcatRowsLimit);
+        tResult.setEnable_hash_join_range_direct_mapping_opt(enableHashJoinRangeDirectMappingOpt);
+
         return tResult;
     }
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -337,6 +337,7 @@ struct TQueryOptions {
 
   160: optional bool enable_join_runtime_filter_pushdown;
   161: optional bool enable_join_runtime_bitset_filter;
+  162: optional bool enable_hash_join_range_direct_mapping_opt
 
   170: optional bool enable_parquet_reader_bloom_filter;
   171: optional bool enable_parquet_reader_page_index;

--- a/test/sql/test_join/R/test_join_range_direct_mapping
+++ b/test/sql/test_join/R/test_join_range_direct_mapping
@@ -1,0 +1,524 @@
+-- name: test_join_range_direct_mapping
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_int int,
+    c_int_null int NULL,
+    c_bigint bigint,
+    c_bigint_null bigint NULL,
+    c_largeint bigint,
+    c_largeint_null bigint NULL,
+    c_double double,
+    c_double_null double NULL,
+    c_string STRING,
+    c_string_null STRING NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 96
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 
+select
+    idx,
+
+    idx, -- c_int
+    if (idx % 13 = 0, idx, null),
+
+    idx, -- c_bigint
+    if (idx % 14 = 0, idx, null),
+
+    idx, -- c_largeint
+    if (idx % 15 = 0, idx, null),
+
+    idx, -- c_double
+    if (idx % 16 = 0, idx, null),
+
+    concat('str-', idx), -- c_string
+    if (idx % 17 = 0, concat('str-', idx), null)
+
+from __row_util;
+-- result:
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int);
+-- result:
+1280000	1280000	1280000	1280000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint);
+-- result:
+1280000	1280000	1280000	1280000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int_null);
+-- result:
+98461	98461	98461	98461
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint_null);
+-- result:
+1280000	1280000	91428	91428
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_int);
+-- result:
+5120000	5120000	5120000	5120000
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_int);
+-- result:
+5120000	5120000	5120000	5120000
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_bigint);
+-- result:
+5120000	5120000	5120000	5120000
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_bigint);
+-- result:
+5120000	5120000	5120000	5120000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int) where t2.c_int % 10 != 0;
+-- result:
+1152000	1152000	1152000	1152000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+-- result:
+1152000	1152000	1152000	1152000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int_null) where t2.c_int % 10 != 0;
+-- result:
+88615	88615	88615	88615
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint_null) where t2.c_int % 10 != 0;
+-- result:
+73143	73143	73143	73143
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 != 0;
+-- result:
+4608000	4608000	4608000	4608000
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 != 0;
+-- result:
+4608000	4608000	4608000	4608000
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+-- result:
+4608000	4608000	4608000	4608000
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+-- result:
+4608000	4608000	4608000	4608000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int) where t2.c_int % 10 < 5;
+-- result:
+640000	640000	640000	640000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint) where t2.c_int % 10 < 5;
+-- result:
+640000	640000	640000	640000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int_null) where t2.c_int % 10 < 5;
+-- result:
+49231	49231	49231	49231
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint_null) where t2.c_int % 10 < 5;
+-- result:
+54857	54857	54857	54857
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 < 5;
+-- result:
+2560000	2560000	2560000	2560000
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 < 5;
+-- result:
+2560000	2560000	2560000	2560000
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 < 5;
+-- result:
+2560000	2560000	2560000	2560000
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 < 5;
+-- result:
+2560000	2560000	2560000	2560000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT SEMI JOIN [broadcast] t1 t2 USING(c_int);
+-- result:
+1280000	1280000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT SEMI JOIN [broadcast] t1 t2 USING(c_bigint);
+-- result:
+E: (1064, "Getting syntax error at line 2, column 13. Detail message: No viable statement for input 'LEFT LEFT'.")
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT SEMI JOIN [broadcast] t1 t2 USING(c_int_null);
+-- result:
+98461	98461
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT SEMI JOIN [broadcast] t1 t2 USING(c_bigint_null);
+-- result:
+E: (1064, "Getting syntax error at line 2, column 13. Detail message: No viable statement for input 'LEFT LEFT'.")
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_int);
+-- result:
+2560000	2560000
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_int);
+-- result:
+2560000	2560000
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_bigint);
+-- result:
+2560000	2560000
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_bigint);
+-- result:
+2560000	2560000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT SEMI JOIN [broadcast] t1 t2 USING(c_int) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column '`t2`.`c_int`' cannot be resolved.")
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT SEMI JOIN [broadcast] t1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting syntax error at line 2, column 13. Detail message: No viable statement for input 'LEFT LEFT'.")
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT SEMI JOIN [broadcast] t1 t2 USING(c_int_null) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column '`t2`.`c_int`' cannot be resolved.")
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT SEMI JOIN [broadcast] t1 t2 USING(c_bigint_null) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting syntax error at line 2, column 13. Detail message: No viable statement for input 'LEFT LEFT'.")
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column '`t2`.`c_int`' cannot be resolved.")
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column '`t2`.`c_int`' cannot be resolved.")
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column '`t2`.`c_int`' cannot be resolved.")
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column '`t2`.`c_int`' cannot be resolved.")
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int);
+-- result:
+0	0
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint);
+-- result:
+E: (1064, "Getting syntax error at line 2, column 13. Detail message: No viable statement for input 'LEFT LEFT'.")
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int_null);
+-- result:
+1181539	1181539
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint_null);
+-- result:
+E: (1064, "Getting syntax error at line 2, column 13. Detail message: No viable statement for input 'LEFT LEFT'.")
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_int);
+-- result:
+0	0
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_int);
+-- result:
+0	0
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_bigint);
+-- result:
+0	0
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_bigint);
+-- result:
+0	0
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column '`t2`.`c_int`' cannot be resolved.")
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting syntax error at line 2, column 13. Detail message: No viable statement for input 'LEFT LEFT'.")
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int_null) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column '`t2`.`c_int`' cannot be resolved.")
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint_null) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting syntax error at line 2, column 13. Detail message: No viable statement for input 'LEFT LEFT'.")
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column '`t2`.`c_int`' cannot be resolved.")
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column '`t2`.`c_int`' cannot be resolved.")
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column '`t2`.`c_int`' cannot be resolved.")
+-- !result
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column '`t2`.`c_int`' cannot be resolved.")
+-- !result
+set enable_hash_join_range_direct_mapping_opt = false;
+-- result:
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int) where t2.c_int % 10 < 5;
+-- result:
+640000	640000	640000	640000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint) where t2.c_int % 10 < 5;
+-- result:
+640000	640000	640000	640000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int_null) where t2.c_int % 10 < 5;
+-- result:
+49231	49231	49231	49231
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint_null) where t2.c_int % 10 < 5;
+-- result:
+54857	54857	54857	54857
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int) where t2.c_int % 10 < 5;
+-- result:
+640000	640000	640000	640000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint) where t2.c_int % 10 < 5;
+-- result:
+640000	640000	640000	640000
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int_null) where t2.c_int % 10 < 5;
+-- result:
+49231	49231	49231	49231
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint_null) where t2.c_int % 10 < 5;
+-- result:
+54857	54857	54857	54857
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int);
+-- result:
+0	0
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint);
+-- result:
+E: (1064, "Getting syntax error at line 2, column 13. Detail message: No viable statement for input 'LEFT LEFT'.")
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int_null);
+-- result:
+1181539	1181539
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint_null);
+-- result:
+E: (1064, "Getting syntax error at line 2, column 13. Detail message: No viable statement for input 'LEFT LEFT'.")
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int);
+-- result:
+0	0
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint);
+-- result:
+E: (1064, "Getting syntax error at line 2, column 13. Detail message: No viable statement for input 'LEFT LEFT'.")
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int_null);
+-- result:
+1181539	1181539
+-- !result
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint_null);
+-- result:
+E: (1064, "Getting syntax error at line 2, column 13. Detail message: No viable statement for input 'LEFT LEFT'.")
+-- !result

--- a/test/sql/test_join/T/test_join_range_direct_mapping
+++ b/test/sql/test_join/T/test_join_range_direct_mapping
@@ -1,0 +1,412 @@
+-- name: test_join_range_direct_mapping
+
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_int int,
+    c_int_null int NULL,
+    c_bigint bigint,
+    c_bigint_null bigint NULL,
+    c_largeint bigint,
+    c_largeint_null bigint NULL,
+    c_double double,
+    c_double_null double NULL,
+    c_string STRING,
+    c_string_null STRING NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 96
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t1 
+select
+    idx,
+
+    idx, -- c_int
+    if (idx % 13 = 0, idx, null),
+
+    idx, -- c_bigint
+    if (idx % 14 = 0, idx, null),
+
+    idx, -- c_largeint
+    if (idx % 15 = 0, idx, null),
+
+    idx, -- c_double
+    if (idx % 16 = 0, idx, null),
+
+    concat('str-', idx), -- c_string
+    if (idx % 17 = 0, concat('str-', idx), null)
+
+from __row_util;
+
+
+-- # RANGE_DIRECT_MAPPING
+-- ## All rows
+-- ### no duplicated key
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int);
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint);
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int_null);
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint_null);
+
+-- ### duplicated key
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_int);
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_int);
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_bigint);
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_bigint);
+
+-- ## Filter some rows
+-- ### no duplicated key
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int) where t2.c_int % 10 != 0;
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int_null) where t2.c_int % 10 != 0;
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint_null) where t2.c_int % 10 != 0;
+
+-- ### duplicated key
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 != 0;
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 != 0;
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+
+
+-- # DENSE_RANGE_DIRECT_MAPPING
+-- ## no duplicated key
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int) where t2.c_int % 10 < 5;
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint) where t2.c_int % 10 < 5;
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int_null) where t2.c_int % 10 < 5;
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint_null) where t2.c_int % 10 < 5;
+
+-- ## duplicated key
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 < 5;
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 < 5;
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 < 5;
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM w1 t1 JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 < 5;
+
+
+-- # DENSE_RANGE_DIRECT_MAPPING for LEFT SEMI JOIN
+-- ## All rows
+-- ### no duplicated key
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT SEMI JOIN [broadcast] t1 t2 USING(c_int);
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT SEMI JOIN [broadcast] t1 t2 USING(c_bigint);
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT SEMI JOIN [broadcast] t1 t2 USING(c_int_null);
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT SEMI JOIN [broadcast] t1 t2 USING(c_bigint_null);
+
+-- ### duplicated key
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_int);
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_int);
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_bigint);
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_bigint);
+
+-- ## Filter some rows
+-- ### no duplicated key
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT SEMI JOIN [broadcast] t1 t2 USING(c_int) where t2.c_int % 10 != 0;
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT SEMI JOIN [broadcast] t1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT SEMI JOIN [broadcast] t1 t2 USING(c_int_null) where t2.c_int % 10 != 0;
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT SEMI JOIN [broadcast] t1 t2 USING(c_bigint_null) where t2.c_int % 10 != 0;
+
+-- ### duplicated key
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 != 0;
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 != 0;
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT SEMI JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+
+
+-- # DENSE_RANGE_DIRECT_MAPPING for LEFT SEMI JOIN
+
+-- ## All rows
+-- ### no duplicated key
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int);
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint);
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int_null);
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint_null);
+
+-- ### duplicated key
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_int);
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_int);
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_bigint);
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_bigint);
+
+-- ## Filter some rows
+-- ### no duplicated key
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int) where t2.c_int % 10 != 0;
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int_null) where t2.c_int % 10 != 0;
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint_null) where t2.c_int % 10 != 0;
+
+-- ### duplicated key
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 != 0;
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_int) where t2.c_int % 10 != 0;
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+
+with w1 as (
+    select * from t1 union all select * from t1
+)
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM w1 t1 LEFT ANTI JOIN [broadcast] w1 t2 USING(c_bigint) where t2.c_int % 10 != 0;
+
+set enable_hash_join_range_direct_mapping_opt = false;
+
+-- # DENSE_RANGE_DIRECT_MAPPING
+-- ## no duplicated key
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int) where t2.c_int % 10 < 5;
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint) where t2.c_int % 10 < 5;
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int_null) where t2.c_int % 10 < 5;
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint_null) where t2.c_int % 10 < 5;
+
+-- # DENSE_RANGE_DIRECT_MAPPING
+-- ## no duplicated key
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int) where t2.c_int % 10 < 5;
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint) where t2.c_int % 10 < 5;
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 JOIN [broadcast] t1 t2 USING(c_int_null) where t2.c_int % 10 < 5;
+
+SELECT count(t1.c_int), count(t1.c_bigint), count(t2.c_int), count(t2.c_bigint)
+FROM t1 LEFT JOIN [broadcast] t1 t2 USING(c_bigint_null) where t2.c_int % 10 < 5;
+
+-- # DENSE_RANGE_DIRECT_MAPPING for LEFT SEMI JOIN
+
+-- ## All rows
+-- ### no duplicated key
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int);
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint);
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int_null);
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint_null);
+
+
+-- # DENSE_RANGE_DIRECT_MAPPING for LEFT SEMI JOIN
+
+-- ## All rows
+-- ### no duplicated key
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int);
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint);
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT ANTI JOIN [broadcast] t1 t2 USING(c_int_null);
+
+SELECT count(t1.c_int), count(t1.c_bigint)
+FROM t1 LEFT LEFT ANTI JOIN [broadcast] t1 t2 USING(c_bigint_null);


### PR DESCRIPTION
## Why I'm doing:


### Adding Implementations for Three RANGE_DIRECT_MAPPING Hash Map Methods
Add three hash map method implementations: `RANGE_DIRECT_MAPPING`, `RANGE_DIRECT_MAPPING_SET`, `DENSE_RANGE_DIRECT_MAPPING`.


#### Implementation Details
Compared to the default BUCKET_CHAINED:
- The similarity lies in the bucket-chained structure formed by first and next.
- The difference is that for a given key, `BUCKET_CHAINED` uses a hash function to map to a position in first, while RANGE_DIRECT_MAPPING uses `key-min_value` and its variants to directly map to first's position.
    - `RANGE_DIRECT_MAPPING`: Uses `key-min_value` as the index for first.
    - `RANGE_DIRECT_MAPPING_SET`: For `LEFT SEMI/ANTI JOIN` (without other conjuncts), replaces `first` and `next` with a `key_bitset`, where each `key-min_value` position is represented by a single bit to indicate existence.
    - `DENSE_RANGE_DIRECT_MAPPING`: Compresses `max_value-min_value` `first` positions down to `row_count` positions by discarding empty `first` slots to save memory. Each dense group stores information for 32 first positions using 64 bits (start_index: 32 bits, bitset: 32 bits). Thus, each `value_interval` position is represented with 2 bits (64 bits / 32 = 2 bits).
       - `start_index`: Indicates the starting position of this dense group within the dense first array.
       - `bitset`: Uses 32 bits to mark which of the 32 positions in this dense group are non-empty.

<br>

**BUCKET_CHAINED**

```
 build keys                       first       next
                                  ┌───┐       ┌───┐
                                  │   │       │   │◄───┐
                                  │   │       │   │◄┐  │
                                  ├───┤       ├───┤ │  │
                                  │   ├─┐     │   │ │  │
                         ┌───────►│   │ │     │   │ │  │
                         │        ├───┤ │     ├───┤ │  │
              ┌────────┐ │        │   │ │     │   ├─┘  │
  ┌──────┐    │        │ │        │   │ │     │   │◄─┐ │
  │ key  ├───►│  Hash  ├─┘        ├───┤ │     ├───┤  │ │
  └──────┘    │        │          │   │ │     │   │  │ │
              └────────┘          │   │ │     │   │  │ │
                                  ├───┤ │     ├───┤  │ │
                                  │   │ └────►│   │  │ │
                                  │   │       │   ├──┘ │
                                  ├───┤       ├───┤    │
                                  │   │       │   │    │
                                  │   │       │   │    │
                                  ├───┤       ├───┤    │
                                  │   │       │   │    │
                                  │   ├──────►│   ├────┘
                                  └───┘       └───┘
```

<br>

**RANGE_DIRECT_MAPPING**

```
 build keys               first       next
                          ┌───┐       ┌───┐
                          │   │       │   │◄───┐
                          │   │       │   │◄┐  │
                          ├───┤       ├───┤ │  │
          key-min_value   │   ├─┐     │   │ │  │
                 ┌───────►│   │ │     │   │ │  │
 ┌──────┐        │        ├───┤ │     ├───┤ │  │
 │ key  ├────────┘        │   │ │     │   ├─┘  │
 └──────┘                 │   │ │     │   │◄─┐ │
                          ├───┤ │     ├───┤  │ │
                          │   │ │     │   │  │ │
                          │   │ │     │   │  │ │
                          ├───┤ │     ├───┤  │ │
                          │   │ └────►│   │  │ │
                          │   │       │   ├──┘ │
                          ├───┤       ├───┤    │
                          │   │       │   │    │
                          │   │       │   │    │
                          ├───┤       ├───┤    │
                          │   │       │   │    │
                          │   ├──────►│   ├────┘
                          └───┘       └───┘
```


<br>

**DENSE_RANGE_DIRECT_MAPPING**

```
 build keys              dense groups       first       next
                         ┌───────────┐      ┌───┐       ┌───┐
                         │start_index┼─┐    │   │       │ 0 │◄───┐
                         │bitset     │ │    │   │       │   │◄┐  │
                         ├───────────┤ │    ├───┤       ├───┤ │  │
                         │           │ │    │   │─┐     │   │ │  │
                         │           │ └───►│   │ │     │   │ │  │
                         ├───────────┤      ├───┤ │     ├───┤ │  │
                         │           │      │   │ │     │   │─┘  │
  ┌──────┐key-min_value  │           │      │   │ │     │   │◄─┐ │
  │ key  ├─────────────► ├───────────┤      ├───┤ │     ├───┤  │ │
  └──────┘               │           │      │   │ │     │   │  │ │
                         │           │      │   │ │     │   │  │ │
                         ├───────────┤      ├───┤ │     ├───┤  │ │
                         │           │      │   │ └────►│   │  │ │
                         │           │      │   │       │   │──┘ │
                         ├───────────┤      ├───┤       ├───┤    │
                         │           │      │   │       │   │    │
                         │           │      │   │       │   │    │
                         ├───────────┤      ├───┤       ├───┤    │
                         │           │      │   │       │   │    │
                         │           │      │   │──────►│   │────┘
                         └───────────┘      └───┘       └───┘
```

#### Usage Scenarios
General principle: 
- Key Column is `INT` or `BIGINT`.
- Use when it doesn’t increase memory compared to BUCKET_CHAINED, that is, `max_value - min_value + 1 <= bucket_size`.

For details, refer to `_try_use_range_direct_mapping` in the file `join_hash_map.cpp`.

#### Benefits
- Eliminates the need for hashing.
- All entries in a single bucket's linked list have identical values, meaning:
    - During probing, there’s no need to compare the probe key against the build key.
    - When builder keys are unique, accessing the `table_items.next` array becomes unnecessary.
- For LEFT SEMI/ANTI JOIN, a bitset suffices without needing the bucket-chained structure of first and next.

### Adding HashMapType Field to Profile
Add a HashMapType field in the profile, formatted as `KeyConstructorType-MapMethodType-KeyLogicalType:<NumPartitions>,...`  
For example:
- HashMapType: ONE_KEY-RANGE_DIRECT_MAPPING-INT:1
- HashMapType: SERIALIZED_KEY-BUCKET_CHAINED-VARCHAR:16


### Test
Environment
- 4 BE (each 16 vCPUs, 64 GB Memory)

Dadataset
- ssb 1T

<br>

**RANGE_DIRECT_MAPPING_SET**

```sql
SELECT SUM(lo_revenue)  FROM lineorder  LEFT SEMI JOIN customer ON lo_custkey=c_custkey and c_region='ASIA';
```
- Before: 11.482s
- After: 5.685s

<br>

**DENSE_RANGE_DIRECT_MAPPING**

```sql
SELECT SUM(lo_revenue), SUM(c_custkey)  FROM lineorder  LEFT JOIN customer ON lo_custkey=c_custkey WHERE c_region='ASIA';
```
- Before: 8.361s
- After: 6.241s


<br>

**RANGE_DIRECT_MAPPING**

```sql
SELECT SUM(lo_revenue), SUM(s_suppkey)  FROM lineorder  LEFT JOIN supplier ON lo_suppkey=s_suppkey;
```
- Before: 8.980s
- After: 3.255s

<br>

**SSB standard queries:**

  | Before | After | Before/After
-- | -- | -- | --
SUM | 47510 | 44517 | 1.07
Q01 | 1802 | 1763 | 1.02
Q02 | 1450 | 1430 | 1.01
Q03 | 1319 | 1351 | 0.98
Q04 | 4753 | 4700 | 1.01
Q05 | 3431 | 3369 | 1.02
Q06 | 3226 | 3314 | 0.97
Q07 | 9028 | 7754 | 1.16
Q08 | 3322 | 3343 | 0.99
Q09 | 3166 | 3128 | 1.01
Q10 | 1673 | 1664 | 1.01
Q11 | 7921 | 6500 | 1.22
Q12 | 3556 | 3410 | 1.04
Q13 | 2863 | 2791 | 1.03


## What I'm doing:


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
