### PR TITLE
[UT] Avoid timeout for some sql tests (backport #61082)

### DIFF
--- a/test/sql/test_scan/test_pushdown_or_predicate/R/test_parse_and_rewrite_or_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/R/test_parse_and_rewrite_or_predicate
@@ -1,4 +1,4 @@
--- name: test_parse_and_rewrite_or_predicate
+-- name: test_parse_and_rewrite_or_predicate @sequential
 set scan_or_to_union_limit = 1;
 -- result:
 -- !result
@@ -1207,7 +1207,7 @@ with
   w1 as (select * from t1 where k1 < 1280000 / 4),
   w2 as (select * from t1 where k1 < 10),
   w3 as (select * from t1 where c_int_1_seq = 1280000+2 or (c_int_2_seq is null or c_int_2_seq is not null))
-select /*+SET_VAR(runtime_filter_scan_wait_time=20000)*/ count(1) 
+select count(1) 
 from 
   w3
     join [shuffle] w1 on w3.k1 = w1.k1

--- a/test/sql/test_scan/test_pushdown_or_predicate/T/test_parse_and_rewrite_or_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/T/test_parse_and_rewrite_or_predicate
@@ -1,4 +1,4 @@
--- name: test_parse_and_rewrite_or_predicate
+-- name: test_parse_and_rewrite_or_predicate @sequential
 
 -- Setup configs.
 set scan_or_to_union_limit = 1;
@@ -602,7 +602,7 @@ with
   w1 as (select * from t1 where k1 < 1280000 / 4),
   w2 as (select * from t1 where k1 < 10),
   w3 as (select * from t1 where c_int_1_seq = 1280000+2 or (c_int_2_seq is null or c_int_2_seq is not null))
-select /*+SET_VAR(runtime_filter_scan_wait_time=20000)*/ count(1) 
+select count(1) 
 from 
   w3
     join [shuffle] w1 on w3.k1 = w1.k1


### PR DESCRIPTION
## Why I'm doing:

The SQL Test cases, `test_runtime_bitset_filter` and `test_parse_and_rewrite_or_predicate`, cost too much time in CI environment. 
- Label `test_runtime_bitset_filter` and `test_parse_and_rewrite_or_predicate` as `@sequential` to avoid executing with other cases.
- Remove `/*+SET_VAR(runtime_filter_scan_wait_time=20000)*/` from `test_parse_and_rewrite_or_predicate`.


After the modification:
- `test_runtime_bitset_filter` costs from 120s to 45s, and `test_parse_and_rewrite_or_predicate` costs from 120s to 33s.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
<hr>This is an automatic backport of pull request #61082 done by [Mergify](https://mergify.com).


