### PR TITLE
[BugFix] fix file-prefix-map, remove the build_XXX part

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -59,8 +59,8 @@ message(STATUS "Build target arch is ${CMAKE_BUILD_TARGET_ARCH}")
 
 # Set dirs
 set(BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-set(RELATIVE_BASE_DIR "be")
-set(FILE_PREFIX_MAP_FLAG "-ffile-prefix-map=${BASE_DIR}=${RELATIVE_BASE_DIR}")
+# CMAKE_BINARY_DIR is set to be $BASE_DIR/be/build_${buildType}
+set(FILE_PREFIX_MAP_FLAG "-ffile-prefix-map=${CMAKE_BINARY_DIR}=. -ffile-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=be")
 set(BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 set(THIRDPARTY_DIR "$ENV{STARROCKS_THIRDPARTY}/installed/")
 set(STARROCKS_THIRDPARTY "$ENV{STARROCKS_THIRDPARTY}")


### PR DESCRIPTION
* -ffile-prefix-map=/build/starrocks/be/build_RELEASE=. -ffile-prefix-map=/build/starrocks/be=be
* before this fix: source file lists 
```
  be/build_RELEASE/be/src/agent/agent_common.h
  be/build_RELEASE/be/src/agent/agent_server.cpp
  ...
  be/build_RELEASE/be/src/util/value_generator.h
  be/build_RELEASE/be/src/util/xxhash.h
``` 
  after this fix: 
```
 ./be/src/agent/agent_common.h
 ./be/src/agent/agent_server.cpp
 ...
 ./be/src/util/value_generator.h
 ./be/src/util/xxhash.h
```

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
