### PR TITLE
[Enhancement] Auto disable replicated_storage when using GIN index

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2Builder.java
@@ -47,6 +47,7 @@ public abstract class AlterJobV2Builder {
     protected List<Integer> sortKeyIdxes;
     protected List<Integer> sortKeyUniqueIds;
     protected ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
+    protected boolean addingGINIndex = false;
 
     // -------- for roll up-----------------
     protected long baseIndexId;
@@ -189,6 +190,11 @@ public abstract class AlterJobV2Builder {
 
     public AlterJobV2Builder withSortKeyUniqueIds(@Nullable List<Integer> sortKeyUniqueIds) {
         this.sortKeyUniqueIds = sortKeyUniqueIds;
+        return this;
+    }
+
+    public AlterJobV2Builder withAddingGINIndex(boolean addingGINIndex) {
+        this.addingGINIndex = addingGINIndex;
         return this;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2Builder.java
@@ -47,7 +47,7 @@ public abstract class AlterJobV2Builder {
     protected List<Integer> sortKeyIdxes;
     protected List<Integer> sortKeyUniqueIds;
     protected ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
-    protected boolean addingGINIndex = false;
+    protected boolean disableReplicatedStorageForGIN = false;
 
     // -------- for roll up-----------------
     protected long baseIndexId;
@@ -193,8 +193,8 @@ public abstract class AlterJobV2Builder {
         return this;
     }
 
-    public AlterJobV2Builder withAddingGINIndex(boolean addingGINIndex) {
-        this.addingGINIndex = addingGINIndex;
+    public AlterJobV2Builder withDisableReplicatedStorageForGIN(boolean disableReplicatedStorageForGIN) {
+        this.disableReplicatedStorageForGIN = disableReplicatedStorageForGIN;
         return this;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
@@ -62,7 +62,7 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
         schemaChangeJob.setStartTime(startTime);
         schemaChangeJob.setSortKeyIdxes(sortKeyIdxes);
         schemaChangeJob.setSortKeyUniqueIds(sortKeyUniqueIds);
-        schemaChangeJob.setAddingGINIndex(addingGINIndex);
+        schemaChangeJob.setDisableReplicatedStorageForGIN(disableReplicatedStorageForGIN);
         /*
          * Create schema change job
          * 1. For each index which has been changed, create a SHADOW index, and save the mapping of origin index to SHADOW index.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
@@ -62,6 +62,7 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
         schemaChangeJob.setStartTime(startTime);
         schemaChangeJob.setSortKeyIdxes(sortKeyIdxes);
         schemaChangeJob.setSortKeyUniqueIds(sortKeyUniqueIds);
+        schemaChangeJob.setAddingGINIndex(addingGINIndex);
         /*
          * Create schema change job
          * 1. For each index which has been changed, create a SHADOW index, and save the mapping of origin index to SHADOW index.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
@@ -46,7 +46,7 @@ class SchemaChangeData {
     private final List<Integer> sortKeyUniqueIds;
     private final long warehouseId;
     private final ComputeResource computeResource;
-    private final boolean addingGINIndex;
+    private final boolean disableReplicatedStorageForGIN;
 
     static Builder newBuilder() {
         return new Builder();
@@ -114,8 +114,8 @@ class SchemaChangeData {
         return computeResource;
     }
 
-    boolean isAddingGINIndex() {
-        return addingGINIndex;
+    boolean isDisableReplicatedStorageForGIN() {
+        return disableReplicatedStorageForGIN;
     }
 
     private SchemaChangeData(Builder builder) {
@@ -133,7 +133,7 @@ class SchemaChangeData {
         this.sortKeyUniqueIds = builder.sortKeyUniqueIds;
         this.warehouseId = builder.warehouseId;
         this.computeResource = builder.computeResource;
-        this.addingGINIndex = builder.addingGINIndex;
+        this.disableReplicatedStorageForGIN = builder.disableReplicatedStorageForGIN;
     }
 
     static class Builder {
@@ -151,7 +151,7 @@ class SchemaChangeData {
         private List<Integer> sortKeyUniqueIds;
         private long warehouseId;
         private ComputeResource computeResource;
-        private boolean addingGINIndex = false;
+        private boolean disableReplicatedStorageForGIN = false;
 
         private Builder() {
         }
@@ -214,8 +214,8 @@ class SchemaChangeData {
             return this;
         }
 
-        Builder withAddingGINIndex(boolean addingGINIndex) {
-            this.addingGINIndex = addingGINIndex;
+        Builder withDisableReplicatedStorageForGIN(boolean disableReplicatedStorageForGIN) {
+            this.disableReplicatedStorageForGIN = disableReplicatedStorageForGIN;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
@@ -46,6 +46,7 @@ class SchemaChangeData {
     private final List<Integer> sortKeyUniqueIds;
     private final long warehouseId;
     private final ComputeResource computeResource;
+    private final boolean addingGINIndex;
 
     static Builder newBuilder() {
         return new Builder();
@@ -113,6 +114,10 @@ class SchemaChangeData {
         return computeResource;
     }
 
+    boolean isAddingGINIndex() {
+        return addingGINIndex;
+    }
+
     private SchemaChangeData(Builder builder) {
         this.database = Objects.requireNonNull(builder.database, "database is null");
         this.table = Objects.requireNonNull(builder.table, "table is null");
@@ -128,6 +133,7 @@ class SchemaChangeData {
         this.sortKeyUniqueIds = builder.sortKeyUniqueIds;
         this.warehouseId = builder.warehouseId;
         this.computeResource = builder.computeResource;
+        this.addingGINIndex = builder.addingGINIndex;
     }
 
     static class Builder {
@@ -145,6 +151,7 @@ class SchemaChangeData {
         private List<Integer> sortKeyUniqueIds;
         private long warehouseId;
         private ComputeResource computeResource;
+        private boolean addingGINIndex = false;
 
         private Builder() {
         }
@@ -204,6 +211,11 @@ class SchemaChangeData {
         Builder withComputeResource(ComputeResource computeResource) {
             this.computeResource = computeResource;
             this.warehouseId = computeResource.getWarehouseId();
+            return this;
+        }
+
+        Builder withAddingGINIndex(boolean addingGINIndex) {
+            this.addingGINIndex = addingGINIndex;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2861,12 +2861,6 @@ public class SchemaChangeHandler extends AlterHandler {
             return;
         }
 
-        /*
-        if (newIndex.getIndexType() == IndexType.GIN && olapTable.enableReplicatedStorage()) {
-            throw new SemanticException("GIN does not support replicated mode");
-        }
-        */
-        // check 
         if (newIndex.getIndexType() == IndexType.GIN) {
             for (Column col : olapTable.getFullSchema()) {
                 if (col.isAutoIncrement()) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1403,11 +1403,11 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         // check gin index
-        // if there are gin index in table, set replicated_stroage to false.
-        boolean addingGINIndex = false;
+        // if there are gin index in table, set replicated_storage to false.
+        boolean disableReplicatedStorageForGIN = false;
         for (Index index : indexes) {
             if (index.getIndexType() == IndexType.GIN && olapTable.enableReplicatedStorage()) {
-                addingGINIndex = true;
+                disableReplicatedStorageForGIN = true;
                 break;
             }
         }
@@ -1500,7 +1500,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 .withAlterIndexInfo(hasIndexChange, indexes)
                 .withBloomFilterColumns(bfColumnIds, bfFpp)
                 .withBloomFilterColumnsChanged(hasBfChange)
-                .withAddingGINIndex(addingGINIndex);
+                .withDisableReplicatedStorageForGIN(disableReplicatedStorageForGIN);
 
         if (RunMode.isSharedDataMode()) {
             // check warehouse
@@ -3146,7 +3146,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 .withSortKeyUniqueIds(schemaChangeData.getSortKeyUniqueIds())
                 .withNewIndexSchema(schemaChangeData.getNewIndexSchema())
                 .withComputeResource(schemaChangeData.getComputeResource())
-                .withAddingGINIndex(schemaChangeData.isAddingGINIndex())
+                .withDisableReplicatedStorageForGIN(schemaChangeData.isDisableReplicatedStorageForGIN())
                 .build();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1402,6 +1402,16 @@ public class SchemaChangeHandler extends AlterHandler {
             hasIndexChange = true;
         }
 
+        // check gin index
+        // if there are gin index in table, set replicated_stroage to false.
+        boolean addingGINIndex = false;
+        for (Index index : indexes) {
+            if (index.getIndexType() == IndexType.GIN && olapTable.enableReplicatedStorage()) {
+                addingGINIndex = true;
+                break;
+            }
+        }
+
         // property 2. bloom filter
         // eg. "bloom_filter_columns" = "k1,k2", "bloom_filter_fpp" = "0.05"
         Set<String> bfColumns = null;
@@ -1489,7 +1499,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 .withTimeoutInSeconds(timeoutSecond)
                 .withAlterIndexInfo(hasIndexChange, indexes)
                 .withBloomFilterColumns(bfColumnIds, bfFpp)
-                .withBloomFilterColumnsChanged(hasBfChange);
+                .withBloomFilterColumnsChanged(hasBfChange)
+                .withAddingGINIndex(addingGINIndex);
 
         if (RunMode.isSharedDataMode()) {
             // check warehouse
@@ -2850,8 +2861,18 @@ public class SchemaChangeHandler extends AlterHandler {
             return;
         }
 
+        /*
         if (newIndex.getIndexType() == IndexType.GIN && olapTable.enableReplicatedStorage()) {
             throw new SemanticException("GIN does not support replicated mode");
+        }
+        */
+        // check 
+        if (newIndex.getIndexType() == IndexType.GIN) {
+            for (Column col : olapTable.getFullSchema()) {
+                if (col.isAutoIncrement()) {
+                    throw new DdlException("Table with AUTO_INCREMENT column can not add GIN Index");
+                }
+            }
         }
 
         if (newIndex.getIndexType() == IndexType.VECTOR) {
@@ -3131,6 +3152,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 .withSortKeyUniqueIds(schemaChangeData.getSortKeyUniqueIds())
                 .withNewIndexSchema(schemaChangeData.getNewIndexSchema())
                 .withComputeResource(schemaChangeData.getComputeResource())
+                .withAddingGINIndex(schemaChangeData.isAddingGINIndex())
                 .build();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -179,6 +179,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
     private List<Integer> sortKeyIdxes;
     @SerializedName(value = "sortKeyUniqueIds")
     private List<Integer> sortKeyUniqueIds;
+    // If disableReplicatedStorageForGIN is true, which means this job is adding gin index and table's replicated_storage is true,
+    // and we need to disable it.
     @SerializedName(value = "disableReplicatedStorageForGIN")
     private boolean disableReplicatedStorageForGIN = false;
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
@@ -73,8 +73,8 @@ public class InvertedIndexUtil {
     }
 
     public static void checkInvertedIndexValid(Column column, Map<String, String> properties, KeysType keysType) {
-        if (keysType != KeysType.DUP_KEYS) {
-            throw new SemanticException("The inverted index can only be build on DUPLICATE table.");
+        if (keysType != KeysType.DUP_KEYS && keysType != KeysType.PRIMARY_KEYS) {
+            throw new SemanticException("The inverted index can only be build on DUPLICATE/PRIMARY_KEYS table.");
         }
         if (!validGinColumnType(column)) {
             throw new SemanticException("The inverted index can only be build on column with type of CHAR/STRING/VARCHAR type.");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -272,9 +272,6 @@ public class OlapTable extends Table {
     @SerializedName(value = "sessionId")
     protected UUID sessionId = null;
 
-    @SerializedName(value = "addingGINIndex")
-    protected boolean addingGINIndex = false;
-
     protected BinlogConfig curBinlogConfig;
 
     // After ensuring that all binlog config of tablets in BE have taken effect,
@@ -449,7 +446,6 @@ public class OlapTable extends Table {
             olapTable.curBinlogConfig = new BinlogConfig(this.curBinlogConfig);
         }
         olapTable.dbName = this.dbName;
-        olapTable.addingGINIndex = this.addingGINIndex;
     }
 
     public void addDoubleWritePartition(long sourcePartitionId, long tempPartitionId) {
@@ -1923,14 +1919,6 @@ public class OlapTable extends Table {
         return tempPartitions.getPartition(partitionId) != null;
     }
 
-    public boolean isAddingGINIndex() {
-        return addingGINIndex;
-    }
-
-    public void setAddingGINIndex(boolean addingGINIndex) {
-        this.addingGINIndex = addingGINIndex;
-    }
-
     @Override
     public TTableDescriptor toThrift(List<ReferencedPartitionInfo> partitions) {
         TOlapTable tOlapTable = new TOlapTable(getName());
@@ -2675,7 +2663,7 @@ public class OlapTable extends Table {
 
     public Boolean enableReplicatedStorage() {
         if (tableProperty != null) {
-            return tableProperty.enableReplicatedStorage() && !addingGINIndex;
+            return tableProperty.enableReplicatedStorage();
         }
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -272,6 +272,9 @@ public class OlapTable extends Table {
     @SerializedName(value = "sessionId")
     protected UUID sessionId = null;
 
+    @SerializedName(value = "addingGINIndex")
+    protected boolean addingGINIndex = false;
+
     protected BinlogConfig curBinlogConfig;
 
     // After ensuring that all binlog config of tablets in BE have taken effect,
@@ -446,6 +449,7 @@ public class OlapTable extends Table {
             olapTable.curBinlogConfig = new BinlogConfig(this.curBinlogConfig);
         }
         olapTable.dbName = this.dbName;
+        olapTable.addingGINIndex = this.addingGINIndex;
     }
 
     public void addDoubleWritePartition(long sourcePartitionId, long tempPartitionId) {
@@ -1919,6 +1923,14 @@ public class OlapTable extends Table {
         return tempPartitions.getPartition(partitionId) != null;
     }
 
+    public boolean isAddingGINIndex() {
+        return addingGINIndex;
+    }
+
+    public void setAddingGINIndex(boolean addingGINIndex) {
+        this.addingGINIndex = addingGINIndex;
+    }
+
     @Override
     public TTableDescriptor toThrift(List<ReferencedPartitionInfo> partitions) {
         TOlapTable tOlapTable = new TOlapTable(getName());
@@ -2663,7 +2675,7 @@ public class OlapTable extends Table {
 
     public Boolean enableReplicatedStorage() {
         if (tableProperty != null) {
-            return tableProperty.enableReplicatedStorage();
+            return tableProperty.enableReplicatedStorage() && !addingGINIndex;
         }
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -521,7 +521,6 @@ public class OlapTableFactory implements AbstractTableFactory {
 
             boolean hasGin = table.getIndexes().stream()
                             .anyMatch(index -> index.getIndexType() == IndexType.GIN);
-            LOG.info("table: {} hasGin: {}, enableReplicatedStorage: {}", tableName, hasGin, table.enableReplicatedStorage());
             if (hasGin && table.enableReplicatedStorage()) {
                 // GIN indexes are incompatible with replicated_storage right now and we will disable replicated_storage
                 // if table contains GIN Index.

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -518,18 +518,23 @@ public class OlapTableFactory implements AbstractTableFactory {
                             properties, PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE,
                             Config.enable_replicated_storage_as_default_engine));
 
+
+            boolean hasGin = table.getIndexes().stream()
+                            .anyMatch(index -> index.getIndexType() == IndexType.GIN);
+            LOG.info("table: {} hasGin: {}, enableReplicatedStorage: {}", tableName, hasGin, table.enableReplicatedStorage());
+            if (hasGin && table.enableReplicatedStorage()) {
+                // GIN indexes are incompatible with replicated_storage right now and we will disable replicated_storage
+                // if table contains GIN Index.
+                table.setEnableReplicatedStorage(false);
+            }
+
             if (table.enableReplicatedStorage().equals(false)) {
                 for (Column col : baseSchema) {
                     if (col.isAutoIncrement()) {
-                        throw new DdlException("Table with AUTO_INCREMENT column must use Replicated Storage");
+                        throw new DdlException("Table with AUTO_INCREMENT column must use Replicated Storage " +
+                                " and not compatible with GIN Index");
                     }
                 }
-            }
-
-            boolean hasGin = table.getIndexes().stream()
-                    .anyMatch(index -> index.getIndexType() == IndexType.GIN);
-            if (hasGin && table.enableReplicatedStorage()) {
-                throw new SemanticException("GIN does not support replicated mode");
             }
 
             TTabletType tabletType = TTabletType.TABLET_TYPE_DISK;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
@@ -67,8 +67,8 @@ public class GINIndexTest extends PlanTestBase {
 
         Assertions.assertThrows(
                 SemanticException.class,
-                () -> InvertedIndexUtil.checkInvertedIndexValid(c1, null, KeysType.PRIMARY_KEYS),
-                "The inverted index can only be build on DUPLICATE table.");
+                () -> InvertedIndexUtil.checkInvertedIndexValid(c1, null, KeysType.UNIQUE_KEYS),
+                "The inverted index can only be build on DUPLICATE/PRIMARY_KEYS table.");
 
         Assertions.assertThrows(
                 SemanticException.class,

--- a/test/sql/test_index/R/test_gin_index
+++ b/test/sql/test_index/R/test_gin_index
@@ -1,0 +1,253 @@
+-- name: test_gin_index_table
+create database test_gin_index;
+-- result:
+-- !result
+use  test_gin_index;
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");
+-- result:
+-- !result
+CREATE TABLE `t1_dup` (
+    `id1` bigint(20) NOT NULL COMMENT "",
+    `value` varchar(255) NOT NULL COMMENT "",
+    INDEX gin_english (`value`) USING GIN ("parser" = "english")
+)
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+    "replicated_storage" = "true",
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+show create table t1_dup;
+-- result:
+t1_dup	CREATE TABLE `t1_dup` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `value` varchar(255) NOT NULL COMMENT "",
+  INDEX gin_english (`value`) USING GIN("imp_lib" = "clucene", "parser" = "english") COMMENT ''
+) ENGINE=OLAP 
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "false",
+"replication_num" = "1"
+);
+-- !result
+CREATE TABLE `t1_unique` (
+    `id1` bigint(20) NOT NULL COMMENT "",
+    `value` varchar(255) NOT NULL COMMENT "",
+    INDEX gin_english (`value`) USING GIN ("parser" = "english")
+)
+UNIQUE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+    "replicated_storage" = "false",
+    "replication_num" = "1"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on DUPLICATE/PRIMARY_KEYS table..')
+-- !result
+CREATE TABLE `t1_agg` (
+    `id1` bigint(20) NOT NULL COMMENT "",
+    `value` varchar(255) REPLACE NOT NULL COMMENT "",
+    `cnt` bigint(20) SUM DEFAULT "0",
+    INDEX gin_english (`value`) USING GIN ("parser" = "english")
+)
+AGGREGATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+    "replicated_storage" = "false",
+    "replication_num" = "1"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on DUPLICATE/PRIMARY_KEYS table..')
+-- !result
+CREATE TABLE `t1_primary` (
+    `id1` bigint(20) NOT NULL COMMENT "",
+    `value` varchar(255) NOT NULL COMMENT "",
+    INDEX gin_english (`value`) USING GIN ("parser" = "english")
+)
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+    "replicated_storage" = "true",
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+show create table t1_primary;
+-- result:
+t1_primary	CREATE TABLE `t1_primary` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `value` varchar(255) NOT NULL COMMENT "",
+  INDEX gin_english (`value`) USING GIN("imp_lib" = "clucene", "parser" = "english") COMMENT ''
+) ENGINE=OLAP 
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "true",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "false",
+"replication_num" = "1"
+);
+-- !result
+insert into t1_primary values (1, 'hello'), (2, 'world'), (3, 'hello world'), (4, 'starrocks database');
+-- result:
+-- !result
+select * from t1_primary where value match 'hello';
+-- result:
+1	hello
+3	hello world
+-- !result
+select * from t1_primary where value match 'starrocks';
+-- result:
+4	starrocks database
+-- !result
+select * from t1_primary where value match 'hello world';
+-- result:
+-- !result
+select * from t1_primary where value match 'starrocks database';
+-- result:
+-- !result
+select * from t1_primary where value match '%hello%';
+-- result:
+1	hello
+3	hello world
+-- !result
+select * from t1_primary where value match '%world%';
+-- result:
+2	world
+3	hello world
+-- !result
+select * from t1_primary where value match '%starrocks%';
+-- result:
+4	starrocks database
+-- !result
+select * from t1_primary where value match '%database%';
+-- result:
+4	starrocks database
+-- !result
+select * from t1_primary where value match '%hello';
+-- result:
+1	hello
+3	hello world
+-- !result
+select * from t1_primary where value match '%world';
+-- result:
+2	world
+3	hello world
+-- !result
+select * from t1_primary where value match 'hello%';
+-- result:
+1	hello
+3	hello world
+-- !result
+select * from t1_primary where value match 'starrocks%';
+-- result:
+4	starrocks database
+-- !result
+CREATE TABLE t2_dup (
+    id1 bigint(20) NOT NULL COMMENT "",
+    value varchar(255) COMMENT ""
+)
+DUPLICATE KEY(id1)
+DISTRIBUTED BY HASH(id1) BUCKETS 1
+PROPERTIES (
+    "replicated_storage" = "true",
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+show create table t2_dup;
+-- result:
+t2_dup	CREATE TABLE `t2_dup` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `value` varchar(255) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+insert into t2_dup values (1, 'hello', 1), (2, 'world', 2), (3, 'hello world', 3), (4, 'starrocks database', 4);
+-- result:
+E: (5604, "Getting analyzing error. Detail message: Inserted target column count: 2 doesn't match select/value column count: 3.")
+-- !result
+ALTER TABLE t2_dup ADD INDEX gin_english(value) USING GIN ("parser" = "english");
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table from t2_dup;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 18. Detail message: Unexpected input 'from', the most similar input is {a legal identifier}.")
+-- !result
+CREATE TABLE t2_primary (
+    id1 bigint(20) NOT NULL COMMENT "",
+    value varchar(255) NOT NULL COMMENT ""
+)
+PRIMARY KEY(id1)
+DISTRIBUTED BY HASH(id1) BUCKETS 1
+PROPERTIES (
+    "replicated_storage" = "true",
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+show create table t2_primary;
+-- result:
+t2_primary	CREATE TABLE `t2_primary` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `value` varchar(255) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "true",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+insert into t2_primary values (1, 'hello'), (2, 'world'), (3, 'hello world'), (4, 'starrocks database');
+-- result:
+-- !result
+ALTER TABLE t2_primary ADD INDEX gin_english(value) USING GIN ("parser" = "english");
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table t2_primary;
+-- result:
+t2_primary	CREATE TABLE `t2_primary` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `value` varchar(255) NOT NULL COMMENT "",
+  INDEX gin_english (`value`) USING GIN("imp_lib" = "clucene", "parser" = "english") COMMENT ''
+) ENGINE=OLAP 
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "true",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "false",
+"replication_num" = "1"
+);
+-- !result
+drop database test_gin_index;
+-- result:
+-- !result

--- a/test/sql/test_index/T/test_gin_index
+++ b/test/sql/test_index/T/test_gin_index
@@ -1,0 +1,136 @@
+-- name: test_gin_index_table
+create database test_gin_index;
+use  test_gin_index;
+
+ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");
+-- DUPLICATE KEY table with GIN index
+CREATE TABLE `t1_dup` (
+    `id1` bigint(20) NOT NULL COMMENT "",
+    `value` varchar(255) NOT NULL COMMENT "",
+    INDEX gin_english (`value`) USING GIN ("parser" = "english")
+)
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+    "replicated_storage" = "true",
+    "replication_num" = "1"
+);
+
+show create table t1_dup;
+
+-- UNIQUE KEY table with GIN index
+CREATE TABLE `t1_unique` (
+    `id1` bigint(20) NOT NULL COMMENT "",
+    `value` varchar(255) NOT NULL COMMENT "",
+    INDEX gin_english (`value`) USING GIN ("parser" = "english")
+)
+UNIQUE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+    "replicated_storage" = "false",
+    "replication_num" = "1"
+);
+
+-- AGGREGATE KEY table with GIN index
+CREATE TABLE `t1_agg` (
+    `id1` bigint(20) NOT NULL COMMENT "",
+    `value` varchar(255) REPLACE NOT NULL COMMENT "",
+    `cnt` bigint(20) SUM DEFAULT "0",
+    INDEX gin_english (`value`) USING GIN ("parser" = "english")
+)
+AGGREGATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+    "replicated_storage" = "false",
+    "replication_num" = "1"
+);
+
+-- PRIMARY KEY table with GIN index
+CREATE TABLE `t1_primary` (
+    `id1` bigint(20) NOT NULL COMMENT "",
+    `value` varchar(255) NOT NULL COMMENT "",
+    INDEX gin_english (`value`) USING GIN ("parser" = "english")
+)
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+    "replicated_storage" = "true",
+    "replication_num" = "1"
+);
+
+show create table t1_primary;
+insert into t1_primary values (1, 'hello'), (2, 'world'), (3, 'hello world'), (4, 'starrocks database');
+
+-- exact match
+select * from t1_primary where value match 'hello';
+select * from t1_primary where value match 'starrocks';
+select * from t1_primary where value match 'hello world';
+select * from t1_primary where value match 'starrocks database';
+
+-- wildcard match with leading and trailing %
+select * from t1_primary where value match '%hello%';
+select * from t1_primary where value match '%world%';
+select * from t1_primary where value match '%starrocks%';
+select * from t1_primary where value match '%database%';
+
+-- wildcard match with leading %
+select * from t1_primary where value match '%hello';
+select * from t1_primary where value match '%world';
+
+-- wildcard match with trailing %
+select * from t1_primary where value match 'hello%';
+select * from t1_primary where value match 'starrocks%';
+
+
+--name: add_GIN_index
+-- DUPLICATE KEY table without GIN index, then add GIN index after data load
+CREATE TABLE t2_dup (
+    id1 bigint(20) NOT NULL COMMENT "",
+    value varchar(255) COMMENT ""
+)
+DUPLICATE KEY(id1)
+DISTRIBUTED BY HASH(id1) BUCKETS 1
+PROPERTIES (
+    "replicated_storage" = "true",
+    "replication_num" = "1"
+);
+
+show create table t2_dup;
+
+insert into t2_dup values (1, 'hello', 1), (2, 'world', 2), (3, 'hello world', 3), (4, 'starrocks database', 4);
+
+ALTER TABLE t2_dup ADD INDEX gin_english(value) USING GIN ("parser" = "english");
+-- wait for index creation to finish
+function: wait_alter_table_finish()
+show create table from t2_dup;
+
+-- PRIMARY KEY table without GIN index, then add GIN index after data load
+CREATE TABLE t2_primary (
+    id1 bigint(20) NOT NULL COMMENT "",
+    value varchar(255) NOT NULL COMMENT ""
+)
+PRIMARY KEY(id1)
+DISTRIBUTED BY HASH(id1) BUCKETS 1
+PROPERTIES (
+    "replicated_storage" = "true",
+    "replication_num" = "1"
+);
+show create table t2_primary;
+
+insert into t2_primary values (1, 'hello'), (2, 'world'), (3, 'hello world'), (4, 'starrocks database');
+
+ALTER TABLE t2_primary ADD INDEX gin_english(value) USING GIN ("parser" = "english");
+-- wait for index creation to finish
+function: wait_alter_table_finish()
+show create table t2_primary;
+
+drop database test_gin_index;
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
## Why I'm doing:
The GIN indexes are incompatible with replicated_storage right now. If we want to create a GIN index, we need to disable replicated_storage manually. This PR will disable replicated_storage when using a GIN index.

## What I'm doing:
1. Disable replicated_storage when using a GIN index.
2. Enable GIN index for primary key table.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
