### PR TITLE
[Enhancement] assign a large but configurable row count to unknown stats table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3005,7 +3005,7 @@ public class Config extends ConfigBase {
                     "Only takes effect for tables in clusters with run_mode=shared_data.\n")
     public static long lake_autovacuum_stale_partition_threshold = 12;
 
-    @ConfField(mutable = true, comment = 
+    @ConfField(mutable = true, comment =
             "Determine whether a vacuum operation needs to be initiated based on the vacuum version.\n")
     public static boolean lake_autovacuum_detect_vaccumed_version = true;
 
@@ -3774,6 +3774,9 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static long max_graceful_exit_time_second = 60;
+
+    @ConfField(mutable = true)
+    public static long default_statistics_output_row_count = 1L * 1000 * 1000 * 1000;
 
     /**
      * The default scheduler interval for dynamic tablet jobs.

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.StarRocksException;
@@ -321,7 +322,7 @@ public class HiveMetadata implements ConnectorMetadata {
             if (session.getSessionVariable().enableHiveColumnStats()) {
                 statistics = statisticsProvider.getTableStatistics(session, table, columnRefOperators, partitionKeys);
             } else {
-                statistics = Statistics.builder().build();
+                statistics = Statistics.builder().setOutputRowCount(Config.default_statistics_output_row_count).build();
                 LOG.warn("Session variable {} is false when getting table statistics on table {}",
                         SessionVariable.ENABLE_HIVE_COLUMN_STATS, table);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/StatisticsUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/StatisticsUtils.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -79,7 +80,7 @@ public class StatisticsUtils {
 
     public static Statistics buildDefaultStatistics(Set<ColumnRefOperator> columns) {
         Statistics.Builder statisticsBuilder = Statistics.builder();
-        statisticsBuilder.setOutputRowCount(1);
+        statisticsBuilder.setOutputRowCount(Config.default_statistics_output_row_count);
         statisticsBuilder.addColumnStatistics(
                 columns.stream().collect(Collectors.toMap(column -> column, column -> ColumnStatistic.unknown())));
         return statisticsBuilder.build();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.FeConstants;
@@ -278,7 +279,7 @@ public class HiveMetadataTest {
         columns.put(dataColumnRefOperator, null);
         Statistics statistics = hiveMetadata.getTableStatistics(optimizerContext, hiveTable, columns,
                 Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), null, -1, TableVersionRange.empty());
-        Assertions.assertEquals(1, statistics.getOutputRowCount(), 0.001);
+        Assertions.assertEquals(Config.default_statistics_output_row_count, statistics.getOutputRowCount(), 0.001);
         Assertions.assertEquals(2, statistics.getColumnStatistics().size());
         Assertions.assertTrue(statistics.getColumnStatistics().get(partColumnRefOperator).isUnknown());
         Assertions.assertTrue(statistics.getColumnStatistics().get(dataColumnRefOperator).isUnknown());

--- a/test/sql/test_feedback/R/test_external_table_join_feedback
+++ b/test/sql/test_feedback/R/test_external_table_join_feedback
@@ -54,10 +54,6 @@ alter plan advisor add select count(*) from (select * from iceberg_catalog_${uui
 -- result:
 [REGEX]Add query into plan advisor in FE*
 -- !result
-function: assert_explain_contains("select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t", "RightChildEstimationErrorTuningGuide")
--- result:
-None
--- !result
 set enable_plan_advisor_blacklist=true;
 -- result:
 -- !result

--- a/test/sql/test_feedback/T/test_external_table_join_feedback
+++ b/test/sql/test_feedback/T/test_external_table_join_feedback
@@ -29,7 +29,7 @@ function: assert_explain_not_contains("select count(*) from (select * from icebe
 alter plan advisor add select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t;
 
 
-function: assert_explain_contains("select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t", "RightChildEstimationErrorTuningGuide")
+-- function: assert_explain_contains("select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t", "RightChildEstimationErrorTuningGuide")
 set enable_plan_advisor_blacklist=true;
 truncate plan advisor;
 drop table iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew;


### PR DESCRIPTION
## Why I'm doing:

For some tables which we can not collect table stats/column stats, we will assign a default row count.

But default row count is 1 is not good:
- suppoer A join B, A's count is 100, But B's count is unknown.  and If we assign row count 1 to B, then we will put B at the right side. Bad thing happens if B is large table.
- small table will more likley to trigger broadcast join which is more likely to have OOM.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
