### PR TITLE
[Enhancement] Add balance statistic class

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/BalanceStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BalanceStat.java
@@ -1,0 +1,185 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.clone;
+
+public abstract class BalanceStat {
+    public enum BalanceType {
+        CLUSTER_DISK("cluster disk"),
+        CLUSTER_TABLET("cluster tablet"),
+        BACKEND_DISK("backend disk"),
+        BACKEND_TABLET("backend tablet");
+
+        private final String label;
+
+        BalanceType(String label) {
+            this.label = label;
+        }
+
+        public String label() {
+            return label;
+        }
+    }
+
+    // Singleton instance indicating that everything is balanced
+    public static final BalanceStat BALANCED_STAT = new BalancedStat();
+
+    private boolean balanced;
+
+    public BalanceStat(boolean balanced) {
+        this.balanced = balanced;
+    }
+
+    public boolean isBalanced() {
+        return balanced;
+    }
+
+    public abstract BalanceType getBalanceType();
+
+    // Factory methods for different balance stat types
+    public static BalanceStat createClusterDiskBalanceStat(long maxBeId, long minBeId, double maxDiskUsage, double minDiskUsage) {
+        return new ClusterDiskBalanceStat(maxBeId, minBeId, maxDiskUsage, minDiskUsage);
+    }
+
+    public static BalanceStat createClusterTabletBalanceStat(long maxBeId, long minBeId, long maxTabletCount,
+                                                             long minTabletCount) {
+        return new ClusterTabletBalanceStat(maxBeId, minBeId, maxTabletCount, minTabletCount);
+    }
+
+    public static BalanceStat createBackendDiskBalanceStat(long beId, String maxPath, String minPath, double maxDiskUsage,
+                                                           double minDiskUsage) {
+        return new BackendDiskBalanceStat(beId, maxPath, minPath, maxDiskUsage, minDiskUsage);
+    }
+
+    public static BalanceStat createBackendTabletBalanceStat(long beId, String maxPath, String minPath, long maxTabletCount,
+                                                             long minTabletCount) {
+        return new BackendTabletBalanceStat(beId, maxPath, minPath, maxTabletCount, minTabletCount);
+    }
+
+    /**
+     * Represents balanced stat
+     */
+    private static class BalancedStat extends BalanceStat {
+        public BalancedStat() {
+            super(true);
+        }
+
+        public BalanceType getBalanceType() {
+            return null;
+        }
+    }
+
+    /**
+     * Base abstract class for all unbalanced stats
+     */
+    private abstract static class UnbalancedStat extends BalanceStat {
+        private BalanceType type;
+
+        public UnbalancedStat(BalanceType type) {
+            super(false);
+            this.type = type;
+        }
+
+        @Override
+        public BalanceType getBalanceType() {
+            return type;
+        }
+    }
+
+    /**
+     * Base abstract class for cluster unbalanced stats
+     */
+    private abstract static class ClusterBalanceStat extends UnbalancedStat {
+        private long maxBeId;
+        private long minBeId;
+
+        public ClusterBalanceStat(BalanceType type, long maxBeId, long minBeId) {
+            super(type);
+            this.maxBeId = maxBeId;
+            this.minBeId = minBeId;
+        }
+    }
+
+    /**
+     * Balance stat for cluster disk usage
+     */
+    private static class ClusterDiskBalanceStat extends ClusterBalanceStat {
+        private double maxUsedPercent;
+        private double minUsedPercent;
+
+        public ClusterDiskBalanceStat(long maxBeId, long minBeId, double maxUsedPercent, double minUsedPercent) {
+            super(BalanceType.CLUSTER_DISK, maxBeId, minBeId);
+            this.maxUsedPercent = maxUsedPercent;
+            this.minUsedPercent = minUsedPercent;
+        }
+    }
+
+    /**
+     * Balance stat for cluster tablet distribution
+     */
+    private static class ClusterTabletBalanceStat extends ClusterBalanceStat {
+        private long maxTabletNum;
+        private long minTabletNum;
+
+        public ClusterTabletBalanceStat(long maxBeId, long minBeId, long maxTabletNum, long minTabletNum) {
+            super(BalanceType.CLUSTER_TABLET, maxBeId, minBeId);
+            this.maxTabletNum = maxTabletNum;
+            this.minTabletNum = minTabletNum;
+        }
+    }
+
+    /**
+     * Base abstract class for backend unbalanced stats
+     */
+    private abstract static class BackendBalanceStat extends UnbalancedStat {
+        private long beId;
+        private String maxPath;
+        private String minPath;
+
+        public BackendBalanceStat(BalanceType type, long beId, String maxPath, String minPath) {
+            super(type);
+            this.beId = beId;
+            this.maxPath = maxPath;
+            this.minPath = minPath;
+        }
+    }
+
+    /**
+     * Balance stat for backend disk usage
+     */
+    private static class BackendDiskBalanceStat extends BackendBalanceStat {
+        private double maxUsedPercent;
+        private double minUsedPercent;
+
+        public BackendDiskBalanceStat(long beId, String maxPath, String minPath, double maxUsedPercent, double minUsedPercent) {
+            super(BalanceType.BACKEND_DISK, beId, maxPath, minPath);
+            this.maxUsedPercent = maxUsedPercent;
+            this.minUsedPercent = minUsedPercent;
+        }
+    }
+
+    /**
+     * Balance stat for backend tablet distribution
+     */
+    private static class BackendTabletBalanceStat extends BackendBalanceStat {
+        private long maxTabletNum;
+        private long minTabletNum;
+
+        public BackendTabletBalanceStat(long beId, String maxPath, String minPath, long maxTabletNum, long minTabletNum) {
+            super(BalanceType.BACKEND_TABLET, beId, maxPath, minPath);
+            this.maxTabletNum = maxTabletNum;
+            this.minTabletNum = minTabletNum;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -54,7 +54,7 @@ import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
-import com.starrocks.clone.DiskAndTabletLoadReBalancer.BalanceType;
+import com.starrocks.clone.BalanceStat.BalanceType;
 import com.starrocks.clone.SchedException.Status;
 import com.starrocks.clone.TabletScheduler.PathSlot;
 import com.starrocks.common.Config;

--- a/fe/fe-core/src/test/java/com/starrocks/clone/BalanceStatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/BalanceStatTest.java
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.clone;
+
+import com.starrocks.clone.BalanceStat.BalanceType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BalanceStatTest {
+
+    @Test
+    public void testNormal() {
+        Assertions.assertTrue(BalanceStat.BALANCED_STAT.isBalanced());
+
+        {
+            BalanceStat stat = BalanceStat.createClusterDiskBalanceStat(1L, 2L, 0.9, 0.1);
+            Assertions.assertFalse(stat.isBalanced());
+            Assertions.assertEquals(BalanceType.CLUSTER_DISK, stat.getBalanceType());
+            Assertions.assertEquals("cluster disk", stat.getBalanceType().label());
+        }
+
+        {
+            BalanceStat stat = BalanceStat.createClusterTabletBalanceStat(1L, 2L, 9L, 1L);
+            Assertions.assertFalse(stat.isBalanced());
+            Assertions.assertEquals(BalanceType.CLUSTER_TABLET, stat.getBalanceType());
+            Assertions.assertEquals("cluster tablet", stat.getBalanceType().label());
+        }
+
+        {
+            BalanceStat stat = BalanceStat.createBackendDiskBalanceStat(1L, "disk1", "disk2", 0.9, 0.1);
+            Assertions.assertFalse(stat.isBalanced());
+            Assertions.assertEquals(BalanceType.BACKEND_DISK, stat.getBalanceType());
+            Assertions.assertEquals("backend disk", stat.getBalanceType().label());
+        }
+
+        {
+            BalanceStat stat = BalanceStat.createBackendTabletBalanceStat(1L, "disk1", "disk2",  9L, 1L);
+            Assertions.assertFalse(stat.isBalanced());
+            Assertions.assertEquals(BalanceType.BACKEND_TABLET, stat.getBalanceType());
+            Assertions.assertEquals("backend tablet", stat.getBalanceType().label());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
@@ -297,10 +297,10 @@ public class TabletSchedCtxTest {
 
         ctx = new TabletSchedCtx(Type.BALANCE, 1, 2, 3, 4, 1001, System.currentTimeMillis());
         ctx.setOrigPriority(Priority.NORMAL);
-        ctx.setBalanceType(DiskAndTabletLoadReBalancer.BalanceType.TABLET_BETWEEN_BACKENDS);
+        ctx.setBalanceType(BalanceStat.BalanceType.CLUSTER_TABLET);
         results = ctx.getBrief();
         Assertions.assertEquals("1001", results.get(0));
         Assertions.assertEquals("BALANCE", results.get(1));
-        Assertions.assertEquals("TABLET_BETWEEN_BACKENDS", results.get(3));
+        Assertions.assertEquals("CLUSTER_TABLET", results.get(3));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. Add balance stat related class for later observability PRs
2. Refactor BalanceType. The balance status is changed to new values in `show proc "/cluster_balance/history_tablets"` result. Related to https://github.com/StarRocks/starrocks/pull/61081

Fixes #61340

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
