### PR TITLE
[Enhancement] enable the shared_scan by default

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1024,7 +1024,13 @@ CONF_mBool(enable_adjustment_page_cache_skip, "true");
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
 CONF_mBool(io_coalesce_adaptive_lazy_active, "true");
+// The number of IO tasks per scan operator
 CONF_Int32(io_tasks_per_scan_operator, "4");
+// The number of chunks of each IO task
+CONF_mInt32(io_task_batch_size, "64");
+// Every N chunks, the shared_scan would switch to a new operator
+CONF_mInt32(io_task_shared_scan_step_size, "16");
+
 CONF_Int32(connector_io_tasks_per_scan_operator, "16");
 CONF_Int32(connector_io_tasks_min_size, "2");
 CONF_Int32(connector_io_tasks_adjust_interval_ms, "50");

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
@@ -37,7 +37,7 @@ public:
     size_t size(int buffer_index) const;
     bool empty(int buffer_index) const;
     bool try_get(int buffer_index, ChunkPtr* output_chunk);
-    bool put(int buffer_index, ChunkPtr chunk, ChunkBufferTokenPtr chunk_token);
+    bool put(int buffer_index, int* actual_buffer, ChunkPtr chunk, ChunkBufferTokenPtr chunk_token);
     void close();
     // Mark that it needn't produce any chunk anymore.
     void set_finished(int buffer_index);

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
@@ -45,6 +45,7 @@ public:
     ChunkBufferLimiter* limiter() { return _limiter.get(); }
     void update_limiter(Chunk* chunk);
 
+    BalanceStrategy strategy() const { return _strategy; }
     int64_t memory_usage() const { return _memory_usage; }
 
 private:

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
@@ -22,7 +22,6 @@
 
 namespace starrocks::pipeline {
 
-// TODO: support hash distribution instead of simple round-robin
 enum BalanceStrategy {
     kDirect,     // Assign chunks from input operator to output operator directly
     kRoundRobin, // Assign chunks from input operator to output with round-robin strategy

--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
@@ -126,24 +126,13 @@ public:
     ChunkBufferTokenPtr pin(int num_chunks) override;
     void unpin(int num_chunks);
 
-    bool is_full() const override {
-        if (_pinned_chunks_counter >= _capacity) {
-            _returned_full_event.store(true, std::memory_order_release);
-            return true;
-        }
-        return false;
-    }
     size_t size() const override { return _pinned_chunks_counter; }
     size_t capacity() const override { return _capacity; }
     size_t default_capacity() const override { return _default_capacity; }
     void update_mem_limit(int64_t value) override;
-    bool has_full_events() override {
-        if (!_has_full_event.load(std::memory_order_acquire)) {
-            return false;
-        }
-        bool val = true;
-        return _has_full_event.compare_exchange_strong(val, false);
-    }
+
+    bool is_full() const override;
+    bool has_full_events() override;
 
 private:
 private:

--- a/be/src/exec/pipeline/scan/chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/chunk_source.cpp
@@ -68,31 +68,42 @@ Status ChunkSource::buffer_next_batch_chunks_blocking(RuntimeState* state, size_
 
             ChunkPtr chunk;
             _status = _read_chunk(state, &chunk);
-            // notify when generate new chunk
-            int actual_seq = _scan_operator_seq;
-            auto notify = scan_defer_notify(_scan_op, actual_seq);
             // we always output a empty chunk instead of nullptr, because we need set tablet_id and is_last_chunk flag
             // in the chunk.
             if (chunk == nullptr) {
                 chunk = std::make_shared<Chunk>();
             }
+
+            int actual_seq = _scan_operator_seq;
+            bool should_exit = false;
+            bool is_last = false;
             if (!_status.ok()) {
-                // end of file is normal case, need process chunk
+                // End of file is a normal case, need to process chunk
                 if (_status.is_end_of_file()) {
-                    chunk->owner_info().set_owner_id(owner_id, true);
-                    _chunk_buffer.put(_scan_operator_seq, &actual_seq, std::move(chunk), std::move(_chunk_token));
+                    is_last = true;
                 } else if (_status.is_time_out()) {
-                    chunk->owner_info().set_owner_id(owner_id, false);
-                    _chunk_buffer.put(_scan_operator_seq, &actual_seq, std::move(chunk), std::move(_chunk_token));
                     _status = Status::OK();
                 }
-                break;
+                should_exit = true;
             }
 
             // schema won't be used by the computing layer, here we just reset it.
             chunk->reset_schema();
-            chunk->owner_info().set_owner_id(owner_id, false);
+            chunk->owner_info().set_owner_id(owner_id, is_last);
             _chunk_buffer.put(_scan_operator_seq, &actual_seq, std::move(chunk), std::move(_chunk_token));
+
+            if (_chunk_buffer.strategy() == kRoundRobin) {
+                // notify the specified operator in round-robin strategy
+                auto notify = scan_defer_notify(_scan_op, actual_seq);
+            } else {
+                // notify the local operator
+                auto notify = scan_defer_notify(_scan_op);
+            }
+
+            if (should_exit) {
+                // Exit the loop after processing the chunk for end of file or timeout
+                break;
+            }
         }
 
         if (time_spent_ns >= workgroup::WorkGroup::YIELD_MAX_TIME_SPENT) {

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -135,7 +135,7 @@ void ScanOperator::close(RuntimeState* state) {
 
 size_t ScanOperator::_buffer_unplug_threshold() const {
     size_t threshold = buffer_capacity() / _dop / 2;
-    threshold = std::max<size_t>(1, std::min<size_t>(kIOTaskBatchSize, threshold));
+    threshold = std::max<size_t>(1, std::min<size_t>(config::io_task_batch_size, threshold));
     return threshold;
 }
 
@@ -480,7 +480,8 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             Status status;
 
             if (start_status.ok()) {
-                status = chunk_source->buffer_next_batch_chunks_blocking(state, kIOTaskBatchSize, _workgroup.get());
+                status = chunk_source->buffer_next_batch_chunks_blocking(state, config::io_task_batch_size,
+                                                                         _workgroup.get());
             }
 
             if (!status.ok() && !status.is_end_of_file()) {

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -115,6 +115,11 @@ public:
         });
     }
 
+    // notify the operator with the given driver sequence
+    auto defer_notify(int& driver_seq) {
+        return DeferOp([this, &driver_seq]() { _source_factory()->observes().notify_source_observer(driver_seq); });
+    }
+
 protected:
     // TODO: remove this to the base ScanContext.
     /// Shared scan
@@ -320,6 +325,11 @@ protected:
 
 inline auto scan_defer_notify(ScanOperator* scan_op) {
     return scan_op->defer_notify([scan_op]() -> bool { return scan_op->need_notify_all(); });
+}
+
+// notify the operator with the given driver sequence
+inline auto scan_defer_notify(ScanOperator* scan_op, int& seq) {
+    return scan_op->defer_notify(seq);
 }
 
 pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperatorFactory> factory, ScanNode* scan_node,

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -117,7 +117,13 @@ public:
 
     // notify the operator with the given driver sequence
     auto defer_notify(int& driver_seq) {
-        return DeferOp([this, &driver_seq]() { _source_factory()->observes().notify_source_observer(driver_seq); });
+        return DeferOp([this, &driver_seq]() {
+            if (driver_seq == _driver_sequence) {
+                _observable.notify_source_observers();
+            } else {
+                _source_factory()->observes().notify_source_observer(driver_seq);
+            }
+        });
     }
 
 protected:

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -41,7 +41,7 @@ public:
 
     ~ScanOperator() override;
 
-    static size_t max_buffer_capacity() { return kIOTaskBatchSize; }
+    static size_t max_buffer_capacity() { return config::io_task_batch_size; }
 
     Status prepare(RuntimeState* state) override;
 
@@ -116,8 +116,6 @@ public:
     }
 
 protected:
-    static constexpr size_t kIOTaskBatchSize = 64;
-
     // TODO: remove this to the base ScanContext.
     /// Shared scan
     virtual void attach_chunk_source(int32_t source_index) = 0;

--- a/be/src/exec/pipeline/schedule/observer.h
+++ b/be/src/exec/pipeline/schedule/observer.h
@@ -117,6 +117,14 @@ public:
             observer->source_trigger();
         }
     }
+    // notify the operator with the given driver sequence
+    // NOTE: The index of _observers directly corresponds to the driver sequence,
+    // because each observer is registered in order during the prepare phase for each operator.
+    // This ensures that observer access by sequence number is safe and consistent.
+    void notify_source_observer(int seq) {
+        DCHECK(seq >= 0 && seq < _observers.size());
+        _observers[seq]->source_trigger();
+    }
     void notify_sink_observers() {
         for (auto* observer : _observers) {
             observer->sink_trigger();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1063,7 +1063,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = TABLET_INTERNAL_PARALLEL_MODE, flag = VariableMgr.INVISIBLE)
     private String tabletInternalParallelMode = "auto";
 
-    @VariableMgr.VarAttr(name = ENABLE_SHARED_SCAN_V2, alias = ENABLE_SHARED_SCAN, show = ENABLE_SHARED_SCAN)
+    @VariableMgr.VarAttr(name = ENABLE_SHARED_SCAN) 
     private boolean enableSharedScan = true;
 
     // max memory used on each fragment instance

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -290,6 +290,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String TABLET_INTERNAL_PARALLEL_MODE = "tablet_internal_parallel_mode";
     public static final String ENABLE_SHARED_SCAN = "enable_shared_scan";
+    public static final String ENABLE_SHARED_SCAN_V2 = "enable_shared_scan_v2";
     public static final String PIPELINE_DOP = "pipeline_dop";
     public static final String MAX_PIPELINE_DOP = "max_pipeline_dop";
 
@@ -1062,8 +1063,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = TABLET_INTERNAL_PARALLEL_MODE, flag = VariableMgr.INVISIBLE)
     private String tabletInternalParallelMode = "auto";
 
-    @VariableMgr.VarAttr(name = ENABLE_SHARED_SCAN)
-    private boolean enableSharedScan = false;
+    @VariableMgr.VarAttr(name = ENABLE_SHARED_SCAN_V2, alias = ENABLE_SHARED_SCAN, show = ENABLE_SHARED_SCAN)
+    private boolean enableSharedScan = true;
 
     // max memory used on each fragment instance
     // NOTE: only used for non-pipeline engine and stream_load

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -290,7 +290,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String TABLET_INTERNAL_PARALLEL_MODE = "tablet_internal_parallel_mode";
     public static final String ENABLE_SHARED_SCAN = "enable_shared_scan";
-    public static final String ENABLE_SHARED_SCAN_V2 = "enable_shared_scan_v2";
     public static final String PIPELINE_DOP = "pipeline_dop";
     public static final String MAX_PIPELINE_DOP = "max_pipeline_dop";
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Behavior Change:  
- **Change**: The default value of the session variable `enable_shared_scan` has been updated from `false` to `true`.  
- **Impact:** Enhances overall performance, particularly in scenarios involving data skew.  
- **Potential Drawback:** May lead to performance degradation under conditions of high query concurrency.  
- **Upgrade Compatibility:** Existing clusters remain unaffected, while newly created clusters will adopt the updated default value.  

Performance test:
  | Concurrency | Disable (Sum) | Enable (Sum)
-- | -- | -- | --
Clickbench | 1 | 7219 | 7172
Clickbench | 32 | 123322 | 123439
ssb-flat | 1 | 1774 | 1802
ssb-flat | 8 | 11104 | 11008
ssb-flat | 16 | 21671 | 21552
ssb-flat | 32 | 43121 | 42937

</byte-sheet-html-origin><!--EndFragment-->

Fixes #61466

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables shared_scan by default and introduces configurable IO batching with step-based round-robin chunk distribution and targeted driver notifications.
> 
> - **Frontend (FE)**:
>   - Default `SessionVariable` `enable_shared_scan` set to `true`.
> - **Backend (BE) Scan/IO**:
>   - Introduce configs: `config::io_task_batch_size` and `config::io_task_shared_scan_step_size` (replace hardcoded batch size, control RR step).
>   - `BalancedChunkBuffer`:
>     - `put` now returns the actual buffer via `int* actual_buffer` and supports step-based round-robin using `io_task_shared_scan_step_size`.
>     - Exposes `strategy()`; includes config.
>   - Targeted notification path:
>     - `ScanOperator` adds `defer_notify(int driver_seq)`; `Observable` adds `notify_source_observer(int seq)`.
>     - `ChunkSource` computes `actual_seq` and notifies a specific operator when in round-robin mode.
>   - Replace usages of constant batch size with `config::io_task_batch_size` in scan task buffering and thresholds.
>   - `DynamicChunkBufferLimiter`: moves `is_full()`/`has_full_events()` implementations to .cpp (no behavior change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f9358ce023773134074650f3d4dd4498c23b80d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->