### PR TITLE
[Enhancement] Support iceberg rest catalog vending credentials for GCP

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -54,6 +54,7 @@ import com.github.benmanes.caffeine.cache.Weigher;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.credential.gcp.GCPCloudConfigurationProvider;
 import com.starrocks.fs.azure.AzBlobURI;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -207,8 +208,8 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
         // build Hadoop configuration from properties for HadoopFileIO
         Configuration copied = new Configuration(conf.get());
         for (Map.Entry<String, String> entry : properties.entrySet()) {
-            // Handle Azure ADLS SAS token
             if (entry.getKey().startsWith(ADLS_SAS_TOKEN) && entry.getKey().endsWith(ADLS_ENDPOINT)) {
+                // Handle Azure ADLS SAS token
                 String endpoint = entry.getKey().substring(ADLS_SAS_TOKEN.length());
                 copied.set(String.format("fs.azure.account.auth.type.%s", endpoint),
                         "SAS");
@@ -216,10 +217,19 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
                         entry.getValue());
                 return copied;
             } else if (entry.getKey().startsWith(ADLS_SAS_TOKEN) && (entry.getKey().endsWith(BLOB_ENDPOINT))) {
+                // Handle Azure Blob SAS token
                 AzBlobURI uri = AzBlobURI.parse(path);
                 String key =
                         String.format("fs.azure.sas.%s.%s.blob.core.windows.net", uri.getContainer(), uri.getAccount());
                 copied.set(key, entry.getValue());
+                return copied;
+            } else if (entry.getKey().equals(GCPCloudConfigurationProvider.GCS_ACCESS_TOKEN)) {
+                // Handle GCS access token
+                copied.set("fs.gs.auth.access.token.provider.impl", GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_IMPL);
+                copied.set(GCPCloudConfigurationProvider.ACCESS_TOKEN_KEY, entry.getValue());
+                copied.set(GCPCloudConfigurationProvider.TOKEN_EXPIRATION_KEY,
+                        properties.getOrDefault(GCPCloudConfigurationProvider.GCS_ACCESS_TOKEN_EXPIRES_AT,
+                                String.valueOf(Long.MAX_VALUE)));
                 return copied;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfiguration.java
@@ -36,7 +36,7 @@ public class GCPCloudConfiguration extends CloudConfiguration {
     @Override
     public void toThrift(TCloudConfiguration tCloudConfiguration) {
         super.toThrift(tCloudConfiguration);
-        tCloudConfiguration.setCloud_type(TCloudType.AZURE);
+        tCloudConfiguration.setCloud_type(TCloudType.GCP);
         Map<String, String> properties = tCloudConfiguration.getCloud_properties();
         gcpCloudCredential.toThrift(properties);
         tCloudConfiguration.setCloud_properties(properties);

--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfigurationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfigurationProvider.java
@@ -27,7 +27,13 @@ import static com.starrocks.connector.share.credential.CloudConfigurationConstan
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.GCP_GCS_SERVICE_ACCOUNT_PRIVATE_KEY_ID;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.GCP_GCS_USE_COMPUTE_ENGINE_SERVICE_ACCOUNT;
 
-public class GCPCloudConfigurationProvoder implements CloudConfigurationProvider {
+public class GCPCloudConfigurationProvider implements CloudConfigurationProvider {
+    public static final String GCS_ACCESS_TOKEN = "gcs.oauth2.token";
+    public static final String GCS_ACCESS_TOKEN_EXPIRES_AT = "gcs.oauth2.token-expires-at";
+    public static final String ACCESS_TOKEN_KEY = "fs.gs.temporary.access.token";
+    public static final String TOKEN_EXPIRATION_KEY = "fs.gs.temporary.token.expiration";
+    public static final String ACCESS_TOKEN_PROVIDER_IMPL =
+            "com.starrocks.connector.gcp.TemporaryGCPAccessTokenProvider";
 
     @Override
     public CloudConfiguration build(Map<String, String> properties) {
@@ -39,7 +45,9 @@ public class GCPCloudConfigurationProvoder implements CloudConfigurationProvider
                 properties.getOrDefault(GCP_GCS_SERVICE_ACCOUNT_EMAIL, ""),
                 properties.getOrDefault(GCP_GCS_SERVICE_ACCOUNT_PRIVATE_KEY_ID, ""),
                 properties.getOrDefault(GCP_GCS_SERVICE_ACCOUNT_PRIVATE_KEY, ""),
-                properties.getOrDefault(GCP_GCS_IMPERSONATION_SERVICE_ACCOUNT, "")
+                properties.getOrDefault(GCP_GCS_IMPERSONATION_SERVICE_ACCOUNT, ""),
+                properties.getOrDefault(GCS_ACCESS_TOKEN, ""),
+                properties.getOrDefault(GCS_ACCESS_TOKEN_EXPIRES_AT, "")
         );
         if (!gcpCloudCredential.validate()) {
             return null;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
@@ -88,7 +88,7 @@ public class IcebergCachingFileIOTest {
     }
 
     @Test
-    public void testBuildAWSConfFromProperties() throws StarRocksException {
+    public void testBuildAzureConfFromProperties() throws StarRocksException {
         Map<String, String> properties = new HashMap<>();
         String key = ADLS_SAS_TOKEN + "account." + ADLS_ENDPOINT;
         String sasToken = "sas_token";

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.ADLS_ENDPOINT;
 import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.ADLS_SAS_TOKEN;
 import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.BLOB_ENDPOINT;
+import static com.starrocks.credential.gcp.GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_IMPL;
+import static com.starrocks.credential.gcp.GCPCloudConfigurationProvider.GCS_ACCESS_TOKEN;
 
 public class IcebergCachingFileIOTest {
 
@@ -86,7 +88,7 @@ public class IcebergCachingFileIOTest {
     }
 
     @Test
-    public void testBuildConfFromProperties() throws StarRocksException {
+    public void testBuildAWSConfFromProperties() throws StarRocksException {
         Map<String, String> properties = new HashMap<>();
         String key = ADLS_SAS_TOKEN + "account." + ADLS_ENDPOINT;
         String sasToken = "sas_token";
@@ -114,5 +116,21 @@ public class IcebergCachingFileIOTest {
 
         token = configuration.get("fs.azure.sas.container.account." + BLOB_ENDPOINT);
         Assertions.assertEquals(sasToken, token);
+    }
+
+    @Test
+    public void testBuildGCSConfFromProperties() throws StarRocksException {
+        Map<String, String> properties = new HashMap<>();
+        String accessToken = "access_token";
+        properties.put(GCS_ACCESS_TOKEN, accessToken);
+        String path = "gs://iceberg_gcp/iceberg_catalog/path/1/2";
+
+        IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
+        cachingFileIO.setConf(new Configuration());
+        Configuration configuration = cachingFileIO.buildConfFromProperties(properties, path);
+        String token = configuration.get("fs.gs.temporary.access.token");
+        Assertions.assertEquals(accessToken, token);
+        Assertions.assertEquals(ACCESS_TOKEN_PROVIDER_IMPL,
+                configuration.get("fs.gs.auth.access.token.provider.impl"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.ADLS_ENDPOINT;
 import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.ADLS_SAS_TOKEN;
 import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.BLOB_ENDPOINT;
+import static com.starrocks.credential.gcp.GCPCloudConfigurationProvider.GCS_ACCESS_TOKEN;
 
 public class CloudConfigurationFactoryTest {
 
@@ -362,7 +363,23 @@ public class CloudConfigurationFactoryTest {
                 "GCPCloudConfiguration{resources='', jars='', hdpuser='', " +
                         "cred=GCPCloudCredential{endpoint='http://xx', useComputeEngineServiceAccount=false, " +
                         "serviceAccountEmail='XX', serviceAccountPrivateKeyId='XX', serviceAccountPrivateKey='XX', " +
-                        "impersonationServiceAccount='XX'}}");
+                        "impersonationServiceAccount='XX', accessToken='', accessTokenExpiresAt=''}}");
+    }
+
+    @Test
+    public void testBuildCloudConfigurationForGCPVendedCredentials() {
+        Map<String, String> map = new HashMap<>();
+        map.put(GCS_ACCESS_TOKEN, "access_token");
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(map,
+                "gs://iceberg_gcp/iceberg_catalog/path/1/2");
+        Assertions.assertNotNull(cloudConfiguration);
+        Assertions.assertEquals(CloudType.GCP, cloudConfiguration.getCloudType());
+        Assertions.assertEquals(
+                "GCPCloudConfiguration{resources='', jars='', hdpuser='', cred=GCPCloudCredential{endpoint='', " +
+                        "useComputeEngineServiceAccount=false, serviceAccountEmail='', serviceAccountPrivateKeyId='', " +
+                        "serviceAccountPrivateKey='', impersonationServiceAccount='', accessToken='access_token', " +
+                        "accessTokenExpiresAt='9223372036854775807'}}",
+                cloudConfiguration.toConfString());
     }
 
     @Test

--- a/java-extensions/hadoop-ext/pom.xml
+++ b/java-extensions/hadoop-ext/pom.xml
@@ -48,11 +48,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector -->
@@ -61,6 +63,7 @@
             <artifactId>gcs-connector</artifactId>
             <version>${gcs.connector.version}</version>
             <classifier>shaded</classifier>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/java-extensions/hadoop-ext/pom.xml
+++ b/java-extensions/hadoop-ext/pom.xml
@@ -44,6 +44,24 @@
             <version>${iceberg.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector -->
+        <dependency>
+            <groupId>com.google.cloud.bigdataoss</groupId>
+            <artifactId>gcs-connector</artifactId>
+            <version>${gcs.connector.version}</version>
+            <classifier>shaded</classifier>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/gcp/TemporaryGCPAccessTokenProvider.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/gcp/TemporaryGCPAccessTokenProvider.java
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.gcp;
+
+import com.google.cloud.hadoop.util.AccessTokenProvider;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+
+public class TemporaryGCPAccessTokenProvider implements AccessTokenProvider {
+    private static final Logger LOG = LogManager.getLogger(TemporaryGCPAccessTokenProvider.class);
+
+    public static final String ACCESS_TOKEN_KEY = "fs.gs.temporary.access.token";
+    public static final String TOKEN_EXPIRATION_KEY = "fs.gs.temporary.token.expiration";
+
+    private Configuration config;
+    private String accessToken;
+    private volatile long expirationTimeMs = Long.MAX_VALUE;
+
+    public TemporaryGCPAccessTokenProvider() {
+        // Default constructor
+    }
+
+    @Override
+    public void setConf(Configuration config) {
+        this.config = config;
+        if (config != null) {
+            String configToken = config.get(ACCESS_TOKEN_KEY);
+            if (configToken != null && !configToken.isEmpty()) {
+                this.accessToken = configToken;
+            }
+
+            this.expirationTimeMs = config.getLong(TOKEN_EXPIRATION_KEY, Long.MAX_VALUE);
+        }
+    }
+
+    @Override
+    public Configuration getConf() {
+        return config;
+    }
+
+    @Override
+    public AccessTokenType getAccessTokenType() {
+        return AccessTokenType.GENERIC;
+    }
+
+    @Override
+    public AccessToken getAccessToken() {
+        if (accessToken == null || accessToken.isEmpty()) {
+            return null;
+        }
+
+        if (isTokenExpired()) {
+            LOG.warn("GCP Access token has expired. Please refresh the token.");
+            return null;
+        }
+        return new AccessToken(accessToken, expirationTimeMs);
+    }
+
+    @Override
+    public void refresh() throws IOException {
+        // do nothing, as this is a temporary token provider
+    }
+
+    public boolean isTokenExpired() {
+        return System.currentTimeMillis() >= expirationTimeMs;
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Support iceberg rest catalog vending credentials for GCP
create statement eg.
use polaris as rest catalog 
```
CREATE EXTERNAL CATALOG polaris_gcp
PROPERTIES (   
    "iceberg.catalog.uri"  = "http://xxxx/api/catalog",   
    "type"  =  "iceberg",   
    "iceberg.catalog.type"  =  "rest",   
    "iceberg.catalog.warehouse" = "iceberg_catalog",
    "iceberg.catalog.security" = "oauth2",
    "iceberg.catalog.oauth2.credential" = "xxx:xxx",
    "iceberg.catalog.oauth2.scope"='PRINCIPAL_ROLE:ALL',
    "iceberg.catalog.rest.nested-namespace-enabled"="true"
 );
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
