### PR TITLE
[BugFix] fix missing partition id in combine txnlog

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1086,7 +1086,7 @@ struct AggregateCompactContext {
     using CompactRequestCtx = RequestContext<CompactResponse>;
     std::vector<CompactRequestCtx> compact_request_ctx;
 
-    AggregateCompactContext(int64_t partition_id) : partition_id(partition_id), begin_us(butil::gettimeofday_us()) {}
+    AggregateCompactContext(int64_t partition_id) : begin_us(butil::gettimeofday_us()), partition_id(partition_id) {}
 
     void handle_failure(const std::string& error) {
         std::lock_guard l(response_mtx);

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1081,11 +1081,12 @@ struct AggregateCompactContext {
     std::unique_ptr<BThreadCountDownLatch> latch;
     CombinedTxnLogPB combined_txn_log;
     int64_t begin_us = 0;
+    int64_t partition_id = 0;
 
     using CompactRequestCtx = RequestContext<CompactResponse>;
     std::vector<CompactRequestCtx> compact_request_ctx;
 
-    AggregateCompactContext() : begin_us(butil::gettimeofday_us()) {}
+    AggregateCompactContext(int64_t partition_id) : partition_id(partition_id), begin_us(butil::gettimeofday_us()) {}
 
     void handle_failure(const std::string& error) {
         std::lock_guard l(response_mtx);
@@ -1100,7 +1101,9 @@ struct AggregateCompactContext {
     void collect_txnlogs(CompactResponse* response) {
         std::lock_guard l(response_mtx);
         for (const auto& log : response->txn_logs()) {
-            combined_txn_log.add_txn_logs()->CopyFrom(log);
+            auto* next_txn_log = combined_txn_log.add_txn_logs();
+            next_txn_log->CopyFrom(log);
+            next_txn_log->set_partition_id(partition_id);
         }
     }
 
@@ -1193,7 +1196,7 @@ void LakeServiceImpl::aggregate_compact(::google::protobuf::RpcController* contr
         return;
     }
 
-    AggregateCompactContext ac_context;
+    AggregateCompactContext ac_context(request->partition_id());
     ac_context.latch = std::make_unique<BThreadCountDownLatch>(request->requests_size());
 
     for (int i = 0; i < request->requests_size(); i++) {

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1069,12 +1069,10 @@ TEST_F(LakeServiceTest, test_aggregate_compact) {
                 TxnLogPB txnlog;
                 txnlog.set_tablet_id(100);
                 txnlog.set_txn_id(100);
-                txnlog.set_partition_id(99);
                 resp->add_txn_logs()->CopyFrom(txnlog);
                 TxnLogPB txnlog2;
                 txnlog2.set_tablet_id(101);
                 txnlog2.set_txn_id(100);
-                txnlog2.set_partition_id(99);
                 resp->add_txn_logs()->CopyFrom(txnlog2);
                 resp->mutable_status()->set_status_code(0);
                 done->Run();
@@ -1096,6 +1094,7 @@ TEST_F(LakeServiceTest, test_aggregate_compact) {
         // add request to agg_request
         agg_request.add_requests()->CopyFrom(request);
         agg_request.add_compute_nodes()->CopyFrom(cn);
+        agg_request.set_partition_id(99);
         agg_compact(&cntl, &agg_request, &response);
         ASSERT_FALSE(cntl.Failed());
         ASSERT_EQ(0, response.failed_tablets_size());
@@ -1117,6 +1116,7 @@ TEST_F(LakeServiceTest, test_aggregate_compact) {
             // add request to agg_request
             agg_request.add_requests()->CopyFrom(request);
             agg_request.add_compute_nodes()->CopyFrom(cn);
+            agg_request.set_partition_id(99);
         }
         CompactResponse response;
         agg_compact(&cntl, &agg_request, &response);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -454,7 +454,7 @@ public class CompactionScheduler extends Daemon {
     }
 
     @NotNull
-    private Map<Long, List<Long>> collectPartitionTablets(PhysicalPartition partition, ComputeResource computeResource) {
+    protected Map<Long, List<Long>> collectPartitionTablets(PhysicalPartition partition, ComputeResource computeResource) {
         List<MaterializedIndex> visibleIndexes = partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE);
         Map<Long, List<Long>> beToTablets = new HashMap<>();
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -352,7 +352,7 @@ public class CompactionScheduler extends Daemon {
         try {
             if (table.isFileBundling()) {
                 CompactionTask task = createAggregateCompactionTask(currentVersion, beToTablets, txnId,
-                        partitionStatisticsSnapshot.getPriority(), info.computeResource);
+                        partitionStatisticsSnapshot.getPriority(), info.computeResource, partition.getId());
                 task.sendRequest();
                 job.setAggregateTask(task);
                 LOG.debug("Create aggregate compaction task. {}", job.getDebugString());
@@ -408,12 +408,13 @@ public class CompactionScheduler extends Daemon {
 
     @NotNull
     private CompactionTask createAggregateCompactionTask(long currentVersion, Map<Long, List<Long>> beToTablets, long txnId,
-            PartitionStatistics.CompactionPriority priority, ComputeResource computeResource)
+            PartitionStatistics.CompactionPriority priority, ComputeResource computeResource, long partitionId)
             throws StarRocksException, RpcException {
         // 1. build AggregateCompactRequest
         AggregateCompactRequest aggRequest = new AggregateCompactRequest();
         aggRequest.requests = Lists.newArrayList();
         aggRequest.computeNodes = Lists.newArrayList();
+        aggRequest.partitionId = partitionId;
 
         for (Map.Entry<Long, List<Long>> entry : beToTablets.entrySet()) {
             ComputeNode node = systemInfoService.getBackendOrComputeNode(entry.getKey());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -322,7 +322,8 @@ public class CompactionSchedulerTest {
                 globalTransactionMgr, globalStateMgr, "");
 
         Method method = CompactionScheduler.class.getDeclaredMethod("createAggregateCompactionTask",
-                long.class, Map.class, long.class, PartitionStatistics.CompactionPriority.class, ComputeResource.class, long.class);
+                long.class, Map.class, long.class, PartitionStatistics.CompactionPriority.class, ComputeResource.class,
+                long.class);
         method.setAccessible(true);
         CompactionTask task = (CompactionTask) method.invoke(scheduler, currentVersion, beToTablets, txnId, priority,
                 WarehouseManager.DEFAULT_RESOURCE, 99L);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -322,10 +322,10 @@ public class CompactionSchedulerTest {
                 globalTransactionMgr, globalStateMgr, "");
 
         Method method = CompactionScheduler.class.getDeclaredMethod("createAggregateCompactionTask",
-                long.class, Map.class, long.class, PartitionStatistics.CompactionPriority.class, ComputeResource.class);
+                long.class, Map.class, long.class, PartitionStatistics.CompactionPriority.class, ComputeResource.class, long.class);
         method.setAccessible(true);
         CompactionTask task = (CompactionTask) method.invoke(scheduler, currentVersion, beToTablets, txnId, priority,
-                WarehouseManager.DEFAULT_RESOURCE);
+                WarehouseManager.DEFAULT_RESOURCE, 99L);
 
         Assertions.assertNotNull(task);
         Assertions.assertTrue(task instanceof AggregateCompactionTask);
@@ -480,12 +480,12 @@ public class CompactionSchedulerTest {
 
         Method method = CompactionScheduler.class.getDeclaredMethod("createAggregateCompactionTask",
                 long.class, Map.class, long.class, PartitionStatistics.CompactionPriority.class,
-                ComputeResource.class);
+                ComputeResource.class, long.class);
         method.setAccessible(true);
         ExceptionChecker.expectThrows(InvocationTargetException.class,
                 () -> {
                     method.invoke(scheduler, currentVersion, beToTablets, txnId, priority,
-                            WarehouseManager.DEFAULT_RESOURCE);
+                            WarehouseManager.DEFAULT_RESOURCE, 99L);
                 });
     }
 }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -120,6 +120,7 @@ message CompactRequest {
 message AggregateCompactRequest {
     repeated ComputeNodePB compute_nodes = 1;
     repeated CompactRequest requests = 2;
+    optional int64 partition_id = 3;
 }
 
 message CompactStat {


### PR DESCRIPTION
## Why I'm doing:
Currently, when do aggregate compact, the combine txnlog collected from compaction tasks will be lack of partition id, and it will lead to BE crash when SR run in DEBUG mode.
<img width="1792" height="1120" alt="image" src="https://github.com/user-attachments/assets/cf81d298-a69e-4160-8531-c38729c55831" />

## What I'm doing:
This pull request introduces changes to support partition-specific compaction in the `LakeService` and its associated components. The updates include modifications to the `AggregateCompactContext` structure, test cases, and related methods to handle a new `partition_id` field. Additionally, the `CompactionScheduler` in the frontend has been updated to pass the `partition_id` during compaction task creation.

### Backend Changes: Partition-Aware Compaction

* Added `partition_id` as a member of the `AggregateCompactContext` structure and updated its constructor to initialize this field. (`be/src/service/service_be/lake_service.cpp`, [be/src/service/service_be/lake_service.cppR1084-R1089](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaR1084-R1089))
* Modified the `collect_txnlogs` method in `AggregateCompactContext` to set the `partition_id` in the transaction logs. (`be/src/service/service_be/lake_service.cpp`, [be/src/service/service_be/lake_service.cppL1103-R1106](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaL1103-R1106))
* Updated the `aggregate_compact` method in `LakeServiceImpl` to pass the `partition_id` from the request to the `AggregateCompactContext`. (`be/src/service/service_be/lake_service.cpp`, [be/src/service/service_be/lake_service.cppL1196-R1199](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaL1196-R1199))

### Test Updates: Validation of Partition Handling

* Removed hardcoded `partition_id` assignments in transaction logs within the `test_aggregate_compact` test case. (`be/test/service/lake_service_test.cpp`, [be/test/service/lake_service_test.cppL1072-L1077](diffhunk://#diff-7e7546a285303649b12ec94135003c7c099a4b032ebe2ae95a044ea791386d5fL1072-L1077))
* Added `partition_id` to the `AggregateCompactRequest` in the test setup to validate its propagation. (`be/test/service/lake_service_test.cpp`, [[1]](diffhunk://#diff-7e7546a285303649b12ec94135003c7c099a4b032ebe2ae95a044ea791386d5fR1097) [[2]](diffhunk://#diff-7e7546a285303649b12ec94135003c7c099a4b032ebe2ae95a044ea791386d5fR1119)

### Frontend Changes: Compaction Scheduler Enhancements

* Updated the `startCompaction` method in `CompactionScheduler` to include `partition_id` when creating aggregate compaction tasks. (`fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java`, [fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.javaL355-R355](diffhunk://#diff-14172f29582d5c45b5f04863493bb95ffcdb733ffa71d9ffbf69898a139349c7L355-R355))
* Modified the `createAggregateCompactionTask` method to accept and set `partition_id` in the `AggregateCompactRequest`. (`fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java`, [fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.javaL411-R417](diffhunk://#diff-14172f29582d5c45b5f04863493bb95ffcdb733ffa71d9ffbf69898a139349c7L411-R417))

### Protocol Buffers Update

* Added an optional `partition_id` field to the `AggregateCompactRequest` message in `lake_service.proto`. (`gensrc/proto/lake_service.proto`, [gensrc/proto/lake_service.protoR123](diffhunk://#diff-5bc50165e4af00c12c8ba0f59f743353ad2f5420e0045cb23d6ae82b867aa337R123))

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
