### PR TITLE
[Enhancement] Show tablet distribution balance statistic

### DIFF
--- a/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
@@ -55,6 +55,7 @@ SchemaScanner::ColumnDesc SchemaPartitionsMetaScanner::_s_columns[] = {
         {"STORAGE_PATH", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
         {"STORAGE_SIZE", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
         {"METADATA_SWITCH_VERSION", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
+        {"TABLET_BALANCED", TypeDescriptor::from_logical_type(TYPE_BOOLEAN), sizeof(bool), false},
 };
 
 SchemaPartitionsMetaScanner::SchemaPartitionsMetaScanner()
@@ -304,6 +305,11 @@ Status SchemaPartitionsMetaScanner::fill_chunk(ChunkPtr* chunk) {
         case 30: {
             // METADATA_SWITCH_VERSION
             fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.metadata_switch_version);
+            break;
+        }
+        case 31: {
+            // TABLET_BALANCED
+            fill_column_with_slot<TYPE_BOOLEAN>(column.get(), (void*)&info.tablet_balanced);
             break;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -375,6 +375,15 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
         this.metadataSwitchVersion = metadataSwitchVersion;
     }
 
+    public boolean isTabletBalanced() {
+        for (MaterializedIndex index : getMaterializedIndices(IndexExtState.VISIBLE)) {
+            if (!index.isTabletBalanced()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public MaterializedIndex getIndex(long indexId) {
         if (baseIndex.getId() == indexId) {
             return baseIndex;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
@@ -62,6 +62,7 @@ public class PartitionsMetaSystemTable {
                         .column("STORAGE_PATH", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("STORAGE_SIZE", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("METADATA_SWITCH_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("TABLET_BALANCED", ScalarType.createType(PrimitiveType.BOOLEAN))
                         .build(), TSchemaTableType.SCH_PARTITIONS_META);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/BalanceStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BalanceStat.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.clone;
 
+import com.google.gson.Gson;
+
 public abstract class BalanceStat {
     public enum BalanceType {
         CLUSTER_DISK("cluster disk"),
@@ -32,6 +34,8 @@ public abstract class BalanceStat {
         }
     }
 
+    private static final Gson GSON = new Gson();
+
     // Singleton instance indicating that everything is balanced
     public static final BalanceStat BALANCED_STAT = new BalancedStat();
 
@@ -46,6 +50,11 @@ public abstract class BalanceStat {
     }
 
     public abstract BalanceType getBalanceType();
+
+    @Override
+    public String toString() {
+        return GSON.toJson(this);
+    }
 
     // Factory methods for different balance stat types
     public static BalanceStat createClusterDiskBalanceStat(long maxBeId, long minBeId, double maxDiskUsage, double minDiskUsage) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
@@ -59,7 +59,7 @@ import java.util.List;
 public class IndicesProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("IndexId").add("IndexName").add("State").add("LastConsistencyCheckTime")
-            .add("VirtualBuckets").add("Tablets")
+            .add("VirtualBuckets").add("Tablets").add("TabletBalanceStat")
             .build();
 
     private Database db;
@@ -92,6 +92,7 @@ public class IndicesProcDir implements ProcDirInterface {
                 indexInfo.add(TimeUtils.longToTimeString(materializedIndex.getLastCheckTime()));
                 indexInfo.add(materializedIndex.getVirtualBuckets().size());
                 indexInfo.add(materializedIndex.getTablets().size());
+                indexInfo.add(materializedIndex.getBalanceStat().toString());
 
                 indexInfos.add(indexInfo);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -155,7 +155,8 @@ public class PartitionsProcDir implements ProcDirInterface {
                     .add("RowCount")
                     .add("DataVersion")
                     .add("VersionEpoch")
-                    .add("VersionTxnType");
+                    .add("VersionTxnType")
+                    .add("TabletBalanced");
             this.titleNames = builder.build();
         }
     }
@@ -380,6 +381,7 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(physicalPartition.getVersionEpoch()); // VersionEpoch
         partitionInfo.add(physicalPartition.getVersionTxnType()); // VersionTxnType
 
+        partitionInfo.add(physicalPartition.isTabletBalanced());
         return partitionInfo;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -499,6 +499,8 @@ public class InformationSchemaDataSource {
         partitionMetaInfo.setVersion_txn_type(physicalPartition.getVersionTxnType().toThrift());
         // STORAGE_SIZE
         partitionMetaInfo.setStorage_size(physicalPartition.storageDataSize() + physicalPartition.getExtraFileSize());
+        // TABLET_BALANCED
+        partitionMetaInfo.setTablet_balanced(physicalPartition.isTabletBalanced());
     }
 
     // tables

--- a/fe/fe-core/src/test/java/com/starrocks/clone/BalanceStatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/BalanceStatTest.java
@@ -22,13 +22,22 @@ public class BalanceStatTest {
 
     @Test
     public void testNormal() {
-        Assertions.assertTrue(BalanceStat.BALANCED_STAT.isBalanced());
+        {
+            BalanceStat stat = BalanceStat.BALANCED_STAT;
+            Assertions.assertTrue(stat.isBalanced());
+            Assertions.assertNull(stat.getBalanceType());
+            Assertions.assertEquals("{\"balanced\":true}", stat.toString());
+        }
 
         {
             BalanceStat stat = BalanceStat.createClusterDiskBalanceStat(1L, 2L, 0.9, 0.1);
             Assertions.assertFalse(stat.isBalanced());
             Assertions.assertEquals(BalanceType.CLUSTER_DISK, stat.getBalanceType());
             Assertions.assertEquals("cluster disk", stat.getBalanceType().label());
+            Assertions.assertEquals(
+                    "{\"maxUsedPercent\":0.9,\"minUsedPercent\":0.1,\"maxBeId\":1,\"minBeId\":2,\"type\":\"CLUSTER_DISK\"," +
+                            "\"balanced\":false}",
+                    stat.toString());
         }
 
         {
@@ -36,6 +45,10 @@ public class BalanceStatTest {
             Assertions.assertFalse(stat.isBalanced());
             Assertions.assertEquals(BalanceType.CLUSTER_TABLET, stat.getBalanceType());
             Assertions.assertEquals("cluster tablet", stat.getBalanceType().label());
+            Assertions.assertEquals(
+                    "{\"maxTabletNum\":9,\"minTabletNum\":1,\"maxBeId\":1,\"minBeId\":2,\"type\":\"CLUSTER_TABLET\"," +
+                            "\"balanced\":false}",
+                    stat.toString());
         }
 
         {
@@ -43,6 +56,10 @@ public class BalanceStatTest {
             Assertions.assertFalse(stat.isBalanced());
             Assertions.assertEquals(BalanceType.BACKEND_DISK, stat.getBalanceType());
             Assertions.assertEquals("backend disk", stat.getBalanceType().label());
+            Assertions.assertEquals(
+                    "{\"maxUsedPercent\":0.9,\"minUsedPercent\":0.1,\"beId\":1,\"maxPath\":\"disk1\",\"minPath\":\"disk2\"," +
+                            "\"type\":\"BACKEND_DISK\",\"balanced\":false}",
+                    stat.toString());
         }
 
         {
@@ -50,6 +67,10 @@ public class BalanceStatTest {
             Assertions.assertFalse(stat.isBalanced());
             Assertions.assertEquals(BalanceType.BACKEND_TABLET, stat.getBalanceType());
             Assertions.assertEquals("backend tablet", stat.getBalanceType().label());
+            Assertions.assertEquals(
+                    "{\"maxTabletNum\":9,\"minTabletNum\":1,\"beId\":1,\"maxPath\":\"disk1\",\"minPath\":\"disk2\"," +
+                            "\"type\":\"BACKEND_TABLET\",\"balanced\":false}",
+                    stat.toString());
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/IndicesProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/IndicesProcDirTest.java
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.proc;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.ListPartitionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndex.IndexState;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.RandomDistributionInfo;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.Type;
+import com.starrocks.clone.BalanceStat;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.thrift.TStorageMedium;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class IndicesProcDirTest {
+
+    @Test
+    public void testFetchResult() throws AnalysisException {
+        Database db = new Database(10000L, "IndicesProcDirTestDB");
+
+        List<Column> col = Lists.newArrayList(new Column("province", Type.VARCHAR));
+        PartitionInfo listPartition = new ListPartitionInfo(PartitionType.LIST, col);
+        long partitionId = 1025;
+        listPartition.setDataProperty(partitionId, DataProperty.DEFAULT_DATA_PROPERTY);
+        listPartition.setIsInMemory(partitionId, false);
+        listPartition.setReplicationNum(partitionId, (short) 1);
+        OlapTable olapTable = new OlapTable(1024L, "olap_table", col, null, listPartition, null);
+        MaterializedIndex index = new MaterializedIndex(1000L, IndexState.NORMAL);
+        index.setBalanceStat(BalanceStat.createClusterTabletBalanceStat(1L, 2L, 9L, 1L));
+        Map<String, Long> indexNameToId = olapTable.getIndexNameToId();
+        indexNameToId.put("index1", index.getId());
+        TabletMeta tabletMeta = new TabletMeta(db.getId(), olapTable.getId(), partitionId, index.getId(), TStorageMedium.HDD);
+        index.addTablet(new LocalTablet(1010L), tabletMeta);
+        index.addTablet(new LocalTablet(1011L), tabletMeta);
+        Partition partition = new Partition(partitionId, 1035, "p1", index, new RandomDistributionInfo(2));
+        olapTable.addPartition(partition);
+
+        db.registerTableUnlocked(olapTable);
+
+        IndicesProcDir indicesProcDir = new IndicesProcDir(db, olapTable, partition.getDefaultPhysicalPartition());
+        BaseProcResult result = (BaseProcResult) indicesProcDir.fetchResult();
+        List<List<String>> rows = result.getRows();
+        Assertions.assertEquals(1, rows.size());
+        List<String> row = rows.get(0);
+        Assertions.assertEquals("1000", row.get(0));
+        Assertions.assertEquals("index1", row.get(1));
+        Assertions.assertEquals("NORMAL", row.get(2));
+        Assertions.assertEquals("\\N", row.get(3)); // last consistency check time
+        Assertions.assertEquals("2", row.get(4)); // virtual buckets
+        Assertions.assertEquals("2", row.get(5)); // tablets
+        Assertions.assertEquals(
+                "{\"maxTabletNum\":9,\"minTabletNum\":1,\"maxBeId\":1,\"minBeId\":2,\"type\":\"CLUSTER_TABLET\"," +
+                        "\"balanced\":false}",
+                row.get(6)); // tablet balance stat
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
@@ -12,59 +12,51 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.common.proc;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.Type;
+import com.starrocks.clone.BalanceStat;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.DdlException;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.lake.LakeTable;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
-
 public class PartitionsProcDirTest {
-    private Database db;
-    private LakeTable cloudNativTable;
 
-    @BeforeEach
-    public void setUp() throws DdlException, AnalysisException {
-        db = new Database(10000L, "PartitionsProcDirTestDB");
-        Map<String, Long> indexNameToId = Maps.newHashMap();
-        indexNameToId.put("index1", 1000L);
+    @Test
+    public void testFetchResultForCloudNativeTable() throws AnalysisException {
+        Database db = new Database(10000L, "PartitionsProcDirTestDB");
 
         List<Column> col = Lists.newArrayList(new Column("province", Type.VARCHAR));
         PartitionInfo listPartition = new ListPartitionInfo(PartitionType.LIST, col);
         DataCacheInfo dataCache = new DataCacheInfo(true, false);
         long partitionId = 1025;
         listPartition.setDataCacheInfo(partitionId, dataCache);
-        cloudNativTable = new LakeTable(1024L, "cloud_native_table", col, null, listPartition, null);
+        LakeTable cloudNativeTable = new LakeTable(1024L, "cloud_native_table", col, null, listPartition, null);
         MaterializedIndex index = new MaterializedIndex(1000L, IndexState.NORMAL);
-        cloudNativTable.addPartition(new Partition(partitionId, 1035,
-                "p1", index, new RandomDistributionInfo(10)));
+        Map<String, Long> indexNameToId = cloudNativeTable.getIndexNameToId();
+        indexNameToId.put("index1", index.getId());
+        cloudNativeTable.addPartition(new Partition(partitionId, 1035, "p1", index, new RandomDistributionInfo(10)));
 
-        db.registerTableUnlocked(cloudNativTable);
-    }
+        db.registerTableUnlocked(cloudNativeTable);
 
-    @Test
-    public void testFetchResult() throws AnalysisException {
-        BaseProcResult result = (BaseProcResult) new PartitionsProcDir(db, cloudNativTable, false).fetchResult();
+        BaseProcResult result = (BaseProcResult) new PartitionsProcDir(db, cloudNativeTable, false).fetchResult();
         List<List<String>> rows = result.getRows();
         List<String> list1 = rows.get(0);
         Assertions.assertEquals("1035", list1.get(0));
@@ -75,5 +67,35 @@ public class PartitionsProcDirTest {
         Assertions.assertEquals("NORMAL", list1.get(5));
         Assertions.assertEquals("province", list1.get(6));
         Assertions.assertEquals("0", list1.get(21));
+    }
+
+    @Test
+    public void testFetchResultForOlapTable() throws AnalysisException {
+        Database db = new Database(10000L, "PartitionsProcDirTestDB");
+
+        List<Column> col = Lists.newArrayList(new Column("province", Type.VARCHAR));
+        PartitionInfo listPartition = new ListPartitionInfo(PartitionType.LIST, col);
+        long partitionId = 1025;
+        listPartition.setDataProperty(partitionId, DataProperty.DEFAULT_DATA_PROPERTY);
+        listPartition.setIsInMemory(partitionId, false);
+        listPartition.setReplicationNum(partitionId, (short) 1);
+        OlapTable olapTable = new OlapTable(1024L, "olap_table", col, null, listPartition, null);
+        MaterializedIndex index = new MaterializedIndex(1000L, IndexState.NORMAL);
+        index.setBalanceStat(BalanceStat.BALANCED_STAT);
+        Map<String, Long> indexNameToId = olapTable.getIndexNameToId();
+        indexNameToId.put("index1", index.getId());
+        olapTable.addPartition(new Partition(partitionId, 1035, "p1", index, new RandomDistributionInfo(10)));
+
+        db.registerTableUnlocked(olapTable);
+
+        BaseProcResult result = (BaseProcResult) new PartitionsProcDir(db, olapTable, false).fetchResult();
+        List<List<String>> rows = result.getRows();
+        List<String> list1 = rows.get(0);
+        Assertions.assertEquals("1035", list1.get(0));
+        Assertions.assertEquals("p1", list1.get(1));
+        Assertions.assertEquals("1", list1.get(2)); // visible version
+        Assertions.assertEquals("NORMAL", list1.get(5));
+        Assertions.assertEquals("province", list1.get(6));
+        Assertions.assertEquals("true", list1.get(21)); // tablet balanced
     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1519,6 +1519,7 @@ struct TPartitionMetaInfo {
     28: optional Types.TTxnType version_txn_type = Types.TTxnType.TXN_NORMAL
     29: optional i64 storage_size
     30: optional i64 metadata_switch_version
+    31: optional bool tablet_balanced
 }
 
 struct TGetPartitionsMetaResponse {

--- a/test/sql/test_information_schema/R/test_partitions_meta
+++ b/test/sql/test_information_schema/R/test_partitions_meta
@@ -50,6 +50,15 @@ partitions_meta_test2	p3	1	TXN_NORMAL	0	0
 admin set frontend config("max_get_partitions_meta_result_count"="100000");
 -- result:
 -- !result
+
+create table partitions_meta_test3 (k1 int, k2 int) distributed by hash(k1) buckets 1;
+-- result:
+-- !result
+select TABLET_BALANCED from INFORMATION_SCHEMA.PARTITIONS_META where table_name = "partitions_meta_test3";
+-- result:
+1
+-- !result
+
 drop database db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_information_schema/T/test_partitions_meta
+++ b/test/sql/test_information_schema/T/test_partitions_meta
@@ -30,4 +30,8 @@ PROPERTIES (
 admin set frontend config("max_get_partitions_meta_result_count"="1");
 select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE, STORAGE_SIZE, METADATA_SWITCH_VERSION from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by table_name asc, partition_name asc;
 admin set frontend config("max_get_partitions_meta_result_count"="100000");
+
+create table partitions_meta_test3 (k1 int, k2 int) distributed by hash(k1) buckets 1;
+select TABLET_BALANCED from INFORMATION_SCHEMA.PARTITIONS_META where table_name = "partitions_meta_test3";
+
 drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Improve some commands to show tablet distribution balance statistic.
1. add `TabletBalanceStat` in `show index proc`.
```
// Cluster or backend tablet distribution balance statistic
mysql> show proc "/dbs/ssb/lineorder/partitions/lineorder";
+---------+-----------+--------+--------------------------+----------------+---------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| IndexId | IndexName | State  | LastConsistencyCheckTime | VirtualBuckets | Tablets | TabletBalanceStat                                                                                                                                                    |
+---------+-----------+--------+--------------------------+----------------+---------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 11129   | lineorder | NORMAL | NULL                     | 100            | 100     | {"maxTabletNum":23,"minTabletNum":21,"beId":10012,"maxPath":"/disk1","minPath":"/disk2","type":"BACKEND_TABLET","balanced":false}                                    |
+---------+-----------+--------+--------------------------+----------------+---------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```

2. add `TabletBalanced` in `show partitions`.
```
// Partitions tablet distribution balanced
mysql> show partitions from lineorder;
+-------------+---------------+----------------+---------------------+--------------------+--------+--------------+-------+-----------------+---------+----------------+---------------+---------------------+--------------------------+----------+-------------+------------+----------+-------------+--------------------+----------------+----------------+
| PartitionId | PartitionName | VisibleVersion | VisibleVersionTime  | VisibleVersionHash | State  | PartitionKey | Range | DistributionKey | Buckets | ReplicationNum | StorageMedium | CooldownTime        | LastConsistencyCheckTime | DataSize | StorageSize | IsInMemory | RowCount | DataVersion | VersionEpoch       | VersionTxnType | TabletBalanced |
+-------------+---------------+----------------+---------------------+--------------------+--------+--------------+-------+-----------------+---------+----------------+---------------+---------------------+--------------------------+----------+-------------+------------+----------+-------------+--------------------+----------------+----------------+
| 3177701     | lineorder     | 7              | 2025-03-14 19:15:08 | 0                  | NORMAL |              |       | lo_orderkey     | 6       | 1              | HDD           | 9999-12-31 23:59:59 | NULL                     | 28.6MB   | 28.6MB      | false      | 36494440 | 7           | 333662776914345984 | TXN_NORMAL     | true           |
+-------------+---------------+----------------+---------------------+--------------------+--------+--------------+-------+-----------------+---------+----------------+---------------+---------------------+--------------------------+----------+-------------+------------+----------+-------------+--------------------+----------------+----------------+
1 row in set (0.00 sec)
```

3. add `TABLET_BALANCED` in `information_schema.partitions_meta`.
```
// Partitions which tablet distribution not balanced
mysql> select * from information_schema.partitions_meta where tablet_balanced = 0;
+--------------+---------------+----------------+--------------+-----------------+-----------------+----------------------+--------------+--------------+--------------------+------------------+-------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------
+---------+-----------------+----------------+---------------------+-----------------------------+--------------+---------+-----------+-----------+------------------+--------+--------+--------+--------------+--------------+-------------------------+-----------------+
| DB_NAME      | TABLE_NAME    | PARTITION_NAME | PARTITION_ID | COMPACT_VERSION | VISIBLE_VERSION | VISIBLE_VERSION_TIME | NEXT_VERSION | DATA_VERSION | VERSION_EPOCH      | VERSION_TXN_TYPE | PARTITION_KEY                                   | PARTITION_VALUE                                                                                      | DISTRIBUTION_KEY
| BUCKETS | REPLICATION_NUM | STORAGE_MEDIUM | COOLDOWN_TIME       | LAST_CONSISTENCY_CHECK_TIME | IS_IN_MEMORY | IS_TEMP | DATA_SIZE | ROW_COUNT | ENABLE_DATACACHE | AVG_CS | P50_CS | MAX_CS | STORAGE_PATH | STORAGE_SIZE | METADATA_SWITCH_VERSION | TABLET_BALANCED |
+--------------+---------------+----------------+--------------+-----------------+-----------------+----------------------+--------------+--------------+--------------------+------------------+-------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------
+---------+-----------------+----------------+---------------------+-----------------------------+--------------+---------+-----------+-----------+------------------+--------+--------+--------+--------------+--------------+-------------------------+-----------------+
| ssb          | lineorder     | lineorder      |        11130 |               0 |               1 | 2025-07-25 15:15:08  |            2 |            1 | 368240825875824640 | TXN_NORMAL       |                                                 |                                                                                                      | lo_orderkey
|     100 |               2 | HDD            | 9999-12-31 23:59:59 | NULL                        |            0 |       0 | 0B        |         0 |                0 |      0 |      0 |      0 |              |            0 |                       0 |               0 |
+--------------+---------------+----------------+--------------+-----------------+-----------------+----------------------+--------------+--------------+--------------------+------------------+-------------------------------------------------+------------------------------------------------------------------------------------------------------+------------------
+---------+-----------------+----------------+---------------------+-----------------------------+--------------+---------+-----------+-----------+------------------+--------+--------+--------+--------------+--------------+-------------------------+-----------------+
1 rows in set (0.08 sec)
```

https://github.com/StarRocks/starrocks/issues/61340

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
