### PR TITLE
[BugFix]: Remove duplicate date function entries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -585,9 +585,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             new BigInteger("57896044618658097711785492504343953926634992332820282019728792003956564819968"); // 2^255
 
     private static final List<String> DATE_FUNCTIONS =
-            Lists.newArrayList(FunctionSet.DATE_ADD,
+            Lists.newArrayList(
+                    FunctionSet.DATE_ADD,
                     FunctionSet.ADDDATE,
-                    FunctionSet.DATE_ADD, FunctionSet.DATE_SUB,
+                    FunctionSet.DATE_SUB,
                     FunctionSet.SUBDATE,
                     FunctionSet.DAYS_SUB);
 


### PR DESCRIPTION
## Why I'm doing:
During the conversion of SQL statements to Abstract Syntax Tree (AST) nodes, when the parser encounters a function call expression, duplicate checking logic exists in the designated function expression parsing module. Specifically, the code redundantly verifies whether the function name exists in the `DATE_FUNCTIONS` list.
## What I'm doing:
In the source code, the `DATE_FUNCTIONS` list contains a redundant duplicate entry of `FunctionSet.DATE_ADD`, for example:
```java
    private static final List<String> DATE_FUNCTIONS =
            Lists.newArrayList(
                    FunctionSet.DATE_ADD,
                    FunctionSet.ADDDATE,
                    FunctionSet.DATE_ADD, //重复项
                    FunctionSet.DATE_SUB,
                    FunctionSet.SUBDATE,
                    FunctionSet.DAYS_SUB);
```
```java
 if (DATE_FUNCTIONS.contains(functionName)) { //源码中的唯一用法
            if (context.expression().size() != 2) {
                throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(functionName), pos);
            }

            Expr e1 = (Expr) visit(context.expression(0));
            Expr e2 = (Expr) visit(context.expression(1));
            if (!(e2 instanceof IntervalLiteral)) {
                e2 = new IntervalLiteral(e2, new UnitIdentifier("DAY"));
            }
            IntervalLiteral intervalLiteral = (IntervalLiteral) e2;

            return new TimestampArithmeticExpr(functionName, e1, intervalLiteral.getValue(),
                    intervalLiteral.getUnitIdentifier().getDescription(), pos);
        }
```

<img width="605" height="161" alt="image" src="https://github.com/user-attachments/assets/7c8b8924-9b43-415c-874d-cd01cf19f837" />

<img width="783" height="111" alt="image" src="https://github.com/user-attachments/assets/d3f1f1e7-d82c-445d-8a80-821d2ef515ef" />


Reasoning:
Duplicate entries in the `DATE_FUNCTIONS` list serve no functional purpose because:
1. For `contains()` checks, duplicates yield no additional effect: Regardless of how many times an element appears, `contains()` will return the same boolean result `(true/false)`.
2. Element frequency doesn't affect logic outcomes: The evaluation behavior remains identical whether an element exists once or multiple times.

Conclusion:
This constitutes redundant code that should be eliminated to maintain code cleanliness and readability. The optimized implementation would be:
```java
 private static final List<String> DATE_FUNCTIONS =
            Lists.newArrayList(
                    FunctionSet.DATE_ADD,
                    FunctionSet.ADDDATE,
                    FunctionSet.DATE_SUB,
                    FunctionSet.SUBDATE,
                    FunctionSet.DAYS_SUB);
```

Fixes #issue


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
