### PR TITLE
[BugFix] Set Content-Type to application/json when responding to stream load http requests

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -148,7 +148,7 @@ static void _send_reply(HttpRequest* req, const std::string& str) {
     if (config::enable_stream_load_verbose_log) {
         LOG(INFO) << "streaming load response: " << str;
     }
-    HttpChannel::send_reply(req, str);
+    HttpChannel::send_reply_json(req, HttpStatus::OK, str);
 }
 
 void StreamLoadAction::handle(HttpRequest* req) {

--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -95,7 +95,7 @@ static void _send_reply(HttpRequest* req, const std::string& str) {
     if (config::enable_stream_load_verbose_log) {
         LOG(INFO) << "transaction streaming load response: " << str;
     }
-    HttpChannel::send_reply(req, str);
+    HttpChannel::send_reply(req, HttpStatus::OK, str, HttpHeaders::JsonType);
 }
 
 void TransactionManagerAction::_send_error_reply(HttpRequest* req, const Status& st) {
@@ -103,7 +103,7 @@ void TransactionManagerAction::_send_error_reply(HttpRequest* req, const Status&
     ctx->label = req->header(HTTP_LABEL_KEY);
 
     auto str = ctx->to_resp_json(req->param(HTTP_TXN_OP_KEY), st);
-    HttpChannel::send_reply(req, str);
+    HttpChannel::send_reply(req, HttpStatus::OK, str, HttpHeaders::JsonType);
 }
 
 void TransactionManagerAction::handle(HttpRequest* req) {

--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -95,7 +95,7 @@ static void _send_reply(HttpRequest* req, const std::string& str) {
     if (config::enable_stream_load_verbose_log) {
         LOG(INFO) << "transaction streaming load response: " << str;
     }
-    HttpChannel::send_reply(req, HttpStatus::OK, str, HttpHeaders::JsonType);
+    HttpChannel::send_reply_json(req, HttpStatus::OK, str);
 }
 
 void TransactionManagerAction::_send_error_reply(HttpRequest* req, const Status& st) {
@@ -103,7 +103,7 @@ void TransactionManagerAction::_send_error_reply(HttpRequest* req, const Status&
     ctx->label = req->header(HTTP_LABEL_KEY);
 
     auto str = ctx->to_resp_json(req->param(HTTP_TXN_OP_KEY), st);
-    HttpChannel::send_reply(req, HttpStatus::OK, str, HttpHeaders::JsonType);
+    HttpChannel::send_reply_json(req, HttpStatus::OK, str);
 }
 
 void TransactionManagerAction::handle(HttpRequest* req) {

--- a/be/src/http/http_channel.cpp
+++ b/be/src/http/http_channel.cpp
@@ -20,9 +20,9 @@
 #include <event2/buffer.h>
 #include <event2/http.h>
 
+#include <optional>
 #include <sstream>
 #include <string>
-#include <optional>
 
 #include "http/http_headers.h"
 #include "http/http_request.h"

--- a/be/src/http/http_channel.cpp
+++ b/be/src/http/http_channel.cpp
@@ -56,8 +56,12 @@ void HttpChannel::send_reply(HttpRequest* request, HttpStatus status, std::strin
     send_reply(request, status, content, std::nullopt);
 }
 
+void HttpChannel::send_reply_json(HttpRequest* request, HttpStatus status, std::string_view content) {
+    send_reply(request, status, content, HttpHeaders::JsonType);
+}
+
 void HttpChannel::send_reply(HttpRequest* request, HttpStatus status, std::string_view content,
-                             std::optional<std::string_view> content_type) {
+                             const std::optional<std::string_view>& content_type) {
 #ifdef BE_TEST
     if (s_injected_send_reply != nullptr) {
         s_injected_send_reply(request, status, content);
@@ -68,7 +72,7 @@ void HttpChannel::send_reply(HttpRequest* request, HttpStatus status, std::strin
     evbuffer_add(evb, content.data(), content.size());
     if (content_type.has_value()) {
         auto headers = evhttp_request_get_output_headers(request->get_evhttp_request());
-        evhttp_add_header(headers, HttpHeaders::CONTENT_TYPE, content_type->data());
+        evhttp_add_header(headers, HttpHeaders::CONTENT_TYPE, std::string(*content_type).c_str());
     }
     evhttp_send_reply(request->get_evhttp_request(), status, defalut_reason(status).c_str(), evb);
     evbuffer_free(evb);

--- a/be/src/http/http_channel.h
+++ b/be/src/http/http_channel.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include <optional>
 
 #include "http/http_status.h"
 
@@ -44,6 +45,8 @@ public:
     static void send_reply(HttpRequest* request, HttpStatus status = HttpStatus::OK);
 
     static void send_reply(HttpRequest* request, HttpStatus status, std::string_view content);
+
+    static void send_reply(HttpRequest* request, HttpStatus status, std::string_view content, std::optional<std::string_view> content_type);
 
     static void send_file(HttpRequest* request, int fd, size_t off, size_t size);
 };

--- a/be/src/http/http_channel.h
+++ b/be/src/http/http_channel.h
@@ -46,7 +46,10 @@ public:
 
     static void send_reply(HttpRequest* request, HttpStatus status, std::string_view content);
 
-    static void send_reply(HttpRequest* request, HttpStatus status, std::string_view content, std::optional<std::string_view> content_type);
+    static void send_reply_json(HttpRequest* request, HttpStatus status, std::string_view content);
+
+    static void send_reply(HttpRequest* request, HttpStatus status, std::string_view content,
+                           const std::optional<std::string_view>& content_type);
 
     static void send_file(HttpRequest* request, int fd, size_t off, size_t size);
 };

--- a/be/src/http/http_channel.h
+++ b/be/src/http/http_channel.h
@@ -18,9 +18,9 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
-#include <optional>
 
 #include "http/http_status.h"
 

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -174,6 +174,9 @@ TEST_F(StreamLoadActionTest, normal) {
     rapidjson::Document doc;
     doc.Parse(k_response_str.c_str());
     ASSERT_STREQ("Success", doc["Status"].GetString());
+    auto* val = evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), "Content-Type");
+    ASSERT_NE(val, nullptr);
+    ASSERT_STREQ("application/json", val);
 }
 
 TEST_F(StreamLoadActionTest, process_exit_abort_stream_load) {

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -162,6 +162,10 @@ TEST_F(TransactionStreamLoadActionTest, txn_begin_normal) {
     rapidjson::Document doc;
     doc.Parse(k_response_str.c_str());
     ASSERT_STREQ("OK", doc["Status"].GetString());
+
+    auto* val = evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), "Content-Type");
+    ASSERT_NE(val, nullptr);
+    ASSERT_STREQ("application/json", val);
 }
 
 TEST_F(TransactionStreamLoadActionTest, txn_commit_fail) {


### PR DESCRIPTION
## Why I'm doing:
When sending a request to the `/api/transaction/{begin,load,commit,...}` endpoints, the content type is wrongly set to `text/html` instead of `application/json`.

## What I'm doing:

Fixes #61130 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
