### PR TITLE
[BugFix] Fix inconsistent status between aliveStatus and becomeDead for BE

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
@@ -29,7 +29,6 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;


### PR DESCRIPTION
## Why I'm doing:

When replay `handleHbResponse`, the status `alive` will be overrided by `hbResponse.aliveStatus `, and the reason is as follows:
> Override the aliveStatus detected by the counter `heartbeatRetryTimes`, in two cases
> 1. the follower has a different `heartbeatRetryTimes` value compared to the Leader, the follower  must follow the leader's aliveStatus decision.
 > 2. editLog replay in leader FE's startup, where the value of `heartbeatRetryTimes` is changed.

However, `becomeDead` is not set for this scenario. And then the status of this BE becomes `alive`, but `becomeDead` will be notified to `CoordinatorMonitor` and kill all the queries related to this BE.

---

The related content in `fe.log` is as follows
```
2025-07-23 13:46:16.911+08:00 INFO (replayer|99) [ComputeNode.handleHbResponse():655] Backend [id=10265, host=127.0.0.1, heartbeatPort=9050, alive=false, status=OK] is dead due to exceed heartbeatRetryTimes
2025-07-23 13:46:16.911+08:00 INFO (replayer|99) [ComputeNode.handleHbResponse():689] Backend [id=10265, host=127.0.0.1, heartbeatPort=9050, alive=true, status=OK] alive status is changed to true
2025-07-23 13:46:16.911+08:00 INFO (replayer|99) [CoordinatorMonitor.addDeadBackend():57] add backend 10265 to dead backend queue
```

---

The related codes:

```java
  if (needSetAlive) {
      if (isAlive.compareAndSet(true, false)) {     // ========== Set `alive` to false.
          LOG.info("{} is dead due to {}", this, deadMessage);
      }
      heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
      Status targetStatus = isShutdown ? Status.SHUTDOWN : Status.DISCONNECTED;
      if (status != targetStatus) {
          status = targetStatus;
          switch (targetStatus) {
              case DISCONNECTED:
                  becomeDead = true;          // ========== Set `becomeDead` to true.
                  break;
          }
      }
  }

  if (!isReplay) {
      hbResponse.aliveStatus = isAlive.get() ?
              HeartbeatResponse.AliveStatus.ALIVE : HeartbeatResponse.AliveStatus.NOT_ALIVE;
  } else {
      if (hbResponse.aliveStatus != null) {
          // Override the aliveStatus detected by the counter `heartbeatRetryTimes`, in two cases
          // 1. the follower has a different `heartbeatRetryTimes` value compared to the Leader, the follower
          //    must follow the leader's aliveStatus decision.
          // 2. editLog replay in leader FE's startup, where the value of `heartbeatRetryTimes` is changed.
          boolean newIsAlive = hbResponse.aliveStatus == HeartbeatResponse.AliveStatus.ALIVE;
          if (setAlive(newIsAlive)) {.  // ========== Set `alive` to true, but `becomeDead` is still true.
              LOG.info("{} alive status is changed to {}", this, newIsAlive);
          }
      }
  }
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
