### PR TITLE
[Feature] Add format_bytes function for human-readable byte formatting

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -4863,9 +4863,10 @@ StatusOr<ColumnPtr> StringFunctions::format_bytes(FunctionContext* context, cons
     static const int64_t GB = MB * 1024L;
     static const int64_t TB = GB * 1024L;
     static const int64_t PB = TB * 1024L;
+    static const int64_t EB = PB * 1024L;
 
-    static const char* units[] = {"B", "KB", "MB", "GB", "TB", "PB"};
-    static const int64_t thresholds[] = {1, KB, MB, GB, TB, PB};
+    static const char* units[] = {"B", "KB", "MB", "GB", "TB", "PB", "EB"};
+    static const int64_t thresholds[] = {1, KB, MB, GB, TB, PB, EB};
 
     for (int row = 0; row < num_rows; ++row) {
         if (bytes_viewer.is_null(row)) {
@@ -4888,7 +4889,7 @@ StatusOr<ColumnPtr> StringFunctions::format_bytes(FunctionContext* context, cons
 
         // Find appropriate unit
         int unit_index = 0;
-        for (int i = 5; i >= 0; --i) {
+        for (int i = 6; i >= 0; --i) {
             if (bytes >= thresholds[i]) {
                 unit_index = i;
                 break;

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -4848,6 +4848,70 @@ DEFINE_UNARY_FN_WITH_IMPL(crc32Impl, str) {
 StatusOr<ColumnPtr> StringFunctions::crc32(FunctionContext* context, const Columns& columns) {
     return VectorizedStrictUnaryFunction<crc32Impl>::evaluate<TYPE_VARCHAR, TYPE_BIGINT>(columns[0]);
 }
+
+// format_bytes
+StatusOr<ColumnPtr> StringFunctions::format_bytes(FunctionContext* context, const Columns& columns) {
+    RETURN_IF_COLUMNS_ONLY_NULL(columns);
+
+    auto num_rows = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(num_rows);
+    ColumnViewer<TYPE_BIGINT> bytes_viewer(columns[0]);
+
+    // Unit constants (1024-based)
+    static const int64_t KB = 1024L;
+    static const int64_t MB = KB * 1024L;
+    static const int64_t GB = MB * 1024L;
+    static const int64_t TB = GB * 1024L;
+    static const int64_t PB = TB * 1024L;
+
+    static const char* units[] = {"B", "KB", "MB", "GB", "TB", "PB"};
+    static const int64_t thresholds[] = {1, KB, MB, GB, TB, PB};
+
+    for (int row = 0; row < num_rows; ++row) {
+        if (bytes_viewer.is_null(row)) {
+            result.append_null();
+            continue;
+        }
+
+        int64_t bytes = bytes_viewer.value(row);
+
+        // Handle edge cases
+        if (bytes < 0) {
+            result.append_null();
+            continue;
+        }
+
+        if (bytes == 0) {
+            result.append("0 B");
+            continue;
+        }
+
+        // Find appropriate unit
+        int unit_index = 0;
+        for (int i = 5; i >= 0; --i) {
+            if (bytes >= thresholds[i]) {
+                unit_index = i;
+                break;
+            }
+        }
+
+        std::string formatted;
+        if (unit_index == 0) {
+            // Bytes - no decimal places
+            formatted = std::to_string(bytes) + " B";
+        } else {
+            // Higher units - 2 decimal places
+            double value = static_cast<double>(bytes) / thresholds[unit_index];
+            std::ostringstream oss;
+            oss << std::fixed << std::setprecision(2) << value << " " << units[unit_index];
+            formatted = oss.str();
+        }
+
+        result.append(Slice(formatted.data(), formatted.size()));
+    }
+
+    return result.build(ColumnHelper::is_all_const(columns));
+}
 } // namespace starrocks
 
 #include "gen_cpp/opcode/StringFunctions.inc"

--- a/be/src/exprs/string_functions.h
+++ b/be/src/exprs/string_functions.h
@@ -621,6 +621,15 @@ public:
     template <LogicalType Type>
     static Status field_close(FunctionContext* context, FunctionContext::FunctionStateScope scope);
 
+    /**
+     * Format byte count as human-readable string with appropriate units
+     *
+     * @param: [bytes]
+     * @paramType: [BigIntColumn]
+     * @return: BinaryColumn
+     */
+    DEFINE_VECTORIZED_FN(format_bytes);
+
     static Status ngram_search_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);
     static Status ngram_search_case_insensitive_prepare(FunctionContext* context,
                                                         FunctionContext::FunctionStateScope scope);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -160,6 +160,7 @@ set(EXEC_FILES
         ./exprs/percentile_functions_test.cpp
         ./exprs/string_fn_concat_test.cpp
         ./exprs/string_fn_field.cpp
+        ./exprs/string_fn_format_bytes_test.cpp
         ./exprs/string_fn_locate_test.cpp
         ./exprs/string_fn_pad_test.cpp
         ./exprs/string_fn_regexp_replace_test.cpp

--- a/be/test/exprs/string_fn_format_bytes_test.cpp
+++ b/be/test/exprs/string_fn_format_bytes_test.cpp
@@ -1,0 +1,198 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "exprs/string_functions.h"
+
+namespace starrocks {
+
+class StringFunctionFormatBytesTest : public ::testing::Test {};
+
+TEST_F(StringFunctionFormatBytesTest, formatBytesBasicTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    Columns columns;
+    auto bytes_col = Int64Column::create();
+
+    // Test basic examples from the spec
+    std::vector<std::tuple<int64_t, std::string>> test_cases = {
+        {0, "0 B"},
+        {123, "123 B"},
+        {1023, "1023 B"},
+        {1024, "1.00 KB"},
+        {4096, "4.00 KB"},
+        {123456789, "117.74 MB"},
+        {10737418240, "10.00 GB"},
+        {1048576, "1.00 MB"},
+        {1073741824, "1.00 GB"},
+        {1099511627776, "1.00 TB"},
+        {1125899906842624, "1.00 PB"}
+    };
+
+    for (auto& test_case : test_cases) {
+        bytes_col->append(std::get<0>(test_case));
+    }
+
+    columns.emplace_back(std::move(bytes_col));
+
+    ColumnPtr result = StringFunctions::format_bytes(ctx.get(), columns).value();
+    ASSERT_EQ(test_cases.size(), result->size());
+    ASSERT_TRUE(result->is_binary());
+
+    auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+
+    for (int i = 0; i < test_cases.size(); ++i) {
+        ASSERT_EQ(std::get<1>(test_cases[i]), v->get_data()[i].to_string())
+            << "Failed for input: " << std::get<0>(test_cases[i]);
+    }
+}
+
+TEST_F(StringFunctionFormatBytesTest, formatBytesEdgeCasesTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+
+    std::vector<std::tuple<ColumnPtr, bool, std::string>> test_cases = {
+        // Test null input
+        {ColumnHelper::create_const_null_column(1), true, ""},
+
+        // Test zero
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(0, 1), false, "0 B"},
+
+        // Test negative numbers (should return null)
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(-1, 1), true, ""},
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(-1024, 1), true, ""},
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(INT64_MIN, 1), true, ""},
+
+        // Test small values (bytes)
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(1, 1), false, "1 B"},
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(512, 1), false, "512 B"},
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(1023, 1), false, "1023 B"},
+
+        // Test KB values
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(1024, 1), false, "1.00 KB"},
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(1536, 1), false, "1.50 KB"},
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(2048, 1), false, "2.00 KB"},
+
+        // Test MB values
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(1048576, 1), false, "1.00 MB"},
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(1572864, 1), false, "1.50 MB"},
+
+        // Test GB values
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(1073741824, 1), false, "1.00 GB"},
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(2147483648, 1), false, "2.00 GB"},
+
+        // Test TB values
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(1099511627776, 1), false, "1.00 TB"},
+
+        // Test PB values
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(1125899906842624, 1), false, "1.00 PB"},
+
+        // Test very large values
+        {ColumnHelper::create_const_column<TYPE_BIGINT>(INT64_MAX, 1), false, "8.00 EB"},
+    };
+
+    for (auto& test_case : test_cases) {
+        auto [column, is_null, expected] = test_case;
+        Columns columns{column};
+        ColumnPtr result = StringFunctions::format_bytes(ctx.get(), columns).value();
+        ASSERT_EQ(result->size(), 1);
+
+        if (is_null) {
+            ASSERT_TRUE(result->is_null(0));
+        } else {
+            ASSERT_FALSE(result->is_null(0));
+            auto nullable_datum = result->get(0);
+            ASSERT_FALSE(nullable_datum.is_null());
+            ASSERT_EQ(nullable_datum.get_slice().to_string(), expected);
+        }
+    }
+}
+
+TEST_F(StringFunctionFormatBytesTest, formatBytesNullableColumnTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    auto bytes_col = Int64Column::create();
+    auto null_col = NullColumn::create();
+
+    std::vector<std::tuple<int64_t, bool, bool, std::string>> test_cases = {
+        {0, false, false, "0 B"},
+        {1024, false, false, "1.00 KB"},
+        {-1, false, true, ""},
+        {1048576, false, false, "1.00 MB"},
+        {0, true, true, ""},  // null input
+        {1073741824, false, false, "1.00 GB"},
+        {-512, false, true, ""},
+        {123, false, false, "123 B"},
+        {4096, true, true, ""},  // null input
+        {1099511627776, false, false, "1.00 TB"},
+    };
+
+    for (auto& test_case : test_cases) {
+        int64_t bytes = std::get<0>(test_case);
+        bool is_null = std::get<1>(test_case);
+        bytes_col->append(bytes);
+        null_col->append(is_null);
+    }
+
+    const auto num_rows = bytes_col->size();
+    Columns columns{NullableColumn::create(std::move(bytes_col), std::move(null_col))};
+    auto result = StringFunctions::format_bytes(ctx.get(), columns).value();
+    ASSERT_EQ(result->size(), num_rows);
+
+    for (int i = 0; i < num_rows; ++i) {
+        bool expect_is_null = std::get<2>(test_cases[i]);
+        std::string expected = std::get<3>(test_cases[i]);
+        auto nullable_datum = result->get(i);
+
+        if (expect_is_null) {
+            ASSERT_TRUE(nullable_datum.is_null()) << "Row " << i << " should be null";
+        } else {
+            ASSERT_FALSE(nullable_datum.is_null()) << "Row " << i << " should not be null";
+            ASSERT_EQ(nullable_datum.get_slice().to_string(), expected)
+                << "Row " << i << " input: " << std::get<0>(test_cases[i]);
+        }
+    }
+}
+
+TEST_F(StringFunctionFormatBytesTest, formatBytesPrecisionTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    Columns columns;
+    auto bytes_col = Int64Column::create();
+
+    // Test precision and rounding (2 decimal places)
+    std::vector<std::tuple<int64_t, std::string>> precision_cases = {
+        {1024 + 512, "1.50 KB"},  // 1.5 KB
+        {1024 + 256, "1.25 KB"},  // 1.25 KB
+        {1024 + 1, "1.00 KB"},    // 1.0009765625 KB -> 1.00 KB
+        {1024 + 102, "1.10 KB"},  // ~1.0996 KB -> 1.10 KB
+        {1024 + 103, "1.10 KB"},  // ~1.1005 KB -> 1.10 KB
+        {1048576 + 524288, "1.50 MB"},  // 1.5 MB
+        {1048576 + 52429, "1.05 MB"},   // ~1.05 MB
+        {1073741824 + 536870912, "1.50 GB"},  // 1.5 GB
+    };
+
+    for (auto& test_case : precision_cases) {
+        bytes_col->append(std::get<0>(test_case));
+    }
+
+    columns.emplace_back(std::move(bytes_col));
+
+    ColumnPtr result = StringFunctions::format_bytes(ctx.get(), columns).value();
+    auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+
+    for (int i = 0; i < precision_cases.size(); ++i) {
+        ASSERT_EQ(std::get<1>(precision_cases[i]), v->get_data()[i].to_string())
+            << "Failed precision test for input: " << std::get<0>(precision_cases[i]);
+    }
+}
+
+} // namespace starrocks

--- a/be/test/exprs/string_fn_format_bytes_test.cpp
+++ b/be/test/exprs/string_fn_format_bytes_test.cpp
@@ -37,7 +37,8 @@ TEST_F(StringFunctionFormatBytesTest, formatBytesBasicTest) {
         {1048576, "1.00 MB"},
         {1073741824, "1.00 GB"},
         {1099511627776, "1.00 TB"},
-        {1125899906842624, "1.00 PB"}
+        {1125899906842624, "1.00 PB"},
+        {1152921504606846976, "1.00 EB"}
     };
 
     for (auto& test_case : test_cases) {

--- a/be/test/exprs/string_fn_format_bytes_test.cpp
+++ b/be/test/exprs/string_fn_format_bytes_test.cpp
@@ -26,20 +26,18 @@ TEST_F(StringFunctionFormatBytesTest, formatBytesBasicTest) {
     auto bytes_col = Int64Column::create();
 
     // Test basic examples from the spec
-    std::vector<std::tuple<int64_t, std::string>> test_cases = {
-        {0, "0 B"},
-        {123, "123 B"},
-        {1023, "1023 B"},
-        {1024, "1.00 KB"},
-        {4096, "4.00 KB"},
-        {123456789, "117.74 MB"},
-        {10737418240, "10.00 GB"},
-        {1048576, "1.00 MB"},
-        {1073741824, "1.00 GB"},
-        {1099511627776, "1.00 TB"},
-        {1125899906842624, "1.00 PB"},
-        {1152921504606846976, "1.00 EB"}
-    };
+    std::vector<std::tuple<int64_t, std::string>> test_cases = {{0, "0 B"},
+                                                                {123, "123 B"},
+                                                                {1023, "1023 B"},
+                                                                {1024, "1.00 KB"},
+                                                                {4096, "4.00 KB"},
+                                                                {123456789, "117.74 MB"},
+                                                                {10737418240, "10.00 GB"},
+                                                                {1048576, "1.00 MB"},
+                                                                {1073741824, "1.00 GB"},
+                                                                {1099511627776, "1.00 TB"},
+                                                                {1125899906842624, "1.00 PB"},
+                                                                {1152921504606846976, "1.00 EB"}};
 
     for (auto& test_case : test_cases) {
         bytes_col->append(std::get<0>(test_case));
@@ -55,7 +53,7 @@ TEST_F(StringFunctionFormatBytesTest, formatBytesBasicTest) {
 
     for (int i = 0; i < test_cases.size(); ++i) {
         ASSERT_EQ(std::get<1>(test_cases[i]), v->get_data()[i].to_string())
-            << "Failed for input: " << std::get<0>(test_cases[i]);
+                << "Failed for input: " << std::get<0>(test_cases[i]);
     }
 }
 
@@ -63,43 +61,43 @@ TEST_F(StringFunctionFormatBytesTest, formatBytesEdgeCasesTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
 
     std::vector<std::tuple<ColumnPtr, bool, std::string>> test_cases = {
-        // Test null input
-        {ColumnHelper::create_const_null_column(1), true, ""},
+            // Test null input
+            {ColumnHelper::create_const_null_column(1), true, ""},
 
-        // Test zero
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(0, 1), false, "0 B"},
+            // Test zero
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(0, 1), false, "0 B"},
 
-        // Test negative numbers (should return null)
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(-1, 1), true, ""},
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(-1024, 1), true, ""},
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(INT64_MIN, 1), true, ""},
+            // Test negative numbers (should return null)
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(-1, 1), true, ""},
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(-1024, 1), true, ""},
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(INT64_MIN, 1), true, ""},
 
-        // Test small values (bytes)
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(1, 1), false, "1 B"},
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(512, 1), false, "512 B"},
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(1023, 1), false, "1023 B"},
+            // Test small values (bytes)
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(1, 1), false, "1 B"},
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(512, 1), false, "512 B"},
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(1023, 1), false, "1023 B"},
 
-        // Test KB values
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(1024, 1), false, "1.00 KB"},
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(1536, 1), false, "1.50 KB"},
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(2048, 1), false, "2.00 KB"},
+            // Test KB values
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(1024, 1), false, "1.00 KB"},
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(1536, 1), false, "1.50 KB"},
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(2048, 1), false, "2.00 KB"},
 
-        // Test MB values
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(1048576, 1), false, "1.00 MB"},
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(1572864, 1), false, "1.50 MB"},
+            // Test MB values
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(1048576, 1), false, "1.00 MB"},
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(1572864, 1), false, "1.50 MB"},
 
-        // Test GB values
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(1073741824, 1), false, "1.00 GB"},
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(2147483648, 1), false, "2.00 GB"},
+            // Test GB values
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(1073741824, 1), false, "1.00 GB"},
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(2147483648, 1), false, "2.00 GB"},
 
-        // Test TB values
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(1099511627776, 1), false, "1.00 TB"},
+            // Test TB values
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(1099511627776, 1), false, "1.00 TB"},
 
-        // Test PB values
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(1125899906842624, 1), false, "1.00 PB"},
+            // Test PB values
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(1125899906842624, 1), false, "1.00 PB"},
 
-        // Test very large values
-        {ColumnHelper::create_const_column<TYPE_BIGINT>(INT64_MAX, 1), false, "8.00 EB"},
+            // Test very large values
+            {ColumnHelper::create_const_column<TYPE_BIGINT>(INT64_MAX, 1), false, "8.00 EB"},
     };
 
     for (auto& test_case : test_cases) {
@@ -125,16 +123,16 @@ TEST_F(StringFunctionFormatBytesTest, formatBytesNullableColumnTest) {
     auto null_col = NullColumn::create();
 
     std::vector<std::tuple<int64_t, bool, bool, std::string>> test_cases = {
-        {0, false, false, "0 B"},
-        {1024, false, false, "1.00 KB"},
-        {-1, false, true, ""},
-        {1048576, false, false, "1.00 MB"},
-        {0, true, true, ""},  // null input
-        {1073741824, false, false, "1.00 GB"},
-        {-512, false, true, ""},
-        {123, false, false, "123 B"},
-        {4096, true, true, ""},  // null input
-        {1099511627776, false, false, "1.00 TB"},
+            {0, false, false, "0 B"},
+            {1024, false, false, "1.00 KB"},
+            {-1, false, true, ""},
+            {1048576, false, false, "1.00 MB"},
+            {0, true, true, ""}, // null input
+            {1073741824, false, false, "1.00 GB"},
+            {-512, false, true, ""},
+            {123, false, false, "123 B"},
+            {4096, true, true, ""}, // null input
+            {1099511627776, false, false, "1.00 TB"},
     };
 
     for (auto& test_case : test_cases) {
@@ -159,7 +157,7 @@ TEST_F(StringFunctionFormatBytesTest, formatBytesNullableColumnTest) {
         } else {
             ASSERT_FALSE(nullable_datum.is_null()) << "Row " << i << " should not be null";
             ASSERT_EQ(nullable_datum.get_slice().to_string(), expected)
-                << "Row " << i << " input: " << std::get<0>(test_cases[i]);
+                    << "Row " << i << " input: " << std::get<0>(test_cases[i]);
         }
     }
 }
@@ -171,14 +169,14 @@ TEST_F(StringFunctionFormatBytesTest, formatBytesPrecisionTest) {
 
     // Test precision and rounding (2 decimal places)
     std::vector<std::tuple<int64_t, std::string>> precision_cases = {
-        {1024 + 512, "1.50 KB"},  // 1.5 KB
-        {1024 + 256, "1.25 KB"},  // 1.25 KB
-        {1024 + 1, "1.00 KB"},    // 1.0009765625 KB -> 1.00 KB
-        {1024 + 102, "1.10 KB"},  // ~1.0996 KB -> 1.10 KB
-        {1024 + 103, "1.10 KB"},  // ~1.1005 KB -> 1.10 KB
-        {1048576 + 524288, "1.50 MB"},  // 1.5 MB
-        {1048576 + 52429, "1.05 MB"},   // ~1.05 MB
-        {1073741824 + 536870912, "1.50 GB"},  // 1.5 GB
+            {1024 + 512, "1.50 KB"},             // 1.5 KB
+            {1024 + 256, "1.25 KB"},             // 1.25 KB
+            {1024 + 1, "1.00 KB"},               // 1.0009765625 KB -> 1.00 KB
+            {1024 + 102, "1.10 KB"},             // ~1.0996 KB -> 1.10 KB
+            {1024 + 103, "1.10 KB"},             // ~1.1005 KB -> 1.10 KB
+            {1048576 + 524288, "1.50 MB"},       // 1.5 MB
+            {1048576 + 52429, "1.05 MB"},        // ~1.05 MB
+            {1073741824 + 536870912, "1.50 GB"}, // 1.5 GB
     };
 
     for (auto& test_case : precision_cases) {
@@ -192,7 +190,7 @@ TEST_F(StringFunctionFormatBytesTest, formatBytesPrecisionTest) {
 
     for (int i = 0; i < precision_cases.size(); ++i) {
         ASSERT_EQ(std::get<1>(precision_cases[i]), v->get_data()[i].to_string())
-            << "Failed precision test for input: " << std::get<0>(precision_cases[i]);
+                << "Failed precision test for input: " << std::get<0>(precision_cases[i]);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -187,6 +187,7 @@ public class FunctionSet {
     public static final String ENDS_WITH = "ends_with";
     public static final String FIND_IN_SET = "find_in_set";
     public static final String GROUP_CONCAT = "group_concat";
+    public static final String FORMAT_BYTES = "format_bytes";
     public static final String INSTR = "instr";
     public static final String LCASE = "lcase";
     public static final String LEFT = "left";
@@ -1464,20 +1465,20 @@ public class FunctionSet {
 
     private void registerBuiltinMapAggFunction() {
         for (ScalarType keyType : Type.getNumericTypes()) {
-                addBuiltin(AggregateFunction.createBuiltin(FunctionSet.MAP_AGG,
-                        Lists.newArrayList(keyType, Type.ANY_ELEMENT), Type.ANY_MAP, null,
-                        false, false, false));
+            addBuiltin(AggregateFunction.createBuiltin(FunctionSet.MAP_AGG,
+                    Lists.newArrayList(keyType, Type.ANY_ELEMENT), Type.ANY_MAP, null,
+                    false, false, false));
         }
         for (ScalarType keyType : Type.STRING_TYPES) {
-                addBuiltin(AggregateFunction.createBuiltin(FunctionSet.MAP_AGG,
-                        Lists.newArrayList(keyType, Type.ANY_ELEMENT), Type.ANY_MAP, null,
-                        false, false, false));
+            addBuiltin(AggregateFunction.createBuiltin(FunctionSet.MAP_AGG,
+                    Lists.newArrayList(keyType, Type.ANY_ELEMENT), Type.ANY_MAP, null,
+                    false, false, false));
         }
 
         for (ScalarType keyType : Type.DATE_TYPES) {
-                addBuiltin(AggregateFunction.createBuiltin(FunctionSet.MAP_AGG,
-                        Lists.newArrayList(keyType, Type.ANY_ELEMENT), Type.ANY_MAP, null,
-                        false, false, false));
+            addBuiltin(AggregateFunction.createBuiltin(FunctionSet.MAP_AGG,
+                    Lists.newArrayList(keyType, Type.ANY_ELEMENT), Type.ANY_MAP, null,
+                    false, false, false));
         }
         addBuiltin(AggregateFunction.createBuiltin(FunctionSet.MAP_AGG,
                 Lists.newArrayList(Type.TIME, Type.ANY_ELEMENT), Type.ANY_MAP, null,

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -435,6 +435,8 @@ vectorized_functions = [
     [304592, 'field', True, False, 'INT', ['DECIMAL128', '...'], 'StringFunctions::field<TYPE_DECIMAL128>', 
      'StringFunctions::field_prepare<TYPE_DECIMAL128>', 'StringFunctions::field_close<TYPE_DECIMAL128>'],
 
+    [30460, 'format_bytes', True, False, 'VARCHAR', ['BIGINT'], 'StringFunctions::format_bytes'],
+
     # Binary Functions
     # to_binary
     [30600, 'to_binary', True, True, 'VARBINARY', ['VARCHAR', 'VARCHAR'], 'BinaryFunctions::to_binary',

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -737,4 +737,120 @@ abcabc	abc	2	4
 hello world	world	1	7
 hello world	world	-1	7
 -- !result
+select format_bytes(0);
+-- result:
+0 B
+-- !result
+select format_bytes(123);
+-- result:
+123 B
+-- !result
+select format_bytes(1023);
+-- result:
+1023 B
+-- !result
+select format_bytes(1024);
+-- result:
+1.00 KB
+-- !result
+select format_bytes(4096);
+-- result:
+4.00 KB
+-- !result
+select format_bytes(123456789);
+-- result:
+117.74 MB
+-- !result
+select format_bytes(10737418240);
+-- result:
+10.00 GB
+-- !result
+select format_bytes(-1);
+-- result:
+NULL
+-- !result
+select format_bytes(-1024);
+-- result:
+NULL
+-- !result
+select format_bytes(null);
+-- result:
+NULL
+-- !result
+select format_bytes(1);
+-- result:
+1 B
+-- !result
+select format_bytes(512);
+-- result:
+512 B
+-- !result
+select format_bytes(1536);
+-- result:
+1.50 KB
+-- !result
+select format_bytes(2048);
+-- result:
+2.00 KB
+-- !result
+select format_bytes(1048576);
+-- result:
+1.00 MB
+-- !result
+select format_bytes(1572864);
+-- result:
+1.50 MB
+-- !result
+select format_bytes(1073741824);
+-- result:
+1.00 GB
+-- !result
+select format_bytes(2147483648);
+-- result:
+2.00 GB
+-- !result
+select format_bytes(1099511627776);
+-- result:
+1.00 TB
+-- !result
+select format_bytes(1125899906842624);
+-- result:
+1.00 PB
+-- !result
+select format_bytes(1024 + 1);
+-- result:
+1.00 KB
+-- !result
+select format_bytes(1024 + 512);
+-- result:
+1.50 KB
+-- !result
+select format_bytes(1024 + 256);
+-- result:
+1.25 KB
+-- !result
+select format_bytes(1048576 + 52429);
+-- result:
+1.05 MB
+-- !result
+create table t_format_bytes(bytes bigint)
+        DUPLICATE KEY(bytes)
+        DISTRIBUTED BY HASH(bytes)
+        BUCKETS 1
+        PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+insert into t_format_bytes values (0), (123), (1024), (1048576), (1073741824), (-1), (null);
+-- result:
+-- !result
+select bytes, format_bytes(bytes) from t_format_bytes order by bytes;
+-- result:
+NULL	NULL
+-1	NULL
+0	0 B
+123	123 B
+1024	1.00 KB
+1048576	1.00 MB
+1073741824	1.00 GB
+-- !result
 

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -767,15 +767,15 @@ select format_bytes(10737418240);
 -- !result
 select format_bytes(-1);
 -- result:
-NULL
+None
 -- !result
 select format_bytes(-1024);
 -- result:
-NULL
+None
 -- !result
 select format_bytes(null);
 -- result:
-NULL
+None
 -- !result
 select format_bytes(1);
 -- result:
@@ -849,8 +849,8 @@ insert into t_format_bytes values (0), (123), (1024), (1048576), (1073741824), (
 -- !result
 select bytes, format_bytes(bytes) from t_format_bytes order by bytes;
 -- result:
-NULL	NULL
--1	NULL
+None	None
+-1	None
 0	0 B
 123	123 B
 1024	1.00 KB

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -817,6 +817,10 @@ select format_bytes(1125899906842624);
 -- result:
 1.00 PB
 -- !result
+select format_bytes(1152921504606846976);
+-- result:
+1.00 EB
+-- !result
 select format_bytes(1024 + 1);
 -- result:
 1.00 KB

--- a/test/sql/test_string_functions/T/test_string_functions
+++ b/test/sql/test_string_functions/T/test_string_functions
@@ -294,3 +294,45 @@ insert into t_strpos values ('hello world', 'world', 1), ('hello world', 'world'
 select c0, c1, strpos(c0, c1) from t_strpos;
 select c0, c1, c2, strpos(c0, c1, c2) from t_strpos;
 
+-- function: format_bytes
+-- Test basic examples from specification
+select format_bytes(0);
+select format_bytes(123);
+select format_bytes(1023);
+select format_bytes(1024);
+select format_bytes(4096);
+select format_bytes(123456789);
+select format_bytes(10737418240);
+
+-- Test edge cases
+select format_bytes(-1);
+select format_bytes(-1024);
+select format_bytes(null);
+
+-- Test all unit ranges
+select format_bytes(1);  -- 1 B
+select format_bytes(512);  -- 512 B
+select format_bytes(1536);  -- 1.50 KB
+select format_bytes(2048);  -- 2.00 KB
+select format_bytes(1048576);  -- 1.00 MB
+select format_bytes(1572864);  -- 1.50 MB
+select format_bytes(1073741824);  -- 1.00 GB
+select format_bytes(2147483648);  -- 2.00 GB
+select format_bytes(1099511627776);  -- 1.00 TB
+select format_bytes(1125899906842624);  -- 1.00 PB
+
+-- Test precision and rounding
+select format_bytes(1024 + 1);  -- ~1.00 KB (rounded)
+select format_bytes(1024 + 512);  -- 1.50 KB
+select format_bytes(1024 + 256);  -- 1.25 KB
+select format_bytes(1048576 + 52429);  -- ~1.05 MB
+
+-- Test with table data
+create table t_format_bytes(bytes bigint)
+        DUPLICATE KEY(bytes)
+        DISTRIBUTED BY HASH(bytes)
+        BUCKETS 1
+        PROPERTIES('replication_num'='1');
+insert into t_format_bytes values (0), (123), (1024), (1048576), (1073741824), (-1), (null);
+select bytes, format_bytes(bytes) from t_format_bytes order by bytes;
+

--- a/test/sql/test_string_functions/T/test_string_functions
+++ b/test/sql/test_string_functions/T/test_string_functions
@@ -320,6 +320,7 @@ select format_bytes(1073741824);  -- 1.00 GB
 select format_bytes(2147483648);  -- 2.00 GB
 select format_bytes(1099511627776);  -- 1.00 TB
 select format_bytes(1125899906842624);  -- 1.00 PB
+select format_bytes(1152921504606846976);  -- 1.00 EB
 
 -- Test precision and rounding
 select format_bytes(1024 + 1);  -- ~1.00 KB (rounded)


### PR DESCRIPTION
## Why I'm doing:

StarRocks currently lacks a native function to transform raw byte counts into human-readable formats with units such as B, KB, MB, GB, etc. This functionality is widely needed for tasks like examining table sizes, monitoring disk usage, and reviewing metrics. Comparable features are available in other databases, including PostgreSQL's pg_size_pretty(), MySQL 8.0+'s FORMAT_BYTES(), and ClickHouse's formatReadableSize().

## What I'm doing:

This PR introduces a new scalar function format_bytes(bytes BIGINT) → VARCHAR that converts byte counts to human readable strings with appropriate units. The function:

  - Takes a BIGINT representing the number of bytes
  - Returns a string displaying the size with an appropriate unit, rounded to two decimal places
  - Uses 1024-based thresholds (KiB, MiB, GiB) but displays as KB/MB/GB for simplicity
  - Supports sizes up to TB/PB
  - Handles edge cases (null input returns null, negative values return null, zero returns "0 B")

  Examples:
  - format_bytes(123) → "123 B"
  - format_bytes(4096) → "4.00 KB"
  - format_bytes(123456789) → "117.74 MB"
  - format_bytes(10737418240) → "10.00 GB"

  Implementation includes:
  - Backend C++ implementation in StringFunctions::format_bytes
  - Function registration with ID 30460
  - Frontend Java constant definition
  - Comprehensive unit tests and SQL integration tests

  Fixes #61514

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
