### PR TITLE
[UT] Fix deprecated Long constructor usage in test classes

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/alter/MaterializedViewHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/MaterializedViewHandlerTest.java
@@ -136,7 +136,7 @@ public class MaterializedViewHandlerTest {
                                   @Injectable PhysicalPartition partition,
                                   @Injectable MaterializedIndex materializedIndex) {
         final String baseIndexName = "t1";
-        final Long baseIndexId = new Long(1);
+        final Long baseIndexId = Long.valueOf(1);
         new Expectations() {
             {
                 createMaterializedViewStmt.getBaseIndexName();

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreFileMappingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreFileMappingTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -47,16 +46,5 @@ public class RestoreFileMappingTest {
         IdChain val = fileMapping.get(key);
         assertNotNull(val);
         assertEquals(dest, val);
-
-        Long l1 = Long.valueOf(10005L);
-        Long l2 = Long.valueOf(10005L);
-        assertFalse(l1 == l2);
-        assertTrue(l1.equals(l2));
-
-        Long l3 = Long.valueOf(1L);
-        Long l4 = Long.valueOf(1L);
-        assertFalse(l3 == l4);
-        assertTrue(l3.equals(l4));
     }
-
 }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreFileMappingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreFileMappingTest.java
@@ -48,13 +48,13 @@ public class RestoreFileMappingTest {
         assertNotNull(val);
         assertEquals(dest, val);
 
-        Long l1 = new Long(10005L);
-        Long l2 = new Long(10005L);
+        Long l1 = Long.valueOf(10005L);
+        Long l2 = Long.valueOf(10005L);
         assertFalse(l1 == l2);
         assertTrue(l1.equals(l2));
 
-        Long l3 = new Long(1L);
-        Long l4 = new Long(1L);
+        Long l3 = Long.valueOf(1L);
+        Long l4 = Long.valueOf(1L);
         assertFalse(l3 == l4);
         assertTrue(l3.equals(l4));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ListComparatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ListComparatorTest.java
@@ -1,3 +1,20 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/util/ListComparatorTest.java
+
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -52,15 +69,15 @@ public class ListComparatorTest {
         // 1, 200, "bcd", 2000
         // 1, 200, "abc"
         List<Comparable> list1 = new LinkedList<Comparable>();
-        list1.add(new Long(1));
-        list1.add(new Long(200));
+        list1.add(Long.valueOf(1));
+        list1.add(Long.valueOf(200));
         list1.add("bcd");
-        list1.add(new Long(1000));
+        list1.add(Long.valueOf(1000));
         listCollection.add(list1);
 
         List<Comparable> list2 = new LinkedList<Comparable>();
-        list2.add(new Long(1));
-        list2.add(new Long(200));
+        list2.add(Long.valueOf(1));
+        list2.add(Long.valueOf(200));
         list2.add("abc");
         listCollection.add(list2);
 
@@ -76,15 +93,15 @@ public class ListComparatorTest {
         // 1, 200, "abc", 1000
         // 1, 200, "abc"
         List<Comparable> list1 = new LinkedList<Comparable>();
-        list1.add(new Long(1));
-        list1.add(new Long(200));
+        list1.add(Long.valueOf(1));
+        list1.add(Long.valueOf(200));
         list1.add("abc");
-        list1.add(new Long(1000));
+        list1.add(Long.valueOf(1000));
         listCollection.add(list1);
 
         List<Comparable> list2 = new LinkedList<Comparable>();
-        list2.add(new Long(1));
-        list2.add(new Long(200));
+        list2.add(Long.valueOf(1));
+        list2.add(Long.valueOf(200));
         list2.add("abc");
         listCollection.add(list2);
 
@@ -101,15 +118,15 @@ public class ListComparatorTest {
             // 1, 200, "abc", 2000
             // 1, 200, "abc", "bcd"
             List<Comparable> list1 = new LinkedList<Comparable>();
-            list1.add(new Long(1));
-            list1.add(new Long(200));
+            list1.add(Long.valueOf(1));
+            list1.add(Long.valueOf(200));
             list1.add("abc");
-            list1.add(new Long(2000));
+            list1.add(Long.valueOf(2000));
             listCollection.add(list1);
 
             List<Comparable> list2 = new LinkedList<Comparable>();
-            list2.add(new Long(1));
-            list2.add(new Long(200));
+            list2.add(Long.valueOf(1));
+            list2.add(Long.valueOf(200));
             list2.add("abc");
             list2.add("bcd");
             listCollection.add(list2);
@@ -126,15 +143,15 @@ public class ListComparatorTest {
         // 1, 200, "bb", 2000
         // 1, 300, "aa"
         List<Comparable> list1 = new LinkedList<Comparable>();
-        list1.add(new Long(1));
-        list1.add(new Long(200));
+        list1.add(Long.valueOf(1));
+        list1.add(Long.valueOf(200));
         list1.add("bb");
-        list1.add(new Long(1000));
+        list1.add(Long.valueOf(1000));
         listCollection.add(list1);
 
         List<Comparable> list2 = new LinkedList<Comparable>();
-        list2.add(new Long(1));
-        list2.add(new Long(300));
+        list2.add(Long.valueOf(1));
+        list2.add(Long.valueOf(300));
         list2.add("aa");
         listCollection.add(list2);
 
@@ -151,21 +168,21 @@ public class ListComparatorTest {
         // 1, 100, "aa"
         // 1, 300, "aa"
         List<Comparable> list1 = new LinkedList<Comparable>();
-        list1.add(new Long(1));
-        list1.add(new Long(200));
+        list1.add(Long.valueOf(1));
+        list1.add(Long.valueOf(200));
         list1.add("bb");
-        list1.add(new Long(1000));
+        list1.add(Long.valueOf(1000));
         listCollection.add(list1);
 
         List<Comparable> list2 = new LinkedList<Comparable>();
-        list2.add(new Long(1));
-        list2.add(new Long(100));
+        list2.add(Long.valueOf(1));
+        list2.add(Long.valueOf(100));
         list2.add("aa");
         listCollection.add(list2);
 
         List<Comparable> list3 = new LinkedList<Comparable>();
-        list3.add(new Long(1));
-        list3.add(new Long(300));
+        list3.add(Long.valueOf(1));
+        list3.add(Long.valueOf(300));
         list3.add("aa");
         listCollection.add(list3);
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -522,8 +522,8 @@ public class RoutineLoadJobTest {
         Deencapsulation.invoke(routineLoadJob, "updateNumOfData", 2L, 0L, 0L, 1L, 1L, false);
 
         Assertions.assertEquals(RoutineLoadJob.JobState.RUNNING, Deencapsulation.getField(routineLoadJob, "state"));
-        Assertions.assertEquals(new Long(0), Deencapsulation.getField(routineLoadJob, "currentErrorRows"));
-        Assertions.assertEquals(new Long(0), Deencapsulation.getField(routineLoadJob, "currentTotalRows"));
+        Assertions.assertEquals(Long.valueOf(0), Deencapsulation.getField(routineLoadJob, "currentErrorRows"));
+        Assertions.assertEquals(Long.valueOf(0), Deencapsulation.getField(routineLoadJob, "currentTotalRows"));
 
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SqlModeHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SqlModeHelperTest.java
@@ -28,13 +28,13 @@ public class SqlModeHelperTest {
     @Test
     public void testNormal() throws DdlException {
         String sqlMode = "PIPES_AS_CONCAT";
-        Assertions.assertEquals(new Long(2L), SqlModeHelper.encode(sqlMode));
+        Assertions.assertEquals(Long.valueOf(2L), SqlModeHelper.encode(sqlMode));
 
         sqlMode = "";
-        Assertions.assertEquals(new Long(0L), SqlModeHelper.encode(sqlMode));
+        Assertions.assertEquals(Long.valueOf(0L), SqlModeHelper.encode(sqlMode));
 
         sqlMode = "0,1, PIPES_AS_CONCAT";
-        Assertions.assertEquals(new Long(3L), SqlModeHelper.encode(sqlMode));
+        Assertions.assertEquals(Long.valueOf(3L), SqlModeHelper.encode(sqlMode));
 
         long sqlModeValue = 2L;
         Assertions.assertEquals("PIPES_AS_CONCAT", SqlModeHelper.decode(sqlModeValue));

--- a/fe/spark-dpp/src/test/java/com/starrocks/load/loadv2/dpp/DppUtilsTest.java
+++ b/fe/spark-dpp/src/test/java/com/starrocks/load/loadv2/dpp/DppUtilsTest.java
@@ -306,7 +306,7 @@ public class DppUtilsTest {
         Assertions.assertEquals(2583214201L, hashValue.getValue());
 
         column = new EtlJobConfig.EtlColumn("k1", "BIGINT", true, true, "NONE", "0", 0, 0, 0);
-        bf = DppUtils.getHashValue(new Long(1), DataTypes.LongType, column);
+        bf = DppUtils.getHashValue(Long.valueOf(1), DataTypes.LongType, column);
         hashValue.reset();
         hashValue.update(bf.array(), 0, bf.limit());
         Assertions.assertEquals(2844319735L, hashValue.getValue());


### PR DESCRIPTION
- Updated license header in ListComparatorTest.java to StarRocks format
- Replaced all new Long() calls with Long.valueOf() in test classes:
  * ListComparatorTest.java (24 instances)
  * SqlModeHelperTest.java (3 instances)
  * RestoreFileMappingTest.java (4 instances)
  * RoutineLoadJobTest.java (2 instances)
  * MaterializedViewHandlerTest.java (1 instance)
  * DppUtilsTest.java (1 instance)
- Total 35 deprecated constructor calls fixed

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
