### PR TITLE
[BugFix] sync OK hbResponse if the heartbeatRetryTimes counter get reset

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -552,6 +552,7 @@ public class ComputeNode implements IComputable, Writable, GsonPostProcessable {
         boolean isChanged = false;
         boolean changedToShutdown = false;
         boolean becomeDead = false;
+        int oldHeartbeatRetryTimes = this.heartbeatRetryTimes;
         if (hbResponse.getStatus() == HeartbeatResponse.HbStatus.OK) {
             if (this.version == null) {
                 return false;
@@ -703,7 +704,8 @@ public class ComputeNode implements IComputable, Writable, GsonPostProcessable {
                 CoordinatorMonitor.getInstance().addDeadBackend(id);
             }
         }
-        return isChanged;
+        // If heartbeatRetryTimes is changed, replicate this HbResponse to followers as well.
+        return isChanged || oldHeartbeatRetryTimes != this.heartbeatRetryTimes;
     }
 
     public Optional<DataCacheMetrics> getDataCacheMetrics() {


### PR DESCRIPTION
* allow FE followers/observers correctly reset its internal heartbeatRetryTimes, so that it can correctly determine if the node is dead or not.

## Why I'm doing:

heartbeat log on leader
```
2025-07-24 11:38:38.158+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:38:53.153+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:39:38.183+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:39:43.194+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Connect timed out
2025-07-24 11:40:03.214+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:40:13.227+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:40:28.240+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:40:33.247+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Connect timed out
2025-07-24 11:40:33.247+08:00 INFO (heartbeat mgr|16) [ComputeNode.handleHbResponse():655] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=OK] is dead due to exceed heartbeatRetryTimes
2025-07-24 11:40:33.248+08:00 INFO (heartbeat mgr|16) [CoordinatorMonitor.addDeadBackend():57] add backend 10008 to dead backend queue
2025-07-24 11:40:33.248+08:00 INFO (heartbeat mgr|16) [TxnStateCallbackFactory.removeCallback():47] remove callback of txn state : 64147. current callback size: 17
2025-07-24 11:40:33.253+08:00 INFO (heartbeat mgr|16) [DatabaseTransactionMgr.abortTransaction():630] transaction:[TransactionState. txn_id: 3501, label: stream_load_1753328295556_N35, db id: 11370, table id list: 11373, callback id: [64147], coordinator: BE: 172.26.80.184, transaction status: ABORTED, error replicas num: 0, unknown replicas num: 0, prepare time: 1753328295908, write end time: -1, allow commit time: -1, commit time: -1, finish time: 1753328433248, total cost: 137340ms, reason: coordinate BE is down, partition commit info:[]] successfully rollback
2025-07-24 11:40:48.257+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:40:53.255+08:00 INFO (heartbeat mgr|16) [ComputeNode.handleHbResponse():608] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=DISCONNECTED] is alive, last start time: 1753326593000, hbTime: 1753328453255
2025-07-24 11:41:13.271+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:41:23.285+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Connect timed out
2025-07-24 11:41:48.281+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:41:58.284+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:42:08.299+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:42:13.306+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Connect timed out
2025-07-24 11:42:13.306+08:00 INFO (heartbeat mgr|16) [ComputeNode.handleHbResponse():655] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=OK] is dead due to exceed heartbeatRetryTimes
2025-07-24 11:42:13.306+08:00 INFO (heartbeat mgr|16) [CoordinatorMonitor.addDeadBackend():57] add backend 10008 to dead backend queue
2025-07-24 11:42:18.319+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Connect timed out
2025-07-24 11:42:33.334+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:42:43.343+08:00 INFO (heartbeat mgr|16) [ComputeNode.handleHbResponse():608] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=DISCONNECTED] is alive, last start time: 1753326593000, hbTime: 1753328563343
2025-07-24 11:42:58.352+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:43:13.364+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
2025-07-24 11:43:18.375+08:00 WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.SocketTimeoutException: Read timed out
```

heartbeat log on folllower

```
2025-07-24 11:39:43.198+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():655] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=OK] is dead due to exceed heartbeatRetryTimes
2025-07-24 11:39:43.198+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():689] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=true, status=OK] alive status is changed to true
2025-07-24 11:40:03.218+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():655] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=OK] is dead due to exceed heartbeatRetryTimes
2025-07-24 11:40:03.218+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():689] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=true, status=OK] alive status is changed to true
2025-07-24 11:40:13.232+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():655] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=OK] is dead due to exceed heartbeatRetryTimes
2025-07-24 11:40:13.232+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():689] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=true, status=OK] alive status is changed to true
2025-07-24 11:40:28.245+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():655] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=OK] is dead due to exceed heartbeatRetryTimes
2025-07-24 11:40:28.245+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():689] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=true, status=OK] alive status is changed to true
2025-07-24 11:40:33.265+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():655] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=OK] is dead due to exceed heartbeatRetryTimes
2025-07-24 11:41:03.264+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():608] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=DISCONNECTED] is alive, last start time: 1753326593000, hbTime: 1753328453255
2025-07-24 11:41:58.288+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():655] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=OK] is dead due to exceed heartbeatRetryTimes
2025-07-24 11:41:58.288+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():689] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=true, status=OK] alive status is changed to true
2025-07-24 11:42:08.303+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():655] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=OK] is dead due to exceed heartbeatRetryTimes
2025-07-24 11:42:08.303+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():689] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=true, status=OK] alive status is changed to true
2025-07-24 11:42:13.314+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():655] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=OK] is dead due to exceed heartbeatRetryTimes
2025-07-24 11:42:43.347+08:00 INFO (replayer|98) [ComputeNode.handleHbResponse():608] Backend [id=10008, host=172.26.80.184, heartbeatPort=9050, alive=false, status=DISCONNECTED] is alive, last start time: 1753326593000, hbTime: 1753328563343
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
