### PR TITLE
[UT] fix junit4 in OuterJoinEliminationRuleTest.java

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/OuterJoinEliminationRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/OuterJoinEliminationRuleTest.java
@@ -31,8 +31,8 @@ public class OuterJoinEliminationRuleTest extends PlanTestBase {
     }
 
     @AfterAll
-    public static void afterClass() throws Exception {
-        PlanTestBase.afterAll();
+    public static void afterClass() {
+        PlanTestBase.afterClass();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/OuterJoinEliminationRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/OuterJoinEliminationRuleTest.java
@@ -15,23 +15,23 @@
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.starrocks.sql.plan.PlanTestBase;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for OuterJoinEliminationRule.
  */
 public class OuterJoinEliminationRuleTest extends PlanTestBase {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeAll();
     }
 
-    @AfterClass
-    public static void afterAll() throws Exception {
+    @AfterAll
+    public static void afterClass() throws Exception {
         PlanTestBase.afterAll();
     }
 
@@ -39,90 +39,90 @@ public class OuterJoinEliminationRuleTest extends PlanTestBase {
     public void testLeftJoinCanBeConvertedToInner() throws Exception {
         String sql = "SELECT * FROM join1 LEFT JOIN join2 ON join1.id = join2.id WHERE join2.id > 1";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("INNER JOIN"));
+        Assertions.assertTrue(plan.contains("INNER JOIN"));
     }
 
     @Test
     public void testRightJoinCanBeConvertedToInner() throws Exception {
         String sql = "SELECT * FROM join1 RIGHT JOIN join2 ON join1.id = join2.id WHERE join1.id > 1";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("INNER JOIN"));
+        Assertions.assertTrue(plan.contains("INNER JOIN"));
     }
 
     @Test
     public void testFullOuterJoinCanBeConvertedToInner() throws Exception {
         String sql = "SELECT * FROM join1 FULL OUTER JOIN join2 ON join1.id = join2.id WHERE join1.id > 10 AND join2.id > 1";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("INNER JOIN"));
+        Assertions.assertTrue(plan.contains("INNER JOIN"));
     }
 
     @Test
     public void testNoEliminateLeftJoinIfFilterOnNull() throws Exception {
         String sql = "SELECT * FROM join1 LEFT JOIN join2 ON join1.id = join2.id WHERE join2.id IS NULL";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("LEFT OUTER JOIN"));
+        Assertions.assertTrue(plan.contains("LEFT OUTER JOIN"));
     }
 
     @Test
     public void testNoEliminateLeftJoinIfHasPostJoinFilterOnInnerTable() throws Exception {
         String sql = "SELECT MIN(join1.dt) FROM join1 LEFT JOIN join2 ON join1.id = join2.id AND join1.dt > join2.dt";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("TABLE: join2"));
+        Assertions.assertTrue(plan.contains("TABLE: join2"));
     }
 
     @Test
     public void testEliminateLeftJoinWithDuplicateInsensitiveAggregatesOnly() throws Exception {
         String sql = "SELECT MIN(join1.dt), MAX(join1.dt) FROM join1 LEFT JOIN join2 ON join1.id = join2.id";
         String plan = getFragmentPlan(sql);
-        Assert.assertFalse(plan.contains("TABLE: join2"));
+        Assertions.assertFalse(plan.contains("TABLE: join2"));
     }
 
     @Test
     public void testEliminateLeftJoinWithGroupByOnPreservedSide() throws Exception {
         String sql = "SELECT MIN(join1.dt) FROM join1 LEFT JOIN join2 ON join1.id = join2.id GROUP BY join1.id";
         String plan = getFragmentPlan(sql);
-        Assert.assertFalse(plan.contains("TABLE: join2"));
+        Assertions.assertFalse(plan.contains("TABLE: join2"));
     }
 
     @Test
     public void testNoEliminateLeftJoinIfReferencingInnerColumnsInSelect() throws Exception {
         String sql = "SELECT MIN(join2.dt) FROM join1 LEFT JOIN join2 ON join1.id = join2.id";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("TABLE: join2"));
+        Assertions.assertTrue(plan.contains("TABLE: join2"));
     }
 
     @Test
     public void testNoEliminateLeftJoinIfUsingDuplicateSensitiveAggregates() throws Exception {
         String sql = "SELECT SUM(join1.dt), AVG(join1.dt) FROM join1 LEFT JOIN join2 ON join1.id = join2.id";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("LEFT OUTER JOIN"));
+        Assertions.assertTrue(plan.contains("LEFT OUTER JOIN"));
     }
 
     @Test
     public void testEliminateRightJoinWithAggregateOnPreservedSide() throws Exception {
         String sql = "SELECT MIN(join2.dt) FROM join1 RIGHT JOIN join2 ON join1.id = join2.id";
         String plan = getFragmentPlan(sql);
-        Assert.assertFalse(plan.contains("TABLE: join1"));
+        Assertions.assertFalse(plan.contains("TABLE: join1"));
     }
 
     @Test
     public void testEliminateLeftJoinAndAddNotNullPredicateIfFKCanBeNull() throws Exception {
         String sql = "SELECT MIN(join1.dt) FROM join1 LEFT JOIN join2 ON join1.id = join2.id WHERE join1.id IS NOT NULL";
         String plan = getFragmentPlan(sql);
-        Assert.assertFalse(plan.contains("TABLE: join2"));
+        Assertions.assertFalse(plan.contains("TABLE: join2"));
     }
 
     @Test
     public void testNoEliminateLeftJoinIfHavingClauseReferencesInnerColumn() throws Exception {
         String sql = "SELECT COUNT(*) FROM join1 LEFT JOIN join2 ON join1.id = join2.id GROUP BY join2.id HAVING join2.id > 1";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("INNER JOIN"));
+        Assertions.assertTrue(plan.contains("INNER JOIN"));
     }
 
     @Test
     public void testNoEliminateLeftJoinIfJoinConditionIsNotStrictEquality() throws Exception {
         String sql = "SELECT MIN(join1.dt) FROM join1 LEFT JOIN join2 ON join1.id < join2.id";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("LEFT OUTER JOIN"));
+        Assertions.assertTrue(plan.contains("LEFT OUTER JOIN"));
     }
 }


### PR DESCRIPTION

## Why I'm doing:

The `OuterJoinEliminationRuleTest.java` file failed to compile because it was using JUnit 4 annotations and assertions, which are incompatible with the project's JUnit 5 requirement.

## What I'm doing:

Upgraded `fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/OuterJoinEliminationRuleTest.java` from JUnit 4 to JUnit 5. This involved updating imports, annotations (`@BeforeClass` to `@BeforeAll`, `@AfterClass` to `@AfterAll`), and assertion calls (`Assert` to `Assertions`).

Fixes #N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


---

[Open in Web](https://www.cursor.com/agents?id=bc-73c8bb65-e4a9-44ee-9d36-57789a921420) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-73c8bb65-e4a9-44ee-9d36-57789a921420)