### PR TITLE
[BugFix] Fix local-passthrough cancel dead lock

### DIFF
--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -563,7 +563,14 @@ void DataStreamRecvr::PipelineSenderQueue::close() {
     clean_buffer_queues();
 }
 
+struct ClosureDeleter {
+    void operator()(google::protobuf::Closure* p) const { p->Run(); };
+};
+
 void DataStreamRecvr::PipelineSenderQueue::clean_buffer_queues() {
+    // avoid run closure in lock scope
+    std::vector<std::unique_ptr<google::protobuf::Closure, ClosureDeleter>> closures;
+
     std::lock_guard<Mutex> l(_lock);
     tls_thread_status.set_mem_tracker(nullptr);
     auto& metrics = _recvr->_metrics[0];
@@ -575,7 +582,7 @@ void DataStreamRecvr::PipelineSenderQueue::clean_buffer_queues() {
             if (chunk_queue.try_dequeue(item)) {
                 if (item.closure != nullptr) {
                     COUNTER_UPDATE(metrics.closure_block_timer, MonotonicNanos() - item.queue_enter_time);
-                    item.closure->Run();
+                    closures.emplace_back(item.closure);
                     chunk_queue_state.blocked_closure_num--;
                 }
                 --_total_chunks;
@@ -589,7 +596,7 @@ void DataStreamRecvr::PipelineSenderQueue::clean_buffer_queues() {
             for (auto& item : chunk_queue) {
                 if (item.closure != nullptr) {
                     COUNTER_UPDATE(metrics.closure_block_timer, MonotonicNanos() - item.queue_enter_time);
-                    item.closure->Run();
+                    closures.emplace_back(item.closure);
                 }
             }
             chunk_queue.clear();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

close https://github.com/StarRocks/StarRocksTest/issues/10050
```
0x2b9057fdf917  __GI___sched_yield                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
     0x79394df  starrocks::SpinLock::slow_acquire()                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
     0x77ab54c  starrocks::DataStreamRecvr::PipelineSenderQueue::decrement_senders(int)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
     0x777c893  starrocks::DataStreamRecvr::remove_sender(int, int)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
     0x7774dde  starrocks::DataStreamMgr::transmit_chunk(starrocks::TUniqueId const&, starrocks::PTransmitChunkParams const&, std::unique_ptr<std::vector<starrocks::ChunkPassThroughItem, std::allocator<starrocks::ChunkPassThroughItem> >, std::default_delete<std::vector<st@                                                                                                                                                                                                                                                                                                                                                                                             |
     0x88b7e73  starrocks::pipeline::SinkBuffer::_try_to_send_local(starrocks::TUniqueId const&, std::function<void ()> const&)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
     0x88b8aa7  std::_Function_handler<void (), starrocks::pipeline::SinkBuffer::_try_to_send_local(starrocks::TUniqueId const&, std::function<void ()> const&)::{lambda()#5}>::_M_invoke(std::_Any_data const&)                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
     0x88baba1  starrocks::DisposablePassThroughClosure::Run()                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
     0x77b17d4  starrocks::DataStreamRecvr::PipelineSenderQueue::clean_buffer_queues()                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
     0x777ce49  starrocks::DataStreamRecvr::close()                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
     0x88ab87c  starrocks::pipeline::ExchangeSourceOperator::set_finishing(starrocks::RuntimeState*)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
     0x8984cac  starrocks::pipeline::PipelineDriver::_mark_operator_finishing(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
     0x8984f23  starrocks::pipeline::PipelineDriver::_mark_operator_finished(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
     0x898563a  starrocks::pipeline::PipelineDriver::_mark_operator_cancelled(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
     0x8985b81  starrocks::pipeline::PipelineDriver::cancel_operators(starrocks::RuntimeState*)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
     0x8e01b66  starrocks::pipeline::PipelineDriverPoller::on_cancel(starrocks::pipeline::PipelineDriver*, std::vector<starrocks::pipeline::PipelineDriver*, std::allocator<starrocks::pipeline::PipelineDriver*> >&, std::__cxx11::list<starrocks::pipeline::PipelineDriver*, s@                                                                                                                                                                                                                                                                                                                                                                                             |
     0x8e02554  starrocks::pipeline::PipelineDriverPoller::run_internal()                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
     0x7966eb0  starrocks::Thread::supervise_thread(void*)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
0x2b9055b29ea5  start_thread                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
0x2b9057ffab0d  __clone      



```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
