### PR TITLE
[Tool] Fix Gradle deprecation warnings in fe-core build script

### DIFF
--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -334,10 +334,13 @@ tasks.register<Task>("generateProtoSources") {
     doFirst {
         mkdir(outputDir)
 
+        // Get ExecOperations service properly
+        val execOps = project.objects.newInstance(ExecOperations::class.java)
+        
         // Process each proto file individually
         protoFiles.forEach { protoFile ->
             logger.info("Processing proto file: $protoFile")
-            project.javaexec {
+            execOps.javaexec {
                 classpath = protoGenClasspath
                 mainClass.set("com.baidu.bjf.remoting.protobuf.command.Main")
                 args = listOf(
@@ -377,8 +380,12 @@ tasks.register<Task>("generateThriftSources") {
 
     doFirst {
         mkdir(outputDir)
+        
+        // Get ExecOperations service properly
+        val execOps = project.objects.newInstance(ExecOperations::class.java)
+        
         // Process each proto file individually
-        project.javaexec {
+        execOps.javaexec {
             classpath = thriftGenClasspath
             mainClass.set("io.github.decster.ThriftCompiler")
             // Build arguments list with the output directory and all thrift files
@@ -403,8 +410,11 @@ tasks.register<Task>("generateByScripts") {
     doFirst {
         mkdir(outputDir)
 
+        // Get ExecOperations service properly
+        val execOps = project.objects.newInstance(ExecOperations::class.java)
+
         // First Python script - build version generation
-        project.exec {
+        execOps.exec {
             commandLine(
                 "python3",
                 "${project.rootProject.projectDir}/../build-support/gen_build_version.py",
@@ -414,7 +424,7 @@ tasks.register<Task>("generateByScripts") {
         }
 
         // Second Python script - function generation
-        project.exec {
+        execOps.exec {
             commandLine(
                 "python3",
                 "${project.rootProject.projectDir}/../gensrc/script/gen_functions.py",


### PR DESCRIPTION
Replace deprecated javaexec() and exec() method calls with ExecOperations service to resolve Gradle 9.0 deprecation warnings in fe-core/build.gradle.kts.

Changes:
- Use ExecOperations service injection for proto generation task
- Use ExecOperations service injection for thrift generation task
- Use ExecOperations service injection for script generation tasks
- Replace direct javaexec/exec calls with execOps.javaexec/exec calls

This maintains the same functionality while using the modern Gradle API and eliminates the deprecation warnings when running gradle tasks.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
