### PR TITLE
[Enhancement] FlatJSON: support predicate pushdown

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -371,7 +371,9 @@ void Chunk::check_or_die() {
         CHECK(_slot_id_to_index.empty());
     } else {
         for (const ColumnPtr& c : _columns) {
-            CHECK_EQ(num_rows(), c->size());
+            if (!c->is_constant()) {
+                CHECK_EQ(num_rows(), c->size());
+            }
             c->check_or_die();
         }
     }

--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -40,6 +40,7 @@ Status ColumnAccessPath::init(const std::string& parent_path, const TColumnAcces
                               ObjectPool* pool) {
     _type = column_path.type;
     _from_predicate = column_path.from_predicate;
+    _extended = column_path.extended;
 
     ExprContext* expr_ctx = nullptr;
     // Todo: may support late materialization? to compute path by other column predicate
@@ -95,6 +96,7 @@ StatusOr<ColumnAccessPathPtr> ColumnAccessPath::convert_by_index(const Field* fi
     path->_absolute_path = this->_absolute_path;
     path->_column_index = index;
     path->_value_type = this->_value_type;
+    path->_extended = this->_extended;
 
     // json field has none sub-fields, and we only convert the root path, child path find reader by name
     if (field->type()->type() == LogicalType::TYPE_JSON) {

--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -181,6 +181,26 @@ void ColumnAccessPath::get_all_leafs(std::vector<ColumnAccessPath*>* result) {
     }
 }
 
+std::string ColumnAccessPath::full_path() const {
+    std::string res;
+    const ColumnAccessPath* iter = this;
+    while (true) {
+        DCHECK(iter->_children.size() <= 1);
+        if (res.empty()) {
+            res += iter->path();
+        } else {
+            res += "." + iter->path();
+        }
+        if (iter->_children.size() == 1) {
+            iter = iter->_children[0].get();
+        } else {
+            break;
+        }
+    }
+
+    return res;
+}
+
 const std::string ColumnAccessPath::to_string() const {
     std::stringstream ss;
     ss << _path << "(" << _type << ")";

--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -183,7 +183,7 @@ void ColumnAccessPath::get_all_leafs(std::vector<ColumnAccessPath*>* result) {
     }
 }
 
-std::string ColumnAccessPath::full_path() const {
+std::string ColumnAccessPath::linear_path() const {
     std::string res;
     const ColumnAccessPath* iter = this;
     while (true) {

--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -203,6 +203,16 @@ std::string ColumnAccessPath::full_path() const {
     return res;
 }
 
+const TypeDescriptor& ColumnAccessPath::leaf_value_type() const {
+    const ColumnAccessPath* node = this;
+    while (!node->_children.empty()) {
+        DCHECK_EQ(1, node->_children.size());
+        // Always go to the first child, as per the linear path assumption
+        node = node->_children[0].get();
+    }
+    return node->_value_type;
+}
+
 const std::string ColumnAccessPath::to_string() const {
     std::stringstream ss;
     ss << _path << "(" << _type << ")";

--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -76,6 +76,8 @@ public:
 
     bool is_from_predicate() const { return _from_predicate; }
 
+    bool is_extended() const { return _extended; }
+
     const std::string& absolute_path() const { return _absolute_path; }
 
     // flat json use this to get the type of the path
@@ -111,6 +113,8 @@ private:
     bool _from_predicate;
 
     bool _from_compaction = false;
+
+    bool _extended = false;
 
     // the data type of the subfield
     TypeDescriptor _value_type;

--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -87,6 +87,7 @@ public:
 
     ColumnAccessPath* get_child(const std::string& path);
 
+    std::string full_path() const;
     const std::string to_string() const;
 
     size_t leaf_size() const;

--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -90,7 +90,7 @@ public:
     ColumnAccessPath* get_child(const std::string& path);
 
     // For linear path like a.b.c
-    std::string full_path() const;
+    std::string linear_path() const;
     const TypeDescriptor& leaf_value_type() const;
 
     const std::string to_string() const;

--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -89,7 +89,10 @@ public:
 
     ColumnAccessPath* get_child(const std::string& path);
 
+    // For linear path like a.b.c
     std::string full_path() const;
+    const TypeDescriptor& leaf_value_type() const;
+
     const std::string to_string() const;
 
     size_t leaf_size() const;

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -100,6 +100,27 @@ public:
 
     void init_sort_key_idxes() { _init_sort_key_idxes(); }
 
+    std::string to_string() const {
+        std::ostringstream oss;
+        oss << "{";
+        oss << "\"fields\": [";
+        for (size_t i = 0; i < _fields.size(); ++i) {
+            oss << _fields[i]->to_string();
+            if (i + 1 < _fields.size()) oss << ", ";
+        }
+        oss << "], ";
+        oss << "\"num_keys\": " << _num_keys << ", ";
+        oss << "\"sort_key_idxes\": [";
+        for (size_t i = 0; i < _sort_key_idxes.size(); ++i) {
+            oss << _sort_key_idxes[i];
+            if (i + 1 < _sort_key_idxes.size()) oss << ", ";
+        }
+        oss << "], ";
+        oss << "\"keys_type\": " << static_cast<int>(_keys_type);
+        oss << "}";
+        return oss.str();
+    }
+
 private:
     void _build_index_map(const Fields& fields);
     void _init_sort_key_idxes() {

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1528,6 +1528,9 @@ CONF_mBool(enable_json_flat_complex_type, "false");
 // flat json use dict-encoding
 CONF_mBool(json_flat_use_dict_encoding, "true");
 
+// enable flat json create zonemap
+CONF_mBool(json_flat_create_zonemap, "true");
+
 // if disable flat complex type, check complex type rate in hyper-type column
 CONF_mDouble(json_flat_complex_type_factor, "0.3");
 

--- a/be/src/common/cow.h
+++ b/be/src/common/cow.h
@@ -229,8 +229,8 @@ protected:
     MutablePtr try_mutate() const {
 #ifndef NDEBUG
         if (VLOG_IS_ON(1)) {
-            VLOG(1) << "[COW] trigger COW: " << this << ", use_count=" << this->use_count() << ", try to "
-                    << (this->use_count() > 1 ? "deep" : "shadow") << " clone";
+            VLOG(10) << "[COW] trigger COW: " << this << ", use_count=" << this->use_count() << ", try to "
+                     << (this->use_count() > 1 ? "deep" : "shadow") << " clone";
         }
 #endif
         if (this->use_count() > 1) {

--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -1113,8 +1113,8 @@ Status ChunkPredicateBuilder<E, Type>::_get_column_predicates(PredicateParser* p
                                                               ColumnPredicatePtrs& col_preds_owner) {
     auto process_filter_conditions = [&]<typename ConditionType>(const std::vector<ConditionType>& filters) {
         for (const auto& filter : filters) {
-            std::unique_ptr<ColumnPredicate> p(parser->parse_thrift_cond(filter));
-            RETURN_IF(!p, Status::RuntimeError("invalid filter"));
+            ASSIGN_OR_RETURN(auto raw_p, parser->parse_thrift_cond(filter));
+            std::unique_ptr<ColumnPredicate> p(raw_p);
             p->set_index_filter_only(filter.is_index_filter_only);
             col_preds_owner.emplace_back(std::move(p));
         }
@@ -1127,8 +1127,8 @@ Status ChunkPredicateBuilder<E, Type>::_get_column_predicates(PredicateParser* p
     }
 
     for (auto& f : is_null_vector) {
-        std::unique_ptr<ColumnPredicate> p(parser->parse_thrift_cond(f));
-        RETURN_IF(!p, Status::RuntimeError("invalid filter"));
+        ASSIGN_OR_RETURN(auto raw_p, parser->parse_thrift_cond(f));
+        std::unique_ptr<ColumnPredicate> p(raw_p);
         col_preds_owner.emplace_back(std::move(p));
     }
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -526,7 +526,6 @@ Status OlapChunkSource::_extend_schema_by_access_paths() {
         RETURN_IF(root_column_index < 0, Status::RuntimeError("unknown access path: " + path->path()));
         const TabletColumn& root_column = _tablet_schema->column(root_column_index);
 
-        // FIXME: retrieve real information
         LogicalType value_type = path->value_type().type;
         TabletColumn column;
         column.set_name(path->full_path());

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -819,6 +819,9 @@ void OlapChunkSource::_update_counter() {
     if (_reader->stats().late_materialize_ns > 0) {
         RuntimeProfile::Counter* c = ADD_CHILD_TIMER(_runtime_profile, "LateMaterialize", IO_TASK_EXEC_TIMER_NAME);
         COUNTER_UPDATE(c, _reader->stats().late_materialize_ns);
+        RuntimeProfile::Counter* rows =
+                ADD_CHILD_COUNTER(_runtime_profile, "LateMaterializeRows", TUnit::UNIT, IO_TASK_EXEC_TIMER_NAME);
+        COUNTER_UPDATE(rows, _reader->stats().late_materialize_rows);
     }
     if (_reader->stats().del_filter_ns > 0) {
         RuntimeProfile::Counter* c1 = ADD_CHILD_TIMER(_runtime_profile, "DeleteFilter", IO_TASK_EXEC_TIMER_NAME);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -349,29 +349,6 @@ Status OlapChunkSource::_init_scanner_columns(std::vector<uint32_t>& scanner_col
         if (!_unused_output_column_ids.count(index)) {
             _query_slots.push_back(slot);
         }
-
-        // bool is_access_path = false;
-        // if (index < 0) {
-        //     // check if it's a access path
-        //     for (auto& path : *access_paths) {
-        //         if (slot->col_name() == path->full_path()) {
-        //             is_access_path = true;
-        //             index = _tablet_schema->num_columns() + 1;
-        //             // _unused_output_column_ids.emplace(index);
-        //             break;
-        //         }
-        //     }
-        //     if (!is_access_path) {
-        //         std::stringstream ss;
-        //         ss << "invalid field name: " << slot->col_name();
-        //         LOG(WARNING) << ss.str();
-        //         return Status::InternalError(ss.str());
-        //     }
-        // }
-        // scanner_columns.push_back(index);
-        // if (!_unused_output_column_ids.count(index) && !is_access_path) {
-        //     _query_slots.push_back(slot);
-        // }
     }
     // Put key columns before non-key columns, as the `MergeIterator` and `AggregateIterator`
     // required.
@@ -528,7 +505,7 @@ Status OlapChunkSource::_extend_schema_by_access_paths() {
 
         LogicalType value_type = path->value_type().type;
         TabletColumn column;
-        column.set_name(path->full_path());
+        column.set_name(path->linear_path());
         column.set_unique_id(++field_number);
         column.set_type(value_type);
         column.set_length(path->value_type().len);
@@ -538,7 +515,7 @@ Status OlapChunkSource::_extend_schema_by_access_paths() {
         column.set_source_column(&root_column);
 
         tmp_schema->append_column(column);
-        VLOG(2) << "extend the access path column: " << path->full_path();
+        VLOG(2) << "extend the access path column: " << path->linear_path();
     }
     _tablet_schema = tmp_schema;
     return {};

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -501,7 +501,6 @@ Status OlapChunkSource::_extend_schema_by_access_paths() {
         }
         int root_column_index = _tablet_schema->field_index(path->path());
         RETURN_IF(root_column_index < 0, Status::RuntimeError("unknown access path: " + path->path()));
-        const TabletColumn& root_column = _tablet_schema->column(root_column_index);
 
         LogicalType value_type = path->value_type().type;
         TabletColumn column;
@@ -512,7 +511,7 @@ Status OlapChunkSource::_extend_schema_by_access_paths() {
         column.set_is_nullable(true);
         column.set_extended(true);
         column.set_access_path(path.get());
-        column.set_source_column(&root_column);
+        column.set_source_column_index(root_column_index);
 
         tmp_schema->append_column(column);
         VLOG(2) << "extend the access path column: " << path->linear_path();

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -69,6 +69,7 @@ private:
     void _decide_chunk_size(bool has_predicate);
     Status _init_column_access_paths(Schema* schema);
     Status _prune_schema_by_access_paths(Schema* schema);
+    Status _extend_schema_by_access_paths();
 
 private:
     TabletReaderParams _params{};

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -195,9 +195,9 @@ private:
     RuntimeProfile::Counter* _segments_read_count = nullptr;
     RuntimeProfile::Counter* _total_columns_data_page_count = nullptr;
     RuntimeProfile::Counter* _read_pk_index_timer = nullptr;
+
+    // FlatJSON
     RuntimeProfile::Counter* _pushdown_access_paths_counter = nullptr;
-    RuntimeProfile::Counter* _access_path_hits_counter = nullptr;
-    RuntimeProfile::Counter* _access_path_unhits_counter = nullptr;
 };
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -342,6 +342,9 @@ Status ColumnPredicateRewriter::_load_segment_dict(std::vector<std::pair<std::st
     if (!dicts->empty()) {
         return Status::OK();
     }
+    if (dynamic_cast<ScalarColumnIterator*>(iter) == nullptr) {
+        return Status::NotSupported("not support dict predicate for non-string column");
+    }
     auto column_iterator = down_cast<ScalarColumnIterator*>(iter);
     auto dict_size = column_iterator->dict_size();
     int dict_codes[dict_size];
@@ -374,6 +377,9 @@ StatusOr<const ColumnPredicateRewriter::DictAndCodes*> ColumnPredicateRewriter::
 
 Status ColumnPredicateRewriter::_load_segment_dict_vec(ColumnIterator* iter, ColumnPtr* dict_column,
                                                        ColumnPtr* code_column, bool field_nullable) {
+    if (dynamic_cast<ScalarColumnIterator*>(iter) == nullptr) {
+        return Status::NotSupported("not support dict predicate for non-string column");
+    }
     auto column_iterator = down_cast<ScalarColumnIterator*>(iter);
     auto dict_size = column_iterator->dict_size();
     int dict_codes[dict_size];

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -66,7 +66,9 @@ struct RewritePredicateTreeVisitor {
         }
 
         const auto& field = _cid_to_field.find(cid)->second;
-        DCHECK(_rewriter._column_iterators[cid]->all_page_dict_encoded());
+        if (!_rewriter._column_iterators[cid]->all_page_dict_encoded()) {
+            return RewriteStatus::UNCHANGED;
+        }
 
         ColumnPredicate* rewrited_pred;
         ASSIGN_OR_RETURN(auto rewrite_status, _rewriter._rewrite_predicate(_pool, field, col_pred, &rewrited_pred));

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -66,6 +66,9 @@ struct RewritePredicateTreeVisitor {
         }
 
         const auto& field = _cid_to_field.find(cid)->second;
+        // NOTE: for regular column, if a column can be rewritten will be checked before
+        // but for JSON extended column, it depends on the segment dicts, if the segment doesn't have the dicts,
+        // the column can't be rewritten, so we need to check it here.
         if (!_rewriter._column_iterators[cid]->all_page_dict_encoded()) {
             return RewriteStatus::UNCHANGED;
         }
@@ -344,6 +347,7 @@ Status ColumnPredicateRewriter::_load_segment_dict(std::vector<std::pair<std::st
     if (!dicts->empty()) {
         return Status::OK();
     }
+    // NOTE: for JSON extended column, it might be a JsonColumnIterator, so we need to check it here.
     if (dynamic_cast<ScalarColumnIterator*>(iter) == nullptr) {
         return Status::NotSupported("not support dict predicate for non-string column");
     }
@@ -379,6 +383,7 @@ StatusOr<const ColumnPredicateRewriter::DictAndCodes*> ColumnPredicateRewriter::
 
 Status ColumnPredicateRewriter::_load_segment_dict_vec(ColumnIterator* iter, ColumnPtr* dict_column,
                                                        ColumnPtr* code_column, bool field_nullable) {
+    // NOTE: for JSON extended column, it might be a JsonColumnIterator, so we need to check it here.
     if (dynamic_cast<ScalarColumnIterator*>(iter) == nullptr) {
         return Status::NotSupported("not support dict predicate for non-string column");
     }

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -446,7 +446,7 @@ Status TabletReader::init_delete_predicates(const TabletReaderParams& params, De
 
         ConjunctivePredicates conjunctions;
         for (const auto& cond : conds) {
-            ColumnPredicate* pred = pred_parser.parse_thrift_cond(cond);
+            ASSIGN_OR_RETURN(ColumnPredicate * pred, pred_parser.parse_thrift_cond(cond));
             if (pred == nullptr) {
                 LOG(WARNING) << "failed to parse delete condition.column_name[" << cond.column_name
                              << "], condition_op[" << cond.condition_op << "], condition_values["

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -228,6 +228,7 @@ struct OlapReaderStatistics {
     int64_t block_seek_ns = 0;
 
     int64_t decode_dict_ns = 0;
+    int64_t decode_dict_count = 0; // rows * columns
     int64_t late_materialize_ns = 0;
 
     int64_t raw_rows_read = 0;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -320,6 +320,7 @@ struct OlapReaderStatistics {
     std::unordered_map<std::string, int64_t> flat_json_hits;
     std::unordered_map<std::string, int64_t> merge_json_hits;
     std::unordered_map<std::string, int64_t> dynamic_json_hits;
+    std::unordered_map<std::string, int64_t> extract_json_hits;
 
     // Counters for data sampling
     int64_t sample_time_ns = 0;               // Records the time to prepare sample, actual IO time is not included

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -230,6 +230,7 @@ struct OlapReaderStatistics {
     int64_t decode_dict_ns = 0;
     int64_t decode_dict_count = 0; // rows * columns
     int64_t late_materialize_ns = 0;
+    int64_t late_materialize_rows = 0; // number of rows that are late materialized after the filter
 
     int64_t raw_rows_read = 0;
 

--- a/be/src/storage/predicate_parser.h
+++ b/be/src/storage/predicate_parser.h
@@ -44,8 +44,8 @@ public:
 
     // Parse |condition| into a predicate that can be pushed down.
     // return nullptr if parse failed.
-    virtual ColumnPredicate* parse_thrift_cond(const TCondition& condition) const = 0;
-    virtual ColumnPredicate* parse_thrift_cond(const GeneralCondition& condition) const = 0;
+    virtual StatusOr<ColumnPredicate*> parse_thrift_cond(const TCondition& condition) const = 0;
+    virtual StatusOr<ColumnPredicate*> parse_thrift_cond(const GeneralCondition& condition) const = 0;
 
     virtual StatusOr<ColumnPredicate*> parse_expr_ctx(const SlotDescriptor& slot_desc, RuntimeState*,
                                                       ExprContext* expr_ctx) const = 0;
@@ -73,8 +73,8 @@ public:
 
     // Parse |condition| into a predicate that can be pushed down.
     // return nullptr if parse failed.
-    ColumnPredicate* parse_thrift_cond(const TCondition& condition) const override;
-    ColumnPredicate* parse_thrift_cond(const GeneralCondition& condition) const override;
+    StatusOr<ColumnPredicate*> parse_thrift_cond(const TCondition& condition) const override;
+    StatusOr<ColumnPredicate*> parse_thrift_cond(const GeneralCondition& condition) const override;
 
     StatusOr<ColumnPredicate*> parse_expr_ctx(const SlotDescriptor& slot_desc, RuntimeState*,
                                               ExprContext* expr_ctx) const override;
@@ -83,7 +83,7 @@ public:
 
 private:
     template <typename ConditionType>
-    ColumnPredicate* t_parse_thrift_cond(const ConditionType& condition) const;
+    StatusOr<ColumnPredicate*> t_parse_thrift_cond(const ConditionType& condition) const;
 
     const TabletSchemaCSPtr _schema = nullptr;
     // const std::vector<SlotDescriptor*>* _slot_desc = nullptr;
@@ -100,8 +100,8 @@ public:
 
     bool can_pushdown(const SlotDescriptor* slot_desc) const override;
 
-    ColumnPredicate* parse_thrift_cond(const TCondition& condition) const override;
-    ColumnPredicate* parse_thrift_cond(const GeneralCondition& condition) const override;
+    StatusOr<ColumnPredicate*> parse_thrift_cond(const TCondition& condition) const override;
+    StatusOr<ColumnPredicate*> parse_thrift_cond(const GeneralCondition& condition) const override;
 
     StatusOr<ColumnPredicate*> parse_expr_ctx(const SlotDescriptor& slot_desc, RuntimeState*,
                                               ExprContext* expr_ctx) const override;

--- a/be/src/storage/rowset/array_column_iterator.h
+++ b/be/src/storage/rowset/array_column_iterator.h
@@ -67,6 +67,8 @@ public:
     StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
                                                                         Column* dst) override;
 
+    std::string name() const override { return "ArrayColumnIterator"; }
+
 private:
     Status next_batch_null_offsets(size_t* n, UInt32Column* offsets, UInt8Column* nulls, size_t* element_rows);
     Status next_batch_null_offsets(const SparseRange<>& range, UInt32Column* offsets, UInt8Column* nulls,

--- a/be/src/storage/rowset/cast_column_iterator.h
+++ b/be/src/storage/rowset/cast_column_iterator.h
@@ -62,6 +62,8 @@ public:
     StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
                                                                         Column* dst) override;
 
+    std::string name() const override { return "CastColumnIterator"; }
+
 private:
     void do_cast(Column* target);
 

--- a/be/src/storage/rowset/cast_column_iterator.h
+++ b/be/src/storage/rowset/cast_column_iterator.h
@@ -52,6 +52,13 @@ public:
         return Status::OK();
     }
 
+    // Disable dict encoding
+    bool all_page_dict_encoded() const override { return false; }
+    int dict_lookup(const Slice& word) override {
+        CHECK(false) << "unreachable";
+        return 0;
+    }
+
     StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
                                                                         Column* dst) override;
 

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -240,6 +240,9 @@ public:
         return nullptr;
     }
 
+    // Return the name of this column iterator for debugging and logging purposes
+    virtual std::string name() const { return "ColumnIterator"; }
+
 protected:
     ColumnIteratorOptions _opts;
 };

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -244,4 +244,6 @@ protected:
     ColumnIteratorOptions _opts;
 };
 
+using ColumnIteratorUPtr = std::unique_ptr<ColumnIterator>;
+
 } // namespace starrocks

--- a/be/src/storage/rowset/column_iterator_decorator.h
+++ b/be/src/storage/rowset/column_iterator_decorator.h
@@ -108,6 +108,8 @@ public:
         return _parent->fetch_subfield_by_rowid(rowids, size, values);
     }
 
+    std::string name() const override { return "ColumnIteratorDecorator"; }
+
 protected:
     ColumnIterator* _parent;
     std::unique_ptr<ColumnIterator> _release_guard;

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -825,7 +825,7 @@ StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::_new_json_iterator(Colum
         // dynamic flattern
         // we must dynamic flat json, because we don't know other segment wasn't the paths
         return create_json_dynamic_flat_iterator(std::move(json_iter), target_paths, target_types,
-                                                 path->is_from_compaction());
+                                                 path->is_from_compaction() || column->is_extended());
     }
 
     std::vector<std::string> source_paths;

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -824,8 +824,9 @@ StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::_new_json_iterator(Colum
         }
         // dynamic flattern
         // we must dynamic flat json, because we don't know other segment wasn't the paths
-        return create_json_dynamic_flat_iterator(std::move(json_iter), target_paths, target_types,
-                                                 path->is_from_compaction() || column->is_extended());
+        return create_json_dynamic_flat_iterator(
+                std::move(json_iter), target_paths, target_types,
+                path->is_from_compaction() || (column != nullptr && column->is_extended()));
     }
 
     std::vector<std::string> source_paths;

--- a/be/src/storage/rowset/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/dictcode_column_iterator.h
@@ -46,6 +46,8 @@ public:
 
     Status next_batch(const SparseRange<>& range, Column* dst) override { return _parent->next_dict_codes(range, dst); }
 
+    std::string name() const override { return "DictCodeColumnIterator"; }
+
 private:
     ColumnId _cid;
 };
@@ -93,6 +95,8 @@ public:
 
     static Status build_code_convert_map(ColumnIterator* file_column_iter, GlobalDictMap* global_dict,
                                          std::vector<int16_t>* code_convert_map);
+
+    std::string name() const override { return "GlobalDictCodeColumnIterator"; }
 
 private:
     Status decode_array_dict_codes(const Column& codes, Column* words);

--- a/be/src/storage/rowset/fill_subfield_iterator.h
+++ b/be/src/storage/rowset/fill_subfield_iterator.h
@@ -50,6 +50,8 @@ public:
 
     ordinal_t num_rows() const override;
 
+    std::string name() const override { return "FillSubfieldIterator"; }
+
 private:
     ColumnId _cid;
     ColumnAccessPath* _predicate_path;

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -708,6 +708,9 @@ private:
     Status do_extract(Column* target) {
         StatusOr<ColumnPtr> output_column;
         switch (_type) {
+        case TYPE_BOOLEAN:
+            output_column = JsonFunctions::get_native_json_bool(_fn_context, _source_chunk.columns());
+            break;
         case TYPE_INT:
             output_column = JsonFunctions::get_native_json_int(_fn_context, _source_chunk.columns());
             break;
@@ -722,7 +725,8 @@ private:
             output_column = JsonFunctions::get_native_json_string(_fn_context, _source_chunk.columns());
             break;
         default:
-            return Status::RuntimeError(fmt::format("not supported type: {}", logical_type_to_string(_type)));
+            return Status::RuntimeError(
+                    fmt::format("JsonExtractIterator not supported type: {}", logical_type_to_string(_type)));
             break;
         }
         RETURN_IF_ERROR(output_column);

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -83,6 +83,8 @@ public:
                                       const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
                                       CompoundNodeType pred_relation) override;
 
+    std::string name() const override { return "JsonFlatColumnIterator"; }
+
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
 private:
@@ -317,6 +319,8 @@ public:
 
     ordinal_t num_rows() const override { return _json_iter->num_rows(); }
 
+    std::string name() const override { return "JsonDynamicColumnIterator"; }
+
     /// for vectorized engine
     Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                       const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
@@ -460,6 +464,8 @@ public:
 
     StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
                                                                         Column* dst) override;
+
+    std::string name() const override { return "JsonMergeIterator"; }
 
 private:
     template <typename FUNC>
@@ -700,6 +706,8 @@ public:
         auto source_column = _source_chunk.get_column_by_index(0);
         return _parent->get_io_range_vec(range, source_column.get());
     }
+
+    std::string name() const override { return "JsonExtractIterator"; }
 
     // Not support various index
     bool has_original_bloom_filter_index() const override { return false; }

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -666,6 +666,12 @@ public:
         CHECK(st.ok()) << st;
     }
 
+    Status init(const ColumnIteratorOptions& opts) override {
+        // record the hits into stats
+        opts.stats->extract_json_hits[_path]++;
+        return _parent->init(opts);
+    }
+
     DISALLOW_COPY_AND_MOVE(JsonExtractIterator);
 
     Status next_batch(size_t* n, Column* dst) override {

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -738,6 +738,8 @@ private:
         RETURN_IF_ERROR(output_column);
 
         ColumnPtr result = output_column.value();
+        VLOG_ROW << "JsonExtractIterator extract from: " << _source_chunk.get_column_by_index(0)->debug_string();
+        VLOG_ROW << "JsonExtractIterator extract: " << result->debug_string();
         if ((target->is_nullable() == result->is_nullable()) && (target->size() == 0)) {
             target->swap_column(*result);
         } else if (!target->is_nullable() && result->is_nullable()) {
@@ -791,7 +793,7 @@ StatusOr<std::unique_ptr<ColumnIterator>> create_json_merge_iterator(
 
 StatusOr<ColumnIteratorUPtr> create_json_extract_iterator(ColumnIteratorUPtr source_iter, const std::string& path,
                                                           LogicalType type) {
-    VLOG(2) << fmt::format("create_json_extract_iterator: {}={}", path, type);
+    VLOG(2) << fmt::format("create_json_extract_iterator: path={} type={}", path, type);
     return std::make_unique<JsonExtractIterator>(std::move(source_iter), path, type);
 }
 

--- a/be/src/storage/rowset/json_column_iterator.h
+++ b/be/src/storage/rowset/json_column_iterator.h
@@ -18,22 +18,68 @@
 
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/column_reader.h"
+#include "storage/rowset/page_decoder.h"
 #include "storage/rowset/scalar_column_iterator.h"
 
 namespace starrocks {
 
+/**
+ * @brief Creates a ColumnIterator that flattens a JSON column into multiple subfields according to the specified target and source paths/types.
+ *
+ * This iterator is used for reading flat JSON columns, mapping source JSON subfields to target columns, and optionally including remaining fields.
+ *
+ * @param reader Pointer to the ColumnReader for the JSON column.
+ * @param null_iter Iterator for the null column (if nullable), or nullptr.
+ * @param iters Iterators for each source subfield column.
+ * @param target_paths List of target JSON paths to extract.
+ * @param target_types List of logical types for each target path.
+ * @param source_paths List of source JSON paths present in the storage.
+ * @param source_types List of logical types for each source path.
+ * @param need_remain Whether to include remaining fields not mapped to target paths.
+ * @return StatusOr containing a unique pointer to the created ColumnIterator on success, or an error status.
+ */
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(
         ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
         std::vector<std::unique_ptr<ColumnIterator>> iters, const std::vector<std::string>& target_paths,
         const std::vector<LogicalType>& target_types, const std::vector<std::string>& source_paths,
         const std::vector<LogicalType>& source_types, bool need_remain = false);
 
+/**
+ * @brief Creates a ColumnIterator that dynamically flattens a JSON column at read time based on the specified target paths/types.
+ *
+ * This iterator is used when the structure of the JSON is not known at write time, and flattening is performed on-the-fly during reads.
+ *
+ * @param json_iter Iterator for the raw JSON column.
+ * @param target_paths List of target JSON paths to extract.
+ * @param target_types List of logical types for each target path.
+ * @param need_remain Whether to include remaining fields not mapped to target paths.
+ * @return StatusOr containing a unique pointer to the created ColumnIterator on success, or an error status.
+ */
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterator(
         std::unique_ptr<ScalarColumnIterator> json_iter, const std::vector<std::string>& target_paths,
         const std::vector<LogicalType>& target_types, bool need_remain = false);
 
+/**
+ * @brief Creates a ColumnIterator that merges multiple JSON subfield columns into a single JSON column.
+ *
+ * This iterator is used for reconstructing a full JSON object from its flattened subfields during reads.
+ *
+ * @param reader Pointer to the ColumnReader for the JSON column.
+ * @param null_iter Iterator for the null column (if nullable), or nullptr.
+ * @param all_iters Iterators for all subfield columns to be merged.
+ * @param merge_paths List of JSON paths to merge.
+ * @param merge_types List of logical types for each merge path.
+ * @return StatusOr containing a unique pointer to the created ColumnIterator on success, or an error status.
+ */
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_merge_iterator(
         ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
         std::vector<std::unique_ptr<ColumnIterator>> all_iters, const std::vector<std::string>& merge_paths,
         const std::vector<LogicalType>& merge_types);
+
+/**
+ * @brief create a ColumnIterator that extract a field from the underlying json column
+ */
+StatusOr<ColumnIteratorUPtr> create_json_extract_iterator(ColumnIteratorUPtr source_iter, const std::string& path,
+                                                          LogicalType type);
+
 } // namespace starrocks

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -191,6 +191,7 @@ Status FlatJsonColumnWriter::_init_flat_writers() {
 
         opts.meta->set_name(_flat_paths[i]);
         opts.need_flat = false;
+        opts.need_zone_map = is_zone_map_key_type(_flat_types[i]);
 
         TabletColumn col(StorageAggregateType::STORAGE_AGGREGATE_NONE, _flat_types[i], true);
         ASSIGN_OR_RETURN(auto fw, ColumnWriter::create(opts, &col, _wfile));

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -191,7 +191,7 @@ Status FlatJsonColumnWriter::_init_flat_writers() {
 
         opts.meta->set_name(_flat_paths[i]);
         opts.need_flat = false;
-        opts.need_zone_map = is_zone_map_key_type(_flat_types[i]);
+        opts.need_zone_map = config::json_flat_create_zonemap && is_zone_map_key_type(_flat_types[i]);
 
         TabletColumn col(StorageAggregateType::STORAGE_AGGREGATE_NONE, _flat_types[i], true);
         ASSIGN_OR_RETURN(auto fw, ColumnWriter::create(opts, &col, _wfile));

--- a/be/src/storage/rowset/map_column_iterator.h
+++ b/be/src/storage/rowset/map_column_iterator.h
@@ -49,6 +49,8 @@ public:
     StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
                                                                         Column* dst) override;
 
+    std::string name() const override { return "MapColumnIterator"; }
+
 private:
     Status get_element_range_vec(const SparseRange<>& range, MapColumn* map_column, bool seek,
                                  SparseRange<>& element_read_range, size_t& read_rows);

--- a/be/src/storage/rowset/rowid_column_iterator.h
+++ b/be/src/storage/rowset/rowid_column_iterator.h
@@ -102,6 +102,8 @@ public:
         return Status::NotSupported("Not supported by RowIdColumnIterator: decode_dict_codes");
     }
 
+    std::string name() const override { return "RowIdColumnIterator"; }
+
 private:
     ColumnIteratorOptions _opts;
     ordinal_t _current_rowid = 0;

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -109,6 +109,8 @@ public:
     StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
                                                                         Column* dst) override;
 
+    std::string name() const override { return "ScalarColumnIterator"; }
+
 private:
     static Status _seek_to_pos_in_page(ParsedPage* page, ordinal_t offset_in_page);
     Status _load_next_page(bool* eos);

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -482,7 +482,8 @@ StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator_or_defaul
 
 StatusOr<ColumnIteratorUPtr> Segment::_new_extended_column_iterator(const TabletColumn& column,
                                                                     ColumnAccessPath* path) {
-    auto source_id = column.source_column()->unique_id();
+    auto source_index = column.source_column_index();
+    auto source_id = _tablet_schema->column(source_index).unique_id();
     std::string full_path = column.access_path()->linear_path();
     auto [col_name, field_name] = JsonFlatPath::split_path(full_path);
     auto& leaf_type = column.access_path()->leaf_value_type();

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -283,6 +283,10 @@ private:
 
     bool _use_segment_zone_map_filter(const SegmentReadOptions& read_options);
 
+    // Create an iterator for extended column
+    StatusOr<std::unique_ptr<ColumnIterator>> _new_extended_column_iterator(const TabletColumn& column,
+                                                                            ColumnAccessPath* path);
+
     friend class SegmentIterator;
 
     std::shared_ptr<FileSystem> _fs;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2055,10 +2055,10 @@ Status SegmentIterator::_rewrite_predicates() {
         ColumnPredicateRewriter rewriter(_column_iterators, _schema, _predicate_need_rewrite, _predicate_columns,
                                          _scan_range);
         auto st = (rewriter.rewrite_predicate(&_obj_pool, _opts.pred_tree));
-        if (!st.is_not_supported()) {
-            return st;
-        } else if (!st.ok()) {
+        if (st.is_not_supported()) {
             VLOG(2) << "not supported predicate rewrite: " << _opts.pred_tree.root().debug_string() << " " << st;
+        } else if (!st.ok()) {
+            return st;
         } else {
             VLOG(2) << "rewrite_predicates: " << _opts.pred_tree.root().debug_string();
         }

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -835,8 +835,8 @@ void SegmentIterator::_init_column_access_paths() {
 ColumnAccessPath* SegmentIterator::_lookup_access_path(ColumnId cid, const TabletColumn& col) {
     ColumnAccessPath* access_path = nullptr;
     if (col.is_extended()) {
-        if (const auto* source_col = col.source_column()) {
-            ColumnId source_id = source_col->unique_id();
+        if (col.source_column_index() >= 0) {
+            ColumnId source_id = _opts.tablet_schema->column(col.source_column_index()).unique_id();
             auto it = _column_access_paths.find(source_id);
             if (it != _column_access_paths.end() && it->second->is_extended()) {
                 access_path = it->second;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2052,6 +2052,8 @@ Status SegmentIterator::_init_global_dict_decoder() {
 
 Status SegmentIterator::_rewrite_predicates() {
     {
+        // in normal case it can always rewrite the predicate,
+        // but for JSON extended column, it might be a JsonExtractColumnIterator, so we need to fallback to the orignal predicate
         ColumnPredicateRewriter rewriter(_column_iterators, _schema, _predicate_need_rewrite, _predicate_columns,
                                          _scan_range);
         auto st = (rewriter.rewrite_predicate(&_obj_pool, _opts.pred_tree));

--- a/be/src/storage/rowset/series_column_iterator.h
+++ b/be/src/storage/rowset/series_column_iterator.h
@@ -62,6 +62,8 @@ public:
 
     ordinal_t num_rows() const override { return 1 + (_stop - _start) / _step; }
 
+    std::string name() const override { return "SeriesColumnIterator"; }
+
 private:
     T _start;
     T _stop;

--- a/be/src/storage/rowset/struct_column_iterator.cpp
+++ b/be/src/storage/rowset/struct_column_iterator.cpp
@@ -61,6 +61,8 @@ public:
     StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
                                                                         Column* dst) override;
 
+    std::string name() const override { return "StructColumnIterator"; }
+
 private:
     ColumnReader* _reader;
 

--- a/be/src/storage/runtime_range_pruner.hpp
+++ b/be/src/storage/runtime_range_pruner.hpp
@@ -115,7 +115,8 @@ struct RuntimeColumnPredicateBuilder {
             }
 
             for (auto& f : filters) {
-                ColumnPredicate* p = pool->add(parser->parse_thrift_cond(f));
+                ASSIGN_OR_RETURN(auto p, parser->parse_thrift_cond(f));
+                p = pool->add(p);
                 VLOG(2) << "build runtime predicate:" << p->debug_string();
                 p->set_index_filter_only(f.is_index_filter_only);
                 preds.emplace_back(p);

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -590,7 +590,7 @@ Status TabletReader::_init_delete_predicates(const TabletReaderParams& params, D
                 LOG(WARNING) << "ignore delete condition of non-key column: " << pred_pb.sub_predicates(i);
                 continue;
             }
-            ColumnPredicate* pred = pred_parser.parse_thrift_cond(cond);
+            ASSIGN_OR_RETURN(ColumnPredicate * pred, pred_parser.parse_thrift_cond(cond));
             if (pred == nullptr) {
                 LOG(WARNING) << "failed to parse delete condition.column_name[" << cond.column_name
                              << "], condition_op[" << cond.condition_op << "], condition_values["
@@ -614,7 +614,7 @@ Status TabletReader::_init_delete_predicates(const TabletReaderParams& params, D
             for (const auto& value : in_predicate.values()) {
                 cond.condition_values.push_back(value);
             }
-            ColumnPredicate* pred = pred_parser.parse_thrift_cond(cond);
+            ASSIGN_OR_RETURN(ColumnPredicate * pred, pred_parser.parse_thrift_cond(cond));
             if (pred == nullptr) {
                 LOG(WARNING) << "failed to parse delete condition.column_name[" << cond.column_name
                              << "], condition_op[" << cond.condition_op << "], condition_values["

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -138,7 +138,7 @@ TabletColumn::TabletColumn(const TabletColumn& rhs)
           _scale(rhs._scale),
           _is_extended(rhs._is_extended),
           _access_path(rhs._access_path),
-          _source_column(rhs._source_column),
+          _source_column_index(rhs._source_column_index),
           _flags(rhs._flags) {
     if (rhs._extra_fields != nullptr) {
         _extra_fields = new ExtraFields(*rhs._extra_fields);
@@ -159,7 +159,7 @@ TabletColumn::TabletColumn(TabletColumn&& rhs) noexcept
           _scale(rhs._scale),
           _is_extended(std::move(rhs._is_extended)),
           _access_path(std::move(rhs._access_path)),
-          _source_column(std::move(rhs._source_column)),
+          _source_column_index(std::move(rhs._source_column_index)),
           _flags(rhs._flags),
           _extra_fields(rhs._extra_fields),
           _agg_state_desc(rhs._agg_state_desc) {
@@ -195,7 +195,7 @@ void TabletColumn::swap(TabletColumn* rhs) {
 
     swap(_is_extended, rhs->_is_extended);
     swap(_access_path, rhs->_access_path);
-    swap(_source_column, rhs->_source_column);
+    swap(_source_column_index, rhs->_source_column_index);
 }
 
 TabletColumn& TabletColumn::operator=(const TabletColumn& rhs) {

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -136,6 +136,9 @@ TabletColumn::TabletColumn(const TabletColumn& rhs)
           _index_length(rhs._index_length),
           _precision(rhs._precision),
           _scale(rhs._scale),
+          _is_extended(rhs._is_extended),
+          _access_path(rhs._access_path),
+          _source_column(rhs._source_column),
           _flags(rhs._flags) {
     if (rhs._extra_fields != nullptr) {
         _extra_fields = new ExtraFields(*rhs._extra_fields);
@@ -154,13 +157,15 @@ TabletColumn::TabletColumn(TabletColumn&& rhs) noexcept
           _index_length(rhs._index_length),
           _precision(rhs._precision),
           _scale(rhs._scale),
+          _is_extended(std::move(rhs._is_extended)),
+          _access_path(std::move(rhs._access_path)),
+          _source_column(std::move(rhs._source_column)),
           _flags(rhs._flags),
           _extra_fields(rhs._extra_fields),
           _agg_state_desc(rhs._agg_state_desc) {
     rhs._extra_fields = nullptr;
     rhs._agg_state_desc = nullptr;
 }
-
 TabletColumn::TabletColumn(const ColumnPB& column) {
     init_from_pb(column);
 }
@@ -187,6 +192,10 @@ void TabletColumn::swap(TabletColumn* rhs) {
     swap(_flags, rhs->_flags);
     swap(_extra_fields, rhs->_extra_fields);
     swap(_agg_state_desc, rhs->_agg_state_desc);
+
+    swap(_is_extended, rhs->_is_extended);
+    swap(_access_path, rhs->_access_path);
+    swap(_source_column, rhs->_source_column);
 }
 
 TabletColumn& TabletColumn::operator=(const TabletColumn& rhs) {

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -198,12 +198,13 @@ public:
 
     bool is_support_checksum() const;
 
+    // Extended access path column
     void set_extended(bool value) { _is_extended = value; }
     bool is_extended() const { return _is_extended; }
     void set_access_path(ColumnAccessPath* access_path) { _access_path = access_path; }
     ColumnAccessPath* access_path() const { return _access_path; }
-    void set_source_column(const TabletColumn* source_column) { _source_column = source_column; }
-    const TabletColumn* source_column() const { return _source_column; }
+    void set_source_column_index(int source_column_index) { _source_column_index = source_column_index; }
+    int source_column_index() const { return _source_column_index; }
 
 private:
     inline static const std::string kEmptyDefaultValue;
@@ -251,8 +252,8 @@ private:
 
     // Extended access path column
     bool _is_extended = false;
-    ColumnAccessPath* _access_path;
-    const TabletColumn* _source_column;
+    ColumnAccessPath* _access_path = nullptr;
+    int _source_column_index = -1;
 
     uint8_t _flags = 0;
 

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -40,6 +40,7 @@
 #include <vector>
 
 #include "column/chunk.h"
+#include "column/column_access_path.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/descriptors.pb.h"
 #include "gen_cpp/olap_file.pb.h"
@@ -197,6 +198,13 @@ public:
 
     bool is_support_checksum() const;
 
+    void set_extended(bool value) { _is_extended = value; }
+    bool is_extended() const { return _is_extended; }
+    void set_access_path(ColumnAccessPath* access_path) { _access_path = access_path; }
+    ColumnAccessPath* access_path() const { return _access_path; }
+    void set_source_column(const TabletColumn* source_column) { _source_column = source_column; }
+    const TabletColumn* source_column() const { return _source_column; }
+
 private:
     inline static const std::string kEmptyDefaultValue;
     constexpr static uint8_t kIsKeyShift = 0;
@@ -240,6 +248,11 @@ private:
     ColumnIndexLength _index_length = 0;
     ColumnPrecision _precision = 0;
     ColumnScale _scale = 0;
+
+    // Extended access path column
+    bool _is_extended = false;
+    ColumnAccessPath* _access_path;
+    const TabletColumn* _source_column;
 
     uint8_t _flags = 0;
 

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -227,6 +227,7 @@ static FlatJsonHashMap<LogicalType, uint8_t> LOGICAL_TYPE_TO_JSON_BITS {
 
 static const FlatJsonHashMap<LogicalType, JsonFlatExtractFunc> JSON_EXTRACT_FUNC {
     {LogicalType::TYPE_TINYINT,         &extract_number<LogicalType::TYPE_TINYINT>},
+    {LogicalType::TYPE_INT,         &extract_number<LogicalType::TYPE_INT>},
     {LogicalType::TYPE_BIGINT,          &extract_number<LogicalType::TYPE_BIGINT>},
     {LogicalType::TYPE_LARGEINT,        &extract_number<LogicalType::TYPE_LARGEINT>},
     {LogicalType::TYPE_DOUBLE,          &extract_number<LogicalType::TYPE_DOUBLE>},
@@ -239,6 +240,7 @@ static const FlatJsonHashMap<LogicalType, JsonFlatExtractFunc> JSON_EXTRACT_FUNC
 // should match with extract function
 static const FlatJsonHashMap<LogicalType, JsonFlatMergeFunc> JSON_MERGE_FUNC {
     {LogicalType::TYPE_TINYINT,       &merge_number<LogicalType::TYPE_TINYINT>},
+    {LogicalType::TYPE_INT,           &merge_number<LogicalType::TYPE_INT>},
     {LogicalType::TYPE_BIGINT,        &merge_number<LogicalType::TYPE_BIGINT>},
     {LogicalType::TYPE_LARGEINT,      &merge_number<LogicalType::TYPE_LARGEINT>},
     {LogicalType::TYPE_DOUBLE,        &merge_number<LogicalType::TYPE_DOUBLE>},
@@ -826,6 +828,8 @@ bool JsonFlattener::_flatten_json(const vpack::Slice& value, const JsonFlatPath*
             DCHECK(_flat_columns.size() > index);
             DCHECK(_flat_columns[index]->is_nullable());
             auto* c = down_cast<NullableColumn*>(_flat_columns[index].get());
+            DCHECK(flat_json::JSON_EXTRACT_FUNC.contains(child->second->type))
+                    << "unsupported json type: " << child->second->type;
             auto func = flat_json::JSON_EXTRACT_FUNC.at(child->second->type);
             func(&v, c);
             *hit_count += 1;

--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -2484,7 +2484,7 @@ TEST_F(FlatJsonColumnRWTest, testSegmentWriterIteratorWithMixedDataTypes) {
             ASSIGN_OR_ABORT(auto path, ColumnAccessPath::create(TAccessPathType::FIELD, "", 0));
             ColumnAccessPath::insert_json_path(path.get(), field_type, field_name);
             // ASSERT_EQ(kJsonColumnName + "." + field_name, path->full_path());
-            ASSERT_EQ(field_name, path->full_path());
+            ASSERT_EQ(field_name, path->linear_path());
 
             TabletColumn col(STORAGE_AGGREGATE_NONE, field_type, true);
             col.set_extended(true);

--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -29,12 +29,18 @@
 #include "fs/fs_memory.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "gutil/casts.h"
+#include "storage/aggregate_type.h"
 #include "storage/chunk_helper.h"
+#include "storage/chunk_iterator.h"
+#include "storage/flat_json_config.h"
+#include "storage/olap_common.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/column_reader.h"
 #include "storage/rowset/column_writer.h"
 #include "storage/rowset/json_column_iterator.h"
 #include "storage/rowset/segment.h"
+#include "storage/rowset/segment_options.h"
+#include "storage/rowset/segment_writer.h"
 #include "storage/tablet_schema_helper.h"
 #include "storage/types.h"
 #include "testutil/assert.h"
@@ -2289,6 +2295,212 @@ GROUP_SLOW_TEST_F(FlatJsonColumnRWTest, testJsonColumnCompression) {
         std::cout << "[JSON] "
                   << "compression=" << CompressionTypePB_Name(param.compression) << " need_flat=" << param.need_flat
                   << " file size: " << wfile->size() << " bytes\n";
+    }
+}
+
+TEST_F(FlatJsonColumnRWTest, testSegmentWriterIteratorWithMixedDataTypes) {
+    const std::string kJsonColumnName = "json_col";
+    TabletSchemaPB schema_pb;
+    {
+        ColumnPB* json_column = schema_pb.add_column();
+        json_column->set_unique_id(0);
+        json_column->set_name(kJsonColumnName);
+        json_column->set_type("json");
+        json_column->set_is_nullable(true);
+    }
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    std::vector<std::string> json_strings = {
+            R"({
+            "id": 1001,
+            "name": "Alice",
+            "age": 25,
+            "salary": 50000.50,
+            "is_active": true,
+            "tags": ["engineer", "python", "data"],
+            "address": {
+                "city": "Beijing",
+                "country": "China",
+                "postal_code": "100000"
+            },
+            "skills": null,
+            "projects": [
+                {"name": "Project A", "duration": 6},
+                {"name": "Project B", "duration": 12}
+            ],
+            "unique1": 123
+        })",
+            R"({
+            "id": 1002,
+            "name": "Bob",
+            "age": 30,
+            "salary": 75000.75,
+            "is_active": false,
+            "tags": ["manager", "leadership"],
+            "address": {
+                "city": "Shanghai",
+                "country": "China",
+                "postal_code": "200000"
+            },
+            "skills": ["Java", "Spring", "MySQL"],
+            "projects": [],
+            "unique2": "123"
+        })",
+            R"({
+            "id": 1003,
+            "name": "Charlie",
+            "age": 28,
+            "salary": 60000.25,
+            "is_active": true,
+            "tags": ["designer", "ui", "ux"],
+            "address": null,
+            "skills": ["Figma", "Sketch", "Photoshop"],
+            "projects": [
+                {"name": "Website Redesign", "duration": 8, "completed": true}
+            ],
+            "unique3": 123.0
+        })"};
+
+    std::string file_name = TEST_DIR + "/test_json_segment.data";
+    auto fs = std::make_shared<MemoryFileSystem>();
+    ASSERT_TRUE(fs->create_dir(TEST_DIR).ok());
+
+    {
+        // write the segment data
+        SegmentWriterOptions opts;
+        opts.flat_json_config = std::make_shared<FlatJsonConfig>();
+        opts.flat_json_config->set_flat_json_enabled(true);
+        ASSIGN_OR_ABORT(auto wfile, fs->new_writable_file(file_name));
+        auto segment_writer = std::make_unique<SegmentWriter>(std::move(wfile), 0, tablet_schema, opts);
+        ASSERT_OK(segment_writer->init());
+
+        auto json_column = JsonColumn::create();
+
+        for (const auto& json_str : json_strings) {
+            JsonValue json_value;
+            ASSERT_OK(JsonValue::parse(json_str, &json_value));
+            json_column->append(&json_value);
+        }
+
+        SchemaPtr chunk_schema = std::make_shared<Schema>(tablet_schema->schema());
+        auto chunk = std::make_shared<Chunk>(Columns{json_column}, chunk_schema);
+        ASSERT_OK(segment_writer->append_chunk(*chunk));
+        uint64_t index_size, segment_file_size;
+        ASSERT_OK(segment_writer->finalize_columns(&index_size));
+        ASSERT_OK(segment_writer->finalize_footer(&segment_file_size));
+    }
+
+    {
+        // read and validate the segment data
+        auto segment = *Segment::open(fs, FileInfo{file_name}, 0, tablet_schema);
+        OlapReaderStatistics stats;
+        SegmentReadOptions read_opts;
+        read_opts.fs = fs;
+        read_opts.tablet_schema = tablet_schema;
+        read_opts.stats = &stats;
+        ASSIGN_OR_ABORT(auto segment_iterator, segment->new_iterator(*tablet_schema->schema(), read_opts));
+
+        auto read_chunk = std::make_shared<Chunk>();
+        read_chunk->append_column(ColumnHelper::create_column(TypeDescriptor::create_json_type(), true), 0);
+
+        ASSERT_OK(segment_iterator->get_next(read_chunk.get()));
+        ASSERT_EQ(read_chunk->num_rows(), json_strings.size());
+
+        auto read_json_column = read_chunk->get_column_by_index(0);
+        for (size_t i = 0; i < json_strings.size(); ++i) {
+            auto json_datum = read_json_column->get(i);
+
+            const JsonValue* read_json = json_datum.get_json();
+            JsonValue expected_json;
+            ASSERT_OK(JsonValue::parse(json_strings[i], &expected_json));
+            ASSERT_EQ(read_json->to_string().value(), expected_json.to_string().value());
+        }
+
+        read_chunk->reset();
+        ASSERT_TRUE(segment_iterator->get_next(read_chunk.get()).is_end_of_file());
+    }
+
+    {
+        // read specific column
+        auto segment = *Segment::open(fs, FileInfo{file_name}, 0, tablet_schema);
+        OlapReaderStatistics stats;
+        SegmentReadOptions read_opts;
+        read_opts.fs = fs;
+        read_opts.tablet_schema = tablet_schema;
+        read_opts.stats = &stats;
+
+        OlapReaderStatistics reader_stats;
+        ColumnIteratorOptions column_opts;
+        column_opts.stats = &reader_stats;
+
+        ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(file_name));
+        column_opts.read_file = read_file.get();
+
+        // clang-format off
+        std::vector<std::tuple<std::string, LogicalType, std::string>> fields = {
+
+            // extract from the FlatJSON.remain
+            {"unique1", TYPE_INT, "[123, NULL, NULL]"},
+            {"unique1", TYPE_BIGINT, "[123, NULL, NULL]"},
+            {"unique1", TYPE_DOUBLE, "[123, NULL, NULL]"},
+            {"unique1", TYPE_BOOLEAN, "[1, NULL, NULL]"},
+            {"unique1", TYPE_VARCHAR, "['123', NULL, NULL]"},
+            {"unique2", TYPE_BIGINT, "[NULL, 123, NULL]"},
+            {"unique3", TYPE_VARCHAR, "[NULL, NULL, '123']"},
+            {"unique3", TYPE_INT, "[NULL, NULL, 123]"},
+            {"unique3", TYPE_BIGINT, "[NULL, NULL, 123]"},
+            {"unique3", TYPE_BOOLEAN, "[NULL, NULL, 1]"},
+            // non-existent
+            {"unique4", TYPE_INT, "[NULL, NULL, NULL]"},
+
+            // flatten columns
+            {"id", TYPE_INT, "[1001, 1002, 1003]"},
+            {"id", TYPE_BIGINT, "[1001, 1002, 1003]"},
+            {"id", TYPE_DOUBLE, "[1001, 1002, 1003]"},
+            {"id", TYPE_VARCHAR, "['1001', '1002', '1003']"},
+            
+            {"name", TYPE_VARCHAR, R"(['Alice', 'Bob', 'Charlie'])"},
+            {"name", TYPE_INT, R"([NULL, NULL, NULL])"},
+            
+            {"age", TYPE_INT, "[25, 30, 28]"},
+
+            {"salary", TYPE_DOUBLE, "[50000.5, 75000.8, 60000.2]"},
+            {"salary", TYPE_INT, "[50000, 75000, 60000]"},
+            {"salary", TYPE_BIGINT, "[50000, 75000, 60000]"},
+            {"salary", TYPE_VARCHAR, "['50000.5', '75000.75', '60000.25']"},
+
+            {"is_active", TYPE_BOOLEAN, "[1, 0, 1]"},
+            {"is_active", TYPE_INT, "[1, 0, 1]"},
+            {"is_active", TYPE_BIGINT, "[1, 0, 1]"},
+            {"is_active", TYPE_VARCHAR, "['true', 'false', 'true']"},
+
+            {"address.city", TYPE_VARCHAR, "['Beijing', 'Shanghai', NULL]"},
+            {"address.country", TYPE_VARCHAR, "['China', 'China', NULL]"},
+            {"address.postal_code", TYPE_BIGINT, "[100000, 200000, NULL]"},
+        };
+        // clang-format on
+
+        for (const auto& [field_name, field_type, result] : fields) {
+            ASSIGN_OR_ABORT(auto path, ColumnAccessPath::create(TAccessPathType::FIELD, "", 0));
+            ColumnAccessPath::insert_json_path(path.get(), field_type, field_name);
+            // ASSERT_EQ(kJsonColumnName + "." + field_name, path->full_path());
+            ASSERT_EQ(field_name, path->full_path());
+
+            TabletColumn col(STORAGE_AGGREGATE_NONE, field_type, true);
+            col.set_extended(true);
+            col.set_source_column(&tablet_schema->column(0));
+            col.set_unique_id(123);
+            col.set_access_path(path.get());
+
+            ASSIGN_OR_ABORT(auto column_iter, segment->new_column_iterator_or_default(col, path.get()));
+            ASSERT_OK(column_iter->init(column_opts));
+            ASSERT_OK(column_iter->seek_to_first());
+            size_t count = 4096;
+            auto column = ColumnHelper::create_column(TypeDescriptor(field_type), true);
+            ASSERT_OK(column_iter->next_batch(&count, column.get()));
+            ASSERT_EQ(column->size(), json_strings.size());
+            ASSERT_EQ(result, column->debug_string()) << fmt::format("field={} type={}", field_name, field_type);
+        }
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DescriptorTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DescriptorTable.java
@@ -40,7 +40,6 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.thrift.TDescriptorTable;
-import com.starrocks.thrift.TJsonPathDescriptor;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -64,8 +63,6 @@ public class DescriptorTable {
     private final IdGenerator<TupleId> tupleIdGenerator_ = TupleId.createGenerator();
     private final IdGenerator<SlotId> slotIdGenerator_ = SlotId.createGenerator();
     private final HashMap<SlotId, SlotDescriptor> slotDescs = Maps.newHashMap();
-    // Rewritten json path to original slot/column
-    private final Map<String, SlotId> jsonPathDescriptor = Maps.newHashMap();
 
     public DescriptorTable() {
     }
@@ -133,14 +130,6 @@ public class DescriptorTable {
         partitions.add(info);
     }
 
-    public Map<String, SlotId> getJsonPathDescriptor() {
-        return jsonPathDescriptor;
-    }
-
-    public void addJsonPathMapping(String jsonPath, SlotId slotId) {
-        this.jsonPathDescriptor.put(jsonPath, slotId);
-    }
-
     /**
      * Marks all slots in list as materialized.
      */
@@ -187,15 +176,6 @@ public class DescriptorTable {
                     tbl.toThrift(referencedPartitionsPerTable.getOrDefault(tbl, Lists.newArrayList())));
         }
 
-        // json path
-        for (var entry : jsonPathDescriptor.entrySet()) {
-            TJsonPathDescriptor desc = new TJsonPathDescriptor();
-            // FIXME: distinguish virtual column name and json path
-            desc.setJson_path(entry.getKey());
-            desc.setVirtual_col_name(entry.getKey());
-            desc.setRef_slot_id(entry.getValue().asInt());
-            result.addToJsonPathDescriptors(desc);
-        }
         return result;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DescriptorTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DescriptorTable.java
@@ -40,6 +40,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.thrift.TDescriptorTable;
+import com.starrocks.thrift.TJsonPathDescriptor;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -63,6 +64,8 @@ public class DescriptorTable {
     private final IdGenerator<TupleId> tupleIdGenerator_ = TupleId.createGenerator();
     private final IdGenerator<SlotId> slotIdGenerator_ = SlotId.createGenerator();
     private final HashMap<SlotId, SlotDescriptor> slotDescs = Maps.newHashMap();
+    // Rewritten json path to original slot/column
+    private final Map<String, SlotId> jsonPathDescriptor = Maps.newHashMap();
 
     public DescriptorTable() {
     }
@@ -130,6 +133,14 @@ public class DescriptorTable {
         partitions.add(info);
     }
 
+    public Map<String, SlotId> getJsonPathDescriptor() {
+        return jsonPathDescriptor;
+    }
+
+    public void addJsonPathMapping(String jsonPath, SlotId slotId) {
+        this.jsonPathDescriptor.put(jsonPath, slotId);
+    }
+
     /**
      * Marks all slots in list as materialized.
      */
@@ -174,6 +185,16 @@ public class DescriptorTable {
         for (Table tbl : referencedTbls.values()) {
             result.addToTableDescriptors(
                     tbl.toThrift(referencedPartitionsPerTable.getOrDefault(tbl, Lists.newArrayList())));
+        }
+
+        // json path
+        for (var entry : jsonPathDescriptor.entrySet()) {
+            TJsonPathDescriptor desc = new TJsonPathDescriptor();
+            // FIXME: distinguish virtual column name and json path
+            desc.setJson_path(entry.getKey());
+            desc.setVirtual_col_name(entry.getKey());
+            desc.setRef_slot_id(entry.getValue().asInt());
+            result.addToJsonPathDescriptors(desc);
         }
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnAccessPath.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnAccessPath.java
@@ -68,6 +68,37 @@ public class ColumnAccessPath {
         this.valueType = valueType;
     }
 
+    /**
+     * Create a linear path like a.b.c
+     */
+    public static ColumnAccessPath createLinearPath(List<String> path, Type valueType) {
+        ColumnAccessPath root = new ColumnAccessPath(TAccessPathType.ROOT, path.get(0), valueType);
+        for (String field : path.subList(1, path.size())) {
+            root.addChildPath(new ColumnAccessPath(TAccessPathType.FIELD, field, valueType));
+        }
+        return root;
+    }
+
+    /**
+     * Return the string representation of linear path like a.b.c
+     */
+    public String getLinearPath() {
+        StringBuilder sb = new StringBuilder();
+        ColumnAccessPath iter = this;
+        while (iter != null) {
+            if (!sb.isEmpty()) {
+                sb.append(".");
+            }
+            sb.append(iter.getPath());
+            if (!iter.children.isEmpty()) {
+                iter = iter.children.get(0);
+            } else {
+                iter = null;
+            }
+        }
+        return sb.toString();
+    }
+
     public void setType(TAccessPathType type) {
         this.type = type;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnAccessPath.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnAccessPath.java
@@ -57,6 +57,8 @@ public class ColumnAccessPath {
 
     private boolean fromPredicate;
 
+    private boolean extended;
+
     // flat json used, to mark the type of the leaf
     private Type valueType;
 
@@ -65,6 +67,7 @@ public class ColumnAccessPath {
         this.path = path;
         this.children = Lists.newArrayList();
         this.fromPredicate = false;
+        this.extended = false;
         this.valueType = valueType;
     }
 
@@ -129,6 +132,14 @@ public class ColumnAccessPath {
 
     public boolean isFromPredicate() {
         return fromPredicate;
+    }
+
+    public boolean isExtended() {
+        return extended;
+    }
+
+    public void setExtended(boolean extended) {
+        this.extended = extended;
     }
 
     public boolean hasChildPath(String path) {
@@ -205,6 +216,7 @@ public class ColumnAccessPath {
         tColumnAccessPath.setPath(new StringLiteral(path).treeToThrift());
         tColumnAccessPath.setChildren(children.stream().map(ColumnAccessPath::toThrift).collect(Collectors.toList()));
         tColumnAccessPath.setFrom_predicate(fromPredicate);
+        tColumnAccessPath.setExtended(extended);
         if (valueType != null) {
             tColumnAccessPath.setType_desc(valueType.toThrift());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -163,9 +163,9 @@ public abstract class ScanNode extends PlanNode {
 
     protected String explainColumnAccessPath(String prefix) {
         String result = "";
-        if (columnAccessPaths.stream().anyMatch(c -> !c.isFromPredicate())) {
+        if (columnAccessPaths.stream().anyMatch(c -> !c.isFromPredicate() && !c.isExtended())) {
             result += prefix + "ColumnAccessPath: [" + columnAccessPaths.stream()
-                    .filter(c -> !c.isFromPredicate())
+                    .filter(c -> !c.isFromPredicate() && !c.isExtended())
                     .map(ColumnAccessPath::explain)
                     .sorted()
                     .collect(Collectors.joining(", ")) + "]\n";
@@ -173,6 +173,14 @@ public abstract class ScanNode extends PlanNode {
         if (columnAccessPaths.stream().anyMatch(ColumnAccessPath::isFromPredicate)) {
             result += prefix + "PredicateAccessPath: [" + columnAccessPaths.stream()
                     .filter(ColumnAccessPath::isFromPredicate)
+                    .map(ColumnAccessPath::explain)
+                    .sorted()
+                    .collect(Collectors.joining(", ")) + "]\n";
+        }
+        // explain the extended column access path if ColumnAccessPath::isExtended
+        if (columnAccessPaths.stream().anyMatch(ColumnAccessPath::isExtended)) {
+            result += prefix + "ExtendedColumnAccessPath: [" + columnAccessPaths.stream()
+                    .filter(ColumnAccessPath::isExtended)
                     .map(ColumnAccessPath::explain)
                     .sorted()
                     .collect(Collectors.joining(", ")) + "]\n";

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1249,6 +1249,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return cboJSONV2Rewrite;
     }
 
+    public void setEnableJSONV2Rewrite(boolean enableJSONV2Rewrite) {
+        this.cboJSONV2Rewrite = enableJSONV2Rewrite;
+    }
+
     /*
      * the parallel exec instance num for one Fragment in one BE
      * 1 means disable this feature

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -389,6 +389,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_ENABLE_SINGLE_NODE_PREFER_TWO_STAGE_AGGREGATE =
             "cbo_enable_single_node_prefer_two_stage_aggregate";
 
+    public static final String CBO_JSON_V2_REWRITE = "cbo_json_v2_rewrite";
+
     public static final String CBO_PUSH_DOWN_DISTINCT_BELOW_WINDOW = "cbo_push_down_distinct_below_window";
     public static final String CBO_PUSH_DOWN_AGGREGATE = "cbo_push_down_aggregate";
     public static final String CBO_PUSH_DOWN_GROUPINGSET = "cbo_push_down_groupingset";
@@ -1239,6 +1241,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CBO_USE_DB_LOCK, flag = VariableMgr.INVISIBLE)
     private boolean cboUseDBLock = false;
+
+    @VarAttr(name = CBO_JSON_V2_REWRITE)
+    private boolean cboJSONV2Rewrite = true;
+
+    public boolean isEnableJSONV2Rewrite() {
+        return cboJSONV2Rewrite;
+    }
 
     /*
      * the parallel exec instance num for one Fragment in one BE

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
@@ -26,7 +26,6 @@ import com.starrocks.sql.optimizer.property.DomainProperty;
 import com.starrocks.sql.optimizer.rule.mv.KeyInference;
 import com.starrocks.sql.optimizer.rule.mv.MVOperatorProperty;
 import com.starrocks.sql.optimizer.rule.mv.ModifyInference;
-import com.starrocks.sql.optimizer.rule.tree.JsonPathRewriteRule;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 
 import java.util.List;
@@ -63,9 +62,6 @@ public class OptExpression {
     private PhysicalPropertySet outputProperty;
 
     private UKFKConstraints constraints;
-
-    private JsonPathRewriteRule.JsonPathRewriteContext jsonPathRewriteContext =
-            new JsonPathRewriteRule.JsonPathRewriteContext();
 
     // the flag if its parent has required data distribution property for this expression
     private boolean existRequiredDistribution = true;
@@ -263,15 +259,6 @@ public class OptExpression {
         return sb.toString();
     }
 
-    public JsonPathRewriteRule.JsonPathRewriteContext getJsonPathRewriteContext() {
-        return jsonPathRewriteContext;
-    }
-
-    public void setJsonPathRewriteContext(
-            JsonPathRewriteRule.JsonPathRewriteContext jsonPathRewriteContext) {
-        this.jsonPathRewriteContext = jsonPathRewriteContext;
-    }
-
     public static Builder builder() {
         return new Builder();
     }
@@ -290,7 +277,6 @@ public class OptExpression {
             optExpression.requiredProperties = other.requiredProperties;
             optExpression.mvOperatorProperty = other.mvOperatorProperty;
             optExpression.outputProperty = other.outputProperty;
-            optExpression.jsonPathRewriteContext = other.jsonPathRewriteContext;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
@@ -26,6 +26,7 @@ import com.starrocks.sql.optimizer.property.DomainProperty;
 import com.starrocks.sql.optimizer.rule.mv.KeyInference;
 import com.starrocks.sql.optimizer.rule.mv.MVOperatorProperty;
 import com.starrocks.sql.optimizer.rule.mv.ModifyInference;
+import com.starrocks.sql.optimizer.rule.tree.JsonPathRewriteRule;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 
 import java.util.List;
@@ -62,6 +63,9 @@ public class OptExpression {
     private PhysicalPropertySet outputProperty;
 
     private UKFKConstraints constraints;
+
+    private JsonPathRewriteRule.JsonPathRewriteContext jsonPathRewriteContext =
+            new JsonPathRewriteRule.JsonPathRewriteContext();
 
     // the flag if its parent has required data distribution property for this expression
     private boolean existRequiredDistribution = true;
@@ -259,6 +263,15 @@ public class OptExpression {
         return sb.toString();
     }
 
+    public JsonPathRewriteRule.JsonPathRewriteContext getJsonPathRewriteContext() {
+        return jsonPathRewriteContext;
+    }
+
+    public void setJsonPathRewriteContext(
+            JsonPathRewriteRule.JsonPathRewriteContext jsonPathRewriteContext) {
+        this.jsonPathRewriteContext = jsonPathRewriteContext;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -277,6 +290,7 @@ public class OptExpression {
             optExpression.requiredProperties = other.requiredProperties;
             optExpression.mvOperatorProperty = other.mvOperatorProperty;
             optExpression.outputProperty = other.outputProperty;
+            optExpression.jsonPathRewriteContext = other.jsonPathRewriteContext;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -28,6 +28,7 @@ import com.starrocks.sql.optimizer.dump.DumpInfo;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.tree.JsonPathRewriteRule;
 import com.starrocks.sql.optimizer.task.TaskContext;
 import com.starrocks.sql.optimizer.task.TaskScheduler;
 import com.starrocks.sql.optimizer.transformer.MVTransformerContext;
@@ -63,6 +64,9 @@ public class OptimizerContext {
     private long uniquePartitionIdGenerator = 0L;
     private final Stopwatch optimizerTimer = Stopwatch.createStarted();
     private final Map<RuleType, Stopwatch> ruleWatchMap = Maps.newHashMap();
+
+    private JsonPathRewriteRule.JsonPathRewriteContext jsonPathRewriteContext =
+            new JsonPathRewriteRule.JsonPathRewriteContext();
 
     // ============================ Task Variables ============================
     // The options for join predicate pushdown rule
@@ -296,5 +300,14 @@ public class OptimizerContext {
                     "3. enlarge new_planner_optimize_timeout session variable",
                     ErrorType.INTERNAL_ERROR);
         }
+    }
+
+    public JsonPathRewriteRule.JsonPathRewriteContext getJsonPathRewriteContext() {
+        return jsonPathRewriteContext;
+    }
+
+    public void setJsonPathRewriteContext(
+            JsonPathRewriteRule.JsonPathRewriteContext jsonPathRewriteContext) {
+        this.jsonPathRewriteContext = jsonPathRewriteContext;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -28,7 +28,6 @@ import com.starrocks.sql.optimizer.dump.DumpInfo;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.RuleType;
-import com.starrocks.sql.optimizer.rule.tree.JsonPathRewriteRule;
 import com.starrocks.sql.optimizer.task.TaskContext;
 import com.starrocks.sql.optimizer.task.TaskScheduler;
 import com.starrocks.sql.optimizer.transformer.MVTransformerContext;
@@ -64,9 +63,6 @@ public class OptimizerContext {
     private long uniquePartitionIdGenerator = 0L;
     private final Stopwatch optimizerTimer = Stopwatch.createStarted();
     private final Map<RuleType, Stopwatch> ruleWatchMap = Maps.newHashMap();
-
-    private JsonPathRewriteRule.JsonPathRewriteContext jsonPathRewriteContext =
-            new JsonPathRewriteRule.JsonPathRewriteContext();
 
     // ============================ Task Variables ============================
     // The options for join predicate pushdown rule
@@ -302,12 +298,4 @@ public class OptimizerContext {
         }
     }
 
-    public JsonPathRewriteRule.JsonPathRewriteContext getJsonPathRewriteContext() {
-        return jsonPathRewriteContext;
-    }
-
-    public void setJsonPathRewriteContext(
-            JsonPathRewriteRule.JsonPathRewriteContext jsonPathRewriteContext) {
-        this.jsonPathRewriteContext = jsonPathRewriteContext;
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -103,6 +103,7 @@ import com.starrocks.sql.optimizer.rule.tree.ExchangeSortToMergeRule;
 import com.starrocks.sql.optimizer.rule.tree.ExtractAggregateColumn;
 import com.starrocks.sql.optimizer.rule.tree.InlineCteProjectPruneRule;
 import com.starrocks.sql.optimizer.rule.tree.JoinLocalShuffleRule;
+import com.starrocks.sql.optimizer.rule.tree.JsonPathRewriteRule;
 import com.starrocks.sql.optimizer.rule.tree.MarkParentRequiredDistributionRule;
 import com.starrocks.sql.optimizer.rule.tree.PhysicalDistributionAggOptRule;
 import com.starrocks.sql.optimizer.rule.tree.PreAggregateTurnOnRule;
@@ -961,6 +962,8 @@ public class QueryOptimizer extends Optimizer {
         Preconditions.checkState(result.getOp().isPhysical());
 
         int planCount = result.getPlanCount();
+
+        result = new JsonPathRewriteRule().rewrite(result, rootTaskContext);
 
         // Since there may be many different plans in the logic phase, it's possible
         // that this switch can't turned on after logical optimization, so we only determine

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorBuilderFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorBuilderFactory.java
@@ -37,7 +37,7 @@ public class OperatorBuilderFactory {
             return (T) c.newInstance();
         } catch (Exception e) {
             throw new StarRocksPlannerException("not implement builder: " + operator.getOpType(),
-                    ErrorType.INTERNAL_ERROR);
+                    ErrorType.INTERNAL_ERROR, e);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.operator.physical;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -336,6 +337,11 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
 
         public Builder setPrunedPartitionPredicates(List<ScalarOperator> prunedPartitionPredicates) {
             builder.prunedPartitionPredicates = prunedPartitionPredicates;
+            return this;
+        }
+
+        public Builder setColumnAccessPath(List<ColumnAccessPath> accessPaths) {
+            builder.setColumnAccessPaths(accessPaths);
             return this;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
@@ -225,6 +225,14 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
             return (B) this;
         }
 
+        public B addColumnAccessPaths(List<ColumnAccessPath> accessPaths) {
+            ImmutableList.Builder<ColumnAccessPath> builder = ImmutableList.<ColumnAccessPath>builder()
+                    .addAll(this.builder.columnAccessPaths)
+                    .addAll(accessPaths);
+            this.builder.setColumnAccessPaths(builder.build());
+            return (B) this;
+        }
+
         @Override
         public O build() {
             O op = super.build();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
@@ -109,6 +109,7 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
         this(type, scanOperator.getTable(), scanOperator.getColRefToColumnMetaMap(), scanOperator.getLimit(),
                 scanOperator.getPredicate(), scanOperator.getProjection(), scanOperator.getTableVersionRange());
         this.scanOptimizeOption = scanOperator.getScanOptimizeOption().copy();
+        this.columnAccessPaths = ImmutableList.copyOf(scanOperator.getColumnAccessPaths());
     }
 
     public List<ColumnRefOperator> getOutputColumns() {
@@ -216,6 +217,11 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
 
         public B setColRefToColumnMetaMap(Map<ColumnRefOperator, Column> colRefToColumnMetaMap) {
             builder.colRefToColumnMetaMap = ImmutableMap.copyOf(colRefToColumnMetaMap);
+            return (B) this;
+        }
+
+        public B setColumnAccessPath(List<ColumnAccessPath> accessPaths) {
+            builder.setColumnAccessPaths(accessPaths);
             return (B) this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -14,13 +14,15 @@
 
 package com.starrocks.sql.optimizer.rule.tree;
 
-import com.google.common.base.Splitter;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -37,14 +39,16 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rewrite.scalar.BottomUpScalarOperatorRewriteRule;
+import com.starrocks.sql.optimizer.rule.tree.prunesubfield.SubfieldAccessPathNormalizer;
 import com.starrocks.sql.optimizer.task.TaskContext;
-import com.starrocks.thrift.TAccessPathType;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * JsonPathRewriteRule rewrites a json function to a json access path
@@ -62,38 +66,20 @@ public class JsonPathRewriteRule implements TreeRewriteRule {
         if (!variables.isEnableJSONV2Rewrite()) {
             return root;
         }
-        JsonPathRewriteContext context = root.getJsonPathRewriteContext();
         ColumnRefFactory columnRefFactory = taskContext.getOptimizerContext().getColumnRefFactory();
-        context.setColumnRefFactory(columnRefFactory);
-        return rewriteOptExpression(root, context);
-    }
-
-    private static OptExpression rewriteOptExpression(OptExpression optExpr, JsonPathRewriteContext context) {
-        JsonPathRewriteVisitor visitor = new JsonPathRewriteVisitor();
-        return optExpr.getOp().accept(visitor, optExpr, context);
-    }
-
-    private static ScalarOperator rewriteScalar(ScalarOperator scalar,
-                                                JsonPathRewriteContext context,
-                                                JsonPathRewriter rewriter) {
-        if (scalar == null) {
-            return null;
-        }
-        ScalarOperatorRewriter scalarOperatorRewriter = new ScalarOperatorRewriter();
-        return scalarOperatorRewriter.rewrite(scalar, Arrays.asList(rewriter));
+        JsonPathRewriteVisitor visitor = new JsonPathRewriteVisitor(columnRefFactory);
+        return root.getOp().accept(visitor, root, null);
     }
 
     // Context to record mapping from original JSON function expressions to rewritten expressions
     public static class JsonPathRewriteContext {
 
-        // c1.f1 => get_json_string(c1, '$.f1')
-        private final Map<ScalarOperator, ScalarOperator> jsonExprMapping = Maps.newHashMap();
         // full path mapping: t1.c1.f1 => c1.f1
         private final Map<String, ColumnRefOperator> pathMap = Maps.newHashMap();
-        // temporary factory
-        private ColumnRefFactory columnRefFactory;
 
-        public void setColumnRefFactory(ColumnRefFactory factory) {
+        private final ColumnRefFactory columnRefFactory;
+
+        public JsonPathRewriteContext(ColumnRefFactory factory) {
             this.columnRefFactory = factory;
         }
 
@@ -101,44 +87,60 @@ public class JsonPathRewriteRule implements TreeRewriteRule {
             return columnRefFactory;
         }
 
-        public Map<String, ColumnRefOperator> getPathMap() {
-            return pathMap;
-        }
-
-        public Pair<Boolean, ColumnRefOperator> getOrCreateColumn(ColumnRefOperator originalColumn,
+        public Pair<Boolean, ColumnRefOperator> getOrCreateColumn(ColumnRefOperator jsonColumn,
                                                                   ColumnAccessPath jsonPath) {
-            Pair<Table, Column> tableAndColumn = columnRefFactory.getTableAndColumn(originalColumn);
+            Pair<Table, Column> tableAndColumn = columnRefFactory.getTableAndColumn(jsonColumn);
             String path = jsonPath.getLinearPath();
-            String fullPath = tableAndColumn.first.getName() + "." + path;
+            String fullPath = tableAndColumn.first.getId() + "." + path;
             ColumnRefOperator res = pathMap.get(fullPath);
             if (res != null) {
                 return Pair.create(true, res);
             }
 
             // create a column in the table
-            Column fakeColumn;
-            if (!tableAndColumn.first.containColumn(path)) {
-                fakeColumn = new Column(path, jsonPath.getValueType(), true);
-                tableAndColumn.first.addColumn(fakeColumn);
+            // get_json_int(c1, '$.f1') => c1.f1
+            Column extendedColumn;
+            Table table = tableAndColumn.first;
+            if (!table.containColumn(path)) {
+                // Add the column in table metadata
+                // For OlapTable, the metadata is a copied for each query, so this change will only affect current
+                // query
+                Preconditions.checkState(table instanceof OlapTable);
+                extendedColumn = new Column(path, jsonPath.getValueType(), true);
+                tableAndColumn.first.addColumn(extendedColumn);
             } else {
-                fakeColumn = tableAndColumn.first.getColumn(path);
+                extendedColumn = tableAndColumn.first.getColumn(path);
             }
 
             res = columnRefFactory.create(path, jsonPath.getValueType(), true);
-            columnRefFactory.updateColumnRefToColumns(res, fakeColumn, tableAndColumn.first);
+            columnRefFactory.updateColumnRefToColumns(res, extendedColumn, tableAndColumn.first);
             pathMap.put(fullPath, res);
             return Pair.create(false, res);
         }
 
-        public void put(ScalarOperator original, ScalarOperator rewritten) {
-            jsonExprMapping.put(original, rewritten);
+        public static Column pathToColumn(ColumnAccessPath path, Type valueType) {
+            return new Column(path.getLinearPath(), valueType, true);
+        }
+
+        public static ColumnAccessPath pathFromColumn(Column column) {
+            String name = column.getName();
+            ColumnAccessPath res = ColumnAccessPath.createFromLinearPath(name, column.getType());
+            res.setExtended(true);
+            return res;
         }
 
     }
 
-    private static class JsonPathRewriteVisitor extends OptExpressionVisitor<OptExpression, JsonPathRewriteContext> {
+    private static class JsonPathRewriteVisitor extends OptExpressionVisitor<OptExpression, Void> {
+
+        private final ColumnRefFactory columnRefFactory;
+
+        public JsonPathRewriteVisitor(ColumnRefFactory factory) {
+            this.columnRefFactory = factory;
+        }
+
         @Override
-        public OptExpression visit(OptExpression optExpr, JsonPathRewriteContext context) {
+        public OptExpression visit(OptExpression optExpr, Void context) {
             List<OptExpression> newInputs = new ArrayList<>();
             for (OptExpression input : optExpr.getInputs()) {
                 OptExpression child = input.getOp().accept(this, input, context);
@@ -149,12 +151,13 @@ public class JsonPathRewriteRule implements TreeRewriteRule {
         }
 
         @Override
-        public OptExpression visitPhysicalScan(OptExpression optExpr, JsonPathRewriteContext context) {
+        public OptExpression visitPhysicalScan(OptExpression optExpr, Void v) {
             PhysicalScanOperator scanOperator = (PhysicalScanOperator) optExpr.getOp();
             PhysicalOlapScanOperator.Builder builder =
                     (PhysicalOlapScanOperator.Builder) OperatorBuilderFactory.build(scanOperator)
                             .withOperator(scanOperator);
 
+            JsonPathRewriteContext context = new JsonPathRewriteContext(columnRefFactory);
             JsonPathRewriter rewriter = new JsonPathRewriter(context);
 
             // Rewrite predicate
@@ -170,49 +173,45 @@ public class JsonPathRewriteRule implements TreeRewriteRule {
             }
 
             // Add the fake columns into ScanOperator
-            if (MapUtils.isNotEmpty(rewriter.getFakeColumns())) {
+            if (MapUtils.isNotEmpty(rewriter.getExtendedColumns())) {
                 Map<ColumnRefOperator, Column> colRefToColumnMetaMap = Maps.newHashMap();
                 colRefToColumnMetaMap.putAll(scanOperator.getColRefToColumnMetaMap());
-                colRefToColumnMetaMap.putAll(rewriter.getFakeColumns());
+                colRefToColumnMetaMap.putAll(rewriter.getExtendedColumns());
                 builder.setColRefToColumnMetaMap(colRefToColumnMetaMap);
             }
 
             // Record the access path into scan node
             List<ColumnAccessPath> paths = Lists.newArrayList();
-            for (var entry : rewriter.getFakeColumns().entrySet()) {
-                Column fakeColumn = entry.getValue();
-                ColumnAccessPath path = buildColumnAccessPathFromFakeColumn(fakeColumn);
+            for (var entry : rewriter.getExtendedColumns().entrySet()) {
+                ColumnAccessPath path = JsonPathRewriteContext.pathFromColumn(entry.getValue());
                 paths.add(path);
             }
             builder.setColumnAccessPath(paths);
 
-            // Recursively rewrite children (should be empty for scan, but for completeness)
-            List<OptExpression> newInputs = new ArrayList<>();
-            for (OptExpression input : optExpr.getInputs()) {
-                newInputs.add(input.getOp().accept(this, input, context));
-            }
-
             Operator newOp = builder.build();
-            return OptExpression.builder().with(optExpr).setOp(newOp).setInputs(newInputs).build();
+            return OptExpression.builder().with(optExpr).setOp(newOp).build();
         }
+    }
 
-        private static ColumnAccessPath buildColumnAccessPathFromFakeColumn(Column column) {
-            List<String> slices = Splitter.on(".").splitToList(column.getName());
-            ColumnAccessPath res = new ColumnAccessPath(TAccessPathType.ROOT, slices.get(0), column.getType());
-            res.setExtended(true);
-            for (int i = 1; i < slices.size(); i++) {
-                res.addChildPath(new ColumnAccessPath(TAccessPathType.FIELD, slices.get(i), column.getType()));
-            }
-            return res;
+    private static ScalarOperator rewriteScalar(ScalarOperator scalar,
+                                                JsonPathRewriteContext context,
+                                                JsonPathRewriter rewriter) {
+        if (scalar == null) {
+            return null;
         }
+        ScalarOperatorRewriter scalarOperatorRewriter = new ScalarOperatorRewriter();
+        return scalarOperatorRewriter.rewrite(scalar, Arrays.asList(rewriter));
     }
 
 
     // The actual rewrite rule for ScalarOperator, now takes a context
     private static class JsonPathRewriter extends BottomUpScalarOperatorRewriteRule {
+        // only simple field access, no array, no functions, no dot in the path
+        private static final Pattern JSON_PATH_VALID_PATTERN = Pattern.compile("^[a-zA-Z0-9]+$");
+
         private final JsonPathRewriteContext context;
         // record added fake columns
-        private final Map<ColumnRefOperator, Column> fakeColumns = Maps.newHashMap();
+        private final Map<ColumnRefOperator, Column> extendedColumns = Maps.newHashMap();
 
         private static final List<String> SUPPORTED_JSON_FUNCTIONS = Arrays.asList(
                 FunctionSet.GET_JSON_STRING,
@@ -225,51 +224,64 @@ public class JsonPathRewriteRule implements TreeRewriteRule {
             this.context = context;
         }
 
-        public Map<ColumnRefOperator, Column> getFakeColumns() {
-            return fakeColumns;
+        public Map<ColumnRefOperator, Column> getExtendedColumns() {
+            return extendedColumns;
         }
 
         @Override
         public ScalarOperator visitCall(CallOperator call, ScalarOperatorRewriteContext rewriteContext) {
             // Only rewrite supported JSON functions with constant path
             if (SUPPORTED_JSON_FUNCTIONS.contains(call.getFnName()) && call.getArguments().size() == 2) {
-                ScalarOperator arg0 = call.getArguments().get(0);
-                ScalarOperator arg1 = call.getArguments().get(1);
-                if (arg1 instanceof ConstantOperator && arg0 instanceof ColumnRefOperator) {
-                    String path = ((ConstantOperator) arg1).getVarchar();
-                    List<String> fields = parseJsonPath(path);
-                    if (fields != null && !fields.isEmpty()) {
-                        List<String> fullPath = Lists.newArrayList();
-                        fullPath.add(((ColumnRefOperator) arg0).getName());
+                return rewriteCall(call, rewriteContext);
+            }
+            return call;
+        }
+
+        private ScalarOperator rewriteCall(CallOperator call, ScalarOperatorRewriteContext rewriteContext) {
+            ScalarOperator arg0 = call.getArguments().get(0);
+            ScalarOperator arg1 = call.getArguments().get(1);
+            if (arg1 instanceof ConstantOperator && arg0 instanceof ColumnRefOperator) {
+                String path = ((ConstantOperator) arg1).getVarchar();
+                List<String> fields = parseJsonPath(path);
+                if (CollectionUtils.isNotEmpty(fields) && isSupported(fields)) {
+                    // full path: columnName.field
+                    List<String> fullPath = Lists.newArrayList();
+                    Pair<Table, Column> tableAndColumn =
+                            context.columnRefFactory.getTableAndColumn((ColumnRefOperator) arg0);
+                    // only rewrite the expression in scan node, so it must be attached with a table
+                    if (tableAndColumn != null) {
+                        fullPath.add(tableAndColumn.second.getName());
                         fullPath.addAll(fields);
                         ColumnAccessPath accessPath = ColumnAccessPath.createLinearPath(fullPath, call.getType());
                         Pair<Boolean, ColumnRefOperator> orCreateColumn =
                                 context.getOrCreateColumn((ColumnRefOperator) arg0, accessPath);
                         if (!orCreateColumn.first) {
-                            fakeColumns.put(orCreateColumn.second,
+                            extendedColumns.put(orCreateColumn.second,
                                     context.getColumnRefFactory().getColumn(orCreateColumn.second));
                         }
                         return orCreateColumn.second;
                     }
                 }
             }
-            // Recursively rewrite children
-            return super.visitCall(call, rewriteContext);
+
+            return call;
         }
 
         // Parses a JSON path like $.f1.f2 into ["f1", "f2"]
         private static List<String> parseJsonPath(String path) {
-            if (path == null || path.isEmpty()) {
-                return null;
+            final int jsonFlattenDepth = 20;
+            List<String> result = Lists.newArrayList();
+            SubfieldAccessPathNormalizer.parseSimpleJsonPath(jsonFlattenDepth, path, result);
+            return result;
+        }
+
+        private static boolean isSupported(List<String> jsonPath) {
+            for (String piece : jsonPath) {
+                if (!JSON_PATH_VALID_PATTERN.matcher(piece).matches()) {
+                    return false;
+                }
             }
-            path = path.trim();
-            if (path.startsWith("$")) {
-                path = path.substring(1);
-            }
-            if (path.startsWith(".")) {
-                path = path.substring(1);
-            }
-            return Splitter.on(".").splitToList(path);
+            return true;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -199,7 +199,7 @@ public class JsonPathRewriteRule implements TreeRewriteRule {
         private static ColumnAccessPath buildColumnAccessPathFromFakeColumn(Column column) {
             List<String> slices = Splitter.on(".").splitToList(column.getName());
             ColumnAccessPath res = new ColumnAccessPath(TAccessPathType.ROOT, slices.get(0), column.getType());
-            res.setFromPredicate(true);
+            res.setExtended(true);
             for (int i = 1; i < slices.size(); i++) {
                 res.addChildPath(new ColumnAccessPath(TAccessPathType.FIELD, slices.get(i), column.getType()));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -31,7 +31,6 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
-import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -151,8 +150,8 @@ public class JsonPathRewriteRule implements TreeRewriteRule {
         }
 
         @Override
-        public OptExpression visitPhysicalScan(OptExpression optExpr, Void v) {
-            PhysicalScanOperator scanOperator = (PhysicalScanOperator) optExpr.getOp();
+        public OptExpression visitPhysicalOlapScan(OptExpression optExpr, Void v) {
+            PhysicalOlapScanOperator scanOperator = (PhysicalOlapScanOperator) optExpr.getOp();
             PhysicalOlapScanOperator.Builder builder =
                     (PhysicalOlapScanOperator.Builder) OperatorBuilderFactory.build(scanOperator)
                             .withOperator(scanOperator);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -61,7 +61,7 @@ public class JsonPathRewriteRule implements TreeRewriteRule {
         if (!variables.isEnableJSONV2Rewrite()) {
             return root;
         }
-        JsonPathRewriteContext context = taskContext.getOptimizerContext().getJsonPathRewriteContext();
+        JsonPathRewriteContext context = root.getJsonPathRewriteContext();
         ColumnRefFactory columnRefFactory = taskContext.getOptimizerContext().getColumnRefFactory();
         context.setColumnRefFactory(columnRefFactory);
         return rewriteOptExpression(root, context);
@@ -87,7 +87,9 @@ public class JsonPathRewriteRule implements TreeRewriteRule {
 
         // c1.f1 => get_json_string(c1, '$.f1')
         private final Map<ScalarOperator, ScalarOperator> jsonExprMapping = Maps.newHashMap();
+        // full path mapping: t1.c1.f1 => c1.f1
         private final Map<String, ColumnRefOperator> pathMap = Maps.newHashMap();
+        // temporary factory
         private ColumnRefFactory columnRefFactory;
 
         public void setColumnRefFactory(ColumnRefFactory factory) {
@@ -96,6 +98,10 @@ public class JsonPathRewriteRule implements TreeRewriteRule {
 
         public ColumnRefFactory getColumnRefFactory() {
             return columnRefFactory;
+        }
+
+        public Map<String, ColumnRefOperator> getPathMap() {
+            return pathMap;
         }
 
         public Pair<Boolean, ColumnRefOperator> getOrCreateColumn(ColumnRefOperator originalColumn,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -1,0 +1,249 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnAccessPath;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Pair;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.rewrite.scalar.BottomUpScalarOperatorRewriteRule;
+import com.starrocks.sql.optimizer.task.TaskContext;
+import org.apache.commons.collections4.MapUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * JsonPathRewriteRule rewrites a json function to a json access path
+ * Example:
+ * get_json_string(c1, '$.f1') = 1
+ * =>
+ * c1.f1 = 1
+ */
+public class JsonPathRewriteRule implements TreeRewriteRule {
+
+
+    @Override
+    public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
+        SessionVariable variables = taskContext.getOptimizerContext().getSessionVariable();
+        if (!variables.isEnableJSONV2Rewrite()) {
+            return root;
+        }
+        JsonPathRewriteContext context = taskContext.getOptimizerContext().getJsonPathRewriteContext();
+        ColumnRefFactory columnRefFactory = taskContext.getOptimizerContext().getColumnRefFactory();
+        context.setColumnRefFactory(columnRefFactory);
+        return rewriteOptExpression(root, context);
+    }
+
+    private static OptExpression rewriteOptExpression(OptExpression optExpr, JsonPathRewriteContext context) {
+        JsonPathRewriteVisitor visitor = new JsonPathRewriteVisitor();
+        return optExpr.getOp().accept(visitor, optExpr, context);
+    }
+
+    private static ScalarOperator rewriteScalar(ScalarOperator scalar,
+                                                JsonPathRewriteContext context,
+                                                JsonPathRewriter rewriter) {
+        if (scalar == null) {
+            return null;
+        }
+        ScalarOperatorRewriter scalarOperatorRewriter = new ScalarOperatorRewriter();
+        return scalarOperatorRewriter.rewrite(scalar, Arrays.asList(rewriter));
+    }
+
+    // Context to record mapping from original JSON function expressions to rewritten expressions
+    public static class JsonPathRewriteContext {
+
+        // c1.f1 => get_json_string(c1, '$.f1')
+        private final Map<ScalarOperator, ScalarOperator> jsonExprMapping = Maps.newHashMap();
+        private final Map<String, ColumnRefOperator> pathMap = Maps.newHashMap();
+        private ColumnRefFactory columnRefFactory;
+
+        public void setColumnRefFactory(ColumnRefFactory factory) {
+            this.columnRefFactory = factory;
+        }
+
+        public ColumnRefFactory getColumnRefFactory() {
+            return columnRefFactory;
+        }
+
+        public Pair<Boolean, ColumnRefOperator> getOrCreateColumn(ColumnRefOperator originalColumn,
+                                                                  ColumnAccessPath jsonPath) {
+            Pair<Table, Column> tableAndColumn = columnRefFactory.getTableAndColumn(originalColumn);
+            String path = jsonPath.getLinearPath();
+            String fullPath = tableAndColumn.first.getName() + "." + path;
+            ColumnRefOperator res = pathMap.get(fullPath);
+            if (res != null) {
+                return Pair.create(true, res);
+            }
+
+            // create a column in the table
+            Column fakeColumn;
+            if (!tableAndColumn.first.containColumn(path)) {
+                fakeColumn = new Column(path, jsonPath.getValueType(), true);
+                tableAndColumn.first.addColumn(fakeColumn);
+            } else {
+                fakeColumn = tableAndColumn.first.getColumn(path);
+            }
+
+            res = columnRefFactory.create(path, jsonPath.getValueType(), true);
+            columnRefFactory.updateColumnRefToColumns(res, fakeColumn, tableAndColumn.first);
+            pathMap.put(fullPath, res);
+            return Pair.create(false, res);
+        }
+
+        public void put(ScalarOperator original, ScalarOperator rewritten) {
+            jsonExprMapping.put(original, rewritten);
+        }
+
+    }
+
+    private static class JsonPathRewriteVisitor extends OptExpressionVisitor<OptExpression, JsonPathRewriteContext> {
+        @Override
+        public OptExpression visit(OptExpression optExpr, JsonPathRewriteContext context) {
+            List<OptExpression> newInputs = new ArrayList<>();
+            for (OptExpression input : optExpr.getInputs()) {
+                OptExpression child = input.getOp().accept(this, input, context);
+                newInputs.add(child);
+            }
+
+            return OptExpression.builder().with(optExpr).setInputs(newInputs).build();
+        }
+
+        @Override
+        public OptExpression visitPhysicalScan(OptExpression optExpr, JsonPathRewriteContext context) {
+            PhysicalScanOperator scanOperator = (PhysicalScanOperator) optExpr.getOp();
+            PhysicalOlapScanOperator.Builder builder =
+                    (PhysicalOlapScanOperator.Builder) OperatorBuilderFactory.build(scanOperator)
+                            .withOperator(scanOperator);
+
+            JsonPathRewriter rewriter = new JsonPathRewriter(context);
+
+            // Rewrite predicate
+            builder.setPredicate(rewriteScalar(scanOperator.getPredicate(), context, rewriter));
+
+            // Rewrite projection
+            if (scanOperator.getProjection() != null) {
+                Map<ColumnRefOperator, ScalarOperator> mapping = Maps.newHashMap();
+                for (var entry : scanOperator.getProjection().getColumnRefMap().entrySet()) {
+                    mapping.put(entry.getKey(), rewriteScalar(entry.getValue(), context, rewriter));
+                }
+                builder.getProjection().getColumnRefMap().putAll(mapping);
+            }
+
+            // Add the fake columns into ScanOperator
+            if (MapUtils.isNotEmpty(rewriter.getFakeColumns())) {
+                Map<ColumnRefOperator, Column> colRefToColumnMetaMap = Maps.newHashMap();
+                colRefToColumnMetaMap.putAll(scanOperator.getColRefToColumnMetaMap());
+                colRefToColumnMetaMap.putAll(rewriter.getFakeColumns());
+                builder.setColRefToColumnMetaMap(colRefToColumnMetaMap);
+            }
+
+            // Recursively rewrite children (should be empty for scan, but for completeness)
+            List<OptExpression> newInputs = new ArrayList<>();
+            for (OptExpression input : optExpr.getInputs()) {
+                newInputs.add(input.getOp().accept(this, input, context));
+            }
+
+            Operator newOp = builder.build();
+            return OptExpression.builder().with(optExpr).setOp(newOp).setInputs(newInputs).build();
+        }
+    }
+
+
+    // The actual rewrite rule for ScalarOperator, now takes a context
+    private static class JsonPathRewriter extends BottomUpScalarOperatorRewriteRule {
+        private final JsonPathRewriteContext context;
+        // record added fake columns
+        private final Map<ColumnRefOperator, Column> fakeColumns = Maps.newHashMap();
+
+        private static final List<String> SUPPORTED_JSON_FUNCTIONS = Arrays.asList(
+                FunctionSet.GET_JSON_STRING,
+                FunctionSet.GET_JSON_INT,
+                FunctionSet.GET_JSON_DOUBLE,
+                FunctionSet.GET_JSON_BOOL
+        );
+
+        public JsonPathRewriter(JsonPathRewriteContext context) {
+            this.context = context;
+        }
+
+        public Map<ColumnRefOperator, Column> getFakeColumns() {
+            return fakeColumns;
+        }
+
+        @Override
+        public ScalarOperator visitCall(CallOperator call, ScalarOperatorRewriteContext rewriteContext) {
+            // Only rewrite supported JSON functions with constant path
+            if (SUPPORTED_JSON_FUNCTIONS.contains(call.getFnName()) && call.getArguments().size() == 2) {
+                ScalarOperator arg0 = call.getArguments().get(0);
+                ScalarOperator arg1 = call.getArguments().get(1);
+                if (arg1 instanceof ConstantOperator && arg0 instanceof ColumnRefOperator) {
+                    String path = ((ConstantOperator) arg1).getVarchar();
+                    List<String> fields = parseJsonPath(path);
+                    if (fields != null && !fields.isEmpty()) {
+                        List<String> fullPath = Lists.newArrayList();
+                        fullPath.add(((ColumnRefOperator) arg0).getName());
+                        fullPath.addAll(fields);
+                        ColumnAccessPath accessPath = ColumnAccessPath.createLinearPath(fullPath, call.getType());
+                        Pair<Boolean, ColumnRefOperator> orCreateColumn =
+                                context.getOrCreateColumn((ColumnRefOperator) arg0, accessPath);
+                        if (!orCreateColumn.first) {
+                            fakeColumns.put(orCreateColumn.second,
+                                    context.getColumnRefFactory().getColumn(orCreateColumn.second));
+                        }
+                        return orCreateColumn.second;
+                    }
+                }
+            }
+            // Recursively rewrite children
+            return super.visitCall(call, rewriteContext);
+        }
+
+        // Parses a JSON path like $.f1.f2 into ["f1", "f2"]
+        private static List<String> parseJsonPath(String path) {
+            if (path == null || path.isEmpty()) {
+                return null;
+            }
+            path = path.trim();
+            if (path.startsWith("$")) {
+                path = path.substring(1);
+            }
+            if (path.startsWith(".")) {
+                path = path.substring(1);
+            }
+            return Splitter.on(".").splitToList(path);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -263,7 +263,7 @@ public class JsonPathRewriteRule implements TreeRewriteRule {
                 ColumnAccessPath path = JsonPathRewriteContext.pathFromColumn(entry.getValue());
                 paths.add(path);
             }
-            builder.setColumnAccessPath(paths);
+            builder.addColumnAccessPaths(paths);
 
             Operator newOp = builder.build();
             return OptExpression.builder().with(optExpr).setOp(newOp).build();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -241,7 +241,7 @@ public class SubfieldAccessPathNormalizer {
         //  $.a.b.c.d.e.f -> [a, b] -- don't support overflown JSON_FLATTEN_DEPTH
         //  a.b.c -> [a, b, c]
         // when meet some unsupported path, return null
-        public boolean formatJsonPath(String path, List<String> result) {
+        private boolean formatJsonPath(String path, List<String> result) {
             path = StringUtils.trimToEmpty(path);
             if (StringUtils.isBlank(path) || StringUtils.contains(path, "..") || StringUtils.equals("$", path) ||
                     StringUtils.countMatches(path, "\"") % 2 != 0) {
@@ -249,7 +249,7 @@ public class SubfieldAccessPathNormalizer {
                 // unpaired quota char
                 return false;
             }
-            
+
             StrTokenizer tokenizer = new StrTokenizer(path, '.', '"');
             String[] tokens = tokenizer.getTokenArray();
 
@@ -308,6 +308,48 @@ public class SubfieldAccessPathNormalizer {
                     .map(Optional::get).forEach(accessPaths::add);
             return currentPath;
         }
+    }
+
+
+
+    // eg.
+    //  $.a.b -> [a, b]
+    //  $.a[0].b -> [a[0], b] -- don't support array index
+    //  $."a.b".c -> ["a.b", c]
+    //  $.a#b.c -> [a#b, c]
+    //  $.a.b.c.d.e.f -> [a, b] -- don't support overflown JSON_FLATTEN_DEPTH
+    //  a.b.c -> [a, b, c]
+    public static boolean parseSimpleJsonPath(int jsonFlattenDepth, String path, List<String> result) {
+        path = StringUtils.trimToEmpty(path);
+        if (StringUtils.isBlank(path) || StringUtils.contains(path, "..") || StringUtils.equals("$", path) ||
+                StringUtils.countMatches(path, "\"") % 2 != 0) {
+            // .. is recursive search in json path, not supported
+            // unpaired quota char
+            return false;
+        }
+
+        StrTokenizer tokenizer = new StrTokenizer(path, '.', '"');
+        String[] tokens = tokenizer.getTokenArray();
+
+        if (tokens.length < 1) {
+            return false;
+        }
+        int size = jsonFlattenDepth;
+        int i = 0;
+        if (tokens[0].equals("$")) {
+            size++;
+            i++;
+        }
+        size = Math.min(tokens.length, size);
+        for (; i < size; i++) {
+            if (tokens[i].contains(".")) {
+                result.add("\"" + tokens[i] + "\"");
+                continue;
+            } else {
+                result.add(tokens[i]);
+            }
+        }
+        return size < tokens.length;
     }
 
     public void collect(List<ScalarOperator> scalarOperators) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -468,25 +468,7 @@ public class PlanFragmentBuilder {
             collectExecStatsIds(fragment.getPlanRoot());
             context.setExecGroups(execGroups.getExecGroups());
             context.setCollectExecStatsIds(collectExecStatsIds);
-            collectJsonPathMapping(optExpression, context);
             return fragment;
-        }
-
-        private void collectJsonPathMapping(OptExpression optExpression, ExecPlan execPlan) {
-            Map<String, ColumnRefOperator> pathMap = optExpression.getJsonPathRewriteContext().getPathMap();
-            DescriptorTable descTbl = execPlan.getDescTbl();
-
-            // traverse the expr tree
-            for (var entry : pathMap.entrySet()) {
-                SlotId slotId = new SlotId(entry.getValue().getId());
-                SlotDescriptor slotDesc = descTbl.getSlotDesc(slotId);
-                Preconditions.checkNotNull(slotDesc, "slot not found: " + entry.getValue());
-                descTbl.addJsonPathMapping(entry.getKey(), slotId);
-            }
-
-            for (var input : optExpression.getInputs()) {
-                collectJsonPathMapping(input, execPlan);
-            }
         }
 
         private void collectExecStatsIds(PlanNode root) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -468,7 +468,25 @@ public class PlanFragmentBuilder {
             collectExecStatsIds(fragment.getPlanRoot());
             context.setExecGroups(execGroups.getExecGroups());
             context.setCollectExecStatsIds(collectExecStatsIds);
+            collectJsonPathMapping(optExpression, context);
             return fragment;
+        }
+
+        private void collectJsonPathMapping(OptExpression optExpression, ExecPlan execPlan) {
+            Map<String, ColumnRefOperator> pathMap = optExpression.getJsonPathRewriteContext().getPathMap();
+            DescriptorTable descTbl = execPlan.getDescTbl();
+
+            // traverse the expr tree
+            for (var entry : pathMap.entrySet()) {
+                SlotId slotId = new SlotId(entry.getValue().getId());
+                SlotDescriptor slotDesc = descTbl.getSlotDesc(slotId);
+                Preconditions.checkNotNull(slotDesc, "slot not found: " + entry.getValue());
+                descTbl.addJsonPathMapping(entry.getKey(), slotId);
+            }
+
+            for (var input : optExpression.getInputs()) {
+                collectJsonPathMapping(input, execPlan);
+            }
         }
 
         private void collectExecStatsIds(PlanNode root) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
@@ -14,11 +14,15 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.analysis.SlotId;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.util.stream.Stream.of;
@@ -105,5 +109,12 @@ public class JsonPathRewriteTest extends PlanTestBase {
                         " <slot 3> : abs(4: c2.f12)"
                 )
         );
+    }
+
+    @Test
+    public void testJsonPathDescriptor() throws Exception {
+        ExecPlan execPlan = getExecPlan("select get_json_string(c2, 'f2') as f2_str from extend_predicate");
+        Map<String, SlotId> jsonPathDescriptor = execPlan.getDescTbl().getJsonPathDescriptor();
+        Assertions.assertEquals(Map.of("extend_predicate.c2.f2", new SlotId(4)), jsonPathDescriptor);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
@@ -1,0 +1,109 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static java.util.stream.Stream.of;
+
+public class JsonPathRewriteTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        starRocksAssert.withTable("create table extend_predicate( c1 int, c2 json ) properties('replication_num'='1')");
+        starRocksAssert.withTable("create table extend_predicate2( c1 int, c2 json ) properties" +
+                "('replication_num'='1')");
+    }
+
+    @ParameterizedTest
+    @MethodSource("jsonPathRewriteTestCases")
+    public void testExtendPredicateParameterized(String sql, String expectedPlanFragment) throws Exception {
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, expectedPlanFragment);
+    }
+
+    private static Stream<Arguments> jsonPathRewriteTestCases() {
+        return of(
+                // Projection: JSON expression in SELECT list
+                Arguments.of(
+                        "select get_json_string(c2, 'f2') as f2_str from extend_predicate",
+                        "  1:Project\n  |  <slot 3> : 4: c2.f2\n"
+                ),
+                // Filter: JSON expression in WHERE clause with different function
+                Arguments.of(
+                        "select * from extend_predicate where get_json_double(c2, 'f3') > 1.5",
+                        "PREDICATES: 3: c2.f3 > 1.5"
+                ),
+                // Order By: JSON expression in ORDER BY
+                Arguments.of(
+                        "select * from extend_predicate order by get_json_string(c2, 'f4')",
+                        "order by: <slot 3> 3: get_json_string ASC"
+                ),
+                // Aggregation: JSON expression in GROUP BY
+                Arguments.of(
+                        "select get_json_int(c2, 'f5'), count(*) from extend_predicate group by get_json_int(c2, 'f5')",
+                        "  2:AGGREGATE (update finalize)\n" +
+                                "  |  output: count(*)\n" +
+                                "  |  group by: 3: get_json_int\n" +
+                                "  |  \n" +
+                                "  1:Project\n" +
+                                "  |  <slot 3> : 5: c2.f5\n"
+                ),
+                // Aggregation: JSON expression in aggregation function
+                Arguments.of(
+                        "select sum(get_json_int(c2, 'f6')) from extend_predicate",
+                        "  2:AGGREGATE (update finalize)\n" +
+                                "  |  output: sum(3: get_json_int)\n" +
+                                "  |  group by: \n" +
+                                "  |  \n" +
+                                "  1:Project\n" +
+                                "  |  <slot 3> : 5: c2.f6\n"
+                ),
+                // Join: JSON expression in join condition
+                Arguments.of(
+                        "select * from extend_predicate t1 join extend_predicate2 t2 on get_json_int(t1.c2, 'f7') = get_json_int(t2.c2, 'f7')",
+                        "  |  <slot 5> : 9: c2.f7\n"
+                ),
+                // Join: JSON expression in projection after join
+                Arguments.of(
+                        "select get_json_string(t1.c2, 'f8'), get_json_string(t2.c2, 'f8') from extend_predicate t1 join extend_predicate2 t2 on t1.c1 = t2.c1",
+                        "  3:Project\n" +
+                                "  |  <slot 3> : 3: c1\n" +
+                                "  |  <slot 8> : 10: c2.f8\n"
+                ),
+                // JSON expression in HAVING clause
+                Arguments.of(
+                        "select get_json_int(c2, 'f9'), count(*) from extend_predicate group by get_json_int(c2, 'f9') having get_json_int(c2, 'f9') > 10",
+                        "  1:Project\n" +
+                                "  |  <slot 3> : 5: c2.f9\n"
+                ),
+                // JSON expression in complex filter (AND/OR)
+                Arguments.of(
+                        "select * from extend_predicate where get_json_int(c2, 'f10') = 1 or get_json_string(c2, 'f11') = 'abc'",
+                        "PREDICATES: (3: c2.f10 = 1) OR (4: c2.f11 = 'abc')"
+                ),
+                // JSON expression in nested function
+                Arguments.of(
+                        "select abs(get_json_int(c2, 'f12')) from extend_predicate",
+                        " <slot 3> : abs(4: c2.f12)"
+                )
+        );
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
@@ -34,9 +34,13 @@ public class JsonPathRewriteTest extends PlanTestBase {
 
     @ParameterizedTest
     @MethodSource("jsonPathRewriteTestCases")
-    public void testExtendPredicateParameterized(String sql, String expectedPlanFragment) throws Exception {
+    public void testExtendPredicateParameterized(String sql, String expectedPlanFragment, String expectedColumnPath)
+            throws Exception {
         String plan = getFragmentPlan(sql);
         assertContains(plan, expectedPlanFragment);
+
+        String verbosePlan = getVerboseExplain(sql);
+        assertContains(verbosePlan, expectedColumnPath);
     }
 
     private static Stream<Arguments> jsonPathRewriteTestCases() {
@@ -44,17 +48,41 @@ public class JsonPathRewriteTest extends PlanTestBase {
                 // Projection: JSON expression in SELECT list
                 Arguments.of(
                         "select get_json_string(c2, 'f2') as f2_str from extend_predicate",
-                        "  1:Project\n  |  <slot 3> : 4: c2.f2\n"
+                        "  1:Project\n  |  <slot 3> : 4: c2.f2\n",
+                        "ExtendedColumnAccessPath: [/c2(varchar)/f2(varchar)]"
+                ),
+                Arguments.of(
+                        "select get_json_string(c2, '$.f2.f3') as f2_str from extend_predicate",
+                        "  1:Project\n  |  <slot 3> : 4: c2.f2.f3\n",
+                        "ExtendedColumnAccessPath: [/c2(varchar)/f2(varchar)/f3(varchar)]"
+                ),
+                Arguments.of(
+                        "select get_json_string(c2, 'f1.f2.f3') as f2_str from extend_predicate",
+                        "  1:Project\n  |  <slot 3> : 4: c2.f1.f2.f3\n",
+                        "ExtendedColumnAccessPath: [/c2(varchar)/f1(varchar)/f2(varchar)/f3(varchar)]"
+                ),
+                Arguments.of(
+                        "select get_json_string(c2, 'f1[1]') as f2_str from extend_predicate",
+                        "  |  <slot 3> : get_json_string(2: c2, 'f1[1]')\n",
+                        ""
+                ),
+                // TODO: support this case
+                Arguments.of(
+                        "select get_json_string(c2, 'f1\".a\"') as f2_str from extend_predicate",
+                        "  |  <slot 3> : get_json_string(2: c2, 'f1\".a\"')\n",
+                        ""
                 ),
                 // Filter: JSON expression in WHERE clause with different function
                 Arguments.of(
                         "select * from extend_predicate where get_json_double(c2, 'f3') > 1.5",
-                        "PREDICATES: 3: c2.f3 > 1.5"
+                        "PREDICATES: 3: c2.f3 > 1.5",
+                        ""
                 ),
                 // Order By: JSON expression in ORDER BY
                 Arguments.of(
                         "select * from extend_predicate order by get_json_string(c2, 'f4')",
-                        "order by: <slot 3> 3: get_json_string ASC"
+                        "order by: <slot 3> 3: get_json_string ASC",
+                        ""
                 ),
                 // Aggregation: JSON expression in GROUP BY
                 Arguments.of(
@@ -64,7 +92,8 @@ public class JsonPathRewriteTest extends PlanTestBase {
                                 "  |  group by: 3: get_json_int\n" +
                                 "  |  \n" +
                                 "  1:Project\n" +
-                                "  |  <slot 3> : 5: c2.f5\n"
+                                "  |  <slot 3> : 5: c2.f5\n",
+                        "ExtendedColumnAccessPath: [/c2(bigint(20))/f5(bigint(20))]"
                 ),
                 // Aggregation: JSON expression in aggregation function
                 Arguments.of(
@@ -74,35 +103,45 @@ public class JsonPathRewriteTest extends PlanTestBase {
                                 "  |  group by: \n" +
                                 "  |  \n" +
                                 "  1:Project\n" +
-                                "  |  <slot 3> : 5: c2.f6\n"
+                                "  |  <slot 3> : 5: c2.f6\n",
+                        "ExtendedColumnAccessPath: [/c2(bigint(20))/f6(bigint(20))]"
                 ),
                 // Join: JSON expression in join condition
                 Arguments.of(
-                        "select * from extend_predicate t1 join extend_predicate2 t2 on get_json_int(t1.c2, 'f7') = get_json_int(t2.c2, 'f7')",
-                        "  |  <slot 5> : 9: c2.f7\n"
+                        "select * from extend_predicate t1 join extend_predicate2 t2 on get_json_int(t1.c2, 'f7') = " +
+                                "get_json_int(t2.c2, 'f7')",
+                        "  |  <slot 5> : 9: c2.f7\n",
+                        ""
                 ),
                 // Join: JSON expression in projection after join
                 Arguments.of(
-                        "select get_json_string(t1.c2, 'f8'), get_json_string(t2.c2, 'f8') from extend_predicate t1 join extend_predicate2 t2 on t1.c1 = t2.c1",
+                        "select get_json_string(t1.c2, 'f8'), get_json_string(t2.c2, 'f8') from extend_predicate t1 " +
+                                "join extend_predicate2 t2 on t1.c1 = t2.c1",
                         "  3:Project\n" +
                                 "  |  <slot 3> : 3: c1\n" +
-                                "  |  <slot 8> : 10: c2.f8\n"
+                                "  |  <slot 8> : 10: c2.f8\n",
+                        "ExtendedColumnAccessPath: [/c2(varchar)/f8(varchar)]"
                 ),
                 // JSON expression in HAVING clause
                 Arguments.of(
-                        "select get_json_int(c2, 'f9'), count(*) from extend_predicate group by get_json_int(c2, 'f9') having get_json_int(c2, 'f9') > 10",
+                        "select get_json_int(c2, 'f9'), count(*) from extend_predicate group by get_json_int(c2, " +
+                                "'f9') having get_json_int(c2, 'f9') > 10",
                         "  1:Project\n" +
-                                "  |  <slot 3> : 5: c2.f9\n"
+                                "  |  <slot 3> : 5: c2.f9\n",
+                        "ExtendedColumnAccessPath: [/c2(bigint(20))/f9(bigint(20))]"
                 ),
                 // JSON expression in complex filter (AND/OR)
                 Arguments.of(
-                        "select * from extend_predicate where get_json_int(c2, 'f10') = 1 or get_json_string(c2, 'f11') = 'abc'",
-                        "PREDICATES: (3: c2.f10 = 1) OR (4: c2.f11 = 'abc')"
+                        "select * from extend_predicate where get_json_int(c2, 'f10') = 1 or get_json_string(c2, " +
+                                "'f11') = 'abc'",
+                        "PREDICATES: (3: c2.f10 = 1) OR (4: c2.f11 = 'abc')",
+                        " ExtendedColumnAccessPath: [/c2(bigint(20))/f10(bigint(20)), /c2(varchar)/f11(varchar)]"
                 ),
                 // JSON expression in nested function
                 Arguments.of(
                         "select abs(get_json_int(c2, 'f12')) from extend_predicate",
-                        " <slot 3> : abs(4: c2.f12)"
+                        " <slot 3> : abs(4: c2.f12)",
+                        "ExtendedColumnAccessPath: [/c2(bigint(20))/f12(bigint(20))]"
                 )
         );
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
@@ -14,15 +14,11 @@
 
 package com.starrocks.sql.plan;
 
-import com.starrocks.analysis.SlotId;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.util.stream.Stream.of;
@@ -109,12 +105,5 @@ public class JsonPathRewriteTest extends PlanTestBase {
                         " <slot 3> : abs(4: c2.f12)"
                 )
         );
-    }
-
-    @Test
-    public void testJsonPathDescriptor() throws Exception {
-        ExecPlan execPlan = getExecPlan("select get_json_string(c2, 'f2') as f2_str from extend_predicate");
-        Map<String, SlotId> jsonPathDescriptor = execPlan.getDescTbl().getJsonPathDescriptor();
-        Assertions.assertEquals(Map.of("extend_predicate.c2.f2", new SlotId(4)), jsonPathDescriptor);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -126,6 +126,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         connectContext.getSessionVariable().setCboCTERuseRatio(0);
         connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(2);
         connectContext.getSessionVariable().setCboPushDownAggregateMode(-1);
+        connectContext.getSessionVariable().setEnableJSONV2Rewrite(false);
     }
 
     @AfterEach

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -1011,6 +1011,7 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
     public void testPushdownSubfield() throws Exception {
         String dumpString = getDumpInfoFromFile("query_dump/pushdown_subfield");
         QueryDumpInfo queryDumpInfo = getDumpInfoFromJson(dumpString);
+        queryDumpInfo.getSessionVariable().setEnableJSONV2Rewrite(false);
         Pair<QueryDumpInfo, String> replayPair = getPlanFragment(dumpString, queryDumpInfo.getSessionVariable(),
                 TExplainLevel.NORMAL);
         Assertions.assertTrue(replayPair.second.contains(

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
@@ -65,6 +65,7 @@ public class ReplayFromDumpTestBase {
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(30000);
         connectContext.getSessionVariable().setJoinImplementationMode("auto");
         connectContext.getSessionVariable().setCboPushDownAggregateMode(-1);
+        connectContext.getSessionVariable().setEnableJSONV2Rewrite(false);
         starRocksAssert = new StarRocksAssert(connectContext);
         FeConstants.runningUnitTest = true;
         FeConstants.showScanNodeLocalShuffleColumnsInExplain = false;

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -58,6 +58,16 @@ struct TSlotDescriptor {
   14: optional string col_physical_name
 }
 
+// Used to represent a virtual column of JSON Path like get_json_int(c1, '$.f1') => c1.f1
+// virtual_col_name: c1.f1
+// json_path: $.f1
+// ref_slot_id: id of c1
+struct TJsonPathDescriptor {
+  1: optional string virtual_col_name
+  2: optional string json_path
+  3: optional Types.TSlotId ref_slot_id
+}
+
 struct TTupleDescriptor {
   1: optional Types.TTupleId id
   2: optional i32 byteSize // Deprecated
@@ -675,6 +685,8 @@ struct TDescriptorTable {
   // all table descriptors referenced by tupleDescriptors
   3: optional list<TTableDescriptor> tableDescriptors;
   4: optional bool is_cached;
+
+  5: optional list<TJsonPathDescriptor> jsonPathDescriptors;
 }
 
 // Describe route info of a Olap Table

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -58,16 +58,6 @@ struct TSlotDescriptor {
   14: optional string col_physical_name
 }
 
-// Used to represent a virtual column of JSON Path like get_json_int(c1, '$.f1') => c1.f1
-// virtual_col_name: c1.f1
-// json_path: $.f1
-// ref_slot_id: id of c1
-struct TJsonPathDescriptor {
-  1: optional string virtual_col_name
-  2: optional string json_path
-  3: optional Types.TSlotId ref_slot_id
-}
-
 struct TTupleDescriptor {
   1: optional Types.TTupleId id
   2: optional i32 byteSize // Deprecated
@@ -685,8 +675,6 @@ struct TDescriptorTable {
   // all table descriptors referenced by tupleDescriptors
   3: optional list<TTableDescriptor> tableDescriptors;
   4: optional bool is_cached;
-
-  5: optional list<TJsonPathDescriptor> jsonPathDescriptors;
 }
 
 // Describe route info of a Olap Table

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -569,6 +569,7 @@ struct TColumnAccessPath {
     3: optional list<TColumnAccessPath> children
     4: optional bool from_predicate
     5: optional Types.TTypeDesc type_desc
+    6: optional bool extended
 }
 
 struct TVectorSearchOptions {

--- a/test/sql/test_semi/R/test_flat_json_predicate
+++ b/test/sql/test_semi/R/test_flat_json_predicate
@@ -26,7 +26,7 @@ set cbo_json_v2_rewrite = true;
 create view profile_late_materialize as
 select trim(unnest) 
 from table(unnest(split(get_query_profile(last_query_id()), '\n')))
-where unnest like '%LateMaterialize%' 
+where unnest like '%LateMaterializeRows%' 
 order by unnest;
 -- result:
 -- !result
@@ -64,7 +64,6 @@ select * from js2 where get_json_int(j1, '$.f1') = 1;
 -- !result
 select * from profile_filter_rows;
 -- result:
-- PredFilterRows: 999
 -- !result
 select * from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1') = 2;
 -- result:
@@ -73,7 +72,6 @@ select * from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1')
 -- !result
 select * from profile_filter_rows;
 -- result:
-- PredFilterRows: 998
 -- !result
 select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
 -- result:
@@ -84,7 +82,6 @@ select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
 -- !result
 select * from profile_filter_rows;
 -- result:
-- PredFilterRows: 996
 -- !result
 select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') = -1;
 -- result:
@@ -161,7 +158,6 @@ select * from js2 where get_json_int(j1, '$.f2') = 1;
 -- !result
 select * from profile_filter_rows;
 -- result:
-- PredFilterRows: 1.999K (1999)
 -- !result
 select * from js2 where get_json_int(j1, '$.f2') = 1 or get_json_int(j1, '$.f2') = 2;
 -- result:
@@ -170,7 +166,6 @@ select * from js2 where get_json_int(j1, '$.f2') = 1 or get_json_int(j1, '$.f2')
 -- !result
 select * from profile_filter_rows;
 -- result:
-- PredFilterRows: 1.998K (1998)
 -- !result
 select * from js2 where get_json_int(j1, '$.f2') in (1, 2, 3, 4);
 -- result:
@@ -181,7 +176,41 @@ select * from js2 where get_json_int(j1, '$.f2') in (1, 2, 3, 4);
 -- !result
 select * from profile_filter_rows;
 -- result:
-- PredFilterRows: 1.996K (1996)
+-- !result
+insert into js3
+select 
+    generate_series, 
+    json_object('f1', concat('a', generate_series%10))
+from (table(generate_series(1, 1000)));
+-- result:
+-- !result
+select count(v1) from js3 where get_json_string(j1, 'f1') = 'a0';
+-- result:
+100
+-- !result
+select * from profile_dict;
+-- result:
+-- !result
+select count(v1) from js3 where get_json_string(j1, 'f1') = 'a10';
+-- result:
+0
+-- !result
+select * from profile_dict;
+-- result:
+-- !result
+select count(get_json_string(j1, 'f1')) from js3 where get_json_string(j1, 'f1') = 'a0';
+-- result:
+100
+-- !result
+select * from profile_dict;
+-- result:
+-- !result
+select count(get_Json_string(j1, 'f1')) from js3 where get_json_string(j1, 'f1') = 'a10';
+-- result:
+0
+-- !result
+select * from profile_dict;
+-- result:
 -- !result
 insert into js2 
 select 
@@ -195,26 +224,5 @@ select count(get_json_int(j1, '$.f2')) from js2 where get_json_int(j1, '$.f1') <
 99
 -- !result
 select * from profile_late_materialize;
--- result:
--- !result
-insert into js3
-select 
-    generate_series, 
-    json_object('f1', concat('a', generate_series%10))
-from (table(generate_series(1, 1000)));
--- result:
--- !result
-select count(*) from js3 where get_json_string(j1, 'f1') = 'a0';
--- result:
-100
--- !result
-select * from profile_dict;
--- result:
--- !result
-select count(*) from js3 where get_json_string(j1, 'f1') = 'a0';
--- result:
-100
--- !result
-select * from profile_dict;
 -- result:
 -- !result

--- a/test/sql/test_semi/R/test_flat_json_predicate
+++ b/test/sql/test_semi/R/test_flat_json_predicate
@@ -176,6 +176,8 @@ select * from js2 where get_json_int(j1, '$.f1') = -1;
 -- !result
 select * from profile_filter_rows;
 -- result:
+- ZoneMapIndexFilterRows: 1.000K (1000)
+- PredFilterRows: 1.000K (1000)
 -- !result
 select * from js2 where get_json_int(j1, '$.f1') = 1;
 -- result:
@@ -222,6 +224,7 @@ select * from js2 where get_json_int(j1, '$.f2') = 1 or get_json_int(j1, '$.f2')
 -- !result
 select * from profile_filter_rows;
 -- result:
+- PredFilterRows: 1.998K (1998)
 -- !result
 select * from js2 where get_json_int(j1, '$.f2') in (1, 2, 3, 4);
 -- result:
@@ -308,7 +311,7 @@ select * from profile_late_materialize;
 -- !result
 insert into js3
 select generate_series, json_object(
-        -- 'f_bool', cast(generate_series % 2 = 0 as boolean),
+        'f_bool', cast(generate_series % 2 = 0 as boolean),
         'f_int', generate_series,
         'f_int1', generate_series,
         'f_int2', generate_series,
@@ -317,19 +320,7 @@ select generate_series, json_object(
 from (table(generate_series(1, 1000)));
 -- result:
 -- !result
-select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
+select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
 -- result:
-499
--- !result
-select count(*) from js3 where get_json_int(j1, 'f_int1') < 500;
--- result:
-499
--- !result
-select count(*) from js3 where get_json_int(j1, 'f_int2') < 500;
--- result:
-499
--- !result
-select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;
--- result:
-499
+500
 -- !result

--- a/test/sql/test_semi/R/test_flat_json_predicate
+++ b/test/sql/test_semi/R/test_flat_json_predicate
@@ -1,0 +1,245 @@
+-- name: test_normal_flat_json_predicate @system
+CREATE TABLE js2 (
+    v1 BIGINT NULL,
+    j1 JSON NULL
+)
+DUPLICATE KEY (v1)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1
+PROPERTIES ( "replication_num" = "1" );
+-- result:
+-- !result
+CREATE TABLE js3 (
+    v1 BIGINT NULL,
+    j1 JSON NULL
+)
+DUPLICATE KEY (v1)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1
+PROPERTIES ( "replication_num" = "1" );
+-- result:
+-- !result
+set enable_profile = true;
+-- result:
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result
+create view profile_late_materialize as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%LateMaterialize%' 
+order by unnest;
+-- result:
+-- !result
+create view profile_filter_rows as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%FilterRows%' AND CAST(REGEXP_EXTRACT(unnest, '(\\d+)', 1) AS INT) != 0
+order by unnest;
+-- result:
+-- !result
+create view profile_dict as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%DictDecodeCount%' AND CAST(REGEXP_EXTRACT(unnest, '(\\d+)', 1) AS INT) != 0
+order by unnest;
+-- result:
+-- !result
+insert into js2 
+select 
+    generate_series, 
+    json_object('f1', generate_series)
+from (table(generate_series(1, 1000)));
+-- result:
+-- !result
+select * from js2 where get_json_int(j1, '$.f1') = -1;
+-- result:
+-- !result
+select * from profile_filter_rows;
+-- result:
+- ZoneMapIndexFilterRows: 1.000K (1000)
+-- !result
+select * from js2 where get_json_int(j1, '$.f1') = 1;
+-- result:
+1	{"f1": 1}
+-- !result
+select * from profile_filter_rows;
+-- result:
+- PredFilterRows: 999
+-- !result
+select * from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1') = 2;
+-- result:
+1	{"f1": 1}
+2	{"f1": 2}
+-- !result
+select * from profile_filter_rows;
+-- result:
+- PredFilterRows: 998
+-- !result
+select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
+-- result:
+1	{"f1": 1}
+2	{"f1": 2}
+3	{"f1": 3}
+4	{"f1": 4}
+-- !result
+select * from profile_filter_rows;
+-- result:
+- PredFilterRows: 996
+-- !result
+select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') = -1;
+-- result:
+-- !result
+select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') = 1;
+-- result:
+1
+-- !result
+select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1') = 2;
+-- result:
+1
+2
+-- !result
+select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
+-- result:
+1
+2
+3
+4
+-- !result
+insert into js2 
+select 
+    generate_series, 
+    json_object('f2', generate_series)
+from (table(generate_series(1, 1000)));
+-- result:
+-- !result
+select * from js2 where get_json_int(j1, '$.f1') = -1;
+-- result:
+-- !result
+select * from profile_filter_rows;
+-- result:
+- ZoneMapIndexFilterRows: 1.000K (1000)
+- PredFilterRows: 1.000K (1000)
+-- !result
+select * from js2 where get_json_int(j1, '$.f1') = 1;
+-- result:
+1	{"f1": 1}
+-- !result
+select * from profile_filter_rows;
+-- result:
+- PredFilterRows: 1.999K (1999)
+-- !result
+select * from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1') = 2;
+-- result:
+1	{"f1": 1}
+2	{"f1": 2}
+-- !result
+select * from profile_filter_rows;
+-- result:
+- PredFilterRows: 1.998K (1998)
+-- !result
+select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
+-- result:
+1	{"f1": 1}
+2	{"f1": 2}
+3	{"f1": 3}
+4	{"f1": 4}
+-- !result
+select * from profile_filter_rows;
+-- result:
+- PredFilterRows: 1.996K (1996)
+-- !result
+select * from js2 where get_json_int(j1, '$.f2') = -1;
+-- result:
+-- !result
+select * from profile_filter_rows;
+-- result:
+- ZoneMapIndexFilterRows: 1.000K (1000)
+- PredFilterRows: 1.000K (1000)
+-- !result
+select * from js2 where get_json_int(j1, '$.f2') = 1;
+-- result:
+1	{"f2": 1}
+-- !result
+select * from profile_filter_rows;
+-- result:
+- PredFilterRows: 1.999K (1999)
+-- !result
+select * from js2 where get_json_int(j1, '$.f2') = 1 or get_json_int(j1, '$.f2') = 2;
+-- result:
+1	{"f2": 1}
+2	{"f2": 2}
+-- !result
+select * from profile_filter_rows;
+-- result:
+- PredFilterRows: 1.998K (1998)
+-- !result
+select * from js2 where get_json_int(j1, '$.f2') in (1, 2, 3, 4);
+-- result:
+1	{"f2": 1}
+2	{"f2": 2}
+3	{"f2": 3}
+4	{"f2": 4}
+-- !result
+select * from profile_filter_rows;
+-- result:
+- PredFilterRows: 1.996K (1996)
+-- !result
+insert into js2 
+select 
+    generate_series, 
+    json_object('f1', generate_series, 'f2', generate_series)
+from (table(generate_series(1, 1000)));
+-- result:
+-- !result
+select count(get_json_int(j1, '$.f2')) from js2 where get_json_int(j1, '$.f1') < 100;
+-- result:
+99
+-- !result
+select * from profile_late_materialize;
+-- result:
+-- !result
+insert into js3
+select 
+    generate_series, 
+    json_object('f1', concat('a', generate_series%10))
+from (table(generate_series(1, 1000)));
+-- result:
+-- !result
+select count(*) from js3 where get_json_string(j1, 'f1') = 'a0';
+-- result:
+100
+-- !result
+select * from profile_dict;
+-- result:
+-- !result
+select count(*) from js3 where get_json_string(j1, 'f1') = 'a0';
+-- result:
+100
+-- !result
+select * from profile_dict;
+-- result:
+-- !result
+insert into js3
+select generate_series, json_object(
+        'f_bool', cast(generate_series % 2 = 0 as boolean),
+        'f_int', generate_series,
+        'f_int1', generate_series,
+        'f_int2', generate_series,
+        -- 'f_double', cast(generate_series as double) * 1.0
+        )
+from (table(generate_series(1, 10000)));
+-- result:
+E: (1064, "Getting syntax error at line 8, column 8. Detail message: Unexpected input ')', the most similar input is {a legal identifier}.")
+-- !result
+select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
+-- result:
+0
+-- !result
+select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
+-- result:
+0
+-- !result
+select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;
+-- result:
+0
+-- !result

--- a/test/sql/test_semi/R/test_flat_json_predicate
+++ b/test/sql/test_semi/R/test_flat_json_predicate
@@ -44,6 +44,13 @@ where unnest like '%DictDecodeCount%' AND CAST(REGEXP_EXTRACT(unnest, '(\\d+)', 
 order by unnest;
 -- result:
 -- !result
+create view profile_access_path as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%AccessPath%'
+order by unnest;
+-- result:
+-- !result
 insert into js2 
 select 
     generate_series, 
@@ -109,13 +116,66 @@ select
 from (table(generate_series(1, 1000)));
 -- result:
 -- !result
+select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') = 1;
+-- result:
+1
+-- !result
+select * from profile_access_path;
+-- result:
+-- !result
+select get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f1') = 1;
+-- result:
+None
+-- !result
+select * from profile_access_path;
+-- result:
+-- !result
+select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f2') = 1;
+-- result:
+None
+-- !result
+select * from profile_access_path;
+-- result:
+-- !result
+select get_json_int(j1, '$.f2'), j1 from js2 where get_json_int(j1, '$.f1') = 1;
+-- result:
+None	{"f1": 1}
+-- !result
+select * from profile_access_path;
+-- result:
+-- !result
+select get_json_int(j1, '$.f2'), j1 from js2 where get_json_int(j1, '$.f3') = 1;
+-- result:
+-- !result
+select * from profile_access_path;
+-- result:
+-- !result
+select get_json_int(j1, '$.f2'), get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f1') = 1;
+-- result:
+None	None
+-- !result
+select * from profile_access_path;
+-- result:
+-- !result
+select count(get_json_int(j1, '$.f2')) from js2 ;
+-- result:
+1000
+-- !result
+select * from profile_access_path;
+-- result:
+-- !result
+select count(get_json_int(j1, '$.f3')) from js2 ;
+-- result:
+0
+-- !result
+select * from profile_access_path;
+-- result:
+-- !result
 select * from js2 where get_json_int(j1, '$.f1') = -1;
 -- result:
 -- !result
 select * from profile_filter_rows;
 -- result:
-- ZoneMapIndexFilterRows: 1.000K (1000)
-- PredFilterRows: 1.000K (1000)
 -- !result
 select * from js2 where get_json_int(j1, '$.f1') = 1;
 -- result:
@@ -123,7 +183,6 @@ select * from js2 where get_json_int(j1, '$.f1') = 1;
 -- !result
 select * from profile_filter_rows;
 -- result:
-- PredFilterRows: 1.999K (1999)
 -- !result
 select * from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1') = 2;
 -- result:
@@ -142,15 +201,12 @@ select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
 -- !result
 select * from profile_filter_rows;
 -- result:
-- PredFilterRows: 1.996K (1996)
 -- !result
 select * from js2 where get_json_int(j1, '$.f2') = -1;
 -- result:
 -- !result
 select * from profile_filter_rows;
 -- result:
-- ZoneMapIndexFilterRows: 1.000K (1000)
-- PredFilterRows: 1.000K (1000)
 -- !result
 select * from js2 where get_json_int(j1, '$.f2') = 1;
 -- result:
@@ -176,6 +232,30 @@ select * from js2 where get_json_int(j1, '$.f2') in (1, 2, 3, 4);
 -- !result
 select * from profile_filter_rows;
 -- result:
+-- !result
+select get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f2') = 1;
+-- result:
+1
+-- !result
+select get_json_int(j1, '$.f1'), get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f2') = 1;
+-- result:
+None	1
+-- !result
+select get_json_int(j1, '$.f1'), get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f2') = 1;
+-- result:
+None	None
+-- !result
+select get_json_int(j1, '$.f1'), get_json_int(j1, '$.f2'), get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f2') = 1;
+-- result:
+None	1	None
+-- !result
+select j1, get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f2') = 1;
+-- result:
+{"f2": 1}	1
+-- !result
+select j1 from js2 where get_json_int(j1, '$.f2') = 1;
+-- result:
+{"f2": 1}
 -- !result
 insert into js3
 select 
@@ -225,4 +305,31 @@ select count(get_json_int(j1, '$.f2')) from js2 where get_json_int(j1, '$.f1') <
 -- !result
 select * from profile_late_materialize;
 -- result:
+-- !result
+insert into js3
+select generate_series, json_object(
+        -- 'f_bool', cast(generate_series % 2 = 0 as boolean),
+        'f_int', generate_series,
+        'f_int1', generate_series,
+        'f_int2', generate_series,
+        'f_double', cast(generate_series as double) * 1.0
+        )
+from (table(generate_series(1, 1000)));
+-- result:
+-- !result
+select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
+-- result:
+499
+-- !result
+select count(*) from js3 where get_json_int(j1, 'f_int1') < 500;
+-- result:
+499
+-- !result
+select count(*) from js3 where get_json_int(j1, 'f_int2') < 500;
+-- result:
+499
+-- !result
+select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;
+-- result:
+499
 -- !result

--- a/test/sql/test_semi/R/test_flat_json_predicate
+++ b/test/sql/test_semi/R/test_flat_json_predicate
@@ -89,6 +89,7 @@ select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
 -- !result
 select * from profile_filter_rows;
 -- result:
+- PredFilterRows: 996
 -- !result
 select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') = -1;
 -- result:
@@ -209,6 +210,8 @@ select * from js2 where get_json_int(j1, '$.f2') = -1;
 -- !result
 select * from profile_filter_rows;
 -- result:
+- ZoneMapIndexFilterRows: 1.000K (1000)
+- PredFilterRows: 1.000K (1000)
 -- !result
 select * from js2 where get_json_int(j1, '$.f2') = 1;
 -- result:
@@ -235,6 +238,7 @@ select * from js2 where get_json_int(j1, '$.f2') in (1, 2, 3, 4);
 -- !result
 select * from profile_filter_rows;
 -- result:
+- PredFilterRows: 1.996K (1996)
 -- !result
 select get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f2') = 1;
 -- result:
@@ -323,4 +327,84 @@ from (table(generate_series(1, 1000)));
 select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
 -- result:
 500
+-- !result
+select count(*) from js3 where get_json_int(j1, 'f_bool') = 1;
+-- result:
+500
+-- !result
+select count(*) from js3 where get_json_string(j1, 'f_bool') = '1';
+-- result:
+0
+-- !result
+select count(*) from js3 where get_json_string(j1, 'f_bool') = 'true';
+-- result:
+500
+-- !result
+select count(*) from js3 where get_json_string(j1, 'f_bool') = 'false';
+-- result:
+500
+-- !result
+select count(*) from js3 where get_json_string(j1, 'f_bool') = 'none';
+-- result:
+0
+-- !result
+select count(*) from js3 where get_json_double(j1, 'f_bool') = 1.0;
+-- result:
+500
+-- !result
+select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
+-- result:
+499
+-- !result
+select count(*) from js3 where get_json_bool(j1, 'f_int') = true;
+-- result:
+1000
+-- !result
+select count(*) from js3 where get_json_string(j1, 'f_int') < 500;
+-- result:
+499
+-- !result
+select count(*) from js3 where get_json_double(j1, 'f_int') < 500;
+-- result:
+499
+-- !result
+select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;
+-- result:
+499
+-- !result
+select count(*) from js3 where get_json_bool(j1, 'f_double') = true;
+-- result:
+1000
+-- !result
+select count(*) from js3 where get_json_int(j1, 'f_double') < 500;
+-- result:
+499
+-- !result
+select count(*) from js3 where get_json_string(j1, 'f_double') < '500';
+-- result:
+447
+-- !result
+select count(*) from js3 where get_json_int(j1, 'f_none') IS NULL;
+-- result:
+2000
+-- !result
+select count(*) from js3 where get_json_int(j1, 'f_none') IS NOT NULL;
+-- result:
+0
+-- !result
+select count(*) from js3 where get_json_int(j1, 'f_none') < 500;
+-- result:
+0
+-- !result
+select count(*) from js3 where get_json_bool(j1, 'f_none') = true;
+-- result:
+0
+-- !result
+select count(*) from js3 where get_json_string(j1, 'f_none') < 500;
+-- result:
+0
+-- !result
+select count(*) from js3 where get_json_double(j1, 'f_none') < 500;
+-- result:
+0
 -- !result

--- a/test/sql/test_semi/R/test_flat_json_predicate
+++ b/test/sql/test_semi/R/test_flat_json_predicate
@@ -20,6 +20,9 @@ PROPERTIES ( "replication_num" = "1" );
 set enable_profile = true;
 -- result:
 -- !result
+set enable_async_profile = false;
+-- result:
+-- !result
 set cbo_json_v2_rewrite = true;
 -- result:
 -- !result
@@ -33,14 +36,14 @@ order by unnest;
 create view profile_filter_rows as
 select trim(unnest) 
 from table(unnest(split(get_query_profile(last_query_id()), '\n')))
-where unnest like '%FilterRows%' AND CAST(REGEXP_EXTRACT(unnest, '(\\d+)', 1) AS INT) != 0
+where unnest like '%FilterRows%'
 order by unnest;
 -- result:
 -- !result
 create view profile_dict as
 select trim(unnest) 
 from table(unnest(split(get_query_profile(last_query_id()), '\n')))
-where unnest like '%DictDecodeCount%' AND CAST(REGEXP_EXTRACT(unnest, '(\\d+)', 1) AS INT) != 0
+where unnest like '%DictDecodeCount%'
 order by unnest;
 -- result:
 -- !result
@@ -63,7 +66,16 @@ select * from js2 where get_json_int(j1, '$.f1') = -1;
 -- !result
 select * from profile_filter_rows;
 -- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
 - ZoneMapIndexFilterRows: 1.000K (1000)
+- DelVecFilterRows: 0
+- PredFilterRows: 0
 -- !result
 select * from js2 where get_json_int(j1, '$.f1') = 1;
 -- result:
@@ -71,6 +83,16 @@ select * from js2 where get_json_int(j1, '$.f1') = 1;
 -- !result
 select * from profile_filter_rows;
 -- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 0
+- DelVecFilterRows: 0
+- PredFilterRows: 999
 -- !result
 select * from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1') = 2;
 -- result:
@@ -79,6 +101,16 @@ select * from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1')
 -- !result
 select * from profile_filter_rows;
 -- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 0
+- DelVecFilterRows: 0
+- PredFilterRows: 998
 -- !result
 select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
 -- result:
@@ -89,6 +121,15 @@ select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
 -- !result
 select * from profile_filter_rows;
 -- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 0
+- DelVecFilterRows: 0
 - PredFilterRows: 996
 -- !result
 select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') = -1;
@@ -123,6 +164,9 @@ select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') = 1;
 -- !result
 select * from profile_access_path;
 -- result:
+- AccessPathExtract: 1
+- AccessPathHits: 3
+- PushdownAccessPaths: 1
 -- !result
 select get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f1') = 1;
 -- result:
@@ -130,6 +174,9 @@ None
 -- !result
 select * from profile_access_path;
 -- result:
+- AccessPathExtract: 2
+- AccessPathHits: 4
+- PushdownAccessPaths: 2
 -- !result
 select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f2') = 1;
 -- result:
@@ -137,6 +184,9 @@ None
 -- !result
 select * from profile_access_path;
 -- result:
+- AccessPathExtract: 2
+- AccessPathHits: 4
+- PushdownAccessPaths: 2
 -- !result
 select get_json_int(j1, '$.f2'), j1 from js2 where get_json_int(j1, '$.f1') = 1;
 -- result:
@@ -144,12 +194,18 @@ None	{"f1": 1}
 -- !result
 select * from profile_access_path;
 -- result:
+- AccessPathExtract: 2
+- AccessPathHits: 4
+- PushdownAccessPaths: 2
 -- !result
 select get_json_int(j1, '$.f2'), j1 from js2 where get_json_int(j1, '$.f3') = 1;
 -- result:
 -- !result
 select * from profile_access_path;
 -- result:
+- AccessPathExtract: 3
+- AccessPathHits: 5
+- PushdownAccessPaths: 2
 -- !result
 select get_json_int(j1, '$.f2'), get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f1') = 1;
 -- result:
@@ -157,6 +213,9 @@ None	None
 -- !result
 select * from profile_access_path;
 -- result:
+- AccessPathExtract: 2
+- AccessPathHits: 4
+- PushdownAccessPaths: 2
 -- !result
 select count(get_json_int(j1, '$.f2')) from js2 ;
 -- result:
@@ -164,6 +223,9 @@ select count(get_json_int(j1, '$.f2')) from js2 ;
 -- !result
 select * from profile_access_path;
 -- result:
+- AccessPathExtract: 1
+- AccessPathHits: 3
+- PushdownAccessPaths: 1
 -- !result
 select count(get_json_int(j1, '$.f3')) from js2 ;
 -- result:
@@ -171,13 +233,24 @@ select count(get_json_int(j1, '$.f3')) from js2 ;
 -- !result
 select * from profile_access_path;
 -- result:
+- AccessPathExtract: 2
+- AccessPathHits: 4
+- PushdownAccessPaths: 1
 -- !result
 select * from js2 where get_json_int(j1, '$.f1') = -1;
 -- result:
 -- !result
 select * from profile_filter_rows;
 -- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
 - ZoneMapIndexFilterRows: 1.000K (1000)
+- DelVecFilterRows: 0
 - PredFilterRows: 1.000K (1000)
 -- !result
 select * from js2 where get_json_int(j1, '$.f1') = 1;
@@ -186,6 +259,16 @@ select * from js2 where get_json_int(j1, '$.f1') = 1;
 -- !result
 select * from profile_filter_rows;
 -- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 0
+- DelVecFilterRows: 0
+- PredFilterRows: 1.999K (1999)
 -- !result
 select * from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1') = 2;
 -- result:
@@ -194,6 +277,16 @@ select * from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1')
 -- !result
 select * from profile_filter_rows;
 -- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 0
+- DelVecFilterRows: 0
+- PredFilterRows: 1.998K (1998)
 -- !result
 select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
 -- result:
@@ -204,13 +297,31 @@ select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
 -- !result
 select * from profile_filter_rows;
 -- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 0
+- DelVecFilterRows: 0
+- PredFilterRows: 1.996K (1996)
 -- !result
 select * from js2 where get_json_int(j1, '$.f2') = -1;
 -- result:
 -- !result
 select * from profile_filter_rows;
 -- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
 - ZoneMapIndexFilterRows: 1.000K (1000)
+- DelVecFilterRows: 0
 - PredFilterRows: 1.000K (1000)
 -- !result
 select * from js2 where get_json_int(j1, '$.f2') = 1;
@@ -219,6 +330,16 @@ select * from js2 where get_json_int(j1, '$.f2') = 1;
 -- !result
 select * from profile_filter_rows;
 -- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 0
+- DelVecFilterRows: 0
+- PredFilterRows: 1.999K (1999)
 -- !result
 select * from js2 where get_json_int(j1, '$.f2') = 1 or get_json_int(j1, '$.f2') = 2;
 -- result:
@@ -227,6 +348,15 @@ select * from js2 where get_json_int(j1, '$.f2') = 1 or get_json_int(j1, '$.f2')
 -- !result
 select * from profile_filter_rows;
 -- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 0
+- DelVecFilterRows: 0
 - PredFilterRows: 1.998K (1998)
 -- !result
 select * from js2 where get_json_int(j1, '$.f2') in (1, 2, 3, 4);
@@ -238,6 +368,15 @@ select * from js2 where get_json_int(j1, '$.f2') in (1, 2, 3, 4);
 -- !result
 select * from profile_filter_rows;
 -- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 0
+- DelVecFilterRows: 0
 - PredFilterRows: 1.996K (1996)
 -- !result
 select get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f2') = 1;
@@ -277,6 +416,7 @@ select count(v1) from js3 where get_json_string(j1, 'f1') = 'a0';
 -- !result
 select * from profile_dict;
 -- result:
+- DictDecodeCount: 0
 -- !result
 select count(v1) from js3 where get_json_string(j1, 'f1') = 'a10';
 -- result:
@@ -291,6 +431,7 @@ select count(get_json_string(j1, 'f1')) from js3 where get_json_string(j1, 'f1')
 -- !result
 select * from profile_dict;
 -- result:
+- DictDecodeCount: 100
 -- !result
 select count(get_Json_string(j1, 'f1')) from js3 where get_json_string(j1, 'f1') = 'a10';
 -- result:
@@ -312,6 +453,15 @@ select count(get_json_int(j1, '$.f2')) from js2 where get_json_int(j1, '$.f1') <
 -- !result
 select * from profile_late_materialize;
 -- result:
+- LateMaterializeRows: 198
+-- !result
+select count(get_json_int(j1, '$.f2')) from js2 where get_json_int(j1, '$.f1') < 200;
+-- result:
+199
+-- !result
+select * from profile_late_materialize;
+-- result:
+- LateMaterializeRows: 398
 -- !result
 insert into js3
 select generate_series, json_object(
@@ -352,6 +502,12 @@ select count(*) from js3 where get_json_double(j1, 'f_bool') = 1.0;
 -- result:
 500
 -- !result
+select * from profile_access_path;
+-- result:
+- AccessPathExtract: 1
+- AccessPathHits: 3
+- PushdownAccessPaths: 1
+-- !result
 select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
 -- result:
 499
@@ -368,6 +524,12 @@ select count(*) from js3 where get_json_double(j1, 'f_int') < 500;
 -- result:
 499
 -- !result
+select * from profile_access_path;
+-- result:
+- AccessPathExtract: 1
+- AccessPathHits: 3
+- PushdownAccessPaths: 1
+-- !result
 select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;
 -- result:
 499
@@ -383,6 +545,12 @@ select count(*) from js3 where get_json_int(j1, 'f_double') < 500;
 select count(*) from js3 where get_json_string(j1, 'f_double') < '500';
 -- result:
 447
+-- !result
+select * from profile_access_path;
+-- result:
+- AccessPathExtract: 1
+- AccessPathHits: 3
+- PushdownAccessPaths: 1
 -- !result
 select count(*) from js3 where get_json_int(j1, 'f_none') IS NULL;
 -- result:
@@ -407,4 +575,10 @@ select count(*) from js3 where get_json_string(j1, 'f_none') < 500;
 select count(*) from js3 where get_json_double(j1, 'f_none') < 500;
 -- result:
 0
+-- !result
+select * from profile_access_path;
+-- result:
+- AccessPathExtract: 2
+- AccessPathHits: 4
+- PushdownAccessPaths: 1
 -- !result

--- a/test/sql/test_semi/R/test_flat_json_predicate
+++ b/test/sql/test_semi/R/test_flat_json_predicate
@@ -135,7 +135,6 @@ select * from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1')
 -- !result
 select * from profile_filter_rows;
 -- result:
-- PredFilterRows: 1.998K (1998)
 -- !result
 select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
 -- result:
@@ -218,28 +217,4 @@ select count(*) from js3 where get_json_string(j1, 'f1') = 'a0';
 -- !result
 select * from profile_dict;
 -- result:
--- !result
-insert into js3
-select generate_series, json_object(
-        'f_bool', cast(generate_series % 2 = 0 as boolean),
-        'f_int', generate_series,
-        'f_int1', generate_series,
-        'f_int2', generate_series,
-        -- 'f_double', cast(generate_series as double) * 1.0
-        )
-from (table(generate_series(1, 10000)));
--- result:
-E: (1064, "Getting syntax error at line 8, column 8. Detail message: Unexpected input ')', the most similar input is {a legal identifier}.")
--- !result
-select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
--- result:
-0
--- !result
-select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
--- result:
-0
--- !result
-select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;
--- result:
-0
 -- !result

--- a/test/sql/test_semi/T/test_flat_json_predicate
+++ b/test/sql/test_semi/T/test_flat_json_predicate
@@ -108,16 +108,16 @@ select count(*) from js3 where get_json_string(j1, 'f1') = 'a0';
 select * from profile_dict;
 
 -- various types
-insert into js3
-select generate_series, json_object(
-        'f_bool', cast(generate_series % 2 = 0 as boolean),
-        'f_int', generate_series,
-        'f_int1', generate_series,
-        'f_int2', generate_series,
-        'f_double', cast(generate_series as double) * 1.0
-        )
-from (table(generate_series(1, 1000)));
+-- insert into js3
+-- select generate_series, json_object(
+--         'f_bool', cast(generate_series % 2 = 0 as boolean),
+--         'f_int', generate_series,
+--         'f_int1', generate_series,
+--         'f_int2', generate_series,
+--         'f_double', cast(generate_series as double) * 1.0
+--         )
+-- from (table(generate_series(1, 1000)));
 
-select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
-select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
-select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;
+-- select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
+-- select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
+-- select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;

--- a/test/sql/test_semi/T/test_flat_json_predicate
+++ b/test/sql/test_semi/T/test_flat_json_predicate
@@ -19,6 +19,7 @@ PROPERTIES ( "replication_num" = "1" );
 
 -- setup variables
 set enable_profile = true;
+set enable_async_profile = false;
 set cbo_json_v2_rewrite = true;
 
 
@@ -32,13 +33,13 @@ order by unnest;
 create view profile_filter_rows as
 select trim(unnest) 
 from table(unnest(split(get_query_profile(last_query_id()), '\n')))
-where unnest like '%FilterRows%' AND CAST(REGEXP_EXTRACT(unnest, '(\\d+)', 1) AS INT) != 0
+where unnest like '%FilterRows%'
 order by unnest;
 
 create view profile_dict as
 select trim(unnest) 
 from table(unnest(split(get_query_profile(last_query_id()), '\n')))
-where unnest like '%DictDecodeCount%' AND CAST(REGEXP_EXTRACT(unnest, '(\\d+)', 1) AS INT) != 0
+where unnest like '%DictDecodeCount%'
 order by unnest;
 
 create view profile_access_path as
@@ -146,6 +147,8 @@ from (table(generate_series(1, 1000)));
 
 select count(get_json_int(j1, '$.f2')) from js2 where get_json_int(j1, '$.f1') < 100;
 select * from profile_late_materialize;
+select count(get_json_int(j1, '$.f2')) from js2 where get_json_int(j1, '$.f1') < 200;
+select * from profile_late_materialize;
 
 
 -- various types
@@ -167,16 +170,19 @@ select count(*) from js3 where get_json_string(j1, 'f_bool') = 'true';
 select count(*) from js3 where get_json_string(j1, 'f_bool') = 'false';
 select count(*) from js3 where get_json_string(j1, 'f_bool') = 'none';
 select count(*) from js3 where get_json_double(j1, 'f_bool') = 1.0;
+select * from profile_access_path;
 
 select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
 select count(*) from js3 where get_json_bool(j1, 'f_int') = true;
 select count(*) from js3 where get_json_string(j1, 'f_int') < 500;
 select count(*) from js3 where get_json_double(j1, 'f_int') < 500;
+select * from profile_access_path;
 
 select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;
 select count(*) from js3 where get_json_bool(j1, 'f_double') = true;
 select count(*) from js3 where get_json_int(j1, 'f_double') < 500;
 select count(*) from js3 where get_json_string(j1, 'f_double') < '500';
+select * from profile_access_path;
 
 select count(*) from js3 where get_json_int(j1, 'f_none') IS NULL;
 select count(*) from js3 where get_json_int(j1, 'f_none') IS NOT NULL;
@@ -184,3 +190,4 @@ select count(*) from js3 where get_json_int(j1, 'f_none') < 500;
 select count(*) from js3 where get_json_bool(j1, 'f_none') = true;
 select count(*) from js3 where get_json_string(j1, 'f_none') < 500;
 select count(*) from js3 where get_json_double(j1, 'f_none') < 500;
+select * from profile_access_path;

--- a/test/sql/test_semi/T/test_flat_json_predicate
+++ b/test/sql/test_semi/T/test_flat_json_predicate
@@ -151,7 +151,7 @@ select * from profile_late_materialize;
 -- various types
 insert into js3
 select generate_series, json_object(
-        -- 'f_bool', cast(generate_series % 2 = 0 as boolean),
+        'f_bool', cast(generate_series % 2 = 0 as boolean),
         'f_int', generate_series,
         'f_int1', generate_series,
         'f_int2', generate_series,
@@ -159,8 +159,8 @@ select generate_series, json_object(
         )
 from (table(generate_series(1, 1000)));
 
--- select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
-select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
-select count(*) from js3 where get_json_int(j1, 'f_int1') < 500;
-select count(*) from js3 where get_json_int(j1, 'f_int2') < 500;
-select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;
+select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
+-- select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
+-- select count(*) from js3 where get_json_int(j1, 'f_int1') < 500;
+-- select count(*) from js3 where get_json_int(j1, 'f_int2') < 500;
+-- select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;

--- a/test/sql/test_semi/T/test_flat_json_predicate
+++ b/test/sql/test_semi/T/test_flat_json_predicate
@@ -159,8 +159,28 @@ select generate_series, json_object(
         )
 from (table(generate_series(1, 1000)));
 
+-- unmatched type
 select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
--- select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
--- select count(*) from js3 where get_json_int(j1, 'f_int1') < 500;
--- select count(*) from js3 where get_json_int(j1, 'f_int2') < 500;
--- select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;
+select count(*) from js3 where get_json_int(j1, 'f_bool') = 1;
+select count(*) from js3 where get_json_string(j1, 'f_bool') = '1';
+select count(*) from js3 where get_json_string(j1, 'f_bool') = 'true';
+select count(*) from js3 where get_json_string(j1, 'f_bool') = 'false';
+select count(*) from js3 where get_json_string(j1, 'f_bool') = 'none';
+select count(*) from js3 where get_json_double(j1, 'f_bool') = 1.0;
+
+select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
+select count(*) from js3 where get_json_bool(j1, 'f_int') = true;
+select count(*) from js3 where get_json_string(j1, 'f_int') < 500;
+select count(*) from js3 where get_json_double(j1, 'f_int') < 500;
+
+select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;
+select count(*) from js3 where get_json_bool(j1, 'f_double') = true;
+select count(*) from js3 where get_json_int(j1, 'f_double') < 500;
+select count(*) from js3 where get_json_string(j1, 'f_double') < '500';
+
+select count(*) from js3 where get_json_int(j1, 'f_none') IS NULL;
+select count(*) from js3 where get_json_int(j1, 'f_none') IS NOT NULL;
+select count(*) from js3 where get_json_int(j1, 'f_none') < 500;
+select count(*) from js3 where get_json_bool(j1, 'f_none') = true;
+select count(*) from js3 where get_json_string(j1, 'f_none') < 500;
+select count(*) from js3 where get_json_double(j1, 'f_none') < 500;

--- a/test/sql/test_semi/T/test_flat_json_predicate
+++ b/test/sql/test_semi/T/test_flat_json_predicate
@@ -17,13 +17,16 @@ DISTRIBUTED BY HASH(`v1`) BUCKETS 1
 PROPERTIES ( "replication_num" = "1" );
 
 
+-- setup variables
 set enable_profile = true;
 set cbo_json_v2_rewrite = true;
 
+
+-- profile checker
 create view profile_late_materialize as
 select trim(unnest) 
 from table(unnest(split(get_query_profile(last_query_id()), '\n')))
-where unnest like '%LateMaterialize%' 
+where unnest like '%LateMaterializeRows%' 
 order by unnest;
 
 create view profile_filter_rows as
@@ -39,7 +42,7 @@ where unnest like '%DictDecodeCount%' AND CAST(REGEXP_EXTRACT(unnest, '(\\d+)', 
 order by unnest;
 
 
--- integer type
+-- integer type: zonemap index
 
 insert into js2 
 select 
@@ -85,6 +88,25 @@ select * from profile_filter_rows;
 select * from js2 where get_json_int(j1, '$.f2') in (1, 2, 3, 4);
 select * from profile_filter_rows;
 
+-- string type: Dict Decode
+insert into js3
+select 
+    generate_series, 
+    json_object('f1', concat('a', generate_series%10))
+from (table(generate_series(1, 1000)));
+
+-- No need to decode dict
+select count(v1) from js3 where get_json_string(j1, 'f1') = 'a0';
+select * from profile_dict;
+select count(v1) from js3 where get_json_string(j1, 'f1') = 'a10';
+select * from profile_dict;
+
+-- Need to decode dict
+select count(get_json_string(j1, 'f1')) from js3 where get_json_string(j1, 'f1') = 'a0';
+select * from profile_dict;
+select count(get_Json_string(j1, 'f1')) from js3 where get_json_string(j1, 'f1') = 'a10';
+select * from profile_dict;
+
 -- late materialization
 insert into js2 
 select 
@@ -95,29 +117,18 @@ from (table(generate_series(1, 1000)));
 select count(get_json_int(j1, '$.f2')) from js2 where get_json_int(j1, '$.f1') < 100;
 select * from profile_late_materialize;
 
--- string type: Dict Decode
-insert into js3
-select 
-    generate_series, 
-    json_object('f1', concat('a', generate_series%10))
-from (table(generate_series(1, 1000)));
-
-select count(*) from js3 where get_json_string(j1, 'f1') = 'a0';
-select * from profile_dict;
-select count(*) from js3 where get_json_string(j1, 'f1') = 'a0';
-select * from profile_dict;
 
 -- various types
--- insert into js3
--- select generate_series, json_object(
---         'f_bool', cast(generate_series % 2 = 0 as boolean),
---         'f_int', generate_series,
---         'f_int1', generate_series,
---         'f_int2', generate_series,
---         'f_double', cast(generate_series as double) * 1.0
---         )
--- from (table(generate_series(1, 1000)));
+insert into js3
+select generate_series, json_object(
+        -- 'f_bool', cast(generate_series % 2 = 0 as boolean),
+        'f_int', generate_series,
+        'f_int1', generate_series,
+        'f_int2', generate_series,
+        'f_double', cast(generate_series as double) * 1.0
+        )
+from (table(generate_series(1, 1000)));
 
--- select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
+select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
 -- select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
 -- select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;

--- a/test/sql/test_semi/T/test_flat_json_predicate
+++ b/test/sql/test_semi/T/test_flat_json_predicate
@@ -1,0 +1,123 @@
+-- name: test_normal_flat_json_predicate @system
+
+CREATE TABLE js2 (
+    v1 BIGINT NULL,
+    j1 JSON NULL
+)
+DUPLICATE KEY (v1)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1
+PROPERTIES ( "replication_num" = "1" );
+
+CREATE TABLE js3 (
+    v1 BIGINT NULL,
+    j1 JSON NULL
+)
+DUPLICATE KEY (v1)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1
+PROPERTIES ( "replication_num" = "1" );
+
+
+set enable_profile = true;
+set cbo_json_v2_rewrite = true;
+
+create view profile_late_materialize as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%LateMaterialize%' 
+order by unnest;
+
+create view profile_filter_rows as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%FilterRows%' AND CAST(REGEXP_EXTRACT(unnest, '(\\d+)', 1) AS INT) != 0
+order by unnest;
+
+create view profile_dict as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%DictDecodeCount%' AND CAST(REGEXP_EXTRACT(unnest, '(\\d+)', 1) AS INT) != 0
+order by unnest;
+
+
+-- integer type
+
+insert into js2 
+select 
+    generate_series, 
+    json_object('f1', generate_series)
+from (table(generate_series(1, 1000)));
+
+select * from js2 where get_json_int(j1, '$.f1') = -1;
+select * from profile_filter_rows;
+select * from js2 where get_json_int(j1, '$.f1') = 1;
+select * from profile_filter_rows;
+select * from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1') = 2;
+select * from profile_filter_rows;
+select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
+select * from profile_filter_rows;
+select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') = -1;
+select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') = 1;
+select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1') = 2;
+select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
+
+insert into js2 
+select 
+    generate_series, 
+    json_object('f2', generate_series)
+from (table(generate_series(1, 1000)));
+
+select * from js2 where get_json_int(j1, '$.f1') = -1;
+select * from profile_filter_rows;
+select * from js2 where get_json_int(j1, '$.f1') = 1;
+select * from profile_filter_rows;
+select * from js2 where get_json_int(j1, '$.f1') = 1 or get_json_int(j1, '$.f1') = 2;
+select * from profile_filter_rows;
+select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
+select * from profile_filter_rows;
+
+
+select * from js2 where get_json_int(j1, '$.f2') = -1;
+select * from profile_filter_rows;
+select * from js2 where get_json_int(j1, '$.f2') = 1;
+select * from profile_filter_rows;
+select * from js2 where get_json_int(j1, '$.f2') = 1 or get_json_int(j1, '$.f2') = 2;
+select * from profile_filter_rows;
+select * from js2 where get_json_int(j1, '$.f2') in (1, 2, 3, 4);
+select * from profile_filter_rows;
+
+-- late materialization
+insert into js2 
+select 
+    generate_series, 
+    json_object('f1', generate_series, 'f2', generate_series)
+from (table(generate_series(1, 1000)));
+
+select count(get_json_int(j1, '$.f2')) from js2 where get_json_int(j1, '$.f1') < 100;
+select * from profile_late_materialize;
+
+-- string type: Dict Decode
+insert into js3
+select 
+    generate_series, 
+    json_object('f1', concat('a', generate_series%10))
+from (table(generate_series(1, 1000)));
+
+select count(*) from js3 where get_json_string(j1, 'f1') = 'a0';
+select * from profile_dict;
+select count(*) from js3 where get_json_string(j1, 'f1') = 'a0';
+select * from profile_dict;
+
+-- various types
+insert into js3
+select generate_series, json_object(
+        'f_bool', cast(generate_series % 2 = 0 as boolean),
+        'f_int', generate_series,
+        'f_int1', generate_series,
+        'f_int2', generate_series,
+        'f_double', cast(generate_series as double) * 1.0
+        )
+from (table(generate_series(1, 1000)));
+
+select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
+select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
+select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;

--- a/test/sql/test_semi/T/test_flat_json_predicate
+++ b/test/sql/test_semi/T/test_flat_json_predicate
@@ -22,7 +22,7 @@ set enable_profile = true;
 set cbo_json_v2_rewrite = true;
 
 
--- profile checker
+-- profile checkers
 create view profile_late_materialize as
 select trim(unnest) 
 from table(unnest(split(get_query_profile(last_query_id()), '\n')))
@@ -41,6 +41,11 @@ from table(unnest(split(get_query_profile(last_query_id()), '\n')))
 where unnest like '%DictDecodeCount%' AND CAST(REGEXP_EXTRACT(unnest, '(\\d+)', 1) AS INT) != 0
 order by unnest;
 
+create view profile_access_path as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%AccessPath%'
+order by unnest;
 
 -- integer type: zonemap index
 
@@ -69,6 +74,24 @@ select
     json_object('f2', generate_series)
 from (table(generate_series(1, 1000)));
 
+-- use various iterators
+select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f1') = 1;
+select * from profile_access_path;
+select get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f1') = 1;
+select * from profile_access_path;
+select get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f2') = 1;
+select * from profile_access_path;
+select get_json_int(j1, '$.f2'), j1 from js2 where get_json_int(j1, '$.f1') = 1;
+select * from profile_access_path;
+select get_json_int(j1, '$.f2'), j1 from js2 where get_json_int(j1, '$.f3') = 1;
+select * from profile_access_path;
+select get_json_int(j1, '$.f2'), get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f1') = 1;
+select * from profile_access_path;
+select count(get_json_int(j1, '$.f2')) from js2 ;
+select * from profile_access_path;
+select count(get_json_int(j1, '$.f3')) from js2 ;
+select * from profile_access_path;
+
 select * from js2 where get_json_int(j1, '$.f1') = -1;
 select * from profile_filter_rows;
 select * from js2 where get_json_int(j1, '$.f1') = 1;
@@ -78,7 +101,6 @@ select * from profile_filter_rows;
 select * from js2 where get_json_int(j1, '$.f1') in (1, 2, 3, 4);
 select * from profile_filter_rows;
 
-
 select * from js2 where get_json_int(j1, '$.f2') = -1;
 select * from profile_filter_rows;
 select * from js2 where get_json_int(j1, '$.f2') = 1;
@@ -87,6 +109,14 @@ select * from js2 where get_json_int(j1, '$.f2') = 1 or get_json_int(j1, '$.f2')
 select * from profile_filter_rows;
 select * from js2 where get_json_int(j1, '$.f2') in (1, 2, 3, 4);
 select * from profile_filter_rows;
+
+-- different projection and predicate
+select get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f2') = 1;
+select get_json_int(j1, '$.f1'), get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f2') = 1;
+select get_json_int(j1, '$.f1'), get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f2') = 1;
+select get_json_int(j1, '$.f1'), get_json_int(j1, '$.f2'), get_json_int(j1, '$.f1') from js2 where get_json_int(j1, '$.f2') = 1;
+select j1, get_json_int(j1, '$.f2') from js2 where get_json_int(j1, '$.f2') = 1;
+select j1 from js2 where get_json_int(j1, '$.f2') = 1;
 
 -- string type: Dict Decode
 insert into js3
@@ -129,6 +159,8 @@ select generate_series, json_object(
         )
 from (table(generate_series(1, 1000)));
 
-select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
--- select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
--- select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;
+-- select count(*) from js3 where get_json_bool(j1, 'f_bool') = true;
+select count(*) from js3 where get_json_int(j1, 'f_int') < 500;
+select count(*) from js3 where get_json_int(j1, 'f_int1') < 500;
+select count(*) from js3 where get_json_int(j1, 'f_int2') < 500;
+select count(*) from js3 where get_json_double(j1, 'f_double') < 500.0;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #60953


### Benefits
- Treats JSON subfields as first-class columns
- Enables predicate pushdown on JSON subfields
- Enables zonemap/late materialization like storage techniques for JSON subfields

### Idea


1. The optimizer rule `JsonPathRewriteRule` transforms SQL queries into a simplified format while capturing `ExtendedColumn` details in `ColumnAccessPath`.  
   - **Before Optimization:** `SELECT * FROM table WHERE get_json_int(json_col, '$.field1') > 100;`  
   - **After Optimization (Internal):** `SELECT * FROM table WHERE json_col.field1 > 100;`  

2. To identify the column `json_col.field1`, the backend modifies the `TabletSchema` during query execution, enabling it to resolve the extended column.  

3. A new `JsonExtractIterator` is introduced to handle JSON field extraction based on the specified path.  

### Backend
New JSON Column Iterator Framework (`be/src/storage/rowset/json_column_iterator.h/.cpp`)
- **`create_json_flat_iterator()`**  
  Flattens JSON columns into subfields (materializes nested fields).
- **`create_json_dynamic_flat_iterator()`**  
  Performs on-the-fly flattening at read time.
- **`create_json_merge_iterator()`**  
  Reconstructs JSON objects from subfields.
- **`create_json_extract_iterator()`**  
  Extracts specific JSON subfields directly without reconstructing full JSON.

Column Access Path Enhancements (`be/src/column/column_access_path.h/.cpp`)
- Extended `ColumnAccessPath` with JSON-specific capabilities:
  - Linear JSON path representation (`a.b.c`)
  - Type information for JSON subfields

Storage Layer Optimizations
- Segment and iterator enhancements for JSON-aware processing
- Predicate parsing and rewriting support for JSON paths
- Updated column predicate rewriter to optimize JSON filters


### Frontend

JSON Path Rewrite Rule  
`fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java`

- Rewrites JSON function calls into direct column/subfield access:
  - Example:  
    ```
    get_json_string(c1, '$.f1') = 1
    ```
    rewrites to:
    ```
    c1.f1 = 1
    ```
- Supports multiple JSON functions:
  - `get_json_int`, `get_json_string`, `get_json_double`, etc.

Column Access Path Integration
- New `ColumnAccessPath` class to represent complex column/subfield access patterns
- Integrated into:
  - Query optimizer
  - `PhysicalOlapScanOperator` / `PhysicalScanOperator`
  - `DescriptorTable` for mapping JSON paths



 ### Configurable Behavior
- Added session variable `enableJSONV2Rewrite` to control JSON path rewrite


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
