### PR TITLE
[Enhancement] Adjust partition hash join strategy

### DIFF
--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -442,6 +442,7 @@ public:
 
     void clone_readable(HashJoinBuilder* builder) override;
 
+    Status prepare_for_spill_start(RuntimeState* state) override;
     ChunkPtr convert_to_spill_schema(const ChunkPtr& chunk) const override;
 
 private:
@@ -905,6 +906,13 @@ Status AdaptivePartitionHashJoinBuilder::do_append_chunk(RuntimeState* state, co
         RETURN_IF_ERROR(_builders[0]->do_append_chunk(state, chunk));
     }
 
+    return Status::OK();
+}
+
+Status AdaptivePartitionHashJoinBuilder::prepare_for_spill_start(RuntimeState* state) {
+    if (_stage == Stage::BUFFERING) {
+        RETURN_IF_ERROR(_transfer_to_appending_stage(state));
+    }
     return Status::OK();
 }
 

--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -637,9 +637,9 @@ void AdaptivePartitionHashJoinBuilder::_adjust_partition_rows(size_t hash_table_
 
         if (_probe_row_shuffle_cost < l2_benefit) { // Partitioned joins benefit from L2 cache.
             _partition_join_l2_min_rows = _fit_L2_cache_max_rows * l2_benefit / (l2_benefit - _probe_row_shuffle_cost);
+            _partition_join_l2_min_rows *= 2; // Make the restriction more stringent
             _partition_join_l2_max_rows =
                     (_fit_L2_cache_max_rows * _partition_num) * l2_benefit / _probe_row_shuffle_cost;
-            _partition_join_l2_max_rows *= 2;
         }
     } else {
         // Partitioned joins don't have performance gains. Not using partition hash join.

--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -546,7 +546,7 @@ size_t AdaptivePartitionHashJoinBuilder::_estimate_hash_table_probing_bytes_per_
         if (join_key.type != nullptr) {
             estimated_each_row += get_size_of_fixed_length_type(join_key.type->type);
             // The benefit from non-fixed key columns is less than those from fixed key columns, so the penalty (/4) is applied here.
-            estimated_each_row += type_estimated_overhead_bytes(join_key.type->type) / 4 * _cache_miss_factor;
+            estimated_each_row += type_estimated_overhead_bytes(join_key.type->type) / 4;
         }
     }
 
@@ -555,7 +555,7 @@ size_t AdaptivePartitionHashJoinBuilder::_estimate_hash_table_probing_bytes_per_
         for (const auto* slot : tuple->slots()) {
             if (param.build_output_slots.empty() || param.build_output_slots.contains(slot->id())) {
                 estimated_each_row += get_size_of_fixed_length_type(slot->type().type);
-                estimated_each_row += type_estimated_overhead_bytes(slot->type().type) * _cache_miss_factor;
+                estimated_each_row += type_estimated_overhead_bytes(slot->type().type);
             }
         }
     }

--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -560,7 +560,7 @@ size_t AdaptivePartitionHashJoinBuilder::_estimate_hash_table_probing_bytes_per_
         }
     }
 
-    return estimated_each_row;
+    return std::max<size_t>(estimated_each_row * _cache_miss_factor, 1);
 }
 
 // We could use a better estimation model.
@@ -575,7 +575,7 @@ size_t AdaptivePartitionHashJoinBuilder::_estimate_probe_row_bytes(const HashTab
         }
     }
 
-    return size;
+    return std::max<size_t>(size, 1);
 }
 
 template <>

--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -911,7 +911,10 @@ Status AdaptivePartitionHashJoinBuilder::do_append_chunk(RuntimeState* state, co
 }
 
 Status AdaptivePartitionHashJoinBuilder::prepare_for_spill_start(RuntimeState* state) {
-    return _flush_buffer_chunks(state);
+    if (_partition_num > 1) {
+        return _flush_buffer_chunks(state);
+    }
+    return Status::OK();
 }
 
 ChunkPtr AdaptivePartitionHashJoinBuilder::convert_to_spill_schema(const ChunkPtr& chunk) const {

--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -120,6 +120,16 @@ public:
 
     const ChunkPtr& back() { return _chunks.back(); }
 
+    void append_selective_to_back(const Chunk& src, const uint32_t* indexes, uint32_t from, uint32_t size) {
+        auto& chunk = _chunks.back();
+        const size_t prev_bytes = chunk->memory_usage();
+
+        chunk->append_selective(src, indexes, from, size);
+        const size_t new_bytes = chunk->memory_usage();
+
+        _tracker->consume(new_bytes - prev_bytes);
+    }
+
     bool is_full() const {
         return _chunks.size() >= 4 || _tracker->consumption() > config::partition_hash_join_probe_limit_size;
     }
@@ -129,6 +139,8 @@ public:
     bool is_empty() const { return _chunks.empty() || _chunks.front()->is_empty(); }
 
     bool not_empty() const { return !is_empty(); }
+
+    size_t memory_usage() const { return _tracker->consumption(); }
 
 private:
     MemTracker* _tracker;
@@ -213,10 +225,10 @@ Status PartitionedHashJoinProberImpl::push_probe_chunk(RuntimeState* state, Chun
     }
     std::vector<uint32_t> hash_values;
     {
-        hash_values.assign(num_rows, HashUtil::FNV_SEED);
+        hash_values.assign(num_rows, 0);
 
         for (const ColumnPtr& column : partition_columns) {
-            column->fnv_hash(hash_values.data(), 0, num_rows);
+            column->crc32_hash(hash_values.data(), 0, num_rows);
         }
         // find partition id
         for (size_t i = 0; i < hash_values.size(); ++i) {
@@ -362,7 +374,7 @@ bool SingleHashJoinBuilder::anti_join_key_column_has_null() const {
     return false;
 }
 
-Status SingleHashJoinBuilder::do_append_chunk(const ChunkPtr& chunk) {
+Status SingleHashJoinBuilder::do_append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
     if (UNLIKELY(_ht.get_row_count() + chunk->num_rows() >= max_hash_table_element_size)) {
         return Status::NotSupported(strings::Substitute("row count of right table in hash join > $0", UINT32_MAX));
     }
@@ -404,7 +416,7 @@ enum class CacheLevel { L2, L3, MEMORY };
 
 class AdaptivePartitionHashJoinBuilder final : public HashJoinBuilder {
 public:
-    AdaptivePartitionHashJoinBuilder(HashJoiner& hash_joiner);
+    explicit AdaptivePartitionHashJoinBuilder(HashJoiner& hash_joiner);
     ~AdaptivePartitionHashJoinBuilder() override = default;
 
     void create(const HashTableParam& param) override;
@@ -413,7 +425,7 @@ public:
 
     void reset(const HashTableParam& param) override;
 
-    Status do_append_chunk(const ChunkPtr& chunk) override;
+    Status do_append_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
     Status build(RuntimeState* state) override;
 
@@ -435,24 +447,48 @@ public:
     ChunkPtr convert_to_spill_schema(const ChunkPtr& chunk) const override;
 
 private:
-    size_t _estimated_row_size(const HashTableParam& param) const;
-    size_t _estimated_probe_cost(const HashTableParam& param) const;
+    static double _calculate_cache_miss_factor(const HashJoiner& hash_joiner);
+
+    size_t _estimate_hash_table_probing_bytes_per_row(const HashTableParam& param) const;
+    size_t _estimate_probe_row_bytes(const HashTableParam& param) const;
     template <CacheLevel T>
-    size_t _estimated_build_cost(size_t build_row_size) const;
-    void _adjust_partition_rows(size_t build_row_size);
+    size_t _estimate_cost_by_bytes(size_t row_bytes) const;
 
     void _init_partition_nums(const HashTableParam& param);
-    Status _convert_to_single_partition();
-    Status _append_chunk_to_partitions(const ChunkPtr& chunk);
+    void _adjust_partition_rows(size_t hash_table_bytes_per_row, size_t hash_table_probing_bytes_per_row);
+
+    Status _do_append_chunk(RuntimeState* state, const ChunkPtr& chunk);
+    Status _append_chunk_to_partitions(RuntimeState* state, const ChunkPtr& chunk);
+    Status _transfer_to_appending_stage(RuntimeState* state);
+    Status _convert_to_single_partition(RuntimeState* state);
+
+    bool _need_partition_join_for_build(size_t ht_num_rows) const;
+    bool _need_partition_join_for_append(size_t ht_num_rows) const;
 
 private:
     std::vector<std::unique_ptr<SingleHashJoinBuilder>> _builders;
 
-    size_t _partition_num = 0;
-    size_t _partition_join_min_rows = 0;
-    size_t _partition_join_max_rows = 0;
+    // Split append chunk into two stages:
+    // - BUFFERING: buffers chunks without partitioning until the number of rows exceeds _partition_join_l2_max_rows or _partition_join_l3_max_rows.
+    // - APPENDING: partitions all incoming chunks.
+    enum class Stage { BUFFERING, APPENDING };
+    Stage _stage = Stage::BUFFERING;
+    MemTracker _mem_tracker;
+    std::vector<PartitionChunkChannel> _partition_input_channels;
+    std::vector<ChunkPtr> _unpartition_chunks;
 
-    size_t _probe_estimated_costs = 0;
+    size_t _partition_num = 0;
+
+    size_t _hash_table_probing_bytes_per_row = 0;
+    size_t _hash_table_bytes_per_row = 0;
+    size_t _partition_join_l2_min_rows = 0;
+    size_t _partition_join_l2_max_rows = 0;
+    size_t _partition_join_l3_min_rows = 0;
+    size_t _partition_join_l3_max_rows = 0;
+
+    size_t _probe_row_shuffle_cost = 0;
+    size_t _l2_benefit = 0;
+    size_t _l3_benefit = 0;
 
     size_t _fit_L2_cache_max_rows = 0;
     size_t _fit_L3_cache_max_rows = 0;
@@ -461,10 +497,15 @@ private:
     size_t _L3_cache_size = 0;
 
     size_t _pushed_chunks = 0;
+
+    // Shared read-only data accessed concurrently by threads can lead to better cache performance.
+    // Therefore, for broadcast joins, this parameter is used to reduce benefit of partitioned hash joins as the number
+    // of prober threads (DOP) increases.
+    const double _cache_miss_factor;
 };
 
 AdaptivePartitionHashJoinBuilder::AdaptivePartitionHashJoinBuilder(HashJoiner& hash_joiner)
-        : HashJoinBuilder(hash_joiner) {
+        : HashJoinBuilder(hash_joiner), _cache_miss_factor(_calculate_cache_miss_factor(hash_joiner)) {
     static constexpr size_t DEFAULT_L2_CACHE_SIZE = 1 * 1024 * 1024;
     static constexpr size_t DEFAULT_L3_CACHE_SIZE = 32 * 1024 * 1024;
     const auto& cache_sizes = CpuInfo::get_cache_sizes();
@@ -474,100 +515,171 @@ AdaptivePartitionHashJoinBuilder::AdaptivePartitionHashJoinBuilder(HashJoiner& h
     _L3_cache_size = _L3_cache_size ? _L3_cache_size : DEFAULT_L3_CACHE_SIZE;
 }
 
-size_t AdaptivePartitionHashJoinBuilder::_estimated_row_size(const HashTableParam& param) const {
+double AdaptivePartitionHashJoinBuilder::_calculate_cache_miss_factor(const HashJoiner& hash_joiner) {
+    if (hash_joiner.distribution_mode() != TJoinDistributionMode::BROADCAST) {
+        return 1.0; // No broadcast join, no cache reuse between different probers.
+    }
+
+    const size_t max_prober_dop = hash_joiner.max_dop();
+    if (max_prober_dop <= 1) {
+        return 1.0;
+    }
+    if (max_prober_dop > 8) {
+        return 0.1;
+    }
+    return 1 - (max_prober_dop - 1) * 0.1;
+}
+
+size_t AdaptivePartitionHashJoinBuilder::_estimate_hash_table_probing_bytes_per_row(const HashTableParam& param) const {
     size_t estimated_each_row = 0;
 
-    for (auto* tuple : param.build_row_desc->tuple_descriptors()) {
-        for (auto slot : tuple->slots()) {
-            if (param.build_output_slots.contains(slot->id())) {
-                estimated_each_row += get_size_of_fixed_length_type(slot->type().type);
-                estimated_each_row += type_estimated_overhead_bytes(slot->type().type);
-            }
+    // Probing a row need
+    // 1. touch `first` and `next` vectors,
+    // 2 and compare join keys between builder and prober.
+    // 3. output columns from the build side.
+
+    // 1. `first` and `next` bytes
+    estimated_each_row += 8;
+
+    // 2. key bytes
+    for (const auto& join_key : param.join_keys) {
+        if (join_key.type != nullptr) {
+            estimated_each_row += get_size_of_fixed_length_type(join_key.type->type);
+            // The benefit from non-fixed key columns is less than those from fixed key columns, so the penalty (/4) is applied here.
+            estimated_each_row += type_estimated_overhead_bytes(join_key.type->type) / 4 * _cache_miss_factor;
         }
     }
 
-    // for hash table bucket
-    estimated_each_row += 4;
+    // 3. output bytes
+    for (auto* tuple : param.build_row_desc->tuple_descriptors()) {
+        for (const auto* slot : tuple->slots()) {
+            if (param.build_output_slots.empty() || param.build_output_slots.contains(slot->id())) {
+                estimated_each_row += get_size_of_fixed_length_type(slot->type().type);
+                estimated_each_row += type_estimated_overhead_bytes(slot->type().type) * _cache_miss_factor;
+            }
+        }
+    }
 
     return estimated_each_row;
 }
 
 // We could use a better estimation model.
-size_t AdaptivePartitionHashJoinBuilder::_estimated_probe_cost(const HashTableParam& param) const {
+size_t AdaptivePartitionHashJoinBuilder::_estimate_probe_row_bytes(const HashTableParam& param) const {
     size_t size = 0;
 
+    // shuffling probe bytes
     for (auto* tuple : param.probe_row_desc->tuple_descriptors()) {
-        for (auto slot : tuple->slots()) {
-            if (param.probe_output_slots.contains(slot->id())) {
-                size += get_size_of_fixed_length_type(slot->type().type);
-                size += type_estimated_overhead_bytes(slot->type().type);
-            }
+        for (const auto* slot : tuple->slots()) {
+            size += get_size_of_fixed_length_type(slot->type().type);
+            size += type_estimated_overhead_bytes(slot->type().type);
         }
     }
-    // we define probe cost is bytes size * 6
-    return size * 6;
+
+    return size;
 }
 
 template <>
-size_t AdaptivePartitionHashJoinBuilder::_estimated_build_cost<CacheLevel::L2>(size_t build_row_size) const {
-    return build_row_size / 2;
+size_t AdaptivePartitionHashJoinBuilder::_estimate_cost_by_bytes<CacheLevel::L2>(size_t row_bytes) const {
+    return row_bytes / 2;
 }
-
 template <>
-size_t AdaptivePartitionHashJoinBuilder::_estimated_build_cost<CacheLevel::L3>(size_t build_row_size) const {
-    return build_row_size;
+size_t AdaptivePartitionHashJoinBuilder::_estimate_cost_by_bytes<CacheLevel::L3>(size_t row_bytes) const {
+    return row_bytes;
 }
-
 template <>
-size_t AdaptivePartitionHashJoinBuilder::_estimated_build_cost<CacheLevel::MEMORY>(size_t build_row_size) const {
-    return build_row_size * 2;
+size_t AdaptivePartitionHashJoinBuilder::_estimate_cost_by_bytes<CacheLevel::MEMORY>(size_t row_bytes) const {
+    return row_bytes * 2;
 }
 
-void AdaptivePartitionHashJoinBuilder::_adjust_partition_rows(size_t build_row_size) {
-    build_row_size = std::max(build_row_size, 4UL);
-    _fit_L2_cache_max_rows = _L2_cache_size / build_row_size;
-    _fit_L3_cache_max_rows = _L3_cache_size / build_row_size;
+bool AdaptivePartitionHashJoinBuilder::_need_partition_join_for_build(size_t ht_num_rows) const {
+    return (_partition_join_l2_min_rows < ht_num_rows && ht_num_rows <= _partition_join_l2_max_rows) ||
+           (_partition_join_l3_min_rows < ht_num_rows && ht_num_rows <= _partition_join_l3_max_rows);
+}
 
-    // If the hash table is smaller than the L2 cache. we don't think partition hash join is needed.
-    _partition_join_min_rows = _fit_L2_cache_max_rows;
-    // If the hash table after partition can't be loaded to L3. we don't think partition hash join is needed.
-    _partition_join_max_rows = _fit_L3_cache_max_rows * _partition_num;
+bool AdaptivePartitionHashJoinBuilder::_need_partition_join_for_append(size_t ht_num_rows) const {
+    return ht_num_rows <= _partition_join_l2_max_rows || ht_num_rows <= _partition_join_l3_max_rows;
+}
 
-    if (_probe_estimated_costs + _estimated_build_cost<CacheLevel::L2>(build_row_size) <
-        _estimated_build_cost<CacheLevel::L3>(build_row_size)) {
-        // overhead after hash table partitioning + probe extra cost < cost before partitioning
-        // nothing to do
-    } else if (_probe_estimated_costs + _estimated_build_cost<CacheLevel::L3>(build_row_size) <
-               _estimated_build_cost<CacheLevel::MEMORY>(build_row_size)) {
-        // It is only after this that performance gains can be realized beyond the L3 cache.
-        _partition_join_min_rows = _fit_L3_cache_max_rows;
+void AdaptivePartitionHashJoinBuilder::_adjust_partition_rows(size_t hash_table_bytes_per_row,
+                                                              size_t hash_table_probing_bytes_per_row) {
+    if (hash_table_bytes_per_row == _hash_table_bytes_per_row &&
+        hash_table_probing_bytes_per_row == _hash_table_probing_bytes_per_row) {
+        return; // No need to adjust partition rows.
+    }
+
+    _hash_table_bytes_per_row = hash_table_bytes_per_row;
+    _hash_table_probing_bytes_per_row = hash_table_probing_bytes_per_row;
+
+    _fit_L2_cache_max_rows = _L2_cache_size / hash_table_bytes_per_row;
+    _fit_L3_cache_max_rows = _L3_cache_size / hash_table_bytes_per_row;
+
+    _partition_join_l2_min_rows = -1;
+    _partition_join_l2_max_rows = 0;
+    _partition_join_l3_min_rows = -1;
+    _partition_join_l3_max_rows = 0;
+
+    const auto l2_benefit = _estimate_cost_by_bytes<CacheLevel::L3>(hash_table_probing_bytes_per_row) -
+                            _estimate_cost_by_bytes<CacheLevel::L2>(hash_table_probing_bytes_per_row);
+    const auto l3_benefit = _estimate_cost_by_bytes<CacheLevel::MEMORY>(hash_table_probing_bytes_per_row) -
+                            _estimate_cost_by_bytes<CacheLevel::L3>(hash_table_probing_bytes_per_row);
+
+    if (_probe_row_shuffle_cost < l3_benefit) { // Partitioned joins benefit from L3 cache.
+        // Partitioned joins benefit from L3 cache when probing a row has cache miss in non-partitioned join but not in partitioned join.
+        // 1. min_rows > (l3_cache_size/hash_table_bytes_per_row)*(l3_benefit/(l3_benefit-_probe_row_shuffle_cost)), because:
+        //   - l3_benefit * non_partition_cache_miss_rate > _probe_row_shuffle_cost
+        //   - non_partition_cache_miss_rate = 1 - l3_cache_size/(min_rows*hash_table_bytes_per_row)
+        // 2. max_rows < (l3_cache_size/hash_table_bytes_per_row)*(l3_benefit/_probe_row_shuffle_cost)*num_partitions, because:
+        //   - l3_benefit * partition_cache_hit_rate > _probe_row_shuffle_cost
+        //   - partition_cache_hit_rate = l3_cache_size/(max_rows_per_partition*hash_table_bytes_per_row)
+        _partition_join_l3_min_rows = _fit_L3_cache_max_rows * l3_benefit / (l3_benefit - _probe_row_shuffle_cost);
+        _partition_join_l3_max_rows = _fit_L3_cache_max_rows * _partition_num * l3_benefit / _probe_row_shuffle_cost;
+        _partition_join_l3_max_rows *= 2; // relax the restriction
+
+        if (_probe_row_shuffle_cost < l2_benefit) { // Partitioned joins benefit from L2 cache.
+            _partition_join_l2_min_rows = _fit_L2_cache_max_rows * l2_benefit / (l2_benefit - _probe_row_shuffle_cost);
+            _partition_join_l2_max_rows =
+                    (_fit_L2_cache_max_rows * _partition_num) * l2_benefit / _probe_row_shuffle_cost;
+            _partition_join_l2_max_rows *= 2;
+        }
     } else {
         // Partitioned joins don't have performance gains. Not using partition hash join.
         _partition_num = 1;
     }
 
-    VLOG_OPERATOR << "TRACE:"
-                  << "partition_num=" << _partition_num << " partition_join_min_rows=" << _partition_join_min_rows
-                  << " partition_join_max_rows=" << _partition_join_max_rows << " probe cost=" << _probe_estimated_costs
-                  << " build cost L2=" << _estimated_build_cost<CacheLevel::L2>(build_row_size)
-                  << " build cost L3=" << _estimated_build_cost<CacheLevel::L3>(build_row_size)
-                  << " build cost Mem=" << _estimated_build_cost<CacheLevel::MEMORY>(build_row_size);
+    _l2_benefit = l2_benefit;
+    _l3_benefit = l3_benefit;
+
+    VLOG_OPERATOR << "TRACE: _adjust_partition_rows "
+                  << "[partition_num=" << _partition_num << "] "
+                  << "[partition_join_l2_min_rows=" << _partition_join_l2_min_rows << "] "
+                  << "[partition_join_l2_max_rows=" << _partition_join_l2_max_rows << "] "
+                  << "[partition_join_l3_min_rows=" << _partition_join_l3_min_rows << "] "
+                  << "[partition_join_l3_max_rows=" << _partition_join_l3_max_rows << "] "
+                  << "[hash_table_probing_bytes_per_row=" << hash_table_probing_bytes_per_row << "] "
+                  << "[hash_table_bytes_per_row=" << hash_table_bytes_per_row << "] "
+                  << "[l2_benefit=" << l2_benefit << "] "
+                  << "[l3_benefit=" << l3_benefit << "] "
+                  << "[probe_shuffle_cost=" << _probe_row_shuffle_cost << "] ";
 }
 
 void AdaptivePartitionHashJoinBuilder::_init_partition_nums(const HashTableParam& param) {
     _partition_num = 16;
 
-    size_t estimated_bytes_each_row = _estimated_row_size(param);
+    _probe_row_shuffle_cost =
+            std::max<size_t>(_estimate_cost_by_bytes<CacheLevel::L3>(_estimate_probe_row_bytes(param)), 1);
 
-    _probe_estimated_costs = _estimated_probe_cost(param);
+    const size_t hash_table_probing_bytes_per_row = _estimate_hash_table_probing_bytes_per_row(param);
+    _adjust_partition_rows(1, hash_table_probing_bytes_per_row);
 
-    _adjust_partition_rows(estimated_bytes_each_row);
-
-    COUNTER_SET(_hash_joiner.build_metrics().partition_nums, (int64_t)_partition_num);
+    COUNTER_SET(_hash_joiner.build_metrics().partition_nums, static_cast<int64_t>(_partition_num));
 }
 
 void AdaptivePartitionHashJoinBuilder::create(const HashTableParam& param) {
     _init_partition_nums(param);
+
+    if (_partition_num > 1) {
+        _partition_input_channels.resize(_partition_num, PartitionChunkChannel(&_mem_tracker));
+    }
     for (size_t i = 0; i < _partition_num; ++i) {
         _builders.emplace_back(std::make_unique<SingleHashJoinBuilder>(_hash_joiner));
         _builders.back()->create(param);
@@ -579,10 +691,14 @@ void AdaptivePartitionHashJoinBuilder::close() {
         builder->close();
     }
     _builders.clear();
+    _partition_input_channels.clear();
     _partition_num = 0;
-    _partition_join_min_rows = 0;
-    _partition_join_max_rows = 0;
-    _probe_estimated_costs = 0;
+    _partition_join_l2_min_rows = 0;
+    _partition_join_l2_max_rows = 0;
+    _partition_join_l3_min_rows = 0;
+    _partition_join_l3_max_rows = 0;
+    _probe_row_shuffle_cost = 0;
+    _hash_table_probing_bytes_per_row = 0;
     _fit_L2_cache_max_rows = 0;
     _fit_L3_cache_max_rows = 0;
     _pushed_chunks = 0;
@@ -637,17 +753,70 @@ int64_t AdaptivePartitionHashJoinBuilder::ht_mem_usage() const {
                            [](int64_t sum, const auto& builder) { return sum + builder->ht_mem_usage(); });
 }
 
-Status AdaptivePartitionHashJoinBuilder::_convert_to_single_partition() {
+Status AdaptivePartitionHashJoinBuilder::_convert_to_single_partition(RuntimeState* state) {
+    VLOG_OPERATOR << "TRACE: convert_to_single_partition "
+                  << "[partition_num=" << _partition_num << "] "
+                  << "[partition_join_l2_min_rows=" << _partition_join_l2_min_rows << "] "
+                  << "[partition_join_l2_max_rows=" << _partition_join_l2_max_rows << "] "
+                  << "[partition_join_l3_min_rows=" << _partition_join_l3_min_rows << "] "
+                  << "[partition_join_l3_max_rows=" << _partition_join_l3_max_rows << "] "
+                  << "[hash_table_row_count=" << hash_table_row_count() << "] ";
+
     // merge all partition data to the first partition
-    for (size_t i = 1; i < _builders.size(); ++i) {
-        _builders[0]->hash_table().merge_ht(_builders[i]->hash_table());
+    if (_stage == Stage::BUFFERING) {
+        _mem_tracker.set(0);
+        for (const auto& unpartition_chunk : _unpartition_chunks) {
+            RETURN_IF_ERROR(_builders[0]->do_append_chunk(state, unpartition_chunk));
+        }
+        _unpartition_chunks.clear();
+    } else {
+        for (size_t i = 0; i < _builders.size(); ++i) {
+            if (i != 0) {
+                _builders[0]->hash_table().merge_ht(_builders[i]->hash_table());
+            }
+            auto& channel = _partition_input_channels[i];
+            while (!channel.is_empty()) {
+                RETURN_IF_ERROR(_builders[0]->do_append_chunk(state, channel.pull()));
+            }
+        }
+        _partition_input_channels.clear();
     }
     _builders.resize(1);
+
     _partition_num = 1;
+    COUNTER_SET(_hash_joiner.build_metrics().partition_nums, static_cast<int64_t>(1));
+
     return Status::OK();
 }
 
-Status AdaptivePartitionHashJoinBuilder::_append_chunk_to_partitions(const ChunkPtr& chunk) {
+Status AdaptivePartitionHashJoinBuilder::_transfer_to_appending_stage(RuntimeState* state) {
+    _stage = Stage::APPENDING;
+    _mem_tracker.set(0); // All the buffered chunks are moved to the partition builders, so clear the memory tracker.
+    for (const auto& unpartition_chunk : _unpartition_chunks) {
+        RETURN_IF_ERROR(_append_chunk_to_partitions(state, unpartition_chunk));
+    }
+    _unpartition_chunks.clear();
+
+    return Status::OK();
+}
+
+Status AdaptivePartitionHashJoinBuilder::_do_append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    if (_stage == Stage::BUFFERING) {
+        _mem_tracker.consume(chunk->memory_usage());
+        _unpartition_chunks.push_back(chunk);
+
+        const size_t num_rows = hash_table_row_count();
+        if (num_rows >= _partition_join_l2_min_rows || num_rows >= _partition_join_l3_min_rows) {
+            RETURN_IF_ERROR(_transfer_to_appending_stage(state));
+        }
+
+        return Status::OK();
+    } else {
+        return _append_chunk_to_partitions(state, chunk);
+    }
+}
+
+Status AdaptivePartitionHashJoinBuilder::_append_chunk_to_partitions(RuntimeState* state, const ChunkPtr& chunk) {
     const std::vector<ExprContext*>& build_partition_keys = _hash_joiner.build_expr_ctxs();
 
     size_t num_rows = chunk->num_rows();
@@ -660,10 +829,10 @@ Status AdaptivePartitionHashJoinBuilder::_append_chunk_to_partitions(const Chunk
     }
     std::vector<uint32_t> hash_values;
     {
-        hash_values.assign(num_rows, HashUtil::FNV_SEED);
+        hash_values.assign(num_rows, 0);
 
         for (const ColumnPtr& column : partition_columns) {
-            column->fnv_hash(hash_values.data(), 0, num_rows);
+            column->crc32_hash(hash_values.data(), 0, num_rows);
         }
         // find partition id
         for (size_t i = 0; i < hash_values.size(); ++i) {
@@ -698,31 +867,44 @@ Status AdaptivePartitionHashJoinBuilder::_append_chunk_to_partitions(const Chunk
         if (size == 0) {
             continue;
         }
-        // TODO: make builder implements append with selective
-        auto partition_chunk = chunk->clone_empty();
-        partition_chunk->append_selective(*chunk, selection.data(), from, size);
-        RETURN_IF_ERROR(_builders[i]->append_chunk(std::move(partition_chunk)));
+
+        auto& channel = _partition_input_channels[i];
+
+        if (channel.is_empty()) {
+            channel.push(chunk->clone_empty());
+        }
+
+        if (channel.back()->num_rows() + size <= state->chunk_size()) {
+            channel.append_selective_to_back(*chunk, selection.data(), from, size);
+        } else {
+            channel.push(chunk->clone_empty());
+            channel.append_selective_to_back(*chunk, selection.data(), from, size);
+        }
+
+        while (channel.is_full()) {
+            RETURN_IF_ERROR(_builders[i]->append_chunk(state, channel.pull()));
+        }
     }
     return Status::OK();
 }
 
-Status AdaptivePartitionHashJoinBuilder::do_append_chunk(const ChunkPtr& chunk) {
-    if (_partition_num > 1 && hash_table_row_count() > _partition_join_max_rows) {
-        RETURN_IF_ERROR(_convert_to_single_partition());
+Status AdaptivePartitionHashJoinBuilder::do_append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    if (_partition_num > 1 && !_need_partition_join_for_append(hash_table_row_count())) {
+        RETURN_IF_ERROR(_convert_to_single_partition(state));
     }
 
     if (_partition_num > 1 && ++_pushed_chunks % 8 == 0) {
-        size_t build_row_size = ht_mem_usage() / hash_table_row_count();
-        _adjust_partition_rows(build_row_size);
+        const size_t build_row_size = (ht_mem_usage() + _mem_tracker.consumption()) / hash_table_row_count();
+        _adjust_partition_rows(build_row_size, _hash_table_probing_bytes_per_row);
         if (_partition_num == 1) {
-            RETURN_IF_ERROR(_convert_to_single_partition());
+            RETURN_IF_ERROR(_convert_to_single_partition(state));
         }
     }
 
     if (_partition_num > 1) {
-        RETURN_IF_ERROR(_append_chunk_to_partitions(chunk));
+        RETURN_IF_ERROR(_do_append_chunk(state, chunk));
     } else {
-        RETURN_IF_ERROR(_builders[0]->do_append_chunk(chunk));
+        RETURN_IF_ERROR(_builders[0]->do_append_chunk(state, chunk));
     }
 
     return Status::OK();
@@ -735,8 +917,20 @@ ChunkPtr AdaptivePartitionHashJoinBuilder::convert_to_spill_schema(const ChunkPt
 Status AdaptivePartitionHashJoinBuilder::build(RuntimeState* state) {
     DCHECK_EQ(_partition_num, _builders.size());
 
-    if (_partition_num > 1 && hash_table_row_count() < _partition_join_min_rows) {
-        RETURN_IF_ERROR(_convert_to_single_partition());
+    if (_partition_num > 1) {
+        if (!_need_partition_join_for_build(hash_table_row_count())) {
+            RETURN_IF_ERROR(_convert_to_single_partition(state));
+        } else {
+            if (_stage == Stage::BUFFERING) {
+                RETURN_IF_ERROR(_transfer_to_appending_stage(state));
+            }
+            for (size_t i = 0; i < _partition_input_channels.size(); ++i) {
+                auto& channel = _partition_input_channels[i];
+                while (!channel.is_empty()) {
+                    RETURN_IF_ERROR(_builders[i]->do_append_chunk(state, channel.pull()));
+                }
+            }
+        }
     }
 
     for (auto& builder : _builders) {
@@ -769,17 +963,20 @@ std::unique_ptr<HashJoinProberImpl> AdaptivePartitionHashJoinBuilder::create_pro
     }
 }
 
-void AdaptivePartitionHashJoinBuilder::clone_readable(HashJoinBuilder* builder) {
+void AdaptivePartitionHashJoinBuilder::clone_readable(HashJoinBuilder* other_builder) {
     for (auto& builder : _builders) {
         DCHECK(builder->ready());
     }
     DCHECK(_ready);
     DCHECK_EQ(_partition_num, _builders.size());
-    auto other = down_cast<AdaptivePartitionHashJoinBuilder*>(builder);
+    auto other = down_cast<AdaptivePartitionHashJoinBuilder*>(other_builder);
     other->_builders.clear();
     other->_partition_num = _partition_num;
-    other->_partition_join_max_rows = _partition_join_max_rows;
-    other->_partition_join_min_rows = _partition_join_min_rows;
+    other->_partition_join_l2_min_rows = _partition_join_l2_min_rows;
+    other->_partition_join_l2_max_rows = _partition_join_l2_max_rows;
+    other->_partition_join_l3_min_rows = _partition_join_l3_min_rows;
+    other->_partition_join_l3_max_rows = _partition_join_l3_max_rows;
+    other->_partition_join_l3_max_rows = _partition_join_l3_max_rows;
     other->_ready = _ready;
     for (size_t i = 0; i < _partition_num; ++i) {
         other->_builders.emplace_back(std::make_unique<SingleHashJoinBuilder>(_hash_joiner));

--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -140,8 +140,6 @@ public:
 
     bool not_empty() const { return !is_empty(); }
 
-    size_t memory_usage() const { return _tracker->consumption(); }
-
 private:
     MemTracker* _tracker;
     std::deque<ChunkPtr> _chunks;

--- a/be/src/exec/hash_join_components.h
+++ b/be/src/exec/hash_join_components.h
@@ -92,11 +92,11 @@ public:
     virtual void create(const HashTableParam& param) = 0;
 
     // append chunk to hash table
-    Status append_chunk(const ChunkPtr& chunk) {
+    Status append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
         _inc_row_count(chunk->num_rows());
-        return do_append_chunk(chunk);
+        return do_append_chunk(state, chunk);
     }
-    virtual Status do_append_chunk(const ChunkPtr& chunk) = 0;
+    virtual Status do_append_chunk(RuntimeState* state, const ChunkPtr& chunk) = 0;
 
     virtual Status build(RuntimeState* state) = 0;
 
@@ -149,7 +149,7 @@ public:
 
     void reset(const HashTableParam& param) override;
 
-    Status do_append_chunk(const ChunkPtr& chunk) override;
+    Status do_append_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
     Status build(RuntimeState* state) override;
 

--- a/be/src/exec/hash_join_components.h
+++ b/be/src/exec/hash_join_components.h
@@ -125,6 +125,7 @@ public:
     // clone readable to to builder
     virtual void clone_readable(HashJoinBuilder* builder) = 0;
 
+    virtual Status prepare_for_spill_start(RuntimeState* state) {}
     virtual ChunkPtr convert_to_spill_schema(const ChunkPtr& chunk) const = 0;
 
 protected:

--- a/be/src/exec/hash_join_components.h
+++ b/be/src/exec/hash_join_components.h
@@ -125,7 +125,7 @@ public:
     // clone readable to to builder
     virtual void clone_readable(HashJoinBuilder* builder) = 0;
 
-    virtual Status prepare_for_spill_start(RuntimeState* state) {}
+    virtual Status prepare_for_spill_start(RuntimeState* state) { return Status::OK(); }
     virtual ChunkPtr convert_to_spill_schema(const ChunkPtr& chunk) const = 0;
 
 protected:

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -483,8 +483,8 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
     HashJoinerParam param(pool, _hash_join_node, _is_null_safes, _build_expr_ctxs, _probe_expr_ctxs,
                           _other_join_conjunct_ctxs, _conjunct_ctxs, child(1)->row_desc(), child(0)->row_desc(),
                           child(1)->type(), child(0)->type(), child(1)->conjunct_ctxs().empty(), _build_runtime_filters,
-                          _output_slots, _output_slots, _distribution_mode, _enable_late_materialization,
-                          _enable_partition_hash_join, _is_skew_join);
+                          _output_slots, _output_slots, context->degree_of_parallelism(), _distribution_mode,
+                          _enable_late_materialization, _enable_partition_hash_join, _is_skew_join);
     auto hash_joiner_factory = std::make_shared<starrocks::pipeline::HashJoinerFactory>(param);
 
     // Create a shared RefCountedRuntimeFilterCollector

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -82,6 +82,7 @@ HashJoiner::HashJoiner(const HashJoinerParam& param)
           _probe_output_slots(param._probe_output_slots),
           _build_runtime_filters(param._build_runtime_filters.begin(), param._build_runtime_filters.end()),
           _enable_late_materialization(param._enable_late_materialization),
+          _max_dop(param._max_dop),
           _is_skew_join(param._is_skew_join) {
     _is_push_down = param._hash_join_node.is_push_down;
     if (_join_type == TJoinOp::LEFT_ANTI_JOIN && param._hash_join_node.is_rewritten_from_not_in) {
@@ -178,7 +179,7 @@ void HashJoiner::_init_hash_table_param(HashTableParam* param, RuntimeState* sta
         }
     }
 }
-Status HashJoiner::append_chunk_to_ht(const ChunkPtr& chunk) {
+Status HashJoiner::append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk) {
     if (_phase != HashJoinPhase::BUILD) {
         return Status::OK();
     }
@@ -187,7 +188,7 @@ Status HashJoiner::append_chunk_to_ht(const ChunkPtr& chunk) {
     }
 
     update_build_rows(chunk->num_rows());
-    return _hash_join_builder->append_chunk(chunk);
+    return _hash_join_builder->append_chunk(state, chunk);
 }
 
 Status HashJoiner::append_chunk_to_spill_buffer(RuntimeState* state, const ChunkPtr& chunk) {

--- a/be/src/exec/join/join_hash_map.cpp
+++ b/be/src/exec/join/join_hash_map.cpp
@@ -617,6 +617,21 @@ void JoinHashTable::merge_ht(const JoinHashTable& ht) {
         }
         columns[i]->append(*other_columns[i], 1, other_columns[i]->size() - 1);
     }
+
+    auto& key_columns = _table_items->key_columns;
+    auto& other_key_columns = ht._table_items->key_columns;
+    for (size_t i = 0; i < key_columns.size(); i++) {
+        // If the join key is slot ref, will get from build chunk directly,
+        // otherwise will append from key_column of input
+        if (_table_items->join_keys[i].col_ref == nullptr) {
+            // upgrade to nullable column
+            if (!key_columns[i]->is_nullable() && other_key_columns[i]->is_nullable()) {
+                const size_t row_count = key_columns[i]->size();
+                key_columns[i] = NullableColumn::create(key_columns[i], NullColumn::create(row_count, 0));
+            }
+            key_columns[i]->append(*other_key_columns[i]);
+        }
+    }
 }
 
 ChunkPtr JoinHashTable::convert_to_spill_schema(const ChunkPtr& chunk) const {

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -38,7 +38,7 @@ HashJoinBuildOperator::HashJoinBuildOperator(OperatorFactory* factory, int32_t i
           _distribution_mode(distribution_mode) {}
 
 Status HashJoinBuildOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
-    return _join_builder->append_chunk_to_ht(chunk);
+    return _join_builder->append_chunk_to_ht(state, chunk);
 }
 
 Status HashJoinBuildOperator::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -236,6 +236,7 @@ StatusOr<std::function<StatusOr<ChunkPtr>()>> SpillableHashJoinBuildOperator::_c
     _hash_tables.clear();
     _hash_table_iterate_idx = 0;
 
+    _join_builder->hash_join_builder()->prepare_for_spill_start(runtime_state());
     _join_builder->hash_join_builder()->visitHt([this](JoinHashTable* ht) { _hash_tables.push_back(ht); });
 
     for (auto* ht : _hash_tables) {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -201,7 +201,7 @@ Status SpillableHashJoinBuildOperator::push_chunk(RuntimeState* state, const Chu
 
     // Estimate the appropriate number of partitions
     if (_is_first_time_spill) {
-        _join_builder->hash_join_builder()->prepare_for_spill_start(runtime_state());
+        RETURN_IF_ERROR(_join_builder->hash_join_builder()->prepare_for_spill_start(runtime_state()));
         RETURN_IF_ERROR(init_spiller_partitions(state, _join_builder->hash_join_builder()));
     }
 

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -85,6 +85,7 @@ Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
     if (!_join_builder->spiller()->spilled()) {
         DCHECK(_is_first_time_spill);
         _is_first_time_spill = false;
+        RETURN_IF_ERROR(_join_builder->hash_join_builder()->prepare_for_spill_start(runtime_state()));
         RETURN_IF_ERROR(init_spiller_partitions(state, _join_builder->hash_join_builder()));
         ASSIGN_OR_RETURN(_hash_table_slice_iterator, _convert_hash_map_to_chunk());
         RETURN_IF_ERROR(_join_builder->append_spill_task(state, _hash_table_slice_iterator));

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -201,6 +201,7 @@ Status SpillableHashJoinBuildOperator::push_chunk(RuntimeState* state, const Chu
 
     // Estimate the appropriate number of partitions
     if (_is_first_time_spill) {
+        _join_builder->hash_join_builder()->prepare_for_spill_start(runtime_state());
         RETURN_IF_ERROR(init_spiller_partitions(state, _join_builder->hash_join_builder()));
     }
 
@@ -236,7 +237,6 @@ StatusOr<std::function<StatusOr<ChunkPtr>()>> SpillableHashJoinBuildOperator::_c
     _hash_tables.clear();
     _hash_table_iterate_idx = 0;
 
-    _join_builder->hash_join_builder()->prepare_for_spill_start(runtime_state());
     _join_builder->hash_join_builder()->visitHt([this](JoinHashTable* ht) { _hash_tables.push_back(ht); });
 
     for (auto* ht : _hash_tables) {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -280,7 +280,7 @@ Status SpillableHashJoinProbeOperator::_load_partition_build_side(workgroup::Yie
 
             if (chunk_st.ok() && chunk_st.value() != nullptr && !chunk_st.value()->is_empty()) {
                 int64_t old_mem_usage = hash_table_mem_usage;
-                RETURN_IF_ERROR(builder->append_chunk(std::move(chunk_st.value())));
+                RETURN_IF_ERROR(builder->append_chunk(state, std::move(chunk_st.value())));
                 hash_table_mem_usage = builder->ht_mem_usage();
                 COUNTER_ADD(metrics.build_partition_peak_memory_usage, hash_table_mem_usage - old_mem_usage);
             } else if (chunk_st.status().is_end_of_file()) {

--- a/test/sql/test_join/R/test_partition_hash_join
+++ b/test/sql/test_join/R/test_partition_hash_join
@@ -1,0 +1,133 @@
+-- name: test_partition_hash_join
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+insert into __row_util_base select * from __row_util_base; -- 2560000
+insert into __row_util_base select * from __row_util_base; -- 5120000
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_bigint_null bigint NULL,
+    c_string STRING
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 96
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 
+select
+    idx,
+    idx, -- c_int
+    uuid() -- c_string
+from __row_util;
+-- result:
+-- !result
+select count(tt1.k1) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null);
+-- result:
+5120000
+-- !result
+select count(tt1.k1) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 2 = 0;
+-- result:
+2560000
+-- !result
+select count(tt1.k1) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 3 = 0;
+-- result:
+1706666
+-- !result
+select count(tt1.k1) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 5 = 0;
+-- result:
+1024000
+-- !result
+select count(tt1.k1) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 10 = 0;
+-- result:
+512000
+-- !result
+select count(tt1.k1) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 100 = 0;
+-- result:
+51200
+-- !result
+select count(tt1.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null);
+-- result:
+5120000
+-- !result
+select count(tt1.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 2 = 0;
+-- result:
+2560000
+-- !result
+select count(tt1.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 3 = 0;
+-- result:
+1706666
+-- !result
+select count(tt1.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 5 = 0;
+-- result:
+1024000
+-- !result
+select count(tt1.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 10 = 0;
+-- result:
+512000
+-- !result
+select count(tt1.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 100 = 0;
+-- result:
+51200
+-- !result
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null);
+-- result:
+5120000
+-- !result
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 2 = 0;
+-- result:
+2560000
+-- !result
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 3 = 0;
+-- result:
+1706666
+-- !result
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 5 = 0;
+-- result:
+1024000
+-- !result
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 10 = 0;
+-- result:
+512000
+-- !result
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 100 = 0;
+-- result:
+51200
+-- !result
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_string);
+-- result:
+5120000
+-- !result

--- a/test/sql/test_join/T/test_partition_hash_join
+++ b/test/sql/test_join/T/test_partition_hash_join
@@ -1,0 +1,74 @@
+-- name: test_partition_hash_join
+
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+insert into __row_util_base select * from __row_util_base; -- 2560000
+insert into __row_util_base select * from __row_util_base; -- 5120000
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_bigint_null bigint NULL,
+    c_string STRING
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 96
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t1 
+select
+    idx,
+    idx, -- c_int
+    uuid() -- c_string
+from __row_util;
+
+select count(tt1.k1) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null);
+select count(tt1.k1) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 2 = 0;
+select count(tt1.k1) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 3 = 0;
+select count(tt1.k1) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 5 = 0;
+select count(tt1.k1) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 10 = 0;
+select count(tt1.k1) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 100 = 0;
+
+
+select count(tt1.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null);
+select count(tt1.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 2 = 0;
+select count(tt1.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 3 = 0;
+select count(tt1.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 5 = 0;
+select count(tt1.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 10 = 0;
+select count(tt1.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 100 = 0;
+
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null);
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 2 = 0;
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 3 = 0;
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 5 = 0;
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 10 = 0;
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_bigint_null) where tt1.k1 % 100 = 0;
+
+select count(tt2.c_string) from t1 tt1 join [broadcast] t1 tt2 using(c_string);
+


### PR DESCRIPTION
## Why I'm doing:


### Strategy Changes

Relax restriction of partition hash join. The primary change to the strategy is that, in addition to the output build columns benefiting from partitioned hash join, probing hash table (`first`/`next` arrays and key comparisons)  can also benefit from it.

**Benefit and overhead for partition**

For a given probing row, the partition **benefit** is `_estimate_cost_by_bytes(probing_ht_bytes)` and includes two parts:
- **Output build columns:** the average bytes per output row from the build side. (This existed in the previous strategy.)
- **Probe hash table:** the average bytes per row for the `first` array, `next` array, and key column. (**This is newly added in this PR.**)

For a given probing row, the partition **overhead** is `_estimate_cost_by_bytes(probe_row_bytes)`.

**When to partition?**  
Require the builder’s row count to fall within either `(_partition_join_l3_min_rows, _partition_join_l3_max_rows]` or `(_partition_join_l2_min_rows, _partition_join_l2_max_rows]`.

$\\_partition\\_join\\_l3\\_min\\_rows=\frac{l3\\_cache\\_size}{hash\\_table\\_bytes\\_per\\_row} \times \frac{l3\\_benefit}{l3\\_benefit-overhead}$  
$\\_partition\\_join\\_l3\\_max\\_rows=\frac{l3\\_cache\\_size}{hash\\_table\\_bytes\\_per\\_row} \times \frac{l3\\_benefit}{overhead} \times num\\_partitions$

**Derivation:**  
$l3\\_benefit \times non\\_partition\\_cache\\_miss\\_rate > overhead$  
$non\\_partition\\_cache\\_miss\\_rate = 1 - \frac{l3\\_cache\\_size}{hash\\_table\\_bytes\\_per\\_row}$

$l3\\_benefit \times partition\\_cache\\_hit\\_rate > overhead$  
$partition\\_cache\\_hit\\_rate = \frac{l3\\_cache\\_size}{max\\_rows\\_per\\_partition \times hash\\_table\\_bytes\\_per\\_row}$  
$max\\_rows = max\\_rows\\_per\\_partition \times num\\_partitions$


**Other changes**

- Additionally, when estimating build output bytes, change
  `if (build_output_slots.contains(slot->id())) {`
  to
  `if (build_output_slots.empty() || build_output_slots.contains(slot->id())) {`.
  This is because `build_output_slots` is not always present; it only exists when the parent of `HashJoinNode` is a `ProjectNode`.

- When estimating probe bytes, remove
  `if (probe_output_slots.contains(slot->id())) {`,
  because every column in the prober chunk needs `append_selective`, not just the output columns.

### Other Adjustments
1. The builder first buffers `_partition_join_l3_min_rows` or `_partition_join_l2_min_rows` rows before running `append_selective` partitioning, to avoid wasting work when the row count is still below `_partition_join_l3_min_rows`.
2. After the builder chunk is partitioned via `append_selective`, do not immediately append to the partitioned hash tables. Instead, buffer until at most 4 chunk for a partition, then append.
3. Use `crc_hash` instead of `fnv_hash` for `append_selective` partitioning; it is 50% faster.


## Test

Environment
- 4BE, each 16Core 64GB Memory

### Join benchmark
```sql
-- Q1
SELECT count(a.bigint_10p), count(b.bigint_10p) FROM test_data_100p a INNER JOIN test_data_100p b ON a.bigint_10p = b.bigint_10p;
-- Q2
SELECT count(a.bigint_30p), count(b.bigint_30p) FROM test_data_100p a INNER JOIN test_data_100p b ON a.bigint_30p = b.bigint_30p;
-- Q3
SELECT count(a.bigint_60p), count(b.bigint_60p) FROM test_data_100p a INNER JOIN test_data_100p b ON a.bigint_60p = b.bigint_60p;
-- Q4
SELECT count(a.varchar_10p), count(b.varchar_10p) FROM test_data_100p a INNER JOIN test_data_100p b ON a.varchar_10p = b.varchar_10p;
-- Q5
SELECT count(a.varchar_30p), count(b.varchar_30p) FROM test_data_100p a INNER JOIN test_data_100p b ON a.varchar_30p = b.varchar_30p;
-- Q6
SELECT count(a.varchar_60p), count(b.varchar_60p) FROM test_data_100p a INNER JOIN test_data_100p b ON a.varchar_60p = b.varchar_60p;
-- Q7
SELECT SUM(a.L_LINENUMBER), SUM(b.L_SUPPKEY)  FROM lineitem as a JOIN lineitem as b ON 
a.L_ORDERKEY=b.L_ORDERKEY WHERE b.L_QUANTITY<=40;
-- Q8
SELECT SUM(a.L_LINENUMBER) FROM lineitem as a LEFT SEMI JOIN lineitem as b ON a.L_ORDERKEY=b.L_ORDERKEY;
```

  | Baseline | Partition Hash Join | Baseline/Partition Hash Join | Partition Hash Join + Linear-Chained | Baseline/Partition Hash Join + Linear-Chained
-- | -- | -- | -- | -- | --
Q01 | 34986 | 30474 | 1.15 | 27128 | 1.29
Q02 | 20885 | 17554 | 1.19 | 16246 | 1.29
Q03 | 16592 | 14884 | 1.11 | 12897 | 1.29
Q04 | 105308 | 98816 | 1.07 | 69335 | 1.52
Q05 | 59838 | 56150 | 1.07 | 49384 | 1.21
Q06 | 48336 | 48134 | 1.00 | 41057 | 1.18
Q07 | 92363 | 59594 | 1.55 | 51708 | 1.79
Q08 | 35984 | 31874 | 1.13 | 26545 | 1.36


### TPC-DS 1T
No significant change

### TPC-H 1T

No significant change

### Queries for different right rows, join_type, duplicated rate, join_key_type, match_degree

- right_rows (left_rows is `right_rows * 4`)
  - p100: 3,2768,0000 rows
  - p30: 30% × 3,2768,0000 rows
  - p10: 10% × 3,2768,0000 rows
- join_type: inner, left, left semi
- duplicated rate: each distinct value repeats x times
- join_key_type: int, bigint, str
- match_degree: x% of rows in the left table can match the right table


  | Disable | Enable | Disable/Enable
-- | -- | -- | --
SUM | 1789590 | 1615795 | 1.14


<details>

<summary>Click to see all the queries</summary>

  |   |   |   |   |   |   | Baseline | PR | Baseline/PR
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
SUM | right_rows | join_type | duplicated | join_key_type | match_degree |   | 1789590 | 1615795 | 1.11
Q001 | p100 | inner | 1 | int | p100 |   | 9413 | 7174 | 1.31
Q002 | p100 | inner | 1 | int | p50 |   | 7639 | 5847 | 1.31
Q003 | p100 | inner | 1 | int | p10 |   | 5680 | 4615 | 1.23
Q004 | p100 | inner | 1 | int | p1 |   | 5126 | 4360 | 1.18
Q005 | p100 | inner | 1 | int | p0 |   | 4404 | 3760 | 1.17
Q006 | p100 | inner | 1 | bigint | p100 |   | 9410 | 7415 | 1.27
Q007 | p100 | inner | 1 | bigint | p50 |   | 7677 | 6275 | 1.22
Q008 | p100 | inner | 1 | bigint | p10 |   | 5505 | 4977 | 1.11
Q009 | p100 | inner | 1 | bigint | p1 |   | 5124 | 4641 | 1.10
Q010 | p100 | inner | 1 | bigint | p0 |   | 5134 | 4478 | 1.15
Q011 | p100 | inner | 1 | str | p100 |   | 29764 | 23354 | 1.27
Q012 | p100 | inner | 1 | str | p50 |   | 24796 | 20111 | 1.23
Q013 | p100 | inner | 1 | str | p10 |   | 18534 | 15756 | 1.18
Q014 | p100 | inner | 1 | str | p1 |   | 16627 | 14413 | 1.15
Q015 | p100 | inner | 1 | str | p0 |   | 13083 | 13946 | 0.94
Q016 | p100 | inner | 3 | int | p100 |   | 5884 | 4394 | 1.34
Q017 | p100 | inner | 3 | int | p50 |   | 4590 | 3710 | 1.24
Q018 | p100 | inner | 3 | int | p10 |   | 2842 | 2547 | 1.12
Q019 | p100 | inner | 3 | int | p1 |   | 2584 | 2278 | 1.13
Q020 | p100 | inner | 3 | int | p0 |   | 2284 | 2048 | 1.12
Q021 | p100 | inner | 3 | bigint | p100 |   | 5102 | 4722 | 1.08
Q022 | p100 | inner | 3 | bigint | p50 |   | 3809 | 3955 | 0.96
Q023 | p100 | inner | 3 | bigint | p10 |   | 2909 | 2821 | 1.03
Q024 | p100 | inner | 3 | bigint | p1 |   | 2546 | 2516 | 1.01
Q025 | p100 | inner | 3 | bigint | p0 |   | 2452 | 2427 | 1.01
Q026 | p100 | inner | 3 | str | p100 |   | 17708 | 15095 | 1.17
Q027 | p100 | inner | 3 | str | p50 |   | 13122 | 11705 | 1.12
Q028 | p100 | inner | 3 | str | p10 |   | 9350 | 8789 | 1.06
Q029 | p100 | inner | 3 | str | p1 |   | 8099 | 7916 | 1.02
Q030 | p100 | inner | 3 | str | p0 |   | 6765 | 7520 | 0.90
Q031 | p100 | inner | 10 | int | p100 |   | 15394 | 10349 | 1.49
Q032 | p100 | inner | 10 | int | p50 |   | 9541 | 7026 | 1.36
Q033 | p100 | inner | 10 | int | p10 |   | 4561 | 4311 | 1.06
Q034 | p100 | inner | 10 | int | p1 |   | 3308 | 3358 | 0.99
Q035 | p100 | inner | 10 | int | p0 |   | 2835 | 2941 | 0.96
Q036 | p100 | inner | 10 | bigint | p100 |   | 16112 | 11867 | 1.36
Q037 | p100 | inner | 10 | bigint | p50 |   | 10310 | 8257 | 1.25
Q038 | p100 | inner | 10 | bigint | p10 |   | 4958 | 5024 | 0.99
Q039 | p100 | inner | 10 | bigint | p1 |   | 3792 | 3966 | 0.96
Q040 | p100 | inner | 10 | bigint | p0 |   | 3562 | 3615 | 0.99
Q041 | p100 | inner | 10 | str | p100 |   | 67624 | 59756 | 1.13
Q042 | p100 | inner | 10 | str | p50 |   | 40770 | 37483 | 1.09
Q043 | p100 | inner | 10 | str | p10 |   | 17924 | 19177 | 0.93
Q044 | p100 | inner | 10 | str | p1 |   | 12253 | 13235 | 0.93
Q045 | p100 | inner | 10 | str | p0 |   | 11428 | 12517 | 0.91
Q046 | p100 | left | 1 | int | p100 |   | 8313 | 6411 | 1.30
Q047 | p100 | left | 1 | int | p50 |   | 6941 | 5603 | 1.24
Q048 | p100 | left | 1 | int | p10 |   | 5528 | 4752 | 1.16
Q049 | p100 | left | 1 | int | p1 |   | 5215 | 4524 | 1.15
Q050 | p100 | left | 1 | int | p0 |   | 4585 | 3979 | 1.15
Q051 | p100 | left | 1 | bigint | p100 |   | 8399 | 6380 | 1.32
Q052 | p100 | left | 1 | bigint | p50 |   | 6944 | 5834 | 1.19
Q053 | p100 | left | 1 | bigint | p10 |   | 5579 | 4950 | 1.13
Q054 | p100 | left | 1 | bigint | p1 |   | 5255 | 4811 | 1.09
Q055 | p100 | left | 1 | bigint | p0 |   | 5108 | 4696 | 1.09
Q056 | p100 | left | 1 | str | p100 |   | 27662 | 22794 | 1.21
Q057 | p100 | left | 1 | str | p50 |   | 23236 | 19462 | 1.19
Q058 | p100 | left | 1 | str | p10 |   | 18300 | 16289 | 1.12
Q059 | p100 | left | 1 | str | p1 |   | 16964 | 15326 | 1.11
Q060 | p100 | left | 1 | str | p0 |   | 13284 | 13483 | 0.99
Q061 | p100 | left | 3 | int | p100 |   | 5457 | 3771 | 1.45
Q062 | p100 | left | 3 | int | p50 |   | 4183 | 3253 | 1.29
Q063 | p100 | left | 3 | int | p10 |   | 2990 | 2587 | 1.16
Q064 | p100 | left | 3 | int | p1 |   | 2717 | 2430 | 1.12
Q065 | p100 | left | 3 | int | p0 |   | 2414 | 2217 | 1.09
Q066 | p100 | left | 3 | bigint | p100 |   | 4982 | 4187 | 1.19
Q067 | p100 | left | 3 | bigint | p50 |   | 3884 | 3592 | 1.08
Q068 | p100 | left | 3 | bigint | p10 |   | 2832 | 2851 | 0.99
Q069 | p100 | left | 3 | bigint | p1 |   | 2613 | 2627 | 0.99
Q070 | p100 | left | 3 | bigint | p0 |   | 2594 | 2554 | 1.02
Q071 | p100 | left | 3 | str | p100 |   | 17003 | 14416 | 1.18
Q072 | p100 | left | 3 | str | p50 |   | 13307 | 11724 | 1.14
Q073 | p100 | left | 3 | str | p10 |   | 9858 | 9138 | 1.08
Q074 | p100 | left | 3 | str | p1 |   | 8802 | 8524 | 1.03
Q075 | p100 | left | 3 | str | p0 |   | 6969 | 7398 | 0.94
Q076 | p100 | left | 10 | int | p100 |   | 14632 | 9919 | 1.48
Q077 | p100 | left | 10 | int | p50 |   | 9050 | 7132 | 1.27
Q078 | p100 | left | 10 | int | p10 |   | 4592 | 4217 | 1.09
Q079 | p100 | left | 10 | int | p1 |   | 3354 | 3421 | 0.98
Q080 | p100 | left | 10 | int | p0 |   | 2882 | 3011 | 0.96
Q081 | p100 | left | 10 | bigint | p100 |   | 15306 | 11512 | 1.33
Q082 | p100 | left | 10 | bigint | p50 |   | 9778 | 8113 | 1.21
Q083 | p100 | left | 10 | bigint | p10 |   | 4959 | 4855 | 1.02
Q084 | p100 | left | 10 | bigint | p1 |   | 3754 | 3989 | 0.94
Q085 | p100 | left | 10 | bigint | p0 |   | 3567 | 3743 | 0.95
Q086 | p100 | left | 10 | str | p100 |   | 64498 | 56763 | 1.14
Q087 | p100 | left | 10 | str | p50 |   | 39505 | 36671 | 1.08
Q088 | p100 | left | 10 | str | p10 |   | 18664 | 19496 | 0.96
Q089 | p100 | left | 10 | str | p1 |   | 12295 | 13609 | 0.90
Q090 | p100 | left | 10 | str | p0 |   | 11424 | 12596 | 0.91
Q091 | p100 | left semi | 1 | int | p100 |   | 3294 | 4174 | 0.79
Q092 | p100 | left semi | 1 | int | p50 |   | 3438 | 4270 | 0.81
Q093 | p100 | left semi | 1 | int | p10 |   | 3341 | 3914 | 0.85
Q094 | p100 | left semi | 1 | int | p1 |   | 3240 | 3731 | 0.87
Q095 | p100 | left semi | 1 | int | p0 |   | 2002 | 3404 | 0.59
Q096 | p100 | left semi | 1 | bigint | p100 |   | 5653 | 5095 | 1.11
Q097 | p100 | left semi | 1 | bigint | p50 |   | 5605 | 5056 | 1.11
Q098 | p100 | left semi | 1 | bigint | p10 |   | 4907 | 4524 | 1.08
Q099 | p100 | left semi | 1 | bigint | p1 |   | 4807 | 4363 | 1.10
Q100 | p100 | left semi | 1 | bigint | p0 |   | 4629 | 4240 | 1.09
Q101 | p100 | left semi | 1 | str | p100 |   | 21738 | 20539 | 1.06
Q102 | p100 | left semi | 1 | str | p50 |   | 19278 | 17974 | 1.07
Q103 | p100 | left semi | 1 | str | p10 |   | 16053 | 14758 | 1.09
Q104 | p100 | left semi | 1 | str | p1 |   | 14956 | 13697 | 1.09
Q105 | p100 | left semi | 1 | str | p0 |   | 12814 | 12096 | 1.06
Q106 | p100 | left semi | 3 | int | p100 |   | 1851 | 2159 | 0.86
Q107 | p100 | left semi | 3 | int | p50 |   | 2001 | 2252 | 0.89
Q108 | p100 | left semi | 3 | int | p10 |   | 1904 | 2021 | 0.94
Q109 | p100 | left semi | 3 | int | p1 |   | 1870 | 1985 | 0.94
Q110 | p100 | left semi | 3 | int | p0 |   | 1208 | 1915 | 0.63
Q111 | p100 | left semi | 3 | bigint | p100 |   | 3009 | 2922 | 1.03
Q112 | p100 | left semi | 3 | bigint | p50 |   | 2747 | 2744 | 1.00
Q113 | p100 | left semi | 3 | bigint | p10 |   | 2478 | 2437 | 1.02
Q114 | p100 | left semi | 3 | bigint | p1 |   | 2441 | 2359 | 1.03
Q115 | p100 | left semi | 3 | bigint | p0 |   | 2389 | 2305 | 1.04
Q116 | p100 | left semi | 3 | str | p100 |   | 10397 | 9711 | 1.07
Q117 | p100 | left semi | 3 | str | p50 |   | 9509 | 8811 | 1.08
Q118 | p100 | left semi | 3 | str | p10 |   | 7931 | 7346 | 1.08
Q119 | p100 | left semi | 3 | str | p1 |   | 7482 | 7060 | 1.06
Q120 | p100 | left semi | 3 | str | p0 |   | 6664 | 6361 | 1.05
Q121 | p100 | left semi | 10 | int | p100 |   | 3011 | 3457 | 0.87
Q122 | p100 | left semi | 10 | int | p50 |   | 3184 | 3428 | 0.93
Q123 | p100 | left semi | 10 | int | p10 |   | 3039 | 3141 | 0.97
Q124 | p100 | left semi | 10 | int | p1 |   | 2916 | 3018 | 0.97
Q125 | p100 | left semi | 10 | int | p0 |   | 1726 | 2787 | 0.62
Q126 | p100 | left semi | 10 | bigint | p100 |   | 5417 | 4271 | 1.27
Q127 | p100 | left semi | 10 | bigint | p50 |   | 4719 | 4185 | 1.13
Q128 | p100 | left semi | 10 | bigint | p10 |   | 3720 | 3950 | 0.94
Q129 | p100 | left semi | 10 | bigint | p1 |   | 3506 | 3733 | 0.94
Q130 | p100 | left semi | 10 | bigint | p0 |   | 3224 | 3616 | 0.89
Q131 | p100 | left semi | 10 | str | p100 |   | 18350 | 18261 | 1.00
Q132 | p100 | left semi | 10 | str | p50 |   | 16084 | 15320 | 1.05
Q133 | p100 | left semi | 10 | str | p10 |   | 12367 | 11981 | 1.03
Q134 | p100 | left semi | 10 | str | p1 |   | 11596 | 11296 | 1.03
Q135 | p100 | left semi | 10 | str | p0 |   | 11128 | 10972 | 1.01
Q136 | p30 | inner | 1 | int | p100 |   | 2544 | 1920 | 1.33
Q137 | p30 | inner | 1 | int | p50 |   | 1958 | 1615 | 1.21
Q138 | p30 | inner | 1 | int | p10 |   | 1487 | 1303 | 1.14
Q139 | p30 | inner | 1 | int | p1 |   | 1314 | 1220 | 1.08
Q140 | p30 | inner | 1 | int | p0 |   | 1279 | 1113 | 1.15
Q141 | p30 | inner | 1 | bigint | p100 |   | 2826 | 2125 | 1.33
Q142 | p30 | inner | 1 | bigint | p50 |   | 2340 | 1888 | 1.24
Q143 | p30 | inner | 1 | bigint | p10 |   | 1650 | 1551 | 1.06
Q144 | p30 | inner | 1 | bigint | p1 |   | 1554 | 1453 | 1.07
Q145 | p30 | inner | 1 | bigint | p0 |   | 1544 | 1448 | 1.07
Q146 | p30 | inner | 1 | str | p100 |   | 8158 | 7761 | 1.05
Q147 | p30 | inner | 1 | str | p50 |   | 6712 | 6630 | 1.01
Q148 | p30 | inner | 1 | str | p10 |   | 5290 | 4954 | 1.07
Q149 | p30 | inner | 1 | str | p1 |   | 4778 | 4545 | 1.05
Q150 | p30 | inner | 1 | str | p0 |   | 3992 | 3838 | 1.04
Q151 | p30 | inner | 3 | int | p100 |   | 2174 | 1419 | 1.53
Q152 | p30 | inner | 3 | int | p50 |   | 1832 | 1373 | 1.33
Q153 | p30 | inner | 3 | int | p10 |   | 1247 | 1176 | 1.06
Q154 | p30 | inner | 3 | int | p1 |   | 1297 | 1062 | 1.22
Q155 | p30 | inner | 3 | int | p0 |   | 1201 | 1096 | 1.10
Q156 | p30 | inner | 3 | bigint | p100 |   | 2305 | 1689 | 1.36
Q157 | p30 | inner | 3 | bigint | p50 |   | 1929 | 1477 | 1.31
Q158 | p30 | inner | 3 | bigint | p10 |   | 1459 | 1258 | 1.16
Q159 | p30 | inner | 3 | bigint | p1 |   | 1367 | 1280 | 1.07
Q160 | p30 | inner | 3 | bigint | p0 |   | 1376 | 1182 | 1.16
Q161 | p30 | inner | 3 | str | p100 |   | 6201 | 6129 | 1.01
Q162 | p30 | inner | 3 | str | p50 |   | 4966 | 4823 | 1.03
Q163 | p30 | inner | 3 | str | p10 |   | 3856 | 3729 | 1.03
Q164 | p30 | inner | 3 | str | p1 |   | 3529 | 3409 | 1.04
Q165 | p30 | inner | 3 | str | p0 |   | 3050 | 2996 | 1.02
Q166 | p30 | inner | 10 | int | p100 |   | 6593 | 2420 | 2.72
Q167 | p30 | inner | 10 | int | p50 |   | 4024 | 1852 | 2.17
Q168 | p30 | inner | 10 | int | p10 |   | 1753 | 1247 | 1.41
Q169 | p30 | inner | 10 | int | p1 |   | 1452 | 1016 | 1.43
Q170 | p30 | inner | 10 | int | p0 |   | 1238 | 869 | 1.42
Q171 | p30 | inner | 10 | bigint | p100 |   | 7354 | 2972 | 2.47
Q172 | p30 | inner | 10 | bigint | p50 |   | 4407 | 2307 | 1.91
Q173 | p30 | inner | 10 | bigint | p10 |   | 2022 | 1516 | 1.33
Q174 | p30 | inner | 10 | bigint | p1 |   | 1591 | 1234 | 1.29
Q175 | p30 | inner | 10 | bigint | p0 |   | 1459 | 1107 | 1.32
Q176 | p30 | inner | 10 | str | p100 |   | 28108 | 19773 | 1.42
Q177 | p30 | inner | 10 | str | p50 |   | 16390 | 11682 | 1.40
Q178 | p30 | inner | 10 | str | p10 |   | 6692 | 5209 | 1.28
Q179 | p30 | inner | 10 | str | p1 |   | 4342 | 3690 | 1.18
Q180 | p30 | inner | 10 | str | p0 |   | 3812 | 3534 | 1.08
Q181 | p30 | left | 1 | int | p100 |   | 2169 | 1753 | 1.24
Q182 | p30 | left | 1 | int | p50 |   | 1812 | 1544 | 1.17
Q183 | p30 | left | 1 | int | p10 |   | 1510 | 1356 | 1.11
Q184 | p30 | left | 1 | int | p1 |   | 1440 | 1292 | 1.11
Q185 | p30 | left | 1 | int | p0 |   | 1336 | 1264 | 1.06
Q186 | p30 | left | 1 | bigint | p100 |   | 2351 | 1899 | 1.24
Q187 | p30 | left | 1 | bigint | p50 |   | 2048 | 1729 | 1.18
Q188 | p30 | left | 1 | bigint | p10 |   | 1642 | 1547 | 1.06
Q189 | p30 | left | 1 | bigint | p1 |   | 1512 | 1540 | 0.98
Q190 | p30 | left | 1 | bigint | p0 |   | 1489 | 1487 | 1.00
Q191 | p30 | left | 1 | str | p100 |   | 7307 | 7413 | 0.99
Q192 | p30 | left | 1 | str | p50 |   | 6381 | 6301 | 1.01
Q193 | p30 | left | 1 | str | p10 |   | 5071 | 5114 | 0.99
Q194 | p30 | left | 1 | str | p1 |   | 4789 | 4726 | 1.01
Q195 | p30 | left | 1 | str | p0 |   | 3966 | 3928 | 1.01
Q196 | p30 | left | 3 | int | p100 |   | 1461 | 1002 | 1.46
Q197 | p30 | left | 3 | int | p50 |   | 1181 | 872 | 1.35
Q198 | p30 | left | 3 | int | p10 |   | 882 | 764 | 1.15
Q199 | p30 | left | 3 | int | p1 |   | 797 | 717 | 1.11
Q200 | p30 | left | 3 | int | p0 |   | 771 | 678 | 1.14
Q201 | p30 | left | 3 | bigint | p100 |   | 1629 | 1132 | 1.44
Q202 | p30 | left | 3 | bigint | p50 |   | 1296 | 1006 | 1.29
Q203 | p30 | left | 3 | bigint | p10 |   | 971 | 858 | 1.13
Q204 | p30 | left | 3 | bigint | p1 |   | 852 | 824 | 1.03
Q205 | p30 | left | 3 | bigint | p0 |   | 835 | 836 | 1.00
Q206 | p30 | left | 3 | str | p100 |   | 4865 | 4781 | 1.02
Q207 | p30 | left | 3 | str | p50 |   | 3805 | 3742 | 1.02
Q208 | p30 | left | 3 | str | p10 |   | 2843 | 2789 | 1.02
Q209 | p30 | left | 3 | str | p1 |   | 2542 | 2673 | 0.95
Q210 | p30 | left | 3 | str | p0 |   | 2140 | 2073 | 1.03
Q211 | p30 | left | 10 | int | p100 |   | 4716 | 2359 | 2.00
Q212 | p30 | left | 10 | int | p50 |   | 3023 | 1908 | 1.58
Q213 | p30 | left | 10 | int | p10 |   | 1434 | 1229 | 1.17
Q214 | p30 | left | 10 | int | p1 |   | 1117 | 1052 | 1.06
Q215 | p30 | left | 10 | int | p0 |   | 953 | 918 | 1.04
Q216 | p30 | left | 10 | bigint | p100 |   | 5007 | 2903 | 1.72
Q217 | p30 | left | 10 | bigint | p50 |   | 3199 | 2253 | 1.42
Q218 | p30 | left | 10 | bigint | p10 |   | 1615 | 1477 | 1.09
Q219 | p30 | left | 10 | bigint | p1 |   | 1238 | 1275 | 0.97
Q220 | p30 | left | 10 | bigint | p0 |   | 1148 | 1235 | 0.93
Q221 | p30 | left | 10 | str | p100 |   | 18594 | 18453 | 1.01
Q222 | p30 | left | 10 | str | p50 |   | 11719 | 11774 | 1.00
Q223 | p30 | left | 10 | str | p10 |   | 5460 | 5423 | 1.01
Q224 | p30 | left | 10 | str | p1 |   | 3840 | 3931 | 0.98
Q225 | p30 | left | 10 | str | p0 |   | 3539 | 3469 | 1.02
Q226 | p30 | left semi | 1 | int | p100 |   | 1200 | 1299 | 0.92
Q227 | p30 | left semi | 1 | int | p50 |   | 1321 | 1371 | 0.96
Q228 | p30 | left semi | 1 | int | p10 |   | 1273 | 1126 | 1.13
Q229 | p30 | left semi | 1 | int | p1 |   | 1279 | 1151 | 1.11
Q230 | p30 | left semi | 1 | int | p0 |   | 793 | 1142 | 0.69
Q231 | p30 | left semi | 1 | bigint | p100 |   | 1685 | 1697 | 0.99
Q232 | p30 | left semi | 1 | bigint | p50 |   | 1602 | 1632 | 0.98
Q233 | p30 | left semi | 1 | bigint | p10 |   | 1467 | 1387 | 1.06
Q234 | p30 | left semi | 1 | bigint | p1 |   | 1422 | 1355 | 1.05
Q235 | p30 | left semi | 1 | bigint | p0 |   | 1336 | 1324 | 1.01
Q236 | p30 | left semi | 1 | str | p100 |   | 5717 | 5550 | 1.03
Q237 | p30 | left semi | 1 | str | p50 |   | 5154 | 5001 | 1.03
Q238 | p30 | left semi | 1 | str | p10 |   | 4647 | 4321 | 1.08
Q239 | p30 | left semi | 1 | str | p1 |   | 4316 | 4185 | 1.03
Q240 | p30 | left semi | 1 | str | p0 |   | 3801 | 3698 | 1.03
Q241 | p30 | left semi | 3 | int | p100 |   | 1114 | 1061 | 1.05
Q242 | p30 | left semi | 3 | int | p50 |   | 1225 | 1166 | 1.05
Q243 | p30 | left semi | 3 | int | p10 |   | 1145 | 1122 | 1.02
Q244 | p30 | left semi | 3 | int | p1 |   | 1062 | 1024 | 1.04
Q245 | p30 | left semi | 3 | int | p0 |   | 1089 | 1032 | 1.06
Q246 | p30 | left semi | 3 | bigint | p100 |   | 1337 | 1281 | 1.04
Q247 | p30 | left semi | 3 | bigint | p50 |   | 1383 | 1295 | 1.07
Q248 | p30 | left semi | 3 | bigint | p10 |   | 1248 | 1212 | 1.03
Q249 | p30 | left semi | 3 | bigint | p1 |   | 1191 | 1196 | 1.00
Q250 | p30 | left semi | 3 | bigint | p0 |   | 1198 | 1182 | 1.01
Q251 | p30 | left semi | 3 | str | p100 |   | 4033 | 4007 | 1.01
Q252 | p30 | left semi | 3 | str | p50 |   | 3755 | 3690 | 1.02
Q253 | p30 | left semi | 3 | str | p10 |   | 3490 | 3345 | 1.04
Q254 | p30 | left semi | 3 | str | p1 |   | 3399 | 3167 | 1.07
Q255 | p30 | left semi | 3 | str | p0 |   | 2890 | 2803 | 1.03
Q256 | p30 | left semi | 10 | int | p100 |   | 1187 | 997 | 1.19
Q257 | p30 | left semi | 10 | int | p50 |   | 1225 | 1062 | 1.15
Q258 | p30 | left semi | 10 | int | p10 |   | 1274 | 990 | 1.29
Q259 | p30 | left semi | 10 | int | p1 |   | 1200 | 929 | 1.29
Q260 | p30 | left semi | 10 | int | p0 |   | 779 | 904 | 0.86
Q261 | p30 | left semi | 10 | bigint | p100 |   | 1488 | 1449 | 1.03
Q262 | p30 | left semi | 10 | bigint | p50 |   | 1322 | 1341 | 0.99
Q263 | p30 | left semi | 10 | bigint | p10 |   | 1142 | 1124 | 1.02
Q264 | p30 | left semi | 10 | bigint | p1 |   | 1074 | 1015 | 1.06
Q265 | p30 | left semi | 10 | bigint | p0 |   | 1035 | 1023 | 1.01
Q266 | p30 | left semi | 10 | str | p100 |   | 5233 | 5005 | 1.05
Q267 | p30 | left semi | 10 | str | p50 |   | 4560 | 4393 | 1.04
Q268 | p30 | left semi | 10 | str | p10 |   | 3953 | 3696 | 1.07
Q269 | p30 | left semi | 10 | str | p1 |   | 3686 | 3446 | 1.07
Q270 | p30 | left semi | 10 | str | p0 |   | 3520 | 3327 | 1.06
Q271 | p10 | inner | 1 | int | p100 |   | 925 | 676 | 1.37
Q272 | p10 | inner | 1 | int | p50 |   | 771 | 632 | 1.22
Q273 | p10 | inner | 1 | int | p10 |   | 635 | 579 | 1.10
Q274 | p10 | inner | 1 | int | p1 |   | 624 | 585 | 1.07
Q275 | p10 | inner | 1 | int | p0 |   | 614 | 571 | 1.08
Q276 | p10 | inner | 1 | bigint | p100 |   | 975 | 806 | 1.21
Q277 | p10 | inner | 1 | bigint | p50 |   | 830 | 770 | 1.08
Q278 | p10 | inner | 1 | bigint | p10 |   | 746 | 719 | 1.04
Q279 | p10 | inner | 1 | bigint | p1 |   | 682 | 706 | 0.97
Q280 | p10 | inner | 1 | bigint | p0 |   | 663 | 664 | 1.00
Q281 | p10 | inner | 1 | str | p100 |   | 2812 | 2634 | 1.07
Q282 | p10 | inner | 1 | str | p50 |   | 2369 | 2307 | 1.03
Q283 | p10 | inner | 1 | str | p10 |   | 1976 | 1833 | 1.08
Q284 | p10 | inner | 1 | str | p1 |   | 1844 | 1790 | 1.03
Q285 | p10 | inner | 1 | str | p0 |   | 1727 | 1656 | 1.04
Q286 | p10 | inner | 3 | int | p100 |   | 510 | 399 | 1.28
Q287 | p10 | inner | 3 | int | p50 |   | 530 | 383 | 1.38
Q288 | p10 | inner | 3 | int | p10 |   | 325 | 359 | 0.91
Q289 | p10 | inner | 3 | int | p1 |   | 323 | 323 | 1.00
Q290 | p10 | inner | 3 | int | p0 |   | 411 | 317 | 1.30
Q291 | p10 | inner | 3 | bigint | p100 |   | 585 | 472 | 1.24
Q292 | p10 | inner | 3 | bigint | p50 |   | 516 | 437 | 1.18
Q293 | p10 | inner | 3 | bigint | p10 |   | 399 | 396 | 1.01
Q294 | p10 | inner | 3 | bigint | p1 |   | 403 | 409 | 0.99
Q295 | p10 | inner | 3 | bigint | p0 |   | 392 | 416 | 0.94
Q296 | p10 | inner | 3 | str | p100 |   | 1826 | 1804 | 1.01
Q297 | p10 | inner | 3 | str | p50 |   | 1423 | 1415 | 1.01
Q298 | p10 | inner | 3 | str | p10 |   | 1122 | 1086 | 1.03
Q299 | p10 | inner | 3 | str | p1 |   | 1030 | 961 | 1.07
Q300 | p10 | inner | 3 | str | p0 |   | 933 | 934 | 1.00
Q301 | p10 | inner | 10 | int | p100 |   | 1108 | 684 | 1.62
Q302 | p10 | inner | 10 | int | p50 |   | 774 | 595 | 1.30
Q303 | p10 | inner | 10 | int | p10 |   | 503 | 505 | 1.00
Q304 | p10 | inner | 10 | int | p1 |   | 413 | 427 | 0.97
Q305 | p10 | inner | 10 | int | p0 |   | 344 | 453 | 0.76
Q306 | p10 | inner | 10 | bigint | p100 |   | 1217 | 851 | 1.43
Q307 | p10 | inner | 10 | bigint | p50 |   | 901 | 767 | 1.17
Q308 | p10 | inner | 10 | bigint | p10 |   | 599 | 597 | 1.00
Q309 | p10 | inner | 10 | bigint | p1 |   | 483 | 527 | 0.92
Q310 | p10 | inner | 10 | bigint | p0 |   | 419 | 581 | 0.72
Q311 | p10 | inner | 10 | str | p100 |   | 6397 | 6077 | 1.05
Q312 | p10 | inner | 10 | str | p50 |   | 3984 | 3700 | 1.08
Q313 | p10 | inner | 10 | str | p10 |   | 1885 | 1791 | 1.05
Q314 | p10 | inner | 10 | str | p1 |   | 1244 | 1294 | 0.96
Q315 | p10 | inner | 10 | str | p0 |   | 1137 | 1151 | 0.99
Q316 | p10 | left | 1 | int | p100 |   | 601 | 443 | 1.36
Q317 | p10 | left | 1 | int | p50 |   | 525 | 444 | 1.18
Q318 | p10 | left | 1 | int | p10 |   | 442 | 403 | 1.10
Q319 | p10 | left | 1 | int | p1 |   | 409 | 376 | 1.09
Q320 | p10 | left | 1 | int | p0 |   | 402 | 369 | 1.09
Q321 | p10 | left | 1 | bigint | p100 |   | 691 | 548 | 1.26
Q322 | p10 | left | 1 | bigint | p50 |   | 662 | 512 | 1.29
Q323 | p10 | left | 1 | bigint | p10 |   | 502 | 527 | 0.95
Q324 | p10 | left | 1 | bigint | p1 |   | 474 | 457 | 1.04
Q325 | p10 | left | 1 | bigint | p0 |   | 481 | 457 | 1.05
Q326 | p10 | left | 1 | str | p100 |   | 2014 | 2060 | 0.98
Q327 | p10 | left | 1 | str | p50 |   | 1756 | 1712 | 1.03
Q328 | p10 | left | 1 | str | p10 |   | 1464 | 1396 | 1.05
Q329 | p10 | left | 1 | str | p1 |   | 1399 | 1320 | 1.06
Q330 | p10 | left | 1 | str | p0 |   | 1352 | 1222 | 1.11
Q331 | p10 | left | 3 | int | p100 |   | 395 | 258 | 1.53
Q332 | p10 | left | 3 | int | p50 |   | 333 | 248 | 1.34
Q333 | p10 | left | 3 | int | p10 |   | 284 | 224 | 1.27
Q334 | p10 | left | 3 | int | p1 |   | 222 | 213 | 1.04
Q335 | p10 | left | 3 | int | p0 |   | 287 | 212 | 1.35
Q336 | p10 | left | 3 | bigint | p100 |   | 421 | 324 | 1.30
Q337 | p10 | left | 3 | bigint | p50 |   | 393 | 312 | 1.26
Q338 | p10 | left | 3 | bigint | p10 |   | 294 | 291 | 1.01
Q339 | p10 | left | 3 | bigint | p1 |   | 275 | 277 | 0.99
Q340 | p10 | left | 3 | bigint | p0 |   | 263 | 259 | 1.02
Q341 | p10 | left | 3 | str | p100 |   | 1531 | 1474 | 1.04
Q342 | p10 | left | 3 | str | p50 |   | 1177 | 1112 | 1.06
Q343 | p10 | left | 3 | str | p10 |   | 852 | 811 | 1.05
Q344 | p10 | left | 3 | str | p1 |   | 786 | 740 | 1.06
Q345 | p10 | left | 3 | str | p0 |   | 731 | 650 | 1.12
Q346 | p10 | left | 10 | int | p100 |   | 1004 | 617 | 1.63
Q347 | p10 | left | 10 | int | p50 |   | 700 | 527 | 1.33
Q348 | p10 | left | 10 | int | p10 |   | 399 | 392 | 1.02
Q349 | p10 | left | 10 | int | p1 |   | 294 | 333 | 0.88
Q350 | p10 | left | 10 | int | p0 |   | 277 | 291 | 0.95
Q351 | p10 | left | 10 | bigint | p100 |   | 1208 | 740 | 1.63
Q352 | p10 | left | 10 | bigint | p50 |   | 866 | 645 | 1.34
Q353 | p10 | left | 10 | bigint | p10 |   | 515 | 466 | 1.11
Q354 | p10 | left | 10 | bigint | p1 |   | 396 | 423 | 0.94
Q355 | p10 | left | 10 | bigint | p0 |   | 357 | 369 | 0.97
Q356 | p10 | left | 10 | str | p100 |   | 5920 | 5860 | 1.01
Q357 | p10 | left | 10 | str | p50 |   | 3700 | 3596 | 1.03
Q358 | p10 | left | 10 | str | p10 |   | 1650 | 1640 | 1.01
Q359 | p10 | left | 10 | str | p1 |   | 1274 | 1179 | 1.08
Q360 | p10 | left | 10 | str | p0 |   | 1222 | 1108 | 1.10
Q361 | p10 | left semi | 1 | int | p100 |   | 692 | 589 | 1.17
Q362 | p10 | left semi | 1 | int | p50 |   | 671 | 610 | 1.10
Q363 | p10 | left semi | 1 | int | p10 |   | 616 | 578 | 1.07
Q364 | p10 | left semi | 1 | int | p1 |   | 601 | 552 | 1.09
Q365 | p10 | left semi | 1 | int | p0 |   | 575 | 549 | 1.05
Q366 | p10 | left semi | 1 | bigint | p100 |   | 715 | 711 | 1.01
Q367 | p10 | left semi | 1 | bigint | p50 |   | 754 | 708 | 1.06
Q368 | p10 | left semi | 1 | bigint | p10 |   | 688 | 661 | 1.04
Q369 | p10 | left semi | 1 | bigint | p1 |   | 656 | 670 | 0.98
Q370 | p10 | left semi | 1 | bigint | p0 |   | 638 | 620 | 1.03
Q371 | p10 | left semi | 1 | str | p100 |   | 2446 | 2368 | 1.03
Q372 | p10 | left semi | 1 | str | p50 |   | 2251 | 2145 | 1.05
Q373 | p10 | left semi | 1 | str | p10 |   | 1884 | 1860 | 1.01
Q374 | p10 | left semi | 1 | str | p1 |   | 1831 | 1834 | 1.00
Q375 | p10 | left semi | 1 | str | p0 |   | 1821 | 1653 | 1.10
Q376 | p10 | left semi | 3 | int | p100 |   | 338 | 318 | 1.06
Q377 | p10 | left semi | 3 | int | p50 |   | 346 | 338 | 1.02
Q378 | p10 | left semi | 3 | int | p10 |   | 326 | 299 | 1.09
Q379 | p10 | left semi | 3 | int | p1 |   | 355 | 301 | 1.18
Q380 | p10 | left semi | 3 | int | p0 |   | 297 | 300 | 0.99
Q381 | p10 | left semi | 3 | bigint | p100 |   | 435 | 393 | 1.11
Q382 | p10 | left semi | 3 | bigint | p50 |   | 446 | 401 | 1.11
Q383 | p10 | left semi | 3 | bigint | p10 |   | 390 | 391 | 1.00
Q384 | p10 | left semi | 3 | bigint | p1 |   | 355 | 422 | 0.84
Q385 | p10 | left semi | 3 | bigint | p0 |   | 366 | 334 | 1.10
Q386 | p10 | left semi | 3 | str | p100 |   | 1347 | 1256 | 1.07
Q387 | p10 | left semi | 3 | str | p50 |   | 1226 | 1157 | 1.06
Q388 | p10 | left semi | 3 | str | p10 |   | 1124 | 1020 | 1.10
Q389 | p10 | left semi | 3 | str | p1 |   | 1029 | 971 | 1.06
Q390 | p10 | left semi | 3 | str | p0 |   | 967 | 915 | 1.06
Q391 | p10 | left semi | 10 | int | p100 |   | 480 | 440 | 1.09
Q392 | p10 | left semi | 10 | int | p50 |   | 436 | 498 | 0.88
Q393 | p10 | left semi | 10 | int | p10 |   | 450 | 442 | 1.02
Q394 | p10 | left semi | 10 | int | p1 |   | 400 | 435 | 0.92
Q395 | p10 | left semi | 10 | int | p0 |   | 340 | 418 | 0.81
Q396 | p10 | left semi | 10 | bigint | p100 |   | 481 | 516 | 0.93
Q397 | p10 | left semi | 10 | bigint | p50 |   | 500 | 489 | 1.02
Q398 | p10 | left semi | 10 | bigint | p10 |   | 480 | 469 | 1.02
Q399 | p10 | left semi | 10 | bigint | p1 |   | 461 | 447 | 1.03
Q400 | p10 | left semi | 10 | bigint | p0 |   | 422 | 483 | 0.87
Q401 | p10 | left semi | 10 | str | p100 |   | 1861 | 1768 | 1.05
Q402 | p10 | left semi | 10 | str | p50 |   | 1710 | 1535 | 1.11
Q403 | p10 | left semi | 10 | str | p10 |   | 1350 | 1311 | 1.03
Q404 | p10 | left semi | 10 | str | p1 |   | 1213 | 1199 | 1.01
Q405 | p10 | left semi | 10 | str | p0 |   | 1159 | 1137 | 1.02

</details>

## What I'm doing:


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
