### PR TITLE
[UT] Fix sse_memcmp UT compilation error on aarch64

### DIFF
--- a/be/test/util/memcmp_test.cpp
+++ b/be/test/util/memcmp_test.cpp
@@ -26,6 +26,7 @@ int vsigned(T v) {
     return (v >> (sizeof(T) * 8 - 1)) & 1;
 }
 
+#if defined(__SSE4_2__)
 TEST(sse_memcmp, Test) {
     ASSERT_EQ(vsigned((int)-1), 1);
     ASSERT_EQ(vsigned((int)1), 0);
@@ -99,5 +100,6 @@ TEST(sse_memcmp, Test) {
         ASSERT_EQ(res, res2);
     }
 }
+#endif
 
 } // namespace starrocks


### PR DESCRIPTION
Fix sse_memcmp UT compilation error on aarch64.

## Why I'm doing:
```
[ 96%] Building CXX object test/CMakeFiles/starrocks_test_objs.dir/util/monotime_test.cpp.o
[ 96%] Building CXX object test/CMakeFiles/starrocks_test_objs.dir/util/mysql_row_buffer_test.cpp.o
/root/starrocks/be/test/util/memcmp_test.cpp: In member function 'virtual void starrocks::sse_memcmp_Test_Test::TestBody()':
/root/starrocks/be/test/util/memcmp_test.cpp:38:20: error: 'sse_memcmp2' was not declared in this scope
   38 |         int res2 = sse_memcmp2(c1, c2, 3);
      |                    ^~~~~~~~~~~
/root/starrocks/be/test/util/memcmp_test.cpp:46:20: error: 'sse_memcmp2' was not declared in this scope
   46 |         int res2 = sse_memcmp2(c1, c2, 3);
      |                    ^~~~~~~~~~~
/root/starrocks/be/test/util/memcmp_test.cpp:54:20: error: 'sse_memcmp2' was not declared in this scope
   54 |         int res2 = sse_memcmp2(c1, c2, 3);
      |                    ^~~~~~~~~~~
/root/starrocks/be/test/util/memcmp_test.cpp:62:20: error: 'sse_memcmp2' was not declared in this scope
   62 |         int res2 = sse_memcmp2(c1, c2, 3);
      |                    ^~~~~~~~~~~
/root/starrocks/be/test/util/memcmp_test.cpp:71:20: error: 'sse_memcmp2' was not declared in this scope
   71 |         int res2 = sse_memcmp2(c1, c2, 3);
      |                    ^~~~~~~~~~~
/root/starrocks/be/test/util/memcmp_test.cpp:80:20: error: 'sse_memcmp2' was not declared in this scope
   80 |         int res2 = sse_memcmp2(c1, c2, 3);
      |                    ^~~~~~~~~~~
/root/starrocks/be/test/util/memcmp_test.cpp:89:20: error: 'sse_memcmp2' was not declared in this scope
   89 |         int res2 = sse_memcmp2(c1, c2, 3);
      |                    ^~~~~~~~~~~
/root/starrocks/be/test/util/memcmp_test.cpp:98:20: error: 'sse_memcmp2' was not declared in this scope
   98 |         int res2 = sse_memcmp2(c1, c2, 3);
      |                    ^~~~~~~~~~~
make[2]: *** [test/CMakeFiles/starrocks_test_objs.dir/util/memcmp_test.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [test/CMakeFiles/starrocks_test_objs.dir/all] Error 2
make: *** [all] Error 2
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
