### PR TITLE
[Feature] support creating iceberg table with sort order.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/OrderByElement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/OrderByElement.java
@@ -143,6 +143,19 @@ public class OrderByElement implements ParseNode {
         return pos;
     }
 
+    /**
+     * Try to extract the column name from the `expr`.
+     * If the `expr` represents a valid column, the column name will be returned.
+     * Otherwise, it will return null.
+     */
+    public String castAsSlotRef() {
+        if (!(expr instanceof SlotRef)) {
+            return null;
+        }
+        SlotRef slotRef = (SlotRef) expr;
+        return slotRef.getColumnName();
+    }
+
     public String explain() {
         StringBuilder strBuilder = new StringBuilder();
         strBuilder.append(expr.explain());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StarRocksIcebergTableScan;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
@@ -177,8 +178,9 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                                Schema schema,
                                PartitionSpec partitionSpec,
                                String location,
+                               SortOrder sortOrder,
                                Map<String, String> properties) {
-        return delegate.createTable(connectContext, dbName, tableName, schema, partitionSpec, location, properties);
+        return delegate.createTable(connectContext, dbName, tableName, schema, partitionSpec, location, sortOrder, properties);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionsTable;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StarRocksIcebergTableScan;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
@@ -93,6 +94,7 @@ public interface IcebergCatalog extends MemoryTrackable {
                                 Schema schema,
                                 PartitionSpec partitionSpec,
                                 String location,
+                                SortOrder sortOrder,
                                 Map<String, String> properties) {
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -105,6 +105,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StarRocksIcebergTableScan;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TableScan;
@@ -290,9 +291,10 @@ public class IcebergMetadata implements ConnectorMetadata {
             properties.put(COMMENT, comment);
         }
         Map<String, String> createTableProperties = IcebergApiConverter.rebuildCreateTableProperties(properties);
+        SortOrder sortOrder = IcebergApiConverter.toIcebergSortOrder(schema, stmt.getOrderByElements());
 
         return icebergCatalog.createTable(context, dbName, tableName, schema, partitionSpec, tableLocation,
-                createTableProperties);
+                sortOrder, createTableProperties);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.aws.glue.GlueCatalog;
@@ -155,6 +156,7 @@ public class IcebergGlueCatalog implements IcebergCatalog {
             Schema schema,
             PartitionSpec partitionSpec,
             String location,
+            SortOrder sortOrder,
             Map<String, String> properties) {
         if (Strings.isNullOrEmpty(location)) {
             String dbLocation = getDB(context, dbName).getLocation();
@@ -169,6 +171,7 @@ public class IcebergGlueCatalog implements IcebergCatalog {
         Table nativeTable = delegate.buildTable(TableIdentifier.of(dbName, tableName), schema)
                 .withLocation(location)
                 .withPartitionSpec(partitionSpec)
+                .withSortOrder(sortOrder)
                 .withProperties(properties)
                 .create();
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hadoop/IcebergHadoopCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hadoop/IcebergHadoopCatalog.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.catalog.Namespace;
@@ -171,10 +172,12 @@ public class IcebergHadoopCatalog implements IcebergCatalog {
             Schema schema,
             PartitionSpec partitionSpec,
             String location,
+            SortOrder sortOrder,
             Map<String, String> properties) {
         Table nativeTable = delegate.buildTable(TableIdentifier.of(dbName, tableName), schema)
                 .withLocation(location)
                 .withPartitionSpec(partitionSpec)
+                .withSortOrder(sortOrder)
                 .withProperties(properties)
                 .create();
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.catalog.Namespace;
@@ -193,10 +194,12 @@ public class IcebergHiveCatalog implements IcebergCatalog {
             Schema schema,
             PartitionSpec partitionSpec,
             String location,
+            SortOrder sortOrder,
             Map<String, String> properties) {
         Table nativeTable =  delegate.buildTable(TableIdentifier.of(dbName, tableName), schema)
                 .withLocation(location)
                 .withPartitionSpec(partitionSpec)
+                .withSortOrder(sortOrder)
                 .withProperties(properties)
                 .create();
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalog.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -182,10 +183,12 @@ public class IcebergJdbcCatalog implements IcebergCatalog {
             Schema schema,
             PartitionSpec partitionSpec,
             String location,
+            SortOrder sortOrder,
             Map<String, String> properties) {
         Table nativeTable = delegate.buildTable(TableIdentifier.of(dbName, tableName), schema)
                 .withLocation(location)
                 .withPartitionSpec(partitionSpec)
+                .withSortOrder(sortOrder)
                 .withProperties(properties)
                 .create();
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.catalog.Namespace;
@@ -293,6 +294,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             Schema schema,
             PartitionSpec partitionSpec,
             String location,
+            SortOrder sortOrder,
             Map<String, String> properties) {
 
         Table nativeTable = null;
@@ -301,6 +303,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                             TableIdentifier.of(convertDbNameToNamespace(dbName), tableName), schema)
                     .withLocation(location)
                     .withPartitionSpec(partitionSpec)
+                    .withSortOrder(sortOrder)
                     .withProperties(properties)
                     .create();
         } catch (RESTException re) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.ast;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.OrderByElement;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
@@ -62,7 +63,12 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     private DistributionDesc distributionDesc;
     private final int queryStartIndex;
     private final int queryStopIndex;
-    private final List<String> sortKeys;
+    // It saves the original sort order elements parsing from the order by clause.
+    // Because other sort properties, such as sort-direction and null-orders, are not supported in materialized view now.
+    // We extract its sort columns to `sortKeys` in analyze phase and use the `sortKeys` instead of it in most places.
+    private final List<OrderByElement> orderByElements;
+    // It will be set based on `orderByElements` in analyze
+    private List<String> sortKeys;
     private KeysType keysType = KeysType.DUP_KEYS;
     // view definition of the mv which has been rewritten by AstToSQLBuilder#toSQL
     protected String inlineViewDef;
@@ -107,7 +113,8 @@ public class CreateMaterializedViewStatement extends DdlStmt {
                                            String comment,
                                            RefreshSchemeClause refreshSchemeDesc,
                                            List<Expr> partitionByExprs,
-                                           DistributionDesc distributionDesc, List<String> sortKeys,
+                                           DistributionDesc distributionDesc,
+                                           List<OrderByElement> orderByElements,
                                            Map<String, String> properties,
                                            QueryStatement queryStatement,
                                            int queryStartIndex,
@@ -123,7 +130,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
         this.refreshSchemeDesc = refreshSchemeDesc;
         this.partitionByExprs = partitionByExprs;
         this.distributionDesc = distributionDesc;
-        this.sortKeys = sortKeys;
+        this.orderByElements = orderByElements;
         this.properties = properties;
         this.queryStartIndex = queryStartIndex;
         this.queryStopIndex = queryStopIndex;
@@ -204,6 +211,14 @@ public class CreateMaterializedViewStatement extends DdlStmt {
 
     public DistributionDesc getDistributionDesc() {
         return distributionDesc;
+    }
+
+    public List<OrderByElement> getOrderByElements() {
+        return orderByElements;
+    }
+
+    public void setSortKeys(List<String> sortKeys) {
+        this.sortKeys = sortKeys;
     }
 
     public List<String> getSortKeys() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTableStmt.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.ast;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.OrderByElement;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Index;
@@ -46,7 +47,7 @@ public class CreateTableStmt extends DdlStmt {
 
     // set in analyze
     private List<Column> columns;
-    private List<String> sortKeys = Lists.newArrayList();
+    private List<OrderByElement> orderByElements;
 
     private List<Index> indexes;
 
@@ -99,9 +100,9 @@ public class CreateTableStmt extends DdlStmt {
                            DistributionDesc distributionDesc,
                            Map<String, String> properties,
                            Map<String, String> extProperties,
-                           String comment, List<AlterClause> ops, List<String> sortKeys) {
+                           String comment, List<AlterClause> ops, List<OrderByElement> orderByElements) {
         this(ifNotExists, isExternal, tableName, columnDefinitions, null, engineName, charsetName, keysDesc, partitionDesc,
-                distributionDesc, properties, extProperties, comment, ops, sortKeys);
+                distributionDesc, properties, extProperties, comment, ops, orderByElements);
     }
 
     public CreateTableStmt(boolean ifNotExists,
@@ -116,10 +117,10 @@ public class CreateTableStmt extends DdlStmt {
                            DistributionDesc distributionDesc,
                            Map<String, String> properties,
                            Map<String, String> extProperties,
-                           String comment, List<AlterClause> rollupAlterClauseList, List<String> sortKeys) {
+                           String comment, List<AlterClause> rollupAlterClauseList, List<OrderByElement> orderByElements) {
         this(ifNotExists, isExternal, tableName, columnDefinitions, indexDefs, engineName, charsetName, keysDesc,
                 partitionDesc, distributionDesc, properties, extProperties, comment, rollupAlterClauseList,
-                sortKeys, NodePosition.ZERO);
+                orderByElements, NodePosition.ZERO);
     }
 
     public CreateTableStmt(boolean ifNotExists,
@@ -134,7 +135,7 @@ public class CreateTableStmt extends DdlStmt {
                            DistributionDesc distributionDesc,
                            Map<String, String> properties,
                            Map<String, String> extProperties,
-                           String comment, List<AlterClause> rollupAlterClauseList, List<String> sortKeys,
+                           String comment, List<AlterClause> rollupAlterClauseList, List<OrderByElement> orderByElements,
                            NodePosition pos) {
         super(pos);
         this.tableName = tableName;
@@ -157,7 +158,7 @@ public class CreateTableStmt extends DdlStmt {
 
         this.tableSignature = -1;
         this.rollupAlterClauseList = rollupAlterClauseList == null ? new ArrayList<>() : rollupAlterClauseList;
-        this.sortKeys = sortKeys;
+        this.orderByElements = orderByElements;
     }
 
     public void addColumnDef(ColumnDef columnDef) {
@@ -220,8 +221,8 @@ public class CreateTableStmt extends DdlStmt {
         return engineName;
     }
 
-    public List<String> getSortKeys() {
-        return sortKeys;
+    public List<OrderByElement> getOrderByElements() {
+        return orderByElements;
     }
 
     public void setEngineName(String engineName) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTemporaryTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTemporaryTableStmt.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.ast;
 
+import com.starrocks.analysis.OrderByElement;
 import com.starrocks.analysis.TableName;
 import com.starrocks.sql.parser.NodePosition;
 
@@ -37,10 +38,10 @@ public class CreateTemporaryTableStmt extends CreateTableStmt {
                            DistributionDesc distributionDesc,
                            Map<String, String> properties,
                            Map<String, String> extProperties,
-                           String comment, List<AlterClause> rollupAlterClauseList, List<String> sortKeys,
+                           String comment, List<AlterClause> rollupAlterClauseList, List<OrderByElement> orderByElements,
                            NodePosition pos) {
         super(ifNotExists, isExternal, tableName, columnDefinitions, indexDefs, engineName, charsetName, keysDesc,
-                partitionDesc, distributionDesc, properties, extProperties, comment, rollupAlterClauseList, sortKeys, pos);
+                partitionDesc, distributionDesc, properties, extProperties, comment, rollupAlterClauseList, orderByElements, pos);
     }
 
     public CreateTemporaryTableStmt(boolean ifNotExists,
@@ -55,10 +56,11 @@ public class CreateTemporaryTableStmt extends CreateTableStmt {
                                     DistributionDesc distributionDesc,
                                     Map<String, String> properties,
                                     Map<String, String> extProperties,
-                                    String comment, List<AlterClause> rollupAlterClauseList, List<String> sortKeys) {
+                                    String comment, List<AlterClause> rollupAlterClauseList,
+                                    List<OrderByElement> orderByElements) {
         super(ifNotExists, isExternal, tableName, columnDefinitions, indexDefs, engineName, charsetName, keysDesc,
                 partitionDesc, distributionDesc, properties, extProperties, comment, rollupAlterClauseList,
-                sortKeys, NodePosition.ZERO);
+                orderByElements, NodePosition.ZERO);
     }
 
     public void setSessionId(UUID sessionId) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/OptimizeClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/OptimizeClause.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.ast;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.alter.AlterOpType;
+import com.starrocks.analysis.OrderByElement;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.io.DataInput;
@@ -37,21 +38,26 @@ public class OptimizeClause extends AlterTableClause {
     @SerializedName(value = "isTableOptimize")
     private boolean isTableOptimize = false;
 
-    private List<String> sortKeys = null;
+    // It saves the original sort order elements parsing from the order by clause.
+    // Because other sort properties, such as sort-direction and null-orders, are not supported in optimize clause now.
+    // We extract its sort columns to `sortKeys` in analyze phase and use the `sortKeys` instead of it in most places.
+    private List<OrderByElement> orderByElements;
+    // It will be set based on `orderByElements` in analyze
+    private List<String> sortKeys;
 
     public OptimizeClause(KeysDesc keysDesc,
                           PartitionDesc partitionDesc,
                           DistributionDesc distributionDesc,
-                          List<String> sortKeys,
+                          List<OrderByElement> orderByElements,
                           PartitionNames partitionNames,
                           OptimizeRange range) {
-        this(keysDesc, partitionDesc, distributionDesc, sortKeys, partitionNames, range, NodePosition.ZERO);
+        this(keysDesc, partitionDesc, distributionDesc, orderByElements, partitionNames, range, NodePosition.ZERO);
     }
 
     public OptimizeClause(KeysDesc keysDesc,
                           PartitionDesc partitionDesc,
                           DistributionDesc distributionDesc,
-                          List<String> sortKeys,
+                          List<OrderByElement> orderByElements,
                           PartitionNames partitionNames,
                           OptimizeRange range,
                           NodePosition pos) {
@@ -59,7 +65,7 @@ public class OptimizeClause extends AlterTableClause {
         this.keysDesc = keysDesc;
         this.partitionDesc = partitionDesc;
         this.distributionDesc = distributionDesc;
-        this.sortKeys = sortKeys;
+        this.orderByElements = orderByElements;
         this.partitionNames = partitionNames;
         this.range = range;
     }
@@ -83,6 +89,14 @@ public class OptimizeClause extends AlterTableClause {
 
     public DistributionDesc getDistributionDesc() {
         return this.distributionDesc;
+    }
+
+    public List<OrderByElement> getOrderByElements() {
+        return orderByElements;
+    }
+
+    public void setSortKeys(List<String> sortKeys) {
+        this.sortKeys = sortKeys;
     }
 
     public List<String> getSortKeys() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -477,7 +477,7 @@ keyDesc
     ;
 
 orderByDesc
-    : ORDER BY identifierList
+    : ORDER BY '(' sortItem (',' sortItem)* ')'
     ;
 
 columnNullable

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.OrderByElement;
 import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MapType;
@@ -35,6 +36,8 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortField;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -482,7 +485,7 @@ public class IcebergApiConverterTest {
                 "Unsupported partition definition");
     }
 
-    @Test 
+    @Test
     public void testIcebergColumnType() {
         org.apache.iceberg.types.Type type;
         type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.INT));
@@ -510,4 +513,27 @@ public class IcebergApiConverterTest {
         type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.VARBINARY));
         assertEquals(org.apache.iceberg.types.Type.TypeID.BINARY, type.typeId());
     }
+
+    @Test
+    public void testToIcebergSortOrder() {
+        List<Types.NestedField> fields = Lists.newArrayList();
+        fields.add(Types.NestedField.optional(1, "id", new Types.IntegerType()));
+        fields.add(Types.NestedField.optional(2, "dt", new Types.DateType()));
+        fields.add(Types.NestedField.optional(3, "data", new Types.StringType()));
+        Schema schema = new Schema(fields);
+
+        SortOrder nullSortOrder = IcebergApiConverter.toIcebergSortOrder(schema, null);
+        assertEquals(nullSortOrder, null);
+
+        List<OrderByElement> orderByElements = new ArrayList<>();
+        Expr expr1 = ColumnIdExpr.fromSql("id").getExpr();
+        orderByElements.add(new OrderByElement(expr1, true, true));
+        Expr expr2 = ColumnIdExpr.fromSql("dt").getExpr();
+        orderByElements.add(new OrderByElement(expr2, false, false));
+
+        SortOrder sortOrder = IcebergApiConverter.toIcebergSortOrder(schema, orderByElements);
+        List<SortField> sortFields = sortOrder.fields();
+        assertEquals(sortFields.size(), 2);
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergJdbcCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergJdbcCatalogTest.java
@@ -246,7 +246,7 @@ public class IcebergJdbcCatalogTest {
         Assertions.assertTrue(exists);
 
         boolean createTableFlag = icebergJdbcCatalog.createTable(connectContext, "db", "tb2", null, null,
-                LOCATION, new HashMap<>());
+                LOCATION, null, new HashMap<>());
         assertEquals(true, createTableFlag);
     }
 
@@ -260,7 +260,7 @@ public class IcebergJdbcCatalogTest {
                 new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", LOCATION,
                 "iceberg.catalog.uri", URI));
         boolean createTableFlag = icebergJdbcCatalog.createTable(connectContext, "db", "tb2", null, null,
-                LOCATION, new HashMap<>());
+                LOCATION, null, new HashMap<>());
         assertEquals(true, createTableFlag);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -346,7 +346,7 @@ public class IcebergRESTCatalogTest {
         ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
                 "Failed to create table using REST Catalog",
                 () -> icebergRESTCatalog.createTable(connectContext, "db", "tbl", null, null, null,
-                        Maps.newHashMap()));
+                        null, Maps.newHashMap()));
 
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AlterTableClauseVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AlterTableClauseVisitorTest.java
@@ -14,7 +14,10 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.OrderByElement;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.persist.ColumnIdExpr;
 import com.starrocks.sql.ast.HashDistributionDesc;
 import com.starrocks.sql.ast.OptimizeClause;
 import com.starrocks.sql.parser.NodePosition;
@@ -38,10 +41,12 @@ public class AlterTableClauseVisitorTest extends DDLTestBase {
         NodePosition nodePosition = new NodePosition(1, 23, 1, 48);
         HashDistributionDesc hashDistributionDesc = new HashDistributionDesc();
 
-        List<String> list = new ArrayList<>();
-        list.add("id");
+        List<OrderByElement> orderByElements = new ArrayList<>();
+        Expr expr = ColumnIdExpr.fromSql("id").getExpr();
+        orderByElements.add(new OrderByElement(expr, true, true));
 
-        OptimizeClause optimizeClause = new OptimizeClause(null, null, hashDistributionDesc, list, null, null, nodePosition);
+        OptimizeClause optimizeClause = new OptimizeClause(null, null, hashDistributionDesc, orderByElements, null, null,
+                nodePosition);
         OlapTable table = new OlapTable();
         AlterTableClauseAnalyzer visitor = new AlterTableClauseAnalyzer(table);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/CreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/CreateTableStmtTest.java
@@ -1,0 +1,140 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.ast;
+
+import com.starrocks.analysis.OrderByElement;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.qe.ConnectContext;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CreateTableStmtTest {
+    @Mocked
+    private ConnectContext ctx;
+
+    @Test
+    public void testOrderBy() throws Exception {
+        String sql = "CREATE TABLE test_create_table_db.starrocks_test_table\n" +
+                "(\n" +
+                "    `tag_id` string,\n" +
+                "    `tag_name` string\n" +
+                ") ENGINE = OLAP PRIMARY KEY(`id`)\n" +
+                "DISTRIBUTED BY HASH(`id`)\n" +
+                "ORDER BY(`id`)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n";
+
+        CreateTableStmt stmt = (CreateTableStmt) com.starrocks.sql.parser.SqlParser.parse(
+                sql, 32).get(0);
+
+        Assertions.assertEquals(stmt.getDbName(), "test_create_table_db");
+        Assertions.assertEquals(stmt.getTableName(), "starrocks_test_table");
+        Assertions.assertEquals(stmt.getProperties().get("replication_num"), "1");
+
+        Assertions.assertEquals(stmt.getOrderByElements().size(), 1);
+        OrderByElement orderByElement = stmt.getOrderByElements().get(0);
+        SlotRef slotRef = (SlotRef) orderByElement.getExpr();
+        Assertions.assertEquals(slotRef.getColumnName(), "id");
+        Assertions.assertTrue(orderByElement.getIsAsc());
+        // If ascending, nulls are first by default
+        Assertions.assertTrue(orderByElement.getNullsFirstParam());
+    }
+
+    @Test
+    public void testOrderByWithDirection() throws Exception {
+        String sql = "CREATE TABLE test_create_table_db.starrocks_test_table\n" +
+                "(\n" +
+                "    `tag_id` string,\n" +
+                "    `tag_name` string\n" +
+                ") ENGINE = OLAP PRIMARY KEY(`id`)\n" +
+                "DISTRIBUTED BY HASH(`id`)\n" +
+                "ORDER BY (`id` DESC)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n";
+
+        CreateTableStmt stmt = (CreateTableStmt) com.starrocks.sql.parser.SqlParser.parse(
+                sql, 32).get(0);
+
+        Assertions.assertEquals(stmt.getDbName(), "test_create_table_db");
+        Assertions.assertEquals(stmt.getTableName(), "starrocks_test_table");
+        Assertions.assertEquals(stmt.getProperties().get("replication_num"), "1");
+
+        Assertions.assertEquals(stmt.getOrderByElements().size(), 1);
+        OrderByElement orderByElement = stmt.getOrderByElements().get(0);
+        SlotRef slotRef = (SlotRef) orderByElement.getExpr();
+        Assertions.assertEquals(slotRef.getColumnName(), "id");
+        Assertions.assertFalse(orderByElement.getIsAsc());
+        // If descending, nulls are last by default
+        Assertions.assertFalse(orderByElement.getNullsFirstParam());
+    }
+
+    @Test
+    public void testOrderByWithNullOrder() throws Exception {
+        String sql = "CREATE TABLE test_create_table_db.starrocks_test_table\n" +
+                "(\n" +
+                "    `tag_id` string,\n" +
+                "    `tag_name` string\n" +
+                ") ENGINE = OLAP PRIMARY KEY(`id`)\n" +
+                "DISTRIBUTED BY HASH(`id`)\n" +
+                "ORDER BY (`id` DESC NULLS FIRST)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n";
+
+        CreateTableStmt stmt = (CreateTableStmt) com.starrocks.sql.parser.SqlParser.parse(
+                sql, 32).get(0);
+
+        Assertions.assertEquals(stmt.getDbName(), "test_create_table_db");
+        Assertions.assertEquals(stmt.getTableName(), "starrocks_test_table");
+        Assertions.assertEquals(stmt.getProperties().get("replication_num"), "1");
+
+        Assertions.assertEquals(stmt.getOrderByElements().size(), 1);
+        OrderByElement orderByElement = stmt.getOrderByElements().get(0);
+        SlotRef slotRef = (SlotRef) orderByElement.getExpr();
+        Assertions.assertEquals(slotRef.getColumnName(), "id");
+        Assertions.assertFalse(orderByElement.getIsAsc());
+        Assertions.assertTrue(orderByElement.getNullsFirstParam());
+    }
+
+    @Test
+    public void testOrderByMultipleColumns() throws Exception {
+        String sql = "CREATE TABLE test_create_table_db.starrocks_test_table\n" +
+                "(\n" +
+                "    `tag_id` string,\n" +
+                "    `tag_name` string\n" +
+                ") ENGINE = OLAP PRIMARY KEY(`id`)\n" +
+                "DISTRIBUTED BY HASH(`id`)\n" +
+                "ORDER BY (`id`, `tag_name` DESC NULLS FIRST)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n";
+
+        CreateTableStmt stmt = (CreateTableStmt) com.starrocks.sql.parser.SqlParser.parse(
+                sql, 32).get(0);
+
+        Assertions.assertEquals(stmt.getDbName(), "test_create_table_db");
+        Assertions.assertEquals(stmt.getTableName(), "starrocks_test_table");
+        Assertions.assertEquals(stmt.getProperties().get("replication_num"), "1");
+
+        Assertions.assertEquals(stmt.getOrderByElements().size(), 2);
+        OrderByElement orderByElement = stmt.getOrderByElements().get(1);
+        SlotRef slotRef = (SlotRef) orderByElement.getExpr();
+        Assertions.assertEquals(slotRef.getColumnName(), "tag_name");
+        Assertions.assertFalse(orderByElement.getIsAsc());
+        Assertions.assertTrue(orderByElement.getNullsFirstParam());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Sorted Iceberg tables can provide a huge increase in query performance and can also lead to a decrease in cloud object storage request costs. 
Iceberg spec introduces sort_order of tables for users to sort their data during the writing process.  In order to further improve the query performance of the Iceberg table, it is also necessary for StarRocks to improve its support for sort_order. 

## What I'm doing:
We support specifying the sorting sequence when creating a table.

As the `ORDER BY` clause has been introduced for StarRocks native table to specify the sorting columns. So we consider reusing the same syntax. And we further expand the existing order by syntax to also support specifying the sort direction and null-order for each sort field separately. For example:

`ORDER BY (action DESC NULLS FIRST, id ASC NULLS LAST)`

  The sort_direction and null_order are optional, so we can also create an iceberg table with the same `ORDER BY` syntax as the native table:

`ORDER BY (action, id)`

In addition, we call the iceberg api to set the `sort-order` property that parsed from `ORDER BY` clause.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
