### PR TITLE
[UT] fix unstable CatalogRecycleBin ut

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
@@ -53,6 +53,7 @@ public class CatalogRecycleBinLakeTableTest {
     public static void beforeClass() {
         UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
         GlobalStateMgr.getCurrentState().getWarehouseMgr().initDefaultWarehouse();
+        GlobalStateMgr.getCurrentState().getRecycleBin().setStop();
     }
 
     private static Table createTable(ConnectContext connectContext, String sql) throws Exception {


### PR DESCRIPTION
* Stop CatalogRecycleBin explicitly to avoid periodic run that may cause unexpected Expectations recording

## Why I'm doing:

```
Unexpected invocation to:
com.starrocks.rpc.LakeService#dropTable(com.starrocks.proto.DropTableRequest@4ecdcf20)
   on mock instance: com.starrocks.rpc.$Impl_LakeService@6e12f38c
	at com.starrocks.lake.LakeTableHelper.removeShardRootDirectory(LakeTableHelper.java:107)
	at com.starrocks.lake.LakeTableCleaner.cleanTable(LakeTableCleaner.java:53)
	at com.starrocks.lake.LakeTableHelper.deleteTableFromRecycleBin(LakeTableHelper.java:76)
	at com.starrocks.lake.LakeTable.deleteFromRecycleBin(LakeTable.java:134)
	at com.starrocks.catalog.CatalogRecycleBin.lambda$eraseTable$6(CatalogRecycleBin.java:597)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: Unexpected invocation
	at com.starrocks.catalog.CatalogRecycleBinLakeTableTest$4.<init>(CatalogRecycleBinLakeTableTest.java:348)
	at com.starrocks.catalog.CatalogRecycleBinLakeTableTest.testRecycleLakeDatabase(CatalogRecycleBinLakeTableTest.java:346)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
