### PR TITLE
feat(query): Tolerate partial BE failures during queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1968,6 +1968,14 @@ public class Config extends ConfigBase {
     public static boolean recover_with_empty_tablet = false;
 
     /**
+     * When this variable is set to true, the system can still execute queries 
+     * even if some BE nodes fail, but completeness of returned results is not guaranteed, 
+     * and this configuration only applies to query operations
+     */
+    @ConfField(mutable = true)
+    public static boolean skip_unavailable_node = false;
+
+    /**
      * Limit on the number of expr children of an expr tree.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/NormalBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/NormalBackendSelector.java
@@ -113,6 +113,9 @@ public class NormalBackendSelector implements BackendSelector {
 
             // fail eventually if it can't find any location.
             if (minLocation == null) {
+                if (Config.skip_unavailable_node) {
+                    continue;
+                }
                 workerProvider.reportDataNodeNotFoundException();
             }
             Preconditions.checkNotNull(minLocation);


### PR DESCRIPTION
## Why I'm doing:
To enhance StarRocks' fault tolerance by allowing queries to proceed when backend (BE) nodes are unhealthy, reducing query failures and operational burdens. This solves the problem of entire queries failing due to single-node issues.

This capability provides critical value in single-replica log retrieval or full-text search scenarios, designed as the counterpart to ClickHouse's skip_unavailable_shards parameter. Consider this typical use case: When fragmented single-replica tablets from multiple tables are distributed across backend (BE) nodes, the failure of any BE node would render the entire StarRocks cluster unavailable. The rationale for single-replica deployment stems from inherent characteristics of log processing scenarios:

Tolerance for partial data loss: Log retrieval results permit missing log segments
Fundamental difference from analytical workloads: Unlike aggregation computations where missing data causes calculation errors, log searches maintain functional validity despite partial gaps


## What I'm doing:
Added dynamic parameter `skip_unavailable_node` that intelligently bypasses unhealthy BE nodes during query planning while maintaining backward compatibility when disabled. Includes FE core modifications and integration with existing node monitoring systems.

Fixes #[Insert Issue Number Here]

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3


## Testing
### Normal Cluster Information

```shell
$ xos-g7cteq7h:/tshiyu/starrocks/siglereplica/output -> kubectl  -n tshiyuoo get po 
NAME                  READY   STATUS    RESTARTS   AGE
kube-starrocks-be-0   1/1     Running   0          40h
kube-starrocks-be-1   1/1     Running   0          17s
kube-starrocks-be-2   1/1     Running   0          17s
kube-starrocks-fe-0   1/1     Running   0          22m
```
```
Databases: testing Table:tshiyu   Partition:p20250722
```
<img width="764" height="312" alt="image" src="https://github.com/user-attachments/assets/67aa0fd8-4dca-4354-93c5-a4b2a4ce0802" />

```
mysql> select count(*)  from testing.tshiyu;
+----------+
| count(*) |
+----------+
|  1197951 |
+----------+
1 row in set (0.03 sec)
```


### Simulate BE Failure Test for Cluster
```
# StarRocks Cluster Information（Scale down the kube-starrocks-be-2 pod to simulate BE node failure）
$ xos-g7cteq7h:/tshiyu/starrocks/siglereplica/output -> kubectl -n tshiyuoo get po
NAME                  READY   STATUS    RESTARTS   AGE
kube-starrocks-be-0   1/1     Running   0          40h
kube-starrocks-be-1   1/1     Running   0          11m
kube-starrocks-fe-0   1/1     Running   0          34m

# Checking the default value of the new parameter
mysql> ADMIN SHOW FRONTEND CONFIG LIKE 'skip_unavailable_node';
+-----------------------+------------+-------+---------+-----------+---------+
| Key                   | AliasNames | Value | Type    | IsMutable | Comment |
+-----------------------+------------+-------+---------+-----------+---------+
| skip_unavailable_node | []         | false | boolean | true      |         |
+-----------------------+------------+-------+---------+-----------+---------+
1 row in set (0.00 sec)

# Attempting a query
mysql> select count(*) from testing.tshiyu;
ERROR 1064 (HY000): Backend node not found. Check if any backend node is down.backend: 
[kube-starrocks-be-2.kube-starrocks-be-search.tshiyuoo.svc.cluster.local alive: false inBlacklist: true]

# Dynamically enabling skip unavailable nodes
mysql> ADMIN SET FRONTEND CONFIG ("skip_unavailable_node" = "true");
Query OK, 0 rows affected (0.01 sec)

# Retrying the query
mysql> select count(*) from testing.tshiyu;
+----------+
| count(*) |
+----------+
|   982344 |
+----------+
1 row in set (0.03 sec)

Note: As shown above, kube-starrocks-be-2 is the simulated failed node. During the query, all data on be-2 was temporarily unavailable. The calculation 251435 + 251554 + 263747 + 215608 = 982344 confirms the data integrity.
```


