### PR TITLE
[Doc] Fix the return type in TIMESTAMPDIFF documentation

### DIFF
--- a/docs/en/sql-reference/sql-functions/date-time-functions/timestampdiff.md
+++ b/docs/en/sql-reference/sql-functions/date-time-functions/timestampdiff.md
@@ -15,7 +15,7 @@ MILLISECOND (since 3.2), SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, or YEAR.
 ## Syntax
 
 ```Haskell
-INT TIMESTAMPDIFF(unit,DATETIME datetime_expr1, DATETIME datetime_expr2)
+BIGINT TIMESTAMPDIFF(unit,DATETIME datetime_expr1, DATETIME datetime_expr2)
 ```
 
 ## Parameters
@@ -25,7 +25,7 @@ INT TIMESTAMPDIFF(unit,DATETIME datetime_expr1, DATETIME datetime_expr2)
 
 ## Return value
 
-Returns an INT value.
+Returns an BIGINT value.
 
 ## Examples
 

--- a/docs/en/sql-reference/sql-functions/date-time-functions/timestampdiff.md
+++ b/docs/en/sql-reference/sql-functions/date-time-functions/timestampdiff.md
@@ -25,7 +25,7 @@ BIGINT TIMESTAMPDIFF(unit,DATETIME datetime_expr1, DATETIME datetime_expr2)
 
 ## Return value
 
-Returns an BIGINT value.
+Returns a BIGINT value.
 
 ## Examples
 

--- a/docs/ja/sql-reference/sql-functions/date-time-functions/timestampdiff.md
+++ b/docs/ja/sql-reference/sql-functions/date-time-functions/timestampdiff.md
@@ -13,7 +13,7 @@ MILLISECOND (3.2 以降)、SECOND、MINUTE、HOUR、DAY、WEEK、MONTH、また�
 ## Syntax
 
 ```Haskell
-INT TIMESTAMPDIFF(unit,DATETIME datetime_expr1, DATETIME datetime_expr2)
+BIGINT TIMESTAMPDIFF(unit,DATETIME datetime_expr1, DATETIME datetime_expr2)
 ```
 
 ## Parameters
@@ -23,7 +23,7 @@ INT TIMESTAMPDIFF(unit,DATETIME datetime_expr1, DATETIME datetime_expr2)
 
 ## Return value
 
-INT 値を返します。
+BIGINT 値を返します。
 
 ## Examples
 

--- a/docs/zh/sql-reference/sql-functions/date-time-functions/timestampdiff.md
+++ b/docs/zh/sql-reference/sql-functions/date-time-functions/timestampdiff.md
@@ -15,7 +15,7 @@ MILLISECOND（3.2 及以后），SECOND，MINUTE，HOUR，DAY，WEEK，MONTH，Y
 ## 语法
 
 ```Haskell
-INT TIMESTAMPDIFF(unit, DATETIME datetime_expr1, DATETIME datetime_expr2)
+BIGINT TIMESTAMPDIFF(unit, DATETIME datetime_expr1, DATETIME datetime_expr2)
 ```
 
 ## 参数说明
@@ -25,7 +25,7 @@ INT TIMESTAMPDIFF(unit, DATETIME datetime_expr1, DATETIME datetime_expr2)
 
 ## 返回值说明
 
-返回 INT 类型的值。
+返回 BIGINT 类型的值。
 
 ## 示例
 


### PR DESCRIPTION
## Why I'm doing:

In the current [documentation](https://docs.starrocks.io/docs/sql-reference/sql-functions/date-time-functions/timestampdiff/) of TIMESTAMPDIFF, its return type is INT. However it actually returns BIGINT.

## What I'm doing:

This PR fixes the doc.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3