### PR TITLE
[UT] Fix varargs warnings in reflection method calls

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -113,11 +113,11 @@ public class TableFunctionTableTest {
 
         TableFunctionTable t = new TableFunctionTable(newProperties());
 
-        Method method = TableFunctionTable.class.getDeclaredMethod("getFileSchema", null);
+        Method method = TableFunctionTable.class.getDeclaredMethod("getFileSchema", (Class<?>[]) null);
         method.setAccessible(true);
 
         try {
-            method.invoke(t, null);
+            method.invoke(t, (Object[]) null);
         } catch (Exception e) {
             Assertions.assertTrue(e.getCause().getMessage().contains("Failed to send proxy request. No alive backends"));
         }
@@ -130,7 +130,7 @@ public class TableFunctionTableTest {
         };
 
         try {
-            method.invoke(t, null);
+            method.invoke(t, (Object[]) null);
         } catch (Exception e) {
             Assertions.assertTrue(e.getCause().getMessage().
                     contains("Failed to send proxy request. No alive backends or compute nodes"));
@@ -159,7 +159,7 @@ public class TableFunctionTableTest {
         };
 
         try {
-            method.invoke(t, null);
+            method.invoke(t, (Object[]) null);
         } catch (Exception e) {
             Assertions.assertFalse(false);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -256,7 +256,7 @@ public class TabletSchedulerTest {
                                          TabletScheduler tabletScheduler)
             throws InvocationTargetException, IllegalAccessException {
         Config.tablet_sched_slot_num_per_path = newSlotPerPath;
-        updateWorkingSlotsMethod.invoke(tabletScheduler, null);
+        updateWorkingSlotsMethod.invoke(tabletScheduler, (Object[]) null);
     }
 
     private long takeSlotNTimes(int nTimes, TabletScheduler.PathSlot pathSlot, long pathHash) throws SchedException {
@@ -301,9 +301,9 @@ public class TabletSchedulerTest {
         systemInfoService.addBackend(be2);
 
         TabletScheduler tabletScheduler = new TabletScheduler(tabletSchedulerStat);
-        Method m = TabletScheduler.class.getDeclaredMethod("updateWorkingSlots", null);
+        Method m = TabletScheduler.class.getDeclaredMethod("updateWorkingSlots", (Class<?>[]) null);
         m.setAccessible(true);
-        m.invoke(tabletScheduler, null);
+        m.invoke(tabletScheduler, (Object[]) null);
         Map<Long, TabletScheduler.PathSlot> bslots = tabletScheduler.getBackendsWorkingSlots();
         Assertions.assertEquals(Config.tablet_sched_slot_num_per_path, bslots.get(1L).peekSlot(11));
         Assertions.assertEquals(Config.tablet_sched_slot_num_per_path, bslots.get(2L).peekSlot(22));

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportPendingTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportPendingTaskTest.java
@@ -79,11 +79,11 @@ public class ExportPendingTaskTest {
         Method method = ExportPendingTask.class.getDeclaredMethod("makeSnapshots");
         method.setAccessible(true);
 
-        Status status = (Status) method.invoke(task, null);
+        Status status = (Status) method.invoke(task, (Object[]) null);
         Assertions.assertEquals(Status.CANCELLED, status);
 
         node.setAlive(true);
-        status = (Status) method.invoke(task, null);
+        status = (Status) method.invoke(task, (Object[]) null);
         Assertions.assertEquals(TStatusCode.CANCELLED, status.getErrorCode());
     }
 }


### PR DESCRIPTION
Fix compiler warnings about non-varargs call of varargs method with inexact argument type for last parameter in test files.

Changes:
- Cast null to (Class<?>[]) null for getDeclaredMethod calls
- Cast null to (Object[]) null for method.invoke calls

Affected files:
- TableFunctionTableTest.java: 4 warnings fixed
- ExportPendingTaskTest.java: 2 warnings fixed
- TabletSchedulerTest.java: 3 warnings fixed

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
