### PR TITLE
[BugFix] Fix the bug where increasing low_cardinality_threshold does not take effect

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
@@ -28,7 +28,7 @@ public final class ColumnDict extends StatsVersion {
 
     public ColumnDict(ImmutableMap<ByteBuffer, Integer> dict, long version) {
         super(version, version);
-        Preconditions.checkState(!dict.isEmpty() && dict.size() <= Config.low_cardinality_threshold,
+        Preconditions.checkState(!dict.isEmpty() && dict.size() <= Config.low_cardinality_threshold + 1,
                 "dict size %s is illegal", dict.size());
         this.dict = dict;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.common.Config;
 
 import java.nio.ByteBuffer;
 
@@ -27,7 +28,7 @@ public final class ColumnDict extends StatsVersion {
 
     public ColumnDict(ImmutableMap<ByteBuffer, Integer> dict, long version) {
         super(version, version);
-        Preconditions.checkState(!dict.isEmpty() && dict.size() <= 256,
+        Preconditions.checkState(!dict.isEmpty() && dict.size() <= Config.low_cardinality_threshold,
                 "dict size %s is illegal", dict.size());
         this.dict = dict;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
@@ -28,6 +28,7 @@ public final class ColumnDict extends StatsVersion {
 
     public ColumnDict(ImmutableMap<ByteBuffer, Integer> dict, long version) {
         super(version, version);
+        // TODO: The default value of low_cardinality_threshold is 255. Should we set the check size to 255 or 256?
         Preconditions.checkState(!dict.isEmpty() && dict.size() <= Config.low_cardinality_threshold + 1,
                 "dict size %s is illegal", dict.size());
         this.dict = dict;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ColumnDictTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ColumnDictTest.java
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.statistics;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.common.Config;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+public class ColumnDictTest {
+    private int previousLowCardinalityThreshold = 0;
+
+    @BeforeEach
+    void setUP() {
+        previousLowCardinalityThreshold = Config.low_cardinality_threshold;
+        Config.low_cardinality_threshold = 512;
+    }
+
+    @AfterEach
+    void tearDown() {
+        Config.low_cardinality_threshold = previousLowCardinalityThreshold;
+    }
+
+    @Test
+    void checkLowCardinalityConfigAvailable() {
+        ImmutableMap.Builder<ByteBuffer, Integer> builder = ImmutableMap.builder();
+
+        for (int i = 0; i < 300; i++) {
+            String key = "string-" + i;
+            byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+            ByteBuffer keyBuffer = ByteBuffer.allocate(keyBytes.length);
+            keyBuffer.put(keyBytes);
+            keyBuffer.flip();
+
+            builder.put(keyBuffer, i);
+        }
+        ImmutableMap<ByteBuffer, Integer> dictMap = builder.build();
+
+        ColumnDict dict = new ColumnDict(dictMap, 1);
+        Assertions.assertEquals(300, dict.getDictSize());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

The constructor of `ColumnDict` does not use `Config.low_cardinality_threshold` to check the dictionary size. Therefore, if we modify `Config.low_cardinality_threshold`, the constructor will still throw an exception, and thus increasing `Config.low_cardinality_threshold` will not take effect.

## What I'm doing:

Fix the bug where increasing low_cardinality_threshold does not take effect

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
