### PR TITLE
[BugFix] fix TableMetricsMgrTest

### DIFF
--- a/be/src/util/metrics.cpp
+++ b/be/src/util/metrics.cpp
@@ -122,6 +122,7 @@ void MetricCollector::remove_metric(Metric* metric) {
         return;
     }
     _metrics.erase(it->second);
+    _metric_labels.erase(it);
 }
 
 Metric* MetricCollector::get_metric(const MetricLabels& labels) const {

--- a/be/src/util/table_metrics.h
+++ b/be/src/util/table_metrics.h
@@ -87,7 +87,7 @@ private:
     int64_t _last_cleanup_ts = 0;
     std::atomic_int64_t _installed_metrics_num = 0;
 
-    static const int64_t kCleanupIntervalSeconds = 15;
+    static const int64_t kCleanupIntervalSeconds = 300;
 };
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

introduced by #58911, when I backport it to branch-3.4, the following test failed.

```text
F20250723 15:05:57.965471 140704602765440 metrics.cpp:159] Check failed: _collectors.empty() _collectors not empty, size=4
  UNKNOWN DEBUG (build UNKNOWN)
  query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000
  [1753283157.965][thread: 140704602765440] je_mallctl execute purge success
  [1753283157.965][thread: 140704602765440] je_mallctl execute dontdump success
  *** Aborted at 1753283157 (unix time) try "date -d @1753283157" if you are using GNU date ***
  PC: @     0x7ff857a969fc pthread_kill
  *** SIGABRT (@0xc9baa) received by PID 826282 (TID 0x7ff857ddb880) from PID 826282; stack trace: ***
      @     0x7ff857a99ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
      @         0x221b1119 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
      @     0x7ff857a42520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
      @     0x7ff857a969fc pthread_kill
      @     0x7ff857a42476 raise
      @     0x7ff857a287f3 abort
      @         0x1862c6f0 starrocks::failure_function()
      @         0x221a48ae google::LogMessage::Fail()
      @         0x221a5b29 google::LogMessageFatal::~LogMessageFatal()
      @         0x1e0ffcfc starrocks::MetricRegistry::~MetricRegistry()
      @         0x16e4ad12 starrocks::TableMetricsManager::~TableMetricsManager()
      @         0x184fd9b7 void std::destroy_at<starrocks::TableMetricsManager>(starrocks::TableMetricsManager*)
      @         0x184fd944 void std::allocator_traits<std::allocator<starrocks::TableMetricsManager> >::destroy<starrocks::TableMetricsManager>(std::allocator<starrocks::TableMetricsManager>&, starrocks::TableMetricsManager*)
      @         0x184fd5c5 std::_Sp_counted_ptr_inplace<starrocks::TableMetricsManager, std::allocator<starrocks::TableMetricsManager>, (__gnu_cxx::_Lock_policy)2>::_M_dispose()
      @         0x15527974 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
      @         0x155252dd std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count()
      @         0x184fa9c2 std::__shared_ptr<starrocks::TableMetricsManager, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr()
      @         0x184fa9e2 std::shared_ptr<starrocks::TableMetricsManager>::~shared_ptr()
      @         0x184f9498 starrocks::TableMetricsMgrTest_test_max_table_metrics_num_Test::TestBody()
      @         0x24692b84 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)
      @         0x2468416e testing::Test::Run()
      @         0x246842d5 testing::TestInfo::Run()
      @         0x246843c5 testing::TestSuite::Run()
      @         0x24684986 testing::internal::UnitTestImpl::RunAllTests()
      @         0x24684bc1 testing::UnitTest::Run()
      @         0x15524b34 RUN_ALL_TESTS()
      @         0x1551ace3 starrocks::init_test_env(int, char**)
      @         0x1551b23c main
      @     0x7ff857a29d90 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
      @     0x7ff857a29e40 __libc_start_main
      @         0x1551a025 _start
```

## What I'm doing:
The metrics_label was not properly maintained when removing_metric, which caused unexpected problems.
In addition, kCleanupIntervalSeconds was incorrectly modified in the previous PR and was changed back in this PR.

Fixes #61220

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
