### PR TITLE
[Refactor] Refactor the `cache select` by compute resource to make sure it work as expected in multiple compute resources.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
@@ -15,79 +15,80 @@
 package com.starrocks.datacache;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.DataCacheSelectStatement;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TUniqueId;
+import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class DataCacheSelectExecutor {
     private static final Logger LOG = LogManager.getLogger(DataCacheSelectExecutor.class);
 
     public static DataCacheSelectMetrics cacheSelect(DataCacheSelectStatement statement,
                                                              ConnectContext connectContext) throws Exception {
-        // backup original session variable
-        SessionVariable sessionVariableBackup = connectContext.getSessionVariable();
-        // clone an new session variable
-        SessionVariable tmpSessionVariable = (SessionVariable) connectContext.getSessionVariable().clone();
-        // overwrite catalog
-        tmpSessionVariable.setCatalog(statement.getCatalog());
-        // force enable datacache and populate
-        tmpSessionVariable.setEnableScanDataCache(true);
-        tmpSessionVariable.setEnablePopulateDataCache(true);
-        tmpSessionVariable.setDataCachePopulateMode(DataCachePopulateMode.ALWAYS.modeName());
-        // make sure all accessed data must be cached
-        tmpSessionVariable.setEnableDataCacheAsyncPopulateMode(false);
-        tmpSessionVariable.setEnableDataCacheIOAdaptor(false);
-        tmpSessionVariable.setDataCacheEvictProbability(100);
-        tmpSessionVariable.setDataCachePriority(statement.getPriority());
-        tmpSessionVariable.setDatacacheTTLSeconds(statement.getTTLSeconds());
-        tmpSessionVariable.setEnableCacheSelect(true);
-        connectContext.setSessionVariable(tmpSessionVariable);
-
         InsertStmt insertStmt = statement.getInsertStmt();
-        StmtExecutor stmtExecutor = StmtExecutor.newInternalExecutor(connectContext, insertStmt);
-        // Register new StmtExecutor into current ConnectContext's StmtExecutor, so we can handle ctrl+c command
-        // If DataCacheSelect is forward to leader, connectContext's Executor is null
-        if (connectContext.getExecutor() != null) {
-            connectContext.getExecutor().registerSubStmtExecutor(stmtExecutor);
-        }
-        stmtExecutor.addRunningQueryDetail(insertStmt);
-        try {
-            stmtExecutor.execute();
-        } finally {
-            stmtExecutor.addFinishedQueryDetail();
-        }
 
-        if (connectContext.getState().isError()) {
-            // throw exception if StmtExecutor execute failed
-            throw new StarRocksException(connectContext.getState().getErrorMessage());
+        final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        final Warehouse wh = warehouseManager.getWarehouse(connectContext.getCurrentWarehouseName());
+        List<StmtExecutor> subStmtExecutors = Lists.newArrayList();
+        for (long workerGroupId : wh.getWorkerGroupIds()) {
+            ConnectContext subContext = buildCacheSelectConnectContext(statement, connectContext);
+            ComputeResource computeResource = warehouseManager.getComputeResourceProvider().ofComputeResource(
+                    wh.getId(), workerGroupId);
+            subContext.setCurrentComputeResource(computeResource);
+            StmtExecutor subStmtExecutor = StmtExecutor.newInternalExecutor(subContext, insertStmt);
+            // Register new StmtExecutor into current ConnectContext's StmtExecutor, so we can handle ctrl+c command
+            // If DataCacheSelect is forward to leader, connectContext's Executor is null
+            if (connectContext.getExecutor() != null) {
+                connectContext.getExecutor().registerSubStmtExecutor(subStmtExecutor);
+            }
+            subStmtExecutor.addRunningQueryDetail(insertStmt);
+            try {
+                subStmtExecutor.execute();
+            } finally {
+                subStmtExecutor.addFinishedQueryDetail();
+            }
+
+            if (subContext.getState().isError()) {
+                // throw exception if StmtExecutor execute failed
+                throw new StarRocksException(subContext.getState().getErrorMessage());
+            }
+            subStmtExecutors.add(subStmtExecutor);
         }
 
         DataCacheSelectMetrics metrics = null;
-        Coordinator coordinator = stmtExecutor.getCoordinator();
-        Preconditions.checkNotNull(coordinator, "Coordinator can't be null");
-        coordinator.join(stmtExecutor.getExecTimeout());
-        if (coordinator.isDone()) {
-            metrics = stmtExecutor.getCoordinator().getDataCacheSelectMetrics();
-        }
-        // set original session variable
-        connectContext.setSessionVariable(sessionVariableBackup);
+        for (StmtExecutor subStmtExecutor : subStmtExecutors) {
+            Coordinator coordinator = subStmtExecutor.getCoordinator();
+            Preconditions.checkNotNull(coordinator, "Coordinator can't be null");
+            coordinator.join(subStmtExecutor.getExecTimeout());
+            if (coordinator.isDone() && metrics == null) {
+                metrics = subStmtExecutor.getCoordinator().getDataCacheSelectMetrics();
+            }
 
-        Preconditions.checkNotNull(metrics, "Failed to retrieve cache select metrics");
-        // Don't update datacache metrics after cache select, because of datacache instance still not unified.
-        // Here update will display wrong metrics in show backends/compute nodes
-        // update backend's datacache metrics after cache select
-        // updateBackendDataCacheMetrics(metrics);
+            Preconditions.checkNotNull(metrics, "Failed to retrieve cache select metrics");
+            // Don't update datacache metrics after cache select, because of datacache instance still not unified.
+            // Here update will display wrong metrics in show backends/compute nodes
+            // update backend's datacache metrics after cache select
+            // updateBackendDataCacheMetrics(metrics);
+        }
         return metrics;
     }
 
@@ -101,5 +102,49 @@ public class DataCacheSelectExecutor {
             }
             computeNode.updateDataCacheMetrics(metric.getValue().getLastDataCacheMetrics());
         }
+    }
+
+    public static ConnectContext buildCacheSelectConnectContext(DataCacheSelectStatement statement,
+                                                                ConnectContext connectContext) {
+        // Create a new ConnectContext for the sub task of cache select.
+        final ConnectContext context = new ConnectContext(null);
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setDatabase(connectContext.getDatabase());
+        context.setQualifiedUser(connectContext.getQualifiedUser());
+        context.setCurrentUserIdentity(connectContext.getCurrentUserIdentity());
+        context.setCurrentRoleIds(connectContext.getCurrentRoleIds());
+        context.setAuditEventBuilder(connectContext.getAuditEventBuilder());
+        context.setSessionId(connectContext.getSessionId());
+        context.setRemoteIP(connectContext.getRemoteIP());
+        context.setQueryId(connectContext.getQueryId());
+        context.getState().reset();
+
+        // Generate one different execution_id here for different compute resources.
+        // We make the high part of query id unchanged to facilitate tracing problem by log.
+        TUniqueId queryId = UUIDUtil.toTUniqueId(connectContext.getQueryId());
+        UUID uuid = UUIDUtil.genUUID();
+        TUniqueId executionId = new TUniqueId(queryId.hi, uuid.getLeastSignificantBits());
+        context.setExecutionId(executionId);
+        LOG.debug("generate a new execution id {} for query {}", DebugUtil.printId(UUIDUtil.fromTUniqueid(executionId)),
+                DebugUtil.printId(connectContext.getQueryId()));
+
+        // NOTE: Ensure the thread local connect context is always the same with the newest ConnectContext.
+        // NOTE: Ensure this thread local is removed after this method to avoid memory leak in JVM.
+        context.setThreadLocalInfo();
+
+        SessionVariable sessionVariable = (SessionVariable) context.getSessionVariable();
+        // force enable datacache and populate
+        sessionVariable.setEnableScanDataCache(true);
+        sessionVariable.setEnablePopulateDataCache(true);
+        sessionVariable.setDataCachePopulateMode(DataCachePopulateMode.ALWAYS.modeName());
+        // make sure all accessed data must be cached
+        sessionVariable.setEnableDataCacheAsyncPopulateMode(false);
+        sessionVariable.setEnableDataCacheIOAdaptor(false);
+        sessionVariable.setDataCacheEvictProbability(100);
+        sessionVariable.setDataCachePriority(statement.getPriority());
+        sessionVariable.setDatacacheTTLSeconds(statement.getTTLSeconds());
+        sessionVariable.setEnableCacheSelect(true);
+
+        return context;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectMetrics.java
@@ -32,8 +32,8 @@ import java.util.concurrent.TimeUnit;
 
 public class DataCacheSelectMetrics {
     private static final ShowResultSetMetaData SIMPLE_META_DATA = ShowResultSetMetaData.builder()
-            .addColumn(new Column("READ_CACHE_SIZE", ScalarType.createVarcharType()))
-            .addColumn(new Column("WRITE_CACHE_SIZE", ScalarType.createVarcharType()))
+            .addColumn(new Column("AVG_READ_CACHE_SIZE", ScalarType.createVarcharType()))
+            .addColumn(new Column("AVG_WRITE_CACHE_SIZE", ScalarType.createVarcharType()))
             .addColumn(new Column("AVG_WRITE_CACHE_TIME", ScalarType.createVarcharType()))
             .addColumn(new Column("TOTAL_CACHE_USAGE", ScalarType.createVarcharType()))
             .build();
@@ -121,8 +121,15 @@ public class DataCacheSelectMetrics {
         List<String> row = Lists.newArrayList();
         rows.add(row);
 
-        row.add(new ByteSizeValue(readCacheSize).toString());
-        row.add(new ByteSizeValue(writeCacheSize).toString());
+        // get avg write and read bytes
+        long avgWriteCacheSize = 0;
+        long avgReadCacheSize = 0;
+        if (!beMetrics.isEmpty()) {
+            avgReadCacheSize = readCacheSize / beMetrics.size();
+            avgWriteCacheSize = writeCacheSize / beMetrics.size();
+        }
+        row.add(new ByteSizeValue(avgReadCacheSize).toString());
+        row.add(new ByteSizeValue(avgWriteCacheSize).toString());
 
         // get avg write cache time
         long avgWriteCacheTime = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -438,6 +438,10 @@ public class ConnectContext {
         return queryDetail;
     }
 
+    public void setAuditEventBuilder(AuditEventBuilder auditEventBuilder) {
+        this.auditEventBuilder = auditEventBuilder;
+    }
+
     public AuditEventBuilder getAuditEventBuilder() {
         return auditEventBuilder;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2924,6 +2924,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableCacheSelect = enableCacheSelect;
     }
 
+    public boolean isEnableCacheSelect() {
+        return enableCacheSelect;
+    }
+
     public void setConnectorIoTasksPerScanOperator(int connectorIoTasksPerScanOperator) {
         this.connectorIoTasksPerScanOperator = connectorIoTasksPerScanOperator;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -532,11 +532,13 @@ public class StmtExecutor {
         context.setIsLeaderTransferred(false);
         context.setCurrentThreadId(Thread.currentThread().getId());
 
-        // set execution id.
-        // Try to use query id as execution id when execute first time.
-        UUID uuid = context.getQueryId();
-        context.setExecutionId(UUIDUtil.toTUniqueId(uuid));
         SessionVariable sessionVariableBackup = context.getSessionVariable();
+        // set execution id.
+        // For statements other than `cache select`, try to use query id as execution id when execute first time.
+        UUID uuid = context.getQueryId();
+        if (!sessionVariableBackup.isEnableCacheSelect()) {
+            context.setExecutionId(UUIDUtil.toTUniqueId(uuid));
+        }
 
         // if use http protocol, use httpResultSender to send result to netty channel
         if (context instanceof HttpConnectContext) {

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
@@ -90,7 +90,7 @@ public class DataCacheSelectMetricsTest {
         dataCacheSelectMetrics.updateLoadDataCacheMetrics(cn1Id, cn1Metrics);
 
         List<List<String>> rows = dataCacheSelectMetrics.getShowResultSet(false).getResultRows();
-        Assertions.assertEquals("6MB,6GB,20s,50.00%", String.join(",", rows.get(0)));
+        Assertions.assertEquals("2MB,2GB,20s,50.00%", String.join(",", rows.get(0)));
         rows = dataCacheSelectMetrics.getShowResultSet(true).getResultRows();
         for (List<String> row : rows) {
             if (row.get(0).equals("127.0.0.2")) {


### PR DESCRIPTION
## Why I'm doing:
After we introduce compute resource, the same query may be scheduled to different compute resource in different time. So, if the `cache select` only executed in a single compute resource, the cache miss may still occur if the related query is scheduled to another compute resource. This behavior does not meet the expectations of users when using `cache select`.

## What I'm doing:
Refactor the `cache select` function by compute resource to make it executed in all compute resources. 
This can ensure the cache hit rate in different schedule policies. In addition,  it can keep the independence between various compute resources and avoid the impact of a certain compute resource going offline on cache hits in elastic scenarios.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
