### PR TITLE
[BugFix] Fix error when building aggregate operator in OuterJoinEliminationRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/OuterJoinEliminationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/OuterJoinEliminationRule.java
@@ -90,7 +90,7 @@ public class OuterJoinEliminationRule extends TransformationRule {
             return false;
         }
 
-        // if a post-join filter exist, transfrom cause wrong elimination
+        // if a post-join filter exist, transform cause wrong elimination
         if (joinOp.getPredicate() != null) {
             return false;
         }
@@ -140,12 +140,7 @@ public class OuterJoinEliminationRule extends TransformationRule {
         int outerSideIdx = joinType.isLeftOuterJoin() ? 0 : 1;
         OptExpression outerChild = input.inputAt(0).inputAt(outerSideIdx);
 
-        OptExpression result = outerChild;
-
-        LogicalAggregationOperator newAggOp = new LogicalAggregationOperator(
-                aggOp.getType(), aggOp.getGroupingKeys(), aggOp.getAggregations());
-
-        return Lists.newArrayList(OptExpression.create(newAggOp, result));
+        return Lists.newArrayList(OptExpression.create(aggOp, outerChild));
     }
 
     /**
@@ -158,7 +153,7 @@ public class OuterJoinEliminationRule extends TransformationRule {
             return true;
         }
 
-        //count disticnt also duplicate-insensitive
+        //count distinct also duplicate-insensitive
         if (FunctionSet.COUNT.equals(fnName) && aggFunc.isDistinct()) {
             return true;
         }
@@ -178,11 +173,9 @@ public class OuterJoinEliminationRule extends TransformationRule {
 
         List<ScalarOperator> conditions = Utils.extractConjuncts(joinCondition);
         for (ScalarOperator condition : conditions) {
-            if (!(condition instanceof BinaryPredicateOperator)) {
+            if (!(condition instanceof BinaryPredicateOperator binary)) {
                 return false;
             }
-
-            BinaryPredicateOperator binary = (BinaryPredicateOperator) condition;
 
             if (!binary.getBinaryType().equals(BinaryType.EQ)) {
                 return false;


### PR DESCRIPTION
## Why I'm doing:
Missing projection when building new LogicalAggregation Operator in OuterJoinEliminationRule.


## What I'm doing:


Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/10035

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
