### PR TITLE
[BugFix] Change task_run_history/load_history default replica to default_replication_num

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SemanticException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SemanticException.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.parser.NodePosition;
@@ -79,6 +80,10 @@ public class SemanticException extends StarRocksPlannerException {
             builder.append(". Detail message: ");
             builder.append(detailMsg);
             builder.append(".");
+        }
+        if (getCause() != null) {
+            builder.append(". Cause: ");
+            builder.append(DebugUtil.getStackTrace(getCause()));
         }
         return builder.toString();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/SemanticExceptionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/SemanticExceptionTest.java
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.sql.parser.NodePosition;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SemanticExceptionTest {
+    @Test
+    public void semanticExceptionIncludesDetailMessage() {
+        SemanticException exception = new SemanticException("Error occurred");
+        Assertions.assertEquals("Error occurred", exception.getDetailMsg());
+    }
+
+    @Test
+    public void semanticExceptionFormatsMessageWithPosition() {
+        NodePosition position = new NodePosition(1, 5, 1, 10);
+        SemanticException exception = new SemanticException("Error occurred", position);
+        String message = exception.getMessage();
+        Assertions.assertTrue(message.contains("Getting analyzing error"));
+        Assertions.assertTrue(message.contains("line 1, column 5 to line 1, column 10"));
+        Assertions.assertTrue(message.contains("Detail message: Error occurred."));
+    }
+
+    @Test
+    public void semanticExceptionAppendsMessageOnlyOnce() {
+        NodePosition position = new NodePosition(1, 1, 1, 1);
+        SemanticException exception = new SemanticException("Initial error", position);
+        SemanticException appendedException = exception.appendOnlyOnceMsg("additional context", position);
+        Assertions.assertEquals("Initial error in additional context", appendedException.getDetailMsg());
+        SemanticException secondAppend = appendedException.appendOnlyOnceMsg("another context", position);
+        Assertions.assertEquals("Initial error in additional context", secondAppend.getDetailMsg());
+    }
+
+    @Test
+    public void semanticExceptionIncludesCauseInMessage() {
+        Exception cause = new RuntimeException("Root cause");
+        SemanticException exception = new SemanticException("Error occurred", cause);
+        String message = exception.getMessage();
+        Assertions.assertTrue(message.contains("Getting analyzing error"));
+        Assertions.assertTrue(message.contains("Detail message: Error occurred."));
+        Assertions.assertTrue(message.contains("Cause: java.lang.RuntimeException: Root cause"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Show materliazed views is failing with:
```
SQL Error [1064] [42000]: Getting analyzing error. Detail message: execute sql failed: WITH MaxStartRunID AS (    SELECT        task_name,        cast(history_content_json->'startTaskRunId' as string) start_run_id    FROM _statistics_.task_run_history     WHERE (task_name, create_time) IN (            SELECT task_name, MAX(create_time)            FROM _statistics_.task_run_history
```
## What I'm doing:
- Add cause message for SemanticException 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
