### PR TITLE
[Refactor] Remove the unused schema hash field from TabletMeta class and related code

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -779,7 +779,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
             PhysicalPartition physicalPartition = tbl.getPhysicalPartition(partitionId);
             TStorageMedium medium = tbl.getPartitionInfo().getDataProperty(physicalPartition.getParentId()).getStorageMedium();
             TabletMeta rollupTabletMeta = new TabletMeta(dbId, tableId, partitionId, rollupIndexId,
-                    rollupSchemaHash, medium);
+                    medium);
 
             for (Tablet rollupTablet : rollupIndex.getTablets()) {
                 invertedIndex.addTablet(rollupTablet.getId(), rollupTabletMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
@@ -93,7 +93,7 @@ public class LakeTableAlterJobV2Builder extends AlterJobV2Builder {
 
                 TStorageMedium medium = table.getPartitionInfo().getDataProperty(partitionId).getStorageMedium();
                 TabletMeta shadowTabletMeta =
-                        new TabletMeta(dbId, tableId, physicalPartitionId, shadowIndexId, 0, medium, true);
+                        new TabletMeta(dbId, tableId, physicalPartitionId, shadowIndexId, medium, true);
                 MaterializedIndex shadowIndex =
                         new MaterializedIndex(shadowIndexId, MaterializedIndex.IndexState.SHADOW, shardGroupId);
                 Map<Long, Long> tabletIdMap = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
@@ -104,7 +104,7 @@ public class LakeTableRollupBuilder extends AlterJobV2Builder {
                 Preconditions.checkState(originTablets.size() == shadowTabletIds.size());
 
                 TabletMeta shadowTabletMeta =
-                        new TabletMeta(dbId, olapTable.getId(), physicalPartitionId, rollupIndexId, 0, medium, true);
+                        new TabletMeta(dbId, olapTable.getId(), physicalPartitionId, rollupIndexId, medium, true);
                 Map<Long, Long> tabletIdMap = new HashMap<>();
                 for (int i = 0; i < originTablets.size(); i++) {
                     Tablet originTablet = originTablets.get(i);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -992,7 +992,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             assert shadowIndexId != null;
             assert shadowIndex != null;
             TStorageMedium medium = table.getPartitionInfo().getDataProperty(physicalPartition.getParentId()).getStorageMedium();
-            TabletMeta shadowTabletMeta = new TabletMeta(dbId, tableId, partitionId, shadowIndexId, 0, medium, true);
+            TabletMeta shadowTabletMeta = new TabletMeta(dbId, tableId, partitionId, shadowIndexId, medium, true);
             for (Tablet shadowTablet : shadowIndex.getTablets()) {
                 invertedIndex.addTablet(shadowTablet.getId(), shadowTabletMeta);
             }
@@ -1068,7 +1068,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
 
                 // Add Tablet to TabletInvertedIndex.
                 TabletMeta shadowTabletMeta =
-                        new TabletMeta(dbId, tableId, partition.getId(), shadowIdxId, 0, medium, true);
+                        new TabletMeta(dbId, tableId, partition.getId(), shadowIdxId, medium, true);
                 for (Tablet tablet : shadowIdx.getTablets()) {
                     invertedIndex.addTablet(tablet.getId(), shadowTabletMeta);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
@@ -95,7 +95,7 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
                 MaterializedIndex shadowIndex = new MaterializedIndex(shadowIndexId, MaterializedIndex.IndexState.SHADOW);
                 MaterializedIndex originIndex = partition.getIndex(originIndexId);
                 TabletMeta shadowTabletMeta = new TabletMeta(
-                        dbId, tableId, physicalPartitionId, shadowIndexId, newSchemaHash, medium);
+                        dbId, tableId, physicalPartitionId, shadowIndexId, medium);
                 Map<Long, Long> tabletIdMap = new HashMap<>();
                 for (Tablet originTablet : originIndex.getTablets()) {
                     long originTabletId = originTablet.getId();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableRollupJobBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableRollupJobBuilder.java
@@ -71,7 +71,7 @@ public class OlapTableRollupJobBuilder extends AlterJobV2Builder {
                 MaterializedIndex mvIndex = new MaterializedIndex(rollupIndexId, MaterializedIndex.IndexState.SHADOW);
                 MaterializedIndex baseIndex = physicalPartition.getIndex(baseIndexId);
                 TabletMeta mvTabletMeta = new TabletMeta(dbId, olapTable.getId(),
-                        physicalPartitionId, rollupIndexId, mvSchemaHash, medium);
+                        physicalPartitionId, rollupIndexId, medium);
                 Map<Long, Long> tabletIdMap = new HashMap<>();
                 for (Tablet baseTablet : baseIndex.getTablets()) {
                     long baseTabletId = baseTablet.getId();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -870,7 +870,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             PhysicalPartition physicalPartition = tbl.getPhysicalPartition(partitionId);
             TStorageMedium medium = tbl.getPartitionInfo().getDataProperty(physicalPartition.getParentId()).getStorageMedium();
             TabletMeta rollupTabletMeta = new TabletMeta(dbId, tableId, partitionId, rollupIndexId,
-                        rollupSchemaHash, medium);
+                    medium);
 
             for (Tablet rollupTablet : rollupIndex.getTablets()) {
                 invertedIndex.addTablet(rollupTablet.getId(), rollupTabletMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -889,7 +889,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                     // log may be replayed to the image, and the image will not persist the TabletInvertedIndex. So we
                     // should add the tablet to TabletInvertedIndex again on finish state.
                     TabletMeta shadowTabletMeta = new TabletMeta(dbId, tableId, physicalPartition.getId(), shadowIdxId,
-                            indexSchemaVersionAndHashMap.get(shadowIdxId).schemaHash, medium);
+                            medium);
                     for (Tablet tablet : shadowIdx.getTablets()) {
                         invertedIndex.addTablet(tablet.getId(), shadowTabletMeta);
                         for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
@@ -1058,7 +1058,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
                 TStorageMedium medium = tbl.getPartitionInfo().getDataProperty(partition.getParentId()).getStorageMedium();
                 TabletMeta shadowTabletMeta = new TabletMeta(dbId, tableId, partitionId, shadowIndexId,
-                        indexSchemaVersionAndHashMap.get(shadowIndexId).schemaHash, medium);
+                        medium);
 
                 for (Tablet shadownTablet : shadowIndex.getTablets()) {
                     invertedIndex.addTablet(shadownTablet.getId(), shadowTabletMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1022,7 +1022,7 @@ public class RestoreJob extends AbstractJob {
             for (MaterializedIndex restoredIdx : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
                 MaterializedIndexMeta indexMeta = localTbl.getIndexMetaByIndexId(restoredIdx.getId());
                 TabletMeta tabletMeta = new TabletMeta(dbId, localTbl.getId(), physicalPartition.getId(),
-                        restoredIdx.getId(), indexMeta.getSchemaHash(), TStorageMedium.HDD);
+                        restoredIdx.getId(), TStorageMedium.HDD);
                 TTabletSchema tabletSchema = SchemaInfo.newBuilder()
                         .setId(indexMeta.getSchemaId())
                         .setKeysType(indexMeta.getKeysType())
@@ -1295,7 +1295,7 @@ public class RestoreJob extends AbstractJob {
             for (MaterializedIndex restoreIdx : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
                 int schemaHash = restoreTbl.getSchemaHashByIndexId(restoreIdx.getId());
                 TabletMeta tabletMeta = new TabletMeta(dbId, restoreTbl.getId(), physicalPartition.getId(),
-                        restoreIdx.getId(), schemaHash, TStorageMedium.HDD);
+                        restoreIdx.getId(), TStorageMedium.HDD);
                 for (Tablet restoreTablet : restoreIdx.getTablets()) {
                     globalStateMgr.getTabletInvertedIndex().addTablet(restoreTablet.getId(), tabletMeta);
                     for (Replica restoreReplica : ((LocalTablet) restoreTablet).getImmutableReplicas()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -946,7 +946,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
                     for (MaterializedIndex index : physicalPartition.getMaterializedIndices(IndexExtState.ALL)) {
                         long indexId = index.getId();
                         int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
-                        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, schemaHash, medium,
+                        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, medium,
                                 table.isCloudNativeTable());
                         for (Tablet tablet : index.getTablets()) {
                             long tabletId = tablet.getId();
@@ -1004,7 +1004,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
                 for (MaterializedIndex index : physicalPartition.getMaterializedIndices(IndexExtState.ALL)) {
                     long indexId = index.getId();
                     int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
-                    TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, schemaHash, medium,
+                    TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, medium,
                             olapTable.isCloudNativeTable());
                     for (Tablet tablet : index.getTablets()) {
                         long tabletId = tablet.getId();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -500,7 +500,7 @@ public class ExternalOlapTable extends OlapTable {
                     }
                     TabletMeta tabletMeta = new TabletMeta(tTabletMeta.getDb_id(), tTabletMeta.getTable_id(),
                             tTabletMeta.getPartition_id(), tTabletMeta.getIndex_id(),
-                            tTabletMeta.getOld_schema_hash(), tTabletMeta.getStorage_medium());
+                            tTabletMeta.getStorage_medium());
                     index.addTablet(tablet, tabletMeta, false);
                 }
                 if (indexMeta.getPartition_id() == physicalPartition.getId()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -67,6 +67,14 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     public List<Integer> sortKeyUniqueIds;
     @SerializedName(value = "schemaVersion")
     private int schemaVersion = 0;
+    /**
+     * Historically, after a schema change, a new schemaHash would be added under the tablet directory
+     * instead of creating a new tablet. Currently, schema change creates a new set of tablets,
+     * and only one schema hash may exist under the tablet directory.
+     * For compatibility with historical data, schemaHash is now only used to construct the path
+     * of data files on disk. It is only meaningful in the storage-compute integrated mode,
+     * and has no significance in the shared-nothing mode.
+     */
     @SerializedName(value = "schemaHash")
     private int schemaHash;
     @SerializedName(value = "schemaId")

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -69,7 +69,7 @@ public class TabletInvertedIndex implements MemoryTrackable {
     public static final int NOT_EXIST_VALUE = -1;
 
     public static final TabletMeta NOT_EXIST_TABLET_META = new TabletMeta(NOT_EXIST_VALUE, NOT_EXIST_VALUE,
-            NOT_EXIST_VALUE, NOT_EXIST_VALUE, NOT_EXIST_VALUE, TStorageMedium.HDD);
+            NOT_EXIST_VALUE, NOT_EXIST_VALUE, TStorageMedium.HDD);
 
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
@@ -36,16 +36,11 @@ package com.starrocks.catalog;
 
 import com.starrocks.thrift.TStorageMedium;
 
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 public class TabletMeta {
     private final long dbId;
     private final long tableId;
     private final long physicalPartitionId;
     private final long indexId;
-
-    private final int oldSchemaHash;
-    private final int newSchemaHash;
 
     private TStorageMedium storageMedium;
 
@@ -56,26 +51,20 @@ public class TabletMeta {
      */
     private Long toBeCleanedTimeMs = null;
 
-    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-
-    public TabletMeta(long dbId, long tableId, long physicalPartitionId, long indexId, int schemaHash,
-                      TStorageMedium storageMedium, boolean isLakeTablet) {
+    public TabletMeta(long dbId, long tableId, long physicalPartitionId, long indexId,
+                      TStorageMedium storageMedium,
+                      boolean isLakeTablet) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.physicalPartitionId = physicalPartitionId;
         this.indexId = indexId;
-
-        this.oldSchemaHash = schemaHash;
-        this.newSchemaHash = -1;
-
         this.storageMedium = storageMedium;
-
         this.isLakeTablet = isLakeTablet;
     }
 
-    public TabletMeta(long dbId, long tableId, long physicalPartitionId, long indexId, int schemaHash,
+    public TabletMeta(long dbId, long tableId, long physicalPartitionId, long indexId,
                       TStorageMedium storageMedium) {
-        this(dbId, tableId, physicalPartitionId, indexId, schemaHash, storageMedium, false);
+        this(dbId, tableId, physicalPartitionId, indexId, storageMedium, false);
     }
 
     public long getDbId() {
@@ -102,24 +91,6 @@ public class TabletMeta {
         this.storageMedium = storageMedium;
     }
 
-    public int getNewSchemaHash() {
-        lock.readLock().lock();
-        try {
-            return this.newSchemaHash;
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    public int getOldSchemaHash() {
-        lock.readLock().lock();
-        try {
-            return this.oldSchemaHash;
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
     public Long getToBeCleanedTime() {
         return toBeCleanedTimeMs;
     }
@@ -132,34 +103,15 @@ public class TabletMeta {
         toBeCleanedTimeMs = null;
     }
 
-    public boolean containsSchemaHash(int schemaHash) {
-        lock.readLock().lock();
-        try {
-            return this.oldSchemaHash == schemaHash || this.newSchemaHash == schemaHash;
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
     public boolean isLakeTablet() {
         return isLakeTablet;
     }
 
     @Override
     public String toString() {
-        lock.readLock().lock();
-        try {
-            StringBuilder sb = new StringBuilder();
-            sb.append("dbId=").append(dbId);
-            sb.append(" tableId=").append(tableId);
-            sb.append(" physicalPartitionId=").append(physicalPartitionId);
-            sb.append(" indexId=").append(indexId);
-            sb.append(" oldSchemaHash=").append(oldSchemaHash);
-            sb.append(" newSchemaHash=").append(newSchemaHash);
-
-            return sb.toString();
-        } finally {
-            lock.readLock().unlock();
-        }
+        return "dbId=" + dbId +
+                " tableId=" + tableId +
+                " physicalPartitionId=" + physicalPartitionId +
+                " indexId=" + indexId;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -284,7 +284,7 @@ public class LakeRestoreJob extends RestoreJob {
             MaterializedIndexMeta indexMeta = restoreTbl.getIndexMetaByIndexId(restoredIdx.getId());
             TStorageMedium medium = restoreTbl.getPartitionInfo().getDataProperty(restorePart.getId()).getStorageMedium();
             TabletMeta tabletMeta = new TabletMeta(dbId, restoreTbl.getId(), restorePart.getId(),
-                    restoredIdx.getId(), indexMeta.getSchemaHash(), medium, true);
+                    restoredIdx.getId(), medium, true);
             for (Tablet restoreTablet : restoredIdx.getTablets()) {
                 GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(restoreTablet.getId(), tabletMeta);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -605,7 +605,6 @@ public class LeaderImpl {
                 }
                 for (int i = 0; i < tabletMetaList.size(); i++) {
                     TabletMeta tabletMeta = tabletMetaList.get(i);
-                    checkReplica(finishTabletInfos.get(i), tabletMeta);
                     long tabletId = tabletIds.get(i);
                     Replica replica =
                             findRelatedReplica(olapTable, physicalPartition, backendId, tabletId, tabletMeta.getIndexId());
@@ -623,32 +622,6 @@ public class LeaderImpl {
             LOG.warn("finish push replica error", e);
         } finally {
             locker.unLockDatabase(db.getId(), LockType.WRITE);
-        }
-    }
-
-    private void checkReplica(TTabletInfo tTabletInfo, TabletMeta tabletMeta)
-            throws MetaNotFoundException {
-        long tabletId = tTabletInfo.getTablet_id();
-        int schemaHash = tTabletInfo.getSchema_hash();
-        // during finishing stage, index's schema hash switched, when old schema hash finished
-        // current index hash != old schema hash and alter job's new schema hash != old schema hash
-        // the check replica will fail
-        // should use tabletid not pushTabletid because in rollup state, the push tabletid != tabletid
-        // and tablet meta will not contain rollup index's schema hash
-        if (tabletMeta == null || tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
-            // rollup may be dropped
-            throw new MetaNotFoundException("tablet " + tabletId + " does not exist");
-        }
-
-        // lake tablet not need to compare schemaHash
-        if (tabletMeta.isLakeTablet()) {
-            return;
-        }
-
-        if (!tabletMeta.containsSchemaHash(schemaHash)) {
-            throw new MetaNotFoundException("tablet[" + tabletId
-                    + "] schemaHash is not equal to index's switchSchemaHash. "
-                    + tabletMeta + " vs. " + schemaHash);
         }
     }
 
@@ -1153,8 +1126,6 @@ public class LeaderImpl {
         tTabletMeta.setPartition_id(tabletMeta.getPhysicalPartitionId());
         tTabletMeta.setIndex_id(tabletMeta.getIndexId());
         tTabletMeta.setStorage_medium(tabletMeta.getStorageMedium());
-        tTabletMeta.setOld_schema_hash(tabletMeta.getOldSchemaHash());
-        tTabletMeta.setNew_schema_hash(tabletMeta.getNewSchemaHash());
     }
 
     @NotNull

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -469,8 +469,6 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
         ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
         // tablet ids which schema hash is valid
         Set<Long> foundTabletsWithValidSchema = new HashSet<Long>();
-        // tablet ids which schema hash is invalid
-        Map<Long, TTabletInfo> foundTabletsWithInvalidSchema = new HashMap<Long, TTabletInfo>();
         // storage medium -> tablet id
         ListMultimap<TStorageMedium, Long> tabletMigrationMap = ArrayListMultimap.create();
 
@@ -490,7 +488,6 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 tabletSyncMap,
                 tabletDeleteFromMeta,
                 foundTabletsWithValidSchema,
-                foundTabletsWithInvalidSchema,
                 tabletMigrationMap,
                 transactionsToPublish,
                 transactionsToCommitTime,
@@ -506,7 +503,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
         deleteFromMeta(tabletDeleteFromMeta, backendId, backendReportVersion);
 
         // 4. handle (be - meta)
-        deleteFromBackend(backendTablets, foundTabletsWithValidSchema, foundTabletsWithInvalidSchema, backendId);
+        deleteFromBackend(backendTablets, foundTabletsWithValidSchema, backendId);
 
         // 5. migration (ssd <-> hdd)
         handleMigration(tabletMigrationMap, backendId);
@@ -556,7 +553,6 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                                     ListMultimap<Long, Long> tabletSyncMap,
                                     ListMultimap<Long, Long> tabletDeleteFromMeta,
                                     Set<Long> foundTabletsWithValidSchema,
-                                    Map<Long, TTabletInfo> foundTabletsWithInvalidSchema,
                                     ListMultimap<TStorageMedium, Long> tabletMigrationMap,
                                     Map<Long, Map<Long, Map<Long, TPartitionVersionInfo>>> transactionsToPublish,
                                     Map<Long, Long> transactionsToCommitTime,
@@ -605,131 +601,126 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                         if (backendTabletInfo.isSetMax_rowset_creation_time()) {
                             replica.setMaxRowsetCreationTime(backendTabletInfo.max_rowset_creation_time);
                         }
-                        if (tabletMeta.containsSchemaHash(backendTabletInfo.getSchema_hash())) {
-                            foundTabletsWithValidSchema.add(tabletId);
-                            // 1. (intersection)
-                            if (needSync(replica, backendTabletInfo)) {
-                                // need sync
-                                tabletSyncMap.put(tabletMeta.getDbId(), tabletId);
-                            }
+                        foundTabletsWithValidSchema.add(tabletId);
+                        // 1. (intersection)
+                        if (needSync(replica, backendTabletInfo)) {
+                            // need sync
+                            tabletSyncMap.put(tabletMeta.getDbId(), tabletId);
+                        }
 
-                            // check and set path,
-                            // path info of replica is only saved in Leader FE
-                            if (backendTabletInfo.isSetPath_hash() &&
-                                    replica.getPathHash() != backendTabletInfo.getPath_hash()) {
-                                replica.setPathHash(backendTabletInfo.getPath_hash());
-                            }
+                        // check and set path,
+                        // path info of replica is only saved in Leader FE
+                        if (backendTabletInfo.isSetPath_hash() &&
+                                replica.getPathHash() != backendTabletInfo.getPath_hash()) {
+                            replica.setPathHash(backendTabletInfo.getPath_hash());
+                        }
 
-                            if (backendTabletInfo.isSetSchema_hash() && replica.getState() == ReplicaState.NORMAL
-                                    && replica.getSchemaHash() != backendTabletInfo.getSchema_hash()) {
-                                // update the schema hash only when replica is normal
-                                replica.setSchemaHash(backendTabletInfo.getSchema_hash());
-                            }
+                        if (backendTabletInfo.isSetSchema_hash() && replica.getState() == ReplicaState.NORMAL
+                                && replica.getSchemaHash() != backendTabletInfo.getSchema_hash()) {
+                            // update the schema hash only when replica is normal
+                            replica.setSchemaHash(backendTabletInfo.getSchema_hash());
+                        }
 
-                            if (!isRestoreReplica(replica, tabletMeta) &&
-                                    needRecover(replica, tabletMeta.getOldSchemaHash(), backendTabletInfo)) {
-                                LOG.warn("replica {} of tablet {} on backend {} need recovery. "
-                                                + "replica in FE: {}, report version {}, report schema hash: {},"
-                                                + " is bad: {}",
-                                        replica.getId(), tabletId, backendId,
-                                        replica, backendTabletInfo.getVersion(), backendTabletInfo.getSchema_hash(),
-                                        backendTabletInfo.isSetUsed() ? backendTabletInfo.isUsed() : "unknown");
-                                tabletRecoveryMap.put(tabletMeta.getDbId(), tabletId);
-                            }
+                        if (!isRestoreReplica(replica, tabletMeta) &&
+                                needRecover(replica, backendTabletInfo)) {
+                            LOG.warn("replica {} of tablet {} on backend {} need recovery. "
+                                            + "replica in FE: {}, report version {}, report schema hash: {},"
+                                            + " is bad: {}",
+                                    replica.getId(), tabletId, backendId,
+                                    replica, backendTabletInfo.getVersion(), backendTabletInfo.getSchema_hash(),
+                                    backendTabletInfo.isSetUsed() ? backendTabletInfo.isUsed() : "unknown");
+                            tabletRecoveryMap.put(tabletMeta.getDbId(), tabletId);
+                        }
 
-                            replica.setLastReportVersion(backendTabletInfo.getVersion());
+                        replica.setLastReportVersion(backendTabletInfo.getVersion());
 
-                            // check if tablet needs migration
-                            long physicalPartitionId = tabletMeta.getPhysicalPartitionId();
-                            OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                    .getTable(tabletMeta.getDbId(), tabletMeta.getTableId());
-                            if (olapTable == null) {
-                                continue;
-                            }
-                            PhysicalPartition physicalPartition = olapTable.getPhysicalPartition(physicalPartitionId);
-                            if (physicalPartition == null) {
-                                continue;
-                            }
+                        // check if tablet needs migration
+                        long physicalPartitionId = tabletMeta.getPhysicalPartitionId();
+                        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(tabletMeta.getDbId(), tabletMeta.getTableId());
+                        if (olapTable == null) {
+                            continue;
+                        }
+                        PhysicalPartition physicalPartition = olapTable.getPhysicalPartition(physicalPartitionId);
+                        if (physicalPartition == null) {
+                            continue;
+                        }
 
-                            TStorageMedium storageMedium = storageMediumMap.get(physicalPartition.getParentId());
-                            if (storageMedium != null && backendTabletInfo.isSetStorage_medium()) {
-                                if (storageMedium != backendTabletInfo.getStorage_medium()) {
-                                    // If storage medium is less than 1, there is no need to send migration tasks to BE.
-                                    // Because BE will ignore this request.
-                                    if (backendStorageTypeCnt <= 1) {
-                                        LOG.debug("available storage medium type count is less than 1, " +
-                                                        "no need to send migrate task. tabletId={}, backendId={}.",
-                                                tabletMeta, backendId);
+                        TStorageMedium storageMedium = storageMediumMap.get(physicalPartition.getParentId());
+                        if (storageMedium != null && backendTabletInfo.isSetStorage_medium()) {
+                            if (storageMedium != backendTabletInfo.getStorage_medium()) {
+                                // If storage medium is less than 1, there is no need to send migration tasks to BE.
+                                // Because BE will ignore this request.
+                                if (backendStorageTypeCnt <= 1) {
+                                    LOG.debug("available storage medium type count is less than 1, " +
+                                                    "no need to send migrate task. tabletId={}, backendId={}.",
+                                            tabletMeta, backendId);
+                                } else {
+                                    tabletMigrationMap.put(storageMedium, tabletId);
+                                }
+                            }
+                            if (storageMedium != tabletMeta.getStorageMedium()) {
+                                tabletMeta.setStorageMedium(storageMedium);
+                            }
+                        }
+                        // check if we should clear transactions
+                        if (backendTabletInfo.isSetTransaction_ids()) {
+                            List<Long> transactionIds = backendTabletInfo.getTransaction_ids();
+                            GlobalTransactionMgr transactionMgr =
+                                    GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+                            for (Long transactionId : transactionIds) {
+                                TransactionState transactionState =
+                                        transactionMgr.getTransactionState(tabletMeta.getDbId(), transactionId);
+                                if (transactionState == null ||
+                                        transactionState.getTransactionStatus() == TransactionStatus.ABORTED) {
+                                    transactionsToClear.put(transactionId, physicalPartitionId);
+                                    LOG.debug("transaction id [{}] is not valid any more, "
+                                            + "clear it from backend [{}]", transactionId, backendId);
+                                } else if (transactionState.getTransactionStatus() ==
+                                        TransactionStatus.VISIBLE) {
+                                    TableCommitInfo tableCommitInfo =
+                                            transactionState.getTableCommitInfo(tabletMeta.getTableId());
+                                    PartitionCommitInfo partitionCommitInfo =
+                                            tableCommitInfo.getPartitionCommitInfo(physicalPartitionId);
+                                    if (partitionCommitInfo == null) {
+                                        /*
+                                         * This may happen as follows:
+                                         * 1. txn is committed on BE, and report commit info to FE
+                                         * 2. FE received report and begin to assemble partitionCommitInfos.
+                                         * 3. At the same time, some partitions have been dropped, so
+                                         *    partitionCommitInfos does not contain these partitions.
+                                         * 4. So we will not able to get partitionCommitInfo here.
+                                         *
+                                         * Just print a log to observe
+                                         */
+                                        LOG.info(
+                                                "failed to find partition commit info. table: {}, " +
+                                                        "partition: {}, tablet: {}, txn_id: {}",
+                                                tabletMeta.getTableId(), physicalPartitionId, tabletId,
+                                                transactionState.getTransactionId());
                                     } else {
-                                        tabletMigrationMap.put(storageMedium, tabletId);
+                                        TPartitionVersionInfo versionInfo =
+                                                new TPartitionVersionInfo(physicalPartitionId,
+                                                        partitionCommitInfo.getVersion(), 0);
+                                        versionInfo.setGtid(transactionState.getGlobalTransactionId());
+                                        Map<Long, Map<Long, TPartitionVersionInfo>> txnMap =
+                                                transactionsToPublish.computeIfAbsent(
+                                                        transactionState.getDbId(), k -> Maps.newHashMap());
+                                        Map<Long, TPartitionVersionInfo> partitionMap =
+                                                txnMap.computeIfAbsent(transactionId, k -> Maps.newHashMap());
+                                        partitionMap.put(versionInfo.getPartition_id(), versionInfo);
+                                        transactionsToCommitTime.put(transactionId,
+                                                transactionState.getCommitTime());
                                     }
-                                }
-                                if (storageMedium != tabletMeta.getStorageMedium()) {
-                                    tabletMeta.setStorageMedium(storageMedium);
                                 }
                             }
-                            // check if we should clear transactions
-                            if (backendTabletInfo.isSetTransaction_ids()) {
-                                List<Long> transactionIds = backendTabletInfo.getTransaction_ids();
-                                GlobalTransactionMgr transactionMgr =
-                                        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
-                                for (Long transactionId : transactionIds) {
-                                    TransactionState transactionState =
-                                            transactionMgr.getTransactionState(tabletMeta.getDbId(), transactionId);
-                                    if (transactionState == null ||
-                                            transactionState.getTransactionStatus() == TransactionStatus.ABORTED) {
-                                        transactionsToClear.put(transactionId, physicalPartitionId);
-                                        LOG.debug("transaction id [{}] is not valid any more, "
-                                                + "clear it from backend [{}]", transactionId, backendId);
-                                    } else if (transactionState.getTransactionStatus() ==
-                                            TransactionStatus.VISIBLE) {
-                                        TableCommitInfo tableCommitInfo =
-                                                transactionState.getTableCommitInfo(tabletMeta.getTableId());
-                                        PartitionCommitInfo partitionCommitInfo =
-                                                tableCommitInfo.getPartitionCommitInfo(physicalPartitionId);
-                                        if (partitionCommitInfo == null) {
-                                            /*
-                                             * This may happen as follows:
-                                             * 1. txn is committed on BE, and report commit info to FE
-                                             * 2. FE received report and begin to assemble partitionCommitInfos.
-                                             * 3. At the same time, some partitions have been dropped, so
-                                             *    partitionCommitInfos does not contain these partitions.
-                                             * 4. So we will not able to get partitionCommitInfo here.
-                                             *
-                                             * Just print a log to observe
-                                             */
-                                            LOG.info(
-                                                    "failed to find partition commit info. table: {}, " +
-                                                            "partition: {}, tablet: {}, txn_id: {}",
-                                                    tabletMeta.getTableId(), physicalPartitionId, tabletId,
-                                                    transactionState.getTransactionId());
-                                        } else {
-                                            TPartitionVersionInfo versionInfo =
-                                                    new TPartitionVersionInfo(physicalPartitionId,
-                                                            partitionCommitInfo.getVersion(), 0);
-                                            versionInfo.setGtid(transactionState.getGlobalTransactionId());
-                                            Map<Long, Map<Long, TPartitionVersionInfo>> txnMap =
-                                                    transactionsToPublish.computeIfAbsent(
-                                                            transactionState.getDbId(), k -> Maps.newHashMap());
-                                            Map<Long, TPartitionVersionInfo> partitionMap =
-                                                    txnMap.computeIfAbsent(transactionId, k -> Maps.newHashMap());
-                                            partitionMap.put(versionInfo.getPartition_id(), versionInfo);
-                                            transactionsToCommitTime.put(transactionId,
-                                                    transactionState.getCommitTime());
-                                        }
-                                    }
-                                }
-                            } // end for txn id
+                        } // end for txn id
 
-                            // update replica's version count
-                            // no need to write log, and no need to get db lock.
-                            if (backendTabletInfo.isSetVersion_count()) {
-                                replica.setVersionCount(backendTabletInfo.getVersion_count());
-                            }
-                        } else {
-                            // tablet with invalid schema hash
-                            foundTabletsWithInvalidSchema.put(tabletId, backendTabletInfo);
-                        } // end for be tablet info
+                        // update replica's version count
+                        // no need to write log, and no need to get db lock.
+                        if (backendTabletInfo.isSetVersion_count()) {
+                            replica.setVersionCount(backendTabletInfo.getVersion_count());
+                        }
                     }
                 } else {
                     // 2. (meta - be)
@@ -743,10 +734,10 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
         }
 
         long end = System.currentTimeMillis();
-        LOG.info("finished to do tablet diff with backend[{}]. sync: {}. metaDel: {}. foundValid: {}. foundInvalid: {}."
+        LOG.info("finished to do tablet diff with backend[{}]. sync: {}. metaDel: {}. foundValid: {}. "
                         + " migration: {}. found invalid transactions {}. found republish transactions {} "
                         + " cost: {} ms", backendId, tabletSyncMap.size(),
-                tabletDeleteFromMeta.size(), foundTabletsWithValidSchema.size(), foundTabletsWithInvalidSchema.size(),
+                tabletDeleteFromMeta.size(), foundTabletsWithValidSchema.size(),
                 tabletMigrationMap.size(), transactionsToClear.size(), transactionsToPublish.size(), (end - start));
     }
 
@@ -798,7 +789,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
      * Be will set `used' to false for bad replicas and `version_miss' to true for replicas with hole
      * in their version chain. In either case, those replicas need to be fixed by TabletScheduler.
      */
-    private static boolean needRecover(Replica replicaInFe, int schemaHashInFe, TTabletInfo backendTabletInfo) {
+    private static boolean needRecover(Replica replicaInFe, TTabletInfo backendTabletInfo) {
         if (replicaInFe.getState() != ReplicaState.NORMAL) {
             // only normal replica need recover
             // case:
@@ -810,8 +801,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
             return false;
         }
 
-        if (schemaHashInFe != backendTabletInfo.getSchema_hash()
-                || backendTabletInfo.getVersion() == -1) {
+        if (backendTabletInfo.getVersion() == -1) {
             // no data file exist on BE, maybe this is a newly created schema change tablet. no need to recovery
             return false;
         }
@@ -1338,7 +1328,6 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
 
     private static void deleteFromBackend(Map<Long, TTablet> backendTablets,
                                           Set<Long> foundTabletsWithValidSchema,
-                                          Map<Long, TTabletInfo> foundTabletsWithInvalidSchema,
                                           long backendId) {
         int deleteFromBackendCounter = 0;
         int addToMetaCounter = 0;
@@ -1408,16 +1397,6 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                     --maxTaskSendPerBe;
                 }
             } // end for tabletInfos
-
-            if (foundTabletsWithInvalidSchema.containsKey(tabletId) && maxTaskSendPerBe > 0) {
-                // this tablet is found in meta but with invalid schema hash.
-                // delete it.
-                int schemaHash = foundTabletsWithInvalidSchema.get(tabletId).getSchema_hash();
-                addDropReplicaTask(batchTask, backendId, tabletId, schemaHash,
-                        "invalid schema hash: " + schemaHash, true);
-                ++deleteFromBackendCounter;
-                --maxTaskSendPerBe;
-            }
         } // end for backendTabletIds
 
         AgentTaskExecutor.submit(batchTask);
@@ -1534,7 +1513,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 }
 
                 // always get old schema hash(as effective one)
-                int effectiveSchemaHash = tabletMeta.getOldSchemaHash();
+                int schemaHash = table.getSchemaHashByIndexId(tabletMeta.getIndexId());
 
                 boolean needRebuildPkIndex = false;
                 Locker locker = new Locker();
@@ -1551,7 +1530,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                     locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
                 }
 
-                StorageMediaMigrationTask task = new StorageMediaMigrationTask(backendId, tabletId, effectiveSchemaHash,
+                StorageMediaMigrationTask task = new StorageMediaMigrationTask(backendId, tabletId, schemaHash,
                         storageMedium, needRebuildPkIndex);
                 batchTask.addTask(task);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -352,7 +352,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         long indexId = index.getId();
                         int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
                         TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId,
-                                indexId, schemaHash, medium, table.isCloudNativeTableOrMaterializedView());
+                                indexId, medium, table.isCloudNativeTableOrMaterializedView());
                         for (Tablet tablet : index.getTablets()) {
                             long tabletId = tablet.getId();
                             invertedIndex.addTablet(tabletId, tabletMeta);
@@ -1346,7 +1346,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                     long indexId = index.getId();
                     int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
                     TabletMeta tabletMeta = new TabletMeta(info.getDbId(), info.getTableId(), physicalPartition.getId(),
-                            index.getId(), schemaHash, info.getDataProperty().getStorageMedium());
+                            index.getId(), info.getDataProperty().getStorageMedium());
                     for (Tablet tablet : index.getTablets()) {
                         long tabletId = tablet.getId();
                         invertedIndex.addTablet(tabletId, tabletMeta);
@@ -1579,7 +1579,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
             // create tablets
             TabletMeta tabletMeta =
-                    new TabletMeta(db.getId(), olapTable.getId(), id, indexId, indexMeta.getSchemaHash(),
+                    new TabletMeta(db.getId(), olapTable.getId(), id, indexId,
                             storageMedium, olapTable.isCloudNativeTableOrMaterializedView());
 
             if (olapTable.isCloudNativeTableOrMaterializedView()) {
@@ -1697,7 +1697,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                     long indexId = index.getId();
                     int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
                     TabletMeta tabletMeta = new TabletMeta(info.getDbId(), info.getTableId(),
-                            physicalPartition.getId(), index.getId(), schemaHash, olapTable.getPartitionInfo().getDataProperty(
+                            physicalPartition.getId(), index.getId(), olapTable.getPartitionInfo().getDataProperty(
                             info.getPartitionId()).getStorageMedium(), false);
                     for (Tablet tablet : index.getTablets()) {
                         long tabletId = tablet.getId();
@@ -1769,7 +1769,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
             // create tablets
             TabletMeta tabletMeta =
-                    new TabletMeta(db.getId(), table.getId(), physicalPartitionId, indexId, indexMeta.getSchemaHash(),
+                    new TabletMeta(db.getId(), table.getId(), physicalPartitionId, indexId,
                             storageMedium, table.isCloudNativeTableOrMaterializedView());
 
             if (table.isCloudNativeTableOrMaterializedView()) {
@@ -2005,7 +2005,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         long indexId = mIndex.getId();
                         int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
                         TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId,
-                                indexId, schemaHash, medium, table.isCloudNativeTableOrMaterializedView());
+                                indexId, medium, table.isCloudNativeTableOrMaterializedView());
                         for (Tablet tablet : mIndex.getTablets()) {
                             long tabletId = tablet.getId();
                             invertedIndex.addTablet(tabletId, tabletMeta);
@@ -2169,10 +2169,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 }
 
                 // create replicas
+                int schemaHash = table.getSchemaHashByIndexId(index.getId());
                 for (long backendId : chosenBackendIds) {
                     long replicaId = getNextId();
-                    Replica replica = new Replica(replicaId, backendId, replicaState, version,
-                            tabletMeta.getOldSchemaHash());
+                    Replica replica = new Replica(replicaId, backendId, replicaState, version, schemaHash);
                     tablet.addReplica(replica);
                 }
                 Preconditions.checkState(chosenBackendIds.size() == replicationNum,
@@ -4634,7 +4634,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                             long indexId = mIndex.getId();
                             int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
                             TabletMeta tabletMeta = new TabletMeta(db.getId(), olapTable.getId(),
-                                    physicalPartition.getId(), indexId, schemaHash, medium,
+                                    physicalPartition.getId(), indexId, medium,
                                     olapTable.isCloudNativeTableOrMaterializedView());
                             for (Tablet tablet : mIndex.getTablets()) {
                                 long tabletId = tablet.getId();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterDataCachePartitionDurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterDataCachePartitionDurationTest.java
@@ -133,7 +133,7 @@ public class LakeTableAlterDataCachePartitionDurationTest {
         MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
         Partition partition = new Partition(partitionId, partitionId + 100, "t0", index, dist);
         TStorageMedium storage = TStorageMedium.HDD;
-        TabletMeta tabletMeta = new TabletMeta(db.getId(), table.getId(), partition.getId(), index.getId(), 0, storage, true);
+        TabletMeta tabletMeta = new TabletMeta(db.getId(), table.getId(), partition.getId(), index.getId(), storage, true);
         for (int i = 0; i < NUM_BUCKETS; i++) {
             Tablet tablet = new LakeTablet(GlobalStateMgr.getCurrentState().getNextId());
             index.addTablet(tablet, tabletMeta);

--- a/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
@@ -280,7 +280,7 @@ public class CatalogMocker {
 
         LocalTablet tablet0 = new LocalTablet(TEST_TABLET0_ID);
         TabletMeta tabletMeta = new TabletMeta(TEST_DB_ID, TEST_TBL_ID, TEST_SINGLE_PARTITION_ID,
-                TEST_TBL_ID, SCHEMA_HASH, TStorageMedium.HDD);
+                TEST_TBL_ID, TStorageMedium.HDD);
         baseIndex.addTablet(tablet0, tabletMeta);
         Replica replica0 = new Replica(TEST_REPLICA0_ID, BACKEND1_ID, 0, ReplicaState.NORMAL);
         Replica replica1 = new Replica(TEST_REPLICA1_ID, BACKEND2_ID, 0, ReplicaState.NORMAL);
@@ -347,7 +347,7 @@ public class CatalogMocker {
 
         LocalTablet baseTabletP1 = new LocalTablet(TEST_BASE_TABLET_P1_ID);
         TabletMeta tabletMetaBaseTabletP1 = new TabletMeta(TEST_DB_ID, TEST_TBL2_ID, TEST_PARTITION1_ID,
-                TEST_TBL2_ID, SCHEMA_HASH, TStorageMedium.HDD);
+                TEST_TBL2_ID, TStorageMedium.HDD);
         baseIndexP1.addTablet(baseTabletP1, tabletMetaBaseTabletP1);
         Replica replica3 = new Replica(TEST_REPLICA3_ID, BACKEND1_ID, 0, ReplicaState.NORMAL);
         Replica replica4 = new Replica(TEST_REPLICA4_ID, BACKEND2_ID, 0, ReplicaState.NORMAL);
@@ -359,7 +359,7 @@ public class CatalogMocker {
 
         LocalTablet baseTabletP2 = new LocalTablet(TEST_BASE_TABLET_P2_ID);
         TabletMeta tabletMetaBaseTabletP2 = new TabletMeta(TEST_DB_ID, TEST_TBL2_ID, TEST_PARTITION2_ID,
-                TEST_TBL2_ID, SCHEMA_HASH, TStorageMedium.HDD);
+                TEST_TBL2_ID, TStorageMedium.HDD);
         baseIndexP2.addTablet(baseTabletP2, tabletMetaBaseTabletP2);
         Replica replica6 = new Replica(TEST_REPLICA6_ID, BACKEND1_ID, 0, ReplicaState.NORMAL);
         Replica replica7 = new Replica(TEST_REPLICA7_ID, BACKEND2_ID, 0, ReplicaState.NORMAL);
@@ -378,7 +378,7 @@ public class CatalogMocker {
         MaterializedIndex rollupIndexP1 = new MaterializedIndex(TEST_ROLLUP_ID, IndexState.NORMAL);
         LocalTablet rollupTabletP1 = new LocalTablet(TEST_ROLLUP_TABLET_P1_ID);
         TabletMeta tabletMetaRollupTabletP1 = new TabletMeta(TEST_DB_ID, TEST_TBL2_ID, TEST_PARTITION1_ID,
-                TEST_ROLLUP_TABLET_P1_ID, ROLLUP_SCHEMA_HASH,
+                TEST_ROLLUP_TABLET_P1_ID,
                 TStorageMedium.HDD);
         rollupIndexP1.addTablet(rollupTabletP1, tabletMetaRollupTabletP1);
         Replica replica9 = new Replica(TEST_REPLICA9_ID, BACKEND1_ID, 0, ReplicaState.NORMAL);
@@ -395,7 +395,7 @@ public class CatalogMocker {
         MaterializedIndex rollupIndexP2 = new MaterializedIndex(TEST_ROLLUP_ID, IndexState.NORMAL);
         LocalTablet rollupTabletP2 = new LocalTablet(TEST_ROLLUP_TABLET_P2_ID);
         TabletMeta tabletMetaRollupTabletP2 = new TabletMeta(TEST_DB_ID, TEST_TBL2_ID, TEST_PARTITION1_ID,
-                TEST_ROLLUP_TABLET_P2_ID, ROLLUP_SCHEMA_HASH,
+                TEST_ROLLUP_TABLET_P2_ID,
                 TStorageMedium.HDD);
         rollupIndexP2.addTablet(rollupTabletP2, tabletMetaRollupTabletP2);
         Replica replica12 = new Replica(TEST_REPLICA12_ID, BACKEND1_ID, 0, ReplicaState.NORMAL);
@@ -454,7 +454,7 @@ public class CatalogMocker {
 
         LocalTablet baseTabletP1Pk = new LocalTablet(TEST_BASE_TABLET_P1_PK_ID);
         TabletMeta tabletMetaBaseTabletP1Pk = new TabletMeta(TEST_DB_ID, TEST_TBL3_ID, TEST_PARTITION1_PK_ID,
-                TEST_TBL3_ID, SCHEMA_HASH, TStorageMedium.HDD);
+                TEST_TBL3_ID, TStorageMedium.HDD);
         baseIndexP1Pk.addTablet(baseTabletP1Pk, tabletMetaBaseTabletP1Pk);
         Replica replica3Pk = new Replica(TEST_REPLICA3_PK_ID, BACKEND1_ID, 0, ReplicaState.NORMAL);
         Replica replica4Pk = new Replica(TEST_REPLICA4_PK_ID, BACKEND2_ID, 0, ReplicaState.NORMAL);
@@ -466,7 +466,7 @@ public class CatalogMocker {
 
         LocalTablet baseTabletP2Pk = new LocalTablet(TEST_BASE_TABLET_P2_PK_ID);
         TabletMeta tabletMetaBaseTabletP2Pk = new TabletMeta(TEST_DB_ID, TEST_TBL3_ID, TEST_PARTITION2_PK_ID,
-                TEST_TBL3_ID, SCHEMA_HASH, TStorageMedium.HDD);
+                TEST_TBL3_ID, TStorageMedium.HDD);
         baseIndexP2Pk.addTablet(baseTabletP2Pk, tabletMetaBaseTabletP2Pk);
         Replica replica6Pk = new Replica(TEST_REPLICA6_PK_ID, BACKEND1_ID, 0, ReplicaState.NORMAL);
         Replica replica7Pk = new Replica(TEST_REPLICA7_PK_ID, BACKEND2_ID, 0, ReplicaState.NORMAL);
@@ -504,7 +504,7 @@ public class CatalogMocker {
 
             baseTabletP1 = new LocalTablet(TEST_BASE_TABLET_P1_ID);
             tabletMetaBaseTabletP1 = new TabletMeta(TEST_DB_ID, TEST_TBL4_ID, TEST_PARTITION1_ID,
-                    TEST_TBL4_ID, SCHEMA_HASH, TStorageMedium.HDD);
+                    TEST_TBL4_ID, TStorageMedium.HDD);
             baseIndexP1.addTablet(baseTabletP1, tabletMetaBaseTabletP1);
             replica3 = new Replica(TEST_REPLICA3_ID, BACKEND1_ID, 0, ReplicaState.NORMAL);
             replica4 = new Replica(TEST_REPLICA4_ID, BACKEND2_ID, 0, ReplicaState.NORMAL);
@@ -516,7 +516,7 @@ public class CatalogMocker {
 
             baseTabletP2 = new LocalTablet(TEST_BASE_TABLET_P2_ID);
             tabletMetaBaseTabletP2 = new TabletMeta(TEST_DB_ID, TEST_TBL4_ID, TEST_PARTITION2_ID,
-                    TEST_TBL4_ID, SCHEMA_HASH, TStorageMedium.HDD);
+                    TEST_TBL4_ID, TStorageMedium.HDD);
             baseIndexP2.addTablet(baseTabletP2, tabletMetaBaseTabletP2);
             replica6 = new Replica(TEST_REPLICA6_ID, BACKEND1_ID, 0, ReplicaState.NORMAL);
             replica7 = new Replica(TEST_REPLICA7_ID, BACKEND2_ID, 0, ReplicaState.NORMAL);
@@ -554,7 +554,7 @@ public class CatalogMocker {
 
             baseTabletP1 = new LocalTablet(TEST_BASE_TABLET_P1_ID);
             tabletMetaBaseTabletP1 = new TabletMeta(TEST_DB_ID, TEST_TBL5_ID, TEST_PARTITION1_ID,
-                    TEST_TBL5_ID, SCHEMA_HASH, TStorageMedium.HDD);
+                    TEST_TBL5_ID, TStorageMedium.HDD);
             baseIndexP1.addTablet(baseTabletP1, tabletMetaBaseTabletP1);
             replica3 = new Replica(TEST_REPLICA3_ID, BACKEND1_ID, 0, ReplicaState.NORMAL);
             replica4 = new Replica(TEST_REPLICA4_ID, BACKEND2_ID, 0, ReplicaState.NORMAL);
@@ -566,7 +566,7 @@ public class CatalogMocker {
 
             baseTabletP2 = new LocalTablet(TEST_BASE_TABLET_P2_ID);
             tabletMetaBaseTabletP2 = new TabletMeta(TEST_DB_ID, TEST_TBL5_ID, TEST_PARTITION2_ID,
-                    TEST_TBL5_ID, SCHEMA_HASH, TStorageMedium.HDD);
+                    TEST_TBL5_ID, TStorageMedium.HDD);
             baseIndexP2.addTablet(baseTabletP2, tabletMetaBaseTabletP2);
             replica6 = new Replica(TEST_REPLICA6_ID, BACKEND1_ID, 0, ReplicaState.NORMAL);
             replica7 = new Replica(TEST_REPLICA7_ID, BACKEND2_ID, 0, ReplicaState.NORMAL);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -261,7 +261,7 @@ public class CatalogRecycleBinTest {
 
         // Index
         MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.SSD);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, TStorageMedium.SSD);
         index.addTablet(tablet, tabletMeta);
 
         // Partition
@@ -335,7 +335,7 @@ public class CatalogRecycleBinTest {
 
         // Index
         MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.SSD);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, TStorageMedium.SSD);
         index.addTablet(tablet, tabletMeta);
 
         // Partition

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
@@ -187,7 +187,7 @@ public class GlobalStateMgrTestUtil {
 
         // index
         MaterializedIndex index = new MaterializedIndex(indexId, IndexState.NORMAL);
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId + 100, indexId, 0, TStorageMedium.HDD);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId + 100, indexId, TStorageMedium.HDD);
         index.addTablet(tablet, tabletMeta);
 
         tablet.addReplica(replica1);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
@@ -108,7 +108,7 @@ public class LocalTabletTest {
         };
 
         tablet = new LocalTablet(1);
-        TabletMeta tabletMeta = new TabletMeta(10, 20, 30, 40, 1, TStorageMedium.HDD);
+        TabletMeta tabletMeta = new TabletMeta(10, 20, 30, 40, TStorageMedium.HDD);
         invertedIndex.addTablet(1, tabletMeta);
         replica1 = new Replica(1L, 1L, 100L, 0, 200000L, 3000L, ReplicaState.NORMAL, 0, 0);
         replica2 = new Replica(2L, 2L, 100L, 0, 200001L, 3001L, ReplicaState.NORMAL, 0, 0);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ReplaceLakePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ReplaceLakePartitionTest.java
@@ -100,7 +100,7 @@ public class ReplaceLakePartitionTest {
         MaterializedIndex index = new MaterializedIndex(indexId);
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
         for (long id : tabletId) {
-            TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, 0, 0, TStorageMedium.HDD, true);
+            TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, 0, TStorageMedium.HDD, true);
             invertedIndex.addTablet(id, tabletMeta);
             index.addTablet(new LakeTablet(id), tabletMeta);
         }
@@ -139,7 +139,7 @@ public class ReplaceLakePartitionTest {
         MaterializedIndex index = new MaterializedIndex(indexId);
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
         for (long id : newTabletId) {
-            TabletMeta tabletMeta = new TabletMeta(dbId, tableId, newPartitionId, 0, 0, TStorageMedium.HDD, true);
+            TabletMeta tabletMeta = new TabletMeta(dbId, tableId, newPartitionId, 0, TStorageMedium.HDD, true);
             invertedIndex.addTablet(id, tabletMeta);
             index.addTablet(new LakeTablet(id), tabletMeta);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TabletStatMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TabletStatMgrTest.java
@@ -81,7 +81,7 @@ public class TabletStatMgrTest {
         columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, "0", ""));
 
         // Tablet2 is LocalTablet
-        TabletMeta tabletMeta2 = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, 0, TStorageMedium.HDD);
+        TabletMeta tabletMeta2 = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
         invertedIndex.addTablet(tablet2Id, tabletMeta2);
         Replica replica = new Replica(tablet2Id + 1, backendId, 0, Replica.ReplicaState.NORMAL);
         invertedIndex.addReplica(tablet2Id, replica);
@@ -151,7 +151,7 @@ public class TabletStatMgrTest {
 
         // Index
         MaterializedIndex index = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
-        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, 0, TStorageMedium.HDD, true);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, TStorageMedium.HDD, true);
         index.addTablet(tablet1, tabletMeta);
         index.addTablet(tablet2, tabletMeta);
 

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ClusterLoadStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ClusterLoadStatisticsTest.java
@@ -138,16 +138,16 @@ public class ClusterLoadStatisticsTest {
         // tablet
         invertedIndex = new TabletInvertedIndex();
 
-        invertedIndex.addTablet(50000, new TabletMeta(1, 2, 3, 4, 5, TStorageMedium.HDD));
+        invertedIndex.addTablet(50000, new TabletMeta(1, 2, 3, 4, TStorageMedium.HDD));
         invertedIndex.addReplica(50000, new Replica(50001, be1.getId(), 0, ReplicaState.NORMAL));
         invertedIndex.addReplica(50000, new Replica(50002, be2.getId(), 0, ReplicaState.NORMAL));
         invertedIndex.addReplica(50000, new Replica(50003, be3.getId(), 0, ReplicaState.NORMAL));
 
-        invertedIndex.addTablet(60000, new TabletMeta(1, 2, 3, 4, 5, TStorageMedium.HDD));
+        invertedIndex.addTablet(60000, new TabletMeta(1, 2, 3, 4, TStorageMedium.HDD));
         invertedIndex.addReplica(60000, new Replica(60002, be2.getId(), 0, ReplicaState.NORMAL));
         invertedIndex.addReplica(60000, new Replica(60003, be3.getId(), 0, ReplicaState.NORMAL));
 
-        invertedIndex.addTablet(70000, new TabletMeta(1, 2, 3, 4, 5, TStorageMedium.HDD));
+        invertedIndex.addTablet(70000, new TabletMeta(1, 2, 3, 4, TStorageMedium.HDD));
         invertedIndex.addReplica(70000, new Replica(70002, be2.getId(), 0, ReplicaState.NORMAL));
         invertedIndex.addReplica(70000, new Replica(70003, be3.getId(), 0, ReplicaState.NORMAL));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
@@ -619,7 +619,7 @@ public class DiskAndTabletLoadReBalancerTest {
                            TStorageMedium medium,
                            long dbId, long tableId, long physicalPartitionId, long indexId, long tabletId, long replicaId,
                            long beId, long dataSize, long pathHash) {
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, 1111, medium);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, medium);
         Replica replica = new Replica(replicaId, beId, 1L, 1111,
                 dataSize, 1000, ReplicaState.NORMAL, -1, 1);
         invertedIndex.addTablet(tabletId, tabletMeta);
@@ -809,13 +809,13 @@ public class DiskAndTabletLoadReBalancerTest {
 
         // add tablet to invertedIndex
         invertedIndex.addTablet(tabletId1,
-                new TabletMeta(1, 2, 3, 4, -1, TStorageMedium.HDD));
+                new TabletMeta(1, 2, 3, 4, TStorageMedium.HDD));
         Replica replica = new Replica(replicaId1, 1, -1, ReplicaState.NORMAL);
         replica.setPathHash(pathHash10);
         invertedIndex.addReplica(tabletId1, replica);
 
         invertedIndex.addTablet(tabletId2,
-                new TabletMeta(1, 2, 3, 4, -1, TStorageMedium.HDD));
+                new TabletMeta(1, 2, 3, 4, TStorageMedium.HDD));
         replica = new Replica(replicaId2, 1, -1, ReplicaState.NORMAL);
         replica.setPathHash(pathHash13);
         invertedIndex.addReplica(tabletId2, replica);

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
@@ -111,7 +111,7 @@ public class TabletSchedCtxTest {
 
         // tablet with single replica
         LocalTablet tablet = new LocalTablet(TABLET_ID_1);
-        TabletMeta tabletMeta = new TabletMeta(DB_ID, TB_ID, PART_ID, INDEX_ID, SCHEMA_HASH, TStorageMedium.HDD);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TB_ID, PART_ID, INDEX_ID, TStorageMedium.HDD);
         GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID_1, tabletMeta);
         GlobalStateMgr.getCurrentState().getTabletInvertedIndex().
                 addReplica(TABLET_ID_1, new Replica(50001, be1.getId(), 0, Replica.ReplicaState.NORMAL));
@@ -235,7 +235,7 @@ public class TabletSchedCtxTest {
 
     @Test
     public void testChooseDestReplicaForVersionIncomplete() {
-        TabletMeta tabletMeta = new TabletMeta(DB_ID, TB_ID, PART_ID, INDEX_ID, SCHEMA_HASH, TStorageMedium.HDD);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TB_ID, PART_ID, INDEX_ID, TStorageMedium.HDD);
         GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID_2, tabletMeta);
         Replica replica1 = new Replica(50011, be1.getId(), 0, Replica.ReplicaState.NORMAL);
         Replica replica2 = new Replica(50012, be2.getId(), 0, Replica.ReplicaState.NORMAL);

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -440,7 +440,7 @@ public class TabletSchedulerTest {
                 .setTabletSchema(tabletSchema)
                 .build();
 
-        TabletMeta tabletMeta = new TabletMeta(dbId, tblId, partitionId, indexId, -1, TStorageMedium.HDD);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tblId, partitionId, indexId, TStorageMedium.HDD);
 
         Replica replica = new Replica(replicaId, beId, -1, Replica.ReplicaState.RECOVER);
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/LakeTabletsProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/LakeTabletsProcNodeTest.java
@@ -94,7 +94,7 @@ public class LakeTabletsProcNodeTest {
 
         // Index
         MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.HDD, true);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, TStorageMedium.HDD, true);
         index.addTablet(tablet1, tabletMeta);
         index.addTablet(tablet2, tabletMeta);
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/LocalTabletsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/LocalTabletsProcDirTest.java
@@ -131,7 +131,7 @@ public class LocalTabletsProcDirTest {
 
         // Index
         MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.SSD);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, TStorageMedium.SSD);
         index.addTablet(tablet1, tabletMeta);
         index.addTablet(tablet2, tabletMeta);
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/UnitTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/UnitTestUtil.java
@@ -122,7 +122,7 @@ public class UnitTestUtil {
 
         // index
         MaterializedIndex index = new MaterializedIndex(indexId, IndexState.NORMAL);
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.HDD);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, TStorageMedium.HDD);
         index.addTablet(tablet, tabletMeta);
 
         tablet.addReplica(replica1);
@@ -199,7 +199,7 @@ public class UnitTestUtil {
 
         // index
         MaterializedIndex index = new MaterializedIndex(indexId, IndexState.NORMAL);
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.HDD);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, TStorageMedium.HDD);
         index.addTablet(tablet, tabletMeta);
 
         tablet.addReplica(replica1);

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
@@ -53,7 +53,7 @@ public class ConsistencyCheckerTest {
         Replica replica = new Replica(replicaId, backendId, 2L, 1111,
                 10, 1000, Replica.ReplicaState.NORMAL, -1, 2);
 
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 1111, medium);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, medium);
         LocalTablet tablet = new LocalTablet(tabletId, Lists.newArrayList(replica));
         materializedIndex.addTablet(tablet, tabletMeta, false);
         PartitionInfo partitionInfo = new PartitionInfo();
@@ -98,7 +98,7 @@ public class ConsistencyCheckerTest {
     @Test
     public void testResetToBeCleanedTime() {
         TabletMeta tabletMeta = new TabletMeta(1, 2, 3,
-                4, 5, TStorageMedium.HDD);
+                4, TStorageMedium.HDD);
         tabletMeta.setToBeCleanedTime(123L);
         tabletMeta.resetToBeCleanedTime();
         Assertions.assertNull(tabletMeta.getToBeCleanedTime());

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -231,7 +231,7 @@ public abstract class StarRocksHttpTestCase {
         // index
         MaterializedIndex baseIndex = new MaterializedIndex(testIndexId, MaterializedIndex.IndexState.NORMAL);
         TabletMeta tabletMeta =
-                new TabletMeta(testDbId, testTableId, testPartitionId, testIndexId, testSchemaHash, TStorageMedium.HDD);
+                new TabletMeta(testDbId, testTableId, testPartitionId, testIndexId, TStorageMedium.HDD);
         baseIndex.addTablet(tablet, tabletMeta);
 
         tablet.addReplica(replica1);

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
@@ -188,7 +188,7 @@ public class TablePartitionActionTest extends StarRocksHttpTestCase {
         // index
         MaterializedIndex baseIndex = new MaterializedIndex(testIndexId, MaterializedIndex.IndexState.NORMAL);
         TabletMeta tabletMeta = new TabletMeta(
-                testDbId, RANGE_PARTITION_TABLE_ID, BASE_PARTITION_ID, testIndexId, testSchemaHash, TStorageMedium.HDD, true);
+                testDbId, RANGE_PARTITION_TABLE_ID, BASE_PARTITION_ID, testIndexId, TStorageMedium.HDD, true);
         baseIndex.addTablet(tablet, tabletMeta);
 
         FilePathInfo.Builder builder = FilePathInfo.newBuilder();
@@ -357,7 +357,7 @@ public class TablePartitionActionTest extends StarRocksHttpTestCase {
         // index
         MaterializedIndex baseIndex = new MaterializedIndex(testIndexId, MaterializedIndex.IndexState.NORMAL);
         TabletMeta tabletMeta = new TabletMeta(
-                testDbId, LIST_PARTITION_TABLE_ID, BASE_PARTITION_ID, testIndexId, testSchemaHash, TStorageMedium.HDD);
+                testDbId, LIST_PARTITION_TABLE_ID, BASE_PARTITION_ID, testIndexId, TStorageMedium.HDD);
         baseIndex.addTablet(tablet, tabletMeta);
 
         tablet.addReplica(new Replica(

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
@@ -145,7 +145,7 @@ public class LakeMaterializedViewTest {
 
         // Index
         MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        TabletMeta tabletMeta = new TabletMeta(dbId, mvId, partitionId, indexId, 0, TStorageMedium.HDD, true);
+        TabletMeta tabletMeta = new TabletMeta(dbId, mvId, partitionId, indexId, TStorageMedium.HDD, true);
         index.addTablet(tablet1, tabletMeta);
         index.addTablet(tablet2, tabletMeta);
 
@@ -421,7 +421,7 @@ public class LakeMaterializedViewTest {
 
         // partition1
         MaterializedIndex index1 = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        TabletMeta tabletMeta1 = new TabletMeta(dbId, mvId, partition1Id, indexId, 0, TStorageMedium.HDD, true);
+        TabletMeta tabletMeta1 = new TabletMeta(dbId, mvId, partition1Id, indexId, TStorageMedium.HDD, true);
         Tablet tablet1 = new LakeTablet(tablet1Id);
         index1.addTablet(tablet1, tabletMeta1);
         Partition partition1 = new Partition(partition1Id, physicalPartitionId1, "p1", index1, distributionInfo);
@@ -434,7 +434,7 @@ public class LakeMaterializedViewTest {
 
         // partition2
         MaterializedIndex index2 = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        TabletMeta tabletMeta2 = new TabletMeta(dbId, mvId, partition2Id, indexId, 0, TStorageMedium.HDD, true);
+        TabletMeta tabletMeta2 = new TabletMeta(dbId, mvId, partition2Id, indexId, TStorageMedium.HDD, true);
         Tablet tablet2 = new LakeTablet(tablet2Id);
         index2.addTablet(tablet2, tabletMeta2);
         Partition partition2 = new Partition(partition2Id, physicalPartitionId2, "p2", index1, distributionInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -177,7 +177,7 @@ public class LakeTableHelperTest {
         Partition partition = new Partition(partitionId, partitionId + 100, "t0", index, dist);
         TStorageMedium storage = TStorageMedium.HDD;
         TabletMeta tabletMeta =
-                new TabletMeta(db.getId(), table.getId(), partition.getId(), index.getId(), 0, storage, true);
+                new TabletMeta(db.getId(), table.getId(), partition.getId(), index.getId(), storage, true);
         for (int i = 0; i < 10; i++) {
             Tablet tablet = new LakeTablet(GlobalStateMgr.getCurrentState().getNextId());
             index.addTablet(tablet, tabletMeta);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
@@ -125,7 +125,7 @@ public class DeleteTest {
 
         // Index
         MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.HDD, true);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, TStorageMedium.HDD, true);
         index.addTablet(tablet1, tabletMeta);
         index.addTablet(tablet2, tabletMeta);
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
@@ -123,7 +123,7 @@ public class DeleteHandlerTest {
             e.printStackTrace();
             Assertions.fail();
         }
-        TabletMeta tabletMeta = new TabletMeta(DB_ID, TBL_ID, PH_PARTITION_ID, TBL_ID, 0, null);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TBL_ID, PH_PARTITION_ID, TBL_ID, null);
         invertedIndex.addTablet(TABLET_ID, tabletMeta);
         invertedIndex.addReplica(TABLET_ID, new Replica(REPLICA_ID_1, BACKEND_ID_1, 0, Replica.ReplicaState.NORMAL));
         invertedIndex.addReplica(TABLET_ID, new Replica(REPLICA_ID_2, BACKEND_ID_2, 0, Replica.ReplicaState.NORMAL));

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportJobTest.java
@@ -88,7 +88,7 @@ public class ExportJobTest {
         //     3        0           3
         //     4        0           4
         //     5        0           5
-        TabletMeta tabletMeta = new TabletMeta(0L, 1L, 2L, 3L, 4, TStorageMedium.HDD, true);
+        TabletMeta tabletMeta = new TabletMeta(0L, 1L, 2L, 3L, TStorageMedium.HDD, true);
         new Expectations() {
             {
                 GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
@@ -167,7 +167,7 @@ public class ExportJobTest {
         //     3        0           3
         //     4        0           4
         //     5        0           5
-        TabletMeta tabletMeta = new TabletMeta(0L, 1L, 2L, 3L, 4, TStorageMedium.HDD, false);
+        TabletMeta tabletMeta = new TabletMeta(0L, 1L, 2L, 3L, TStorageMedium.HDD, false);
         new Expectations() {
             {
                 GlobalStateMgr.getCurrentState().getTabletInvertedIndex();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -267,7 +267,7 @@ public class OlapTableSinkTest {
 
         // Index
         MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, 0, TStorageMedium.SSD);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, TStorageMedium.SSD);
         index.addTablet(tablet, tabletMeta);
 
         // Partition
@@ -365,7 +365,7 @@ public class OlapTableSinkTest {
             tablet.addReplica(replica3);
 
             // Index
-            TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, 0, TStorageMedium.SSD);
+            TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, TStorageMedium.SSD);
             index.addTablet(tablet, tabletMeta);
         }
 
@@ -719,7 +719,7 @@ public class OlapTableSinkTest {
         partitionInfo.setReplicationNum(partitionId, (short) 3);
         // Index
         MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, 0, TStorageMedium.SSD);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, TStorageMedium.SSD);
         index.addTablet(tablet, tabletMeta);
         // Partition
         Partition partition = new Partition(partitionId, physicalPartitionId, "p1", index, distributionInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -180,7 +180,7 @@ public class LocalMetaStoreTest {
         int schemaHash = table.getSchemaHashByIndexId(p.getBaseIndex().getId());
         MaterializedIndex index = new MaterializedIndex();
         TabletMeta tabletMeta = new TabletMeta(db.getId(), table.getId(), p.getId(),
-                    index.getId(), schemaHash, table.getPartitionInfo().getDataProperty(p.getParentId()).getStorageMedium());
+                    index.getId(), table.getPartitionInfo().getDataProperty(p.getParentId()).getStorageMedium());
         index.addTablet(new LocalTablet(0), tabletMeta);
         PhysicalPartitionPersistInfoV2 info = new PhysicalPartitionPersistInfoV2(
                     db.getId(), table.getId(), p.getParentId(), new PhysicalPartition(123, "", p.getId(), index));

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -862,7 +862,7 @@ public class SharedDataStorageVolumeMgrTest {
 
                 // Index
                 MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-                TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.HDD, true);
+                TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, TStorageMedium.HDD, true);
                 index.addTablet(tablet1, tabletMeta);
                 index.addTablet(tablet2, tabletMeta);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUpdateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUpdateTest.java
@@ -130,7 +130,7 @@ public class AnalyzeUpdateTest {
                 // Index
                 MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
                 TabletMeta tabletMeta =
-                        new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.HDD, true);
+                        new TabletMeta(dbId, tableId, partitionId, indexId, TStorageMedium.HDD, true);
                 index.addTablet(tablet, tabletMeta);
 
                 // Partition

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTestHelper.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTestHelper.java
@@ -44,7 +44,7 @@ public class LakeTableTestHelper {
         MaterializedIndex index = new MaterializedIndex(indexId);
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
         for (long id : tabletId) {
-            TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, 0, 0, TStorageMedium.HDD, true);
+            TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, 0, TStorageMedium.HDD, true);
             invertedIndex.addTablet(id, tabletMeta);
             index.addTablet(new LakeTablet(id), tabletMeta);
         }


### PR DESCRIPTION
This pull request simplifies the `TabletMeta` class and updates its usage across the codebase to remove schema hash-related fields and methods, which are no longer relevant. Additionally, it includes minor cleanups and refactoring to improve code maintainability.

Historically, after a schema change, a new schemaHash would be added under the tablet directory instead of creating a new tablet. Currently, schema change creates a new set of tablets, and only one schema hash may exist under the tablet directory.For compatibility with historical data, schemaHash is now only used to construct the path of data files on disk. It is only meaningful in the storage-compute integrated mode, and has no significance in the storage-compute separated mode.

## What I'm doing:
Removed `oldSchemaHash` and `newSchemaHash` fields and associated methods (`getOldSchemaHash`, `getNewSchemaHash`, `containsSchemaHash`, etc.) from `TabletMeta`. These fields are no longer relevant due to changes in schema management. 

Impact:
- Reduces memory usage for TabletMeta objects
- Simplifies code logic and improves maintainability
- No functional impact as the field was not being used effectively


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
