### PR TITLE
[BugFix] Fix case when simplification causing outer-join or grouping set results to be incorrect

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SimplifyCaseWhenPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SimplifyCaseWhenPredicateRule.java
@@ -19,11 +19,16 @@ import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalRepeatOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.task.TaskContext;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -40,9 +45,32 @@ public class SimplifyCaseWhenPredicateRule implements TreeRewriteRule {
         private Rewriter() {
         }
 
+        // case when simplification is a null-sensitive Rule.
+        // We should not apply this rule to operators whose child produces a null output.
+        private boolean hasNullableGenerateChild(OptExpression optExpression) {
+            final Operator op = optExpression.getOp();
+            if (op instanceof LogicalRepeatOperator) {
+                return true;
+            }
+            if (op instanceof LogicalJoinOperator join) {
+                return join.getJoinType().isOuterJoin();
+            }
+
+            for (OptExpression input : optExpression.getInputs()) {
+                if (hasNullableGenerateChild(input)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         @Override
         public Optional<OptExpression> visit(OptExpression optExpression, Void context) {
             ScalarOperator predicate = optExpression.getOp().getPredicate();
+            if (hasNullableGenerateChild(optExpression)) {
+                return Optional.empty();
+            }
             if (predicate == null) {
                 return Optional.empty();
             }
@@ -59,6 +87,9 @@ public class SimplifyCaseWhenPredicateRule implements TreeRewriteRule {
         @Override
         public Optional<OptExpression> visitLogicalJoin(OptExpression optExpression, Void context) {
             LogicalJoinOperator joinOperator = optExpression.getOp().cast();
+            if (hasNullableGenerateChild(optExpression)) {
+                return Optional.empty();
+            }
             Optional<ScalarOperator> optNewOnPredicate =
                     Optional.ofNullable(joinOperator.getOnPredicate()).map(predicate -> {
                         ScalarOperator newPredicate = ScalarOperatorRewriter.simplifyCaseWhen(predicate);
@@ -69,9 +100,6 @@ public class SimplifyCaseWhenPredicateRule implements TreeRewriteRule {
                         ScalarOperator newPredicate = ScalarOperatorRewriter.simplifyCaseWhen(predicate);
                         return newPredicate == predicate ? null : newPredicate;
                     });
-            if (!optNewOnPredicate.isPresent() && !optNewPredicate.isPresent()) {
-                return Optional.empty();
-            }
             Operator newOperator = LogicalJoinOperator.builder().withOperator(joinOperator)
                     .setOnPredicate(optNewOnPredicate.orElse(joinOperator.getOnPredicate()))
                     .setPredicate(optNewPredicate.orElse(joinOperator.getPredicate()))

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SimplifyCaseWhenPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SimplifyCaseWhenPredicateRule.java
@@ -20,15 +20,11 @@ import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalRepeatOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.task.TaskContext;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -3326,7 +3326,8 @@ public class JoinTest extends PlanTestBase {
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 1: v1 = 5: v4\n" +
                 "  |  equal join conjunct: 4: count = 8: count\n" +
-                "  |  other predicates: ((1: v1 != 1) AND (if(8: count = 1, 'a', 'b') = 'b')) OR ((1: v1 = 1) AND (if(8: count = 1, 'a', 'b') = 'b')), if(8: count = 1, 'a', 'b') = 'b'\n" +
+                "  |  other predicates: ((1: v1 != 1) AND (if(8: count = 1, 'a', 'b') = 'b')) OR ((1: v1 = 1) AND " +
+                "(if(8: count = 1, 'a', 'b') = 'b')), if(8: count = 1, 'a', 'b') = 'b'\n" +
                 "  |  \n" +
                 "  |----5:EXCHANGE\n" +
                 "  |    \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -3301,4 +3301,36 @@ public class JoinTest extends PlanTestBase {
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: coalesce('cccc', CAST(1: v1 AS VARCHAR)) = '1'");
     }
+
+    @Test
+    public void testPredicatePushDown() throws Exception {
+        String query = "with j1 as (\n" +
+                "    select * from \n" +
+                "    (\n" +
+                "        select v1, count(distinct v2) c1 from t0 group by v1\n" +
+                "    ) t0\n" +
+                "    left join [shuffle]\n" +
+                "    (\n" +
+                "        select v4, count(distinct v5) c3 from t1 group by v4\n" +
+                "    ) t1\n" +
+                "    on t0.v1 = t1.v4 and  t0.c1 = t1.c3\n" +
+                ")\n" +
+                "select * from j1 where v1 = 1 and if (c3 = 1, 'a', 'b') = 'b'\n" +
+                "union all \n" +
+                "select * from j1 where v1 != 1 and if (c3 = 1, 'a', 'b') = 'b'";
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
+        connectContext.getSessionVariable().setCboCteReuse(true);
+        String plan = getFragmentPlan(query);
+        assertContains(plan, "  6:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (PARTITIONED)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 5: v4\n" +
+                "  |  equal join conjunct: 4: count = 8: count\n" +
+                "  |  other predicates: ((1: v1 != 1) AND (if(8: count = 1, 'a', 'b') = 'b')) OR ((1: v1 = 1) AND (if(8: count = 1, 'a', 'b') = 'b')), if(8: count = 1, 'a', 'b') = 'b'\n" +
+                "  |  \n" +
+                "  |----5:EXCHANGE\n" +
+                "  |    \n" +
+                "  2:EXCHANGE");
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

reproduce case:
```
-- test_push_down_cte

CREATE TABLE `t0` (
  `c0` bigint DEFAULT NULL,
  `c1` bigint DEFAULT NULL
) ENGINE=OLAP
DUPLICATE KEY(`c0`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`c0`) BUCKETS 1
PROPERTIES (
"replication_num" = "1"
);

CREATE TABLE `t1` (
  `c2` bigint DEFAULT NULL,
  `c3` bigint DEFAULT NULL
) ENGINE=OLAP
DUPLICATE KEY(`c2`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`c2`) BUCKETS 1
PROPERTIES (
"replication_num" = "1"
);

insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  40960));
insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  40960));
insert into t1 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  40960));

set cbo_cte_reuse_rate_v2 = 0;
with j1 as (
    select * from 
    (
        select c0, count(distinct c1) c1 from t0 group by c0
    ) t0
    left join [shuffle]
    (
        select c2, count(distinct c3) c3 from t1 group by c2
    ) t1
    on t0.c0=t1.c2 and  t0.c1 = t1.c3
)
select * from j1 where c0 = 1 and if (c3 = 1, 'a', 'b') = 'b'
union all 
select * from j1 where c0 != 1 and if (c3 = 1, 'a', 'b') = 'b';

```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
