### PR TITLE
[BugFix] Fix antlr conflict in gradle

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -39,6 +39,7 @@ subprojects {
     ext {
         set("starrocks.home", "${rootDir}/../")
         // var sync start
+        set("antlr.version", "4.9.3")
         set("arrow.version", "18.0.0")
         set("async-profiler.version", "4.0")
         set("avro.version", "1.12.0")
@@ -154,7 +155,7 @@ subprojects {
             implementation("javax.validation:validation-api:1.1.0.Final")
             implementation("javax.xml.ws:jaxws-api:2.3.0")
             implementation("net.sourceforge.czt.dev:java-cup:0.11-a-czt02-cdh")
-            implementation("org.antlr:antlr4:4.9.2")
+            implementation("org.antlr:antlr4-runtime:${project.ext["antlr.version"]}")
             implementation("org.apache.arrow:arrow-jdbc:${project.ext["arrow.version"]}")
             implementation("org.apache.arrow:arrow-memory-netty:${project.ext["arrow.version"]}")
             implementation("org.apache.arrow:arrow-vector:${project.ext["arrow.version"]}")

--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -47,15 +47,12 @@ java {
 }
 
 
-//configurations.configureEach {
-//    if (name != "thriftGenClasspath") {
-//        // thrfit gen plugin uses antlr 4.13, which conflict with current antlr version
-//        resolutionStrategy.force("org.antlr:antlr4-runtime:4.9.3")
-//    }
-//}
+configurations.configureEach {
+    resolutionStrategy.force("org.antlr:antlr4-runtime:${project.ext["antlr.version"]}")
+}
 
 dependencies {
-    antlr("org.antlr:antlr4:4.9.3")
+    antlr("org.antlr:antlr4:${project.ext["antlr.version"]}")
 
     // Internal project dependencies
     implementation(project(":fe-common"))
@@ -157,9 +154,7 @@ dependencies {
     implementation("javax.annotation:javax.annotation-api")
     implementation("javax.validation:validation-api")
     implementation("net.openhft:zero-allocation-hashing:0.16")
-    implementation("org.antlr:antlr4") {
-        exclude(group = "commons-lang", module = "commons-lang")
-    }
+    implementation("org.antlr:antlr4-runtime")
     implementation("org.apache.arrow:arrow-jdbc")
     implementation("org.apache.arrow:arrow-memory-netty")
     implementation("org.apache.arrow:arrow-vector")
@@ -291,7 +286,6 @@ dependencies {
     implementation("com.starrocks:jprotobuf-starrocks:${project.ext["jprotobuf-starrocks.version"]}")
     implementation("org.apache.groovy:groovy:4.0.9")
     testImplementation("org.apache.spark:spark-sql_2.12")
-    implementation("org.antlr:antlr4-runtime:4.9.3")
     implementation("software.amazon.awssdk:s3-transfer-manager")
     implementation("net.openhft:zero-allocation-hashing:0.16")
 }

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -562,10 +562,10 @@ under the License.
             <classifier>shaded</classifier>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.antlr/antlr4 -->
+        <!-- https://mvnrepository.com/artifact/org.antlr/antlr4-runtime -->
         <dependency>
             <groupId>org.antlr</groupId>
-            <artifactId>antlr4</artifactId>
+            <artifactId>antlr4-runtime</artifactId>
         </dependency>
 
         <dependency>
@@ -975,7 +975,7 @@ under the License.
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.9.2</version>
+                <version>${antlr.version}</version>
                 <executions>
                     <execution>
                         <id>antlr</id>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -49,6 +49,7 @@ under the License.
         <parquet.version>1.15.2</parquet.version>
         <hadoop.version>3.4.1</hadoop.version>
         <gcs.connector.version>hadoop3-2.2.26</gcs.connector.version>
+        <antlr.version>4.9.3</antlr.version>
         <skip.plugin>false</skip.plugin>
         <hudi.version>1.0.2</hudi.version>
         <hive-apache.version>3.1.2-22</hive-apache.version>
@@ -1460,17 +1461,11 @@ under the License.
                 </exclusions>
             </dependency>
 
-            <!-- https://mvnrepository.com/artifact/org.antlr/antlr4 -->
+            <!-- https://mvnrepository.com/artifact/org.antlr/antlr4-runtime -->
             <dependency>
                 <groupId>org.antlr</groupId>
-                <artifactId>antlr4</artifactId>
-                <version>4.9.2</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-lang</groupId>
-                        <artifactId>commons-lang</artifactId>
-                    </exclusion>
-                </exclusions>
+                <artifactId>antlr4-runtime</artifactId>
+                <version>${antlr.version}</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.jboss.byteman/byteman -->


### PR DESCRIPTION
## Why I'm doing:
when running ut with gradle, got this error:

```
ShowCreateRoutineLoadStmtTest > testBackquote() STANDARD_ERROR
    ANTLR Tool version 4.9.3 used for code generation does not match the current runtime version 4.11.1
```

trino-parser:385 must use antlr4-runtime 4.9.3, otherwise runtime error.
but some other packages uses antlr4-runtime 4.11.1, so upgrade to trino-parser:396(latest version which not break current compile), which is compactable with antlr4-runtime:4.11.1

Note: should upgrade trino-parser to newer version in the futures(current version is too old), but this requires code change, mainly in `fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java`

Update:

unfortunately, spark 3.5.5 uses antlr4-runtime:4.9.3, and there is no new version to upgrade, so we cannot upgrade our antlr4-runtime, stuck at 4.9.3


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
