### PR TITLE
[Enhancement] Update balance statistic during balancing

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
@@ -210,8 +210,15 @@ public class BackendLoadStatistic {
     }
 
     // Get max|min path used percent.
-    // Return Pair<max, min>, return null if be has no medium path.
+    // Return Pair<maxUsedPercent, minUsedPercent>, return null if be has no medium path.
     public Pair<Double, Double> getMaxMinPathUsedPercent(TStorageMedium medium) {
+        Pair<Pair<Double, String>, Pair<Double, String>> maxMin = getMaxMinPathUsedPercentWithPath(medium);
+        return maxMin == null ? null : Pair.create(maxMin.first.first, maxMin.second.first);
+    }
+
+    // Get max|min path used percent with path.
+    // Return Pair<Pair<maxUsedPercent, maxPath>, Pair<minUsedPercent, minPath>>, return null if be has no medium path.
+    public Pair<Pair<Double, String>, Pair<Double, String>> getMaxMinPathUsedPercentWithPath(TStorageMedium medium) {
         List<RootPathLoadStatistic> pathStats = getPathStatistics(medium);
         if (pathStats.isEmpty()) {
             return null;
@@ -219,6 +226,8 @@ public class BackendLoadStatistic {
 
         double maxUsedPercent = Double.MIN_VALUE;
         double minUsedPercent = Double.MAX_VALUE;
+        String maxPath = "";
+        String minPath = "";
         for (RootPathLoadStatistic pathStat : pathStats) {
             if (pathStat.getDiskState() != DiskState.ONLINE) {
                 continue;
@@ -227,12 +236,14 @@ public class BackendLoadStatistic {
             double usedPercent = pathStat.getUsedPercent();
             if (usedPercent > maxUsedPercent) {
                 maxUsedPercent = usedPercent;
+                maxPath = pathStat.getPath();
             }
             if (usedPercent < minUsedPercent) {
                 minUsedPercent = usedPercent;
+                minPath = pathStat.getPath();
             }
         }
-        return Pair.create(maxUsedPercent, minUsedPercent);
+        return Pair.create(Pair.create(maxUsedPercent, maxPath), Pair.create(minUsedPercent, minPath));
     }
 
     public long getReplicaNum(TStorageMedium medium) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ClusterLoadStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ClusterLoadStatistic.java
@@ -40,6 +40,8 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.clone.BackendLoadStatistic.Classification;
 import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStorageMedium;
@@ -49,6 +51,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /*
@@ -70,6 +73,12 @@ public class ClusterLoadStatistic {
     private Map<TStorageMedium, Integer> backendNumMap = Maps.newHashMap();
     private List<BackendLoadStatistic> beLoadStatistics = Lists.newArrayList();
     private Map<Long, String> pathHashToRootPath = Maps.newHashMap();
+
+    // Disk balance stats
+    // TStorageMedium -> BalanceStat
+    private final Map<TStorageMedium, BalanceStat> clusterDiskBalanceStats = new ConcurrentHashMap<>();
+    // Pair<TStorageMedium, BeId> -> BalanceStat
+    private final Map<Pair<TStorageMedium, Long>, BalanceStat> backendDiskBalanceStats = new ConcurrentHashMap<>();
 
     public ClusterLoadStatistic(SystemInfoService infoService, TabletInvertedIndex invertedIndex) {
         this.infoService = infoService;
@@ -240,5 +249,51 @@ public class ClusterLoadStatistic {
 
     public String getPath(long pathHash) {
         return pathHashToRootPath.get(pathHash);
+    }
+
+    public BalanceStat getClusterDiskBalanceStat(TStorageMedium medium) {
+        return clusterDiskBalanceStats.getOrDefault(medium, BalanceStat.BALANCED_STAT);
+    }
+
+    public Map<TStorageMedium, BalanceStat> getClusterDiskBalanceStats() {
+        return clusterDiskBalanceStats;
+    }
+
+    public void updateClusterDiskBalanceStat(TStorageMedium medium, BalanceStat balanceStat) {
+        clusterDiskBalanceStats.put(medium, balanceStat);
+    }
+
+    public void updateClusterDiskBalanceStats(Map<TStorageMedium, BalanceStat> clusterDiskBalanceStats) {
+        this.clusterDiskBalanceStats.putAll(clusterDiskBalanceStats);
+    }
+
+    public BalanceStat getBackendDiskBalanceStat(TStorageMedium medium, long beId) {
+        return backendDiskBalanceStats.getOrDefault(Pair.create(medium, beId), BalanceStat.BALANCED_STAT);
+    }
+
+    public Map<Pair<TStorageMedium, Long>, BalanceStat> getBackendDiskBalanceStats() {
+        return backendDiskBalanceStats;
+    }
+
+    public void updateBackendDiskBalanceStat(Pair<TStorageMedium, Long> mediumBeId, BalanceStat balanceStat) {
+        backendDiskBalanceStats.put(mediumBeId, balanceStat);
+    }
+
+    public void updateBackendDiskBalanceStats(Map<Pair<TStorageMedium, Long>, BalanceStat> backendDiskBalanceStats) {
+        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        for (BackendLoadStatistic beStat : beLoadStatistics) {
+            long beId = beStat.getBeId();
+            if (!systemInfoService.checkBackendAvailable(beId)) {
+                continue;
+            }
+
+            for (TStorageMedium medium : TStorageMedium.values()) {
+                if (beStat.getTotalCapacityB(medium) > 0) {
+                    Pair<TStorageMedium, Long> mediumBeId = Pair.create(medium, beId);
+                    this.backendDiskBalanceStats.put(
+                            mediumBeId, backendDiskBalanceStats.getOrDefault(mediumBeId, BalanceStat.BALANCED_STAT));
+                }
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ClusterLoadStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ClusterLoadStatistic.java
@@ -69,6 +69,7 @@ public class ClusterLoadStatistic {
     // storage medium -> number of backend which has this kind of medium
     private Map<TStorageMedium, Integer> backendNumMap = Maps.newHashMap();
     private List<BackendLoadStatistic> beLoadStatistics = Lists.newArrayList();
+    private Map<Long, String> pathHashToRootPath = Maps.newHashMap();
 
     public ClusterLoadStatistic(SystemInfoService infoService, TabletInvertedIndex invertedIndex) {
         this.infoService = infoService;
@@ -120,6 +121,13 @@ public class ClusterLoadStatistic {
 
         // sort be stats by mix load score
         Collections.sort(beLoadStatistics, BackendLoadStatistic.MIX_COMPARATOR);
+
+        // create path hash to root path map
+        for (BackendLoadStatistic beStatistic : beLoadStatistics) {
+            for (RootPathLoadStatistic pathLoadStat : beStatistic.getPathStatistics()) {
+                pathHashToRootPath.put(pathLoadStat.getPathHash(), pathLoadStat.getPath());
+            }
+        }
     }
 
     /*
@@ -228,5 +236,9 @@ public class ClusterLoadStatistic {
             sb.append("    ").append(backendLoadStatistic).append("\n");
         }
         return sb.toString();
+    }
+
+    public String getPath(long pathHash) {
+        return pathHashToRootPath.get(pathHash);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -333,7 +333,7 @@ public class ColocateTableBalancer extends FrontendDaemon {
             if (db == null) {
                 continue;
             }
-            ClusterLoadStatistic statistic = globalStateMgr.getTabletScheduler().getLoadStatistic();
+            ClusterLoadStatistic statistic = globalStateMgr.getTabletScheduler().getClusterLoadStatistic();
             if (statistic == null) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/Rebalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/Rebalancer.java
@@ -97,4 +97,10 @@ public abstract class Rebalancer {
     public void updateLoadStatistic(ClusterLoadStatistic loadStatistic) {
         this.loadStatistic = loadStatistic;
     }
+
+    // For show proc
+    // Get cluster disk usage balance stat by storage medium.
+    public abstract BalanceStat getClusterDiskBalanceStat(TStorageMedium medium);
+    // Get backend disk usage balance stat by storage medium.
+    public abstract BalanceStat getBackendDiskBalanceStat(TStorageMedium medium, long beId);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ClusterLoadStatisticProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ClusterLoadStatisticProcDir.java
@@ -60,7 +60,7 @@ public class ClusterLoadStatisticProcDir implements ProcDirInterface {
         BaseProcResult result = new BaseProcResult();
         result.setNames(TITLE_NAMES);
 
-        ClusterLoadStatistic statistic = GlobalStateMgr.getCurrentState().getTabletScheduler().getLoadStatistic();
+        ClusterLoadStatistic statistic = GlobalStateMgr.getCurrentState().getTabletScheduler().getClusterLoadStatistic();
         statistic.getClusterStatistic(medium).forEach(result::addRow);
 
         return result;

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
@@ -35,6 +35,7 @@ import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.clone.BalanceStat.BalanceType;
 import com.starrocks.clone.DiskAndTabletLoadReBalancer.BackendBalanceState;
 import com.starrocks.common.Config;
 import com.starrocks.server.GlobalStateMgr;
@@ -201,6 +202,10 @@ public class DiskAndTabletLoadReBalancerTest {
         Assertions.assertTrue(tablets.stream().allMatch(t -> (t.getDestBackendId() == beId3)));
         Assertions.assertTrue(tablets.stream().anyMatch(t -> (t.getSrcBackendId() == beId1)));
         Assertions.assertTrue(tablets.stream().anyMatch(t -> (t.getSrcBackendId() == beId2)));
+
+        // check balance stat
+        Assertions.assertFalse(materializedIndex.isTabletBalanced());
+        Assertions.assertEquals(BalanceType.CLUSTER_TABLET, materializedIndex.getBalanceType());
 
         // set table state to schema_change, balance should be ignored
         table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
@@ -570,6 +575,14 @@ public class DiskAndTabletLoadReBalancerTest {
         Assertions.assertTrue(tablets.stream().anyMatch(t -> (t.getSrcPathHash() == pathHash10)));
         Assertions.assertTrue(tablets.stream().anyMatch(t -> (t.getSrcPathHash() == pathHash13)));
 
+        // check balance stat
+        BalanceStat stat0 = rebalancer.getBackendDiskBalanceStat(TStorageMedium.HDD, beId1);
+        Assertions.assertFalse(stat0.isBalanced());
+        Assertions.assertEquals(BalanceType.BACKEND_DISK, stat0.getBalanceType());
+        BalanceStat stat1 = rebalancer.getBackendDiskBalanceStat(TStorageMedium.SSD, beId1);
+        Assertions.assertFalse(stat1.isBalanced());
+        Assertions.assertEquals(BalanceType.BACKEND_DISK, stat1.getBalanceType());
+
         // set Config.balance_load_disk_safe_threshold to 0.9 to trigger backend tablet distribution balance
         Config.tablet_sched_balance_load_disk_safe_threshold = 0.9;
         tablets = rebalancer.selectAlternativeTablets();
@@ -580,6 +593,11 @@ public class DiskAndTabletLoadReBalancerTest {
         Assertions.assertTrue(tablets.stream().anyMatch(t -> (t.getDestPathHash() == pathHash14)));
         Assertions.assertTrue(tablets.stream().anyMatch(t -> (t.getSrcPathHash() == pathHash10)));
         Assertions.assertTrue(tablets.stream().anyMatch(t -> (t.getSrcPathHash() == pathHash13)));
+
+        // check balance stat
+        BalanceStat stat2 = materializedIndex.getBalanceStat();
+        Assertions.assertFalse(stat2.isBalanced());
+        Assertions.assertEquals(BalanceType.BACKEND_TABLET, stat2.getBalanceType());
 
         // set table state to schema_change, balance should be ignored
         table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
@@ -761,6 +779,11 @@ public class DiskAndTabletLoadReBalancerTest {
 
         Assertions.assertEquals(4, be1SourceCnt);
         Assertions.assertEquals(4, be2SourceCnt);
+
+        // check balance stat
+        BalanceStat stat = rebalancer.getClusterDiskBalanceStat(TStorageMedium.HDD);
+        Assertions.assertFalse(stat.isBalanced());
+        Assertions.assertEquals(BalanceType.CLUSTER_DISK, stat.getBalanceType());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
@@ -576,10 +576,10 @@ public class DiskAndTabletLoadReBalancerTest {
         Assertions.assertTrue(tablets.stream().anyMatch(t -> (t.getSrcPathHash() == pathHash13)));
 
         // check balance stat
-        BalanceStat stat0 = rebalancer.getBackendDiskBalanceStat(TStorageMedium.HDD, beId1);
+        BalanceStat stat0 = clusterLoadStatistic.getBackendDiskBalanceStat(TStorageMedium.HDD, beId1);
         Assertions.assertFalse(stat0.isBalanced());
         Assertions.assertEquals(BalanceType.BACKEND_DISK, stat0.getBalanceType());
-        BalanceStat stat1 = rebalancer.getBackendDiskBalanceStat(TStorageMedium.SSD, beId1);
+        BalanceStat stat1 = clusterLoadStatistic.getBackendDiskBalanceStat(TStorageMedium.SSD, beId1);
         Assertions.assertFalse(stat1.isBalanced());
         Assertions.assertEquals(BalanceType.BACKEND_DISK, stat1.getBalanceType());
 
@@ -781,7 +781,7 @@ public class DiskAndTabletLoadReBalancerTest {
         Assertions.assertEquals(4, be2SourceCnt);
 
         // check balance stat
-        BalanceStat stat = rebalancer.getClusterDiskBalanceStat(TStorageMedium.HDD);
+        BalanceStat stat = clusterLoadStatistic.getClusterDiskBalanceStat(TStorageMedium.HDD);
         Assertions.assertFalse(stat.isBalanced());
         Assertions.assertEquals(BalanceType.CLUSTER_DISK, stat.getBalanceType());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
@@ -143,7 +143,7 @@ public class TabletSchedCtxTest {
 
         // mock tabletScheduler
         tabletScheduler = new TabletScheduler(stat);
-        tabletScheduler.setLoadStatistic(clusterLoadStatistic);
+        tabletScheduler.setClusterLoadStatistic(clusterLoadStatistic);
         GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends().forEach(be -> {
             List<Long> pathHashes =
                     be.getDisks().values().stream().map(DiskInfo::getPathHash).collect(Collectors.toList());
@@ -159,7 +159,7 @@ public class TabletSchedCtxTest {
         clusterLoadStatistic = new ClusterLoadStatistic(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
                 GlobalStateMgr.getCurrentState().getTabletInvertedIndex());
         clusterLoadStatistic.init();
-        tabletScheduler.setLoadStatistic(clusterLoadStatistic);
+        tabletScheduler.setClusterLoadStatistic(clusterLoadStatistic);
 
         LocalTablet missedTablet = new LocalTablet(TABLET_ID_1,
                 GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getReplicasByTabletId(TABLET_ID_1));


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. Update balance statistics during balancing, includes cluster disk, cluster tablet distribution, backend disk and backend tablet distribution balance types.
2. Make `loadStatistic` in `TabletScheduler` and `Rebalancer` as `AtomicReference` object.

https://github.com/StarRocks/starrocks/issues/61340

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
