### PR TITLE
[Refactor] Fix deprecated Integer constructor usage across codebase

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -836,7 +836,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                 List<Column> differences = originSchema.stream().filter(element ->
                         !shadowSchema.contains(element)).collect(Collectors.toList());
                 // can just drop one column one time, so just one element in differences
-                Integer dropIdx = new Integer(originSchema.indexOf(differences.get(0)));
+                Integer dropIdx = Integer.valueOf(originSchema.indexOf(differences.get(0)));
                 modifiedColumns.add(originSchema.get(dropIdx).getName());
             } else {
                 // add column should not affect old mv, just ignore.

--- a/fe/spark-dpp/src/test/java/com/starrocks/load/loadv2/dpp/DppUtilsTest.java
+++ b/fe/spark-dpp/src/test/java/com/starrocks/load/loadv2/dpp/DppUtilsTest.java
@@ -300,7 +300,7 @@ public class DppUtilsTest {
         Assertions.assertEquals(1489118142L, hashValue.getValue());
 
         column = new EtlJobConfig.EtlColumn("k1", "INT", true, true, "NONE", "0", 0, 0, 0);
-        bf = DppUtils.getHashValue(new Integer(1), DataTypes.IntegerType, column);
+        bf = DppUtils.getHashValue(Integer.valueOf(1), DataTypes.IntegerType, column);
         hashValue.reset();
         hashValue.update(bf.array(), 0, bf.limit());
         Assertions.assertEquals(2583214201L, hashValue.getValue());

--- a/fe/spark-dpp/src/test/java/com/starrocks/load/loadv2/dpp/StarRocksRangePartitionerTest.java
+++ b/fe/spark-dpp/src/test/java/com/starrocks/load/loadv2/dpp/StarRocksRangePartitionerTest.java
@@ -30,23 +30,23 @@ public class StarRocksRangePartitionerTest {
     @Test
     public void testRangePartitioner() {
         List<Object> startKeys = new ArrayList<>();
-        startKeys.add(new Integer(0));
+        startKeys.add(Integer.valueOf(0));
         List<Object> endKeys = new ArrayList<>();
-        endKeys.add(new Integer(100));
+        endKeys.add(Integer.valueOf(100));
         EtlJobConfig.EtlPartition partition1 = new EtlJobConfig.EtlPartition(
                 10000, startKeys, endKeys, false, false, 3);
 
         List<Object> startKeys2 = new ArrayList<>();
-        startKeys2.add(new Integer(100));
+        startKeys2.add(Integer.valueOf(100));
         List<Object> endKeys2 = new ArrayList<>();
-        endKeys2.add(new Integer(200));
+        endKeys2.add(Integer.valueOf(200));
         EtlJobConfig.EtlPartition partition2 = new EtlJobConfig.EtlPartition(
                 10001, startKeys2, endKeys2, false, false, 4);
 
         List<Object> startKeys3 = new ArrayList<>();
-        startKeys3.add(new Integer(200));
+        startKeys3.add(Integer.valueOf(200));
         List<Object> endKeys3 = new ArrayList<>();
-        endKeys3.add(new Integer(300));
+        endKeys3.add(Integer.valueOf(300));
         EtlJobConfig.EtlPartition partition3 = new EtlJobConfig.EtlPartition(
                 10002, startKeys3, endKeys3, false, false, 5);
 
@@ -124,14 +124,14 @@ public class StarRocksRangePartitionerTest {
     public void testMinPartitionWithNull() {
         List<Object> startKeys = new ArrayList<>();
         List<Object> endKeys = new ArrayList<>();
-        endKeys.add(new Integer(100));
+        endKeys.add(Integer.valueOf(100));
         EtlJobConfig.EtlPartition partition1 = new EtlJobConfig.EtlPartition(
                 10000, startKeys, endKeys, true, false, 3);
 
         List<Object> startKeys2 = new ArrayList<>();
-        startKeys2.add(new Integer(100));
+        startKeys2.add(Integer.valueOf(100));
         List<Object> endKeys2 = new ArrayList<>();
-        endKeys2.add(new Integer(200));
+        endKeys2.add(Integer.valueOf(200));
         EtlJobConfig.EtlPartition partition2 = new EtlJobConfig.EtlPartition(
                 10001, startKeys2, endKeys2, false, false, 4);
 


### PR DESCRIPTION
- Replace new Integer() with Integer.valueOf() in SchemaChangeJobV2.java (1 instance)
- Replace new Integer() with Integer.valueOf() in DppUtilsTest.java (1 instance)
- Replace new Integer() with Integer.valueOf() in StarRocksRangePartitionerTest.java (8 instances)
- Total 10 deprecated Integer constructor calls fixed
- Complements previous Long constructor fixes for complete wrapper deprecation cleanup

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
