### PR TITLE
[Feature] Add ability to send FE logs to open telemetry

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -670,12 +670,26 @@ under the License.
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <version>1.34.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-exporter-otlp -->
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-log4j-appender-2.17 -->
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-log4j-appender-2.17</artifactId>
+            <version>2.18.1-alpha</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-resources</artifactId>
+            <version>2.18.1-alpha</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client -->

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -124,6 +124,15 @@ public class Config extends ConfigBase {
     public static int sys_log_json_profile_max_string_length = 104857600;
 
     /**
+     * OpenTelemetry collector endpoint URL for logs
+     * Example: http://localhost:4318/v1/logs
+     * If empty or not set, OpenTelemetry logging will not be enabled.
+     * Default is empty
+     */
+    @ConfField
+    public static String otlp_exporter_http_log_endpoint = "";
+
+    /**
      * audit_log_dir:
      * This specifies FE audit log dir.
      * Audit log fe.audit.log contains all requests with related infos such as user, host, cost, status, etc.

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1087,10 +1087,11 @@ under the License.
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>1.14.0</version>
+                <version>1.52.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
 
             <!-- https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client -->
             <dependency>


### PR DESCRIPTION
## Why I'm doing:

See the issue description

## What I'm doing:

Fixes [#61460](https://github.com/StarRocks/starrocks/issues/61460)

Added ability to export logs to open telemetry directly.

Updated OTEL sdk to more fresh version.

Specifying version of jaeger explicitly, because it was deprecated and removed from otel-bom.
Not adding otel-instrumentation bom, because `log4j-appender-2.17` is not part of it.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
