### PR TITLE
[Enhancement] Simplify chunks_sorter_full_sort by removing the merge

### DIFF
--- a/be/src/bench/chunks_sorter_bench.cpp
+++ b/be/src/bench/chunks_sorter_bench.cpp
@@ -227,7 +227,6 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Logical
     int64_t data_size = 0;
     int64_t mem_usage = 0;
     const int64_t max_buffered_rows = 1024 * 1024;
-    const int64_t max_buffered_bytes = max_buffered_rows * 256;
     const std::vector<SlotId> early_materialized_slots;
 
     for (auto _ : state) {
@@ -241,8 +240,7 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Logical
         switch (sorter_algo) {
         case FullSort: {
             sorter = std::make_unique<ChunksSorterFullSort>(suite._runtime_state.get(), &sort_exprs, &asc_arr,
-                                                            &null_first, "", max_buffered_rows, max_buffered_bytes,
-                                                            early_materialized_slots);
+                                                            &null_first, "");
             expected_rows = total_rows;
             break;
         }

--- a/be/src/exec/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/chunks_sorter_full_sort.cpp
@@ -25,13 +25,8 @@ namespace starrocks {
 
 ChunksSorterFullSort::ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                                            const std::vector<bool>* is_asc_order,
-                                           const std::vector<bool>* is_null_first, const std::string& sort_keys,
-                                           int64_t max_buffered_rows, int64_t max_buffered_bytes,
-                                           const std::vector<SlotId>& early_materialized_slots)
-        : ChunksSorter(state, sort_exprs, is_asc_order, is_null_first, sort_keys, false),
-          max_buffered_rows(static_cast<size_t>(max_buffered_rows)),
-          max_buffered_bytes(max_buffered_bytes),
-          _early_materialized_slots(early_materialized_slots.begin(), early_materialized_slots.end()) {}
+                                           const std::vector<bool>* is_null_first, const std::string& sort_keys)
+        : ChunksSorter(state, sort_exprs, is_asc_order, is_null_first, sort_keys, false) {}
 
 ChunksSorterFullSort::~ChunksSorterFullSort() = default;
 
@@ -40,14 +35,11 @@ void ChunksSorterFullSort::setup_runtime(RuntimeState* state, RuntimeProfile* pr
     _runtime_profile = profile;
     _parent_mem_tracker = parent_mem_tracker;
     _object_pool = std::make_unique<ObjectPool>();
-    _runtime_profile->add_info_string("MaxBufferedRows", std::to_string(max_buffered_rows));
-    _runtime_profile->add_info_string("MaxBufferedBytes", std::to_string(max_buffered_bytes));
     _profiler = _object_pool->add(new ChunksSorterFullSortProfiler(profile, parent_mem_tracker));
 }
 
 Status ChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr& chunk) {
     RETURN_IF_ERROR(_merge_unsorted(state, chunk));
-    RETURN_IF_ERROR(_partial_sort(state, false));
 
     return Status::OK();
 }
@@ -55,9 +47,9 @@ Status ChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr& chunk) 
 // Accumulate unsorted input chunks into a larger chunk
 Status ChunksSorterFullSort::_merge_unsorted(RuntimeState* state, const ChunkPtr& chunk) {
     SCOPED_TIMER(_build_timer);
-    _staging_unsorted_chunks.push_back(std::move(chunk));
     _staging_unsorted_rows += chunk->num_rows();
     _staging_unsorted_bytes += chunk->bytes_usage();
+    _staging_unsorted_chunks.push_back(chunk);
     return Status::OK();
 }
 
@@ -73,7 +65,7 @@ static void reserve_memory(Column* dst_col, const std::vector<ChunkPtr>& src_chu
     binary_dst_col->get_bytes().reserve(total_num_bytes);
 }
 
-static void concat_chunks(ChunkPtr& dst_chunk, const std::vector<ChunkPtr>& src_chunks, size_t num_rows) {
+static void concat_chunks(ChunkPtr& dst_chunk, std::vector<ChunkPtr>&& src_chunks, size_t num_rows) {
     DCHECK(!src_chunks.empty());
     // Columns like FixedLengthColumn have already reserved memory when invoke Chunk::clone_empty(num_rows).
     dst_chunk = src_chunks.front()->clone_empty(num_rows);
@@ -88,8 +80,9 @@ static void concat_chunks(ChunkPtr& dst_chunk, const std::vector<ChunkPtr>& src_
             reserve_memory<LargeBinaryColumn>(dst_data_col, src_chunks, i);
         }
     }
-    for (const auto& src_chk : src_chunks) {
+    for (auto& src_chk : src_chunks) {
         dst_chunk->append(*src_chk);
+        src_chk.reset();
     }
 }
 // Sort the large chunk
@@ -97,198 +90,74 @@ Status ChunksSorterFullSort::_partial_sort(RuntimeState* state, bool done) {
     if (!_staging_unsorted_rows) {
         return Status::OK();
     }
-    bool reach_limit = _staging_unsorted_rows >= max_buffered_rows || _staging_unsorted_bytes >= max_buffered_bytes;
-    if (done || reach_limit) {
-        _max_num_rows = std::max<int>(_max_num_rows, _staging_unsorted_rows);
-        _profiler->input_required_memory->update(_staging_unsorted_bytes);
-        concat_chunks(_unsorted_chunk, _staging_unsorted_chunks, _staging_unsorted_rows);
-        _staging_unsorted_chunks.clear();
-        RETURN_IF_ERROR(_unsorted_chunk->upgrade_if_overflow());
+    _max_num_rows = std::max<int>(_max_num_rows, _staging_unsorted_rows);
+    _profiler->input_required_memory->update(_staging_unsorted_bytes);
 
-        SCOPED_TIMER(_sort_timer);
-        DataSegment segment(_sort_exprs, _unsorted_chunk);
-        _sort_permutation.resize(0);
-        RETURN_IF_ERROR(
-                sort_and_tie_columns(state->cancelled_ref(), segment.order_by_columns, _sort_desc, &_sort_permutation));
-        auto sorted_chunk = _unsorted_chunk->clone_empty_with_slot(_unsorted_chunk->num_rows());
-        materialize_by_permutation(sorted_chunk.get(), {_unsorted_chunk}, _sort_permutation);
-        RETURN_IF_ERROR(sorted_chunk->upgrade_if_overflow());
+    concat_chunks(_unsorted_chunk, std::move(_staging_unsorted_chunks), _staging_unsorted_rows);
+    RETURN_IF_ERROR(_unsorted_chunk->upgrade_if_overflow());
+    _staging_unsorted_chunks.clear();
+    RETURN_IF_ERROR(_unsorted_chunk->upgrade_if_overflow());
 
-        _sorted_chunks.emplace_back(std::move(sorted_chunk));
-        _total_rows += _unsorted_chunk->num_rows();
-        _unsorted_chunk->reset();
-        _staging_unsorted_rows = 0;
-        _staging_unsorted_bytes = 0;
+    SCOPED_TIMER(_sort_timer);
+    DataSegment segment(_sort_exprs, _unsorted_chunk);
+    Permutation sort_permutation{};
+    RETURN_IF_ERROR(
+            sort_and_tie_columns(state->cancelled_ref(), segment.order_by_columns, _sort_desc, &sort_permutation));
+    const size_t max_chunk_size = _state->chunk_size();
+    const size_t total_rows = _unsorted_chunk->num_rows();
+    const size_t total_chunks = (total_rows - 1 + max_chunk_size) / max_chunk_size;
+    _sorted_chunks.resize(total_chunks);
+    for (size_t i = 0; i < total_chunks; ++i) {
+        const size_t begin = i * max_chunk_size;
+        const size_t curr_chunk_size = std::min((i + 1) * max_chunk_size, total_rows) - begin;
+        const auto permutation_view = array_view{sort_permutation.data() + begin, curr_chunk_size};
+        ChunkPtr newChunk = _unsorted_chunk->clone_empty(curr_chunk_size);
+        materialize_by_permutation(newChunk.get(), {_unsorted_chunk}, permutation_view);
+        _sorted_chunks[total_chunks - 1 - i] = std::move(newChunk);
     }
+    sort_permutation.clear();
+    _total_rows += _unsorted_chunk->num_rows();
+    _unsorted_chunk->reset();
 
     return Status::OK();
 }
 
-Status ChunksSorterFullSort::_merge_sorted(RuntimeState* state) {
-    SCOPED_TIMER(_merge_timer);
-    _profiler->num_sorted_runs->set((int64_t)_sorted_chunks.size());
-    // TODO: introduce an extra merge before cascading merge to handle the case that has a lot of sortruns
-    // In cascading merging phase, the height of merging tree is ceiling(log2(num_sorted_runs)) + 1,
-    // so when num_sorted_runs is 1 or 2, the height merging tree is less than 2, the sorted runs just be processed
-    // in at most one pass. there is no need to enable lazy materialization which eliminates non-order-by output
-    // columns's permutation in multiple passes.
-    if (_early_materialized_slots.empty() || _sorted_chunks.size() < 3) {
-        _early_materialized_slots.clear();
-        _runtime_profile->add_info_string("LateMaterialization", "False");
-        RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _sorted_chunks, &_merged_runs));
-    } else {
-        _runtime_profile->add_info_string("LateMaterialization", "True");
-        _split_late_and_early_chunks();
-        _assign_ordinals();
-        RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _early_materialized_chunks, &_merged_runs));
-    }
-
-    return Status::OK();
-}
-
-void ChunksSorterFullSort::_assign_ordinals() {
-    _chunk_idx_bits = (int)std::ceil(std::log2(_early_materialized_chunks.size()));
-    _chunk_idx_bits = std::max(1, _chunk_idx_bits);
-    _offset_in_chunk_bits = (int)std::ceil(std::log2(_max_num_rows));
-    _offset_in_chunk_bits = std::max(1, _offset_in_chunk_bits);
-    // 64 bit ordinal only used when data skew is extremely drastic, for an example, a PipelineDriver processes
-    // 4 billion rows, it may happen in product environment extremely rarely, if it really happens,
-    // 64 bit ordinal is adopted.
-    auto use_64bit_ordinal = (_chunk_idx_bits + _offset_in_chunk_bits) > 32;
-    _runtime_profile->add_info_string("LateMaterializationUse64BitOrdinal",
-                                      strings::Substitute("$0", use_64bit_ordinal));
-
-    if (use_64bit_ordinal) {
-        _assign_ordinals_tmpl<uint64_t>();
-    } else {
-        _assign_ordinals_tmpl<uint32_t>();
-    }
-}
-TYPE_GUARD(OrdinalGuard, type_is_ordinal, uint32_t, uint64_t);
-
-template <typename T, typename = OrdinalGuard<T>>
-using OrdinalColumn = FixedLengthColumn<T>;
-
-template <typename T>
-void ChunksSorterFullSort::_assign_ordinals_tmpl() {
-    static_assert(type_is_ordinal<T>, "T must be uint32_t or uint64_t");
-    size_t chunk_idx = 0;
-    for (auto& partial_sort_chunk : _early_materialized_chunks) {
-        if (partial_sort_chunk->is_empty()) {
-            ++chunk_idx;
-            continue;
-        }
-        size_t num_rows = partial_sort_chunk->num_rows();
-        auto ordinal_column = OrdinalColumn<T>::create();
-        auto& ordinal_data = down_cast<OrdinalColumn<T>*>(ordinal_column.get())->get_data();
-        raw::make_room(&ordinal_data, num_rows);
-        for (T offset = 0; offset < num_rows; ++offset) {
-            ordinal_data[offset] = static_cast<T>((chunk_idx << _offset_in_chunk_bits) | offset);
-        }
-        partial_sort_chunk->append_column(std::move(ordinal_column), Chunk::SORT_ORDINAL_COLUMN_SLOT_ID);
-        ++chunk_idx;
-    }
-}
-
-void ChunksSorterFullSort::_split_late_and_early_chunks() {
-    _early_materialized_chunks.reserve(_sorted_chunks.size());
-    _late_materialized_chunks.reserve(_sorted_chunks.size());
-    auto& slot_id_to_column_id = _sorted_chunks[0]->get_slot_id_to_index_map();
-    _column_id_to_slot_id.resize(slot_id_to_column_id.size());
-    for (auto it : _sorted_chunks[0]->get_slot_id_to_index_map()) {
-        _column_id_to_slot_id[it.second] = it.first;
-    }
-    for (auto& chunk : _sorted_chunks) {
-        auto eager_chunk = std::make_unique<Chunk>();
-        auto lazy_chunk = std::make_unique<Chunk>();
-        for (auto column_id = 0; column_id < chunk->num_columns(); ++column_id) {
-            auto slot_id = _column_id_to_slot_id[column_id];
-            auto column = chunk->columns()[column_id];
-            if (_early_materialized_slots.count(slot_id)) {
-                eager_chunk->append_column(column, slot_id);
-            } else {
-                lazy_chunk->append_column(column, slot_id);
-            }
-        }
-        _early_materialized_chunks.push_back(std::move(eager_chunk));
-        _late_materialized_chunks.push_back(std::move(lazy_chunk));
-    }
-    _sorted_chunks.clear();
-}
-
-ChunkPtr ChunksSorterFullSort::_late_materialize(const starrocks::ChunkPtr& chunk) {
-    auto use_64bit_ordinal = (_chunk_idx_bits + _offset_in_chunk_bits) > 32;
-    if (use_64bit_ordinal) {
-        return _late_materialize_tmpl<uint64_t>(chunk);
-    } else {
-        return _late_materialize_tmpl<uint32_t>(chunk);
-    }
-}
-
-template <typename T>
-starrocks::ChunkPtr ChunksSorterFullSort::_late_materialize_tmpl(const starrocks::ChunkPtr& sorted_eager_chunk) {
-    static_assert(type_is_ordinal<T>, "T must be uint32_t or uint64_t");
-    const auto num_rows = sorted_eager_chunk->num_rows();
-    auto sorted_lazy_chunk = _late_materialized_chunks[0]->clone_empty(num_rows);
-    auto ordinal_column = sorted_eager_chunk->get_column_by_slot_id(Chunk::SORT_ORDINAL_COLUMN_SLOT_ID);
-    auto& ordinal_data = down_cast<OrdinalColumn<T>*>(ordinal_column.get())->get_data();
-    T _offset_in_chunk_mask = static_cast<T>((1L << _offset_in_chunk_bits) - 1);
-    for (auto i = 0; i < num_rows; ++i) {
-        T ordinal = ordinal_data[i];
-        T chunk_idx = ordinal >> _offset_in_chunk_bits;
-        T off_in_chunk = ordinal & _offset_in_chunk_mask;
-        sorted_lazy_chunk->append(*_late_materialized_chunks[chunk_idx], off_in_chunk, 1);
-    }
-    auto final_chunk = std::make_shared<Chunk>();
-    for (auto slot_id : _column_id_to_slot_id) {
-        if (_early_materialized_slots.count(slot_id)) {
-            final_chunk->append_column(sorted_eager_chunk->get_column_by_slot_id(slot_id), slot_id);
-        } else {
-            final_chunk->append_column(sorted_lazy_chunk->get_column_by_slot_id(slot_id), slot_id);
-        }
-    }
-    return final_chunk;
-}
 Status ChunksSorterFullSort::do_done(RuntimeState* state) {
     RETURN_IF_ERROR(_partial_sort(state, true));
-    {
-        _sort_permutation = {};
-        _unsorted_chunk.reset();
-    }
-    RETURN_IF_ERROR(_merge_sorted(state));
 
     return Status::OK();
 }
 
 Status ChunksSorterFullSort::get_next(ChunkPtr* chunk, bool* eos) {
     SCOPED_TIMER(_output_timer);
-    if (_merged_runs.num_chunks() == 0) {
+    if (_sorted_chunks.empty()) {
         *chunk = nullptr;
         *eos = true;
         return Status::OK();
     }
-    size_t chunk_size = _state->chunk_size();
-    SortedRun& run = _merged_runs.front();
-    *chunk = run.steal_chunk(chunk_size);
+    *chunk = std::move(_sorted_chunks.back());
+    _sorted_chunks.pop_back();
     if (*chunk != nullptr) {
-        if (!_early_materialized_slots.empty()) {
-            *chunk = _late_materialize(*chunk);
-        }
         RETURN_IF_ERROR((*chunk)->downgrade());
-    }
-    if (run.empty()) {
-        _merged_runs.pop_front();
     }
     *eos = false;
     return Status::OK();
 }
 
 size_t ChunksSorterFullSort::get_output_rows() const {
-    return _merged_runs.num_rows();
+    size_t num_rows = 0;
+    for (const auto& chunk : _sorted_chunks) {
+        num_rows += chunk->num_rows();
+    }
+    return num_rows;
 }
 
 int64_t ChunksSorterFullSort::mem_usage() const {
-    return _merged_runs.mem_usage();
+    size_t mem_usage = 0;
+    for (const auto& chunk : _sorted_chunks) {
+        mem_usage += chunk->memory_usage();
+    }
+    return mem_usage;
 }
 
 } // namespace starrocks

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -131,9 +131,9 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver
                     max_buffered_chunks);
         }
     } else {
-        chunks_sorter = std::make_unique<ChunksSorterFullSort>(
-                runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
-                _sort_keys, _max_buffered_rows, _max_buffered_bytes, _early_materialized_slots);
+        chunks_sorter =
+                std::make_unique<ChunksSorterFullSort>(runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
+                                                       &_is_asc_order, &_is_null_first, _sort_keys);
     }
 
     auto sort_context = _sort_context_factory->create(driver_sequence);

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -111,8 +111,7 @@ OperatorPtr SpillablePartitionSortSinkOperatorFactory::create(int32_t degree_of_
     std::shared_ptr<ChunksSorter> chunks_sorter;
 
     chunks_sorter = std::make_unique<SpillableChunksSorterFullSort>(
-            runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first, _sort_keys,
-            _max_buffered_rows, _max_buffered_bytes, _early_materialized_slots);
+            runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first, _sort_keys);
 
     auto spiller = _spill_factory->create(*_spill_options);
     auto spill_channel = _spill_channel_factory->get_or_create(driver_sequence);

--- a/be/src/exec/sorting/sort_helper.h
+++ b/be/src/exec/sorting/sort_helper.h
@@ -160,9 +160,9 @@ static inline Status sort_and_tie_helper_nullable_vertical(const std::atomic<boo
 /// For example, given two columns `(null(3), null(2), null(1)), (1, 2, 3)`, if the datum values of null elements are
 /// not set to the same, the sorting result is `(null(1), null(2), null(3)), (3, 2, 1)`, but the expected result
 /// should be (null(3), null(2), null(1)), (1, 2, 3).
-template <class NullPred>
+template <class NullPred, class P>
 static inline Status partition_null_and_nonnull_helper(const std::atomic<bool>& cancel, NullPred null_pred,
-                                                       const SortDesc& sort_desc, SmallPermutation& permutation,
+                                                       const SortDesc& sort_desc, P& permutation,
                                                        Tie& tie, std::pair<int, int> range) {
     TieIterator iterator(tie, range.first, range.second);
     while (iterator.next()) {
@@ -200,10 +200,10 @@ static inline Status partition_null_and_nonnull_helper(const std::atomic<bool>& 
 
 // 1. Partition null and notnull values
 // 2. Sort by not-null values
-template <class NullPred>
+template <class NullPred, class P>
 static inline Status sort_and_tie_helper_nullable(const std::atomic<bool>& cancel, const NullableColumn* column,
                                                   const ColumnPtr& data_column, NullPred null_pred,
-                                                  const SortDesc& sort_desc, SmallPermutation& permutation, Tie& tie,
+                                                  const SortDesc& sort_desc, P& permutation, Tie& tie,
                                                   std::pair<int, int> range, bool build_tie) {
     RETURN_IF_ERROR(partition_null_and_nonnull_helper(cancel, null_pred, sort_desc, permutation, tie, range));
 

--- a/be/src/exec/sorting/sorting.h
+++ b/be/src/exec/sorting/sorting.h
@@ -22,6 +22,7 @@
 #include "common/status.h"
 #include "exec/sorting/sort_permute.h"
 #include "runtime/chunk_cursor.h"
+#include "sort_permute.h"
 
 namespace starrocks {
 
@@ -34,10 +35,16 @@ struct SortDescs;
 // @param permutation input and output permutation
 // @param tie input and output tie
 // @param range sort range, {0, 0} means not build tie but sort data
+template<SingleContainerPermutation P>
 Status sort_and_tie_column(const std::atomic<bool>& cancel, ColumnPtr& column, const SortDesc& sort_desc,
-                           SmallPermutation& permutation, Tie& tie, std::pair<int, int> range, const bool build_tie);
+                           P& permutation, Tie& tie, std::pair<int, int> range, const bool build_tie);
+template<SingleContainerPermutation P>
 Status sort_and_tie_column(const std::atomic<bool>& cancel, const ColumnPtr& column, const SortDesc& sort_desc,
-                           SmallPermutation& permutation, Tie& tie, std::pair<int, int> range, const bool build_tie);
+                           P& permutation, Tie& tie, std::pair<int, int> range, const bool build_tie);
+
+template <SingleContainerPermutation P>
+Status sort_and_tie_columns2(const std::atomic<bool>& cancel, const Columns& columns, const SortDescs& sort_desc,
+                             P& permutation);
 
 // Sort multiple columns using column-wise algorithm, output the order in permutation array
 Status sort_and_tie_columns(const std::atomic<bool>& cancel, const Columns& columns, const SortDescs& sort_desc,

--- a/be/src/exec/spillable_chunks_sorter_full_sort.cpp
+++ b/be/src/exec/spillable_chunks_sorter_full_sort.cpp
@@ -147,9 +147,6 @@ std::function<StatusOr<ChunkPtr>()> SpillableChunksSorterFullSort::_spill_proces
         if (_process_staging_unsorted_chunk_idx != _staging_unsorted_chunks.size()) {
             return std::move(_staging_unsorted_chunks[_process_staging_unsorted_chunk_idx++]);
         }
-        if (_process_early_materialized_chunks_idx != _early_materialized_chunks.size()) {
-            return _late_materialize(std::move(_early_materialized_chunks[_process_early_materialized_chunks_idx++]));
-        }
         if (_process_sorted_chunk_idx != _sorted_chunks.size()) {
             return std::move(_sorted_chunks[_process_sorted_chunk_idx++]);
         }

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -237,8 +237,7 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
 
     } else {
         _chunks_sorter = std::make_unique<ChunksSorterFullSort>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                                &_is_asc_order, &_is_null_first, _sort_keys, 1024000,
-                                                                16 * 1024 * 1024, _early_materialized_slots);
+                                                                &_is_asc_order, &_is_null_first, _sort_keys);
     }
 
     bool eos = false;

--- a/be/src/util/array_view.hpp
+++ b/be/src/util/array_view.hpp
@@ -22,6 +22,8 @@ namespace starrocks {
 template <typename T>
 class array_view {
 public:
+    using value_type = T;
+
     array_view(T* ptr, size_t len) noexcept : _ptr(ptr), _len(len) {}
     template <class Container>
     array_view(const Container& container) noexcept : _ptr(container.data()), _len(container.size()) {}

--- a/be/test/exec/chunks_sorter_test.cpp
+++ b/be/test/exec/chunks_sorter_test.cpp
@@ -597,8 +597,7 @@ TEST_F(ChunksSorterTest, full_sort_incremental) {
     ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
     auto pool = std::make_unique<ObjectPool>();
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
-                                slots);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
     sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
                          pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
@@ -810,8 +809,7 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_first) {
 
     auto pool = std::make_unique<ObjectPool>();
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
-                                slots);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
     sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
                          pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
@@ -850,8 +848,7 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_last) {
 
     auto pool = std::make_unique<ObjectPool>();
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
-                                slots);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
     sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
                          pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
@@ -893,8 +890,7 @@ TEST_F(ChunksSorterTest, full_sort_by_3_columns) {
 
     auto pool = std::make_unique<ObjectPool>();
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
-                                slots);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
     sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
                          pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
@@ -939,8 +935,7 @@ TEST_F(ChunksSorterTest, full_sort_by_4_columns) {
 
     auto pool = std::make_unique<ObjectPool>();
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
-                                slots);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
     sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
                          pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();


### PR DESCRIPTION
**!This is currently still a draft, because the changes only support 32bit indexes!**

## Why I'm doing:
(If you want I can also create an issue for the topics mentioned here, that are not touched by this PR. However you prefer it.)
The sort is currently quite slow. There are multiple ways to improve this, this is just a first step. There are two separate parts to this:
1. Large partitions (partition by partitions) are routed through a single chunks_sorter_full_sort node, leading to all elements being sorted by a single thread. This probably needs more fundamental changes in the task scheduling system.
2. The sort code itself is not optimal. This is split into the part of the code the code related to the ChunksSorter and the part that is done in parallel_merge_source_operators. This PR only touches the former and here only the chunks_sorter_full_sort. When looking at the code I was wondering why the sort is not completely handled by the parallel_merge_source operators. Another point would be to generate the comparison function with llvm (and probably add fixed template instantiations for sorting 1 or two columns). This would reduce the amount of indirections to a minimum (one indirect function call per row vs. more than one virtual function call per row and column).

## What I'm doing:

The chunks_sorter_full_sort is split into two steps. First batches of chunks are aggregated and then (after a threshold is hit) sorted by _partial_sort. Once all data is read for the node, these batches are then merged. As we need to wait for all chunks to arrive anyway, I would say that there is no reason to split the sort like this. This is why I removed the merge part completly and just used _partial_sort (I just realized I probably should rename this). In local tests, this improved the runtime for 100mio strings in very skewed partitions from 90s to 75s and it made the code much simpler. This should allow future improvements to be implemented much quicker.

## Open points
- [ ] Make the code work for more than 2**32 elements.
I tried to use sort_vertical_chunks for that, but it made the code ~5 times slower. I removed some shared pointer copies, but I still could not make it faster, which is why I want to stay with the current approach.
- [ ] Ensure that the spilling changes are correct.
As I do not understand the spilling code, it would be good if you can check whether the changes are fine.
- [ ] Check whether (parts of) the merge related code can be removed.
I did not check yet whether other code still uses the merge code that was used in chunks_sorter_full_sort. If not this code can be removed as well.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
