### PR TITLE
[BugFix] fix insert into select's audit log 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -2233,36 +2233,46 @@ public class StmtExecutor {
     }
 
     public PQueryStatistics getQueryStatisticsForAuditLog() {
+        // for one StmtExecutor, only consume PQueryStatistics once
+        // so call getQueryStatisticsForAuditLog will return a emtpy PQueryStatistics if this is not the first call
         if (statisticsConsumed) {
-            // for one StmtExecutor, only consumed statistics once
-            statisticsForAuditLog = new PQueryStatistics();
-        } else if (statisticsForAuditLog == null && coord != null) {
-            // for insert stmt
-            statisticsForAuditLog = coord.getAuditStatistics();
+            // create a empty PQueryStatistics
+            PQueryStatistics stats = normalizeQueryStatistics(null);
+            statisticsForAuditLog = stats;
+            return stats;
         }
 
-        if (statisticsForAuditLog == null) {
-            statisticsForAuditLog = new PQueryStatistics();
+        PQueryStatistics stats = statisticsForAuditLog;
+        if (stats == null && coord != null) {
+            // for insert stmt
+            stats = coord.getAuditStatistics();
         }
-        if (statisticsForAuditLog.scanBytes == null) {
-            statisticsForAuditLog.scanBytes = 0L;
+
+        stats = normalizeQueryStatistics(stats);
+
+        statisticsForAuditLog = stats;
+        statisticsConsumed = true;
+        return stats;
+    }
+
+    private PQueryStatistics normalizeQueryStatistics(PQueryStatistics stats) {
+        PQueryStatistics normalized = (stats != null) ? stats : new PQueryStatistics();
+        if (normalized.scanBytes == null) {
+            normalized.scanBytes = 0L;
         }
-        if (statisticsForAuditLog.scanRows == null) {
-            statisticsForAuditLog.scanRows = 0L;
+        if (normalized.scanRows == null) {
+            normalized.scanRows = 0L;
         }
-        if (statisticsForAuditLog.cpuCostNs == null) {
-            statisticsForAuditLog.cpuCostNs = 0L;
+        if (normalized.cpuCostNs == null) {
+            normalized.cpuCostNs = 0L;
         }
-        if (statisticsForAuditLog.memCostBytes == null) {
-            statisticsForAuditLog.memCostBytes = 0L;
+        if (normalized.memCostBytes == null) {
+            normalized.memCostBytes = 0L;
         }
-        if (statisticsForAuditLog.spillBytes == null) {
-            statisticsForAuditLog.spillBytes = 0L;
+        if (normalized.spillBytes == null) {
+            normalized.spillBytes = 0L;
         }
-        if (statisticsConsumed == false) {
-            statisticsConsumed = true;
-        }
-        return statisticsForAuditLog;
+        return normalized;
     }
 
     public void handleInsertOverwrite(InsertStmt insertStmt) throws Exception {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -303,6 +303,7 @@ public class StmtExecutor {
     private List<ByteBuffer> proxyResultBuffer = null;
     private ShowResultSet proxyResultSet = null;
     private PQueryStatistics statisticsForAuditLog;
+    private boolean statisticsConsumed = false;
     private List<StmtExecutor> subStmtExecutors;
     private Optional<Boolean> isForwardToLeaderOpt = Optional.empty();
     private HttpResultSender httpResultSender;
@@ -2232,9 +2233,14 @@ public class StmtExecutor {
     }
 
     public PQueryStatistics getQueryStatisticsForAuditLog() {
-        if (statisticsForAuditLog == null && coord != null) {
+        if (statisticsConsumed) {
+            // for one StmtExecutor, only consumed statistics once
+            statisticsForAuditLog = new PQueryStatistics();
+        } else if (statisticsForAuditLog == null && coord != null) {
+            // for insert stmt
             statisticsForAuditLog = coord.getAuditStatistics();
         }
+
         if (statisticsForAuditLog == null) {
             statisticsForAuditLog = new PQueryStatistics();
         }
@@ -2252,6 +2258,9 @@ public class StmtExecutor {
         }
         if (statisticsForAuditLog.spillBytes == null) {
             statisticsForAuditLog.spillBytes = 0L;
+        }
+        if (statisticsConsumed == false) {
+            statisticsConsumed = true;
         }
         return statisticsForAuditLog;
     }


### PR DESCRIPTION
## Why I'm doing:
for insert into select, right now audit log will double the value. because recordExecStatsIntoContext will be called twice:
```
StmtExecute:: execute
    StmtExecute::handleDMLStmtWithProfile
        StmtExecute::handleDMLStmt
            StmtExecute::recordExecStatsIntoContext
    StmtExecute::recordExecStatsIntoContext
```

and recordExecStatsIntoContext will call addScanRows instead of setScanRows because analyze task will have mutiple StmtExecutor sharing same ConnectContext.


## What I'm doing:
for one StmtExecutor, only record ExecStats once!

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
