### PR TITLE
[BugFix] partition-statistics: load it fully async

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2218,6 +2218,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "Whether to allow auto collection of the NDV of array columns")
     public static boolean enable_auto_collect_array_ndv = false;
 
+    @ConfField(mutable = true, comment = "Synchronously load statistics for testing purpose")
+    public static boolean enable_sync_statistics_load = false;
+
     /**
      * default bucket size of histogram statistics
      */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -52,7 +52,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 
@@ -415,16 +414,16 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
             CompletableFuture<Map<ColumnStatsCacheKey, Optional<PartitionStats>>> resultFuture =
                     partitionStatistics.getAll(cacheKeys);
 
-            Map<ColumnStatsCacheKey, Optional<PartitionStats>> result = resultFuture.get(5, TimeUnit.SECONDS);
-            return columns.stream()
-                    .collect(Collectors.toMap(
-                            column -> column,
-                            column -> result.getOrDefault(new ColumnStatsCacheKey(table.getId(), column), Optional.empty())
-                                    .orElse(null)
-                    ));
-
-        } catch (TimeoutException e) {
-            LOG.warn("Get partition NDV timeout", e);
+            if (resultFuture.isDone()) {
+                Map<ColumnStatsCacheKey, Optional<PartitionStats>> result = resultFuture.get();
+                return columns.stream()
+                        .collect(Collectors.toMap(
+                                column -> column,
+                                column -> result.getOrDefault(new ColumnStatsCacheKey(table.getId(), column),
+                                                Optional.empty())
+                                        .orElse(null)
+                        ));
+            }
             return Collections.emptyMap();
         } catch (InterruptedException e) {
             LOG.warn("Get partition NDV interrupted", e);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -413,6 +413,9 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
         try {
             CompletableFuture<Map<ColumnStatsCacheKey, Optional<PartitionStats>>> resultFuture =
                     partitionStatistics.getAll(cacheKeys);
+            if (Config.enable_sync_statistics_load) {
+                resultFuture.get();
+            }
 
             if (resultFuture.isDone()) {
                 Map<ColumnStatsCacheKey, Optional<PartitionStats>> result = resultFuture.get();

--- a/test/sql/test_list_partition/R/test_list_partition_cardinality
+++ b/test/sql/test_list_partition/R/test_list_partition_cardinality
@@ -8,6 +8,9 @@ CREATE DATABASE test_list_partition_cardinality;
 USE test_list_partition_cardinality;
 -- result:
 -- !result
+ADMIN SET FRONTEND CONFIG ("enable_sync_statistics_load" = "true");
+-- result:
+-- !result
 CREATE TABLE partitions_multi_column_1 (
     c1 int NOT NULL,
     c2 int NOT NULL,

--- a/test/sql/test_list_partition/R/test_list_partition_selectivity
+++ b/test/sql/test_list_partition/R/test_list_partition_selectivity
@@ -8,6 +8,9 @@ CREATE DATABASE test_list_partition_selectivity;
 USE test_list_partition_selectivity;
 -- result:
 -- !result
+ADMIN SET FRONTEND CONFIG ("enable_sync_statistics_load" = "true");
+-- result:
+-- !result
 CREATE TABLE partitions_multi_column_1 (
     c1 int NOT NULL,
     c2 int NOT NULL,

--- a/test/sql/test_list_partition/T/test_list_partition_cardinality
+++ b/test/sql/test_list_partition/T/test_list_partition_cardinality
@@ -3,6 +3,7 @@
 DROP DATABASE IF EXISTS test_list_partition_cardinality;
 CREATE DATABASE test_list_partition_cardinality;
 USE test_list_partition_cardinality;
+ADMIN SET FRONTEND CONFIG ("enable_sync_statistics_load" = "true");
 
 CREATE TABLE partitions_multi_column_1 (
     c1 int NOT NULL,

--- a/test/sql/test_list_partition/T/test_list_partition_selectivity
+++ b/test/sql/test_list_partition/T/test_list_partition_selectivity
@@ -3,6 +3,7 @@
 DROP DATABASE IF EXISTS test_list_partition_selectivity;
 CREATE DATABASE test_list_partition_selectivity;
 USE test_list_partition_selectivity;
+ADMIN SET FRONTEND CONFIG ("enable_sync_statistics_load" = "true");
 
 CREATE TABLE partitions_multi_column_1 (
     c1 int NOT NULL,


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Sync partition-statistics cache loading can lead to a logical deadlock under specific circumstances:

1. **Query Thread**: Acquires the lock for the current database (e.g., `db1`) and waits for the partition-statistics cache to load, which will attempt to acquire the lock of `_statistics_` db
3. **Other Thread**: background tasks may hold both the `_statistics_` db and `db1`, even WriteLock
4. **Outcome**: The fair lock policy may result in a logical deadlock due to conflicting lock requests.

**Root Cause**: The current LockManager design imposes limitations, where threads should avoid two-phase locking—attempting to acquire additional locks while already holding one. Because it could potentially violate the sequential locking policy requirements.

**Solution**: use asynchronous cache loading to  prevent deadlocks.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
