### PR TITLE
[Feature] support catalog/database/table name case-insensitive

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LabelName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LabelName.java
@@ -42,6 +42,7 @@ import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.FeNameFormat;
 import com.starrocks.sql.parser.NodePosition;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import static com.starrocks.common.util.Util.normalizeName;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -64,7 +65,7 @@ public class LabelName implements ParseNode, Writable {
 
     public LabelName(String dbName, String labelName, NodePosition pos) {
         this.pos = pos;
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.labelName = labelName;
     }
 
@@ -73,7 +74,7 @@ public class LabelName implements ParseNode, Writable {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public String getLabelName() {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
@@ -246,7 +246,7 @@ public class SlotRef extends Expr {
     }
 
     public boolean isFromLambda() {
-        return tblName != null && tblName.getTbl().equals(TableName.LAMBDA_FUNC_TABLE);
+        return tblName != null && tblName.getTbl().equalsIgnoreCase(TableName.LAMBDA_FUNC_TABLE);
     }
 
     public void setTblName(TableName name) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
@@ -58,6 +58,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class TableName implements Writable, GsonPreProcessable, GsonPostProcessable {
     public static final String LAMBDA_FUNC_TABLE = "__LAMBDA_TABLE";
 
@@ -84,9 +86,9 @@ public class TableName implements Writable, GsonPreProcessable, GsonPostProcessa
 
     public TableName(String catalog, String db, String tbl, NodePosition pos) {
         this.pos = pos;
-        this.catalog = catalog;
-        this.db = db;
-        this.tbl = tbl;
+        this.catalog = normalizeName(catalog);
+        this.db = normalizeName(db);
+        this.tbl = normalizeName(tbl);
     }
 
     public static TableName fromString(String name) {
@@ -112,11 +114,11 @@ public class TableName implements Writable, GsonPreProcessable, GsonPostProcessa
 
     public void analyze(Analyzer analyzer) throws AnalysisException {
         if (Strings.isNullOrEmpty(catalog)) {
-            catalog = analyzer.getDefaultCatalog();
+            catalog = normalizeName(analyzer.getDefaultCatalog());
         }
 
         if (Strings.isNullOrEmpty(db)) {
-            db = analyzer.getDefaultDb();
+            db = normalizeName(analyzer.getDefaultDb());
             if (Strings.isNullOrEmpty(db)) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);
             }
@@ -132,11 +134,11 @@ public class TableName implements Writable, GsonPreProcessable, GsonPostProcessa
             if (Strings.isNullOrEmpty(connectContext.getCurrentCatalog())) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_CATALOG_ERROR, catalog);
             }
-            catalog = connectContext.getCurrentCatalog();
+            catalog = normalizeName(connectContext.getCurrentCatalog());
         }
 
         if (Strings.isNullOrEmpty(db)) {
-            db = connectContext.getDatabase();
+            db = normalizeName(connectContext.getDatabase());
             if (Strings.isNullOrEmpty(db)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_NO_DB_ERROR);
             }
@@ -152,7 +154,7 @@ public class TableName implements Writable, GsonPreProcessable, GsonPostProcessa
     }
 
     public void setDb(String db) {
-        this.db = db;
+        this.db = normalizeName(db);
     }
 
     public String getTbl() {
@@ -164,12 +166,12 @@ public class TableName implements Writable, GsonPreProcessable, GsonPostProcessa
     }
 
     public void setCatalog(String catalog) {
-        this.catalog = catalog;
+        this.catalog = normalizeName(catalog);
     }
 
     // for rename table
     public void setTbl(String tbl) {
-        this.tbl = tbl;
+        this.tbl = normalizeName(tbl);
     }
 
     public boolean isEmpty() {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TaskName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TaskName.java
@@ -16,6 +16,7 @@
 package com.starrocks.analysis;
 
 import com.starrocks.sql.parser.NodePosition;
+import static com.starrocks.common.util.Util.normalizeName;
 
 public class TaskName {
 
@@ -26,17 +27,13 @@ public class TaskName {
     private final NodePosition pos;
 
     public TaskName(String dbName, String name, NodePosition pos) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.name = name;
         this.pos = pos;
     }
 
     public String getDbName() {
         return dbName;
-    }
-
-    public void setDbName(String dbName) {
-        this.dbName = dbName;
     }
 
     public String getName() {

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ObjectType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ObjectType.java
@@ -110,6 +110,19 @@ public class ObjectType {
                     .put(20003, new Pair<>("WAREHOUSE", "WAREHOUSES"))
                     .build();
 
+    public static final Set<String> CASE_INSENSITIVE_NAMES = new ImmutableSet.Builder<String>().add(
+            "TABLE",
+            "TABLES",
+            "DATABASE",
+            "DATABASES",
+            "VIEW",
+            "VIEWS",
+            "CATALOG",
+            "CATALOGS",
+            "MATERIALIZED VIEW",
+            "MATERIALIZED VIEWS"
+    ).build();
+
     public static final Map<String, ObjectType> NAME_TO_OBJECT = VALID_OBJECT_TYPE.stream().collect(Collectors.toMap(
             ObjectType::name, Function.identity()));
 

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/TablePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/TablePEntryObject.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.ExternalCatalog;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.qe.GlobalVariable;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.MetaNotFoundException;
@@ -181,7 +182,7 @@ public class TablePEntryObject implements PEntryObject {
     }
 
     private boolean matchTableUUID(TablePEntryObject other) {
-        if (isExternalCatalog(this.catalogId)) {
+        if (isExternalCatalog(this.catalogId) || GlobalVariable.enableTableNameCaseInsensitive) {
             return Catalog.getCompatibleTableUUID(this.tableUUID)
                     .equalsIgnoreCase(Catalog.getCompatibleTableUUID(other.tableUUID));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -27,8 +27,6 @@ import com.starrocks.thrift.TTableType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.net.URI;
 import java.security.MessageDigest;
@@ -38,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 
 public class JDBCTable extends Table {
-    private static final Logger LOG = LogManager.getLogger(JDBCTable.class);
 
     private static final String TABLE = "table";
     private static final String RESOURCE = "resource";

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3806,4 +3806,8 @@ public class Config extends ConfigBase {
      */
     @ConfField
     public static int deploy_serialization_queue_size = -1;
+
+    @ConfField(comment = "Enable case-insensitive catalog/database/table names. " +
+            "Only configurable during cluster initialization, immutable once set.")
+    public static boolean enable_table_name_case_insensitive = false;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/SRStringUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/SRStringUtils.java
@@ -35,6 +35,7 @@
 package com.starrocks.common.util;
 
 import com.starrocks.catalog.Table;
+import com.starrocks.qe.GlobalVariable;
 
 import java.security.SecureRandom;
 
@@ -65,11 +66,11 @@ public class SRStringUtils {
         if (table == null) {
             return false;
         }
-
-        if (table.isNativeTableOrMaterializedView()) {
-            return table.getName().equals(toCheck);
+        String tableName = table.getName();
+        if (table.isNativeTableOrMaterializedView() && !GlobalVariable.enableTableNameCaseInsensitive) {
+            return tableName.equals(toCheck);
         } else {
-            return table.getName().equalsIgnoreCase(toCheck);
+            return tableName.equalsIgnoreCase(toCheck);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
@@ -519,7 +519,8 @@ public class Util {
     }
 
     public static GrantRevokePrivilegeObjects normalizeNames(String objectType, GrantRevokePrivilegeObjects objectsUnResolved) {
-        if (!GlobalVariable.enableTableNameCaseInsensitive || !CASE_INSENSITIVE_NAMES.contains(objectType)) {
+        if (!GlobalVariable.enableTableNameCaseInsensitive || !CASE_INSENSITIVE_NAMES.contains(objectType) ||
+                objectsUnResolved == null || objectType == null) {
             return objectsUnResolved;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
@@ -48,8 +48,10 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.TimeoutException;
 import com.starrocks.http.WebUtils;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.GlobalVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.GrantRevokePrivilegeObjects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -73,6 +75,8 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 import java.util.zip.Adler32;
 import java.util.zip.DeflaterOutputStream;
+
+import static com.starrocks.authorization.ObjectType.CASE_INSENSITIVE_NAMES;
 
 public class Util {
     private static final Logger LOG = LogManager.getLogger(Util.class);
@@ -509,4 +513,22 @@ public class Util {
     public static boolean isRunningInContainer() {
         return new File("/.dockerenv").exists();
     }
+
+    public static String normalizeName(String name) {
+        return GlobalVariable.enableTableNameCaseInsensitive && name != null ? name.toLowerCase() : name;
+    }
+
+    public static GrantRevokePrivilegeObjects normalizeNames(String objectType, GrantRevokePrivilegeObjects objectsUnResolved) {
+        if (!GlobalVariable.enableTableNameCaseInsensitive || !CASE_INSENSITIVE_NAMES.contains(objectType)) {
+            return objectsUnResolved;
+        }
+
+        List<List<String>> privilegeObjectNameTokensList = objectsUnResolved.getPrivilegeObjectNameTokensList().stream()
+                .map(nameList -> nameList.stream().map(String::toLowerCase).toList())
+                .toList();
+        objectsUnResolved.setPrivilegeObjectNameTokensList(privilegeObjectNameTokensList);
+        return objectsUnResolved;
+    }
+
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -113,6 +113,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // When one client connect in, we create a connection context for it.
 // We store session information here. Meanwhile, ConnectScheduler all
 // connect with its connection id.
@@ -1344,6 +1346,7 @@ public class ConnectContext {
     // We can support "use 'catalog <catalog_name>'" from mysql client or "use catalog <catalog_name>" from jdbc.
     public void changeCatalog(String newCatalogName) throws DdlException {
         CatalogMgr catalogMgr = globalStateMgr.getCatalogMgr();
+        newCatalogName = normalizeName(newCatalogName);
         if (!catalogMgr.catalogExists(newCatalogName)) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_CATALOG_ERROR, newCatalogName);
         }
@@ -1377,7 +1380,7 @@ public class ConnectContext {
         if (parts.length == 1) { // use database
             dbName = identifier;
         } else { // use catalog.database
-            String newCatalogName = parts[0];
+            String newCatalogName = normalizeName(parts[0]);
             if (!catalogMgr.catalogExists(newCatalogName)) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_BAD_CATALOG_ERROR, newCatalogName);
             }
@@ -1393,6 +1396,8 @@ public class ConnectContext {
             this.setCurrentCatalog(newCatalogName);
             dbName = parts[1];
         }
+
+        dbName = normalizeName(dbName);
 
         if (!Strings.isNullOrEmpty(dbName) && metadataMgr.getDb(this, this.getCurrentCatalog(), dbName) == null) {
             LOG.debug("Unknown catalog {} and db {}", this.getCurrentCatalog(), dbName);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -90,6 +90,9 @@ public final class GlobalVariable {
 
     public static final String SPM_CAPTURE_INCLUDE_TABLE_PATTERN = "plan_capture_include_pattern";
 
+    public static final String ENABLE_TABLE_NAME_CASE_INSENSITIVE = "enable_table_name_case_insensitive";
+
+
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
     public static String versionComment = Version.STARROCKS_VERSION + "-" + Version.STARROCKS_COMMIT_HASH;
 
@@ -130,6 +133,29 @@ public final class GlobalVariable {
     // Compatible with jdbc that version > 8.0.15
     @VariableMgr.VarAttr(name = "performance_schema", flag = VariableMgr.READ_ONLY)
     private static boolean performanceSchema = false;
+
+    /**
+     * This configuration controls case sensitivity for SQL catalog/database/table names.
+     * When enabled, these database object names are treated as case-insensitive.
+     * IMPORTANT NOTES:
+     * - This setting can ONLY be configured during the initial cluster setup via
+     *   {@link Config#enable_table_name_case_insensitive} on the FE leader node
+     *
+     * - Once set during first initialization, this value is IMMUTABLE and will NOT
+     *   be modified by any subsequent operations including:
+     *   * Cluster upgrades/downgrades
+     *   * Fe node restarts
+     *   * Any other maintenance operations
+     *
+     * - During FE restart or leader failover, if the leader node's
+     *   {@link Config#enable_table_name_case_insensitive} differs from the cluster's initially
+     *   recorded enableTableNameCaseInsensitive value, the leader node will FAIL to start
+     *
+     * - Existing clusters CANNOT modify this value. it can only be configured
+     *   in NEW clusters during initial setup
+     */
+    @VariableMgr.VarAttr(name = ENABLE_TABLE_NAME_CASE_INSENSITIVE, flag = VariableMgr.READ_ONLY)
+    public static boolean enableTableNameCaseInsensitive = false;
 
     /**
      * Query will be pending when BE is overloaded, if `enableQueryQueueXxx` is true.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Field.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Field.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.StructField;
 import com.starrocks.catalog.StructType;
 import com.starrocks.catalog.Type;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.GlobalVariable;
 import com.starrocks.sql.ast.QualifiedName;
 
 import java.util.LinkedList;
@@ -174,7 +175,11 @@ public class Field {
                 part = part.toLowerCase();
                 comparedPart = comparedPart.toLowerCase();
             }
-            if (!part.equals(comparedPart)) {
+            boolean matches = !GlobalVariable.enableTableNameCaseInsensitive
+                    ? part.equals(comparedPart)
+                    : part.equalsIgnoreCase(comparedPart);
+
+            if (!matches) {
                 return false;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AbstractBackupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AbstractBackupStmt.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class AbstractBackupStmt extends DdlStmt {
     public enum BackupObjectType {
         TABLE,
@@ -76,7 +78,7 @@ public class AbstractBackupStmt extends DdlStmt {
             this.allMarker = Sets.newHashSet();
         }
 
-        this.originDbName = originDbName;
+        this.originDbName = normalizeName(originDbName);
         this.withOnClause = withOnClause;
         this.properties = properties == null ? Maps.newHashMap() : properties;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterCatalogStmt.java
@@ -15,13 +15,15 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class AlterCatalogStmt extends DdlStmt {
     private final String catalogName;
     private final AlterClause alterClause;
 
     public AlterCatalogStmt(String catalogName, AlterClause alterClause, NodePosition pos) {
         super(pos);
-        this.catalogName = catalogName;
+        this.catalogName = normalizeName(catalogName);
         this.alterClause = alterClause;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterDatabaseQuotaStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterDatabaseQuotaStmt.java
@@ -17,6 +17,8 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class AlterDatabaseQuotaStmt extends DdlStmt {
     private String catalog;
     private String dbName;
@@ -36,7 +38,7 @@ public class AlterDatabaseQuotaStmt extends DdlStmt {
 
     public AlterDatabaseQuotaStmt(String dbName, QuotaType quotaType, String quotaValue, NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.quotaType = quotaType;
         this.quotaValue = quotaValue;
     }
@@ -46,7 +48,7 @@ public class AlterDatabaseQuotaStmt extends DdlStmt {
     }
 
     public void setCatalogName(String catalogName) {
-        this.catalog = catalogName;
+        this.catalog = normalizeName(catalogName);
     }
 
     public String getDbName() {
@@ -62,7 +64,7 @@ public class AlterDatabaseQuotaStmt extends DdlStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public void setQuota(long quota) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterDatabaseRenameStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterDatabaseRenameStatement.java
@@ -17,6 +17,8 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class AlterDatabaseRenameStatement extends DdlStmt {
     private String catalog;
     private String dbName;
@@ -28,8 +30,8 @@ public class AlterDatabaseRenameStatement extends DdlStmt {
 
     public AlterDatabaseRenameStatement(String dbName, String newDbName, NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
-        this.newDbName = newDbName;
+        this.dbName = normalizeName(dbName);
+        this.newDbName = normalizeName(newDbName);
     }
 
     public String getCatalogName() {
@@ -37,7 +39,7 @@ public class AlterDatabaseRenameStatement extends DdlStmt {
     }
 
     public void setCatalogName(String catalogName) {
-        this.catalog = catalogName;
+        this.catalog = normalizeName(catalogName);
     }
 
     public String getDbName() {
@@ -49,7 +51,7 @@ public class AlterDatabaseRenameStatement extends DdlStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseGrantRevokePrivilegeStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseGrantRevokePrivilegeStmt.java
@@ -24,6 +24,8 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 
+import static com.starrocks.common.util.Util.normalizeNames;
+
 public class BaseGrantRevokePrivilegeStmt extends DdlStmt {
     protected GrantRevokeClause clause;
     protected GrantRevokePrivilegeObjects objectsUnResolved;
@@ -55,7 +57,7 @@ public class BaseGrantRevokePrivilegeStmt extends DdlStmt {
         this.privilegeTypeUnResolved = privilegeTypeUnResolved;
         this.objectTypeUnResolved = objectTypeUnResolved;
         this.clause = clause;
-        this.objectsUnResolved = objectsUnResolved;
+        this.objectsUnResolved = normalizeNames(objectTypeUnResolved, objectsUnResolved);
         this.role = clause.getRoleName();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
@@ -19,6 +19,8 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class CTERelation extends Relation {
     private final int cteMouldId;
     private final String name;
@@ -35,7 +37,7 @@ public class CTERelation extends Relation {
                        QueryStatement cteQueryStatement, NodePosition pos) {
         super(pos);
         this.cteMouldId = cteMouldId;
-        this.name = name;
+        this.name = normalizeName(name);
         this.explicitColumnNames = columnOutputNames;
         this.cteQueryStatement = cteQueryStatement;
         this.refs = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CancelBackupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CancelBackupStmt.java
@@ -17,6 +17,8 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class CancelBackupStmt extends CancelStmt {
 
     private String dbName;
@@ -34,7 +36,7 @@ public class CancelBackupStmt extends CancelStmt {
     public CancelBackupStmt(String dbName, boolean isRestore, boolean isExternalCatalog,
                             NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.isRestore = isRestore;
         this.isExternalCatalog = isExternalCatalog;
     }
@@ -44,7 +46,7 @@ public class CancelBackupStmt extends CancelStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public boolean isRestore() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CancelExportStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CancelExportStmt.java
@@ -20,6 +20,8 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.UUID;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 /**
  * syntax:
  * CANCEL EXPORT FROM example_db WHERE queryid = "921d8f80-7c9d-11eb-9342-acde48001122"
@@ -31,7 +33,7 @@ public class CancelExportStmt extends DdlStmt {
     private UUID queryId;
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public void setQueryId(UUID queryId) {
@@ -56,7 +58,7 @@ public class CancelExportStmt extends DdlStmt {
 
     public CancelExportStmt(String dbName, Expr whereClause, NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.whereClause = whereClause;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CancelLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CancelLoadStmt.java
@@ -18,6 +18,8 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.Expr;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class CancelLoadStmt extends DdlStmt {
 
     private String dbName;
@@ -30,7 +32,7 @@ public class CancelLoadStmt extends DdlStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public Expr getWhereClause() {
@@ -51,7 +53,7 @@ public class CancelLoadStmt extends DdlStmt {
 
     public CancelLoadStmt(String dbName, Expr whereClause, NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.whereClause = whereClause;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateAnalyzeJobStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateAnalyzeJobStmt.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class CreateAnalyzeJobStmt extends DdlStmt {
     private String catalogName;
     private long dbId;
@@ -127,7 +129,7 @@ public class CreateAnalyzeJobStmt extends DdlStmt {
     }
 
     public void setCatalogName(String catalogName) {
-        this.catalogName = catalogName;
+        this.catalogName = normalizeName(catalogName);
     }
 
     public StatsConstants.AnalyzeType getAnalyzeType() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateCatalogStmt.java
@@ -19,6 +19,8 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Map;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class CreateCatalogStmt extends DdlStmt {
     public static final String TYPE = "type";
 
@@ -36,7 +38,7 @@ public class CreateCatalogStmt extends DdlStmt {
     public CreateCatalogStmt(String catalogName, String comment, Map<String, String> properties,
                              boolean ifNotExists, NodePosition pos) {
         super(pos);
-        this.catalogName = catalogName;
+        this.catalogName = normalizeName(catalogName);
         this.comment = comment;
         this.properties = properties;
         this.ifNotExists = ifNotExists;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateDbStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateDbStmt.java
@@ -20,6 +20,8 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Map;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class CreateDbStmt extends DdlStmt {
     private final boolean ifNotExists;
     private String catalogName;
@@ -38,8 +40,8 @@ public class CreateDbStmt extends DdlStmt {
                         Map<String, String> properties, NodePosition pos) {
         super(pos);
         this.ifNotExists = ifNotExists;
-        this.catalogName = catalogName;
-        this.dbName = dbName;
+        this.catalogName = normalizeName(catalogName);
+        this.dbName = normalizeName(dbName);
         this.properties = properties;
     }
 
@@ -60,7 +62,7 @@ public class CreateDbStmt extends DdlStmt {
     }
 
     public void setCatalogName(String catalogName) {
-        this.catalogName = catalogName;
+        this.catalogName = normalizeName(catalogName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFileStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFileStmt.java
@@ -24,6 +24,8 @@ import com.starrocks.sql.parser.NodePosition;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class CreateFileStmt extends DdlStmt {
     public static final String PROP_CATALOG_DEFAULT = "DEFAULT";
     private static final String PROP_CATALOG = "catalog";
@@ -53,7 +55,7 @@ public class CreateFileStmt extends DdlStmt {
     public CreateFileStmt(String fileName, String dbName, Map<String, String> properties, NodePosition pos) {
         super(pos);
         this.fileName = fileName;
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.properties = properties;
     }
 
@@ -66,7 +68,7 @@ public class CreateFileStmt extends DdlStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public String getCatalogName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -49,6 +49,8 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 /*
  Create routine Load statement,  continually load data from a streaming app
 
@@ -267,7 +269,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
                                  NodePosition pos) {
         super(pos);
         this.labelName = labelName;
-        this.tableName = tableName;
+        this.tableName = normalizeName(tableName);
         this.loadPropertyList = loadPropertyList;
         this.jobProperties = jobProperties == null ? Maps.newHashMap() : jobProperties;
         this.typeName = typeName.toUpperCase();
@@ -323,7 +325,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     }
 
     public void setDBName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public String getTableName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DataDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DataDescription.java
@@ -55,6 +55,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+
+import static com.starrocks.common.util.Util.normalizeName;
 // used to describe data info which is needed to import.
 //
 //      data_desc:
@@ -180,7 +182,7 @@ public class DataDescription implements ParseNode {
                            Expr whereExpr,
                            CsvFormat csvFormat, NodePosition pos) {
         this.pos = pos;
-        this.tableName = tableName;
+        this.tableName = normalizeName(tableName);
         this.partitionNames = partitionNames;
         this.filePaths = filePaths;
         this.fileFieldNames = columns;
@@ -212,7 +214,7 @@ public class DataDescription implements ParseNode {
                            List<Expr> columnMappingList,
                            Expr whereExpr, NodePosition pos) {
         this.pos = pos;
-        this.tableName = tableName;
+        this.tableName = normalizeName(tableName);
         this.partitionNames = partitionNames;
         this.filePaths = null;
         this.fileFieldNames = null;
@@ -223,7 +225,7 @@ public class DataDescription implements ParseNode {
         this.isNegative = isNegative;
         this.columnMappingList = columnMappingList;
         this.whereExpr = whereExpr;
-        this.srcTableName = srcTableName;
+        this.srcTableName = normalizeName(srcTableName);
     }
 
     public String getTableName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropCatalogStmt.java
@@ -17,6 +17,8 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // ToDo(zhuodong): to support internal catalog in the future
 public class DropCatalogStmt extends DdlStmt {
 
@@ -34,7 +36,7 @@ public class DropCatalogStmt extends DdlStmt {
 
     public DropCatalogStmt(String name, boolean ifExists, NodePosition pos) {
         super(pos);
-        this.name = name;
+        this.name = normalizeName(name);
         this.ifExists = ifExists;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropDbStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropDbStmt.java
@@ -17,6 +17,8 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // DROP DB Statement
 public class DropDbStmt extends DdlStmt {
     private final boolean ifExists;
@@ -35,8 +37,8 @@ public class DropDbStmt extends DdlStmt {
     public DropDbStmt(boolean ifExists, String catalog, String dbName, boolean forceDrop, NodePosition pos) {
         super(pos);
         this.ifExists = ifExists;
-        this.catalog = catalog;
-        this.dbName = dbName;
+        this.catalog = normalizeName(catalog);
+        this.dbName = normalizeName(dbName);
         this.forceDrop = forceDrop;
     }
 
@@ -50,7 +52,7 @@ public class DropDbStmt extends DdlStmt {
     }
 
     public void setCatalogName(String catalogName) {
-        this.catalog = catalogName;
+        this.catalog = normalizeName(catalogName);
     }
 
     public String getDbName() {
@@ -58,7 +60,7 @@ public class DropDbStmt extends DdlStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public boolean isForceDrop() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropFileStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropFileStmt.java
@@ -20,6 +20,8 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Map;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class DropFileStmt extends DdlStmt {
     public static final String PROP_CATALOG = "catalog";
 
@@ -36,7 +38,7 @@ public class DropFileStmt extends DdlStmt {
     public DropFileStmt(String fileName, String dbName, Map<String, String> properties, NodePosition pos) {
         super(pos);
         this.fileName = fileName;
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.properties = properties;
     }
 
@@ -49,7 +51,7 @@ public class DropFileStmt extends DdlStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public String getCatalogName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RecoverDbStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RecoverDbStmt.java
@@ -17,6 +17,8 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class RecoverDbStmt extends DdlStmt {
     private String catalog;
     private String dbName;
@@ -27,7 +29,7 @@ public class RecoverDbStmt extends DdlStmt {
 
     public RecoverDbStmt(String dbName, NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public String getDbName() {
@@ -35,7 +37,7 @@ public class RecoverDbStmt extends DdlStmt {
     }
 
     public void setDbName(String dbname) {
-        this.dbName = dbname;
+        this.dbName = normalizeName(dbname);
     }
 
     public String getCatalogName() {
@@ -43,7 +45,7 @@ public class RecoverDbStmt extends DdlStmt {
     }
 
     public void setCatalogName(String catalogName) {
-        this.catalog = catalogName;
+        this.catalog = normalizeName(catalogName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetCatalogStmt.java
@@ -18,6 +18,8 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 /*
   Set catalog specified by catalog name
 
@@ -29,7 +31,7 @@ public class SetCatalogStmt extends StatementBase {
 
     public SetCatalogStmt(String catalogName, NodePosition pos) {
         super(pos);
-        this.catalogName = catalogName;
+        this.catalogName = normalizeName(catalogName);
     }
 
     public String getCatalogName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAlterStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAlterStmt.java
@@ -34,6 +34,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 /*
  * ShowAlterStmt: used to show process state of alter statement.
  * Syntax:
@@ -64,7 +66,7 @@ public class ShowAlterStmt extends ShowStmt {
                          LimitElement limitElement, NodePosition pos) {
         super(pos);
         this.type = type;
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.whereClause = whereClause;
         this.orderByElements = orderByElements;
         this.limitElement = limitElement;
@@ -79,7 +81,7 @@ public class ShowAlterStmt extends ShowStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public HashMap<String, Expr> getFilterMap() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBackupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBackupStmt.java
@@ -22,6 +22,8 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class ShowBackupStmt extends ShowStmt {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("JobId").add("SnapshotName").add("DbName").add("State").add("BackupObjs").add("CreateTime")
@@ -37,15 +39,11 @@ public class ShowBackupStmt extends ShowStmt {
 
     public ShowBackupStmt(String dbName, NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public String getDbName() {
         return dbName;
-    }
-
-    public void setDbName(String dbName) {
-        this.dbName = dbName;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowColumnStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowColumnStmt.java
@@ -31,6 +31,8 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // SHOW COLUMNS
 public class ShowColumnStmt extends ShowStmt {
     private static final TableName TABLE_NAME = new TableName(InfoSchemaDb.DATABASE_NAME, "COLUMNS");
@@ -76,7 +78,7 @@ public class ShowColumnStmt extends ShowStmt {
                           Expr where, NodePosition pos) {
         super(pos);
         this.tableName = tableName;
-        this.db = db;
+        this.db = normalizeName(db);
         this.pattern = pattern;
         this.isVerbose = isVerbose;
         this.where = where;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowCreateDbStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowCreateDbStmt.java
@@ -20,6 +20,8 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // Show create database statement
 //  Syntax:
 //      SHOW CREATE DATABASE db
@@ -39,7 +41,7 @@ public class ShowCreateDbStmt extends ShowStmt {
 
     public ShowCreateDbStmt(String db, NodePosition pos) {
         super(pos);
-        this.db = db;
+        this.db = normalizeName(db);
     }
 
     public String getCatalogName() {
@@ -47,7 +49,7 @@ public class ShowCreateDbStmt extends ShowStmt {
     }
 
     public void setCatalogName(String catalogName) {
-        this.catalog = catalogName;
+        this.catalog = normalizeName(catalogName);
     }
 
     public String getDb() {
@@ -55,7 +57,7 @@ public class ShowCreateDbStmt extends ShowStmt {
     }
 
     public void setDb(String db) {
-        this.db = db;
+        this.db = normalizeName(db);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowCreateExternalCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowCreateExternalCatalogStmt.java
@@ -20,6 +20,8 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // SHOW CREATE EXTERNAL CATALOG statement.
 public class ShowCreateExternalCatalogStmt extends ShowStmt {
     private static final ShowResultSetMetaData META_DATA =
@@ -36,7 +38,7 @@ public class ShowCreateExternalCatalogStmt extends ShowStmt {
 
     public ShowCreateExternalCatalogStmt(String catalogName, NodePosition pos) {
         super(pos);
-        this.catalogName = catalogName;
+        this.catalogName = normalizeName(catalogName);
     }
 
     public String getCatalogName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDbStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDbStmt.java
@@ -25,6 +25,8 @@ import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // Show database statement.
 public class ShowDbStmt extends ShowStmt {
     private static final TableName TABLE_NAME = new TableName(InfoSchemaDb.DATABASE_NAME, "schemata");
@@ -58,7 +60,7 @@ public class ShowDbStmt extends ShowStmt {
         super(pos);
         this.pattern = pattern;
         this.where = where;
-        this.catalogName = catalogName;
+        this.catalogName = normalizeName(catalogName);
     }
 
     public String getPattern() {
@@ -67,10 +69,6 @@ public class ShowDbStmt extends ShowStmt {
 
     public String getCatalogName() {
         return catalogName;
-    }
-
-    public void setCatalogName(String catalogName) {
-        this.catalogName = catalogName;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDeleteStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDeleteStmt.java
@@ -21,6 +21,8 @@ import com.starrocks.common.proc.DeleteInfoProcDir;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class ShowDeleteStmt extends ShowStmt {
 
     private String dbName;
@@ -31,7 +33,7 @@ public class ShowDeleteStmt extends ShowStmt {
 
     public ShowDeleteStmt(String dbName, NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public String getDbName() {
@@ -39,7 +41,7 @@ public class ShowDeleteStmt extends ShowStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDynamicPartitionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDynamicPartitionStmt.java
@@ -22,6 +22,8 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class ShowDynamicPartitionStmt extends ShowStmt {
     private String db;
     private static final ShowResultSetMetaData SHOW_DYNAMIC_PARTITION_META_DATA =
@@ -49,7 +51,7 @@ public class ShowDynamicPartitionStmt extends ShowStmt {
 
     public ShowDynamicPartitionStmt(String db, NodePosition pos) {
         super(pos);
-        this.db = db;
+        this.db = normalizeName(db);
     }
 
     public String getDb() {
@@ -57,7 +59,7 @@ public class ShowDynamicPartitionStmt extends ShowStmt {
     }
 
     public void setDb(String db) {
-        this.db = db;
+        this.db = normalizeName(db);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowExportStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowExportStmt.java
@@ -34,6 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // SHOW EXPORT STATUS statement used to get status of load job.
 //
 // syntax:
@@ -62,7 +64,7 @@ public class ShowExportStmt extends ShowStmt {
     public ShowExportStmt(String db, Expr whereExpr, List<OrderByElement> orderByElements,
                           LimitElement limitElement, NodePosition pos) {
         super(pos);
-        this.dbName = db;
+        this.dbName = normalizeName(db);
         this.whereClause = whereExpr;
         this.orderByElements = orderByElements;
         this.limitElement = limitElement;
@@ -85,7 +87,7 @@ public class ShowExportStmt extends ShowStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public void setOrderByPairs(ArrayList<OrderByPair> orderByPairs) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowFunctionsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowFunctionsStmt.java
@@ -20,6 +20,8 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class ShowFunctionsStmt extends ShowStmt {
     private static final ShowResultSetMetaData META_DATA =
             ShowResultSetMetaData.builder()
@@ -45,7 +47,7 @@ public class ShowFunctionsStmt extends ShowStmt {
     public ShowFunctionsStmt(String dbName, boolean isBuiltin, boolean isGlobal, boolean isVerbose, String wild,
                              Expr expr, NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.isBuiltin = isBuiltin;
         this.isGlobal = isGlobal;
         this.isVerbose = isVerbose;
@@ -83,7 +85,7 @@ public class ShowFunctionsStmt extends ShowStmt {
     }
 
     public void setDbName(String db) {
-        this.dbName = db;
+        this.dbName = normalizeName(db);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowIndexStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowIndexStmt.java
@@ -22,6 +22,8 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class ShowIndexStmt extends ShowStmt {
     private static final ShowResultSetMetaData META_DATA =
             ShowResultSetMetaData.builder()
@@ -47,7 +49,7 @@ public class ShowIndexStmt extends ShowStmt {
 
     public ShowIndexStmt(String dbName, TableName tableName, NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.tableName = tableName;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowLoadStmt.java
@@ -33,6 +33,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // SHOW LOAD STATUS statement used to get status of load job.
 //
 // syntax:
@@ -58,7 +60,7 @@ public class ShowLoadStmt extends ShowStmt {
     public ShowLoadStmt(String db, Expr labelExpr, List<OrderByElement> orderByElements,
                         LimitElement limitElement, NodePosition pos) {
         super(pos);
-        this.dbName = db;
+        this.dbName = normalizeName(db);
         this.whereClause = labelExpr;
         this.orderByElements = orderByElements;
         this.limitElement = limitElement;
@@ -69,7 +71,7 @@ public class ShowLoadStmt extends ShowStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public Expr getWhereClause() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowLoadWarningsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowLoadWarningsStmt.java
@@ -26,6 +26,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.net.URL;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // SHOW LOAD WARNINGS statement used to get error detail of src data.
 public class ShowLoadWarningsStmt extends ShowStmt {
     private static final Logger LOG = LogManager.getLogger(ShowLoadWarningsStmt.class);
@@ -54,7 +56,7 @@ public class ShowLoadWarningsStmt extends ShowStmt {
     public ShowLoadWarningsStmt(String db, String url, Expr labelExpr, LimitElement limitElement,
                                 NodePosition pos) {
         super(pos);
-        this.dbName = db;
+        this.dbName = normalizeName(db);
         this.rawUrl = url;
         this.whereClause = labelExpr;
         this.limitElement = limitElement;
@@ -66,7 +68,7 @@ public class ShowLoadWarningsStmt extends ShowStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public Expr getWhereClause() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
@@ -36,6 +36,8 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Map;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // Show rollup statement, used to show rollup information of one table.
 //
 // Syntax:
@@ -105,8 +107,8 @@ public class ShowMaterializedViewsStmt extends ShowStmt {
 
     public ShowMaterializedViewsStmt(String catalogName, String db, String pattern, Expr where, NodePosition pos) {
         super(pos);
-        this.catalogName = catalogName;
-        this.db = db;
+        this.catalogName = normalizeName(catalogName);
+        this.db = normalizeName(db);
         this.pattern = pattern;
         this.where = where;
     }
@@ -116,7 +118,7 @@ public class ShowMaterializedViewsStmt extends ShowStmt {
     }
 
     public void setDb(String db) {
-        this.db = db;
+        this.db = normalizeName(db);
     }
 
     public String getPattern() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRestoreStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRestoreStmt.java
@@ -23,6 +23,8 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class ShowRestoreStmt extends ShowStmt {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("JobId").add("Label").add("Timestamp").add("DbName").add("State")
@@ -42,7 +44,7 @@ public class ShowRestoreStmt extends ShowStmt {
 
     public ShowRestoreStmt(String dbName, Expr where, NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.where = where;
     }
 
@@ -55,7 +57,7 @@ public class ShowRestoreStmt extends ShowStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRoutineLoadTaskStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRoutineLoadTaskStmt.java
@@ -32,6 +32,8 @@ import com.starrocks.sql.parser.NodePosition;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 /*
     show all of task belong to job
     SHOW ROUTINE LOAD TASK FROM DB where expr;
@@ -72,7 +74,7 @@ public class ShowRoutineLoadTaskStmt extends ShowStmt {
 
     public ShowRoutineLoadTaskStmt(String dbName, Expr jobNameExpr, NodePosition pos) {
         super(pos);
-        this.dbFullName = dbName;
+        this.dbFullName = normalizeName(dbName);
         this.jobNameExpr = jobNameExpr;
     }
 
@@ -85,7 +87,7 @@ public class ShowRoutineLoadTaskStmt extends ShowStmt {
     }
 
     public void setDbFullName(String dbFullName) {
-        this.dbFullName = dbFullName;
+        this.dbFullName = normalizeName(dbFullName);
     }
 
     public void checkJobNameExpr() throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowSmallFilesStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowSmallFilesStmt.java
@@ -20,6 +20,8 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class ShowSmallFilesStmt extends ShowStmt {
     private static final ShowResultSetMetaData META_DATA =
             ShowResultSetMetaData.builder()
@@ -40,7 +42,7 @@ public class ShowSmallFilesStmt extends ShowStmt {
 
     public ShowSmallFilesStmt(String dbName, NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public String getDbName() {
@@ -48,7 +50,7 @@ public class ShowSmallFilesStmt extends ShowStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStatusStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStatusStmt.java
@@ -26,6 +26,8 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // SHOW TABLE STATUS
 public class ShowTableStatusStmt extends ShowStmt {
     private static final TableName TABLE_NAME = new TableName(InfoSchemaDb.DATABASE_NAME, "tables");
@@ -61,13 +63,13 @@ public class ShowTableStatusStmt extends ShowStmt {
 
     public ShowTableStatusStmt(String db, String wild, Expr where, NodePosition pos) {
         super(pos);
-        this.db = db;
+        this.db = normalizeName(db);
         this.wild = wild;
         this.where = where;
     }
 
     public void setDb(String db) {
-        this.db = db;
+        this.db = normalizeName(db);
     }
 
     public String getDb() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStmt.java
@@ -29,6 +29,8 @@ import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // SHOW TABLES
 public class ShowTableStmt extends ShowStmt {
     private static final String NAME_COL_PREFIX = "Tables_in_";
@@ -55,11 +57,11 @@ public class ShowTableStmt extends ShowStmt {
     public ShowTableStmt(String db, boolean isVerbose, String pattern, Expr where,
                          String catalogName, NodePosition pos) {
         super(pos);
-        this.db = db;
+        this.db = normalizeName(db);
         this.isVerbose = isVerbose;
         this.pattern = pattern;
         this.where = where;
-        this.catalogName = catalogName;
+        this.catalogName = normalizeName(catalogName);
     }
 
     public String getDb() {
@@ -123,7 +125,7 @@ public class ShowTableStmt extends ShowStmt {
     }
 
     public void setDb(String db) {
-        this.db = db;
+        this.db = normalizeName(db);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTransactionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTransactionStmt.java
@@ -23,6 +23,8 @@ import com.starrocks.common.proc.TransProcDir;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // syntax:
 //      SHOW TRANSACTION  WHERE id=123
 public class ShowTransactionStmt extends ShowStmt {
@@ -37,7 +39,7 @@ public class ShowTransactionStmt extends ShowStmt {
 
     public ShowTransactionStmt(String dbName, Expr whereClause, NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.whereClause = whereClause;
     }
 
@@ -54,7 +56,7 @@ public class ShowTransactionStmt extends ShowStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public void setTxnId(long txnId) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SwapTableClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SwapTableClause.java
@@ -18,6 +18,8 @@ package com.starrocks.sql.ast;
 import com.starrocks.alter.AlterOpType;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 // clause which is used to swap table
 // eg:
 // ALTER TABLE tbl SWAP WITH TABLE tbl2;
@@ -30,7 +32,7 @@ public class SwapTableClause extends AlterTableClause {
 
     public SwapTableClause(String tblName, NodePosition pos) {
         super(AlterOpType.SWAP, pos);
-        this.tblName = tblName;
+        this.tblName = normalizeName(tblName);
     }
 
     public String getTblName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRenameClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRenameClause.java
@@ -18,6 +18,8 @@ package com.starrocks.sql.ast;
 import com.starrocks.alter.AlterOpType;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class TableRenameClause extends AlterTableClause {
     private final String newTableName;
 
@@ -27,7 +29,7 @@ public class TableRenameClause extends AlterTableClause {
 
     public TableRenameClause(String newTableName, NodePosition pos) {
         super(AlterOpType.RENAME, pos);
-        this.newTableName = newTableName;
+        this.newTableName = normalizeName(newTableName);
     }
 
     public String getNewTableName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
@@ -18,6 +18,8 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 /*
   Use catalog specified by catalog name
 
@@ -45,7 +47,8 @@ public class UseCatalogStmt extends StatementBase {
 
     public UseCatalogStmt(String catalogParts, NodePosition pos) {
         super(pos);
-        this.catalogParts = catalogParts;
+        this.catalogParts = normalizeName(catalogParts);
+        this.catalogName = normalizeName(catalogParts);
     }
 
     public String getCatalogParts() {
@@ -57,7 +60,7 @@ public class UseCatalogStmt extends StatementBase {
     }
 
     public void setCatalogName(String catalogName) {
-        this.catalogName = catalogName;
+        this.catalogName = normalizeName(catalogName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseDbStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseDbStmt.java
@@ -18,6 +18,8 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.sql.parser.NodePosition;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 /**
  * Representation of a USE [catalog.]db statement.
  * Queries from MySQL client will not generate UseDbStmt, it will be handled by the COM_INIT_DB protocol.
@@ -33,8 +35,8 @@ public class UseDbStmt extends StatementBase {
 
     public UseDbStmt(String catalog, String database, NodePosition pos) {
         super(pos);
-        this.catalog = catalog;
-        this.database = database;
+        this.catalog = normalizeName(catalog);
+        this.database = normalizeName(database);
     }
 
     public String getCatalogName() {
@@ -42,7 +44,7 @@ public class UseDbStmt extends StatementBase {
     }
 
     public void setCatalogName(String catalogName) {
-        this.catalog = catalogName;
+        this.catalog = normalizeName(catalogName);
     }
 
     public String getDbName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/pipe/PipeName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/pipe/PipeName.java
@@ -21,6 +21,8 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Objects;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class PipeName extends StatementBase {
 
     private String dbName;
@@ -34,18 +36,18 @@ public class PipeName extends StatementBase {
 
     public PipeName(String dbName, String pipeName) {
         super(NodePosition.ZERO);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.pipeName = pipeName;
     }
 
     public PipeName(NodePosition pos, String dbName, String pipeName) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.pipeName = pipeName;
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public String getDbName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/pipe/ShowPipeStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/pipe/ShowPipeStmt.java
@@ -34,6 +34,8 @@ import com.starrocks.sql.parser.NodePosition;
 import java.util.List;
 import java.util.Optional;
 
+import static com.starrocks.common.util.Util.normalizeName;
+
 public class ShowPipeStmt extends ShowStmt {
 
     private static final ShowResultSetMetaData META_DATA =
@@ -58,7 +60,7 @@ public class ShowPipeStmt extends ShowStmt {
     public ShowPipeStmt(String dbName, String like, Expr where, List<OrderByElement> orderBy, LimitElement limit,
                         NodePosition pos) {
         super(pos);
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
         this.like = like;
         this.where = where;
         this.orderBy = orderBy;
@@ -85,7 +87,7 @@ public class ShowPipeStmt extends ShowStmt {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = dbName;
+        this.dbName = normalizeName(dbName);
     }
 
     public String getDbName() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/TableObjectCaseInsensitiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/TableObjectCaseInsensitiveTest.java
@@ -1,0 +1,390 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.common.AlreadyExistsException;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.ExceptionChecker;
+import com.starrocks.common.InvalidConfException;
+import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.qe.SetExecutor;
+import com.starrocks.qe.ShowExecutor;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.AdminSetConfigStmt;
+import com.starrocks.sql.ast.CreateDbStmt;
+import com.starrocks.sql.ast.CreateViewStmt;
+import com.starrocks.sql.ast.SetStmt;
+import com.starrocks.sql.ast.ShowTableStmt;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.connectContext;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.starRocksAssert;
+
+public class TableObjectCaseInsensitiveTest {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        Config.enable_table_name_case_insensitive = true;
+        AnalyzeTestUtil.initWithoutTableAndDb(RunMode.SHARED_NOTHING);
+        starRocksAssert.withDatabase("test_db").useDatabase("test_db");
+        starRocksAssert.withTable("CREATE TABLE test_db.t0 (\n" +
+                "  `v1` bigint NULL COMMENT \"\",\n" +
+                "  `v2` bigint NULL COMMENT \"\",\n" +
+                "  `v3` bigint NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`, `v2`, v3)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+    }
+
+    @Test
+    public void testModifyConfigFailed() throws Exception {
+        AdminSetConfigStmt adminSetConfigStmt = (AdminSetConfigStmt) UtFrameUtils.parseStmtWithNewParser(
+                "admin set frontend config(\"enable_table_name_case_insensitive\" = \"false\");",
+                connectContext);
+        ExceptionChecker.expectThrowsWithMsg(InvalidConfException.class,
+                "Config 'enable_table_name_case_insensitive' does not exist or is not mutable",
+                () -> DDLStmtExecutor.execute(adminSetConfigStmt, connectContext));
+
+        SetStmt stmt = (SetStmt) UtFrameUtils.parseStmtWithNewParser(
+                "set global enable_table_name_case_insensitive = false", connectContext);
+        SetExecutor executor = new SetExecutor(connectContext, stmt);
+
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "Variable 'enable_table_name_case_insensitive' is a read only variable",
+                executor::execute);
+    }
+
+    @Test
+    public void testTableObjectCaseInsensitive() throws Exception {
+        CreateDbStmt createDbStmt =
+                (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser("create database TEST_db", connectContext);
+        ExceptionChecker.expectThrowsWithMsg(AlreadyExistsException.class,
+                "Database Already Exists",
+                () -> GlobalStateMgr.getCurrentState().getLocalMetastore().createDb(createDbStmt.getFullDbName()));
+
+        analyzeSuccess("use test_db");
+        analyzeSuccess("use TEST_Db");
+        analyzeSuccess("set catalog Default_cataLOG");
+        analyzeFail("select * from non_db");
+        analyzeSuccess("select * from TEST_db.T0");
+        analyzeSuccess("select * from DEFAULT_cataLOG.TEST_db.T0");
+        analyzeSuccess("select A.V1 from t0 a");
+        analyzeSuccess("with X0 as (select 111 v1) select L.* from X0 l join X0 r on L.v1 = R.V1");
+        analyzeSuccess("with cte as (select 222 c2) select C2 from CTE");
+
+        ShowTableStmt stmt = new ShowTableStmt("test_DB", false, null);
+        ShowResultSet res = ShowExecutor.execute(stmt, connectContext);
+        Assertions.assertEquals("t0", res.getResultRows().get(0).get(0));
+    }
+
+    @Test
+    public void testViewCaseInsensitive() throws Exception {
+        String createView = "create view test_Db.viEw1 as select * from test_db.t0";
+        analyzeSuccess(createView);
+        CreateViewStmt createViewStmt =
+                (CreateViewStmt) UtFrameUtils.parseStmtWithNewParser(createView, connectContext);
+        connectContext.getGlobalStateMgr().getLocalMetastore().createView(createViewStmt);
+
+        analyzeSuccess("select * from test_db.VIEW1");
+
+        ShowTableStmt stmt = new ShowTableStmt("test_DB", false, null);
+        ShowResultSet res = ShowExecutor.execute(stmt, connectContext);
+        Assertions.assertEquals("view1", res.getResultRows().get(1).get(0));
+    }
+
+    @Test
+    public void testBasicTableReferenceCaseInsensitive() {
+        analyzeSuccess("select * from t0");
+        analyzeSuccess("select * from T0");
+        analyzeSuccess("select * from TEST_db.t0");
+        analyzeSuccess("select * from test_DB.T0");
+        analyzeSuccess("select * from DEFAULT_catalog.test_db.T0");
+        analyzeSuccess("select * from default_CATALOG.TEST_db.t0");
+    }
+
+    @Test
+    public void testColumnReferenceCaseInsensitive() {
+        analyzeSuccess("select V1, v2, V3 from t0");
+        analyzeSuccess("select v1, V2, v3 from T0");
+        analyzeSuccess("select t0.V1, t0.v2 from T0");
+
+        analyzeSuccess("select A.V1, a.v2, A.V3 from t0 a");
+        analyzeSuccess("select T.v1, t.V2 from T0 T");
+    }
+
+    @Test
+    public void testWhereCaseInsensitive() {
+        analyzeSuccess("select * from t0 where V1 > 100");
+        analyzeSuccess("select * from T0 where v1 > 100 and V2 < 200");
+        analyzeSuccess("select * from t0 where V1 = V2 or v3 is null");
+    }
+
+    @Test
+    public void testGroupByCaseInsensitive() {
+        analyzeSuccess("select V1, count(*) from t0 group by v1");
+        analyzeSuccess("select v1, V2, sum(V3) from T0 group by V1, v2");
+        analyzeSuccess("select V1, count(*) from t0 group by V1 having count(*) > 1");
+    }
+
+    @Test
+    public void testOrderByCaseInsensitive() {
+        analyzeSuccess("select * from t0 order by V1");
+        analyzeSuccess("select * from T0 order by v1 desc, V2 asc");
+        analyzeSuccess("select V1 as id, V2 as value from t0 order by ID, Value");
+    }
+
+    @Test
+    public void testJoinCaseInsensitive() {
+        analyzeSuccess("select * from t0 A inner join T0 B on A.v1 = B.V1");
+        analyzeSuccess("select A.V1, b.v2 from T0 a left join t0 B on a.V1 = b.v1");
+        analyzeSuccess("select * from t0 T1 cross join T0 t2");
+
+        analyzeSuccess("select * from t0 A, T0 B where A.v1 = B.V1 and a.V2 > b.v2");
+    }
+
+    @Test
+    public void testSubqueryCaseInsensitive() {
+        analyzeSuccess("select * from (select V1, v2 from t0) AS SUb where sub.V1 > 100");
+        analyzeSuccess("select * from t0 where V1 in (select v1 from T0 where V2 > 50)");
+        analyzeSuccess("select * from t0 where exists (select 1 from T0 t where t.V1 = t0.v1)");
+
+        analyzeSuccess("select * from t0 outer_t where V1 > (select avg(v1) from T0 inner_t where inner_t.V2 = outer_t.v2)");
+    }
+
+    @Test
+    public void testCTEComplexCaseInsensitive() {
+        analyzeSuccess("with High_Values as (select V1, v2 from t0 where V1 > 100), " +
+                "Low_Values as (select v1, V2 from T0 where v1 <= 100) " +
+                "select * from HIGH_values union all select * from low_VALUES");
+
+        analyzeSuccess("with cte as (select V1, V2 from t0) select CTE.v1, cte.V2 from CTE");
+    }
+
+    @Test
+    public void testWindowFunctionCaseInsensitive() {
+        analyzeSuccess("select V1, row_number() over (partition by V2 order by v1) from t0");
+        analyzeSuccess("select v1, V2, rank() over (order by V1 desc) from T0");
+        analyzeSuccess("select V1, sum(v2) over (partition by V3) from t0");
+    }
+
+    @Test
+    public void testAggregateFunctionCaseInsensitive() {
+        analyzeSuccess("select COUNT(*), SUM(V1), AVG(v2), MAX(V3), MIN(v1) from t0");
+        analyzeSuccess("select count(distinct V1), sum(distinct v2) from T0");
+        analyzeSuccess("select V1, count(*) from t0 group by v1 having COUNT(*) > 1");
+    }
+
+    @Test
+    public void testCaseSensitiveInStringLiterals() {
+        analyzeSuccess("select * from t0 where cast(V1 as varchar) = 'Test'");
+        analyzeSuccess("select 'Hello' as greeting, V1 from T0");
+
+        analyzeSuccess("select 'test' as Test_Col, V1 as test_COL from t0");
+    }
+
+    @Test
+    public void testInsertSelectCaseInsensitive() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE test_db.t1 (\n" +
+                "  `v1` bigint NULL COMMENT \"\",\n" +
+                "  `v2` bigint NULL COMMENT \"\",\n" +
+                "  `v3` bigint NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`, `v2`, v3)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+
+        analyzeSuccess("insert into T1 select V1, v2, V3 from t0");
+        analyzeSuccess("insert into t1 (V1, v2, V3) select v1, V2, v3 from T0 where V1 > 100");
+    }
+
+    @Test
+    public void testComplexExpressionsCaseInsensitive() {
+        analyzeSuccess("select V1 + v2 as sum_val, V2 * V3 as product from t0");
+        analyzeSuccess("select case when V1 > v2 then V1 else v2 end as max_val from T0");
+        analyzeSuccess("select coalesce(V1, v2, V3) from t0");
+
+        analyzeSuccess("select concat(cast(V1 as varchar), '_', cast(v2 as varchar)) from T0");
+        analyzeSuccess("select if(V1 > v2, 'greater', 'less_or_equal') from t0");
+    }
+
+    @Test
+    public void testUnionWithCaseInsensitive() {
+        analyzeSuccess("select V1, v2 from t0 union select v2, V3 from T0");
+        analyzeSuccess("select V1 as col1, V2 as col2 from t0 union all select v3, V1 from T0 order by COL1");
+    }
+
+    @Test
+    public void testShowCreateStatements() {
+        analyzeSuccess("show create table T0");
+        analyzeSuccess("show create table t0");
+        analyzeSuccess("show create table test_db.T0");
+    }
+
+    @Test
+    public void testExplainWithCaseInsensitive() {
+        analyzeSuccess("explain select V1, count(*) from T0 group by v1");
+        analyzeSuccess("explain verbose select * from t0 where V1 > 100 order by v2");
+    }
+
+    @Test
+    public void testErrorHandlingCaseInsensitive() {
+        analyzeFail("select * from non_existent_table");
+        analyzeFail("select * from NON_EXISTENT_TABLE");
+
+        analyzeFail("select non_existent_column from t0");
+        analyzeFail("select NON_EXISTENT_COLUMN from T0");
+
+        analyzeFail("select V1 from t0, T0");
+
+        analyzeSuccess("select A.V1 from t0 A, T0 B where A.v1 = B.V1");
+    }
+
+    @Test
+    public void testDDLStatementsCaseInsensitive() {
+        analyzeSuccess("ALTER DATABASE Test_DB SET DATA QUOTA 1024MB");
+        analyzeSuccess("alter database TEST_db set data quota 1024MB");
+
+        analyzeSuccess("ALTER TABLE T0 ADD COLUMN new_col INT");
+        analyzeSuccess("alter table t0 add column NEW_col int");
+
+        analyzeSuccess("DROP DATABASE IF EXISTS Test_DB");
+        analyzeSuccess("drop database if exists TEST_db");
+
+        analyzeSuccess("DROP TABLE IF EXISTS Test_DB.New_Table");
+        analyzeSuccess("drop table if exists test_db.NEW_table");
+    }
+
+    @Test
+    public void testCatalogStatementsCaseInsensitive() {
+        analyzeSuccess("CREATE EXTERNAL CATALOG Test_Catalog PROPERTIES('type'='hive')");
+        analyzeSuccess("create external catalog TEST_catalog properties('type'='hive')");
+
+        analyzeSuccess("SET CATALOG Test_Catalog");
+        analyzeSuccess("set catalog TEST_catalog");
+
+        analyzeSuccess("DROP CATALOG IF EXISTS Test_Catalog");
+        analyzeSuccess("drop catalog TEST_catalog");
+    }
+
+    @Test
+    public void testShowStatementsCaseInsensitive() {
+        analyzeSuccess("SHOW TABLES FROM aa");
+        analyzeSuccess("show tables from TEST_db");
+        analyzeSuccess("SHOW TABLES IN Test_DB LIKE 'T%'");
+        analyzeSuccess("show tables in test_db like 't%'");
+
+        analyzeSuccess("SHOW COLUMNS FROM T0");
+        analyzeSuccess("show columns from t0");
+        analyzeSuccess("SHOW COLUMNS FROM Test_DB.T0");
+        analyzeSuccess("show columns from test_db.t0");
+
+        analyzeSuccess("SHOW CREATE DATABASE Test_DB");
+        analyzeSuccess("show create database TEST_db");
+        analyzeSuccess("SHOW CREATE TABLE T0");
+        analyzeSuccess("show create table t0");
+
+        analyzeSuccess("SHOW INDEX FROM T0");
+        analyzeSuccess("show index from t0");
+
+        analyzeSuccess("SHOW TABLE STATUS FROM Test_DB");
+        analyzeSuccess("show table status from TEST_db");
+
+        analyzeSuccess("SHOW ALTER TABLE column from TEST_db");
+    }
+
+    @Test
+    public void testBackupRestoreStatementsCaseInsensitive() {
+        analyzeSuccess("SHOW BACKUP FROM Test_DB");
+        analyzeSuccess("show backup from TEST_db");
+
+        analyzeSuccess("SHOW RESTORE FROM Test_DB");
+        analyzeSuccess("show restore from TEST_db");
+
+        analyzeSuccess("CANCEL BACKUP FROM Test_DB");
+        analyzeSuccess("cancel backup from TEST_db");
+    }
+
+    @Test
+    public void testExportStatementsCaseInsensitive() {
+        analyzeSuccess("SHOW EXPORT FROM Test_DB");
+        analyzeSuccess("show export from TEST_db");
+        analyzeSuccess("CANCEL EXPORT FROM Test_DB WHERE queryid = \"921d8f80-7c9d-11eb-9342-acde48001122\"");
+    }
+
+    @Test
+    public void testTransactionStatementsCaseInsensitive() {
+        analyzeSuccess("SHOW TRANSACTION FROM Test_DB WHERE Id = 123");
+        analyzeSuccess("show transaction from TEST_db where ID = 123");
+    }
+
+    @Test
+    public void testPartitionStatementsCaseInsensitive() {
+        analyzeSuccess("SHOW DYNAMIC PARTITION TABLES FROM Test_DB");
+        analyzeSuccess("show dynamic partition tables from TEST_db");
+    }
+
+    @Test
+    public void testMaterializedViewStatementsCaseInsensitive() {
+        analyzeSuccess("SHOW MATERIALIZED VIEWS FROM Test_DB");
+        analyzeSuccess("show materialized views from TEST_db");
+    }
+
+    @Test
+    public void testDeleteStatementsCaseInsensitive() {
+        analyzeSuccess("SHOW DELETE FROM T0");
+        analyzeSuccess("show delete from t0");
+    }
+
+    @Test
+    public void testTableOperationsCaseInsensitive() {
+        analyzeSuccess("ALTER TABLE T0 ADD ROLLUP Test_Rollup (V1, V2)");
+        analyzeSuccess("alter table t0 add rollup TEST_rollup (v1, v2)");
+
+        analyzeSuccess("ALTER TABLE T0 SWAP WITH T1");
+        analyzeSuccess("alter table t0 swap with t1");
+    }
+
+    @Test
+    public void testComplexIdentifiersCaseInsensitive() {
+        analyzeSuccess("select * from `T0`");
+        analyzeSuccess("select * from `t0`");
+
+        analyzeSuccess("select T0.V1 from t0");
+        analyzeSuccess("select t0.v1 from T0");
+
+        analyzeSuccess("select `T0`.V1, t0.v2 from `T0` T0");
+        analyzeSuccess("select T0.`V1`, T0.v2 from t0 T0");
+    }
+
+    @Test
+    public void testGrantCaseInsensitive() {
+        analyzeSuccess("grant select on table T0 to root;");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Currently, StarRocks is case-sensitive for catalog/database/table names. For many users migrating from case-insensitive database systems, this requires manually rewriting SQL statements during the migration process. To ease this migration burden, we need to support case-insensitive handling for common database objects.

## What I'm doing:
Support case-insensitive for catalog/database/table/materialized view/CTE/table alias names.

This patch introduces case-insensitive support for catalog/database/table/materialized view/CTE/table alias names through a cluster-wide immutable configuration approach.

### Key Implementation Details:

1. **Initialization-Only Configuration**: Case sensitivity mode can ONLY be configured during initial cluster setup via the FE config `enable_table_name_case_insensitive` on the leader node. Default value is `False`. 

2. **Immutable Design**: Once set during cluster first initialization, this configuration becomes permanently immutable and cannot be modified by:
   - Cluster upgrades/downgrades
   - FE node restarts
   - Any maintenance operations
   - Runtime configuration changes

3. **Strict Consistency Enforcement**: During FE restart or leader failover, if the leader node's configuration differs from the cluster's stored value, the current leader node will fail to start, ensuring cluster-wide consistency.

4. **New Clusters Only**: This feature is exclusively available for new cluster deployments - existing clusters cannot enable case-insensitive mode.

5. **Lowercase Storage**: When case-insensitive mode is enabled, all database object names in DDL statements are normalized to lowercase for storage, ensuring consistent internal representation while maintaining case-insensitive query behavior.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
