### PR TITLE
[BugFix] Fix auto increment value lost when partial update in COLUMN_UPSERT_MODE for share nothing

### DIFF
--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -688,7 +688,21 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
     std::vector<ColumnUID> update_column_uids;
     std::vector<ColumnUID> unique_update_column_ids;
     const auto& tschema = rowset->schema();
+    /* 
+      * skip overwrite the auto increment column using data in .upt files if user partially update it for the existed keys
+
+      * In current implementation, if user partially update the auto increment column, it will also be included in partial schema
+      * in writing phrase. Because we need to allocate the id in this phrase. It means that .upt files will contains auto increment
+      * column data even it is partially updated (does not specfied by user).
+      * 
+      * For the keys which have already existed in the tablet, we will write "0" in .upt file. In the apply phrase, such "0" data is not
+      * used and we need to discard the column for the keys which have already existed in the tablet.
+    */
     for (ColumnId cid : txn_meta.partial_update_column_ids()) {
+        if (txn_meta.has_auto_increment_partial_update_column_id() && cid == txn_meta.auto_increment_partial_update_column_id()) {
+            // skip auto increment column if it is being used for partial update
+            continue;
+        }
         if (cid >= tschema->num_key_columns()) {
             update_column_ids.push_back(cid);
             update_column_uids.push_back((ColumnUID)cid);
@@ -702,7 +716,12 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
             LOG(ERROR) << msg;
             return Status::InternalError(msg);
         }
-        if (!tschema->column(cid).is_key()) {
+        const auto& column = tschema->column(cid);
+        if (txn_meta.has_auto_increment_partial_update_column_id() && column.is_auto_increment()) {
+            // skip auto increment column if it is being used for partial update
+            continue;
+        }
+        if (!column.is_key()){
             unique_update_column_ids.push_back(uid);
         }
     }

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -699,7 +699,8 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
       * used and we need to discard the column for the keys which have already existed in the tablet.
     */
     for (ColumnId cid : txn_meta.partial_update_column_ids()) {
-        if (txn_meta.has_auto_increment_partial_update_column_id() && cid == txn_meta.auto_increment_partial_update_column_id()) {
+        if (txn_meta.has_auto_increment_partial_update_column_id() &&
+            cid == txn_meta.auto_increment_partial_update_column_id()) {
             // skip auto increment column if it is being used for partial update
             continue;
         }
@@ -721,7 +722,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
             // skip auto increment column if it is being used for partial update
             continue;
         }
-        if (!column.is_key()){
+        if (!column.is_key()) {
             unique_update_column_ids.push_back(uid);
         }
     }

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -767,7 +767,7 @@ SELECT * FROM t_auto_increment_partial_update_column_upsert;
 -- result:
 1	1	3	4
 -- !result
-shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_auto_increment_partial_update_only.csv -XPUT -H partial_update:true  -H partial_update_mode:column -H label:test_auto_increment_partial_update_column_upsert_12345 -H column_separator:, -H columns:k,v2,v3 ${url}/api/test_auto_increment_partial_update_column_upsert/t_auto_increment_partial_update_column_upsert/_stream_load
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_auto_increment_partial_update_only.csv -XPUT -H partial_update:true  -H partial_update_mode:column -H label:test_auto_increment_partial_update_column_upsert_12345 -H column_separator:, -H columns:k,v2,xx ${url}/api/test_auto_increment_partial_update_column_upsert/t_auto_increment_partial_update_column_upsert/_stream_load
 -- result:
 0
 {
@@ -781,7 +781,7 @@ sync;
 SELECT * FROM t_auto_increment_partial_update_column_upsert;
 -- result:
 1	1	20	30
-2	2	40	50
+2	2	40	NULL
 -- !result
 INSERT INTO t_auto_increment_partial_update_column_upsert VALUES (1, 300, 20, 30), (2, 301, 40 ,50);
 -- result:

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -746,7 +746,7 @@ CREATE DATABASE test_auto_increment_partial_update_column_upsert;
 -- result:
 -- !result
 ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
-USE DATABASE test_auto_increment_partial_update_column_upsert;
+USE test_auto_increment_partial_update_column_upsert;
 -- result:
 -- !result
 CREATE TABLE `t_auto_increment_partial_update_column_upsert` (

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -746,6 +746,9 @@ CREATE DATABASE test_auto_increment_partial_update_column_upsert;
 -- result:
 -- !result
 ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
+USE DATABASE test_auto_increment_partial_update_column_upsert;
+-- result:
+-- !result
 CREATE TABLE `t_auto_increment_partial_update_column_upsert` (
   `k`  BIGINT NOT NULL COMMENT "",
   `v1` BIGINT AUTO_INCREMENT,

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -741,3 +741,59 @@ SELECT * FROM t_auto_increment_insert_partial_update order by id;
 DROP TABLE t_auto_increment_insert_partial_update force;
 -- result:
 -- !result
+-- name: test_auto_increment_partial_update_column_upsert @sequential
+CREATE DATABASE test_auto_increment_partial_update_column_upsert;
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
+CREATE TABLE `t_auto_increment_partial_update_column_upsert` (
+  `k`  BIGINT NOT NULL COMMENT "",
+  `v1` BIGINT AUTO_INCREMENT,
+  `v2` BIGINT,
+  `v3` BIGINT
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t_auto_increment_partial_update_column_upsert VALUES (1, DEFAULT, 3, 4);
+-- result:
+-- !result
+SELECT * FROM t_auto_increment_partial_update_column_upsert;
+-- result:
+1	1	3	4
+-- !result
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_auto_increment_partial_update_only.csv -XPUT -H partial_update:true  -H partial_update_mode:column -H label:test_auto_increment_partial_update_column_upsert_12345 -H column_separator:, -H columns:k,v2,v3 ${url}/api/test_auto_increment_partial_update_column_upsert/t_auto_increment_partial_update_column_upsert/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+SELECT * FROM t_auto_increment_partial_update_column_upsert;
+-- result:
+1	1	20	30
+2	2	40	50
+-- !result
+INSERT INTO t_auto_increment_partial_update_column_upsert VALUES (1, 300, 20, 30), (2, 301, 40 ,50);
+-- result:
+-- !result
+SELECT * FROM t_auto_increment_partial_update_column_upsert;
+-- result:
+1	300	20	30
+2	301	40	50
+-- !result
+DROP TABLE t_auto_increment_partial_update_column_upsert;
+-- result:
+-- !result
+DROP DATABASE test_auto_increment_partial_update_column_upsert;
+-- result:
+-- !result

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -783,8 +783,8 @@ sync;
 -- !result
 SELECT * FROM t_auto_increment_partial_update_column_upsert;
 -- result:
-1	1	20	30
-2	2	40	NULL
+1	1	20	4
+2	2	40	None
 -- !result
 INSERT INTO t_auto_increment_partial_update_column_upsert VALUES (1, 300, 20, 30), (2, 301, 40 ,50);
 -- result:

--- a/test/sql/test_auto_increment/T/test_auto_increment
+++ b/test/sql/test_auto_increment/T/test_auto_increment
@@ -329,6 +329,7 @@ DROP TABLE t_auto_increment_insert_partial_update force;
 -- name: test_auto_increment_partial_update_column_upsert @sequential
 CREATE DATABASE test_auto_increment_partial_update_column_upsert;
 ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
+USE DATABASE test_auto_increment_partial_update_column_upsert;
 CREATE TABLE `t_auto_increment_partial_update_column_upsert` (
   `k`  BIGINT NOT NULL COMMENT "",
   `v1` BIGINT AUTO_INCREMENT,

--- a/test/sql/test_auto_increment/T/test_auto_increment
+++ b/test/sql/test_auto_increment/T/test_auto_increment
@@ -325,3 +325,32 @@ insert into t_auto_increment_insert_partial_update (ts, testString) select 100, 
 insert into t_auto_increment_insert_partial_update (ts, testString) select 100, "abc";
 SELECT * FROM t_auto_increment_insert_partial_update order by id;
 DROP TABLE t_auto_increment_insert_partial_update force;
+
+-- name: test_auto_increment_partial_update_column_upsert @sequential
+CREATE DATABASE test_auto_increment_partial_update_column_upsert;
+ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
+CREATE TABLE `t_auto_increment_partial_update_column_upsert` (
+  `k`  BIGINT NOT NULL COMMENT "",
+  `v1` BIGINT AUTO_INCREMENT,
+  `v2` BIGINT,
+  `v3` BIGINT
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+INSERT INTO t_auto_increment_partial_update_column_upsert VALUES (1, DEFAULT, 3, 4);
+SELECT * FROM t_auto_increment_partial_update_column_upsert;
+
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_auto_increment_partial_update_only.csv -XPUT -H partial_update:true  -H partial_update_mode:column -H label:test_auto_increment_partial_update_column_upsert_12345 -H column_separator:, -H columns:k,v2,v3 ${url}/api/test_auto_increment_partial_update_column_upsert/t_auto_increment_partial_update_column_upsert/_stream_load
+sync;
+
+SELECT * FROM t_auto_increment_partial_update_column_upsert;
+INSERT INTO t_auto_increment_partial_update_column_upsert VALUES (1, 300, 20, 30), (2, 301, 40 ,50);
+SELECT * FROM t_auto_increment_partial_update_column_upsert;
+
+DROP TABLE t_auto_increment_partial_update_column_upsert;
+DROP DATABASE test_auto_increment_partial_update_column_upsert;

--- a/test/sql/test_auto_increment/T/test_auto_increment
+++ b/test/sql/test_auto_increment/T/test_auto_increment
@@ -329,7 +329,7 @@ DROP TABLE t_auto_increment_insert_partial_update force;
 -- name: test_auto_increment_partial_update_column_upsert @sequential
 CREATE DATABASE test_auto_increment_partial_update_column_upsert;
 ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
-USE DATABASE test_auto_increment_partial_update_column_upsert;
+USE test_auto_increment_partial_update_column_upsert;
 CREATE TABLE `t_auto_increment_partial_update_column_upsert` (
   `k`  BIGINT NOT NULL COMMENT "",
   `v1` BIGINT AUTO_INCREMENT,

--- a/test/sql/test_auto_increment/T/test_auto_increment
+++ b/test/sql/test_auto_increment/T/test_auto_increment
@@ -345,7 +345,7 @@ PROPERTIES (
 INSERT INTO t_auto_increment_partial_update_column_upsert VALUES (1, DEFAULT, 3, 4);
 SELECT * FROM t_auto_increment_partial_update_column_upsert;
 
-shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_auto_increment_partial_update_only.csv -XPUT -H partial_update:true  -H partial_update_mode:column -H label:test_auto_increment_partial_update_column_upsert_12345 -H column_separator:, -H columns:k,v2,v3 ${url}/api/test_auto_increment_partial_update_column_upsert/t_auto_increment_partial_update_column_upsert/_stream_load
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_auto_increment_partial_update_only.csv -XPUT -H partial_update:true  -H partial_update_mode:column -H label:test_auto_increment_partial_update_column_upsert_12345 -H column_separator:, -H columns:k,v2,xx ${url}/api/test_auto_increment_partial_update_column_upsert/t_auto_increment_partial_update_column_upsert/_stream_load
 sync;
 
 SELECT * FROM t_auto_increment_partial_update_column_upsert;


### PR DESCRIPTION
## Why I'm doing:
In current impl, if we partial update a auto increment column in share nothing mode, we may lost the value:
1. Use COLUMN_UPSERT_MODE for partial update.
2. Key has been inserted before. 

In this case, .upt files contains 0 data for the auto increment column because it expect finish the load using the data coming from the old version, thus such 0 data in .upt files should not be used. But does use such 0 data in apply phrase get overwrite the existed auto increment column value by 0 and lost the old value.

This problem is only occur in share nothing because COLUMN_UPSERT_MODE does not supported in share data mode.

## What I'm doing:
Do not use auto increment column data in .upt file for the existed keys.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
