### PR TITLE
[BugFix] Fix resource group cpu usage

### DIFF
--- a/be/src/agent/resource_group_usage_recorder.cpp
+++ b/be/src/agent/resource_group_usage_recorder.cpp
@@ -61,8 +61,8 @@ std::vector<TResourceGroupUsage> ResourceGroupUsageRecorder::get_resource_group_
             prev_runtime_ns = iter_prev->second;
         }
 
-        int32_t cpu_core_used_permille = (cpu_runtime_ns - prev_runtime_ns) * 1000 / delta_ns;
-        cpu_core_used_permille = std::clamp(cpu_core_used_permille, 0, CpuInfo::num_cores() * 1000);
+        int64_t cpu_core_used_permille = (cpu_runtime_ns - prev_runtime_ns) * 1000 / delta_ns;
+        cpu_core_used_permille = std::clamp<int64_t>(cpu_core_used_permille, 0, CpuInfo::num_cores() * 1000);
         group_to_usage[group_id].__set_cpu_core_used_permille(cpu_core_used_permille);
     }
     _group_to_cpu_runtime_ns = std::move(curr_group_to_cpu_runtime_ns);

--- a/be/src/agent/resource_group_usage_recorder.cpp
+++ b/be/src/agent/resource_group_usage_recorder.cpp
@@ -62,7 +62,7 @@ std::vector<TResourceGroupUsage> ResourceGroupUsageRecorder::get_resource_group_
         }
 
         int32_t cpu_core_used_permille = (cpu_runtime_ns - prev_runtime_ns) * 1000 / delta_ns;
-        cpu_core_used_permille = std::clamp(cpu_core_used_permille, 0, CpuInfo::num_cores());
+        cpu_core_used_permille = std::clamp(cpu_core_used_permille, 0, CpuInfo::num_cores() * 1000);
         group_to_usage[group_id].__set_cpu_core_used_permille(cpu_core_used_permille);
     }
     _group_to_cpu_runtime_ns = std::move(curr_group_to_cpu_runtime_ns);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(EXEC_FILES
         ./agent/agent_task_test.cpp
         ./agent/heartbeat_server_test.cpp
         ./agent/master_info_test.cpp
+        ./agent/resource_group_usage_recorder_test.cpp
         ./column/array_column_test.cpp
         ./column/column_view_test.cpp
         ./column/array_view_column_test.cpp

--- a/be/test/agent/resource_group_usage_recorder_test.cpp
+++ b/be/test/agent/resource_group_usage_recorder_test.cpp
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "agent/resource_group_usage_recorder.h"
+
+#include "exec/workgroup/work_group.h"
+#include "gtest/gtest.h"
+#include "runtime/exec_env.cpp"
+
+namespace starrocks {
+
+TEST(ResourceGroupUsageRecorderTest, test_get_resource_group_usages) {
+    const size_t num_cores = CpuInfo::num_cores();
+
+    auto& exec_env = *ExecEnv::GetInstance();
+    workgroup::PipelineExecutorSetConfig executors_manager_opts(
+            CpuInfo::num_cores(), num_cores, num_cores, num_cores, CpuInfo::get_core_ids(), true,
+            config::enable_resource_group_cpu_borrowing, StarRocksMetrics::instance()->get_pipeline_executor_metrics());
+    exec_env._workgroup_manager = std::make_unique<workgroup::WorkGroupManager>(std::move(executors_manager_opts));
+
+    workgroup::DefaultWorkGroupInitialization default_workgroup_init;
+    auto default_wg = exec_env.workgroup_manager()->get_default_workgroup();
+
+    ResourceGroupUsageRecorder recorder;
+    ASSERT_TRUE(recorder.get_resource_group_usages().empty());
+
+    default_wg->incr_cpu_runtime_ns(num_cores * 1000'000'000'000ull);
+    const auto group_usages = recorder.get_resource_group_usages();
+    ASSERT_EQ(group_usages.size(), 1);
+    ASSERT_EQ(group_usages[0].group_id, default_wg->id());
+    ASSERT_EQ(group_usages[0].cpu_core_used_permille, num_cores * 1000);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:



`ResourceGroupUsageRecorder` is used to generate per-second reports on each resource group's CPU utilization and other metrics on BEs. 

#51386 constrained the CPU utilization metric `cpu_core_used_permille` to the range `[0, num_cores]`. 

However, since `cpu_core_used_permille` is measured in per-mille units (thousandths), it should actually be constrained to `[0, num_cores * 1000]`.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
