### PR TITLE
[BugFix] fix mem alloc issue of AggHashSetOfSerializedKey

### DIFF
--- a/be/src/exec/aggregate/agg_hash_set.h
+++ b/be/src/exec/aggregate/agg_hash_set.h
@@ -540,7 +540,7 @@ struct AggHashSetOfSerializedKey : public AggHashSet<HashSet, AggHashSetOfSerial
             _mem_pool->clear();
             // reserved extra SLICE_MEMEQUAL_OVERFLOW_PADDING bytes to prevent SIMD instructions
             // from accessing out-of-bound memory.
-            _buffer = _mem_pool->allocate(max_one_row_size * _chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING);
+            _buffer = _mem_pool->allocate(max_one_row_size * chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING);
         }
 
         for (const auto& key_column : key_columns) {

--- a/be/src/exec/aggregate/agg_hash_set.h
+++ b/be/src/exec/aggregate/agg_hash_set.h
@@ -534,13 +534,13 @@ struct AggHashSetOfSerializedKey : public AggHashSet<HashSet, AggHashSetOfSerial
             not_founds->assign(chunk_size, 0);
         }
 
-        size_t cur_max_one_row_size = get_max_serialize_size(key_columns);
-        if (UNLIKELY(cur_max_one_row_size > max_one_row_size)) {
-            max_one_row_size = cur_max_one_row_size;
+        max_one_row_size = get_max_serialize_size(key_columns);
+        size_t new_buffer_size = max_one_row_size * chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING;
+        if (UNLIKELY(new_buffer_size > _mem_pool->total_allocated_bytes())) {
             _mem_pool->clear();
             // reserved extra SLICE_MEMEQUAL_OVERFLOW_PADDING bytes to prevent SIMD instructions
             // from accessing out-of-bound memory.
-            _buffer = _mem_pool->allocate(max_one_row_size * chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING);
+            _buffer = _mem_pool->allocate(new_buffer_size);
         }
 
         for (const auto& key_column : key_columns) {

--- a/test/sql/test_agg/R/test_serialize_key_agg
+++ b/test/sql/test_agg/R/test_serialize_key_agg
@@ -40,3 +40,33 @@ select length(c0), max(length(c1)), max(length(c2)) from (select * from t0 union
 1	4	1
 2	4	2
 -- !result
+SET @var = array_map(x -> CAST(x AS STRING), array_generate(1, 20000000, 1));
+-- result:
+-- !result
+with input as (SELECT @var AS a UNION ALL SELECT ["A", "B", "C"] AS a)
+SELECT count(*) from (select a from input group by 1) AS t;
+-- result:
+2
+-- !result
+CREATE TABLE `t1` (
+  `id` int(11) NULL COMMENT "",
+  `array_varchar` array<varchar(100)>
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 select generate_series, array_map(x -> cast(x as string), array_generate(1, generate_series % 100, 1)) from table(generate_series(1, 10000));
+-- result:
+-- !result
+insert into t1 values (0, array_map(x -> CAST(x AS STRING), array_generate(1, 100000, 1))),
+(10001, array_map(x -> CAST(x AS STRING), array_generate(1, 100000, 1)));
+-- result:
+-- !result
+select count() from (select distinct array_varchar from t1) t;
+-- result:
+101
+-- !result

--- a/test/sql/test_agg/T/test_serialize_key_agg
+++ b/test/sql/test_agg/T/test_serialize_key_agg
@@ -13,3 +13,20 @@ insert into t0 SELECT generate_series, 4096 - generate_series, generate_series F
 select max(length(c0)), max(length(c1)) from (select distinct c0, c1 from t0) tb;
 select max(length(c0)), max(length(c1)) from (select distinct c0, c1 from (select * from t0 union all select space(1000000) as c0, space(1000000) as c1, space(1000000) as c2) tb) tb order by 1, 2 desc limit 10;
 select length(c0), max(length(c1)), max(length(c2)) from (select * from t0 union all select space(1000000) as c0, space(1000000) as c1, space(1000000) as c2) tb group by c0, c1, c2 order by 1, 2 desc limit 10;
+
+SET @var = array_map(x -> CAST(x AS STRING), array_generate(1, 20000000, 1));
+with input as (SELECT @var AS a UNION ALL SELECT ["A", "B", "C"] AS a)
+SELECT count(*) from (select a from input group by 1) AS t;
+CREATE TABLE `t1` (
+  `id` int(11) NULL COMMENT "",
+  `array_varchar` array<varchar(100)>
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into t1 select generate_series, array_map(x -> cast(x as string), array_generate(1, generate_series % 100, 1)) from table(generate_series(1, 10000));
+insert into t1 values (0, array_map(x -> CAST(x AS STRING), array_generate(1, 100000, 1))),
+(10001, array_map(x -> CAST(x AS STRING), array_generate(1, 100000, 1)));
+select count() from (select distinct array_varchar from t1) t;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #61595
we should use the real input chunk's size to preallocate memory

agg hash map also has the similar problem, I will fix it in later PR.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
