### PR TITLE
[BugFix] Fix compile error due to removing the unused schema hash field from TabletMeta

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplitTabletJobFactory.java
@@ -302,10 +302,11 @@ public class SplitTabletJobFactory implements DynamicTabletJobFactory {
         TStorageMedium storageMedium = table.getPartitionInfo()
                 .getDataProperty(physicalPartition.getParentId()).getStorageMedium();
 
+        TabletMeta tabletMeta = new TabletMeta(db.getId(), table.getId(), physicalPartition.getId(), newIndexId,
+                storageMedium, table.isCloudNativeTableOrMaterializedView());
+
         for (long tabletId : dynamicTablets.getNewTabletIds()) {
             Tablet tablet = new LakeTablet(tabletId);
-            TabletMeta tabletMeta = new TabletMeta(db.getId(), table.getId(), physicalPartition.getId(), newIndexId,
-                    0, storageMedium, true);
             newIndex.addTablet(tablet, tabletMeta, true);
         }
 


### PR DESCRIPTION
## Why I'm doing:
Unused schema hash field is removed from TabletMeta, but some pending PR still use this field, when those PRs are merged into, there are compile errors.

## What I'm doing:
Fix compile error due to removing the unused schema hash field from TabletMeta.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
