### PR TITLE
[Enhancement] Support iceberg REST catalog vended credentials for Azure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfigurationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfigurationProvider.java
@@ -49,6 +49,10 @@ public class AzureCloudConfigurationProvider implements CloudConfigurationProvid
     // Used to retrieve azure load path from configuration map
     public static final String AZURE_PATH_KEY = "azure_path_key";
 
+    public static final String ADLS_ENDPOINT = "dfs.core.windows.net";
+    public static final String BLOB_ENDPOINT = "blob.core.windows.net";
+    public static final String ADLS_SAS_TOKEN = "adls.sas-token.";
+
     @Override
     public CloudConfiguration build(Map<String, String> properties) {
         Preconditions.checkNotNull(properties);

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
@@ -324,8 +324,10 @@ class AzureADLS2CloudCredential extends AzureStorageCloudCredential {
                 "oauth2ManagedIdentity=" + oauth2ManagedIdentity +
                 ", oauth2TenantId='" + oauth2TenantId + '\'' +
                 ", oauth2ClientId='" + oauth2ClientId + '\'' +
+                ", endpoint='" + endpoint + '\'' +
                 ", storageAccount='" + storageAccount + '\'' +
                 ", sharedKey='" + sharedKey + '\'' +
+                ", sasToken='" + sasToken + '\'' +
                 ", oauth2ClientSecret='" + oauth2ClientSecret + '\'' +
                 ", oauth2ClientEndpoint='" + oauth2ClientEndpoint + '\'' +
                 '}';

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -148,7 +148,8 @@ public class IcebergScanNode extends ScanNode {
         // Hard coding here
         // Try to get tabular signed temporary credential
         CloudConfiguration vendedCredentialsCloudConfiguration = CloudConfigurationFactory.
-                buildCloudConfigurationForVendedCredentials(icebergTable.getNativeTable().io().properties());
+                buildCloudConfigurationForVendedCredentials(icebergTable.getNativeTable().io().properties(),
+                        icebergTable.getNativeTable().location());
         if (vendedCredentialsCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
             // If we get CloudConfiguration succeed from iceberg FileIO's properties, we just using it.
             cloudConfiguration = vendedCredentialsCloudConfiguration;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
@@ -69,7 +69,8 @@ public class IcebergTableSink extends DataSink {
 
         // Try to set for tabular
         CloudConfiguration tabularTempCloudConfiguration = CloudConfigurationFactory.
-                buildCloudConfigurationForVendedCredentials(icebergTable.getNativeTable().io().properties());
+                buildCloudConfigurationForVendedCredentials(icebergTable.getNativeTable().io().properties(),
+                        this.location);
         if (tabularTempCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
             this.cloudConfiguration = tabularTempCloudConfiguration;
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.iceberg.io;
 
 import com.starrocks.common.StarRocksException;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.io.InputFile;
 import org.junit.jupiter.api.Assertions;
@@ -63,6 +64,25 @@ public class IcebergCachingFileIOTest {
         long cacheIOInputFileSize = cachingFileIOInputFile.getLength();
         Assertions.assertEquals(cacheIOInputFileSize, 39);
         cachingFileIO.deleteFile(path);
+    }
+
+    @Test
+    public void testNewFileWithException() {
+        IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
+        cachingFileIO.setConf(new Configuration());
+        Map<String, String> icebergProperties = new HashMap<>();
+        String key = ADLS_SAS_TOKEN + "account." + BLOB_ENDPOINT;
+        icebergProperties.put(key, "sas_token");
+        cachingFileIO.initialize(icebergProperties);
+
+        String path = "file:/tmp/non_existent_file.json";
+        Assertions.assertThrows(StarRocksConnectorException.class, () -> {
+            cachingFileIO.newInputFile(path);
+        });
+
+        Assertions.assertThrows(StarRocksConnectorException.class, () -> {
+            cachingFileIO.newOutputFile(path);
+        });
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.iceberg.io;
 
+import com.starrocks.common.StarRocksException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.io.InputFile;
 import org.junit.jupiter.api.Assertions;
@@ -24,6 +25,10 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
+import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.ADLS_ENDPOINT;
+import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.ADLS_SAS_TOKEN;
+import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.BLOB_ENDPOINT;
 
 public class IcebergCachingFileIOTest {
 
@@ -58,5 +63,36 @@ public class IcebergCachingFileIOTest {
         long cacheIOInputFileSize = cachingFileIOInputFile.getLength();
         Assertions.assertEquals(cacheIOInputFileSize, 39);
         cachingFileIO.deleteFile(path);
+    }
+
+    @Test
+    public void testBuildConfFromProperties() throws StarRocksException {
+        Map<String, String> properties = new HashMap<>();
+        String key = ADLS_SAS_TOKEN + "account." + ADLS_ENDPOINT;
+        String sasToken = "sas_token";
+        properties.put(key, sasToken);
+        String path = "abfss://container@account.dfs.core.windows.net/path/1/2";
+
+        IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
+        cachingFileIO.setConf(new Configuration());
+        Configuration configuration = cachingFileIO.buildConfFromProperties(properties, path);
+
+        String authType = configuration.get("fs.azure.account.auth.type.account." + ADLS_ENDPOINT);
+        Assertions.assertEquals("SAS", authType);
+        String token = configuration.get("fs.azure.sas.fixed.token.account." + ADLS_ENDPOINT);
+        Assertions.assertEquals(sasToken, token);
+
+        properties = new HashMap<>();
+        key = ADLS_SAS_TOKEN + "account." + BLOB_ENDPOINT;
+        sasToken = "blob_sas_token";
+        properties.put(key, sasToken);
+        path = "wasbs://container@account.blob.core.windows.net/path/1/2";
+
+        cachingFileIO = new IcebergCachingFileIO();
+        cachingFileIO.setConf(new Configuration());
+        configuration = cachingFileIO.buildConfFromProperties(properties, path);
+
+        token = configuration.get("fs.azure.sas.container.account." + BLOB_ENDPOINT);
+        Assertions.assertEquals(sasToken, token);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -291,8 +291,8 @@ public class CloudConfigurationFactoryTest {
         cc.toFileStoreInfo();
         Assertions.assertEquals(cc.toConfString(),
                 "AzureCloudConfiguration{resources='', jars='', hdpuser='', " +
-                        "cred=AzureADLS2CloudCredential{oauth2ManagedIdentity=false, " +
-                        "oauth2TenantId='XX', oauth2ClientId='XX', storageAccount='XX', sharedKey='XX', " +
+                        "cred=AzureADLS2CloudCredential{oauth2ManagedIdentity=false, oauth2TenantId='XX', " +
+                        "oauth2ClientId='XX', endpoint='', storageAccount='XX', sharedKey='XX', sasToken='', " +
                         "oauth2ClientSecret='XX', oauth2ClientEndpoint='XX'}}");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -28,17 +28,22 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.ADLS_ENDPOINT;
+import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.ADLS_SAS_TOKEN;
+import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.BLOB_ENDPOINT;
+
 public class CloudConfigurationFactoryTest {
 
     @Test
-    public void testBuildCloudConfigurationForVendedCredentials() {
+    public void testBuildCloudConfigurationForAWSVendedCredentials() {
         Map<String, String> map = new HashMap<>();
         map.put(S3FileIOProperties.ACCESS_KEY_ID, "ak");
         map.put(S3FileIOProperties.SECRET_ACCESS_KEY, "sk");
         map.put(S3FileIOProperties.SESSION_TOKEN, "token");
         map.put(S3FileIOProperties.PATH_STYLE_ACCESS, "true");
         map.put(AwsClientProperties.CLIENT_REGION, "region");
-        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(map);
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(map,
+                "");
         Assertions.assertNotNull(cloudConfiguration);
         Assertions.assertEquals(CloudType.AWS, cloudConfiguration.getCloudType());
         Assertions.assertEquals(
@@ -53,7 +58,7 @@ public class CloudConfigurationFactoryTest {
         map.remove(S3FileIOProperties.PATH_STYLE_ACCESS);
         map.put(S3FileIOProperties.ENDPOINT, "endpoint");
         map.put(CloudConfigurationConstants.AWS_S3_REGION, "us-west-2");
-        cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(map);
+        cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(map, "");
         Assertions.assertNotNull(cloudConfiguration);
         Assertions.assertEquals(CloudType.AWS, cloudConfiguration.getCloudType());
         Assertions.assertEquals(
@@ -62,6 +67,35 @@ public class CloudConfigurationFactoryTest {
                         "useInstanceProfile=false, accessKey='ak', secretKey='sk', " +
                         "sessionToken='token', iamRoleArn='', stsRegion='', stsEndpoint='', externalId='', " +
                         "region='us-west-2', endpoint='endpoint'}, enablePathStyleAccess=false, enableSSL=true}",
+                cloudConfiguration.toConfString());
+    }
+
+    @Test
+    public void testBuildCloudConfigurationForAzureVendedCredentials() {
+        Map<String, String> map = new HashMap<>();
+        map.put(ADLS_SAS_TOKEN + "account." + ADLS_ENDPOINT, "sas_token");
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(map,
+                "abfss://container@account.dfs.core.windows.net/path/1/2");
+        Assertions.assertNotNull(cloudConfiguration);
+        Assertions.assertEquals(CloudType.AZURE, cloudConfiguration.getCloudType());
+        Assertions.assertEquals(
+                "AzureCloudConfiguration{resources='', jars='', hdpuser='', " +
+                        "cred=AzureADLS2CloudCredential{oauth2ManagedIdentity=false, oauth2TenantId='', oauth2ClientId='', " +
+                        "endpoint='account.dfs.core.windows.net', storageAccount='', sharedKey='', " +
+                        "sasToken='sas_token', oauth2ClientSecret='', oauth2ClientEndpoint=''}}",
+                cloudConfiguration.toConfString());
+
+        map = new HashMap<>();
+        map.put(ADLS_SAS_TOKEN + "account." + BLOB_ENDPOINT, "sas_token");
+        cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(map,
+                "wasbs://container@account.blob.core.windows.net/path/1/2");
+        Assertions.assertNotNull(cloudConfiguration);
+        Assertions.assertEquals(CloudType.AZURE, cloudConfiguration.getCloudType());
+        Assertions.assertEquals(
+                "AzureCloudConfiguration{resources='', jars='', hdpuser='', " +
+                        "cred=AzureBlobCloudCredential{endpoint='', storageAccount='account', sharedKey='', " +
+                        "container='container', sasToken='sas_token', useManagedIdentity='false', clientId='', " +
+                        "clientSecret='', tenantId=''}}",
                 cloudConfiguration.toConfString());
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Support iceberg REST catalog vended credentials for Azure
Fixes #56817

use polaris as rest catalog with vending credentials
eg. 
```
CREATE EXTERNAL CATALOG polaris_azure
PROPERTIES (   
    "iceberg.catalog.uri"  = "http://xxx:xxx/api/catalog",   
    "type"  =  "iceberg",   
    "iceberg.catalog.type"  =  "rest",   
    "iceberg.catalog.warehouse" = "iceberg_catalog",
    "iceberg.catalog.security" = "oauth2",
    "iceberg.catalog.oauth2.credential" = "xxxxx:xxxx",
    "iceberg.catalog.oauth2.scope"='PRINCIPAL_ROLE:ALL',
    "iceberg.catalog.rest.nested-namespace-enabled"="true"
 );
```
 no need to set azure storage credentails

This PR support ADLS2/Blob storage vended credentials


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
