### PR TITLE
[Enhancement]DataCache supports TTL

### DIFF
--- a/be/src/cache/cache_options.h
+++ b/be/src/cache/cache_options.h
@@ -61,8 +61,7 @@ struct CacheOptions {
     double skip_read_factor = 0;
     uint32_t inline_item_count_limit = 0;
     std::string eviction_policy;
-    uint32_t ttl_check_interval_ms = 0;
-    uint32_t ttl_remove_batch = 100;
+    uint32_t ttl_check_interval_ms = 1000;
 };
 
 struct WriteCacheOptions {

--- a/be/src/cache/cache_options.h
+++ b/be/src/cache/cache_options.h
@@ -61,7 +61,7 @@ struct CacheOptions {
     double skip_read_factor = 0;
     uint32_t inline_item_count_limit = 0;
     std::string eviction_policy;
-    uint32_t ttl_check_interval_ms = 1000;
+    uint32_t ttl_check_interval_ms = 0;
 };
 
 struct WriteCacheOptions {

--- a/be/src/cache/cache_options.h
+++ b/be/src/cache/cache_options.h
@@ -61,6 +61,8 @@ struct CacheOptions {
     double skip_read_factor = 0;
     uint32_t inline_item_count_limit = 0;
     std::string eviction_policy;
+    uint32_t ttl_check_interval_ms = 0;
+    uint32_t ttl_remove_batch = 100;
 };
 
 struct WriteCacheOptions {

--- a/be/src/cache/datacache.cpp
+++ b/be/src/cache/datacache.cpp
@@ -241,7 +241,6 @@ StatusOr<CacheOptions> DataCache::_init_cache_options() {
         cache_options.inline_item_count_limit = config::datacache_inline_item_count_limit;
         cache_options.eviction_policy = config::datacache_eviction_policy;
         cache_options.ttl_check_interval_ms = config::datacache_ttl_check_interval_ms;
-        cache_options.ttl_remove_batch = config::datacache_ttl_remove_batch;
     }
 
     return cache_options;

--- a/be/src/cache/datacache.cpp
+++ b/be/src/cache/datacache.cpp
@@ -240,6 +240,8 @@ StatusOr<CacheOptions> DataCache::_init_cache_options() {
         cache_options.enable_datacache_persistence = config::datacache_persistence_enable;
         cache_options.inline_item_count_limit = config::datacache_inline_item_count_limit;
         cache_options.eviction_policy = config::datacache_eviction_policy;
+        cache_options.ttl_check_interval_ms = config::datacache_ttl_check_interval_ms;
+        cache_options.ttl_remove_batch = config::datacache_ttl_remove_batch;
     }
 
     return cache_options;

--- a/be/src/cache/starcache_engine.cpp
+++ b/be/src/cache/starcache_engine.cpp
@@ -55,7 +55,7 @@ Status StarCacheEngine::init(const CacheOptions& options) {
     }
     opt.lru_segment_freq_bits = 0;
     opt.ttl_check_interval_ms = options.ttl_check_interval_ms;
-    opt.ttl_remove_batch = options.ttl_remove_batch;
+    opt.ttl_remove_batch = 1000;
 
     _enable_tiered_cache = options.enable_tiered_cache;
     _enable_datacache_persistence = options.enable_datacache_persistence;

--- a/be/src/cache/starcache_engine.cpp
+++ b/be/src/cache/starcache_engine.cpp
@@ -54,6 +54,8 @@ Status StarCacheEngine::init(const CacheOptions& options) {
         opt.lru_segment_ratios = {35, 65};
     }
     opt.lru_segment_freq_bits = 0;
+    opt.ttl_check_interval_ms = options.ttl_check_interval_ms;
+    opt.ttl_remove_batch = options.ttl_remove_batch;
 
     _enable_tiered_cache = options.enable_tiered_cache;
     _enable_datacache_persistence = options.enable_datacache_persistence;

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1318,8 +1318,9 @@ CONF_mInt64(datacache_mem_adjust_period, "20");
 CONF_mInt64(datacache_mem_adjust_interval_seconds, "10");
 
 CONF_Int32(datacache_inline_item_count_limit, "130172");
-CONF_Int32(datacache_ttl_check_interval_ms, "0");
-CONF_Int32(datacache_ttl_remove_batch, "100");
+// The interval for ttl reaper to check the expired cache item.
+// If set to 0, the ttl dose not take effect.
+CONF_Int32(datacache_ttl_check_interval_ms, "1000");
 // Whether use an unified datacache instance.
 CONF_Bool(datacache_unified_instance_enable, "true");
 // The eviction policy for datacache, alternatives: [lru, slru].

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1318,6 +1318,8 @@ CONF_mInt64(datacache_mem_adjust_period, "20");
 CONF_mInt64(datacache_mem_adjust_interval_seconds, "10");
 
 CONF_Int32(datacache_inline_item_count_limit, "130172");
+CONF_Int32(datacache_ttl_check_interval_ms, "0");
+CONF_Int32(datacache_ttl_remove_batch, "100");
 // Whether use an unified datacache instance.
 CONF_Bool(datacache_unified_instance_enable, "true");
 // The eviction policy for datacache, alternatives: [lru, slru].

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1320,7 +1320,7 @@ CONF_mInt64(datacache_mem_adjust_interval_seconds, "10");
 CONF_Int32(datacache_inline_item_count_limit, "130172");
 // The interval for ttl reaper to check the expired cache item.
 // If set to 0, the ttl dose not take effect.
-CONF_Int32(datacache_ttl_check_interval_ms, "1000");
+CONF_Int32(datacache_ttl_check_interval_ms, "0");
 // Whether use an unified datacache instance.
 CONF_Bool(datacache_unified_instance_enable, "true");
 // The eviction policy for datacache, alternatives: [lru, slru].

--- a/be/test/cache/block_cache/block_cache_test.cpp
+++ b/be/test/cache/block_cache/block_cache_test.cpp
@@ -25,7 +25,6 @@
 #include "common/statusor.h"
 #include "fs/fs_util.h"
 #include "testutil/assert.h"
-#include "util/await.h"
 
 namespace starrocks {
 

--- a/be/test/cache/block_cache/block_cache_test.cpp
+++ b/be/test/cache/block_cache/block_cache_test.cpp
@@ -335,5 +335,8 @@ TEST_F(BlockCacheTest, cache_ttl) {
     // It is necessary to wait enough time for StarCache remove the cache
     sleep(10);
     ASSERT_FALSE(cache->exist(cache_key, 0, batch_size));
+
+    ASSERT_OK(cache->shutdown());
+    ASSERT_OK(fs::remove_all(cache_dir));
 }
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -543,6 +543,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_DATACACHE_ASYNC_POPULATE_MODE = "enable_datacache_async_populate_mode";
     public static final String ENABLE_DATACACHE_IO_ADAPTOR = "enable_datacache_io_adaptor";
     public static final String DATACACHE_EVICT_PROBABILITY = "datacache_evict_probability";
+    public static final String DATACACHE_TTL_SECONDS = "datacache_ttl_seconds";
 
     // The following configurations will be deprecated, and we use the `datacache` suffix instead.
     // But it is temporarily necessary to keep them for a period of time to be compatible with
@@ -2085,6 +2086,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     private int datacachePriority = 0;
 
+    @VariableMgr.VarAttr(name = DATACACHE_TTL_SECONDS)
     private long datacacheTTLSeconds = 0L;
 
     private boolean enableCacheSelect = false;
@@ -2918,6 +2920,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setDatacacheTTLSeconds(long datacacheTTLSeconds) {
         this.datacacheTTLSeconds = datacacheTTLSeconds;
+    }
+
+    public long getDatacacheTTLSeconds() {
+        return this.datacacheTTLSeconds;
     }
 
     public void setEnableCacheSelect(boolean enableCacheSelect) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2086,7 +2086,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     private int datacachePriority = 0;
 
-    @VariableMgr.VarAttr(name = DATACACHE_TTL_SECONDS)
+    @VariableMgr.VarAttr(name = DATACACHE_TTL_SECONDS, flag = VariableMgr.INVISIBLE)
     private long datacacheTTLSeconds = 0L;
 
     private boolean enableCacheSelect = false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DataCacheStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DataCacheStmtAnalyzer.java
@@ -154,7 +154,7 @@ public class DataCacheStmtAnalyzer {
             // Duration for cache remains active.
             // Use PT0M to prevent expiration of the rule.
             // Use duration specified in ISO-8601 duration format (PnDTnHnMn).
-            long ttlSeconds = context.getSessionVariable().getDatacacheTTLSeconds();;
+            long ttlSeconds = context.getSessionVariable().getDatacacheTTLSeconds();
             if (properties.containsKey("ttl")) {
                 try {
                     ttlSeconds = Duration.parse(properties.get("ttl")).toSeconds();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DataCacheStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DataCacheStmtAnalyzer.java
@@ -154,13 +154,15 @@ public class DataCacheStmtAnalyzer {
             // Duration for cache remains active.
             // Use PT0M to prevent expiration of the rule.
             // Use duration specified in ISO-8601 duration format (PnDTnHnMn).
-            long ttlSeconds = 0L;
-            try {
-                ttlSeconds = Duration.parse(properties.getOrDefault("ttl", "PT0M")).toSeconds();
-            } catch (DateTimeParseException e) {
-                throw new SemanticException(String.format(
-                        "Illegal ttl format, use duration specified in ISO-8601 duration format (PnDTnHnMn). Error msg: %s",
-                        e.getMessage()));
+            long ttlSeconds = context.getSessionVariable().getDatacacheTTLSeconds();;
+            if (properties.containsKey("ttl")) {
+                try {
+                    ttlSeconds = Duration.parse(properties.get("ttl")).toSeconds();
+                } catch (DateTimeParseException e) {
+                    throw new SemanticException(String.format(
+                            "Illegal ttl format, use duration specified in ISO-8601 duration format (PnDTnHnMn). Error msg: %s",
+                            e.getMessage()));
+                }
             }
             if (priority > 0 && ttlSeconds == 0) {
                 throw new SemanticException("TTL must be specified when priority > 0");


### PR DESCRIPTION
## Why I'm doing:
   When using SR on HIve with datacache，some users want to custom datacache TTL instead of LRU.

## What I'm doing:
   The StarCache has implemented TTL functionality in fact, the pr just control whether to enable this TTL function
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
