### PR TITLE
[BugFix] fix mv duplicate histogram metrics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
@@ -92,14 +92,6 @@ public class MaterializedViewMetricsRegistry {
                     .addLabel(new MetricLabel("mv_id", String.valueOf(mvId.getId())));
             visitor.visit(m);
         }
-
-        // Histogram metrics should only output once
-        if (!minifyMetrics) {
-            for (Map.Entry<String, Histogram> e : MaterializedViewMetricsRegistry.getInstance()
-                    .metricRegistry.getHistograms().entrySet()) {
-                visitor.visitHistogram(e.getKey(), e.getValue());
-            }
-        }
     }
 
     // collect materialized-view-level metrics
@@ -117,6 +109,14 @@ public class MaterializedViewMetricsRegistry {
             } catch (Exception e) {
                 LOG.warn("Failed to collect materialized view metrics for mvId: {}", entry.getKey(),
                         DebugUtil.getStackTrace(e));
+            }
+        }
+
+        // Histogram metrics should only output once
+        if (!minifyMetrics) {
+            for (Map.Entry<String, Histogram> e : MaterializedViewMetricsRegistry.getInstance()
+                    .metricRegistry.getHistograms().entrySet()) {
+                visitor.visitHistogram(e.getKey(), e.getValue());
             }
         }
     }


### PR DESCRIPTION
## Why I'm doing:

```java
// Histogram metrics should only output once
        if (!minifyMetrics) {
            for (Map.Entry<String, Histogram> e : MaterializedViewMetricsRegistry.getInstance()
                    .metricRegistry.getHistograms().entrySet()) {
                visitor.visitHistogram(e.getKey(), e.getValue());
            }
        }
```
the above codes are called inside the mv loop, causing duplicate histogram metrics in `/metrics?with_table_metrics=minified&with_materialized_view_metrics=all"
`
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
