### PR TITLE
[Enhancement] Add a cleaner for BrpcStubCache to cleanup unused connections

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -58,6 +58,9 @@ CONF_String(ssl_private_key_path, "");
 // The max number of single connections maintained by the brpc client and each server.
 // These connections are created during the first few access and will be used thereafter
 CONF_Int32(brpc_max_connections_per_server, "1");
+// BRPC stub cache expire configurations
+// The expire time of BRPC stub cache, default 60 minutes.
+CONF_mInt32(brpc_stub_expire_s, "3600"); // 60 minutes
 
 // Declare a selection strategy for those servers have many ips.
 // Note that there should at most one ip match this list.

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -498,7 +498,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
 #endif
     _load_channel_mgr = new LoadChannelMgr();
     _load_stream_mgr = new LoadStreamMgr();
-    _brpc_stub_cache = new BrpcStubCache();
+    _brpc_stub_cache = new BrpcStubCache(this);
     _stream_load_executor = new StreamLoadExecutor(this);
     _stream_context_mgr = new StreamContextMgr();
     _transaction_mgr = new TransactionMgr(this);

--- a/be/src/util/brpc_stub_cache.cpp
+++ b/be/src/util/brpc_stub_cache.cpp
@@ -25,7 +25,6 @@ namespace starrocks {
 
 BrpcStubCache::BrpcStubCache(ExecEnv* exec_env) : _pipeline_timer(exec_env->pipeline_timer()) {
     _stub_map.init(239);
-    _pipeline_timer = exec_env->pipeline_timer();
     REGISTER_GAUGE_STARROCKS_METRIC(brpc_endpoint_stub_count, [this]() {
         std::lock_guard<SpinLock> l(_lock);
         return _stub_map.size();

--- a/be/src/util/brpc_stub_cache.cpp
+++ b/be/src/util/brpc_stub_cache.cpp
@@ -14,17 +14,16 @@
 
 #include "util/brpc_stub_cache.h"
 
-#include <runtime/exec_env.h>
-
 #include "common/config.h"
 #include "gen_cpp/internal_service.pb.h"
 #include "gen_cpp/lake_service.pb.h"
+#include "runtime/exec_env.h"
 #include "util/failpoint/fail_point.h"
 #include "util/starrocks_metrics.h"
 
 namespace starrocks {
 
-BrpcStubCache::BrpcStubCache(ExecEnv* exec_env) {
+BrpcStubCache::BrpcStubCache(ExecEnv* exec_env) : _pipeline_timer(exec_env->pipeline_timer()) {
     _stub_map.init(239);
     _pipeline_timer = exec_env->pipeline_timer();
     REGISTER_GAUGE_STARROCKS_METRIC(brpc_endpoint_stub_count, [this]() {
@@ -61,11 +60,12 @@ std::shared_ptr<PInternalService_RecoverableStub> BrpcStubCache::get_stub(const 
         stub_pool = _stub_map.seek(endpoint);
     }
 
-    _pipeline_timer->unschedule((*stub_pool)->_cleanup_task);
-    timespec tm = butil::seconds_from_now(config::brpc_stub_expire_s);
-    auto status = _pipeline_timer->schedule((*stub_pool)->_cleanup_task, tm);
-    if (!status.ok()) {
-        LOG(WARNING) << "Failed to schedule brpc cleanup task: " << endpoint;
+    if (_pipeline_timer->unschedule((*stub_pool)->_cleanup_task) != 1) {
+        timespec tm = butil::seconds_from_now(config::brpc_stub_expire_s);
+        auto status = _pipeline_timer->schedule((*stub_pool)->_cleanup_task, tm);
+        if (!status.ok()) {
+            LOG(WARNING) << "Failed to schedule brpc cleanup task: " << endpoint;
+        }
     }
 
     return (*stub_pool)->get_or_create(endpoint);
@@ -134,7 +134,6 @@ HttpBrpcStubCache* HttpBrpcStubCache::getInstance() {
 
 HttpBrpcStubCache::HttpBrpcStubCache() {
     _stub_map.init(500);
-    _task_map.init(500);
     _pipeline_timer = ExecEnv::GetInstance()->pipeline_timer();
 }
 
@@ -143,8 +142,8 @@ HttpBrpcStubCache::~HttpBrpcStubCache() {
 
     {
         std::lock_guard<SpinLock> l(_lock);
-        for (auto& stub : _task_map) {
-            task_to_cleanup.push_back(stub.second);
+        for (auto& stub : _stub_map) {
+            task_to_cleanup.push_back(stub.second.second);
         }
     }
 
@@ -153,7 +152,6 @@ HttpBrpcStubCache::~HttpBrpcStubCache() {
     }
 
     _stub_map.clear();
-    _task_map.clear();
 }
 
 StatusOr<std::shared_ptr<PInternalService_RecoverableStub>> HttpBrpcStubCache::get_http_stub(
@@ -176,32 +174,29 @@ StatusOr<std::shared_ptr<PInternalService_RecoverableStub>> HttpBrpcStubCache::g
     // get is exist
     std::lock_guard<SpinLock> l(_lock);
 
-    // schedule clean up task
-    auto task = _task_map.seek(endpoint);
-    if (task == nullptr) {
+    auto stub_pair_ptr = _stub_map.seek(endpoint);
+    if (stub_pair_ptr == nullptr) {
+        // create
         auto new_task = std::make_shared<HttpEndpointCleanupTask>(this, endpoint);
-        _task_map.insert(endpoint, new_task);
-        task = _task_map.seek(endpoint);
-    }
-    _pipeline_timer->unschedule((*task).get());
-    timespec tm = butil::seconds_from_now(config::brpc_stub_expire_s);
-    auto status = _pipeline_timer->schedule((*task).get(), tm);
-    if (!status.ok()) {
-        LOG(WARNING) << "Failed to schedule http brpc cleanup task: " << endpoint;
+        auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint, "http");
+        if (!stub->reset_channel().ok()) {
+            return Status::RuntimeError("init brpc http channel error on " + taddr.hostname + ":" +
+                                        std::to_string(taddr.port));
+        }
+        _stub_map.insert(endpoint, std::make_pair(stub, new_task));
+        stub_pair_ptr = _stub_map.seek(endpoint);
     }
 
-    auto stub_ptr = _stub_map.seek(endpoint);
-    if (stub_ptr != nullptr) {
-        return *stub_ptr;
+    // schedule clean up task
+    if (_pipeline_timer->unschedule((*stub_pair_ptr).second.get()) != 1) {
+        timespec tm = butil::seconds_from_now(config::brpc_stub_expire_s);
+        auto status = _pipeline_timer->schedule((*stub_pair_ptr).second.get(), tm);
+        if (!status.ok()) {
+            LOG(WARNING) << "Failed to schedule http brpc cleanup task: " << endpoint;
+        }
     }
-    // create
-    auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint, "http");
-    if (!stub->reset_channel().ok()) {
-        return Status::RuntimeError("init brpc http channel error on " + taddr.hostname + ":" +
-                                    std::to_string(taddr.port));
-    }
-    _stub_map.insert(endpoint, stub);
-    return stub;
+
+    return (*stub_pair_ptr).first;
 }
 
 void HttpBrpcStubCache::cleanup_expired(const butil::EndPoint& endpoint) {
@@ -209,7 +204,6 @@ void HttpBrpcStubCache::cleanup_expired(const butil::EndPoint& endpoint) {
 
     LOG(INFO) << "cleanup http stubs from endpoint:" << endpoint;
     _stub_map.erase(endpoint);
-    _task_map.erase(endpoint);
 }
 
 LakeServiceBrpcStubCache* LakeServiceBrpcStubCache::getInstance() {
@@ -219,7 +213,6 @@ LakeServiceBrpcStubCache* LakeServiceBrpcStubCache::getInstance() {
 
 LakeServiceBrpcStubCache::LakeServiceBrpcStubCache() {
     _stub_map.init(500);
-    _task_map.init(500);
     _pipeline_timer = ExecEnv::GetInstance()->pipeline_timer();
 }
 
@@ -228,8 +221,8 @@ LakeServiceBrpcStubCache::~LakeServiceBrpcStubCache() {
 
     {
         std::lock_guard<SpinLock> l(_lock);
-        for (auto& stub : _task_map) {
-            task_to_cleanup.push_back(stub.second);
+        for (auto& stub : _stub_map) {
+            task_to_cleanup.push_back(stub.second.second);
         }
     }
 
@@ -238,7 +231,6 @@ LakeServiceBrpcStubCache::~LakeServiceBrpcStubCache() {
     }
 
     _stub_map.clear();
-    _task_map.clear();
 }
 
 DEFINE_FAIL_POINT(get_stub_return_nullptr);
@@ -258,33 +250,29 @@ StatusOr<std::shared_ptr<starrocks::LakeService_RecoverableStub>> LakeServiceBrp
     // get if exist
     std::lock_guard<SpinLock> l(_lock);
 
-    // schedule clean up task
-    auto task = _task_map.seek(endpoint);
-    if (task == nullptr) {
+    auto stub_pair_ptr = _stub_map.seek(endpoint);
+    FAIL_POINT_TRIGGER_EXECUTE(get_stub_return_nullptr, { stub_pair_ptr = nullptr; });
+    if (stub_pair_ptr == nullptr) {
+        // create
+        auto stub = std::make_shared<starrocks::LakeService_RecoverableStub>(endpoint, "");
         auto new_task = std::make_shared<LakeEndpointCleanupTask>(this, endpoint);
-        _task_map.insert(endpoint, new_task);
-        task = _task_map.seek(endpoint);
-    }
-    _pipeline_timer->unschedule((*task).get());
-    timespec tm = butil::seconds_from_now(config::brpc_stub_expire_s);
-    auto status = _pipeline_timer->schedule((*task).get(), tm);
-    if (!status.ok()) {
-        LOG(WARNING) << "Failed to schedule lake brpc cleanup task: " << endpoint;
+        if (!stub->reset_channel().ok()) {
+            return Status::RuntimeError("init brpc lake channel error on " + host + ":" + std::to_string(port));
+        }
+        _stub_map.insert(endpoint, std::make_pair(stub, new_task));
+        stub_pair_ptr = _stub_map.seek(endpoint);
     }
 
-    auto stub_ptr = _stub_map.seek(endpoint);
-    FAIL_POINT_TRIGGER_EXECUTE(get_stub_return_nullptr, { stub_ptr = nullptr; });
-    if (stub_ptr != nullptr) {
-        return *stub_ptr;
+    // schedule clean up task
+    if (_pipeline_timer->unschedule((*stub_pair_ptr).second.get()) != 1) {
+        timespec tm = butil::seconds_from_now(config::brpc_stub_expire_s);
+        auto status = _pipeline_timer->schedule((*stub_pair_ptr).second.get(), tm);
+        if (!status.ok()) {
+            LOG(WARNING) << "Failed to schedule lake brpc cleanup task: " << endpoint;
+        }
     }
-    // create
-    auto stub = std::make_shared<starrocks::LakeService_RecoverableStub>(endpoint, "");
 
-    if (!stub->reset_channel().ok()) {
-        return Status::RuntimeError("init brpc http channel error on " + host + ":" + std::to_string(port));
-    }
-    _stub_map.insert(endpoint, stub);
-    return stub;
+    return (*stub_pair_ptr).first;
 }
 
 void LakeServiceBrpcStubCache::cleanup_expired(const butil::EndPoint& endpoint) {
@@ -292,7 +280,6 @@ void LakeServiceBrpcStubCache::cleanup_expired(const butil::EndPoint& endpoint) 
 
     LOG(INFO) << "cleanup lake service stubs from endpoint:" << endpoint;
     _stub_map.erase(endpoint);
-    _task_map.erase(endpoint);
 }
 
 void EndpointCleanupTask::Run() {

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -34,13 +34,12 @@
 
 #pragma once
 
-#include <exec/pipeline/schedule/pipeline_timer.h>
-
 #include <memory>
 #include <mutex>
 #include <vector>
 
 #include "common/statusor.h"
+#include "exec/pipeline/schedule/pipeline_timer.h"
 #include "gen_cpp/Types_types.h" // TNetworkAddress
 #include "service/brpc.h"
 #include "util/internal_service_recoverable_stub.h"
@@ -94,8 +93,9 @@ private:
     ~HttpBrpcStubCache();
 
     SpinLock _lock;
-    butil::FlatMap<butil::EndPoint, std::shared_ptr<PInternalService_RecoverableStub>> _stub_map;
-    butil::FlatMap<butil::EndPoint, std::shared_ptr<HttpEndpointCleanupTask>> _task_map;
+    butil::FlatMap<butil::EndPoint, std::pair<std::shared_ptr<PInternalService_RecoverableStub>,
+                                              std::shared_ptr<HttpEndpointCleanupTask>>>
+            _stub_map;
     pipeline::PipelineTimer* _pipeline_timer;
 };
 
@@ -112,8 +112,9 @@ private:
     ~LakeServiceBrpcStubCache();
 
     SpinLock _lock;
-    butil::FlatMap<butil::EndPoint, std::shared_ptr<LakeService_RecoverableStub>> _stub_map;
-    butil::FlatMap<butil::EndPoint, std::shared_ptr<LakeEndpointCleanupTask>> _task_map;
+    butil::FlatMap<butil::EndPoint,
+                   std::pair<std::shared_ptr<LakeService_RecoverableStub>, std::shared_ptr<LakeEndpointCleanupTask>>>
+            _stub_map;
     pipeline::PipelineTimer* _pipeline_timer;
 };
 

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -91,7 +91,7 @@ public:
         config::streaming_load_max_mb = 1;
 
         _env._load_stream_mgr = new LoadStreamMgr();
-        _env._brpc_stub_cache = new BrpcStubCache();
+        _env._brpc_stub_cache = new BrpcStubCache(&_env);
         _env._stream_load_executor = new StreamLoadExecutor(&_env);
 
         _evhttp_req = evhttp_request_new(nullptr, nullptr);

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -68,7 +68,7 @@ public:
         config::streaming_load_max_mb = 1;
 
         _env._load_stream_mgr = new LoadStreamMgr();
-        _env._brpc_stub_cache = new BrpcStubCache();
+        _env._brpc_stub_cache = new BrpcStubCache(&_env);
         _env._stream_load_executor = new StreamLoadExecutor(&_env);
         _env._stream_context_mgr = new StreamContextMgr();
         _env._transaction_mgr = new TransactionMgr(&_env);

--- a/be/test/util/brpc_stub_cache_test.cpp
+++ b/be/test/util/brpc_stub_cache_test.cpp
@@ -138,4 +138,37 @@ TEST_F(BrpcStubCacheTest, test_cleanup) {
     ASSERT_NE(stub3, stub1);
 }
 
+TEST_F(BrpcStubCacheTest, test_lake_cleanup) {
+    config::brpc_stub_expire_s = 1;
+    LakeServiceBrpcStubCache cache;
+    std::string hostname = "127.0.0.1";
+    int32_t port = 123;
+    auto stub1 = cache.get_stub(hostname, port);
+    ASSERT_TRUE(stub1.ok());
+    ASSERT_NE(nullptr, *stub1);
+    auto stub2 = cache.get_stub(hostname, port);
+    ASSERT_TRUE(stub1.ok());
+    ASSERT_EQ(*stub2, *stub1);
+
+    sleep(2);
+    auto stub3 = cache.get_stub(hostname, port);
+    ASSERT_NE(*stub3, *stub1);
+}
+
+TEST_F(BrpcStubCacheTest, test_http_cleanup) {
+    config::brpc_stub_expire_s = 1;
+    HttpBrpcStubCache cache;
+    TNetworkAddress address;
+    address.hostname = "127.0.0.1";
+    address.port = 123;
+    auto stub1 = cache.get_http_stub(address);
+    ASSERT_NE(nullptr, *stub1);
+    auto stub2 = cache.get_http_stub(address);
+    ASSERT_EQ(*stub2, *stub1);
+
+    sleep(2);
+    auto stub3 = cache.get_http_stub(address);
+    ASSERT_NE(*stub3, *stub1);
+}
+
 } // namespace starrocks

--- a/be/test/util/brpc_stub_cache_test.cpp
+++ b/be/test/util/brpc_stub_cache_test.cpp
@@ -18,7 +18,9 @@
 #include "util/brpc_stub_cache.h"
 
 #include <gtest/gtest.h>
+#include <testutil/assert.h>
 
+#include "runtime/exec_env.h"
 #include "util/failpoint/fail_point.h"
 
 namespace starrocks {
@@ -27,10 +29,22 @@ class BrpcStubCacheTest : public testing::Test {
 public:
     BrpcStubCacheTest() = default;
     ~BrpcStubCacheTest() override = default;
+    void SetUp() override {
+        _env._pipeline_timer = new pipeline::PipelineTimer();
+        ASSERT_OK(_env._pipeline_timer->start());
+    }
+    void TearDown() override {
+        delete _env._pipeline_timer;
+        _env._pipeline_timer = nullptr;
+        config::brpc_stub_expire_s = 3600;
+    }
+
+private:
+    ExecEnv _env;
 };
 
 TEST_F(BrpcStubCacheTest, normal) {
-    BrpcStubCache cache;
+    BrpcStubCache cache(&_env);
     TNetworkAddress address;
     address.hostname = "127.0.0.1";
     address.port = 123;
@@ -46,7 +60,7 @@ TEST_F(BrpcStubCacheTest, normal) {
 }
 
 TEST_F(BrpcStubCacheTest, invalid) {
-    BrpcStubCache cache;
+    BrpcStubCache cache(&_env);
     TNetworkAddress address;
     address.hostname = "invalid.cm.invalid";
     address.port = 123;
@@ -55,7 +69,7 @@ TEST_F(BrpcStubCacheTest, invalid) {
 }
 
 TEST_F(BrpcStubCacheTest, reset) {
-    BrpcStubCache cache;
+    BrpcStubCache cache(&_env);
     TNetworkAddress address;
     address.hostname = "127.0.0.1";
     address.port = 123;
@@ -106,6 +120,22 @@ TEST_F(BrpcStubCacheTest, test_http_stub) {
     address.hostname = "invalid.cm.invalid";
     auto stub4 = cache.get_http_stub(address);
     ASSERT_EQ(nullptr, *stub4);
+}
+
+TEST_F(BrpcStubCacheTest, test_cleanup) {
+    config::brpc_stub_expire_s = 1;
+    BrpcStubCache cache(&_env);
+    TNetworkAddress address;
+    address.hostname = "127.0.0.1";
+    address.port = 123;
+    auto stub1 = cache.get_stub(address);
+    ASSERT_NE(nullptr, stub1);
+    auto stub2 = cache.get_stub(address);
+    ASSERT_EQ(stub2, stub1);
+
+    sleep(2);
+    auto stub3 = cache.get_stub(address);
+    ASSERT_NE(stub3, stub1);
 }
 
 } // namespace starrocks

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -256,6 +256,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Description: The maximum body size of a bRPC.
 - Introduced in: -
 
+##### brpc_stub_expire_s
+
+- Default: 3600
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: The expire time of BRPC stub cache, default 60 minutes.
+- Introduced in: -
+
 <!--
 ##### brpc_socket_max_unwritten_bytes
 


### PR DESCRIPTION
[Enhancement] Add a cleaner for BrpcStubCache to cleanup unused connections
## Why I'm doing:
The BRPC Stub cache will never be evicted and will always stored in the cache.
Therefore there will be some bug here.
In the case that when users are using K8s to deploy the StarRocks backend, after sometime running there will be many log like this.
<img width="2184" height="1038" alt="image" src="https://github.com/user-attachments/assets/1fe656df-b846-4a72-9323-936fa32dd10f" />
After check the BRPC code in https://github.com/apache/brpc/blob/1.8.0/src/brpc/socket.cpp#L1340
And from the grafana monitor 
<img width="3296" height="1150" alt="image" src="https://github.com/user-attachments/assets/2a4d5470-173e-457e-af61-526a00339636" />
This cluster have 148 BE nodes, normally it will be about 148 BRPC stub but after some times running, some pods restarted and the IP changed, some of the node BRPC stub creased to over 200.
And as we all known the endpoint in BRPC are made of ip and host, that means if the IP is changed the endpoint will still in the cache.
## What I'm doing:
Here I introduce a BrpcStubManager to periodically check and cleanup expired BRPC stub for BrpcStubCache, HttpBrpcStubCache and LakeServiceBrpcStubCache 
1. Record the last access time when get the stub for given endpoint
2. Loop all the endpoint in `_stub_map` or `_last_access_time_map` check if now - last_access_time is larger than expire time or not
3. If less, will not clean up the endpoint
4. If larger or equal, will try to clean up the endpoint
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3