### PR TITLE
[BugFix] fixing login issue because of special characters in usernames

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/UserAuthenticationInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/UserAuthenticationInfo.java
@@ -46,7 +46,15 @@ public class UserAuthenticationInfo implements Writable {
     protected PatternMatcher hostPattern;
 
     public boolean matchUser(String remoteUser) {
-        return isAnyUser || userPattern.match(remoteUser);
+        if (isAnyUser) {
+            return true;
+        }
+
+        if (CaseSensibility.USER.getCaseSensibility()) {
+            return origUser.equals(remoteUser);
+        } else {
+            return origUser.equalsIgnoreCase(remoteUser);
+        }
     }
 
     public boolean matchHost(String remoteHost) {
@@ -56,8 +64,14 @@ public class UserAuthenticationInfo implements Writable {
     public void analyze() throws AuthenticationException {
         isAnyUser = origUser.equals(ANY_USER);
         isAnyHost = origHost.equals(ANY_HOST);
-        userPattern = PatternMatcher.createMysqlPattern(origUser, CaseSensibility.USER.getCaseSensibility());
+
         hostPattern = PatternMatcher.createMysqlPattern(origHost, CaseSensibility.HOST.getCaseSensibility());
+
+        if (isAnyUser) {
+            userPattern = PatternMatcher.createMysqlPattern(origUser, CaseSensibility.USER.getCaseSensibility());
+        } else {
+            userPattern = null;
+        }
     }
 
     public byte[] getPassword() {
@@ -70,6 +84,14 @@ public class UserAuthenticationInfo implements Writable {
 
     public String getOrigHost() {
         return origHost;
+    }
+
+    public String getOrigUser() {
+        return origUser;
+    }
+
+    public boolean isAnyUser() {
+        return isAnyUser;
     }
 
     public String getAuthString() {

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/UserAuthenticationInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/UserAuthenticationInfoTest.java
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class UserAuthenticationInfoTest {
+
+    @Test
+    public void testUsernameExactMatch() throws Exception {
+        UserAuthenticationInfo authInfo = new UserAuthenticationInfo();
+        authInfo.setOrigUserHost("test_1", "%");
+
+        // Should match exact username
+        Assertions.assertTrue(authInfo.matchUser("test_1"));
+
+        // Should NOT match variations to prevent authentication bypass
+        Assertions.assertFalse(authInfo.matchUser("test.1"));
+        Assertions.assertFalse(authInfo.matchUser("test=1"));
+        Assertions.assertFalse(authInfo.matchUser("test*1"));
+        Assertions.assertFalse(authInfo.matchUser("testa1"));
+        Assertions.assertFalse(authInfo.matchUser("test 1"));
+        Assertions.assertFalse(authInfo.matchUser("test1"));
+        Assertions.assertFalse(authInfo.matchUser("test_11"));
+        Assertions.assertFalse(authInfo.matchUser("test_"));
+    }
+
+    @Test
+    public void testWildcardUser() throws Exception {
+        UserAuthenticationInfo authInfo = new UserAuthenticationInfo();
+        authInfo.setOrigUserHost("%", "%");
+
+        // Wildcard user should match any username
+        Assertions.assertTrue(authInfo.matchUser("test_1"));
+        Assertions.assertTrue(authInfo.matchUser("test.1"));
+        Assertions.assertTrue(authInfo.matchUser("anyuser"));
+        Assertions.assertTrue(authInfo.matchUser("user_with_underscores"));
+    }
+
+    @Test
+    public void testUsernameWithSpecialCharacters() throws Exception {
+        String[] testUsernames = {
+                "user.name@domain",
+                "app_user_db_1",
+                "service-account",
+                "user$special"
+        };
+
+        for (String username : testUsernames) {
+            UserAuthenticationInfo authInfo = new UserAuthenticationInfo();
+            authInfo.setOrigUserHost(username, "%");
+
+            Assertions.assertTrue(authInfo.matchUser(username));
+
+            String modified = username.replace("_", ".").replace(".", "_");
+            if (!modified.equals(username)) {
+                Assertions.assertFalse(authInfo.matchUser(modified));
+            }
+        }
+    }
+
+    @Test
+    public void testCaseSensitiveUsernames() throws Exception {
+        UserAuthenticationInfo authInfo = new UserAuthenticationInfo();
+        authInfo.setOrigUserHost("TestUser", "%");
+
+        Assertions.assertTrue(authInfo.matchUser("TestUser"));
+
+        Assertions.assertFalse(authInfo.matchUser("testuser"));
+        Assertions.assertFalse(authInfo.matchUser("TESTUSER"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

<img width="481" height="56" alt="image" src="https://github.com/user-attachments/assets/28508294-45fa-4605-b982-6ffe7b244930" />

<img width="793" height="441" alt="image" src="https://github.com/user-attachments/assets/707d6e2f-08df-49c1-9fce-47368a277154" />



Fixes #61525 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces exact, case-aware username matching (except wildcard %) and adds tests covering special characters and case sensitivity.
> 
> - **Authentication**:
>   - Change `matchUser` to perform exact username comparison respecting `CaseSensibility.USER`; retain `%` wildcard behavior via `isAnyUser`.
>   - Update `analyze()` to only build `userPattern` for `%` users; set `userPattern` to `null` otherwise.
>   - Add `getOrigUser()` and `isAnyUser()` accessors.
> - **Tests**:
>   - Add `UserAuthenticationInfoTest` with cases for exact match, wildcard user, special-character usernames, and case sensitivity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32e5fa5aa0b5f6050332df3d53d21d0e34f91989. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->