### PR TITLE
[BugFix] Fix set null value for auto_increment column will reject the valid data if they are in the same chunk

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -1008,7 +1008,7 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
                         }
 #endif
                         // If enable_log_rejected_record is true, we need to log the rejected record.
-                        if (nullable->is_null(j) && state->enable_log_rejected_record()) {
+                        if (state->enable_log_rejected_record()) {
                             state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), ss.str(), "");
                         }
                     }

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -991,26 +991,28 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
         if (_has_auto_increment && _auto_increment_slot_id == desc->id() && column_ptr->is_nullable()) {
             auto* nullable = down_cast<NullableColumn*>(column_ptr.get());
             // If nullable->has_null() && _null_expr_in_auto_increment == true, it means that user specify a
-            // null value in auto increment column, we abort the entire chunk and append a single error msg.
+            // null value in auto increment column, we abort the all rows with null.
             // Because be know nothing about whether this row is specified by the user as null or setted during planning.
             if (nullable->has_null() && _null_expr_in_auto_increment) {
                 std::stringstream ss;
                 ss << "NULL value in auto increment column '" << desc->col_name() << "'";
-
+                NullData& nulls = nullable->null_column_data();
                 for (size_t j = 0; j < num_rows; ++j) {
-                    _validate_selection[j] = VALID_SEL_FAILED;
-                    // If enable_log_rejected_record is true, we need to log the rejected record.
-                    if (nullable->is_null(j) && state->enable_log_rejected_record()) {
-                        state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), ss.str(), "");
+                    if (nulls[j] && _validate_selection[j] != VALID_SEL_FAILED) {
+                        _validate_selection[j] = VALID_SEL_FAILED;
+#if BE_TEST
+                        LOG(INFO) << ss.str();
+#else
+                        if (!state->has_reached_max_error_msg_num()) {
+                            state->append_error_msg_to_file(chunk->debug_row(j), ss.str());
+                        }
+#endif
+                        // If enable_log_rejected_record is true, we need to log the rejected record.
+                        if (nullable->is_null(j) && state->enable_log_rejected_record()) {
+                            state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), ss.str(), "");
+                        }
                     }
                 }
-#if BE_TEST
-                LOG(INFO) << ss.str();
-#else
-                if (!state->has_reached_max_error_msg_num()) {
-                    state->append_error_msg_to_file("", ss.str());
-                }
-#endif
             }
             chunk->update_column(nullable->data_column(), desc->id());
         }

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -153,7 +153,30 @@ INSERT INTO t1 (id, idx) properties ("max_filter_ratio" = "1") SELECT id, idx FR
 INSERT INTO t1 (id) SELECT id FROM t2;
 -- result:
 -- !result
-SELECT * FROM t1;
+SELECT * FROM t1 ORDER BY id;
+-- result:
+1	5
+2	6
+10	1
+20	2
+-- !result
+DROP TABLE t1;
+-- result:
+-- !result
+CREATE TABLE t1 ( id BIGINT NOT NULL, idx BIGINT AUTO_INCREMENT )
+Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+INSERT INTO t1 (id, idx) properties ("max_filter_ratio" = "1") SELECT * FROM t2;
+-- result:
+-- !result
+INSERT INTO t1 (id, idx) properties ("max_filter_ratio" = "1") SELECT id, idx FROM t2;
+-- result:
+-- !result
+INSERT INTO t1 (id) SELECT id FROM t2;
+-- result:
+-- !result
+SELECT * FROM t1 ORDER BY id;
 -- result:
 1	5
 2	6

--- a/test/sql/test_auto_increment/T/test_auto_increment
+++ b/test/sql/test_auto_increment/T/test_auto_increment
@@ -199,7 +199,15 @@ Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" 
 INSERT INTO t1 (id, idx) properties ("max_filter_ratio" = "1") SELECT * FROM t2;
 INSERT INTO t1 (id, idx) properties ("max_filter_ratio" = "1") SELECT id, idx FROM t2;
 INSERT INTO t1 (id) SELECT id FROM t2;
-SELECT * FROM t1;
+SELECT * FROM t1 ORDER BY id;
+
+DROP TABLE t1;
+CREATE TABLE t1 ( id BIGINT NOT NULL, idx BIGINT AUTO_INCREMENT )
+Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+INSERT INTO t1 (id, idx) properties ("max_filter_ratio" = "1") SELECT * FROM t2;
+INSERT INTO t1 (id, idx) properties ("max_filter_ratio" = "1") SELECT id, idx FROM t2;
+INSERT INTO t1 (id) SELECT id FROM t2;
+SELECT * FROM t1 ORDER BY id;
 
 DROP TABLE t1;
 DROP TABLE t2;


### PR DESCRIPTION
## Why I'm doing:
If a null value set by user for auto_increment, during the validation in tablet sink, it will reject the entire chunk if the some row is not null.

## What I'm doing:
Just reject the rows with null.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
