### PR TITLE
[Enhancement] Implement ProfileActionV2 and QueryDetailActionV2 to obtain query information across all FEs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
@@ -132,6 +132,21 @@ public class BaseRequest {
         return params.get(key);
     }
 
+    public String getSingleParameter(String key, String defaultValue) {
+        String uri = request.uri();
+        if (decoder == null) {
+            decoder = new QueryStringDecoder(uri);
+        }
+
+        List<String> values = decoder.parameters().get(key);
+        if (values != null && !values.isEmpty()) {
+            return values.get(0);
+        }
+
+        return params.get(key) != null ? params.get(key) : defaultValue;
+    }
+
+
     public String getContent() throws DdlException {
         if (request instanceof FullHttpRequest) {
             FullHttpRequest fullHttpRequest = (FullHttpRequest) request;

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
@@ -146,7 +146,6 @@ public class BaseRequest {
         return params.get(key) != null ? params.get(key) : defaultValue;
     }
 
-
     public String getContent() throws DdlException {
         if (request instanceof FullHttpRequest) {
             FullHttpRequest fullHttpRequest = (FullHttpRequest) request;

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -99,6 +99,7 @@ import com.starrocks.http.rest.TableSchemaAction;
 import com.starrocks.http.rest.TransactionLoadAction;
 import com.starrocks.http.rest.TriggerAction;
 import com.starrocks.http.rest.v2.ProfileActionV2;
+import com.starrocks.http.rest.v2.QueryDetailActionV2;
 import com.starrocks.http.rest.v2.TablePartitionAction;
 import com.starrocks.metric.GaugeMetric;
 import com.starrocks.metric.GaugeMetricImpl;
@@ -227,6 +228,7 @@ public class HttpServer {
         ProfileActionV2.registerAction(controller);
         QueryProgressAction.registerAction(controller);
         QueryDetailAction.registerAction(controller);
+        QueryDetailActionV2.registerAction(controller);
         ConnectionAction.registerAction(controller);
         ShowDataAction.registerAction(controller);
         QueryDumpAction.registerAction(controller);

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -98,6 +98,7 @@ import com.starrocks.http.rest.TableRowCountAction;
 import com.starrocks.http.rest.TableSchemaAction;
 import com.starrocks.http.rest.TransactionLoadAction;
 import com.starrocks.http.rest.TriggerAction;
+import com.starrocks.http.rest.v2.ProfileActionV2;
 import com.starrocks.http.rest.v2.TablePartitionAction;
 import com.starrocks.metric.GaugeMetric;
 import com.starrocks.metric.GaugeMetricImpl;
@@ -223,6 +224,7 @@ public class HttpServer {
         ColocateMetaService.UpdateGroupAction.registerAction(controller);
         GlobalDictMetaService.ForbitTableAction.registerAction(controller);
         ProfileAction.registerAction(controller);
+        ProfileActionV2.registerAction(controller);
         QueryProgressAction.registerAction(controller);
         QueryDetailAction.registerAction(controller);
         ConnectionAction.registerAction(controller);

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
@@ -137,7 +137,9 @@ public class HttpUtils {
         }
     }
 
-    private static String executeRequest(String uri, HttpUriRequest request, AbstractHttpEntity entity) throws HttpRequestException {
+    private static String executeRequest(String uri,
+                                         HttpUriRequest request,
+                                         AbstractHttpEntity entity) throws HttpRequestException {
         CloseableHttpClient httpClient = getInstance();
         if (Objects.isNull(httpClient)) {
             LOG.error("HttpClient is null for uri: {}", uri);

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
@@ -137,11 +137,11 @@ public class HttpUtils {
         }
     }
 
-    private static String executeRequest(String uri, HttpUriRequest request, AbstractHttpEntity entity) throws Exception {
+    private static String executeRequest(String uri, HttpUriRequest request, AbstractHttpEntity entity) throws HttpRequestException {
         CloseableHttpClient httpClient = getInstance();
         if (Objects.isNull(httpClient)) {
             LOG.error("HttpClient is null for uri: {}", uri);
-            throw new RuntimeException("HttpClient is null");
+            throw new HttpRequestException("HttpClient is null for uri: " + uri);
         }
         try (CloseableHttpResponse response = httpClient.execute(request)) {
             int code = response.getStatusLine().getStatusCode();
@@ -150,16 +150,21 @@ public class HttpUtils {
                 return result;
             } else {
                 if (entity != null) {
-                    LOG.error("request url:{}, error code:{}, body:{}, result:{}", uri, code, entity, result);
-                    throw new RuntimeException("Http request failed, url: " + uri + ", code: " + code + ", body: " + entity + ", response: " + result);
+                    String msg = String.format("Http request failed, url=%s, code=%d, body=%s, response=%s",
+                            uri, code, entity, result);
+                    LOG.error(msg);
+                    throw new HttpRequestException(msg);
                 } else {
-                    LOG.error("request url:{}, error code:{}, result:{}", uri, code, result);
-                    throw new RuntimeException("Http request failed, url: " + uri + ", code: " + code + ", response: " + result);
+                    String msg = String.format("Http request failed, url=%s, code=%d, response=%s",
+                            uri, code, result);
+                    LOG.error(msg);
+                    throw new HttpRequestException(msg);
                 }
             }
         } catch (IOException e) {
-            LOG.error("http request exception, uri: {}", uri, e);
-            throw new RuntimeException("Http request exception, uri: " + uri, e);
+            String msg = "Http request exception, uri=" + uri;
+            LOG.error(msg, e);
+            throw new HttpRequestException(msg, e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
@@ -53,24 +53,21 @@ import javax.net.ssl.SSLContext;
 
 public class HttpUtils {
 
-    public static final Logger LOG = LoggerFactory.getLogger(HttpUtils.class);
+    private static final Logger LOG = LoggerFactory.getLogger(HttpUtils.class);
 
-    private static volatile CloseableHttpClient httpClient;
+
+    private static class SingletonHolder {
+        private static final CloseableHttpClient INSTANCE = getHttpClient();
+    }
+
+    public static CloseableHttpClient getInstance() {
+        return SingletonHolder.INSTANCE;
+    }
 
     private static PoolingHttpClientConnectionManager clientConnectionManager;
 
-    public static CloseableHttpClient getInstance() {
-        if (httpClient == null) {
-            synchronized (HttpUtils.class) {
-                if (httpClient == null) {
-                    httpClient = getHttpClient();
-                }
-            }
-        }
-        return httpClient;
-    }
 
-    public static CloseableHttpClient getHttpClient() {
+    private static CloseableHttpClient getHttpClient() {
 
         RequestConfig  requestConfig = RequestConfig.custom().setCookieSpec(CookieSpecs.IGNORE_COOKIES)
                 .setExpectContinueEnabled(Boolean.TRUE)
@@ -111,9 +108,6 @@ public class HttpUtils {
         } catch (KeyStoreException e) {
             LOG.error("Got KeyStoreException when SSLContext init", e);
         }
-
-        httpClient = getHttpClient();
-
         LOG.info(" initial http client successfully");
 
     }

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
@@ -64,10 +64,10 @@ public class HttpUtils {
         return SingletonHolder.INSTANCE;
     }
 
-    private static final PoolingHttpClientConnectionManager clientConnectionManager;
+    private static final PoolingHttpClientConnectionManager CLIENT_CONNECTION_MANAGER;
 
     private static CloseableHttpClient getHttpClient() {
-        Objects.requireNonNull(clientConnectionManager, "clientConnectionManager is not initialized");
+        Objects.requireNonNull(CLIENT_CONNECTION_MANAGER, "clientConnectionManager is not initialized");
 
         RequestConfig  requestConfig = RequestConfig.custom().setCookieSpec(CookieSpecs.IGNORE_COOKIES)
                 .setExpectContinueEnabled(Boolean.TRUE)
@@ -80,7 +80,7 @@ public class HttpUtils {
                 .build();
 
         return HttpClients.custom()
-                .setConnectionManager(clientConnectionManager)
+                .setConnectionManager(CLIENT_CONNECTION_MANAGER)
                 .setDefaultRequestConfig(requestConfig)
                 .setRetryHandler(new DefaultHttpRequestRetryHandler(5, false))
                 .build();
@@ -109,7 +109,7 @@ public class HttpUtils {
         } catch (KeyStoreException e) {
             LOG.error("Got KeyStoreException when SSLContext init", e);
         }
-        clientConnectionManager = poolingHttpClientConnectionManager;
+        CLIENT_CONNECTION_MANAGER = poolingHttpClientConnectionManager;
         LOG.info(" initial http client successfully");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
@@ -59,7 +59,10 @@ public class HttpUtils {
     private static PoolingHttpClientConnectionManager clientConnectionManager;
 
 
-    public static CloseableHttpClient getInstance() {
+    private static CloseableHttpClient getInstance() {
+        if (httpClient == null) {
+            httpClient = getHttpClient();
+        }
         return httpClient;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
@@ -12,26 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/http/action/WebBaseAction.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 package com.starrocks.http;
 
 
@@ -127,7 +107,7 @@ public class HttpUtils {
 
         httpClient = getHttpClient();
 
-        LOG.info(" initial http client successfully......");
+        LOG.info(" initial http client successfully");
 
     }
 
@@ -135,7 +115,7 @@ public class HttpUtils {
     public static String get(String uri, Map<String, String> header) {
         CloseableHttpClient httpclient = getInstance();
         if (Objects.isNull(httpClient)) {
-            LOG.error("HttpClient is null");
+            LOG.error("HttpClient is null for uri: {}", uri);
             return null;
         }
         HttpGet httpGet = new HttpGet(uri);
@@ -150,18 +130,18 @@ public class HttpUtils {
             if (code == HttpStatus.SC_OK) {
                 return result;
             } else {
-                LOG.error("request {} error code:{}, result:{}", uri, code, result);
+                LOG.error("request {}, error code:{}, result:{}", uri, code, result);
                 return null;
             }
         } catch (IOException e) {
-            LOG.error("http get exception ", e);
+            LOG.error("http get exception", e);
         } finally {
             try {
                 if (response != null) {
                     response.close();
                 }
             } catch (IOException e) {
-                LOG.error("close exception ", e);
+                LOG.error("Get close exception in http get method", e);
             }
         }
         return null;
@@ -170,7 +150,7 @@ public class HttpUtils {
     public static String post(String uri, AbstractHttpEntity entity, Map<String, String> header) {
         CloseableHttpClient httpclient = getInstance();
         if (Objects.isNull(httpClient)) {
-            LOG.error("HttpClient is null");
+            LOG.error("HttpClient is null for uri: {}", uri);
             return null;
         }
         HttpPost httpPost = new HttpPost(uri);
@@ -186,18 +166,18 @@ public class HttpUtils {
             if (code == HttpStatus.SC_OK) {
                 return result;
             } else {
-                LOG.error("request url{} error code:{}, body:{}, result:{}", uri, code, entity, result);
+                LOG.error("request url{}, error code:{}, body:{}, result:{}", uri, code, entity, result);
                 return null;
             }
         } catch (IOException e) {
-            LOG.error("http post exception ", e);
+            LOG.error("http post exception", e);
         } finally {
             try {
                 if (response != null) {
                     response.close();
                 }
             } catch (IOException e) {
-                LOG.error("close exception ", e);
+                LOG.error("Get close exception in http post method", e);
             }
         }
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpUtils.java
@@ -1,0 +1,205 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/http/action/WebBaseAction.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.http;
+
+
+import org.apache.http.HttpStatus;
+import org.apache.http.client.config.AuthSchemes;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.entity.AbstractHttpEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import javax.net.ssl.SSLContext;
+
+import static org.apache.http.Consts.UTF_8;
+
+public class HttpUtils {
+
+    public static final Logger LOG = LoggerFactory.getLogger(HttpUtils.class);
+
+    private static CloseableHttpClient httpClient;
+
+    private static PoolingHttpClientConnectionManager clientConnectionManager;
+
+
+    public static CloseableHttpClient getInstance() {
+        return httpClient;
+    }
+
+    public static CloseableHttpClient getHttpClient() {
+
+        RequestConfig  requestConfig = RequestConfig.custom().setCookieSpec(CookieSpecs.IGNORE_COOKIES)
+                .setExpectContinueEnabled(Boolean.TRUE)
+                .setTargetPreferredAuthSchemes(Arrays.asList(AuthSchemes.NTLM, AuthSchemes.DIGEST, AuthSchemes.SPNEGO))
+                .setProxyPreferredAuthSchemes(Arrays.asList(AuthSchemes.BASIC, AuthSchemes.SPNEGO))
+                .setConnectTimeout(5000)
+                .setSocketTimeout(5000)
+                .setConnectionRequestTimeout(5000)
+                .setRedirectsEnabled(true)
+                .build();
+
+        return HttpClients.custom()
+                .setConnectionManager(clientConnectionManager)
+                .setDefaultRequestConfig(requestConfig)
+                .setRetryHandler(new DefaultHttpRequestRetryHandler(5, false))
+                .build();
+    }
+
+    static {
+        try {
+            SSLContextBuilder builder = new SSLContextBuilder();
+            builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+            SSLContext sslContext = builder.build();
+            SSLConnectionSocketFactory socketFactory = new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
+            Registry<ConnectionSocketFactory> socketFactoryRegistry =
+                    RegistryBuilder.<ConnectionSocketFactory>create()
+                            .register("http", PlainConnectionSocketFactory.getSocketFactory())
+                            .register("https", socketFactory)
+                            .build();
+            clientConnectionManager = new PoolingHttpClientConnectionManager(socketFactoryRegistry);
+            clientConnectionManager.setDefaultMaxPerRoute(50);
+            clientConnectionManager.setMaxTotal(100);
+
+        } catch (NoSuchAlgorithmException e) {
+            LOG.error("Got NoSuchAlgorithmException when SSLContext init", e);
+        } catch (KeyManagementException e) {
+            LOG.error("Got KeyManagementException when SSLContext init", e);
+        } catch (KeyStoreException e) {
+            LOG.error("Got KeyStoreException when SSLContext init", e);
+        }
+
+        httpClient = getHttpClient();
+
+        LOG.info(" initial http client successfully......");
+
+    }
+
+
+    public static String get(String uri, Map<String, String> header) {
+        CloseableHttpClient httpclient = getInstance();
+        if (Objects.isNull(httpClient)) {
+            LOG.error("HttpClient is null");
+            return null;
+        }
+        HttpGet httpGet = new HttpGet(uri);
+        CloseableHttpResponse response = null;
+        try {
+            if (header != null && !header.isEmpty()) {
+                header.forEach(httpGet::addHeader);
+            }
+            response = httpclient.execute(httpGet);
+            int code = response.getStatusLine().getStatusCode();
+            String result = EntityUtils.toString(response.getEntity(), UTF_8);
+            if (code == HttpStatus.SC_OK) {
+                return result;
+            } else {
+                LOG.error("request {} error code:{}, result:{}", uri, code, result);
+                return null;
+            }
+        } catch (IOException e) {
+            LOG.error("http get exception ", e);
+        } finally {
+            try {
+                if (response != null) {
+                    response.close();
+                }
+            } catch (IOException e) {
+                LOG.error("close exception ", e);
+            }
+        }
+        return null;
+    }
+
+    public static String post(String uri, AbstractHttpEntity entity, Map<String, String> header) {
+        CloseableHttpClient httpclient = getInstance();
+        if (Objects.isNull(httpClient)) {
+            LOG.error("HttpClient is null");
+            return null;
+        }
+        HttpPost httpPost = new HttpPost(uri);
+        CloseableHttpResponse response = null;
+        try {
+            httpPost.setEntity(entity);
+            if (header != null && !header.isEmpty()) {
+                header.forEach(httpPost::addHeader);
+            }
+            response = httpclient.execute(httpPost);
+            int code = response.getStatusLine().getStatusCode();
+            String result = EntityUtils.toString(response.getEntity(), UTF_8);
+            if (code == HttpStatus.SC_OK) {
+                return result;
+            } else {
+                LOG.error("request url{} error code:{}, body:{}, result:{}", uri, code, entity, result);
+                return null;
+            }
+        } catch (IOException e) {
+            LOG.error("http post exception ", e);
+        } finally {
+            try {
+                if (response != null) {
+                    response.close();
+                }
+            } catch (IOException e) {
+                LOG.error("close exception ", e);
+            }
+        }
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -350,10 +350,13 @@ public class RestBaseAction extends BaseAction {
     }
 
     public static Pair<String, Integer> getCurrentFe() {
-
-        return GlobalStateMgr.getCurrentState()
-                .getNodeMgr()
-                .getSelfNode();
+        if (GlobalStateMgr.getCurrentState() == null) {
+            return null;
+        } else {
+            return GlobalStateMgr.getCurrentState()
+                    .getNodeMgr()
+                    .getSelfNode();
+        }
     }
 
     public static List<Pair<String, Integer>> getOtherAliveFe() {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -336,13 +336,17 @@ public class RestBaseAction extends BaseAction {
 
     public static List<Pair<String, Integer>> getAllAliveFe() {
 
-        return GlobalStateMgr.getCurrentState()
-                .getNodeMgr()
-                .getAllFrontends()
-                .stream()
-                .filter(Frontend::isAlive)
-                .map(fe -> new Pair<>(fe.getHost(), Config.http_port))
-                .collect(Collectors.toList());
+        if (GlobalStateMgr.getCurrentState() == null) {
+            return List.of();
+        } else {
+            return GlobalStateMgr.getCurrentState()
+                    .getNodeMgr()
+                    .getAllFrontends()
+                    .stream()
+                    .filter(Frontend::isAlive)
+                    .map(fe -> new Pair<>(fe.getHost(), Config.http_port))
+                    .collect(Collectors.toList());
+        }
     }
 
     public static Pair<String, Integer> getCurrentFe() {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -299,14 +299,18 @@ public class RestBaseAction extends BaseAction {
         });
     }
 
-    protected List<String> queryOtherFrontendNodes(String queryPlainUrl, String authorization,
+    public static List<String> fetchResultFromOtherFrontendNodes(String queryPath,
+                                                   String authorization,
                                                  HttpMethod method) {
         List<Pair<String, Integer>> frontends = getOtherAliveFe();
+        if (frontends.isEmpty()) {
+            return List.of();
+        }
         ImmutableMap<String, String> header = ImmutableMap.<String, String>builder()
                 .put(HttpHeaders.AUTHORIZATION, authorization).build();
         List<String> result = Lists.newArrayList();
         for (Pair<String, Integer> front : frontends) {
-            String url = String.format("http://%s%s", front, queryPlainUrl);
+            String url = String.format("http://%s%s", front, queryPath);
             try {
                 String data = null;
                 if (method == HttpMethod.GET) {
@@ -345,15 +349,15 @@ public class RestBaseAction extends BaseAction {
     public static List<Pair<String, Integer>> getOtherAliveFe() {
         List<Pair<String, Integer>> allAliveFe = getAllAliveFe();
         if (allAliveFe.isEmpty()) {
-            return null;
+            return List.of();
         }
         Pair<String, Integer> currentFe = getCurrentFe();
         if (currentFe == null) {
-            return null;
+            return List.of();
         }
-        String ip = currentFe.first;
+        String currentFeAddress = currentFe.first;
         return allAliveFe.stream()
-                .filter(fe -> !fe.first.equals(ip))
+                .filter(fe -> !fe.first.equals(currentFeAddress))
                 .collect(Collectors.toList());
 
     }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -299,14 +299,14 @@ public class RestBaseAction extends BaseAction {
         });
     }
 
-    protected List<String> queryAllFrontendNodes(String relativeUrl, String authorization,
+    protected List<String> queryOtherFrontendNodes(String queryPlainUrl, String authorization,
                                                  HttpMethod method) {
-        List<Pair<String, Integer>> frontends = getAllAliveFe();
+        List<Pair<String, Integer>> frontends = getOtherAliveFe();
         ImmutableMap<String, String> header = ImmutableMap.<String, String>builder()
                 .put(HttpHeaders.AUTHORIZATION, authorization).build();
         List<String> result = Lists.newArrayList();
         for (Pair<String, Integer> front : frontends) {
-            String url = String.format("http://%s/%s", front, relativeUrl);
+            String url = String.format("http://%s%s", front, queryPlainUrl);
             try {
                 String data = null;
                 if (method == HttpMethod.GET) {
@@ -356,6 +356,16 @@ public class RestBaseAction extends BaseAction {
                 .filter(fe -> !fe.first.equals(ip))
                 .collect(Collectors.toList());
 
+    }
+
+    protected void sendSuccessResponse(BaseResponse response, String content, BaseRequest request) {
+        response.getContent().append(content);
+        sendResult(request, response);
+    }
+
+    protected void sendErrorResponse(BaseResponse response, String message, HttpResponseStatus status, BaseRequest request) {
+        response.getContent().append(message);
+        sendResult(request, response, status);
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
@@ -12,26 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/http/rest/ProfileAction.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 package com.starrocks.http.rest.v2;
 
 import com.starrocks.common.util.ProfileManager;
@@ -50,7 +30,7 @@ import java.util.List;
 //   wget http://fe_host:fe_http_port/api/v2/profile?query_id=123456&is_request_all_frontend=true;
 public class ProfileActionV2 extends RestBaseAction {
 
-    private static final String QUERY_PLAN_URI = "api/profile?query_id=%s";
+    private static final String QUERY_PLAN_URI = "api/v2/profile?query_id=%s";
 
     public ProfileActionV2(ActionController controller) {
         super(controller);
@@ -65,7 +45,7 @@ public class ProfileActionV2 extends RestBaseAction {
         String authorization = request.getAuthorizationHeader();
         String queryId = request.getSingleParameter("query_id");
         String isRequestAllStr = request.getSingleParameter("is_request_all_frontend", "false");
-        boolean isRequestAll = Boolean.parseBoolean(isRequestAllStr);;
+        boolean isRequestAll = Boolean.parseBoolean(isRequestAllStr);
 
         if (queryId == null || queryId.isEmpty()) {
             sendErrorResponse(response,
@@ -83,10 +63,10 @@ public class ProfileActionV2 extends RestBaseAction {
         }
 
         if (isRequestAll) {
-            // If the query profile is not found in the local node,
+            // If the query profile is not found in the local fe's ProfileManager,
             // we will query other frontend nodes to get the query profile.
-            String queryPlainUrl = String.format(QUERY_PLAN_URI, queryId);
-            List<String> profileList = queryOtherFrontendNodes(queryPlainUrl, authorization, HttpMethod.GET);
+            String queryPath = String.format(QUERY_PLAN_URI, queryId);
+            List<String> profileList = fetchResultFromOtherFrontendNodes(queryPath, authorization, HttpMethod.GET);
             for (String profile : profileList) {
                 if (profile != null) {
                     sendSuccessResponse(response, profile, request);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
@@ -30,7 +30,7 @@ import java.util.List;
 //   wget http://fe_host:fe_http_port/api/v2/profile?query_id=123456&is_request_all_frontend=true;
 public class ProfileActionV2 extends RestBaseAction {
 
-    private static final String QUERY_PLAN_URI = "api/v2/profile?query_id=%s";
+    private static final String QUERY_PLAN_URI = "/api/v2/profile?query_id=%s";
 
     public ProfileActionV2(ActionController controller) {
         super(controller);
@@ -66,7 +66,7 @@ public class ProfileActionV2 extends RestBaseAction {
             // If the query profile is not found in the local fe's ProfileManager,
             // we will query other frontend nodes to get the query profile.
             String queryPath = String.format(QUERY_PLAN_URI, queryId);
-            List<String> profileList = fetchResultFromOtherFrontendNodes(queryPath, authorization, HttpMethod.GET);
+            List<String> profileList = fetchResultFromOtherFrontendNodes(queryPath, authorization, HttpMethod.GET, false);
             for (String profile : profileList) {
                 if (profile != null) {
                     sendSuccessResponse(response, profile, request);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/http/rest/ProfileAction.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.http.rest.v2;
+
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import com.starrocks.http.rest.RestBaseAction;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.List;
+
+// This class is a RESTFUL interface to get query profile from all frontend nodes.
+// Usage:
+//   wget http://fe_host:fe_http_port/api/v2/profile?query_id=123456
+public class ProfileActionV2 extends RestBaseAction {
+
+    private static final String QUERY_PLAN_URI = "api/profile?query_id=%s";
+
+    public ProfileActionV2(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller) throws IllegalArgException {
+        controller.registerHandler(HttpMethod.GET, "/api/v2/profile", new ProfileActionV2(controller));
+    }
+
+    @Override
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+        String authorization = request.getAuthorizationHeader();
+        String queryId = request.getSingleParameter("query_id");
+        if (queryId == null) {
+            response.getContent().append("not valid parameter");
+            sendResult(request, response, HttpResponseStatus.BAD_REQUEST);
+            return;
+        }
+        String relativeUrl = String.format(QUERY_PLAN_URI, queryId);
+        List<String> dataList = queryAllFrontendNodes(relativeUrl, authorization, HttpMethod.GET);
+        for (String data : dataList) {
+            if (data != null) {
+                response.getContent().append(data);
+                sendResult(request, response);
+                return;
+            }
+        }
+        response.getContent().append("query id " + queryId + " not found.");
+        sendResult(request, response, HttpResponseStatus.NOT_FOUND);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/QueryDetailActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/QueryDetailActionV2.java
@@ -25,6 +25,8 @@ import com.starrocks.qe.QueryDetailQueue;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 // This class is a RESTFUL interface to get query profile from all frontend nodes.
@@ -76,12 +78,13 @@ public class QueryDetailActionV2 extends RestBaseAction {
             if (user != null && !user.isEmpty()) {
                 queryPath += "&user=" + user;
             }
-            List<String> dataList = fetchResultFromOtherFrontendNodes(queryPath, authorization, HttpMethod.GET);
-            for (String data : dataList) {
-                if (data != null) {
-                    Gson gson = new Gson();
-                    QueryDetail queryDetail = gson.fromJson(data, QueryDetail.class);
-                    queryDetails.add(queryDetail);
+            List<String> dataList = fetchResultFromOtherFrontendNodes(queryPath, authorization, HttpMethod.GET, true);
+            if (dataList != null) {
+                for (String data : dataList) {
+                    if (data != null) {
+                        Gson gson = new Gson();
+                        QueryDetail[] queryDetailArray = gson.fromJson(data, QueryDetail[].class);
+                        queryDetails.addAll(Arrays.asList(queryDetailArray));                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/QueryDetailActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/QueryDetailActionV2.java
@@ -1,0 +1,94 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2;
+
+import com.google.gson.Gson;
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import com.starrocks.http.rest.RestBaseAction;
+import com.starrocks.qe.QueryDetail;
+import com.starrocks.qe.QueryDetailQueue;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.List;
+
+// This class is a RESTFUL interface to get query profile from all frontend nodes.
+// Usage:
+//   wget http://fe_host:fe_http_port/api/v2/query_detail?user=root&event_time=1753671088&is_request_all_frontend=true;
+public class QueryDetailActionV2 extends RestBaseAction {
+
+    private static final String QUERY_PLAN_URI = "/api/v2/query_detail";
+
+    public QueryDetailActionV2(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller) throws IllegalArgException {
+        controller.registerHandler(HttpMethod.GET, QUERY_PLAN_URI, new QueryDetailActionV2(controller));
+    }
+
+    @Override
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+        String authorization = request.getAuthorizationHeader();
+        String eventTimeStr = request.getSingleParameter("event_time");
+        String user = request.getSingleParameter("user");
+        String isRequestAllStr = request.getSingleParameter("is_request_all_frontend", "false");
+        boolean isRequestAll = Boolean.parseBoolean(isRequestAllStr);
+
+        if (eventTimeStr == null || eventTimeStr.isEmpty()) {
+            sendErrorResponse(response,
+                    "not valid parameter",
+                    HttpResponseStatus.BAD_REQUEST,
+                    request);
+            return;
+        }
+
+        long eventTime = Long.parseLong(eventTimeStr.trim());
+
+        List<QueryDetail> queryDetails;
+        if (user != null && !user.isEmpty()) {
+            // If user is specified, we will filter the query details by user.
+            queryDetails = QueryDetailQueue.getQueryDetailsAfterTime(eventTime, user);
+        } else {
+            // If user is not specified, we will get all query details after the specified event time
+            queryDetails = QueryDetailQueue.getQueryDetailsAfterTime(eventTime);
+        }
+
+        if (isRequestAll) {
+            // If the query profile is not found in the local fe's ProfileManager,
+            // we will query other frontend nodes to get the query profile.
+            String queryPath = QUERY_PLAN_URI + "?event_time=" + eventTimeStr;
+            if (user != null && !user.isEmpty()) {
+                queryPath += "&user=" + user;
+            }
+            List<String> dataList = fetchResultFromOtherFrontendNodes(queryPath, authorization, HttpMethod.GET);
+            for (String data : dataList) {
+                if (data != null) {
+                    Gson gson = new Gson();
+                    QueryDetail queryDetail = gson.fromJson(data, QueryDetail.class);
+                    queryDetails.add(queryDetail);
+                }
+            }
+        }
+
+        Gson gson = new Gson();
+        String jsonString = gson.toJson(queryDetails);
+        response.getContent().append(jsonString);
+        sendResult(request, response);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/QueryDetailActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/QueryDetailActionV2.java
@@ -83,7 +83,8 @@ public class QueryDetailActionV2 extends RestBaseAction {
                     if (data != null) {
                         Gson gson = new Gson();
                         QueryDetail[] queryDetailArray = gson.fromJson(data, QueryDetail[].class);
-                        queryDetails.addAll(Arrays.asList(queryDetailArray));                    }
+                        queryDetails.addAll(Arrays.asList(queryDetailArray));
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/QueryDetailActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/QueryDetailActionV2.java
@@ -25,7 +25,6 @@ import com.starrocks.qe.QueryDetailQueue;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetailQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetailQueue.java
@@ -82,6 +82,16 @@ public class QueryDetailQueue {
         return results;
     }
 
+    public static List<QueryDetail> getQueryDetailsAfterTime(long eventTime, String user) {
+        List<QueryDetail> results = Lists.newArrayList();
+        for (QueryDetail queryDetail : TOTAL_QUERIES) {
+            if (queryDetail.getEventTime() > eventTime && queryDetail.getUser().equalsIgnoreCase(user)) {
+                results.add(queryDetail);
+            }
+        }
+        return results;
+    }
+
     public static long getTotalQueriesCount() {
         return TOTAL_QUERIES.size();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
@@ -14,9 +14,6 @@
 
 package com.starrocks.http;
 
-import com.starrocks.common.Pair;
-import com.starrocks.server.GlobalStateMgr;
-import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.http.HttpHeaders;
@@ -25,7 +22,6 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.protocol.HttpContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
@@ -12,26 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 package com.starrocks.http;
 
 import org.apache.http.HttpHeaders;
@@ -55,7 +35,7 @@ public class HttpUtilsTest extends StarRocksHttpTestCase {
     }
 
     @Test
-    public void testHttpGet() {
+    public void testHttpGet() throws Exception {
         Map<String, String> header = Map.of(HttpHeaders.AUTHORIZATION, rootAuth);
         String url = "http://localhost:" + HTTP_PORT + QUERY_PLAN_URI + "?path=/backends";
         String result = HttpUtils.get(url, header);
@@ -64,14 +44,13 @@ public class HttpUtilsTest extends StarRocksHttpTestCase {
     }
 
     @Test
-    public void testHttpPost() {
+    public void testHttpPost() throws Exception {
         Map<String, String> header = Map.of(HttpHeaders.AUTHORIZATION, rootAuth);
         String url = URI + "/_query_plan";
         StringEntity entity = new StringEntity(
                 "{ \"sql\" :  \" select k1 as alias_1,k2 from " + DB_NAME + "." + TABLE_NAME + " \" }",
                 StandardCharsets.UTF_8);
         String result = HttpUtils.post(url, entity, header);
-        Assertions.assertTrue(true);
         Assertions.assertNull(result);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
@@ -49,7 +49,7 @@ public class HttpUtilsTest extends StarRocksHttpTestCase {
         StringEntity entity = new StringEntity(
                 "{ \"sql\" :  \" select k1 as alias_1,k2 from " + DB_NAME + "." + TABLE_NAME + " \" }",
                 StandardCharsets.UTF_8);
-        Assertions.assertThrows(RuntimeException.class, () -> {
+        Assertions.assertThrows(HttpRequestException.class, () -> {
             HttpUtils.post(url, entity, header);
         });
     }

--- a/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
@@ -39,18 +39,18 @@ public class HttpUtilsTest extends StarRocksHttpTestCase {
         Map<String, String> header = Map.of(HttpHeaders.AUTHORIZATION, rootAuth);
         String url = "http://localhost:" + HTTP_PORT + QUERY_PLAN_URI + "?path=/backends";
         String result = HttpUtils.get(url, header);
-        Assertions.assertTrue(true);
         Assertions.assertNotNull(result);
     }
 
     @Test
-    public void testHttpPost() throws Exception {
+    public void testHttpPost()  {
         Map<String, String> header = Map.of(HttpHeaders.AUTHORIZATION, rootAuth);
         String url = URI + "/_query_plan";
         StringEntity entity = new StringEntity(
                 "{ \"sql\" :  \" select k1 as alias_1,k2 from " + DB_NAME + "." + TABLE_NAME + " \" }",
                 StandardCharsets.UTF_8);
-        String result = HttpUtils.post(url, entity, header);
-        Assertions.assertNull(result);
+        Assertions.assertThrows(RuntimeException.class, () -> {
+            HttpUtils.post(url, entity, header);
+        });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
@@ -1,0 +1,42 @@
+package com.starrocks.http;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public class HttpUtilsTest extends StarRocksHttpTestCase {
+
+    private static final String QUERY_PLAN_URI = "/system";
+
+    @Test
+    public void testGetHttpClient() {
+        CloseableHttpClient httpClient1 = HttpUtils.getInstance();
+        CloseableHttpClient httpClient2 = HttpUtils.getInstance();
+        Assertions.assertEquals(httpClient1, httpClient2);
+    }
+
+    @Test
+    public void testHttpGet() {
+        Map<String, String> header = Map.of(HttpHeaders.AUTHORIZATION, rootAuth);
+        String url = "http://localhost:" + HTTP_PORT + QUERY_PLAN_URI + "?path=/backends";
+        String result = HttpUtils.get(url, header);
+        Assertions.assertTrue(true);
+        Assertions.assertNotNull(result);
+    }
+
+    @Test
+    public void testHttpPost() {
+        Map<String, String> header = Map.of(HttpHeaders.AUTHORIZATION, rootAuth);
+        String url = URI + "/_query_plan";
+        StringEntity entity = new StringEntity("{ \"sql\" :  \" select k1 as alias_1,k2 from " + DB_NAME + "." + TABLE_NAME + " \" }", StandardCharsets.UTF_8);
+        String result = HttpUtils.post(url, entity, header);
+        Assertions.assertTrue(true);
+        Assertions.assertNull(result);
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
@@ -1,3 +1,37 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package com.starrocks.http;
 
 import org.apache.http.HttpHeaders;
@@ -38,5 +72,4 @@ public class HttpUtilsTest extends StarRocksHttpTestCase {
         Assertions.assertTrue(true);
         Assertions.assertNull(result);
     }
-
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
@@ -67,7 +67,9 @@ public class HttpUtilsTest extends StarRocksHttpTestCase {
     public void testHttpPost() {
         Map<String, String> header = Map.of(HttpHeaders.AUTHORIZATION, rootAuth);
         String url = URI + "/_query_plan";
-        StringEntity entity = new StringEntity("{ \"sql\" :  \" select k1 as alias_1,k2 from " + DB_NAME + "." + TABLE_NAME + " \" }", StandardCharsets.UTF_8);
+        StringEntity entity = new StringEntity(
+                "{ \"sql\" :  \" select k1 as alias_1,k2 from " + DB_NAME + "." + TABLE_NAME + " \" }", 
+                StandardCharsets.UTF_8);
         String result = HttpUtils.post(url, entity, header);
         Assertions.assertTrue(true);
         Assertions.assertNull(result);

--- a/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/HttpUtilsTest.java
@@ -68,7 +68,7 @@ public class HttpUtilsTest extends StarRocksHttpTestCase {
         Map<String, String> header = Map.of(HttpHeaders.AUTHORIZATION, rootAuth);
         String url = URI + "/_query_plan";
         StringEntity entity = new StringEntity(
-                "{ \"sql\" :  \" select k1 as alias_1,k2 from " + DB_NAME + "." + TABLE_NAME + " \" }", 
+                "{ \"sql\" :  \" select k1 as alias_1,k2 from " + DB_NAME + "." + TABLE_NAME + " \" }",
                 StandardCharsets.UTF_8);
         String result = HttpUtils.post(url, entity, header);
         Assertions.assertTrue(true);

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
 import mockit.Mock;
 import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -110,8 +111,7 @@ public class RestBaseActionTest {
 
         List<Pair<String, Integer>> fronts = restBaseAction.getOtherAliveFe();
 
-        assert fronts.size() == 1;
-
+        Assertions.assertEquals(fronts.size(), 1);
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.http;
 
-import autovalue.shaded.com.google.common.common.collect.Lists;
+import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.ha.FrontendNodeType;

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -14,8 +14,13 @@
 
 package com.starrocks.http;
 
+import autovalue.shaded.com.google.common.common.collect.Lists;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
+import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.http.rest.RestBaseAction;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TNetworkAddress;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -24,6 +29,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
@@ -112,6 +118,59 @@ public class RestBaseActionTest {
         List<Pair<String, Integer>> fronts = restBaseAction.getOtherAliveFe();
 
         Assertions.assertEquals(fronts.size(), 1);
+    }
+
+    @Test
+    public void verifyGetEmptyOtherAliveFronts() {
+
+        new Expectations(GlobalStateMgr.getCurrentState().getNodeMgr()) {
+            {
+
+                GlobalStateMgr.getCurrentState();
+                minTimes = 1;
+                result = null;
+            }
+        };
+
+        List<Pair<String, Integer>> fronts = restBaseAction.getOtherAliveFe();
+
+        Assertions.assertEquals(fronts.size(), 0);
+    }
+
+    @Test
+    public void verifyGetNullCurrentFe() {
+
+        new Expectations(GlobalStateMgr.getCurrentState()) {
+            {
+
+                GlobalStateMgr.getCurrentState();
+                minTimes = 1;
+                result = null;
+            }
+        };
+
+        Pair<String, Integer> currentFe = restBaseAction.getCurrentFe();
+
+        Assertions.assertNull(currentFe);
+    }
+
+    @Test
+    public void testGetAllAliveFe() {
+        Frontend frontend = new Frontend(0, FrontendNodeType.LEADER, "", "localhost", 0);
+        frontend.setAlive(true);
+        new Expectations(GlobalStateMgr.getCurrentState().getNodeMgr()) {
+            {
+                GlobalStateMgr.getCurrentState().getNodeMgr().getAllFrontends();
+                minTimes = 1;
+                result = Lists.newArrayList(frontend);
+            }
+        };
+
+        List<Pair<String, Integer>> result = restBaseAction.getAllAliveFe();
+
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(frontend.getHost(), result.get(0).first);
+        Assertions.assertEquals(Config.http_port, result.get(0).second);
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -100,13 +100,12 @@ public class RestBaseActionTest {
     public void testGetOtherAliveFronts() {
         new MockUp<RestBaseAction>() {
             @Mock
-            public static List<Pair<String, Integer>> getAllAliveFe(){
+            public static List<Pair<String, Integer>> getAllAliveFe() {
                 return List.of(
                         new Pair<>("fe1", 8030),
                         new Pair<>("fe2", 8031)
                 );
-
-        }
+            }
 
             @Mock
             public static Pair<String, Integer> getCurrentFe() {

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.http;
 
+import com.starrocks.common.Pair;
 import com.starrocks.http.rest.RestBaseAction;
 import com.starrocks.thrift.TNetworkAddress;
 import io.netty.channel.ChannelHandlerContext;
@@ -23,10 +24,13 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.util.List;
 
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -85,4 +89,36 @@ public class RestBaseActionTest {
         restBaseAction.redirectTo(mockRequest, mockResponse, mockAddr);
         verify(mockResponse).updateHeader(HttpHeaderNames.LOCATION.toString(), asciiUri);
     }
+
+    @Test
+    public void verifyCallGetAllAliveFe() {
+        List<Pair<String, Integer>> fronts = restBaseAction.getOtherAliveFe();
+        verify(restBaseAction).getAllAliveFe();
+    }
+
+    @Test
+    public void testGetOtherAliveFronts() {
+        new MockUp<RestBaseAction>() {
+            @Mock
+            public static List<Pair<String, Integer>> getAllAliveFe(){
+                return List.of(
+                        new Pair<>("fe1", 8030),
+                        new Pair<>("fe2", 8031)
+                );
+
+        }
+
+            @Mock
+            public static Pair<String, Integer> getCurrentFe() {
+                return new Pair<>("fe1", 8030);
+            }
+
+    };
+        List<Pair<String, Integer>> fronts = restBaseAction.getOtherAliveFe();
+        verify(restBaseAction).getCurrentFe();
+
+        assert fronts.size() == 1;
+
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -111,8 +111,8 @@ public class RestBaseActionTest {
             public static Pair<String, Integer> getCurrentFe() {
                 return new Pair<>("fe1", 8030);
             }
+        };
 
-    };
         List<Pair<String, Integer>> fronts = restBaseAction.getOtherAliveFe();
         verify(restBaseAction).getCurrentFe();
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -90,11 +90,6 @@ public class RestBaseActionTest {
         verify(mockResponse).updateHeader(HttpHeaderNames.LOCATION.toString(), asciiUri);
     }
 
-    @Test
-    public void verifyCallGetAllAliveFe() {
-        List<Pair<String, Integer>> fronts = restBaseAction.getOtherAliveFe();
-        verify(restBaseAction).getAllAliveFe();
-    }
 
     @Test
     public void testGetOtherAliveFronts() {
@@ -114,7 +109,6 @@ public class RestBaseActionTest {
         };
 
         List<Pair<String, Integer>> fronts = restBaseAction.getOtherAliveFe();
-        verify(restBaseAction).getCurrentFe();
 
         assert fronts.size() == 1;
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -559,11 +559,11 @@ public abstract class StarRocksHttpTestCase {
                 result = frontend;
 
                 nodeMgr.getAllFrontends();
-                minTimes = 1;
+                minTimes = 0;
                 result = Lists.newArrayList(frontend);
 
                 nodeMgr.getSelfNode();
-                minTimes = 1;
+                minTimes = 0;
                 result = new Pair<>(frontend.getHost(), HTTP_PORT);
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -59,7 +59,6 @@ import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker.ThrowingRunnable;
-import com.starrocks.common.Pair;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.ha.FrontendNodeType;

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -559,17 +559,14 @@ public abstract class StarRocksHttpTestCase {
                 result = frontend;
 
                 nodeMgr.getAllFrontends();
-                minTimes = 0;
+                minTimes = 1;
                 result = Lists.newArrayList(frontend);
 
                 nodeMgr.getSelfNode();
-                minTimes = 0;
+                minTimes = 1;
                 result = new Pair<>(frontend.getHost(), HTTP_PORT);
             }
         };
-
-
-
 
         // init default warehouse
         globalStateMgr.getWarehouseMgr().initDefaultWarehouse();

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -557,14 +557,6 @@ public abstract class StarRocksHttpTestCase {
                 nodeMgr.getMySelf();
                 minTimes = 0;
                 result = frontend;
-
-                nodeMgr.getAllFrontends();
-                minTimes = 0;
-                result = Lists.newArrayList(frontend);
-
-                nodeMgr.getSelfNode();
-                minTimes = 0;
-                result = new Pair<>(frontend.getHost(), HTTP_PORT);
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -546,7 +546,7 @@ public abstract class StarRocksHttpTestCase {
             }
         };
 
-        Frontend frontend = new Frontend(0, FrontendNodeType.LEADER, "","localhost", 0);
+        Frontend frontend = new Frontend(0, FrontendNodeType.LEADER, "", "localhost", 0);
         frontend.setAlive(true);
         new Expectations(nodeMgr) {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -57,8 +57,10 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker.ThrowingRunnable;
+import com.starrocks.common.Pair;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.ha.FrontendNodeType;
@@ -561,6 +563,10 @@ public abstract class StarRocksHttpTestCase {
                 nodeMgr.getAllFrontends();
                 minTimes = 0;
                 result = Lists.newArrayList(frontend);
+
+                nodeMgr.getSelfNode();
+                minTimes = 0;
+                result = new Pair<>(frontend.getHost(),  Config.http_port);
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -57,7 +57,6 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.Type;
-import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker.ThrowingRunnable;
 import com.starrocks.common.Pair;
@@ -103,7 +102,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.opentest4j.AssertionFailedError;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -113,7 +111,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import static com.starrocks.common.Config.http_port;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public abstract class StarRocksHttpTestCase {
@@ -567,7 +564,7 @@ public abstract class StarRocksHttpTestCase {
 
                 nodeMgr.getSelfNode();
                 minTimes = 0;
-                result = new Pair<>(frontend.getHost(),  HTTP_PORT);
+                result = new Pair<>(frontend.getHost(), HTTP_PORT);
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -101,6 +101,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.opentest4j.AssertionFailedError;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -545,7 +546,8 @@ public abstract class StarRocksHttpTestCase {
             }
         };
 
-        Frontend frontend = new Frontend(0, FrontendNodeType.LEADER, "", "", 0);
+        Frontend frontend = new Frontend(0, FrontendNodeType.LEADER, "", InetAddress.getLocalHost().getHostAddress(), 0);
+        frontend.setAlive(true);
         new Expectations(nodeMgr) {
             {
                 nodeMgr.getClusterInfo();
@@ -555,6 +557,10 @@ public abstract class StarRocksHttpTestCase {
                 nodeMgr.getMySelf();
                 minTimes = 0;
                 result = frontend;
+
+                nodeMgr.getAllFrontends();
+                minTimes = 0;
+                result = Lists.newArrayList(frontend);
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -113,6 +113,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+import static com.starrocks.common.Config.http_port;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public abstract class StarRocksHttpTestCase {
@@ -548,7 +549,7 @@ public abstract class StarRocksHttpTestCase {
             }
         };
 
-        Frontend frontend = new Frontend(0, FrontendNodeType.LEADER, "", InetAddress.getLocalHost().getHostAddress(), 0);
+        Frontend frontend = new Frontend(0, FrontendNodeType.LEADER, "","localhost", 0);
         frontend.setAlive(true);
         new Expectations(nodeMgr) {
             {
@@ -566,9 +567,12 @@ public abstract class StarRocksHttpTestCase {
 
                 nodeMgr.getSelfNode();
                 minTimes = 0;
-                result = new Pair<>(frontend.getHost(),  Config.http_port);
+                result = new Pair<>(frontend.getHost(),  HTTP_PORT);
             }
         };
+
+
+
 
         // init default warehouse
         globalStateMgr.getWarehouseMgr().initDefaultWarehouse();

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
@@ -14,13 +14,11 @@
 
 package com.starrocks.http.rest.v2;
 
-import com.google.common.collect.Lists;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.http.StarRocksHttpTestCase;
 import com.starrocks.http.rest.RestBaseAction;
 import com.starrocks.server.GlobalStateMgr;
-import io.netty.handler.codec.http.HttpMethod;
 import mockit.Mock;
 import mockit.MockUp;
 import okhttp3.Request;

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
@@ -33,7 +33,7 @@ public class ProfileActionV2Test extends StarRocksHttpTestCase {
                 .build();
         Response response = networkClient.newCall(request).execute();
         String respStr = response.body().string();
-        Assertions.assertTrue(respStr.contains("query id 123456 not found."));
+        Assertions.assertTrue(respStr.contains("Query id 123456 not found."));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.http.rest.v2;
+
+import com.starrocks.http.StarRocksHttpTestCase;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class ProfileActionV2Test extends StarRocksHttpTestCase {
+
+    private static final String QUERY_PLAN_URI = "/api/v2/profile";
+
+    private void sendHttp() throws IOException {
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url("http://localhost:" + HTTP_PORT + QUERY_PLAN_URI + "?query_id=123456")
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        String respStr = response.body().string();
+        Assertions.assertTrue(respStr.contains("query id 123456 not found."));
+    }
+
+    @Test
+    public void testQueryProfile() throws IOException {
+        sendHttp();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
@@ -11,33 +11,80 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package com.starrocks.http.rest.v2;
 
+import com.google.common.collect.Lists;
 import com.starrocks.http.StarRocksHttpTestCase;
+import com.starrocks.http.rest.RestBaseAction;
+import io.netty.handler.codec.http.HttpMethod;
+import mockit.Mock;
+import mockit.MockUp;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 public class ProfileActionV2Test extends StarRocksHttpTestCase {
 
     private static final String QUERY_PLAN_URI = "/api/v2/profile";
 
-    private void sendHttp() throws IOException {
+    @Test
+    public void testQueryProfile() throws IOException {
         Request request = new Request.Builder()
                 .get()
                 .addHeader("Authorization", rootAuth)
-                .url("http://localhost:" + HTTP_PORT + QUERY_PLAN_URI + "?query_id=123456")
+                .url("http://localhost:" + HTTP_PORT + QUERY_PLAN_URI + "?query_id=eaff21d2-3734-11ee-909f-8e20563011de")
                 .build();
         Response response = networkClient.newCall(request).execute();
         String respStr = response.body().string();
-        Assertions.assertTrue(respStr.contains("Query id 123456 not found."));
+        Assertions.assertTrue(respStr.contains("Query id eaff21d2-3734-11ee-909f-8e20563011de not found."));
     }
 
     @Test
-    public void testQueryProfile() throws IOException {
-        sendHttp();
+    public void testQueryProfileFromFronts() throws IOException {
+        new MockUp<RestBaseAction>() {
+
+            @Mock
+            public static List<String> fetchResultFromOtherFrontendNodes(String queryPath,
+                                                                         String authorization,
+                                                                         HttpMethod method) {
+                String queryProfileStr = "Query:\n" +
+                        "  Summary:\n" +
+                        "     - Query ID: eaff21d2-3734-11ee-909f-8e20563011de\n" +
+                        "     - Start Time: 2023-08-10 12:18:11\n" +
+                        "     - End Time: 2023-08-10 12:18:11\n" +
+                        "     - Total: 150ms\n" +
+                        "     - Query Type: Query\n" +
+                        "     - Query State: Finished\n" +
+                        "     - StarRocks Version: bugfix2-0da335ff34\n" +
+                        "     - User: root\n" +
+                        "     - Test: a<b<c\n" +
+                        "     - Default Db: ssb\n" +
+                        "     - Sql Statement: select count(s_suppkey), count(s_name), count(s_address), count(s_city), " +
+                        "count(s_nation), count(s_region), count(s_phone), count(lo_revenue), count(lo_shipmode), " +
+                        "count(lo_quantity), count(lo_partkey), count(lo_discount) from lineorder join supplier on " +
+                        "lo_suppkey=s_suppkey and lo_partkey<s_suppkey and lo_quantity>100\n" +
+                        "     - Variables: parallel_fragment_exec_instance_num=1,max_parallel_scan_instance_num=-1," +
+                        "pipeline_dop=0,enable_adaptive_sink_dop=true,enable_runtime_adaptive_dop=false," +
+                        "runtime_profile_report_interval=10\n" +
+                        "     - Collect Profile Time: 41ms";
+                return Lists.newArrayList(queryProfileStr);
+            }
+
+        };
+
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url("http://localhost:" + HTTP_PORT + QUERY_PLAN_URI + "?query_id=eaff21d2-3734-11ee-909f-8e20563011de"
+                 + "&is_request_all_frontend=true")
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        String respStr = response.body().string();
+        Assertions.assertTrue(respStr.contains("Query ID: eaff21d2-3734-11ee-909f-8e20563011de"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
@@ -15,8 +15,11 @@
 package com.starrocks.http.rest.v2;
 
 import com.google.common.collect.Lists;
+import com.starrocks.common.Pair;
+import com.starrocks.common.util.ProfileManager;
 import com.starrocks.http.StarRocksHttpTestCase;
 import com.starrocks.http.rest.RestBaseAction;
+import com.starrocks.server.GlobalStateMgr;
 import io.netty.handler.codec.http.HttpMethod;
 import mockit.Mock;
 import mockit.MockUp;
@@ -26,6 +29,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ProfileActionV2Test extends StarRocksHttpTestCase {
@@ -45,36 +49,35 @@ public class ProfileActionV2Test extends StarRocksHttpTestCase {
     }
 
     @Test
-    public void testQueryProfileFromFronts() throws IOException {
-        new MockUp<RestBaseAction>() {
-
+    public void testQueryProfileFromLeaderFront() throws IOException {
+        new MockUp<ProfileManager>() {
             @Mock
-            public static List<String> fetchResultFromOtherFrontendNodes(String queryPath,
-                                                                         String authorization,
-                                                                         HttpMethod method) {
-                String queryProfileStr = "Query:\n" +
-                        "  Summary:\n" +
-                        "     - Query ID: eaff21d2-3734-11ee-909f-8e20563011de\n" +
-                        "     - Start Time: 2023-08-10 12:18:11\n" +
-                        "     - End Time: 2023-08-10 12:18:11\n" +
-                        "     - Total: 150ms\n" +
-                        "     - Query Type: Query\n" +
-                        "     - Query State: Finished\n" +
-                        "     - StarRocks Version: bugfix2-0da335ff34\n" +
-                        "     - User: root\n" +
-                        "     - Test: a<b<c\n" +
-                        "     - Default Db: ssb\n" +
-                        "     - Sql Statement: select count(s_suppkey), count(s_name), count(s_address), count(s_city), " +
-                        "count(s_nation), count(s_region), count(s_phone), count(lo_revenue), count(lo_shipmode), " +
-                        "count(lo_quantity), count(lo_partkey), count(lo_discount) from lineorder join supplier on " +
-                        "lo_suppkey=s_suppkey and lo_partkey<s_suppkey and lo_quantity>100\n" +
-                        "     - Variables: parallel_fragment_exec_instance_num=1,max_parallel_scan_instance_num=-1," +
-                        "pipeline_dop=0,enable_adaptive_sink_dop=true,enable_runtime_adaptive_dop=false," +
-                        "runtime_profile_report_interval=10\n" +
-                        "     - Collect Profile Time: 41ms";
-                return Lists.newArrayList(queryProfileStr);
+            public String getProfile(String queryId) {
+                if (queryId.equalsIgnoreCase("eaff21d2-3734-11ee-909f-8e20563011de")) {
+                    String queryProfileStr = "Query:\n" +
+                            "  Summary:\n" +
+                            "     - Query ID: eaff21d2-3734-11ee-909f-8e20563011de\n" +
+                            "     - Start Time: 2023-08-10 12:18:11\n" +
+                            "     - End Time: 2023-08-10 12:18:11\n" +
+                            "     - Total: 150ms\n" +
+                            "     - Query Type: Query\n" +
+                            "     - Query State: Finished\n" +
+                            "     - StarRocks Version: bugfix2-0da335ff34\n" +
+                            "     - User: root\n" +
+                            "     - Test: a<b<c\n" +
+                            "     - Default Db: ssb\n" +
+                            "     - Sql Statement: select count(s_suppkey), count(s_name), count(s_address), count(s_city), " +
+                            "count(s_nation), count(s_region), count(s_phone), count(lo_revenue), count(lo_shipmode), " +
+                            "count(lo_quantity), count(lo_partkey), count(lo_discount) from lineorder join supplier on " +
+                            "lo_suppkey=s_suppkey and lo_partkey<s_suppkey and lo_quantity>100\n" +
+                            "     - Variables: parallel_fragment_exec_instance_num=1,max_parallel_scan_instance_num=-1," +
+                            "pipeline_dop=0,enable_adaptive_sink_dop=true,enable_runtime_adaptive_dop=false," +
+                            "runtime_profile_report_interval=10\n" +
+                            "     - Collect Profile Time: 41ms";
+                    return queryProfileStr;
+                }
+                return null;
             }
-
         };
 
         Request request = new Request.Builder()
@@ -82,6 +85,66 @@ public class ProfileActionV2Test extends StarRocksHttpTestCase {
                 .addHeader("Authorization", rootAuth)
                 .url("http://localhost:" + HTTP_PORT + QUERY_PLAN_URI + "?query_id=eaff21d2-3734-11ee-909f-8e20563011de"
                  + "&is_request_all_frontend=true")
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        String respStr = response.body().string();
+        Assertions.assertTrue(respStr.contains("Query ID: eaff21d2-3734-11ee-909f-8e20563011de"));
+    }
+
+    @Test
+    public void testQueryProfileFromFronts() throws IOException {
+        new MockUp<RestBaseAction>() {
+            @Mock
+            public static List<Pair<String, Integer>> getOtherAliveFe() {
+                Pair<String, Integer> frontNode = GlobalStateMgr.getCurrentState()
+                        .getNodeMgr()
+                        .getSelfNode();
+                List<Pair<String, Integer>> frontNodes = new ArrayList<>();
+                frontNodes.add(frontNode);
+                return frontNodes;
+            }
+        };
+
+        new MockUp<ProfileManager>() {
+            int callCount = 0;
+            @Mock
+            public String getProfile(String queryId) {
+
+                if (callCount <= 0) {
+                    callCount++;
+                    // Simulate that the profile is not found in the local ProfileManager
+                    return null;
+                }
+
+                    String queryProfileStr = "Query:\n" +
+                            "  Summary:\n" +
+                            "     - Query ID: eaff21d2-3734-11ee-909f-8e20563011de\n" +
+                            "     - Start Time: 2023-08-10 12:18:11\n" +
+                            "     - End Time: 2023-08-10 12:18:11\n" +
+                            "     - Total: 150ms\n" +
+                            "     - Query Type: Query\n" +
+                            "     - Query State: Finished\n" +
+                            "     - StarRocks Version: bugfix2-0da335ff34\n" +
+                            "     - User: root\n" +
+                            "     - Test: a<b<c\n" +
+                            "     - Default Db: ssb\n" +
+                            "     - Sql Statement: select count(s_suppkey), count(s_name), count(s_address), count(s_city), " +
+                            "count(s_nation), count(s_region), count(s_phone), count(lo_revenue), count(lo_shipmode), " +
+                            "count(lo_quantity), count(lo_partkey), count(lo_discount) from lineorder join supplier on " +
+                            "lo_suppkey=s_suppkey and lo_partkey<s_suppkey and lo_quantity>100\n" +
+                            "     - Variables: parallel_fragment_exec_instance_num=1,max_parallel_scan_instance_num=-1," +
+                            "pipeline_dop=0,enable_adaptive_sink_dop=true,enable_runtime_adaptive_dop=false," +
+                            "runtime_profile_report_interval=10\n" +
+                            "     - Collect Profile Time: 41ms";
+                    return queryProfileStr;
+            }
+        };
+
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url("http://localhost:" + HTTP_PORT + QUERY_PLAN_URI + "?query_id=eaff21d2-3734-11ee-909f-8e20563011de"
+                        + "&is_request_all_frontend=true")
                 .build();
         Response response = networkClient.newCall(request).execute();
         String respStr = response.body().string();

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/QueryDetailV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/QueryDetailV2Test.java
@@ -16,11 +16,14 @@ package com.starrocks.http.rest.v2;
 
 import com.google.gson.Gson;
 import com.starrocks.common.Pair;
+import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.http.StarRocksHttpTestCase;
 import com.starrocks.http.rest.RestBaseAction;
 import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.QueryDetailQueue;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Frontend;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import okhttp3.Request;
@@ -76,6 +79,17 @@ public class QueryDetailV2Test extends StarRocksHttpTestCase {
 
     @Test
     public void testQueryDetailFromFronts() throws IOException {
+
+        Frontend frontend = new Frontend(0, FrontendNodeType.LEADER, "", "localhost", 0);
+
+        new Expectations(GlobalStateMgr.getCurrentState().getNodeMgr()) {
+            {
+
+                GlobalStateMgr.getCurrentState().getNodeMgr().getSelfNode();
+                minTimes = 1;
+                result = new Pair<>(frontend.getHost(), HTTP_PORT);
+            }
+        };
 
         QueryDetail startQueryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e3", false, 1, "127.0.0.1",
                 System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/QueryDetailV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/QueryDetailV2Test.java
@@ -126,6 +126,6 @@ public class QueryDetailV2Test extends StarRocksHttpTestCase {
         String respStr = Objects.requireNonNull(response.body()).string();
         Gson gson = new Gson();
         QueryDetail[] details = gson.fromJson(respStr, QueryDetail[].class);
-        Assertions.assertTrue(details.length == 3);
+        Assertions.assertEquals(3, details.length);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/QueryDetailV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/QueryDetailV2Test.java
@@ -1,0 +1,130 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2;
+
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import com.starrocks.http.StarRocksHttpTestCase;
+import com.starrocks.http.rest.RestBaseAction;
+import com.starrocks.qe.QueryDetail;
+import com.starrocks.qe.QueryDetailQueue;
+import io.netty.handler.codec.http.HttpMethod;
+import mockit.Mock;
+import mockit.MockUp;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+public class QueryDetailV2Test extends StarRocksHttpTestCase {
+
+    private static final String QUERY_PLAN_URI = "/api/v2/query_detail";
+
+    @Test
+    public void testQueryDetailWithoutResult() throws IOException {
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url("http://localhost:" + HTTP_PORT + QUERY_PLAN_URI + "?event_time=1753671088")
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        String respStr = response.body().string();
+        Assertions.assertNotNull(respStr);
+    }
+
+    @Test
+    public void testQueryDetail() throws IOException {
+
+        QueryDetail startQueryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e3", false, 1, "127.0.0.1",
+                System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
+                "testDb", "select * from table1 limit 1",
+                "root", "", "default_catalog");
+        startQueryDetail.setScanRows(100);
+        startQueryDetail.setScanBytes(10001);
+        startQueryDetail.setReturnRows(1);
+        startQueryDetail.setCpuCostNs(1002);
+        startQueryDetail.setMemCostBytes(100003);
+        QueryDetailQueue.addQueryDetail(startQueryDetail);
+
+        long eventTime  = startQueryDetail.getEventTime() - 1;
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url("http://localhost:" + HTTP_PORT + QUERY_PLAN_URI + "?event_time=" + eventTime)
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        String respStr = response.body().string();
+        Assertions.assertTrue(respStr.contains("219a2d5443c542d4-8fc938db37c892e3"));
+    }
+
+    @Test
+    public void testQueryDetailFromFronts() throws IOException {
+
+        QueryDetail startQueryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e3", false, 1, "127.0.0.1",
+                System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
+                "testDb", "select * from table1 limit 1",
+                "root", "", "default_catalog");
+        startQueryDetail.setScanRows(100);
+        startQueryDetail.setScanBytes(10001);
+        startQueryDetail.setReturnRows(1);
+        startQueryDetail.setCpuCostNs(1002);
+        startQueryDetail.setMemCostBytes(100003);
+        QueryDetailQueue.addQueryDetail(startQueryDetail);
+
+
+        new MockUp<RestBaseAction>() {
+
+            @Mock
+            public static List<String> fetchResultFromOtherFrontendNodes(String queryPath,
+                                                                         String authorization,
+                                                                         HttpMethod method) {
+                QueryDetail startQueryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e5", false, 1, "127.0.0.1",
+                        System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
+                        "testDb", "select * from table2 limit 1",
+                        "root", "", "default_catalog");
+                startQueryDetail.setScanRows(150);
+                startQueryDetail.setScanBytes(10005);
+                startQueryDetail.setReturnRows(1);
+                startQueryDetail.setCpuCostNs(1005);
+                startQueryDetail.setMemCostBytes(100005);
+                QueryDetailQueue.addQueryDetail(startQueryDetail);
+
+                Gson gson = new Gson();
+                String startQueryDetailStr = gson.toJson(startQueryDetail);
+                return Lists.newArrayList(startQueryDetailStr);
+            }
+
+        };
+
+        long eventTime  = startQueryDetail.getEventTime() - 1;
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url("http://localhost:" + HTTP_PORT + QUERY_PLAN_URI +
+                      "?event_time=" + eventTime +
+                      "&user=root" +
+                      "&is_request_all_frontend=true")
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        String respStr = Objects.requireNonNull(response.body()).string();
+        Gson gson = new Gson();
+        QueryDetail[] details = gson.fromJson(respStr, QueryDetail[].class);
+        Assertions.assertTrue(details.length == 2);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/QueryDetailV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/QueryDetailV2Test.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.http.rest.v2;
 
-import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.starrocks.common.Pair;
 import com.starrocks.http.StarRocksHttpTestCase;
@@ -22,7 +21,6 @@ import com.starrocks.http.rest.RestBaseAction;
 import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.QueryDetailQueue;
 import com.starrocks.server.GlobalStateMgr;
-import io.netty.handler.codec.http.HttpMethod;
 import mockit.Mock;
 import mockit.MockUp;
 import okhttp3.Request;


### PR DESCRIPTION
## Why I'm doing:
Each Frontend (FE) node stores query profile and detail data independently, and does not replicate this across FEs. This makes it challenging to retrieve:

-  All current queries across the cluster
- A specific query’s profile, if you're not sure which FE processed it

## What I'm doing:
as title

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
