### PR TITLE
[BugFix] Fix nullptr exception during clone.

### DIFF
--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -269,6 +269,8 @@ Status EngineCloneTask::_do_clone(Tablet* tablet) {
                 LOG(WARNING) << "Fail to load tablet from dir: " << status << " tablet:" << _clone_req.tablet_id
                              << ". schema_hash_dir='" << schema_hash_dir;
                 _error_msgs->push_back("load tablet from dir failed.");
+                (void)fs::remove_all(tablet_dir);
+                return status;
             }
 
             std::string dcgs_snapshot_file = strings::Substitute("$0/$1.dcgs_snapshot", schema_hash_dir, tablet_id);
@@ -282,6 +284,11 @@ Status EngineCloneTask::_do_clone(Tablet* tablet) {
                 }
 
                 auto new_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
+                if (new_tablet == nullptr) {
+                    std::string error_msg = strings::Substitute("tablet: $0 is not exist", tablet_id);
+                    LOG(WARNING) << error_msg;
+                    return Status::InternalError(error_msg);
+                }
 
                 auto data_dir = new_tablet->data_dir();
                 rocksdb::WriteBatch wb;


### PR DESCRIPTION
## Why I'm doing:
When clone and drop table run concurrency, the `new_tablet` during clone maybe dropped and throw null exception.

## What I'm doing:
Fix the bug.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
