### PR TITLE
[Enhancement] reuse I/O when reading bundled tablet meta

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -48,6 +48,7 @@
 #include "storage/rowset/segment.h"
 #include "storage/tablet_schema_map.h"
 #include "testutil/sync_point.h"
+#include "util/defer_op.h"
 #include "util/failpoint/fail_point.h"
 #include "util/raw_container.h"
 #include "util/trace.h"
@@ -63,6 +64,10 @@ static bvar::LatencyRecorder g_put_tablet_metadata_latency("lake", "put_tablet_m
 static bvar::LatencyRecorder g_get_txn_log_latency("lake", "get_txn_log");
 static bvar::LatencyRecorder g_put_txn_log_latency("lake", "put_txn_log");
 static bvar::LatencyRecorder g_del_txn_log_latency("lake", "del_txn_log");
+static bvar::Adder<int64_t> g_read_bundle_tablet_meta_cnt("lake", "lake_read_bundle_tablet_meta_cnt");
+static bvar::Adder<int64_t> g_read_bundle_tablet_meta_real_access_cnt("lake",
+                                                                      "lake_read_bundle_tablet_meta_real_access_cnt");
+static bvar::LatencyRecorder g_read_bundle_tablet_meta_latency("lake", "lake_read_bundle_tablet_meta_latency");
 
 TabletManager::TabletManager(std::shared_ptr<LocationProvider> location_provider, UpdateManager* update_mgr,
                              int64_t cache_capacity)
@@ -503,6 +508,7 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
         return Status::NotFound("Not found expected tablet metadata");
     }
     auto path = bundle_tablet_metadata_location(tablet_id, version);
+    ASSIGN_OR_RETURN(auto real_path, _location_provider->real_location(path));
     std::shared_ptr<FileSystem> file_system;
     if (!fs) {
         ASSIGN_OR_RETURN(file_system, FileSystem::CreateSharedFromString(path));
@@ -514,10 +520,16 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
     // `read_all` only need to one api call and not increase the IOPS
     // but it will incur additional IO bandwidth overhead
     // Perhaps we need to consider the additional costs of IO bandwidth and IOPS later.
-    auto serialized_string = _bundle_tablet_metadata_group.Do(path, [&]() {
-        ASSIGN_OR_RETURN(auto input_file, file_system->new_random_access_file(opts, path));
-        return input_file->read_all();
-    });
+    g_read_bundle_tablet_meta_cnt << 1;
+    auto t0 = butil::gettimeofday_us();
+    // use real path as key, so that every tablet can share a same path of bundle tablet meta.
+    ASSIGN_OR_RETURN(auto serialized_string,
+                     _bundle_tablet_metadata_group.Do(real_path, [&]() -> StatusOr<std::string> {
+                         g_read_bundle_tablet_meta_real_access_cnt << 1;
+                         ASSIGN_OR_RETURN(auto input_file, file_system->new_random_access_file(opts, path));
+                         return input_file->read_all();
+                     }));
+    g_read_bundle_tablet_meta_latency << (butil::gettimeofday_us() - t0);
 
     auto file_size = serialized_string.size();
     ASSIGN_OR_RETURN(auto bundle_metadata, parse_bundle_tablet_metadata(path, serialized_string));

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -253,6 +253,7 @@ private:
 
     bthreads::singleflight::Group<std::string, StatusOr<TabletSchemaPtr>> _schema_group;
     bthreads::singleflight::Group<std::string, StatusOr<CombinedTxnLogPtr>> _combined_txn_log_group;
+    bthreads::singleflight::Group<std::string, StatusOr<std::string>> _bundle_tablet_metadata_group;
 };
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -699,8 +699,8 @@ TEST_F(LakeTabletManagerTest, put_bundle_tablet_metadata) {
                         auto res = _tablet_manager->get_tablet_metadata(i + 1, 2);
                         ASSERT_TRUE(res.ok());
                         TabletMetadataPtr metadata = std::move(res).value();
-                        ASSERT_EQ(metadata->schema().id(), 10);
-                        ASSERT_EQ(metadata->historical_schemas_size(), 2);
+                        ASSERT_EQ(metadata->schema().id(), 10 + i);
+                        ASSERT_EQ(metadata->historical_schemas_size(), 2 + i);
                         // check id
                         ASSERT_EQ(metadata->id(), i + 1);
                         // check version
@@ -714,6 +714,8 @@ TEST_F(LakeTabletManagerTest, put_bundle_tablet_metadata) {
     }
 
     {
+        // prune metacache
+        _tablet_manager->prune_metacache();
         std::string fp_name = "tablet_schema_not_found_in_bundle_metadata";
         auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get(fp_name);
         PFailPointTriggerMode trigger_mode;

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -690,6 +690,29 @@ TEST_F(LakeTabletManagerTest, put_bundle_tablet_metadata) {
         ASSERT_EQ(metadata->historical_schemas_size(), 2);
     }
 
+    // multi thread read
+    {
+        std::vector<std::thread> threads;
+        for (int i = 0; i < 2; ++i) {
+            threads.emplace_back(
+                    [&](int i) {
+                        auto res = _tablet_manager->get_tablet_metadata(i + 1, 2);
+                        ASSERT_TRUE(res.ok());
+                        TabletMetadataPtr metadata = std::move(res).value();
+                        ASSERT_EQ(metadata->schema().id(), 10);
+                        ASSERT_EQ(metadata->historical_schemas_size(), 2);
+                        // check id
+                        ASSERT_EQ(metadata->id(), i + 1);
+                        // check version
+                        ASSERT_EQ(metadata->version(), 2);
+                    },
+                    i);
+        }
+        for (auto& thread : threads) {
+            thread.join();
+        }
+    }
+
     {
         std::string fp_name = "tablet_schema_not_found_in_bundle_metadata";
         auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get(fp_name);


### PR DESCRIPTION
## Why I'm doing:
The bundle tablet meta file may be read by multiple tablets simultaneously. In this case, I/O reuse can be used to reduce I/O bandwidth overhead.

## What I'm doing:
This pull request introduces enhancements to the `TabletManager` in the `lake` storage module, focusing on improving metadata handling, performance monitoring, and concurrency support. Key changes include adding latency and access counters, implementing a singleflight group for shared metadata access, and enhancing test coverage for multithreaded scenarios.

### Enhancements to metadata handling and performance monitoring:

* Added new latency and access counters (`g_read_bundle_tablet_meta_cnt`, `g_read_bundle_tablet_meta_real_access_cnt`, and `g_read_bundle_tablet_meta_latency`) to monitor metadata access patterns and performance. (`be/src/storage/lake/tablet_manager.cpp`, [be/src/storage/lake/tablet_manager.cppR67-R70](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4R67-R70))
* Updated `get_single_tablet_metadata` to use a real path for metadata lookup and added performance tracking for metadata access latency and I/O operations. (`be/src/storage/lake/tablet_manager.cpp`, [[1]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4R511) [[2]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4R523-R532)

### Concurrency and shared metadata access:

* Introduced a `bthreads::singleflight::Group` (`_bundle_tablet_metadata_group`) to ensure shared access to bundle tablet metadata, reducing redundant I/O operations. (`be/src/storage/lake/tablet_manager.h`, [be/src/storage/lake/tablet_manager.hR256](diffhunk://#diff-b77a64b082da0ac0fd8b28d7f521dbe7e1d235289127491a7aa865f774a6446bR256))

### Test coverage improvements:

* Added a multithreaded test case to verify the correctness of concurrent metadata access in `LakeTabletManagerTest`. (`be/test/storage/lake/tablet_manager_test.cpp`, [be/test/storage/lake/tablet_manager_test.cppR693-R715](diffhunk://#diff-6f0e388b15b892ba0dfe1c361354d61cc3ba3577b328fa11c1c3d49fe345fef6R693-R715))

### Additional updates:

* Included the `defer_op.h` utility header to support deferred operations. (`be/src/storage/lake/tablet_manager.cpp`, [be/src/storage/lake/tablet_manager.cppR51](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4R51))

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
