### PR TITLE
[BugFix] don't try to build MFV versions for the instructions turned off

### DIFF
--- a/be/src/simd/multi_version.h
+++ b/be/src/simd/multi_version.h
@@ -24,22 +24,58 @@
     _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wunused-function\"") \
             ATTR static IMPL _Pragma("GCC diagnostic pop")
 
+#if defined(__SSE4_2__)
 #define MFV_SSE42(IMPL) MFV_IMPL(IMPL, __attribute__((target("sse4.2"))))
+#endif
+
+#if defined(__AVX2__)
 #define MFV_AVX2(IMPL) MFV_IMPL(IMPL, __attribute__((target("avx2"))))
+#endif
+
+#if defined(__AVX512F__)
 #define MFV_AVX512F(IMPL) MFV_IMPL(IMPL, __attribute__((target("avx512f"))))
+#endif
+
+#if defined(__AVX512BW__)
 #define MFV_AVX512BW(IMPL) MFV_IMPL(IMPL, __attribute__((target("avx512bw"))))
+#endif
+
+#if defined(__AVX512VL__)
 #define MFV_AVX512VL(IMPL) MFV_IMPL(IMPL, __attribute__((target("avx512vl"))))
+#endif
+
+#if defined(__AVX512F__) && defined(__AVX512BW__) && defined(__AVX512VL__)
 #define MFV_AVX512VLBW(IMPL) MFV_IMPL(IMPL, __attribute__((target("avx512f,avx512vl,avx512bw"))))
+#endif
+
 #define MFV_DEFAULT(IMPL) MFV_IMPL(IMPL, __attribute__((target("default"))))
 
-#else
+#endif // end of defined(__GNUC__) && defined(__x86_64__)
 
+#if !defined(MFV_SSE42)
 #define MFV_SSE42(IMPL)
-#define MFV_AVX2(IMPL)
-#define MFV_AVX512F(IMPL)
-#define MFV_AVX512BW(IMPL)
-#define MFV_AVX512VL(IMPL)
-#define MFV_AVX512VLBW(IMPL)
-#define MFV_DEFAULT(IMPL) IMPL
+#endif
 
+#if !defined(MFV_AVX2)
+#define MFV_AVX2(IMPL)
+#endif
+
+#if !defined(MFV_AVX512F)
+#define MFV_AVX512F(IMPL)
+#endif
+
+#if !defined(MFV_AVX512BW)
+#define MFV_AVX512BW(IMPL)
+#endif
+
+#if !defined(MFV_AVX512VL)
+#define MFV_AVX512VL(IMPL)
+#endif
+
+#if !defined(MFV_AVX512VLBW)
+#define MFV_AVX512VLBW(IMPL)
+#endif
+
+#if !defined(MFV_DEFAULT)
+#define MFV_DEFAULT(IMPL) IMPL
 #endif


### PR DESCRIPTION
* the cpu instruction is off either because of not wanted the target instruction set or the build machine doesn't have the instruction supported. Be respectful to the instruction switch.

## Why I'm doing:

## What I'm doing:

Fixes #60717

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
