### PR TITLE
[BugFix] fix cache might not be used when upgraded from 3.3 (backport #60973)

### DIFF
--- a/be/src/block_cache/datacache_utils.cpp
+++ b/be/src/block_cache/datacache_utils.cpp
@@ -19,6 +19,8 @@
 
 #include <filesystem>
 
+#include "absl/status/statusor.h"
+#include "absl/strings/str_split.h"
 #include "fs/fs.h"
 #include "gutil/strings/split.h"
 #include "util/disk_info.h"
@@ -234,5 +236,65 @@ dev_t DataCacheUtils::disk_device_id(const std::string& disk_path) {
     }
     return s.st_dev;
 }
+
+#ifdef USE_STAROS
+StatusOr<std::vector<std::string>> DataCacheUtils::get_corresponding_starlet_cache_dir(
+        const std::vector<StorePath>& store_paths, const std::string& starlet_cache_dir) {
+    std::vector<std::string> corresponding_starlet_dirs;
+    if (starlet_cache_dir.empty()) {
+        return corresponding_starlet_dirs;
+    }
+    absl::StatusOr<std::vector<std::string>> vec_or = absl::StrSplit(starlet_cache_dir, ':', absl::SkipWhitespace());
+    if (!vec_or.ok()) {
+        std::string error_str = "Fail to parse starlet_cache_dir, error: " + std::string(vec_or.status().message());
+        return Status::InternalError(error_str);
+    }
+    std::vector<std::string> starlet_paths = *vec_or;
+    if (starlet_paths.empty()) {
+        return corresponding_starlet_dirs;
+    }
+    std::unordered_map<dev_t, std::string> starlet_devices;
+    for (auto& starlet_path : starlet_paths) {
+        auto id = DataCacheUtils::disk_device_id(starlet_path);
+        if (id == 0) {
+            std::string error_str =
+                    "Fail to get device id for " + starlet_path + ", error: " + std::string(strerror(errno));
+            return Status::InternalError(error_str);
+        }
+        auto iter = starlet_devices.find(id);
+        if (iter == starlet_devices.end()) {
+            starlet_devices[id] = starlet_path;
+        } else {
+            std::string error_str = "Find 2 starlet cache dir on same device, " + starlet_path + ":" + iter->second;
+            return Status::InternalError(error_str);
+        }
+    }
+
+    for (auto& store_path : store_paths) {
+        std::string root_path = store_path.path;
+        auto id = DataCacheUtils::disk_device_id(root_path);
+        if (id == 0) {
+            std::string error_str =
+                    "Fail to get device id for " + root_path + ", error: " + std::string(strerror(errno));
+            return Status::InternalError(error_str);
+        }
+        auto iter = starlet_devices.find(id);
+        if (iter != starlet_devices.end()) {
+            corresponding_starlet_dirs.push_back(iter->second + "/star_cache");
+            starlet_devices.erase(id);
+        } else {
+            corresponding_starlet_dirs.push_back(root_path + "/starlet_cache/star_cache");
+        }
+    }
+    if (!starlet_devices.empty()) {
+        std::string error_str = "can not find corresponding storage path for starlet cache dir, ";
+        for (auto& e : starlet_devices) {
+            error_str += e.second + ":";
+        }
+        return Status::InternalError(error_str);
+    }
+    return corresponding_starlet_dirs;
+}
+#endif
 
 } // namespace starrocks

--- a/be/src/block_cache/datacache_utils.h
+++ b/be/src/block_cache/datacache_utils.h
@@ -16,6 +16,7 @@
 
 #include "block_cache/kv_cache.h"
 #include "gen_cpp/DataCache_types.h"
+#include "storage/options.h"
 
 namespace starrocks {
 
@@ -44,6 +45,12 @@ public:
     static Status change_disk_path(const std::string& old_disk_path, const std::string& new_disk_path);
 
     static dev_t disk_device_id(const std::string& disk_path);
+
+#ifdef USE_STAROS
+    // for each dir in `store_paths`, get each corresponding dir in `starlet_cache_dir`
+    static StatusOr<std::vector<std::string>> get_corresponding_starlet_cache_dir(
+            const std::vector<StorePath>& store_paths, const std::string& starlet_cache_dir);
+#endif
 };
 
 } // namespace starrocks

--- a/be/test/block_cache/datacache_utils_test.cpp
+++ b/be/test/block_cache/datacache_utils_test.cpp
@@ -251,4 +251,85 @@ TEST_F(DataCacheUtilsTest, change_cache_path_from_nonexist_src) {
     fs::remove_all(new_dir);
 }
 
+#ifdef USE_STAROS
+TEST_F(DataCacheUtilsTest, get_corresponding_starlet_cache_dir) {
+    // normal
+    {
+        std::string starlet_dir = "./starlet_dir_path";
+        std::string storage_dir = "./storage";
+        ASSERT_TRUE(fs::create_directories(starlet_dir).ok());
+        ASSERT_TRUE(fs::create_directories(storage_dir).ok());
+        std::vector<StorePath> store_paths;
+        store_paths.push_back(StorePath(storage_dir));
+        auto vec_or = DataCacheUtils::get_corresponding_starlet_cache_dir(store_paths, starlet_dir);
+        ASSERT_TRUE(vec_or.ok());
+        auto vec = *vec_or;
+        ASSERT_TRUE(vec.size() == 1);
+        ASSERT_EQ(vec[0], starlet_dir + "/star_cache");
+        fs::remove_all(starlet_dir);
+        fs::remove_all(storage_dir);
+    }
+
+    // starlet cache dir on the same device
+    {
+        std::string starlet_dir = "./starlet_dir_path";
+        std::string starlet_dir2 = "./starlet_dir_path2";
+        ASSERT_TRUE(fs::create_directories(starlet_dir).ok());
+        ASSERT_TRUE(fs::create_directories(starlet_dir2).ok());
+        std::string starlet_dirs = "./starlet_dir_path:./starlet_dir_path2";
+        auto vec_or = DataCacheUtils::get_corresponding_starlet_cache_dir({}, starlet_dirs);
+        ASSERT_FALSE(vec_or.ok());
+        ASSERT_TRUE(vec_or.status().message().find("Find 2 starlet cache dir on same device") != std::string::npos);
+        fs::remove_all(starlet_dir);
+        fs::remove_all(starlet_dir2);
+    }
+
+    // starlet cache dir count is bigger
+    {
+        std::string starlet_dir = "./starlet_dir_path";
+        ASSERT_TRUE(fs::create_directories(starlet_dir).ok());
+        auto vec_or = DataCacheUtils::get_corresponding_starlet_cache_dir({}, starlet_dir);
+        ASSERT_FALSE(vec_or.ok());
+        ASSERT_TRUE(vec_or.status().message().find("can not find corresponding storage path for starlet cache dir") !=
+                    std::string::npos);
+        fs::remove_all(starlet_dir);
+    }
+
+    // storage dir count is bigger
+    {
+        std::string starlet_dir = "./starlet_dir_path";
+        std::string storage_dir = "./storage";
+        std::string storage_dir2 = "./storage2";
+        ASSERT_TRUE(fs::create_directories(starlet_dir).ok());
+        ASSERT_TRUE(fs::create_directories(storage_dir).ok());
+        ASSERT_TRUE(fs::create_directories(storage_dir2).ok());
+        std::vector<StorePath> store_paths;
+        store_paths.push_back(StorePath(storage_dir));
+        store_paths.push_back(StorePath(storage_dir2));
+        auto vec_or = DataCacheUtils::get_corresponding_starlet_cache_dir(store_paths, starlet_dir);
+        ASSERT_TRUE(vec_or.ok());
+        auto vec = *vec_or;
+        ASSERT_TRUE(vec.size() == 2);
+        ASSERT_EQ(vec[0], starlet_dir + "/star_cache");
+        ASSERT_EQ(vec[1], "./storage2/starlet_cache/star_cache");
+        fs::remove_all(starlet_dir);
+        fs::remove_all(storage_dir);
+        fs::remove_all(storage_dir2);
+    }
+
+    // empty starlet cache dir
+    {
+        std::string starlet_dir = "";
+        auto vec_or = DataCacheUtils::get_corresponding_starlet_cache_dir({}, starlet_dir);
+        ASSERT_TRUE(vec_or.ok());
+        ASSERT_TRUE((*vec_or).empty());
+
+        std::string starlet_dir2 = "   ";
+        auto vec_or2 = DataCacheUtils::get_corresponding_starlet_cache_dir({}, starlet_dir2);
+        ASSERT_TRUE(vec_or2.ok());
+        ASSERT_TRUE((*vec_or2).empty());
+    }
+}
+#endif
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

