### PR TITLE
[Enhancement]exchange node support bucket aware execution

### DIFF
--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -518,6 +518,13 @@ OperatorFactoryPtr DataSink::_create_exchange_sink_operator(pipeline::PipelineBu
         DCHECK_GT(dest_dop, 0);
     }
 
+    std::vector<TBucketProperty> bucket_properties;
+    if (sender->get_partition_type() == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
+        if (stream_sink.output_partition.__isset.bucket_properties) {
+            bucket_properties = stream_sink.output_partition.bucket_properties;
+        }
+    }
+
     std::shared_ptr<SinkBuffer> sink_buffer =
             std::make_shared<SinkBuffer>(fragment_ctx, sender->destinations(), is_dest_merge);
 
@@ -526,7 +533,8 @@ OperatorFactoryPtr DataSink::_create_exchange_sink_operator(pipeline::PipelineBu
             sender->destinations(), is_pipeline_level_shuffle, dest_dop, sender->sender_id(),
             sender->get_dest_node_id(), sender->get_partition_exprs(),
             !is_dest_merge && sender->get_enable_exchange_pass_through(),
-            sender->get_enable_exchange_perf() && !context->has_aggregation, fragment_ctx, sender->output_columns());
+            sender->get_enable_exchange_perf() && !context->has_aggregation, fragment_ctx, sender->output_columns(),
+            bucket_properties);
     return exchange_sink;
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -338,7 +338,7 @@ ExchangeSinkOperator::ExchangeSinkOperator(
         const int32_t num_shuffles_per_channel, int32_t sender_id, PlanNodeId dest_node_id,
         const std::vector<ExprContext*>& partition_expr_ctxs, bool enable_exchange_pass_through,
         bool enable_exchange_perf, FragmentContext* const fragment_ctx, const std::vector<int32_t>& output_columns,
-        std::atomic<int32_t>& num_sinkers)
+        const std::vector<TBucketProperty>& bucket_properties, std::atomic<int32_t>& num_sinkers)
         : Operator(factory, id, "exchange_sink", plan_node_id, false, driver_sequence),
           _buffer(buffer),
           _part_type(part_type),
@@ -349,6 +349,7 @@ ExchangeSinkOperator::ExchangeSinkOperator(
           _partition_expr_ctxs(partition_expr_ctxs),
           _fragment_ctx(fragment_ctx),
           _output_columns(output_columns),
+          _bucket_properties(bucket_properties),
           _num_sinkers(num_sinkers) {
     std::map<int64_t, int64_t> fragment_id_to_channel_index;
 
@@ -585,18 +586,20 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chu
                 for (const ColumnPtr& column : _partitions_columns) {
                     column->fnv_hash(&_hash_values[0], 0, num_rows);
                 }
-            } else {
+            } else if (_bucket_properties.empty()) {
                 // The data distribution was calculated using CRC32_HASH,
                 // and bucket shuffle need to use the same hash function when sending data
                 _hash_values.assign(num_rows, 0);
                 for (const ColumnPtr& column : _partitions_columns) {
                     column->crc32_hash(&_hash_values[0], 0, num_rows);
                 }
+            } else {
+                _calc_hash_values_and_bucket_ids();
             }
 
             // Compute row indexes for each channel's each shuffle
             _channel_row_idx_start_points.assign(_num_shuffles + 1, 0);
-            _shuffler->exchange_shuffle(_shuffle_channel_ids, _hash_values, num_rows);
+            _shuffler->exchange_shuffle(_shuffle_channel_ids, _hash_values, _bucket_ids, num_rows);
 
             for (size_t i = 0; i < num_rows; ++i) {
                 _channel_row_idx_start_points[_shuffle_channel_ids[i]]++;
@@ -636,6 +639,40 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chu
         }
     }
     return Status::OK();
+}
+
+void ExchangeSinkOperator::_calc_hash_values_and_bucket_ids() {
+    size_t num_rows = _partitions_columns[0]->size();
+    _hash_values.assign(num_rows, 0);
+    _bucket_ids.assign(num_rows, 0);
+    for (int i = 0; i < _partitions_columns.size(); ++i) {
+        // TODO, enhance it if we try to support more bucket functions.
+        DCHECK(_bucket_properties[i].bucket_func == TBucketFunction::MURMUR3_X86_32);
+        _round_hashes.assign(num_rows, 0);
+        _round_ids.assign(num_rows, 0);
+        _partitions_columns[i]->murmur_hash3_x86_32(&_round_hashes[0], 0, num_rows);
+        for (int j = 0; j < num_rows; j++) {
+            _hash_values[j] ^= _round_hashes[j];
+            _round_ids[j] = (_round_hashes[j] & std::numeric_limits<int>::max()) % _bucket_properties[i].bucket_num;
+        }
+        if (_partitions_columns[i]->has_null()) {
+            const auto& null_data = down_cast<const NullableColumn*>(_partitions_columns[i].get())->null_column()->get_data();
+            for (int j = 0; j < num_rows; j++) {
+                _round_ids[j] = null_data[j] ? _bucket_properties[i].bucket_num : _round_ids[j];
+            }
+        }
+
+        if (i == _partitions_columns.size() - 1) {
+            for (int j = 0; j < num_rows; j++) {
+                _bucket_ids[j] += _round_ids[j];
+            }
+        } else {
+            for (int j = 0; j < num_rows; j++) {
+                // bucket mapping, same behavior as FE
+                _bucket_ids[j] = (_round_ids[j] + _bucket_ids[j]) * (_bucket_properties[i + 1].bucket_num + 1);
+            }
+        }
+    }
 }
 
 void ExchangeSinkOperator::update_metrics(RuntimeState* state) {
@@ -793,7 +830,8 @@ ExchangeSinkOperatorFactory::ExchangeSinkOperatorFactory(
         const std::vector<TPlanFragmentDestination>& destinations, bool is_pipeline_level_shuffle,
         int32_t num_shuffles_per_channel, int32_t sender_id, PlanNodeId dest_node_id,
         std::vector<ExprContext*> partition_expr_ctxs, bool enable_exchange_pass_through, bool enable_exchange_perf,
-        FragmentContext* const fragment_ctx, std::vector<int32_t> output_columns)
+        FragmentContext* const fragment_ctx, std::vector<int32_t> output_columns,
+        std::vector<TBucketProperty> bucket_properties)
         : OperatorFactory(id, "exchange_sink", plan_node_id),
           _buffer(std::move(buffer)),
           _part_type(part_type),
@@ -806,14 +844,15 @@ ExchangeSinkOperatorFactory::ExchangeSinkOperatorFactory(
           _enable_exchange_pass_through(enable_exchange_pass_through),
           _enable_exchange_perf(enable_exchange_perf),
           _fragment_ctx(fragment_ctx),
-          _output_columns(std::move(output_columns)) {}
+          _output_columns(std::move(output_columns)),
+          _bucket_properties(std::move(bucket_properties)) {}
 
 OperatorPtr ExchangeSinkOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
     _increment_num_sinkers_no_barrier();
     return std::make_shared<ExchangeSinkOperator>(
             this, _id, _plan_node_id, driver_sequence, _buffer, _part_type, _destinations, _is_pipeline_level_shuffle,
             _num_shuffles_per_channel, _sender_id, _dest_node_id, _partition_expr_ctxs, _enable_exchange_pass_through,
-            _enable_exchange_perf, _fragment_ctx, _output_columns, _num_sinkers);
+            _enable_exchange_perf, _fragment_ctx, _output_columns, _bucket_properties, _num_sinkers);
 }
 
 Status ExchangeSinkOperatorFactory::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -656,7 +656,8 @@ void ExchangeSinkOperator::_calc_hash_values_and_bucket_ids() {
             _round_ids[j] = (_round_hashes[j] & std::numeric_limits<int>::max()) % _bucket_properties[i].bucket_num;
         }
         if (_partitions_columns[i]->has_null()) {
-            const auto& null_data = down_cast<const NullableColumn*>(_partitions_columns[i].get())->null_column()->get_data();
+            const auto& null_data =
+                    down_cast<const NullableColumn*>(_partitions_columns[i].get())->null_column()->get_data();
             for (int j = 0; j < num_rows; j++) {
                 _round_ids[j] = null_data[j] ? _bucket_properties[i].bucket_num : _round_ids[j];
             }

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -52,7 +52,8 @@ public:
                          const int32_t num_shuffles_per_channel, int32_t sender_id, PlanNodeId dest_node_id,
                          const std::vector<ExprContext*>& partition_expr_ctxs, bool enable_exchange_pass_through,
                          bool enable_exchange_perf, FragmentContext* const fragment_ctx,
-                         const std::vector<int32_t>& output_columns, std::atomic<int32_t>& num_sinkers);
+                         const std::vector<int32_t>& output_columns,
+                         const std::vector<TBucketProperty>& bucket_properties, std::atomic<int32_t>& num_sinkers);
 
     ~ExchangeSinkOperator() override = default;
 
@@ -92,6 +93,7 @@ private:
         // ref olap_scan_node.cpp release_large_columns
         return sz > runtime_state()->chunk_size() * 512;
     }
+    void _calc_hash_values_and_bucket_ids();
 
 private:
     class Channel;
@@ -210,6 +212,10 @@ private:
     FragmentContext* const _fragment_ctx;
 
     const std::vector<int32_t>& _output_columns;
+    const std::vector<TBucketProperty>& _bucket_properties;
+    std::vector<uint32_t> _round_hashes;
+    std::vector<uint32_t> _round_ids;
+    std::vector<uint32_t> _bucket_ids;
 
     std::unique_ptr<Shuffler> _shuffler;
 
@@ -224,7 +230,8 @@ public:
                                 bool is_pipeline_level_shuffle, int32_t num_shuffles_per_channel, int32_t sender_id,
                                 PlanNodeId dest_node_id, std::vector<ExprContext*> partition_expr_ctxs,
                                 bool enable_exchange_pass_through, bool enable_exchange_perf,
-                                FragmentContext* const fragment_ctx, std::vector<int32_t> output_columns);
+                                FragmentContext* const fragment_ctx, std::vector<int32_t> output_columns,
+                                std::vector<TBucketProperty> bucket_properties);
 
     ~ExchangeSinkOperatorFactory() override = default;
 
@@ -257,6 +264,7 @@ private:
     FragmentContext* const _fragment_ctx;
 
     const std::vector<int32_t> _output_columns;
+    const std::vector<TBucketProperty> _bucket_properties;
 
     std::atomic<int32_t> _num_sinkers = 0;
 };

--- a/be/src/exec/pipeline/exchange/shuffler.h
+++ b/be/src/exec/pipeline/exchange/shuffler.h
@@ -24,10 +24,11 @@ namespace starrocks::pipeline {
 class Shuffler {
 public:
     Shuffler(bool compatibility, bool is_two_level_shuffle, TPartitionType::type partition_type, size_t num_channels,
-             int32_t num_shuffles_per_channel)
+             int32_t num_shuffles_per_channel, bool bucket_aware = false)
             : _part_type(partition_type),
               _num_channels(num_channels),
-              _num_shuffles_per_channel(num_shuffles_per_channel) {
+              _num_shuffles_per_channel(num_shuffles_per_channel),
+              _bucket_aware(bucket_aware) {
         if (_part_type == TPartitionType::HASH_PARTITIONED && !compatibility) {
             if (is_two_level_shuffle) {
                 _exchange_shuffle = &Shuffler::exchange_shuffle<true, ReduceOp>;
@@ -50,8 +51,8 @@ public:
     }
 
     void exchange_shuffle(std::vector<uint32_t>& shuffle_channel_ids, const std::vector<uint32_t>& hash_values,
-                          size_t num_rows) {
-        (this->*_exchange_shuffle)(shuffle_channel_ids, hash_values, num_rows);
+                          const std::vector<uint32_t>& bucket_ids, size_t num_rows) {
+        (this->*_exchange_shuffle)(shuffle_channel_ids, hash_values, bucket_ids, num_rows);
     }
 
     void local_exchange_shuffle(std::vector<uint32_t>& shuffle_channel_ids, std::vector<uint32_t>& hash_values,
@@ -61,16 +62,18 @@ public:
 
 private:
     void (Shuffler::*_exchange_shuffle)(std::vector<uint32_t>& shuffle_channel_ids,
-                                        const std::vector<uint32_t>& hash_values, size_t num_rows) = nullptr;
+                                        const std::vector<uint32_t>& hash_values,
+                                        const std::vector<uint32_t>& bucket_ids, size_t num_rows) = nullptr;
 
     void (Shuffler::*_local_exchange_shuffle)(std::vector<uint32_t>& shuffle_channel_ids,
                                               std::vector<uint32_t>& hash_values, size_t num_rows) = nullptr;
 
     template <bool two_level_shuffle, typename ReduceOp>
     void exchange_shuffle(std::vector<uint32_t>& shuffle_channel_ids, const std::vector<uint32_t>& hash_values,
-                          size_t num_rows) {
+                          const std::vector<uint32_t>& bucket_ids, size_t num_rows) {
         for (size_t i = 0; i < num_rows; ++i) {
-            size_t channel_id = ReduceOp()(hash_values[i], _num_channels);
+            size_t channel_id = _bucket_aware ? ReduceOp()(bucket_ids[i], _num_channels)
+                                              : ReduceOp()(hash_values[i], _num_channels);
             size_t shuffle_id;
             if constexpr (!two_level_shuffle) {
                 shuffle_id = channel_id;
@@ -101,5 +104,6 @@ private:
     const TPartitionType::type _part_type = TPartitionType::UNPARTITIONED;
     const size_t _num_channels;
     const size_t _num_shuffles_per_channel;
+    bool _bucket_aware;
 };
 } // namespace starrocks::pipeline

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -67,7 +67,7 @@ set(EXEC_FILES
         ./exec/pipeline/sink/export_sink_operator_test.cpp
         ./exec/pipeline/sink/table_function_table_sink_operator_test.cpp
         ./exec/pipeline/sink/memory_scratch_sink_operator_test.cpp
-        ./exec/pipeline/exchange_pass_through_test.cpp
+        exec/pipeline/exchange_test.cpp
         ./exec/pipeline/limit_operator_test.cpp
         ./exec/pipeline/mem_limited_chunk_queue_test.cpp
         ./exec/query_cache/query_cache_test.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -67,7 +67,8 @@ set(EXEC_FILES
         ./exec/pipeline/sink/export_sink_operator_test.cpp
         ./exec/pipeline/sink/table_function_table_sink_operator_test.cpp
         ./exec/pipeline/sink/memory_scratch_sink_operator_test.cpp
-        exec/pipeline/exchange_test.cpp
+        ./exec/pipeline/exchange_bucket_aware_test.cpp
+        ./exec/pipeline/exchange_pass_through_test.cpp
         ./exec/pipeline/limit_operator_test.cpp
         ./exec/pipeline/mem_limited_chunk_queue_test.cpp
         ./exec/query_cache/query_cache_test.cpp

--- a/be/test/exec/pipeline/exchange_bucket_aware_test.cpp
+++ b/be/test/exec/pipeline/exchange_bucket_aware_test.cpp
@@ -1,0 +1,188 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/datum.h"
+#include "exec/pipeline/exchange/exchange_sink_operator.h"
+#include "exec/pipeline/fragment_context.h"
+#include "gen_cpp/DataSinks_types.h"
+#include "gen_cpp/InternalService_types.h"
+#include "gen_cpp/Partitions_types.h"
+#include "gen_cpp/Types_types.h"
+#include "runtime/data_stream_mgr.h"
+#include "runtime/data_stream_recvr.h"
+#include "runtime/runtime_state.h"
+#include "testutil/assert.h"
+
+namespace starrocks::pipeline {
+
+class ExchangeBucketAwareTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        BackendOptions::set_localhost("0.0.0.0");
+
+        _exec_env = ExecEnv::GetInstance();
+
+        _query_context = std::make_shared<QueryContext>();
+        _query_context->set_exec_env(_exec_env);
+        _query_context->init_mem_tracker(-1, GlobalEnv::GetInstance()->process_mem_tracker());
+
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        _runtime_state = std::make_shared<RuntimeState>(_fragment_id, query_options, query_globals, _exec_env);
+        _runtime_state->set_query_ctx(_query_context.get());
+        _runtime_state->init_instance_mem_tracker();
+
+        _fragment_context = std::make_shared<pipeline::FragmentContext>();
+        _fragment_context->set_fragment_instance_id(_fragment_id);
+        _fragment_context->set_runtime_state(std::shared_ptr<RuntimeState>{_runtime_state});
+        _runtime_state->set_fragment_ctx(_fragment_context.get());
+
+        TNetworkAddress address;
+        address.__set_hostname(BackendOptions::get_local_ip());
+        address.__set_port(config::brpc_port);
+        _destination.__set_fragment_instance_id(_fragment_id);
+        _destination.__set_brpc_server(address);
+    }
+
+    void TearDown() override {
+        _recvr->close();
+        _exec_env->stream_mgr()->close();
+        _query_context->set_exec_env(nullptr);
+    }
+
+protected:
+    TUniqueId _fragment_id;
+    ExecEnv* _exec_env;
+    std::shared_ptr<QueryContext> _query_context;
+    std::shared_ptr<RuntimeState> _runtime_state;
+    std::shared_ptr<pipeline::FragmentContext> _fragment_context;
+
+    std::shared_ptr<SinkBuffer> _sink_buffer;
+    std::shared_ptr<DataStreamRecvr> _recvr;
+    std::shared_ptr<RuntimeProfile> _runtime_profile;
+    std::shared_ptr<ExchangeSinkOperatorFactory> _exchange_sink_factory;
+
+    TPlanFragmentDestination _destination;
+    int32_t _dest_node_id = 0;
+    ObjectPool _object_pool;
+};
+
+TEST_F(ExchangeBucketAwareTest, test_exchange_bucket_aware) {
+    std::vector<TExprNode> nodes;
+    TExprNode node1;
+    node1.node_type = TExprNodeType::SLOT_REF;
+    node1.type = gen_type_desc(TPrimitiveType::INT);
+    node1.num_children = 0;
+    TSlotRef t_slot_ref = TSlotRef();
+    t_slot_ref.slot_id = 1;
+    t_slot_ref.tuple_id = 0;
+    node1.__set_slot_ref(t_slot_ref);
+    node1.is_nullable = true;
+    nodes.emplace_back(node1);
+
+    TExpr t_expr;
+    t_expr.nodes = nodes;
+
+    std::vector<TExpr> t_conjuncts;
+    t_conjuncts.emplace_back(t_expr);
+    std::vector<ExprContext*> partition_exprs;
+    Expr::create_expr_trees(&_object_pool, t_conjuncts, &partition_exprs, nullptr);
+    Expr::prepare(partition_exprs, _runtime_state.get());
+    Expr::open(partition_exprs, _runtime_state.get());
+
+    TBucketProperty bucket_prperty = TBucketProperty();
+    bucket_prperty.bucket_func = TBucketFunction::MURMUR3_X86_32;
+    bucket_prperty.bucket_num = 2;
+    auto bucket_properies = std::vector<TBucketProperty>();
+    bucket_properies.emplace_back(bucket_prperty);
+
+    // destinations
+    std::vector<TPlanFragmentDestination> destinations;
+    destinations.assign(3, _destination);
+
+    _sink_buffer = std::make_shared<SinkBuffer>(_fragment_context.get(), destinations, /*is_dest_merge*/ false);
+
+    _exchange_sink_factory = std::make_shared<ExchangeSinkOperatorFactory>(
+            0, 0, _sink_buffer, TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED, destinations,
+            /*is_pipeline_level_shuffle*/ true,
+            /*dest_dop*/ 2,
+            /*sender_id*/ 0, _dest_node_id, /*partition_exprs*/ partition_exprs,
+            /*enable_exchange_pass_through*/ true, /*enable_exchange_perf*/ false, _fragment_context.get(),
+            /*output_columns*/ std::vector<int32_t>(), bucket_properies);
+    _exchange_sink_factory->set_runtime_state(_runtime_state.get());
+
+    RowDescriptor input_row_desc;
+    _recvr = _exec_env->stream_mgr()->create_recvr(_runtime_state.get(), input_row_desc, _fragment_id, 0, 3,
+                                                   config::exchg_node_buffer_size_bytes, _dest_node_id,
+                                                   std::make_shared<QueryStatisticsRecvr>(),
+                                                   /*is_pipeline*/ true, 2, /*keep_order*/ false);
+    std::stringstream ss;
+    ss << "exchange (id=" << _dest_node_id << ")";
+    auto runtime_profile = std::make_shared<RuntimeProfile>(ss.str());
+    runtime_profile->set_metadata(_dest_node_id);
+    _recvr->bind_profile(0, runtime_profile);
+    _recvr->bind_profile(1, runtime_profile);
+
+    auto exchange_sink = _exchange_sink_factory->create(2, 0);
+    ASSERT_OK(exchange_sink->prepare(_runtime_state.get()));
+
+    auto chunk = std::make_shared<Chunk>();
+    auto col = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
+    col->append_datum(Datum(1));
+    col->append_datum(Datum(2));
+    col->append_datum(Datum(3));
+    col->append_nulls(1);
+    col->append_datum(Datum(4));
+
+    std::vector<uint32_t> hash_values(col->size());
+    col->murmur_hash3_x86_32(hash_values.data(), 0, col->size());
+    int pipe0 = 0;
+    for (auto hash : hash_values) {
+        if (HashUtil::xorshift32(hash) % 2 == 0) {
+            pipe0 += 1;
+        }
+    }
+
+    chunk->append_column(std::move(col), 1);
+
+    ASSERT_OK(exchange_sink->push_chunk(_runtime_state.get(), chunk));
+    ASSERT_OK(exchange_sink->set_finishing(_runtime_state.get()));
+
+    int row_num = 0;
+
+    std::unique_ptr<Chunk> received_chunk = nullptr;
+    do {
+        std::ignore = _recvr->get_chunk_for_pipeline(&received_chunk, 0);
+        if (received_chunk != nullptr) {
+            row_num += received_chunk->num_rows();
+        }
+    } while (received_chunk);
+
+    ASSERT_EQ(pipe0, row_num);
+
+    do {
+        std::ignore = _recvr->get_chunk_for_pipeline(&received_chunk, 1);
+        if (received_chunk != nullptr) {
+            row_num += received_chunk->num_rows();
+        }
+    } while (received_chunk);
+
+    ASSERT_EQ(chunk->num_rows(), row_num);
+
+    exchange_sink->close(_runtime_state.get());
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/exchange_pass_through_test.cpp
+++ b/be/test/exec/pipeline/exchange_pass_through_test.cpp
@@ -92,7 +92,7 @@ public:
                 /*dest_dop*/ 1,
                 /*sender_id*/ 0, _dest_node_id, /*partition_exprs*/ std::vector<ExprContext*>(),
                 /*enable_exchange_pass_through*/ true, /*enable_exchange_perf*/ false, _fragment_context.get(),
-                /*output_columns*/ std::vector<int32_t>());
+                /*output_columns*/ std::vector<int32_t>(), std::vector<TBucketProperty>());
         _exchange_sink_factory->set_runtime_state(_runtime_state.get());
     }
 

--- a/gensrc/thrift/Partitions.thrift
+++ b/gensrc/thrift/Partitions.thrift
@@ -110,6 +110,7 @@ struct TDataPartition {
   1: required TPartitionType type
   2: optional list<Exprs.TExpr> partition_exprs
   3: optional list<TRangePartition> partition_infos
+  4: optional list<TBucketProperty> bucket_properties
 }
 
 


### PR DESCRIPTION
## Why I'm doing:
bucket-aware execution for iceberg needs to shuffle data based on bucket-id, 
the differences from olap table is that iceberg table needs to calc bucket id 
based on hash value of each column, mapping to final bucket id and then 
choose channel based on bucket id and choose pipeline driver based on hash 
value(which means reshuffle on pipelines so that we can get parallelism on 
each be instance)   

## What I'm doing:

Fixes #issue
#61287 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
