### PR TITLE
[BugFix] Fix UAF in local-partition preagg

### DIFF
--- a/be/src/exec/pipeline/sort/local_partition_topn_context.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.h
@@ -137,29 +137,11 @@ private:
     std::vector<PartitionColumnType> _partition_types;
     bool _has_nullable_key = false;
 
-    // only set when _enable_pre_agg=true
+    // used in preagg
+    std::unique_ptr<MemPool> _mem_pool = nullptr;
     bool _enable_pre_agg;
+    // only set when _enable_pre_agg=true
     std::unique_ptr<PreAggState> _pre_agg;
-    // bool _is_first_chunk_of_current_sorter = true;
-    // const std::vector<TExpr>& _t_pre_agg_exprs;
-    // const std::vector<TSlotId>& _t_pre_agg_output_slot_id;
-
-    // // The offset of the n-th aggregate function in a row of aggregate functions.
-    // std::vector<size_t> _agg_states_offsets;
-    // // The total size of the row for the aggregate function state.
-    // size_t _agg_states_total_size = 0;
-    // // The max align size for all aggregate state
-    // size_t _max_agg_state_align_size = 1;
-    // // The followings are aggregate function information:
-    // std::vector<FunctionContext*> _agg_fn_ctxs;
-    // std::vector<const AggregateFunction*> _agg_functions;
-    // std::vector<std::vector<ExprContext*>> _agg_expr_ctxs;
-    // std::vector<Columns> _agg_input_columns;
-    // //raw pointers in order to get multi-column values
-    // std::vector<std::vector<const Column*>> _agg_input_raw_columns;
-    // std::vector<FunctionTypes> _agg_fn_types;
-    // // every partition has one Agg State
-    // std::vector<ManagedFunctionStatesPtr<LocalPartitionTopnContext>> _managed_fn_states;
 
     // No more input chunks if after _is_sink_complete is set to true
     bool _is_sink_complete = false;
@@ -179,8 +161,6 @@ private:
     const TTopNType::type _topn_type;
 
     int32_t _sorter_index = 0;
-
-    std::unique_ptr<MemPool> _mem_pool = nullptr;
 
     PipeObservable _observable;
 };


### PR DESCRIPTION
## Why I'm doing:

```
==755006==ERROR: AddressSanitizer: heap-use-after-free on address 0x625002696028 at pc 0x000018aff7a6 bp 0x7ffcd55ead00 sp 0x7ffcd55eacf0
READ of size 8 at 0x625002696028 thread T746
    #0 0x18aff7a5 in std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 0ul, std::allocator<unsigned char> > >::~vector() /usr/include/c++/12/bits/stl_vector.h:730
    #1 0x1bb355a9 in starrocks::MinAggregateData<(starrocks::LogicalType)17, int>::~MinAggregateData() be/src/exprs/agg/maxmin.h:76
    #2 0x1bc6054f in starrocks::NullableAggregateFunctionState<starrocks::MinAggregateData<(starrocks::LogicalType)17, int>, true>::~NullableAggregateFunctionState() be/src/exprs/agg/nullable_aggregate.h:63
    #3 0x1bc6057f in starrocks::AggregateFunctionStateHelper<starrocks::NullableAggregateFunctionState<starrocks::MinAggregateData<(starrocks::LogicalType)17, int>, true> >::destroy(starrocks::FunctionContext*, unsigned char*) const be/src/exprs/agg/aggregate.h:350
    #4 0x19cc2104 in starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>::~ManagedFunctionStates() be/src/exec/analytor.h:378
    #5 0x19cbf89f in std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> >::operator()(starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>*) const /usr/include/c++/12/bits/unique_ptr.h:95
    #6 0x19cbc8b4 in std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > >::~unique_ptr() /usr/include/c++/12/bits/unique_ptr.h:396
    #7 0x19cc6dea in void std::destroy_at<std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > > >(std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > >*) /usr/include/c++/12/bits/stl_construct.h:88
    #8 0x19cccbfd in void std::_Destroy<std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > > >(std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > >*) /usr/include/c++/12/bits/stl_construct.h:149
    #9 0x19cc4d5b in void std::_Destroy_aux<false>::__destroy<std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > >*>(std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > >*, std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > >*) /usr/include/c++/12/bits/stl_construct.h:163
    #10 0x19cc0efd in void std::_Destroy<std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > >*>(std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > >*, std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > >*) /usr/include/c++/12/bits/stl_construct.h:196
    #11 0x19cbd468 in void std::_Destroy<std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > >*, std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > > >(std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > >*, std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > >*, std::allocator<std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > > >&) /usr/include/c++/12/bits/alloc_traits.h:850
    #12 0x19cbbaed in std::vector<std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > >, std::allocator<std::unique_ptr<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState>, std::default_delete<starrocks::ManagedFunctionStates<starrocks::pipeline::PreAggState> > > > >::~vector() /usr/include/c++/12/bits/stl_vector.h:730
    #13 0x19cbd5bd in starrocks::pipeline::PreAggState::~PreAggState() be/src/exec/pipeline/sort/local_partition_topn_context.h:39
    #14 0x19cbd65d in std::default_delete<starrocks::pipeline::PreAggState>::operator()(starrocks::pipeline::PreAggState*) const /usr/include/c++/12/bits/unique_ptr.h:95
    #15 0x19cbbc4c in std::unique_ptr<starrocks::pipeline::PreAggState, std::default_delete<starrocks::pipeline::PreAggState> >::~unique_ptr() /usr/include/c++/12/bits/unique_ptr.h:396
    #16 0x19d7885d in starrocks::pipeline::LocalPartitionTopnContext::~LocalPartitionTopnContext() be/src/exec/pipeline/sort/local_partition_topn_context.h:75
    #17 0x19d7889c in void std::destroy_at<starrocks::pipeline::LocalPartitionTopnContext>(starrocks::pipeline::LocalPartitionTopnContext*) /usr/include/c++/12/bits/stl_construct.h:88
    #18 0x19d7871a in void std::_Destroy<starrocks::pipeline::LocalPartitionTopnContext>(starrocks::pipeline::LocalPartitionTopnContext*) /usr/include/c++/12/bits/stl_construct.h:149
```

## What I'm doing:
reproduce case see test_low_cardinality_window

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
