### PR TITLE
[Enhancement] optimize tablet meta copy when enable file bundling 

### DIFF
--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -2615,11 +2615,19 @@ TEST_F(LakeServiceTest, test_aggregate_publish_version) {
         _lake_service.aggregate_publish_version(&cntl, &request, &response, done);
 
         EXPECT_EQ(response.status().status_code(), 0);
+        // read tablet id - 1
         auto res = _tablet_mgr->get_single_tablet_metadata(1, 2);
         ASSERT_TRUE(res.ok());
+        // check tablet id
+        ASSERT_EQ(res.value()->id(), 1);
         TabletMetadataPtr metadata3 = std::move(res).value();
         ASSERT_EQ(metadata3->schema().id(), 10);
         ASSERT_EQ(metadata3->historical_schemas_size(), 2);
+        // read tablet id - 2
+        auto res2 = _tablet_mgr->get_single_tablet_metadata(2, 2);
+        ASSERT_TRUE(res2.ok());
+        // check tablet id
+        ASSERT_EQ(res2.value()->id(), 2);
     }
 
     // publish version failed


### PR DESCRIPTION
## Why I'm doing:
When file bundling is enabled, we need to collect tablet meta and assemble them into a bundled meta. To speed up this process, we need to accelerate the copy operations involved.

## What I'm doing:
This pull request optimizes metadata handling in the `LakeServiceImpl::publish_version` method and improves test coverage for the `LakeServiceTest` suite. Key changes include reducing lock contention by moving metadata operations outside of critical sections, enhancing efficiency with `Swap` to avoid unnecessary copies, and adding assertions to validate tablet metadata in tests.

### Metadata handling optimizations:
* [`be/src/service/service_be/lake_service.cpp`](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaR246-R247): Introduced a preallocated `TabletMetadataPB` pointer to defer metadata copying outside the critical section, reducing lock contention and enabling parallel execution. [[1]](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaR246-R247) [[2]](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaL257-R264)
* [`be/src/service/service_be/lake_service.cpp`](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaL353-R361): Replaced `emplace` with `Swap` in `AggregatePublishContext` to avoid unnecessary metadata copying, improving performance.

### Test enhancements:
* [`be/test/service/lake_service_test.cpp`](diffhunk://#diff-7e7546a285303649b12ec94135003c7c099a4b032ebe2ae95a044ea791386d5fR2618-R2630): Added assertions in `test_aggregate_publish_version` to validate tablet metadata correctness for multiple tablet IDs, improving test coverage and reliability.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
