### PR TITLE
[BugFix] fix query hang because of incorrect scan range delivery

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -228,6 +228,9 @@ public class FragmentInstanceExecState {
                     return get();
                 }
             };
+        } finally {
+            serializedRequest = null; // clear serializedRequest after deploy
+            requestToDeploy = null; // clear requestToDeploy after deploy
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR is to:
1. remove tail call to reduce stack depth.
2. notify `deployer` to cancel if there is exception. otherwise exception thrown in thread pool which be swallowed and invisble forever. 
3. add some logs to BE if incremental scan ranges are not processed.

But the most important fix is here

```Java
        } finally {
            serializedRequest = null; // clear serializedRequest after deploy
            requestToDeploy = null; // clear requestToDeploy after deploy
        }
```

So if you don' clear `serializedRequest`, then in the next round,  if concurrent serialize request is rejected, we will still deploy old request instead of the new one. (rejection is introduced in this pr https://github.com/StarRocks/starrocks/pull/61150)

```java
        for (FragmentInstanceExecState execState : execStates) {
            try {
                Future<?> f = EXECUTOR.submit(execState::serializeRequest);
                futures.add(f);
            } catch (RejectedExecutionException e) {
                // If the thread pool is full, we will serialize the request in the current thread.
            }
        }

    public void serializeRequest() {
        try {
            TSerializer serializer = AttachmentRequest.getSerializer(jobSpec.getPlanProtocol());
            serializedRequest = serializer.serialize(requestToDeploy);
            requestToDeploy = null;
        } catch (TException ignore) {
            // throw exception means serializedRequest will be empty, and then we will treat it as not serialized
        }
    }
```


Fixes https://github.com/StarRocks/StarRocksTest/issues/10046

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
