### PR TITLE
[Enhancement] Add prepared_timeout configuration for transaction stream load

### DIFF
--- a/be/src/http/http_common.h
+++ b/be/src/http/http_common.h
@@ -52,7 +52,11 @@ static const std::string HTTP_TRIM_SPACE = "trim_space";
 static const std::string HTTP_ENCLOSE = "enclose";
 static const std::string HTTP_ESCAPE = "escape";
 static const std::string HTTP_MAX_FILTER_RATIO = "max_filter_ratio";
+// For stream load, the timeout for transaction from PREPARE -> COMMITTED.
+// For transaction stream load, the timeout for transaction from PREPARE -> PREPARED.
 static const std::string HTTP_TIMEOUT = "timeout";
+// Only valid for transaction stream load, the timeout for transaction from PREPARED -> COMMITTED
+static const std::string HTTP_PREPARED_TIMEOUT = "prepared_timeout";
 static const std::string HTTP_IDLE_TRANSACTION_TIMEOUT = "idle_transaction_timeout";
 static const std::string HTTP_PARTITIONS = "partitions";
 static const std::string HTTP_TEMP_PARTITIONS = "temporary_partitions";

--- a/be/src/http/http_common.h
+++ b/be/src/http/http_common.h
@@ -54,8 +54,10 @@ static const std::string HTTP_ESCAPE = "escape";
 static const std::string HTTP_MAX_FILTER_RATIO = "max_filter_ratio";
 // For stream load, the timeout for transaction from PREPARE -> COMMITTED.
 // For transaction stream load, the timeout for transaction from PREPARE -> PREPARED.
+// The transaction will be aborted automatically if the timeout is exceeded.
 static const std::string HTTP_TIMEOUT = "timeout";
-// Only valid for transaction stream load, the timeout for transaction from PREPARED -> COMMITTED
+// Only valid for transaction stream load, the timeout for transaction from PREPARED -> COMMITTED.
+// The transaction will be aborted automatically if the timeout is exceeded.
 static const std::string HTTP_PREPARED_TIMEOUT = "prepared_timeout";
 static const std::string HTTP_IDLE_TRANSACTION_TIMEOUT = "idle_transaction_timeout";
 static const std::string HTTP_PARTITIONS = "partitions";

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -297,7 +297,7 @@ public:
     std::unique_ptr<ConcurrentLimiterGuard> _http_limiter_guard;
 
     // =================== transaction stream load ===================
-    
+
     // Transaction begin timestamp for timeout detection
     std::atomic<int64_t> begin_txn_ts = 0;
     // Last active timestamp for idle timeout detection

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -261,8 +261,6 @@ public:
     int64_t total_received_data_cost_nanos = 0;
     int64_t received_data_cost_nanos = 0;
     int64_t write_data_cost_nanos = 0;
-    std::atomic<int64_t> begin_txn_ts = 0;
-    std::atomic<int64_t> last_active_ts = 0;
 
     std::string error_url;
     std::string rejected_record_path;
@@ -277,9 +275,6 @@ public:
     std::vector<TTabletFailInfo> fail_infos;
 
     std::mutex lock;
-    // Whether the transaction stream load is detected as timeout. This flag is used to tell
-    // the new request that the transaction is timeout and will be aborted
-    std::atomic<bool> timeout_detected{false};
 
     std::shared_ptr<MessageBodySink> body_sink;
     bool need_rollback = false;
@@ -289,9 +284,6 @@ public:
     std::future<Status> future = promise.get_future();
 
     Status status;
-
-    int32_t idle_timeout_sec = -1;
-    int channel_id = -1;
 
     // buffer for reading data from ev_buffer
     static constexpr size_t kDefaultBufferSize = 64 * 1024;
@@ -303,6 +295,22 @@ public:
 
     int64_t load_deadline_sec = -1;
     std::unique_ptr<ConcurrentLimiterGuard> _http_limiter_guard;
+
+    // =================== transaction stream load ===================
+    
+    // Transaction begin timestamp for timeout detection
+    std::atomic<int64_t> begin_txn_ts = 0;
+    // Last active timestamp for idle timeout detection
+    std::atomic<int64_t> last_active_ts = 0;
+    // The timeout in seconds for a prepared transaction timeout
+    int32_t prepared_timeout_second = -1;
+    // Whether the transaction stream load is detected as timeout. This flag is used to tell
+    // the new request that the transaction is timeout and will be aborted
+    std::atomic<bool> timeout_detected{false};
+    // Idle transaction timeout in seconds
+    int32_t idle_timeout_sec = -1;
+    // Channel ID for multi-channel stream load
+    int channel_id = -1;
 
     // =================== merge commit ===================
 

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -36,9 +36,7 @@
 
 #include <fmt/format.h>
 
-#include <algorithm>
 #include <string_view>
-#include <utility>
 
 #include "agent/master_info.h"
 #include "common/process_exit.h"

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -36,7 +36,9 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
 #include <string_view>
+#include <utility>
 
 #include "agent/master_info.h"
 #include "common/process_exit.h"
@@ -345,6 +347,9 @@ Status StreamLoadExecutor::prepare_txn(StreamLoadContext* ctx) {
         rpc_timeout_ms = std::max(ctx->timeout_second * 1000 / 4, rpc_timeout_ms);
     }
     request.__set_thrift_rpc_timeout_ms(rpc_timeout_ms);
+    if (ctx->prepared_timeout_second != -1) {
+        request.__set_prepared_timeout_second(ctx->prepared_timeout_second);
+    }
 
     // set attachment if has
     TTxnCommitAttachment attachment;
@@ -361,6 +366,8 @@ Status StreamLoadExecutor::prepare_txn(StreamLoadContext* ctx) {
             [&request, &result](FrontendServiceConnection& client) { client->loadTxnPrepare(result, request); },
             rpc_timeout_ms));
 #else
+    // Add sync point for testing prepared_timeout_second setting
+    TEST_SYNC_POINT_CALLBACK("StreamLoadExecutor::prepare_txn::rpc", &request);
     result = k_stream_load_commit_result;
 #endif
     // Return if this transaction is prepare successful; otherwise, we need try

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -837,9 +837,7 @@ TEST_F(TransactionStreamLoadActionTest, txn_not_same_load) {
         SyncPoint::GetInstance()->SetCallBack("ByteBuffer::allocate_with_tracker", [](void* arg) { \
             *((Status*)arg) = Status::MemoryLimitExceeded("TestFail");                             \
         });                                                                                        \
-        {                                                                                          \
-            stmt;                                                                                  \
-        }                                                                                          \
+        { stmt; }                                                                                  \
     } while (0)
 
 TEST_F(TransactionStreamLoadActionTest, huge_malloc) {

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -20,6 +20,8 @@
 #include <gtest/gtest.h>
 #include <rapidjson/document.h>
 
+#include <string>
+
 #include "gen_cpp/FrontendService_types.h"
 #include "gen_cpp/HeartbeatService_types.h"
 #include "http/http_channel.h"
@@ -344,51 +346,148 @@ TEST_F(TransactionStreamLoadActionTest, txn_commit_success) {
     }
 }
 
-TEST_F(TransactionStreamLoadActionTest, txn_prepared_success) {
+// Setup transaction stream load flow for prepare testing
+void setup_prepare_txn_test(TransactionManagerAction& txn_action, ExecEnv* env, evhttp_request* ev_request) {
+    // Begin transaction
+    HttpRequest b(ev_request);
+    b._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    b._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    b._headers.emplace(HTTP_LABEL_KEY, "123");
+    b._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&b);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("OK", doc["Status"].GetString());
+
+    // Perform load
+    TransactionStreamLoadAction action(env);
+    HttpRequest request(ev_request);
+    request.set_handler(&action);
+
+    request._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    request._headers.emplace(HttpHeaders::CONTENT_LENGTH, "16");
+    request._headers.emplace(HTTP_LABEL_KEY, "123");
+    action.on_header(&request);
+    action.handle(&request);
+
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("OK", doc["Status"].GetString());
+}
+
+TEST_F(TransactionStreamLoadActionTest, txn_prepared_success_without_timeout) {
     TransactionManagerAction txn_action(&_env);
+    setup_prepare_txn_test(txn_action, &_env, _evhttp_req);
 
-    {
-        HttpRequest b(_evhttp_req);
-        b._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
-        b._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
-        b._headers.emplace(HTTP_LABEL_KEY, "123");
-        b._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
-        txn_action.handle(&b);
+    // Enable sync point to capture the prepared_timeout_second value
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("StreamLoadExecutor::prepare_txn:rpc");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
 
-        rapidjson::Document doc;
-        doc.Parse(k_response_str.c_str());
-        ASSERT_STREQ("OK", doc["Status"].GetString());
-    }
+    SyncPoint::GetInstance()->SetCallBack("StreamLoadExecutor::prepare_txn:rpc", [&](void* arg) {
+        auto* request = static_cast<TLoadTxnCommitRequest*>(arg);
+        EXPECT_FALSE(request->__isset.prepared_timeout_second);
+    });
 
-    {
-        TransactionStreamLoadAction action(&_env);
+    HttpRequest b(_evhttp_req);
+    b._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    b._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    b._headers.emplace(HTTP_LABEL_KEY, "123");
+    b._params.emplace(HTTP_TXN_OP_KEY, TXN_PREPARE);
+    txn_action.handle(&b);
 
-        HttpRequest request(_evhttp_req);
-        request.set_handler(&action);
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("OK", doc["Status"].GetString());
+}
 
-        request._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
-        request._headers.emplace(HttpHeaders::CONTENT_LENGTH, "16");
-        request._headers.emplace(HTTP_LABEL_KEY, "123");
-        action.on_header(&request);
-        action.handle(&request);
+TEST_F(TransactionStreamLoadActionTest, txn_prepared_success_with_timeout) {
+    TransactionManagerAction txn_action(&_env);
+    setup_prepare_txn_test(txn_action, &_env, _evhttp_req);
 
-        rapidjson::Document doc;
-        doc.Parse(k_response_str.c_str());
-        ASSERT_STREQ("OK", doc["Status"].GetString());
-    }
+    // Enable sync point to capture the prepared_timeout_second value
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("StreamLoadExecutor::prepare_txn:rpc");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
 
-    {
-        HttpRequest b(_evhttp_req);
-        b._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
-        b._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
-        b._headers.emplace(HTTP_LABEL_KEY, "123");
-        b._params.emplace(HTTP_TXN_OP_KEY, TXN_PREPARE);
-        txn_action.handle(&b);
+    SyncPoint::GetInstance()->SetCallBack("StreamLoadExecutor::prepare_txn:rpc", [&](void* arg) {
+        auto* request = static_cast<TLoadTxnCommitRequest*>(arg);
+        EXPECT_TRUE(request->__isset.prepared_timeout_second);
+        EXPECT_EQ(300, request->prepared_timeout_second);
+    });
 
-        rapidjson::Document doc;
-        doc.Parse(k_response_str.c_str());
-        ASSERT_STREQ("OK", doc["Status"].GetString());
-    }
+    HttpRequest b(_evhttp_req);
+    b._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    b._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    b._headers.emplace(HTTP_LABEL_KEY, "123");
+    b._headers.emplace(HTTP_PREPARED_TIMEOUT, "300");
+    b._params.emplace(HTTP_TXN_OP_KEY, TXN_PREPARE);
+    txn_action.handle(&b);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("OK", doc["Status"].GetString());
+}
+
+TEST_F(TransactionStreamLoadActionTest, txn_prepared_with_invalid_timeout) {
+    TransactionManagerAction txn_action(&_env);
+    setup_prepare_txn_test(txn_action, &_env, _evhttp_req);
+
+    // Test invalid timeout format
+    HttpRequest b(_evhttp_req);
+    b._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    b._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    b._headers.emplace(HTTP_LABEL_KEY, "123");
+    b._headers.emplace(HTTP_PREPARED_TIMEOUT, "invalid_timeout");
+    b._params.emplace(HTTP_TXN_OP_KEY, TXN_PREPARE);
+    txn_action.handle(&b);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("INVALID_ARGUMENT", doc["Status"].GetString());
+    ASSERT_NE(nullptr, std::strstr(doc["Message"].GetString(), "Invalid prepared_timeout: invalid_timeout"));
+}
+
+TEST_F(TransactionStreamLoadActionTest, txn_prepared_with_negative_timeout) {
+    TransactionManagerAction txn_action(&_env);
+    setup_prepare_txn_test(txn_action, &_env, _evhttp_req);
+
+    // Test negative timeout value
+    HttpRequest b(_evhttp_req);
+    b._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    b._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    b._headers.emplace(HTTP_LABEL_KEY, "123");
+    b._headers.emplace(HTTP_PREPARED_TIMEOUT, "-1");
+    b._params.emplace(HTTP_TXN_OP_KEY, TXN_PREPARE);
+    txn_action.handle(&b);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("INVALID_ARGUMENT", doc["Status"].GetString());
+    ASSERT_NE(nullptr, std::strstr(doc["Message"].GetString(), "Invalid prepared_timeout: -1"));
+}
+
+TEST_F(TransactionStreamLoadActionTest, txn_prepared_with_zero_timeout) {
+    TransactionManagerAction txn_action(&_env);
+    setup_prepare_txn_test(txn_action, &_env, _evhttp_req);
+
+    // Test zero timeout value
+    HttpRequest b(_evhttp_req);
+    b._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    b._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    b._headers.emplace(HTTP_LABEL_KEY, "123");
+    b._headers.emplace(HTTP_PREPARED_TIMEOUT, "0");
+    b._params.emplace(HTTP_TXN_OP_KEY, TXN_PREPARE);
+    txn_action.handle(&b);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("INVALID_ARGUMENT", doc["Status"].GetString());
+    ASSERT_NE(nullptr, std::strstr(doc["Message"].GetString(), "Invalid prepared_timeout: 0"));
 }
 
 TEST_F(TransactionStreamLoadActionTest, txn_put_fail) {
@@ -738,7 +837,9 @@ TEST_F(TransactionStreamLoadActionTest, txn_not_same_load) {
         SyncPoint::GetInstance()->SetCallBack("ByteBuffer::allocate_with_tracker", [](void* arg) { \
             *((Status*)arg) = Status::MemoryLimitExceeded("TestFail");                             \
         });                                                                                        \
-        { stmt; }                                                                                  \
+        {                                                                                          \
+            stmt;                                                                                  \
+        }                                                                                          \
     } while (0)
 
 TEST_F(TransactionStreamLoadActionTest, huge_malloc) {

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -2090,7 +2090,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Unit: Seconds
 - Is mutable: Yes
 - Description: The default timeout duration for a prepared transaction.
-- Introduced in: v3.5
+- Introduced in: -
 
 ##### spark_dpp_version
 

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -2094,6 +2094,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: The minimum timeout duration allowed for a load job. This limit applies to all types of load jobs.
 - Introduced in: -
 
+##### prepared_transaction_default_timeout_second
+
+- Default: 86400
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: The default timeout duration for a prepared transaction.
+- Introduced in: -
+
 ##### spark_dpp_version
 
 - Default: 1.0.0

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -2065,17 +2065,6 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Introduced in: -
 -->
 
-<!--
-##### prepared_transaction_default_timeout_second
-
-- Default: 86400
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description:
-- Introduced in: -
--->
-
 ##### max_load_timeout_second
 
 - Default: 259200
@@ -2101,7 +2090,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Unit: Seconds
 - Is mutable: Yes
 - Description: The default timeout duration for a prepared transaction.
-- Introduced in: -
+- Introduced in: v3.5
 
 ##### spark_dpp_version
 

--- a/docs/en/loading/Stream_Load_transaction_interface.md
+++ b/docs/en/loading/Stream_Load_transaction_interface.md
@@ -62,7 +62,7 @@ When you begin a transaction, you can use the `timeout` field in the HTTP reques
 
 When you begin a transaction, you can also use the `idle_transaction_timeout` field in the HTTP request header to specify a timeout period (in seconds) within which the transaction can stay idle. If no data is written within this period, the transaction will be automatically rolled back.
 
-When you prepare a transaction, you can use the `prepared_timeout` field in the HTTP request header to specify a timeout period (in seconds) for the transaction from `PREPARED` to `COMMITTED` state. If the transaction has not been committed after this period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) (Default: 86400 seconds). `prepared_timeout` is supported from v4.0.0 onwards.
+When you prepare a transaction, you can use the `prepared_timeout` field in the HTTP request header to specify a timeout period (in seconds) for the transaction from `PREPARED` to `COMMITTED` state. If the transaction has not been committed after this period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) (Default: 86400 seconds). `prepared_timeout` is supported from v3.5.4 onwards.
 
 ## Benefits
 
@@ -301,7 +301,7 @@ curl --location-trusted -u <jack>:<123456> -H "label:streamload_txn_example1_tab
 
 > **NOTE**
 >
-> The `prepared_timeout` field is optional. If it is not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) (Default: 86400 seconds). `prepared_timeout` is supported from v4.0.0 onwards.
+> The `prepared_timeout` field is optional. If it is not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) (Default: 86400 seconds). `prepared_timeout` is supported from v3.5.4 onwards.
 
 #### Return result
 

--- a/docs/en/loading/Stream_Load_transaction_interface.md
+++ b/docs/en/loading/Stream_Load_transaction_interface.md
@@ -25,17 +25,28 @@ The Stream Load transaction interface provides the following API operations, whi
 
 - `/api/transaction/begin`: starts a new transaction.
 
+- `/api/transaction/prepare`: pre-commits the current transaction and make data changes temporarily persistent. After you pre-commit a transaction, you can proceed to commit or roll back the transaction. If your StarRocks cluster breaks down after a transaction is pre-committed, you can still proceed to commit the transaction after your StarRocks cluster is restored to normal.
+
 - `/api/transaction/commit`: commits the current transaction to make data changes persistent.
 
 - `/api/transaction/rollback`: rolls back the current transaction to abort data changes.
 
-### Transaction pre-commit
-
-The Stream Load transaction interface provides the `/api/transaction/prepare` operation, which is used to pre-commit the current transaction and make data changes temporarily persistent. After you pre-commit a transaction, you can proceed to commit or roll back the transaction. If your StarRocks cluster breaks down after a transaction is pre-committed, you can still proceed to commit the transaction after your StarRocks cluster is restored to normal.
-
 > **NOTE**
 >
 > After the transaction is pre-committed, do not continue to write data using the transaction. If you continue to write data using the transaction, your write request returns errors.
+
+
+The following diagram shows the relationship between transaction states and operations:
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> PREPARE : begin
+    PREPARE --> PREPARED : prepare
+    PREPARE --> ABORTED : rollback
+    PREPARED --> COMMITTED : commit
+    PREPARED --> ABORTED : rollback
+```
 
 ### Data write
 
@@ -47,13 +58,11 @@ The Stream Load transaction interface carries over the labeling mechanism of Sta
 
 ### Transaction timeout management
 
-You can use the `stream_load_default_timeout_second` parameter in the configuration file of each FE to specify a default transaction timeout period for that FE.
+When you begin a transaction, you can use the `timeout` field in the HTTP request header to specify a timeout period for the transaction from `PREPARE` to `PREPARED` state. If do not prepare the transaction within this timeout period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`stream_load_default_timeout_second`](../administration/management/FE_configuration.md#stream_load_default_timeout_second).
 
-When you create a transaction, you can use the `timeout` field in the HTTP request header to specify a timeout period for the transaction.
+When you begin a transaction, you can also use the `idle_transaction_timeout` field in the HTTP request header to specify a timeout period within which the transaction can stay idle. If no data is written within the timeout period, the transaction automatically rolls back.
 
-When you create a transaction, you can also use the `idle_transaction_timeout` field in the HTTP request header to specify a timeout period within which the transaction can stay idle. If no data is written within the timeout period, the transaction automatically rolls back.
-
-When you prepare a transaction, you can use the `prepared_timeout` field in the HTTP request header to specify a timeout period for the transaction from `PREPARED` to `COMMITTED` state. If the transaction is not committed within this timeout period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second). `prepared_timeout` is supported from version 4.0.0 onwards.
+When you prepare a transaction, you can use the `prepared_timeout` field in the HTTP request header to specify a timeout period for the transaction from `PREPARED` to `COMMITTED` state. If do not commit the transaction within this timeout period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second). `prepared_timeout` is supported from version 4.0.0 onwards.
 
 ## Benefits
 

--- a/docs/en/loading/Stream_Load_transaction_interface.md
+++ b/docs/en/loading/Stream_Load_transaction_interface.md
@@ -58,11 +58,11 @@ The Stream Load transaction interface carries over the labeling mechanism of Sta
 
 ### Transaction timeout management
 
-When you begin a transaction, you can use the `timeout` field in the HTTP request header to specify a timeout period for the transaction from `PREPARE` to `PREPARED` state. If do not prepare the transaction within this timeout period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`stream_load_default_timeout_second`](../administration/management/FE_configuration.md#stream_load_default_timeout_second).
+When you begin a transaction, you can use the `timeout` field in the HTTP request header to specify a timeout period (in seconds) for the transaction from `PREPARE` to `PREPARED` state. If do not prepare the transaction within this timeout period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`stream_load_default_timeout_second`](../administration/management/FE_configuration.md#stream_load_default_timeout_second).
 
-When you begin a transaction, you can also use the `idle_transaction_timeout` field in the HTTP request header to specify a timeout period within which the transaction can stay idle. If no data is written within the timeout period, the transaction automatically rolls back.
+When you begin a transaction, you can also use the `idle_transaction_timeout` field in the HTTP request header to specify a timeout period (in seconds) within which the transaction can stay idle. If no data is written within the timeout period, the transaction automatically rolls back.
 
-When you prepare a transaction, you can use the `prepared_timeout` field in the HTTP request header to specify a timeout period for the transaction from `PREPARED` to `COMMITTED` state. If do not commit the transaction within this timeout period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second). `prepared_timeout` is supported from version 4.0.0 onwards.
+When you prepare a transaction, you can use the `prepared_timeout` field in the HTTP request header to specify a timeout period (in seconds) for the transaction from `PREPARED` to `COMMITTED` state. If do not commit the transaction within this timeout period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second). `prepared_timeout` is supported from version 4.0.0 onwards.
 
 ## Benefits
 

--- a/docs/en/loading/Stream_Load_transaction_interface.md
+++ b/docs/en/loading/Stream_Load_transaction_interface.md
@@ -25,7 +25,7 @@ The Stream Load transaction interface provides the following API operations, whi
 
 - `/api/transaction/begin`: starts a new transaction.
 
-- `/api/transaction/prepare`: pre-commits the current transaction and make data changes temporarily persistent. After you pre-commit a transaction, you can proceed to commit or roll back the transaction. If your StarRocks cluster breaks down after a transaction is pre-committed, you can still proceed to commit the transaction after your StarRocks cluster is restored to normal.
+- `/api/transaction/prepare`: pre-commits the current transaction and make data changes temporarily persistent. After you pre-commit a transaction, you can proceed to commit or roll back the transaction. If your cluster crashes after a transaction is pre-committed, you can still proceed to commit the transaction after the cluster is restored.
 
 - `/api/transaction/commit`: commits the current transaction to make data changes persistent.
 
@@ -58,11 +58,11 @@ The Stream Load transaction interface carries over the labeling mechanism of Sta
 
 ### Transaction timeout management
 
-When you begin a transaction, you can use the `timeout` field in the HTTP request header to specify a timeout period (in seconds) for the transaction from `PREPARE` to `PREPARED` state. If do not prepare the transaction within this timeout period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`stream_load_default_timeout_second`](../administration/management/FE_configuration.md#stream_load_default_timeout_second).
+When you begin a transaction, you can use the `timeout` field in the HTTP request header to specify a timeout period (in seconds) for the transaction from `PREPARE` to `PREPARED` state. If the transaction has not been prepared after this period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`stream_load_default_timeout_second`](../administration/management/FE_configuration.md#stream_load_default_timeout_second) (Default: 600 seconds).
 
-When you begin a transaction, you can also use the `idle_transaction_timeout` field in the HTTP request header to specify a timeout period (in seconds) within which the transaction can stay idle. If no data is written within the timeout period, the transaction automatically rolls back.
+When you begin a transaction, you can also use the `idle_transaction_timeout` field in the HTTP request header to specify a timeout period (in seconds) within which the transaction can stay idle. If no data is written within this period, the transaction will be automatically rolled back.
 
-When you prepare a transaction, you can use the `prepared_timeout` field in the HTTP request header to specify a timeout period (in seconds) for the transaction from `PREPARED` to `COMMITTED` state. If do not commit the transaction within this timeout period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second). `prepared_timeout` is supported from version 4.0.0 onwards.
+When you prepare a transaction, you can use the `prepared_timeout` field in the HTTP request header to specify a timeout period (in seconds) for the transaction from `PREPARED` to `COMMITTED` state. If the transaction has not been committed after this period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) (Default: 86400 seconds). `prepared_timeout` is supported from v4.0.0 onwards.
 
 ## Benefits
 
@@ -301,7 +301,7 @@ curl --location-trusted -u <jack>:<123456> -H "label:streamload_txn_example1_tab
 
 > **NOTE**
 >
-> The `prepared_timeout` field is optional. If not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second). It is supported from version 4.0.0 onwards.
+> The `prepared_timeout` field is optional. If it is not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) (Default: 86400 seconds). `prepared_timeout` is supported from v4.0.0 onwards.
 
 #### Return result
 

--- a/docs/en/loading/Stream_Load_transaction_interface.md
+++ b/docs/en/loading/Stream_Load_transaction_interface.md
@@ -53,6 +53,8 @@ When you create a transaction, you can use the `timeout` field in the HTTP reque
 
 When you create a transaction, you can also use the `idle_transaction_timeout` field in the HTTP request header to specify a timeout period within which the transaction can stay idle. If no data is written within the timeout period, the transaction automatically rolls back.
 
+When you prepare a transaction, you can use the `prepared_timeout` field in the HTTP request header to specify a timeout period for the transaction from `PREPARED` to `COMMITTED` state. If the transaction is not committed within this timeout period, it will be automatically aborted. If this field is not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second). `prepared_timeout` is supported from version 4.0.0 onwards.
+
 ## Benefits
 
 The Stream Load transaction interface brings the following benefits:
@@ -274,6 +276,7 @@ curl --location-trusted -u <jack>:<123456> -H "label:streamload_txn_example1_tab
 curl --location-trusted -u <username>:<password> -H "label:<label_name>" \
     -H "Expect:100-continue" \
     -H "db:<database_name>" \
+    [-H "prepared_timeout:<timeout_seconds>"] \
     -XPOST http://<fe_host>:<fe_http_port>/api/transaction/prepare
 ```
 
@@ -283,8 +286,13 @@ curl --location-trusted -u <username>:<password> -H "label:<label_name>" \
 curl --location-trusted -u <jack>:<123456> -H "label:streamload_txn_example1_table1" \
     -H "Expect:100-continue" \
     -H "db:test_db" \
+    -H "prepared_timeout:300" \
     -XPOST http://<fe_host>:<fe_http_port>/api/transaction/prepare
 ```
+
+> **NOTE**
+>
+> The `prepared_timeout` field is optional. If not specified, the default value is determined by the FE configuration [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second). It is supported from version 4.0.0 onwards.
 
 #### Return result
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
@@ -43,14 +43,14 @@ PreparedTimeoutMs: 86400000
 * ABORTED: transaction failed
 * LoadJobSourceType: type of import task.
 * PrepareTime: transaction start time
-* PreparedTime: the time when the transaction is successfully prepared (supported from v4.0.0)
+* PreparedTime: the time when the transaction is successfully prepared (supported from v3.5.4)
 * CommitTime: the time when the transaction is successfully committed
 * FinishTime: the time when the data is visible
 * Reason: error message
 * ErrorReplicasCount: number of replicas with errors
 * ListenerId: id of the related import job
 * TimeoutMs: timeout for the transaction from `PREPARE` to `PREPARED` state, in milliseconds
-* PreparedTimeoutMs: timeout for the transaction from `PREPARED` to `COMMITTED` state, in milliseconds (supported from v4.0.0)
+* PreparedTimeoutMs: timeout for the transaction from `PREPARED` to `COMMITTED` state, in milliseconds (supported from v3.5.4)
 
 ## Examples
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
@@ -49,8 +49,8 @@ PreparedTimeoutMs: 86400000
 * Reason: error message
 * ErrorReplicasCount: number of replicas with errors
 * ListenerId: id of the related import job
-* TimeoutMs: transaction timeout, in milliseconds
-* PreparedTimeoutMs: timeout for the transaction from PREPARED to COMMITTED state, in milliseconds (supported from version 4.0.0)
+* TimeoutMs: timeout for the transaction from `PREPARE` to `PREPARED` state, in milliseconds
+* PreparedTimeoutMs: timeout for the transaction from `PREPARED` to `COMMITTED` state, in milliseconds (supported from version 4.0.0)
 
 ## Examples
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
@@ -43,14 +43,14 @@ PreparedTimeoutMs: 86400000
 * ABORTED: transaction failed
 * LoadJobSourceType: type of import task.
 * PrepareTime: transaction start time
-* PreparedTime: the time when the transaction is successfully prepared (supported from version 4.0.0)
+* PreparedTime: the time when the transaction is successfully prepared (supported from v4.0.0)
 * CommitTime: the time when the transaction is successfully committed
 * FinishTime: the time when the data is visible
 * Reason: error message
 * ErrorReplicasCount: number of replicas with errors
 * ListenerId: id of the related import job
 * TimeoutMs: timeout for the transaction from `PREPARE` to `PREPARED` state, in milliseconds
-* PreparedTimeoutMs: timeout for the transaction from `PREPARED` to `COMMITTED` state, in milliseconds (supported from version 4.0.0)
+* PreparedTimeoutMs: timeout for the transaction from `PREPARED` to `COMMITTED` state, in milliseconds (supported from v4.0.0)
 
 ## Examples
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
@@ -23,12 +23,14 @@ Coordinator: FE: 10.74.167.16
 TransactionStatus: VISIBLE
 LoadJobSourceType: INSERT_STREAMING
 PrepareTime: 2020-01-09 14:59:07
+PreparedTime: 2020-01-09 14:59:08
 CommitTime: 2020-01-09 14:59:09
 FinishTime: 2020-01-09 14:59:09
 Reason:
 ErrorReplicasCount: 0
 ListenerId: -1
 TimeoutMs: 300000
+PreparedTimeoutMs: 86400000
 ```
 
 * TransactionId: transaction id
@@ -41,12 +43,14 @@ TimeoutMs: 300000
 * ABORTED: transaction failed
 * LoadJobSourceType: type of import task.
 * PrepareTime: transaction start time
+* PreparedTime: the time when the transaction is successfully prepared (supported from version 4.0.0)
 * CommitTime: the time when the transaction is successfully committed
 * FinishTime: the time when the data is visible
 * Reason: error message
 * ErrorReplicasCount: number of replicas with errors
 * ListenerId: id of the related import job
 * TimeoutMs: transaction timeout, in milliseconds
+* PreparedTimeoutMs: timeout for the transaction from PREPARED to COMMITTED state, in milliseconds (supported from version 4.0.0)
 
 ## Examples
 

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -1427,6 +1427,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: ロードジョブに許可される最小タイムアウト期間。この制限はすべてのタイプのロードジョブに適用されます。
 - 導入バージョン: -
 
+##### prepared_transaction_default_timeout_second
+
+- デフォルト: 86400
+- タイプ: Int
+- 単位: 秒
+- 変更可能: はい
+- 説明: 準備済みトランザクションのデフォルトのタイムアウト期間。
+- 導入バージョン: v3.5
+
 ##### spark_dpp_version
 
 - デフォルト: 1.0.0

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -1434,7 +1434,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 単位: 秒
 - 変更可能: はい
 - 説明: 準備済みトランザクションのデフォルトのタイムアウト期間。
-- 導入バージョン: v3.5
+- 導入バージョン: -
 
 ##### spark_dpp_version
 

--- a/docs/ja/loading/Stream_Load_transaction_interface.md
+++ b/docs/ja/loading/Stream_Load_transaction_interface.md
@@ -61,7 +61,7 @@ Stream Load トランザクションインターフェースは、StarRocks の�
 
 トランザクションを開始する際、HTTP リクエストヘッダーの `idle_transaction_timeout` フィールドを使用して、トランザクションがアイドル状態のまま保持できるタイムアウト期間（秒単位）を指定できます。この期間内にデータが書き込まれない場合、トランザクションは自動的にロールバックされます。
 
-トランザクションを準備する際、HTTP リクエストヘッダーの `prepared_timeout` フィールドを使用して、トランザクションが `PREPARED` 状態から `COMMITTED` 状態に移行するまでのタイムアウト期間（秒単位）を指定できます。この期間内にトランザクションがコミットされない場合、自動的に中止されます。このフィールドが指定されていない場合、デフォルト値は FE 設定の [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) によって決定されます（デフォルト：86400秒）。`prepared_timeout` は v4.0.0 以降でサポートされています。
+トランザクションを準備する際、HTTP リクエストヘッダーの `prepared_timeout` フィールドを使用して、トランザクションが `PREPARED` 状態から `COMMITTED` 状態に移行するまでのタイムアウト期間（秒単位）を指定できます。この期間内にトランザクションがコミットされない場合、自動的に中止されます。このフィールドが指定されていない場合、デフォルト値は FE 設定の [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) によって決定されます（デフォルト：86400秒）。`prepared_timeout` は v3.5.4 以降でサポートされています。
 
 ## 利点
 
@@ -300,7 +300,7 @@ curl --location-trusted -u <jack>:<123456> -H "label:streamload_txn_example1_tab
 
 > **NOTE**
 >
-> `prepared_timeout` フィールドはオプションです。指定されない場合、デフォルト値は FE 設定 [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) によって決定されます（デフォルト: 86400 秒）。`prepared_timeout` は v4.0.0 以降でサポートされています。
+> `prepared_timeout` フィールドはオプションです。指定されない場合、デフォルト値は FE 設定 [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) によって決定されます（デフォルト: 86400 秒）。`prepared_timeout` は v3.5.4 以降でサポートされています。
 
 #### 戻り結果
 

--- a/docs/ja/loading/Stream_Load_transaction_interface.md
+++ b/docs/ja/loading/Stream_Load_transaction_interface.md
@@ -25,17 +25,27 @@ Stream Load トランザクションインターフェースは、トランザ�
 
 - `/api/transaction/begin`: 新しいトランザクションを開始します。
 
+- `/api/transaction/prepare`: 現在のトランザクションを事前コミットし、データ変更を一時的に永続化します。トランザクションを事前コミットした後、コミットまたはロールバックを実行できます。トランザクションが事前コミットされた後にクラスターがクラッシュした場合でも、クラスターが復旧した後、トランザクションをコミットし続けることができます。
+
 - `/api/transaction/commit`: 現在のトランザクションをコミットしてデータの変更を永続化します。
 
 - `/api/transaction/rollback`: 現在のトランザクションをロールバックしてデータの変更を中止します。
 
-### トランザクションの事前コミット
-
-Stream Load トランザクションインターフェースは、現在のトランザクションを事前コミットし、データの変更を一時的に永続化するための `/api/transaction/prepare` 操作を提供します。トランザクションを事前コミットした後、トランザクションをコミットまたはロールバックすることができます。トランザクションが事前コミットされた後に StarRocks クラスターがダウンした場合でも、StarRocks クラスターが正常に復旧した後にトランザクションをコミットすることができます。
-
 > **NOTE**
 >
 > トランザクションが事前コミットされた後は、そのトランザクションを使用してデータを書き続けないでください。トランザクションを使用してデータを書き続けると、書き込みリクエストがエラーを返します。
+
+以下の図は、トランザクションの状態と操作の関係を示しています：
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> PREPARE : begin
+    PREPARE --> PREPARED : prepare
+    PREPARE --> ABORTED : rollback
+    PREPARED --> COMMITTED : commit
+    PREPARED --> ABORTED : rollback
+```
 
 ### データ書き込み
 
@@ -47,11 +57,11 @@ Stream Load トランザクションインターフェースは、StarRocks の�
 
 ### トランザクションのタイムアウト管理
 
-各 FE の設定ファイルで `stream_load_default_timeout_second` パラメータを使用して、その FE のデフォルトのトランザクションタイムアウト期間を指定できます。
+トランザクションを開始する際、HTTP リクエストヘッダーの `timeout` フィールドを使用して、`PREPARE` 状態から `PREPARED` 状態へのトランザクションのタイムアウト期間（秒単位）を指定できます。この期間内にトランザクションが準備完了状態に達しない場合、自動的に中止されます。このフィールドが指定されていない場合、デフォルト値は FE 設定の [`stream_load_default_timeout_second`](../administration/management/FE_configuration.md#stream_load_default_timeout_second)によって決定されます（デフォルト：600 秒）。
 
-トランザクションを作成する際、HTTP リクエストヘッダーの `timeout` フィールドを使用して、トランザクションのタイムアウト期間を指定できます。
+トランザクションを開始する際、HTTP リクエストヘッダーの `idle_transaction_timeout` フィールドを使用して、トランザクションがアイドル状態のまま保持できるタイムアウト期間（秒単位）を指定できます。この期間内にデータが書き込まれない場合、トランザクションは自動的にロールバックされます。
 
-トランザクションを作成する際、HTTP リクエストヘッダーの `idle_transaction_timeout` フィールドを使用して、トランザクションがアイドル状態でいられるタイムアウト期間を指定することもできます。タイムアウト期間内にデータが書き込まれない場合、トランザクションは自動的にロールバックされます。
+トランザクションを準備する際、HTTP リクエストヘッダーの `prepared_timeout` フィールドを使用して、トランザクションが `PREPARED` 状態から `COMMITTED` 状態に移行するまでのタイムアウト期間（秒単位）を指定できます。この期間内にトランザクションがコミットされない場合、自動的に中止されます。このフィールドが指定されていない場合、デフォルト値は FE 設定の [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) によって決定されます（デフォルト：86400秒）。`prepared_timeout` は v4.0.0 以降でサポートされています。
 
 ## 利点
 
@@ -274,6 +284,7 @@ curl --location-trusted -u <jack>:<123456> -H "label:streamload_txn_example1_tab
 curl --location-trusted -u <username>:<password> -H "label:<label_name>" \
     -H "Expect:100-continue" \
     -H "db:<database_name>" \
+    [-H "prepared_timeout:<timeout_seconds>"] \
     -XPOST http://<fe_host>:<fe_http_port>/api/transaction/prepare
 ```
 
@@ -283,8 +294,13 @@ curl --location-trusted -u <username>:<password> -H "label:<label_name>" \
 curl --location-trusted -u <jack>:<123456> -H "label:streamload_txn_example1_table1" \
     -H "Expect:100-continue" \
     -H "db:test_db" \
+    -H "prepared_timeout:300" \
     -XPOST http://<fe_host>:<fe_http_port>/api/transaction/prepare
 ```
+
+> **NOTE**
+>
+> `prepared_timeout` フィールドはオプションです。指定されない場合、デフォルト値は FE 設定 [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) によって決定されます（デフォルト: 86400 秒）。`prepared_timeout` は v4.0.0 以降でサポートされています。
 
 #### 戻り結果
 

--- a/docs/ja/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
+++ b/docs/ja/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
@@ -45,14 +45,14 @@ PreparedTimeoutMs: 86400000
 * ABORTED: トランザクションが失敗
 * LoadJobSourceType: インポートタスクのタイプ
 * PrepareTime: トランザクションの開始時間
-* PreparedTime: トランスアクションが正常に準備された時点（v4.0.0からサポートされています）
+* PreparedTime: トランスアクションが正常に準備された時点（v3.5.4からサポートされています）
 * CommitTime: トランザクションが正常にコミットされた時間
 * FinishTime: データが見えるようになった時間
 * Reason: エラーメッセージ
 * ErrorReplicasCount: エラーのあるレプリカの数
 * ListenerId: 関連するインポートジョブの ID
 * TimeoutMs: トランザクションが `PREPARE` 状態から `PREPARED` 状態に移行するまでのタイムアウト時間（ミリ秒単位）
-* PreparedTimeoutMs: トランザクションが `PREPARED` 状態から `COMMITTED` 状態に移行するまでのタイムアウト時間（ミリ秒単位）（v4.0.0からサポートされています）
+* PreparedTimeoutMs: トランザクションが `PREPARED` 状態から `COMMITTED` 状態に移行するまでのタイムアウト時間（ミリ秒単位）（v3.5.4からサポートされています）
 
 ## 例
 

--- a/docs/ja/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
+++ b/docs/ja/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
@@ -25,12 +25,14 @@ Coordinator: FE: 10.74.167.16
 TransactionStatus: VISIBLE
 LoadJobSourceType: INSERT_STREAMING
 PrepareTime: 2020-01-09 14:59:07
+PreparedTime: 2020-01-09 14:59:08
 CommitTime: 2020-01-09 14:59:09
 FinishTime: 2020-01-09 14:59:09
 Reason:
 ErrorReplicasCount: 0
 ListenerId: -1
 TimeoutMs: 300000
+PreparedTimeoutMs: 86400000
 ```
 
 * TransactionId: トランザクション ID
@@ -43,12 +45,14 @@ TimeoutMs: 300000
 * ABORTED: トランザクションが失敗
 * LoadJobSourceType: インポートタスクのタイプ
 * PrepareTime: トランザクションの開始時間
+* PreparedTime: トランスアクションが正常に準備された時点（v4.0.0からサポートされています）
 * CommitTime: トランザクションが正常にコミットされた時間
 * FinishTime: データが見えるようになった時間
 * Reason: エラーメッセージ
 * ErrorReplicasCount: エラーのあるレプリカの数
 * ListenerId: 関連するインポートジョブの ID
-* TimeoutMs: トランザクションのタイムアウト時間（ミリ秒）
+* TimeoutMs: トランザクションが `PREPARE` 状態から `PREPARED` 状態に移行するまでのタイムアウト時間（ミリ秒単位）
+* PreparedTimeoutMs: トランザクションが `PREPARED` 状態から `COMMITTED` 状態に移行するまでのタイムアウト時間（ミリ秒単位）（v4.0.0からサポートされています）
 
 ## 例
 

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -2082,7 +2082,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 单位：Seconds
 - 是否动态：是
 - 描述：预提交事务的默认超时时间。
-- 引入版本：v3.5
+- 引入版本：-
 
 ##### spark_dpp_version
 

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -2057,17 +2057,6 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 引入版本：-
 -->
 
-<!--
-##### prepared_transaction_default_timeout_second
-
-- 默认值：86400
-- 类型：Int
-- 单位：Seconds
-- 是否动态：是
-- 描述：
-- 引入版本：-
--->
-
 ##### max_load_timeout_second
 
 - 默认值：259200
@@ -2085,6 +2074,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：是
 - 描述：导入作业的最小超时时间，适用于所有导入。
 - 引入版本：-
+
+##### prepared_transaction_default_timeout_second
+
+- 默认值：86400
+- 类型：Int
+- 单位：Seconds
+- 是否动态：是
+- 描述：预提交事务的默认超时时间。
+- 引入版本：v3.5
 
 ##### spark_dpp_version
 

--- a/docs/zh/loading/Stream_Load_transaction_interface.md
+++ b/docs/zh/loading/Stream_Load_transaction_interface.md
@@ -61,7 +61,7 @@ stateDiagram-v2
 
 当开始事务时，您还可以通过HTTP请求 Header 中的 `idle_transaction_timeout` 字段指定事务可保持空闲状态的超时时间（以秒为单位）。若在此期间内未写入任何数据，该事务将被自动回滚。
 
-在预提交事务时，您可以通过 HTT P请求 Header 中的 `prepared_timeout` 字段指定事务从 `PREPARED` 状态转换为 `COMMITTED` 状态的超时时间（以秒为单位）。如果在此时间段内事务未完成提交，系统将自动取消该事务。如果未指定此字段，默认值由 FE 配置 [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) 决定（默认：86400 秒）。`prepared_timeout` 自 v4.0.0 版本起支持。
+在预提交事务时，您可以通过 HTT P请求 Header 中的 `prepared_timeout` 字段指定事务从 `PREPARED` 状态转换为 `COMMITTED` 状态的超时时间（以秒为单位）。如果在此时间段内事务未完成提交，系统将自动取消该事务。如果未指定此字段，默认值由 FE 配置 [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) 决定（默认：86400 秒）。`prepared_timeout` 自 v3.5.4 版本起支持。
 
 ## 接口优势
 
@@ -300,7 +300,7 @@ curl --location-trusted -u <jack>:<123456> -H "label:streamload_txn_example1_tab
 
 > **说明**
 >
-> `prepared_timeout` 字段为可选。如果未指定该字段，其默认值由 FE 配置中的 [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) 决定（默认值：86400 秒）。`prepared_timeout` 自 v4.0.0 版本起支持。
+> `prepared_timeout` 字段为可选。如果未指定该字段，其默认值由 FE 配置中的 [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) 决定（默认值：86400 秒）。`prepared_timeout` 自 v3.5.4 版本起支持。
 
 #### 返回结果
 

--- a/docs/zh/loading/Stream_Load_transaction_interface.md
+++ b/docs/zh/loading/Stream_Load_transaction_interface.md
@@ -25,17 +25,27 @@ Stream Load 支持导入 CSV 和 JSON 格式的数据，并且建议在导入的
 
 - `/api/transaction/begin`：开启一个新事务。
 
+- `/api/transaction/prepare`: 预提交当前事务并使数据更改暂时持久化。预提交事务后，您可以继续提交或回滚该事务。如果集群在事务预提交后发生故障，您仍可在集群恢复后继续提交该事务。
+
 - `/api/transaction/commit`：提交当前事务，持久化变更。
 
 - `/api/transaction/rollback`：回滚当前事务，回滚变更。
 
-### 事务预提交
-
-提供 `/api/transaction/prepare` 接口，用于预提交当前事务，临时持久化变更。预提交一个事务后，您可以继续提交或者回滚该事务。这种机制下，如果在事务预提交成功以后 StarRocks 发生宕机，您仍然可以在系统恢复后继续执行提交。
-
 > **说明**
 >
 > 在事务预提交以后，请勿继续写入数据。继续写入数据的话，写入请求会报错。
+
+下图展示了事务状态与操作之间的关系：
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> PREPARE : begin
+    PREPARE --> PREPARED : prepare
+    PREPARE --> ABORTED : rollback
+    PREPARED --> COMMITTED : commit
+    PREPARED --> ABORTED : rollback
+```
 
 ### 数据写入
 
@@ -47,11 +57,11 @@ Stream Load 支持导入 CSV 和 JSON 格式的数据，并且建议在导入的
 
 ### 超时管理
 
-支持通过 FE 配置中的 `stream_load_default_timeout_second` 参数设置默认的事务超时时间。
+当开始事务时，您可以使用 HTTP 请求 Header 中的 `timeout` 字段来指定从 `PREPARE` 状态到 `PREPARED` 状态的超时时间（以秒为单位）。如果在此时间段内事务未完成准备，将自动取消该事务。如果未指定此字段，默认值由 FE 配置 [`stream_load_default_timeout_second`](../administration/management/FE_configuration.md#stream_load_default_timeout_second) 决定（默认：600 秒）。
 
-开启事务时，可以通过 HTTP 请求头中的 `timeout` 字段来指定当前事务的超时时间。
+当开始事务时，您还可以通过HTTP请求 Header 中的 `idle_transaction_timeout` 字段指定事务可保持空闲状态的超时时间（以秒为单位）。若在此期间内未写入任何数据，该事务将被自动回滚。
 
-开启事务时，还可以通过 HTTP 请求头中的 `idle_transaction_timeout` 字段来指定空闲事务超时时间。当事务超过 `idle_transaction_timeout` 所设置的超时时间而没有数据写入时，事务将自动回滚。
+在预提交事务时，您可以通过 HTT P请求 Header 中的 `prepared_timeout` 字段指定事务从 `PREPARED` 状态转换为 `COMMITTED` 状态的超时时间（以秒为单位）。如果在此时间段内事务未完成提交，系统将自动取消该事务。如果未指定此字段，默认值由 FE 配置 [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) 决定（默认：86400 秒）。`prepared_timeout` 自 v4.0.0 版本起支持。
 
 ## 接口优势
 
@@ -274,6 +284,7 @@ curl --location-trusted -u <jack>:<123456> -H "label:streamload_txn_example1_tab
 curl --location-trusted -u <username>:<password> -H "label:<label_name>" \
     -H "Expect:100-continue" \
     -H "db:<database_name>" \
+    [-H "prepared_timeout:<timeout_seconds>"] \
     -XPOST http://<fe_host>:<fe_http_port>/api/transaction/prepare
 ```
 
@@ -283,8 +294,13 @@ curl --location-trusted -u <username>:<password> -H "label:<label_name>" \
 curl --location-trusted -u <jack>:<123456> -H "label:streamload_txn_example1_table1" \
     -H "Expect:100-continue" \
     -H "db:test_db" \
+    -H "prepared_timeout:300" \
     -XPOST http://<fe_host>:<fe_http_port>/api/transaction/prepare
 ```
+
+> **说明**
+>
+> `prepared_timeout` 字段为可选。如果未指定该字段，其默认值由 FE 配置中的 [`prepared_transaction_default_timeout_second`](../administration/management/FE_configuration.md#prepared_transaction_default_timeout_second) 决定（默认值：86400 秒）。`prepared_timeout` 自 v4.0.0 版本起支持。
 
 #### 返回结果
 

--- a/docs/zh/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
+++ b/docs/zh/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
@@ -45,14 +45,14 @@ PreparedTimeoutMs: 86400000
 * ABORTED：事务失败
 * LoadJobSourceType：导入任务的类型
 * PrepareTime：事务开始时间
-* PreparedTime: 事务预提交成功的时间（自v4.0.0版本起支持）
+* PreparedTime: 事务预提交成功的时间（自v3.5.4版本起支持）
 * CommitTime：事务提交成功的时间
 * FinishTime：数据可见的时间
 * Reason：错误信息
 * ErrorReplicasCount：有错误的副本数
 * ListenerId：相关的导入作业的 id
 * TimeoutMs: 从 `PREPARE` 状态到 `PREPARED` 状态的事务超时时间，单位为毫秒
-* PreparedTimeoutMs: 从 `PREPARED` 状态到 `COMMITTED` 状态的事务超时时间，单位为毫秒（从 v4.0.0 版本开始支持）
+* PreparedTimeoutMs: 从 `PREPARED` 状态到 `COMMITTED` 状态的事务超时时间，单位为毫秒（从 v3.5.4 版本开始支持）
 
 ## 示例
 

--- a/docs/zh/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
+++ b/docs/zh/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
@@ -25,12 +25,14 @@ Coordinator: FE: 10.74.167.16
 TransactionStatus: VISIBLE
 LoadJobSourceType: INSERT_STREAMING
 PrepareTime: 2020-01-09 14:59:07
+PreparedTime: 2020-01-09 14:59:08
 CommitTime: 2020-01-09 14:59:09
 FinishTime: 2020-01-09 14:59:09
 Reason:
 ErrorReplicasCount: 0
 ListenerId: -1
 TimeoutMs: 300000
+PreparedTimeoutMs: 86400000
 ```
 
 * TransactionId：事务 id
@@ -43,12 +45,14 @@ TimeoutMs: 300000
 * ABORTED：事务失败
 * LoadJobSourceType：导入任务的类型
 * PrepareTime：事务开始时间
+* PreparedTime: 事务预提交成功的时间（自v4.0.0版本起支持）
 * CommitTime：事务提交成功的时间
 * FinishTime：数据可见的时间
 * Reason：错误信息
 * ErrorReplicasCount：有错误的副本数
 * ListenerId：相关的导入作业的 id
-* TimeoutMs：事务超时时间，单位毫秒
+* TimeoutMs: 从 `PREPARE` 状态到 `PREPARED` 状态的事务超时时间，单位为毫秒
+* PreparedTimeoutMs: 从 `PREPARED` 状态到 `COMMITTED` 状态的事务超时时间，单位为毫秒（从 v4.0.0 版本开始支持）
 
 ## 示例
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/TransProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/TransProcDir.java
@@ -51,6 +51,7 @@ public class TransProcDir implements ProcDirInterface {
             .add("TransactionStatus")
             .add("LoadJobSourceType")
             .add("PrepareTime")
+            .add("PreparedTime")
             .add("CommitTime")
             .add("PublishTime")
             .add("FinishTime")
@@ -58,6 +59,7 @@ public class TransProcDir implements ProcDirInterface {
             .add("ErrorReplicasCount")
             .add("ListenerId")
             .add("TimeoutMs")
+            .add("PreparedTimeoutMs")
             .add("ErrMsg")
             .build();
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -102,7 +102,10 @@ public class TransactionLoadAction extends RestBaseAction {
     private static final long DEFAULT_TXN_TIMEOUT_MILLIS = 20000L;
 
     private static final String TXN_OP_KEY = "txn_op";
+    // The timeout for transaction from PREPARE -> PREPARED
     private static final String TIMEOUT_KEY = "timeout";
+    // The timeout for transaction from PREPARED -> COMMITTED
+    private static final String PREPARED_TIMEOUT_KEY = "prepared_timeout";
     private static final String CHANNEL_NUM_STR = "channel_num";
     private static final String CHANNEL_ID_STR = "channel_id";
     private static final String SOURCE_TYPE = "source_type";
@@ -338,6 +341,10 @@ public class TransactionLoadAction extends RestBaseAction {
                 .map(Long::parseLong)
                 .map(sec -> sec * 1000L)
                 .orElse(DEFAULT_TXN_TIMEOUT_MILLIS);
+        Long preparedTimeoutMillis = Optional.ofNullable(request.getRequest().headers().get(PREPARED_TIMEOUT_KEY))
+                .map(Long::parseLong)
+                .map(sec -> sec * 1000L)
+                .orElse(-1L);
         LoadJobSourceType sourceType = parseSourceType(request.getSingleParameter(SOURCE_TYPE));
 
         Integer channelId = Optional
@@ -389,6 +396,7 @@ public class TransactionLoadAction extends RestBaseAction {
                 label,
                 txnOperation,
                 timeoutMillis,
+                preparedTimeoutMillis,
                 channel,
                 sourceType,
                 body

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/BypassWriteTransactionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/BypassWriteTransactionHandler.java
@@ -82,7 +82,7 @@ public class BypassWriteTransactionHandler implements TransactionOperationHandle
                 break;
             case TXN_PREPARE:
                 result = handlePrepareTransaction(
-                        db, label,
+                        db, label, txnOperationParams.getPreparedTimeoutMillis(),
                         Optional.ofNullable(requestBody.getCommittedTablets()).orElse(new ArrayList<>(0)),
                         Optional.ofNullable(requestBody.getFailedTablets()).orElse(new ArrayList<>(0)),
                         timeoutMillis
@@ -124,6 +124,7 @@ public class BypassWriteTransactionHandler implements TransactionOperationHandle
 
     private TransactionResult handlePrepareTransaction(Database db,
                                                        String label,
+                                                       long preparedTimeoutMs,
                                                        List<TabletCommitInfo> committedTablets,
                                                        List<TabletFailInfo> failedTablets,
                                                        long timeoutMillis) throws StarRocksException {
@@ -135,7 +136,8 @@ public class BypassWriteTransactionHandler implements TransactionOperationHandle
         switch (txnStatus) {
             case PREPARE:
                 GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().prepareTransaction(
-                        dbId, txnId, committedTablets, failedTablets, new MiniLoadTxnCommitAttachment(), timeoutMillis);
+                        dbId, txnId, preparedTimeoutMs, committedTablets, failedTablets,
+                        new MiniLoadTxnCommitAttachment(), timeoutMillis);
                 result.addResultEntry(TransactionResult.TXN_ID_KEY, txnId);
                 result.addResultEntry(TransactionResult.LABEL_KEY, label);
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionOperationParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionOperationParams.java
@@ -35,6 +35,7 @@ public class TransactionOperationParams {
     private final String label;
     private final TransactionOperation txnOperation;
     private final Long timeoutMillis;
+    private final Long preparedTimeoutMillis;
     private final Channel channel;
 
     /* queries */
@@ -51,6 +52,7 @@ public class TransactionOperationParams {
                                       String label,
                                       TransactionOperation txnOperation,
                                       Long timeoutMillis,
+                                      Long preparedTimeoutMillis,
                                       Channel channel,
                                       LoadJobSourceType sourceType,
                                       Body body) {
@@ -60,6 +62,7 @@ public class TransactionOperationParams {
         this.label = label;
         this.txnOperation = txnOperation;
         this.timeoutMillis = timeoutMillis;
+        this.preparedTimeoutMillis = preparedTimeoutMillis;
         this.channel = channel;
         this.sourceType = sourceType;
         this.body = body;
@@ -149,6 +152,10 @@ public class TransactionOperationParams {
 
     public Long getTimeoutMillis() {
         return timeoutMillis;
+    }
+
+    public Long getPreparedTimeoutMillis() {
+        return preparedTimeoutMillis;
     }
 
     public Channel getChannel() {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionWithChannelHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionWithChannelHandler.java
@@ -74,7 +74,8 @@ public class TransactionWithChannelHandler implements TransactionOperationHandle
                 if (!result.stateOK() || result.containMsg()) {
                     return new ResultWrapper(result);
                 }
-                GlobalStateMgr.getCurrentState().getStreamLoadMgr().tryPrepareLoadTaskTxn(label, result);
+                GlobalStateMgr.getCurrentState().getStreamLoadMgr().tryPrepareLoadTaskTxn(label,
+                        txnOperationParams.getPreparedTimeoutMillis(), result);
                 return new ResultWrapper(result);
             case TXN_COMMIT:
                 GlobalStateMgr.getCurrentState().getStreamLoadMgr().commitLoadTask(label, result);

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -335,7 +335,7 @@ public class StreamLoadMgr implements MemoryTrackable {
         }
     }
 
-    public void tryPrepareLoadTaskTxn(String label, TransactionResult resp)
+    public void tryPrepareLoadTaskTxn(String label, long preparedTimeoutMs, TransactionResult resp)
             throws StarRocksException {
         boolean needUnLock = true;
         readLock();
@@ -347,7 +347,7 @@ public class StreamLoadMgr implements MemoryTrackable {
             readUnlock();
             needUnLock = false;
             if (task.checkNeedPrepareTxn()) {
-                task.waitCoordFinishAndPrepareTxn(resp);
+                task.waitCoordFinishAndPrepareTxn(preparedTimeoutMs, resp);
             }
         } finally {
             if (needUnLock) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1393,9 +1393,13 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             throw new StarRocksException("unknown database, database=" + dbName);
         }
 
+        long preparedTimeoutMs = TransactionState.DEFAULT_PREPARED_TIMEOUT_MS;
+        if (request.isSetPrepared_timeout_second() && request.getPrepared_timeout_second() > 0) {
+            preparedTimeoutMs = request.getPrepared_timeout_second() * 1000L;
+        }
         TxnCommitAttachment attachment = TxnCommitAttachment.fromThrift(request.txnCommitAttachment);
         GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().prepareTransaction(
-                db.getId(), request.getTxnId(),
+                db.getId(), request.getTxnId(), preparedTimeoutMs,
                 TabletCommitInfo.fromThrift(request.getCommitInfos()),
                 TabletFailInfo.fromThrift(request.getFailInfos()),
                 attachment);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -326,6 +326,7 @@ public class DatabaseTransactionMgr {
      * @param tabletCommitInfos tabletCommitInfos
      */
     public void prepareTransaction(long transactionId,
+                                   long preparedTimeoutMs,
                                    List<TabletCommitInfo> tabletCommitInfos,
                                    List<TabletFailInfo> tabletFailInfos,
                                    TxnCommitAttachment txnCommitAttachment,
@@ -405,7 +406,7 @@ public class DatabaseTransactionMgr {
 
                 // update transaction state version
                 transactionState.setTransactionStatus(TransactionStatus.PREPARED);
-                transactionState.setPreparedTime(System.currentTimeMillis());
+                transactionState.setPreparedTimeAndTimeout(System.currentTimeMillis(), preparedTimeoutMs);
 
                 for (TransactionStateListener listener : stateListeners) {
                     listener.preWriteCommitLog(transactionState);
@@ -564,7 +565,8 @@ public class DatabaseTransactionMgr {
                                                 @NotNull List<TabletFailInfo> tabletFailInfos,
                                                 @Nullable TxnCommitAttachment txnCommitAttachment)
             throws StarRocksException {
-        prepareTransaction(transactionId, tabletCommitInfos, tabletFailInfos, txnCommitAttachment, false);
+        prepareTransaction(transactionId, TransactionState.DEFAULT_PREPARED_TIMEOUT_MS,
+                tabletCommitInfos, tabletFailInfos, txnCommitAttachment, false);
         return commitPreparedTransaction(transactionId);
     }
 
@@ -781,6 +783,7 @@ public class DatabaseTransactionMgr {
         info.add(txnState.getTransactionStatus().name());
         info.add(txnState.getSourceType().name());
         info.add(TimeUtils.longToTimeString(txnState.getPrepareTime()));
+        info.add(TimeUtils.longToTimeString(txnState.getPreparedTime()));
         info.add(TimeUtils.longToTimeString(txnState.getCommitTime()));
         info.add(TimeUtils.longToTimeString(txnState.getPublishVersionTime()));
         info.add(TimeUtils.longToTimeString(txnState.getFinishTime()));
@@ -788,6 +791,7 @@ public class DatabaseTransactionMgr {
         info.add(String.valueOf(txnState.getErrorReplicas().size()));
         info.add(String.valueOf(txnState.getCallbackId()));
         info.add(String.valueOf(txnState.getTimeoutMs()));
+        info.add(String.valueOf(txnState.getPreparedTimeoutMs()));
         info.add(txnState.getErrMsg());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -311,6 +311,17 @@ public class TransactionState implements Writable, GsonPreProcessable {
     @SerializedName("to")
     private long timeoutMs = Config.stream_load_default_timeout_second * 1000L;
 
+    // The default timeout value (in milliseconds) for a transaction in the PREPARED state.
+    // A value of -1 indicates that the actual timeout will be determined dynamically at
+    // runtime by Config.prepared_transaction_default_timeout_second.
+    public static final long DEFAULT_PREPARED_TIMEOUT_MS = -1;
+
+    // The timeout (in milliseconds) that a transaction can remain in the PREPARED state
+    // before it must be either COMMITTED or ABORTED. This value is lazily set when the
+    // transaction transitions to the PREPARED state.
+    @SerializedName("pto")
+    private long preparedTimeoutMs = DEFAULT_PREPARED_TIMEOUT_MS;
+
     // optional
     @SerializedName("ta")
     private TxnCommitAttachment txnCommitAttachment;
@@ -756,8 +767,18 @@ public class TransactionState implements Writable, GsonPreProcessable {
         this.prepareTime = prepareTime;
     }
 
-    public void setPreparedTime(long preparedTime) {
+    public void setPreparedTimeAndTimeout(long preparedTime, long preparedTimeoutMs) {
         this.preparedTime = preparedTime;
+        this.preparedTimeoutMs = preparedTimeoutMs;
+    }
+
+    public long getPreparedTime() {
+        return preparedTime;
+    }
+
+    public long getPreparedTimeoutMs() {
+        return preparedTimeoutMs == DEFAULT_PREPARED_TIMEOUT_MS ?
+            Config.prepared_transaction_default_timeout_second * 1000L : preparedTimeoutMs;
     }
 
     public void setCommitTime(long commitTime) {
@@ -825,9 +846,15 @@ public class TransactionState implements Writable, GsonPreProcessable {
 
     // return true if txn is running but timeout
     public boolean isTimeout(long currentMillis) {
-        return (transactionStatus == TransactionStatus.PREPARE && currentMillis - prepareTime > timeoutMs)
-                || (transactionStatus == TransactionStatus.PREPARED && (currentMillis - preparedTime)
-                / 1000 > Config.prepared_transaction_default_timeout_second);
+        if (transactionStatus == TransactionStatus.PREPARE) {
+            return currentMillis - prepareTime > timeoutMs;
+        }
+        if (transactionStatus == TransactionStatus.PREPARED) {
+            long timeoutMs = preparedTimeoutMs > 0 ?
+                    preparedTimeoutMs : Config.prepared_transaction_default_timeout_second * 1000L;
+            return (currentMillis - preparedTime) > timeoutMs;
+        }
+        return false;
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -850,9 +850,9 @@ public class TransactionState implements Writable, GsonPreProcessable {
             return currentMillis - prepareTime > timeoutMs;
         }
         if (transactionStatus == TransactionStatus.PREPARED) {
-            long timeoutMs = preparedTimeoutMs > 0 ?
+            long timeout = preparedTimeoutMs > 0 ?
                     preparedTimeoutMs : Config.prepared_transaction_default_timeout_second * 1000L;
-            return (currentMillis - preparedTime) > timeoutMs;
+            return (currentMillis - preparedTime) > timeout;
         }
         return false;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTransactionStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTransactionStmtTest.java
@@ -34,14 +34,16 @@ public class ShowTransactionStmtTest {
         Assertions.assertEquals("TransactionStatus", metaData.getColumn(3).getName());
         Assertions.assertEquals("LoadJobSourceType", metaData.getColumn(4).getName());
         Assertions.assertEquals("PrepareTime", metaData.getColumn(5).getName());
-        Assertions.assertEquals("CommitTime", metaData.getColumn(6).getName());
-        Assertions.assertEquals("PublishTime", metaData.getColumn(7).getName());
-        Assertions.assertEquals("FinishTime", metaData.getColumn(8).getName());
-        Assertions.assertEquals("Reason", metaData.getColumn(9).getName());
-        Assertions.assertEquals("ErrorReplicasCount", metaData.getColumn(10).getName());
-        Assertions.assertEquals("ListenerId", metaData.getColumn(11).getName());
-        Assertions.assertEquals("TimeoutMs", metaData.getColumn(12).getName());
-        Assertions.assertEquals("ErrMsg", metaData.getColumn(13).getName());
+        Assertions.assertEquals("PreparedTime", metaData.getColumn(6).getName());
+        Assertions.assertEquals("CommitTime", metaData.getColumn(7).getName());
+        Assertions.assertEquals("PublishTime", metaData.getColumn(8).getName());
+        Assertions.assertEquals("FinishTime", metaData.getColumn(9).getName());
+        Assertions.assertEquals("Reason", metaData.getColumn(10).getName());
+        Assertions.assertEquals("ErrorReplicasCount", metaData.getColumn(11).getName());
+        Assertions.assertEquals("ListenerId", metaData.getColumn(12).getName());
+        Assertions.assertEquals("TimeoutMs", metaData.getColumn(13).getName());
+        Assertions.assertEquals("PreparedTimeoutMs", metaData.getColumn(14).getName());
+        Assertions.assertEquals("ErrMsg", metaData.getColumn(15).getName());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -689,7 +689,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                     times = 1;
                     result = new Delegate<Void>() {
 
-                        public void tryPrepareLoadTaskTxn(String label, TransactionResult resp) throws
+                        public void tryPrepareLoadTaskTxn(String label, long preparedTimeoutMs, TransactionResult resp) throws
                                 StarRocksException {
                             resp.addResultEntry(TransactionResult.LABEL_KEY, label);
                         }

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -649,7 +649,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
 
                     };
 
-                    streamLoadMgr.tryPrepareLoadTaskTxn(anyString, (TransactionResult) any);
+                    streamLoadMgr.tryPrepareLoadTaskTxn(anyString, anyLong, (TransactionResult) any);
                     times = 1;
                     result = new StarRocksException("try prepare load task txn error");
                 }
@@ -685,7 +685,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
 
                     };
 
-                    streamLoadMgr.tryPrepareLoadTaskTxn(anyString, (TransactionResult) any);
+                    streamLoadMgr.tryPrepareLoadTaskTxn(anyString, anyLong, (TransactionResult) any);
                     times = 1;
                     result = new Delegate<Void>() {
 
@@ -800,7 +800,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                     );
 
                     globalTransactionMgr.prepareTransaction(
-                            anyLong, anyLong,
+                            anyLong, anyLong, anyLong,
                             (List<TabletCommitInfo>) any,
                             (List<TabletFailInfo>) any,
                             (TxnCommitAttachment) any, anyLong);
@@ -834,7 +834,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                     );
 
                     globalTransactionMgr.prepareTransaction(
-                            anyLong, anyLong,
+                            anyLong, anyLong, anyLong,
                             (List<TabletCommitInfo>) any,
                             (List<TabletFailInfo>) any,
                             (TxnCommitAttachment) any, anyLong);
@@ -1268,7 +1268,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 result = txnId;
 
                 globalTransactionMgr.prepareTransaction(
-                        anyLong, anyLong,
+                        anyLong, anyLong, anyLong,
                         (List<TabletCommitInfo>) any,
                         (List<TabletFailInfo>) any,
                         (TxnCommitAttachment) any, anyLong);

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -454,10 +454,12 @@ public class DatabaseTransactionMgrTest {
         assertTrue(currentTime > TimeUtils.timeStringToLong(txnInfo.get(6)));
         assertTrue(currentTime > TimeUtils.timeStringToLong(txnInfo.get(7)));
         assertTrue(currentTime > TimeUtils.timeStringToLong(txnInfo.get(8)));
-        assertEquals("", txnInfo.get(9));
-        assertEquals("0", txnInfo.get(10));
-        assertEquals("[-1]", txnInfo.get(11));
-        assertEquals(String.valueOf(Config.stream_load_default_timeout_second * 1000L), txnInfo.get(12));
+        assertTrue(currentTime > TimeUtils.timeStringToLong(txnInfo.get(9)));
+        assertEquals("", txnInfo.get(10));
+        assertEquals("0", txnInfo.get(11));
+        assertEquals("[-1]", txnInfo.get(12));
+        assertEquals(String.valueOf(Config.stream_load_default_timeout_second * 1000L), txnInfo.get(13));
+        assertEquals(String.valueOf(Config.prepared_transaction_default_timeout_second * 1000L), txnInfo.get(14));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -847,7 +847,7 @@ public class GlobalTransactionMgrTest {
         assertEquals(0, entity.counterStreamLoadRowsTotal.getValue().intValue());
         assertEquals(0, entity.counterStreamLoadBytesTotal.getValue().intValue());
         assertEquals(0, entity.counterStreamLoadFinishedTotal.getValue().intValue());
-        masterTransMgr.prepareTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
+        masterTransMgr.prepareTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, -1, transTablets,
                 Lists.newArrayList(), txnCommitAttachment);
         TransactionState transactionState = fakeEditLog.getTransaction(transactionId);
         assertEquals(TransactionStatus.PREPARED, transactionState.getTransactionStatus());

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.persist.gson.GsonUtils;
@@ -44,6 +45,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TransactionStateTest {
 
@@ -123,7 +128,7 @@ public class TransactionStateTest {
 
         String json = GsonUtils.GSON.toJson(transactionState);
         TransactionState readTransactionState = GsonUtils.GSON.fromJson(json, TransactionState.class);
-        Assertions.assertTrue(readTransactionState.isNewFinish());
+        assertTrue(readTransactionState.isNewFinish());
     }
 
     @Test
@@ -165,26 +170,73 @@ public class TransactionStateTest {
         state.setTabletCommitInfos(infos);
 
         // replica state is not normal and clone
-        Assertions.assertFalse(state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.ALTER, 1L, 0), pcInfo));
-        Assertions.assertFalse(
+        assertFalse(state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.ALTER, 1L, 0), pcInfo));
+        assertFalse(
                 state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.SCHEMA_CHANGE, 1L, 0), pcInfo));
-        Assertions.assertTrue(state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.NORMAL, 1L, 0), pcInfo));
-        Assertions.assertTrue(state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.CLONE, 1L, 0), pcInfo));
+        assertTrue(state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.NORMAL, 1L, 0), pcInfo));
+        assertTrue(state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.CLONE, 1L, 0), pcInfo));
 
         // replica is in tabletCommitInfos
-        Assertions.assertFalse(state.checkReplicaNeedSkip(tablet1, new Replica(2L, 10001L, ReplicaState.NORMAL, 99L, 0), pcInfo));
-        Assertions.assertFalse(state.checkReplicaNeedSkip(tablet1, new Replica(3L, 10002L, ReplicaState.NORMAL, 99L, 0), pcInfo));
-        Assertions.assertFalse(state.checkReplicaNeedSkip(tablet2, new Replica(4L, 10002L, ReplicaState.NORMAL, 99L, 0), pcInfo));
+        assertFalse(state.checkReplicaNeedSkip(tablet1, new Replica(2L, 10001L, ReplicaState.NORMAL, 99L, 0), pcInfo));
+        assertFalse(state.checkReplicaNeedSkip(tablet1, new Replica(3L, 10002L, ReplicaState.NORMAL, 99L, 0), pcInfo));
+        assertFalse(state.checkReplicaNeedSkip(tablet2, new Replica(4L, 10002L, ReplicaState.NORMAL, 99L, 0), pcInfo));
 
         // replica current version >= commit version
-        Assertions.assertFalse(state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.NORMAL, 100L, 0), pcInfo));
+        assertFalse(state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.NORMAL, 100L, 0), pcInfo));
 
         // follower tabletCommitInfos is null
         Deencapsulation.setField(state, "tabletCommitInfos", null);
-        Assertions.assertFalse(state.checkReplicaNeedSkip(tablet0, new Replica(5L, 1L, ReplicaState.NORMAL, 1L, 0), pcInfo));
+        assertFalse(state.checkReplicaNeedSkip(tablet0, new Replica(5L, 1L, ReplicaState.NORMAL, 1L, 0), pcInfo));
 
         // follower tabletCommitInfos is null and unknownReplicas contains the replica
         state.addUnknownReplica(5L);
-        Assertions.assertTrue(state.checkReplicaNeedSkip(tablet0, new Replica(5L, 1L, ReplicaState.NORMAL, 1L, 0), pcInfo));
+        assertTrue(state.checkReplicaNeedSkip(tablet0, new Replica(5L, 1L, ReplicaState.NORMAL, 1L, 0), pcInfo));
+    }
+
+    @Test
+    public void testTimeout() {
+        {
+            TransactionState txn = new TransactionState(1000L, Lists.newArrayList(20000L),
+                    3000, "label123", UUIDUtil.genTUniqueId(),
+                    LoadJobSourceType.BACKEND_STREAMING, new TxnCoordinator(TxnSourceType.BE, "127.0.0.1"), 50000L,
+                    1000L);
+
+            txn.setTransactionStatus(TransactionStatus.PREPARE);
+            txn.setPrepareTime(1);
+            assertEquals(1, txn.getPrepareTime());
+            assertFalse(txn.isTimeout(500));
+            assertTrue(txn.isTimeout(1500));
+
+            txn.setTransactionStatus(TransactionStatus.PREPARED);
+            txn.setPreparedTimeAndTimeout(2000, TransactionState.DEFAULT_PREPARED_TIMEOUT_MS);
+            assertEquals(Config.prepared_transaction_default_timeout_second * 1000L, txn.getPreparedTimeoutMs());
+            assertFalse(txn.isTimeout(2000 + Config.prepared_transaction_default_timeout_second * 1000L));
+            assertTrue(txn.isTimeout(2000 + Config.prepared_transaction_default_timeout_second * 1000L + 10));
+
+            txn.setTransactionStatus(TransactionStatus.COMMITTED);
+            assertFalse(txn.isTimeout(4000));
+        }
+
+        {
+            TransactionState txn = new TransactionState(1000L, Lists.newArrayList(20000L),
+                    3000, "label123", UUIDUtil.genTUniqueId(),
+                    LoadJobSourceType.BACKEND_STREAMING, new TxnCoordinator(TxnSourceType.BE, "127.0.0.1"), 50000L,
+                    1000L);
+
+            txn.setTransactionStatus(TransactionStatus.PREPARE);
+            txn.setPrepareTime(1);
+            assertEquals(1, txn.getPrepareTime());
+            assertFalse(txn.isTimeout(500));
+            assertTrue(txn.isTimeout(1500));
+
+            txn.setTransactionStatus(TransactionStatus.PREPARED);
+            txn.setPreparedTimeAndTimeout(2000, 1000);
+            assertEquals(1000, txn.getPreparedTimeoutMs());
+            assertFalse(txn.isTimeout(2500));
+            assertTrue(txn.isTimeout(3500));
+
+            txn.setTransactionStatus(TransactionStatus.COMMITTED);
+            assertFalse(txn.isTimeout(4000));
+        }
     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1062,6 +1062,8 @@ struct TLoadTxnCommitRequest {
     11: optional TTxnCommitAttachment txnCommitAttachment
     12: optional i64 thrift_rpc_timeout_ms
     13: optional list<Types.TTabletFailInfo> failInfos
+    // The timeout for prepared transaction. Only valid if this requerst is sent by rpc loadTxnPrepare
+    14: optional i32 prepared_timeout_second
 }
 
 struct TLoadTxnCommitResult {

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2971,3 +2971,82 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
             return True
 
         return False
+
+    def get_transaction_meta(self, db_name, label, column_separator, *column_names):
+        """
+        Get transaction metadata by label and column names.
+        :param db_name: database name
+        :param label: transaction label
+        :param column_separator: separator for concatenating column values
+        :param column_names: column names to retrieve
+        :return: concatenated column values or error message if not found
+        """
+        # Column name to index mapping based on show proc output
+        column_mapping = {
+            'TransactionId': 0,
+            'Label': 1,
+            'Coordinator': 2,
+            'TransactionStatus': 3,
+            'LoadJobSourceType': 4,
+            'PrepareTime': 5,
+            'PreparedTime': 6,
+            'CommitTime': 7,
+            'PublishTime': 8,
+            'FinishTime': 9,
+            'Reason': 10,
+            'ErrorReplicasCount': 11,
+            'ListenerId': 12,
+            'TimeoutMs': 13,
+            'PreparedTimeoutMs': 14,
+            'ErrMsg': 15
+        }
+        
+        sql = f"show proc '/transactions/{db_name}/finished'"
+        log.info(f"Executing SQL: {sql}")
+        result = self.execute_sql(sql, True)
+        
+        if not result["status"]:
+            error_msg = f"Failed to execute SQL: {result}"
+            log.error(error_msg)
+            return error_msg
+            
+        if "result" not in result or len(result["result"]) == 0:
+            error_msg = f"No transactions found in database {db_name}"
+            log.info(error_msg)
+            return error_msg
+            
+        log.info(f"Found {len(result['result'])} transactions in database {db_name}")
+        
+        # Find the row matching the label
+        target_row = None
+        for row in result["result"]:
+            if len(row) > 1 and row[1] == label:  # Label is at index 1
+                target_row = row
+                log.info(f"Found transaction with label '{label}'")
+                break
+                
+        if target_row is None:
+            error_msg = f"No transaction found with label '{label}' in database {db_name}"
+            log.info(error_msg)
+            return error_msg
+            
+        # Extract column values
+        column_values = []
+        for column_name in column_names:
+            if column_name not in column_mapping:
+                error_msg = f"Unknown column name: {column_name}"
+                log.error(error_msg)
+                return error_msg
+                
+            column_index = column_mapping[column_name]
+            if column_index >= len(target_row):
+                error_msg = f"Column index {column_index} out of range for column {column_name}"
+                log.error(error_msg)
+                return error_msg
+                
+            column_values.append(str(target_row[column_index]))
+            log.info(f"Column {column_name} = {target_row[column_index]}")
+            
+        result_str = column_separator.join(column_values)
+        log.info(f"Final result: {result_str}")
+        return result_str

--- a/test/sql/test_stream_load/R/test_prepared_timeout
+++ b/test/sql/test_stream_load/R/test_prepared_timeout
@@ -1,4 +1,4 @@
--- name: test_prepared_timeout
+-- name: test_prepared_timeout @slow
 create database db_prepared_timeout_normal_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_stream_load/R/test_prepared_timeout
+++ b/test/sql/test_stream_load/R/test_prepared_timeout
@@ -1,0 +1,225 @@
+-- name: test_prepared_timeout
+create database db_prepared_timeout_normal_${uuid0};
+-- result:
+-- !result
+use db_prepared_timeout_normal_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `id` int
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test_normal" -H "db:db_prepared_timeout_normal_${uuid0}" -H "table:test_normal" -XPOST ${url}/api/transaction/begin
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "test_normal",
+    "TxnId": 239,
+    "BeginTxnTimeMs": 0
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test_normal" -H "Expect:100-continue" -H "db:db_prepared_timeout_normal_${uuid0}" -H "table:test_normal" -d '1' -X PUT  ${url}/api/transaction/load
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "test_normal",
+    "TxnId": 239,
+    "LoadBytes": 1,
+    "StreamLoadPlanTimeMs": 1,
+    "ReceivedDataTimeMs": 0
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test_normal" -H "db:db_prepared_timeout_normal_${uuid0}" -H "prepared_timeout:300" -XPOST ${url}/api/transaction/prepare
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "test_normal",
+    "TxnId": 239,
+    "NumberTotalRows": 1,
+    "NumberLoadedRows": 1,
+    "NumberFilteredRows": 0,
+    "NumberUnselectedRows": 0,
+    "LoadBytes": 1,
+    "LoadTimeMs": 36,
+    "StreamLoadPlanTimeMs": 1,
+    "ReceivedDataTimeMs": 0,
+    "WriteDataTimeMs": 20,
+    "CommitAndPublishTimeMs": 2
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test_normal" -H "db:db_prepared_timeout_normal_${uuid0}" -XPOST ${url}/api/transaction/commit
+-- result:
+0
+{
+  "Label": "test_normal",
+  "Status": "OK",
+  "TxnId": 239,
+  "Message": ""
+}
+-- !result
+select * from test_normal order by id;
+-- result:
+1
+-- !result
+function: get_transaction_meta("db_prepared_timeout_normal_${uuid0}", "test_normal", "|", "TransactionStatus", "PreparedTimeoutMs")
+-- result:
+VISIBLE|300000
+-- !result
+create database db_prepared_timeout_default_${uuid0};
+-- result:
+-- !result
+use db_prepared_timeout_default_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `test_default` (
+  `id` int
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test_default" -H "db:db_prepared_timeout_default_${uuid0}" -H "table:test_default" -XPOST ${url}/api/transaction/begin
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "test_default",
+    "TxnId": 240,
+    "BeginTxnTimeMs": 0
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test_default" -H "Expect:100-continue" -H "db:db_prepared_timeout_default_${uuid0}" -H "table:test_default" -d '2' -X PUT  ${url}/api/transaction/load
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "test_default",
+    "TxnId": 240,
+    "LoadBytes": 1,
+    "StreamLoadPlanTimeMs": 1,
+    "ReceivedDataTimeMs": 0
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test_default" -H "db:db_prepared_timeout_default_${uuid0}" -XPOST ${url}/api/transaction/prepare
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "test_default",
+    "TxnId": 240,
+    "NumberTotalRows": 1,
+    "NumberLoadedRows": 1,
+    "NumberFilteredRows": 0,
+    "NumberUnselectedRows": 0,
+    "LoadBytes": 1,
+    "LoadTimeMs": 33,
+    "StreamLoadPlanTimeMs": 1,
+    "ReceivedDataTimeMs": 0,
+    "WriteDataTimeMs": 19,
+    "CommitAndPublishTimeMs": 2
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test_default" -H "db:db_prepared_timeout_default_${uuid0}" -XPOST ${url}/api/transaction/commit
+-- result:
+0
+{
+  "Label": "test_default",
+  "Status": "OK",
+  "TxnId": 240,
+  "Message": ""
+}
+-- !result
+select * from test_default order by id;
+-- result:
+2
+-- !result
+function: get_transaction_meta("db_prepared_timeout_default_${uuid0}", "test_default", "|", "TransactionStatus", "PreparedTimeoutMs")
+-- result:
+VISIBLE|86400000
+-- !result
+create database db_prepared_timeout_timeout_${uuid0};
+-- result:
+-- !result
+use db_prepared_timeout_timeout_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `test_timeout` (
+  `id` int
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test_timeout" -H "db:db_prepared_timeout_timeout_${uuid0}" -H "table:test_timeout" -XPOST ${url}/api/transaction/begin
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "test_timeout",
+    "TxnId": 241,
+    "BeginTxnTimeMs": 0
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test_timeout" -H "Expect:100-continue" -H "db:db_prepared_timeout_timeout_${uuid0}" -H "table:test_timeout" -d '3' -X PUT  ${url}/api/transaction/load
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "test_timeout",
+    "TxnId": 241,
+    "LoadBytes": 1,
+    "StreamLoadPlanTimeMs": 1,
+    "ReceivedDataTimeMs": 0
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test_timeout" -H "db:db_prepared_timeout_timeout_${uuid0}" -H "prepared_timeout:1" -XPOST ${url}/api/transaction/prepare
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "test_timeout",
+    "TxnId": 241,
+    "NumberTotalRows": 1,
+    "NumberLoadedRows": 1,
+    "NumberFilteredRows": 0,
+    "NumberUnselectedRows": 0,
+    "LoadBytes": 1,
+    "LoadTimeMs": 36,
+    "StreamLoadPlanTimeMs": 1,
+    "ReceivedDataTimeMs": 0,
+    "WriteDataTimeMs": 21,
+    "CommitAndPublishTimeMs": 2
+}
+-- !result
+function: wait_db_transaction_finish("db_prepared_timeout_timeout_${uuid0}", 300)
+-- result:
+None
+-- !result
+function: get_transaction_meta("db_prepared_timeout_timeout_${uuid0}", "test_timeout", "|", "TransactionStatus", "PreparedTimeoutMs", "Reason")
+-- result:
+ABORTED|1000|timeout by txn manager
+-- !result

--- a/test/sql/test_stream_load/T/test_prepared_timeout
+++ b/test/sql/test_stream_load/T/test_prepared_timeout
@@ -1,4 +1,4 @@
--- name: test_prepared_timeout
+-- name: test_prepared_timeout @slow
 
 -- Scenario 1: Normal prepared_timeout setting
 create database db_prepared_timeout_normal_${uuid0};

--- a/test/sql/test_stream_load/T/test_prepared_timeout
+++ b/test/sql/test_stream_load/T/test_prepared_timeout
@@ -1,0 +1,66 @@
+-- name: test_prepared_timeout
+
+-- Scenario 1: Normal prepared_timeout setting
+create database db_prepared_timeout_normal_${uuid0};
+use db_prepared_timeout_normal_${uuid0};
+
+CREATE TABLE `test_normal` (
+  `id` int
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+[UC]shell: curl --location-trusted -u root: -H "label:test_normal" -H "db:db_prepared_timeout_normal_${uuid0}" -H "table:test_normal" -XPOST ${url}/api/transaction/begin
+[UC]shell: curl --location-trusted -u root: -H "label:test_normal" -H "Expect:100-continue" -H "db:db_prepared_timeout_normal_${uuid0}" -H "table:test_normal" -d '1' -X PUT  ${url}/api/transaction/load
+[UC]shell: curl --location-trusted -u root: -H "label:test_normal" -H "db:db_prepared_timeout_normal_${uuid0}" -H "prepared_timeout:300" -XPOST ${url}/api/transaction/prepare
+[UC]shell: curl --location-trusted -u root: -H "label:test_normal" -H "db:db_prepared_timeout_normal_${uuid0}" -XPOST ${url}/api/transaction/commit
+
+select * from test_normal order by id;
+
+function: get_transaction_meta("db_prepared_timeout_normal_${uuid0}", "test_normal", "|", "TransactionStatus", "PreparedTimeoutMs")
+
+-- Scenario 2: Default prepared_timeout (not set)
+create database db_prepared_timeout_default_${uuid0};
+use db_prepared_timeout_default_${uuid0};
+
+CREATE TABLE `test_default` (
+  `id` int
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+[UC]shell: curl --location-trusted -u root: -H "label:test_default" -H "db:db_prepared_timeout_default_${uuid0}" -H "table:test_default" -XPOST ${url}/api/transaction/begin
+[UC]shell: curl --location-trusted -u root: -H "label:test_default" -H "Expect:100-continue" -H "db:db_prepared_timeout_default_${uuid0}" -H "table:test_default" -d '2' -X PUT  ${url}/api/transaction/load
+[UC]shell: curl --location-trusted -u root: -H "label:test_default" -H "db:db_prepared_timeout_default_${uuid0}" -XPOST ${url}/api/transaction/prepare
+[UC]shell: curl --location-trusted -u root: -H "label:test_default" -H "db:db_prepared_timeout_default_${uuid0}" -XPOST ${url}/api/transaction/commit
+
+select * from test_default order by id;
+
+function: get_transaction_meta("db_prepared_timeout_default_${uuid0}", "test_default", "|", "TransactionStatus", "PreparedTimeoutMs")
+
+-- Scenario 3: Timeout mechanism verification
+create database db_prepared_timeout_timeout_${uuid0};
+use db_prepared_timeout_timeout_${uuid0};
+
+CREATE TABLE `test_timeout` (
+  `id` int
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+[UC]shell: curl --location-trusted -u root: -H "label:test_timeout" -H "db:db_prepared_timeout_timeout_${uuid0}" -H "table:test_timeout" -XPOST ${url}/api/transaction/begin
+[UC]shell: curl --location-trusted -u root: -H "label:test_timeout" -H "Expect:100-continue" -H "db:db_prepared_timeout_timeout_${uuid0}" -H "table:test_timeout" -d '3' -X PUT  ${url}/api/transaction/load
+[UC]shell: curl --location-trusted -u root: -H "label:test_timeout" -H "db:db_prepared_timeout_timeout_${uuid0}" -H "prepared_timeout:1" -XPOST ${url}/api/transaction/prepare
+
+function: wait_db_transaction_finish("db_prepared_timeout_timeout_${uuid0}", 300)
+
+function: get_transaction_meta("db_prepared_timeout_timeout_${uuid0}", "test_timeout", "|", "TransactionStatus", "PreparedTimeoutMs", "Reason")


### PR DESCRIPTION
## Why I'm doing:

Currently, users can only configure the timeout for prepared transactions through the global FE configuration `prepared_transaction_default_timeout_second`. This approach lacks flexibility as it requires all transactions to use the same timeout value. Users need the ability to specify different timeout values for different transactions based on their specific requirements, especially in production environments where precise control over transaction lifecycle is crucial.

## What I'm doing:

This PR adds support for the `prepared_timeout` configuration in transaction stream load, allowing users to specify a timeout period for transactions from PREPARED to COMMITTED state. The implementation includes:

**Backend Changes:**
- Added `HTTP_PREPARED_TIMEOUT` constant in `be/src/http/http_common.h`
- Extended `StreamLoadContext` with `prepared_timeout_second` field
- Modified `TransactionMgr` to parse `prepared_timeout` HTTP header
- Updated `StreamLoadExecutor::prepare_txn` to pass timeout to FE
- Enhanced `TransactionState` with `preparedTimeoutMs` field and timeout detection logic
- Updated Thrift interface `TLoadTxnCommitRequest` with `prepared_timeout_second` field

**Frontend Changes:**
- Modified `TransactionLoadAction` to parse `prepared_timeout` parameter
- Updated `TransactionState` with `setPreparedTimeAndTimeout` method
- Enhanced `DatabaseTransactionMgr` and `GlobalTransactionMgr` to handle prepared timeout
- Updated transaction timeout detection logic in `TransactionState::isTimeout`

**Usage Example:**
```bash
# Begin transaction
curl --location-trusted -u root: -H "label:test_txn" -H "timeout:300" -H "db:test_db" -H "table:test_table" \
    -XPOST http://fe_host:8030/api/transaction/begin

# Load data
curl --location-trusted -u root: -H "label:test_txn" -H "db:test_db" -H "table:test_table" \
    -d '1' -XPUT http://fe_host:8030/api/transaction/load

# Prepare transaction with custom timeout (60 seconds)
curl --location-trusted -u root: -H "label:test_txn" -H "db:test_db" \
    -H "prepared_timeout:60" -XPOST http://fe_host:8030/api/transaction/prepare

# Commit transaction
curl --location-trusted -u root: -H "label:test_txn" -H "db:test_db" \
    -XPOST http://fe_host:8030/api/transaction/commit

# View transaction details including PreparedTime and PreparedTimeoutMs
SHOW TRANSACTION WHERE id = <transaction_id>;
+---------------+--------+---------------+-------------------+-------------------+---------------------+---------------------+---------------------+---------------------+---------------------+--------+--------------------+------------+-----------+-------------------+--------+
| TransactionId | Label  | Coordinator   | TransactionStatus | LoadJobSourceType | PrepareTime         | PreparedTime        | CommitTime          | PublishTime         | FinishTime          | Reason | ErrorReplicasCount | ListenerId | TimeoutMs | PreparedTimeoutMs | ErrMsg |
+---------------+--------+---------------+-------------------+-------------------+---------------------+---------------------+---------------------+---------------------+---------------------+--------+--------------------+------------+-----------+-------------------+--------+
| 1633          | test_txn | BE: 127.0.0.1 | VISIBLE           | BACKEND_STREAMING | 2025-08-03 11:02:54 | 2025-08-03 11:03:10 | 2025-08-03 11:03:14 | 2025-08-03 11:03:14 | 2025-08-03 11:03:14 |        | 0                  | [12237]    | 300000    | 60000             |        |
+---------------+--------+---------------+-------------------+-------------------+---------------------+---------------------+---------------------+---------------------+---------------------+--------+--------------------+------------+-----------+-------------------+--------+
```

**Documentation:**
- Updated `Stream_Load_transaction_interface.md` with `prepared_timeout` usage instructions
- Modified `SHOW_TRANSACTION.md` to document new `PreparedTime` and `PreparedTimeoutMs` fields
- Added version information indicating support from 3.5.4 onwards

The feature provides backward compatibility by using the FE configuration `prepared_transaction_default_timeout_second` as the default value when `prepared_timeout` is not specified.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3