### PR TITLE
[Enhancement] Show disk balance statistic

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
 
 public class BackendLoadStatistic {
     private static final Logger LOG = LogManager.getLogger(BackendLoadStatistic.class);
@@ -502,7 +503,7 @@ public class BackendLoadStatistic {
         return json.toString();
     }
 
-    public List<String> getInfo(TStorageMedium medium) {
+    public List<String> getInfo(TStorageMedium medium, @NotNull BalanceStat balanceStat) {
         List<String> info = Lists.newArrayList();
         info.add(String.valueOf(beId));
         info.add(clusterName);
@@ -519,6 +520,7 @@ public class BackendLoadStatistic {
         info.add(String.valueOf(loadScore.replicaNumCoefficient));
         info.add(String.valueOf(loadScore.score));
         info.add(clazzMap.getOrDefault(medium, Classification.INIT).name());
+        info.add(balanceStat.toString());
         return info;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/BalanceStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BalanceStat.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.clone;
 
+import com.google.gson.Gson;
+
 public abstract class BalanceStat {
     public enum BalanceType {
         CLUSTER_DISK("cluster disk"),
@@ -32,6 +34,8 @@ public abstract class BalanceStat {
         }
     }
 
+    private static final Gson GSON = new Gson();
+
     // Singleton instance indicating that everything is balanced
     public static final BalanceStat BALANCED_STAT = new BalancedStat();
 
@@ -46,6 +50,11 @@ public abstract class BalanceStat {
     }
 
     public abstract BalanceType getBalanceType();
+
+    @Override
+    public String toString() {
+        return GSON.toJson(this);
+    }
 
     // Factory methods for different balance stat types
     public static BalanceStat createClusterDiskBalanceStat(long maxBeId, long minBeId, double maxDiskUsage, double minDiskUsage) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -89,6 +89,7 @@ import com.starrocks.thrift.TFinishTaskRequest;
 import com.starrocks.thrift.TGetTabletScheduleRequest;
 import com.starrocks.thrift.TGetTabletScheduleResponse;
 import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TStorageMedium;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -1979,6 +1980,21 @@ public class TabletScheduler extends FrontendDaemon {
 
             cleanedTablets.forEach(t -> releaseTabletCtx(t, TabletSchedCtx.State.CANCELLED));
         }
+    }
+
+    public Set<TStorageMedium> getStorageMediums() {
+        ClusterLoadStatistic clusterLoadStat = getClusterLoadStatistic();
+        return clusterLoadStat == null ? Sets.newHashSet() : clusterLoadStat.getStorageMediums();
+    }
+
+    public List<List<String>> getClusterLoadStats() {
+        ClusterLoadStatistic clusterLoadStat = getClusterLoadStatistic();
+        return clusterLoadStat == null ? Lists.newArrayList() : clusterLoadStat.getClusterLoadStats();
+    }
+
+    public List<List<String>> getBackendLoadStats(TStorageMedium medium) {
+        ClusterLoadStatistic clusterLoadStat = getClusterLoadStatistic();
+        return clusterLoadStat == null ? Lists.newArrayList() : clusterLoadStat.getBackendLoadStats(medium);
     }
 
     public List<List<String>> getPendingTabletsInfo(int limit) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ClusterBalanceProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ClusterBalanceProcDir.java
@@ -67,7 +67,7 @@ public class ClusterBalanceProcDir implements ProcDirInterface {
     @Override
     public ProcNodeInterface lookup(String name) throws AnalysisException {
         if (name.equals(CLUSTER_LOAD)) {
-            return new ClusterLoadStatByMedium();
+            return new ClusterLoadStatByMedium(GlobalStateMgr.getCurrentState().getTabletScheduler());
         } else if (name.equals(WORKING_SLOTS)) {
             return new SchedulerWorkingSlotsProcDir();
         } else if (name.equals(SCHED_STAT)) {

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ClusterLoadStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ClusterLoadStatisticsTest.java
@@ -156,7 +156,7 @@ public class ClusterLoadStatisticsTest {
     public void test() {
         ClusterLoadStatistic loadStatistic = new ClusterLoadStatistic(systemInfoService, invertedIndex);
         loadStatistic.init();
-        List<List<String>> infos = loadStatistic.getClusterStatistic(TStorageMedium.HDD);
+        List<List<String>> infos = loadStatistic.getBackendLoadStats(TStorageMedium.HDD);
         System.out.println(infos);
         Assertions.assertEquals(3, infos.size());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/ClusterLoadStatByMediumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/ClusterLoadStatByMediumTest.java
@@ -1,0 +1,100 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.proc;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.DiskInfo;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.clone.BalanceStat;
+import com.starrocks.clone.ClusterLoadStatistic;
+import com.starrocks.clone.TabletScheduler;
+import com.starrocks.clone.TabletSchedulerStat;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TStorageMedium;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class ClusterLoadStatByMediumTest {
+
+    @Test
+    public void testFetchResult() throws AnalysisException {
+        // system info service
+        // be1
+        Backend be1 = new Backend(10001L, "192.168.0.1", 9051);
+        Map<String, DiskInfo> disks = Maps.newHashMap();
+        DiskInfo diskInfo1 = new DiskInfo("/path1");
+        diskInfo1.setTotalCapacityB(1000000L);
+        diskInfo1.setAvailableCapacityB(500000L);
+        diskInfo1.setDataUsedCapacityB(480000L);
+        diskInfo1.setStorageMedium(TStorageMedium.HDD);
+        disks.put(diskInfo1.getRootPath(), diskInfo1);
+        DiskInfo diskInfo2 = new DiskInfo("/path2");
+        diskInfo2.setTotalCapacityB(1000000L);
+        diskInfo2.setAvailableCapacityB(500000L);
+        diskInfo2.setDataUsedCapacityB(480000L);
+        diskInfo2.setStorageMedium(TStorageMedium.SSD);
+        disks.put(diskInfo2.getRootPath(), diskInfo2);
+        be1.setDisks(ImmutableMap.copyOf(disks));
+        be1.setAlive(true);
+
+        SystemInfoService systemInfoService = new SystemInfoService();
+        systemInfoService.addBackend(be1);
+
+        // tablet inverted index
+        TabletInvertedIndex invertedIndex = new TabletInvertedIndex();
+
+        invertedIndex.addTablet(50000L, new TabletMeta(1L, 2L, 3L, 4L, TStorageMedium.HDD));
+        invertedIndex.addReplica(50000L, new Replica(50001L, be1.getId(), 0, Replica.ReplicaState.NORMAL));
+
+        invertedIndex.addTablet(60000L, new TabletMeta(1L, 2L, 3L, 4L, TStorageMedium.SSD));
+        invertedIndex.addReplica(60000L, new Replica(60002L, be1.getId(), 0, Replica.ReplicaState.NORMAL));
+
+        // cluster load statistic
+        ClusterLoadStatistic clusterLoadStat = new ClusterLoadStatistic(systemInfoService, invertedIndex);
+        clusterLoadStat.init();
+        clusterLoadStat.updateClusterDiskBalanceStat(
+                TStorageMedium.HDD, BalanceStat.createClusterDiskBalanceStat(1L, 2L, 0.9, 0.1));
+
+        // tablet scheduler
+        TabletScheduler tabletScheduler = new TabletScheduler(new TabletSchedulerStat());
+        tabletScheduler.setClusterLoadStatistic(clusterLoadStat);
+
+        // test
+        ClusterLoadStatByMedium proc = new ClusterLoadStatByMedium(tabletScheduler);
+        BaseProcResult result = (BaseProcResult) proc.fetchResult();
+        List<List<String>> rows = result.getRows();
+        Assertions.assertEquals(2, rows.size());
+
+        List<String> row0 = rows.get(0);
+        Assertions.assertEquals(2, row0.size());
+        Assertions.assertEquals("HDD", row0.get(0));
+        Assertions.assertEquals(
+                "{\"maxUsedPercent\":0.9,\"minUsedPercent\":0.1,\"maxBeId\":1,\"minBeId\":2,\"type\":\"CLUSTER_DISK\"," +
+                        "\"balanced\":false}",
+                row0.get(1));
+
+        List<String> row1 = rows.get(1);
+        Assertions.assertEquals("SSD", row1.get(0));
+        Assertions.assertEquals("{\"balanced\":true}", row1.get(1));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/ClusterLoadStatisticProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/ClusterLoadStatisticProcDirTest.java
@@ -1,0 +1,126 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.proc;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.DiskInfo;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.clone.BalanceStat;
+import com.starrocks.clone.ClusterLoadStatistic;
+import com.starrocks.clone.TabletScheduler;
+import com.starrocks.clone.TabletSchedulerStat;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Pair;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TStorageMedium;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class ClusterLoadStatisticProcDirTest {
+
+    @Test
+    public void testFetchResult() throws AnalysisException {
+        // system info service
+        // be1
+        Backend be1 = new Backend(10001L, "192.168.0.1", 9051);
+        Map<String, DiskInfo> disks = Maps.newHashMap();
+        DiskInfo diskInfo1 = new DiskInfo("/path1");
+        diskInfo1.setTotalCapacityB(1000000L);
+        diskInfo1.setAvailableCapacityB(100000L);
+        diskInfo1.setDataUsedCapacityB(880000L);
+        diskInfo1.setStorageMedium(TStorageMedium.HDD);
+        disks.put(diskInfo1.getRootPath(), diskInfo1);
+        DiskInfo diskInfo2 = new DiskInfo("/path2");
+        diskInfo2.setTotalCapacityB(1000000L);
+        diskInfo2.setAvailableCapacityB(900000L);
+        diskInfo2.setDataUsedCapacityB(80000L);
+        diskInfo2.setStorageMedium(TStorageMedium.HDD);
+        disks.put(diskInfo2.getRootPath(), diskInfo2);
+        be1.setDisks(ImmutableMap.copyOf(disks));
+        be1.setAlive(true);
+
+        // be2
+        Backend be2 = new Backend(10002L, "192.168.0.2", 9051);
+        disks = Maps.newHashMap();
+        diskInfo1 = new DiskInfo("/path1");
+        diskInfo1.setTotalCapacityB(1000000L);
+        diskInfo1.setAvailableCapacityB(500000L);
+        diskInfo1.setDataUsedCapacityB(480000L);
+        diskInfo1.setStorageMedium(TStorageMedium.HDD);
+        disks.put(diskInfo1.getRootPath(), diskInfo1);
+        diskInfo2 = new DiskInfo("/path2");
+        diskInfo2.setTotalCapacityB(1000000L);
+        diskInfo2.setAvailableCapacityB(500000L);
+        diskInfo2.setDataUsedCapacityB(480000L);
+        diskInfo2.setStorageMedium(TStorageMedium.HDD);
+        disks.put(diskInfo2.getRootPath(), diskInfo2);
+        be2.setDisks(ImmutableMap.copyOf(disks));
+        be2.setAlive(true);
+
+        SystemInfoService systemInfoService = new SystemInfoService();
+        systemInfoService.addBackend(be1);
+        systemInfoService.addBackend(be2);
+
+        // tablet inverted index
+        TabletInvertedIndex invertedIndex = new TabletInvertedIndex();
+
+        invertedIndex.addTablet(50000L, new TabletMeta(1L, 2L, 3L, 4L, TStorageMedium.HDD));
+        invertedIndex.addReplica(50000L, new Replica(50001L, be1.getId(), 0, Replica.ReplicaState.NORMAL));
+
+        invertedIndex.addTablet(60000L, new TabletMeta(1L, 2L, 3L, 4L, TStorageMedium.HDD));
+        invertedIndex.addReplica(60000L, new Replica(60002L, be2.getId(), 0, Replica.ReplicaState.NORMAL));
+
+        // cluster load statistic
+        ClusterLoadStatistic clusterLoadStat = new ClusterLoadStatistic(systemInfoService, invertedIndex);
+        clusterLoadStat.init();
+        clusterLoadStat.updateBackendDiskBalanceStat(Pair.create(TStorageMedium.HDD, be1.getId()),
+                BalanceStat.createBackendDiskBalanceStat(be1.getId(), "/path1", "/path2", 0.9, 0.1));
+
+        // tablet scheduler
+        TabletScheduler tabletScheduler = new TabletScheduler(new TabletSchedulerStat());
+        tabletScheduler.setClusterLoadStatistic(clusterLoadStat);
+
+        // test
+        ClusterLoadStatisticProcDir proc = new ClusterLoadStatisticProcDir(TStorageMedium.HDD, tabletScheduler);
+        BaseProcResult result = (BaseProcResult) proc.fetchResult();
+        List<List<String>> rows = result.getRows();
+        Assertions.assertEquals(2, rows.size());
+
+        for (int i = 0; i < 2; ++i) {
+            List<String> row = rows.get(i);
+            Assertions.assertEquals(12, row.size());
+            Assertions.assertEquals("true", row.get(2));
+            Assertions.assertEquals("960000", row.get(3));
+            Assertions.assertEquals("1960000", row.get(4));
+            Assertions.assertEquals("48.980", row.get(5));
+            String beId = row.get(0);
+            if (beId.equals("10001")) {
+                Assertions.assertEquals(
+                        "{\"maxUsedPercent\":0.9,\"minUsedPercent\":0.1,\"beId\":10001,\"maxPath\":\"/path1\"," +
+                                "\"minPath\":\"/path2\",\"type\":\"BACKEND_DISK\",\"balanced\":false}",
+                        row.get(11));
+            } else if (beId.equals("10002")) {
+                Assertions.assertEquals("{\"balanced\":true}", row.get(11));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Improve some commands to show disk balance statistic.

1. Add `ClusterDiskBalanceStat` in show `cluster_load_stat` proc.
```
// Cluster disk balance stat 
mysql> show proc "/cluster_balance/cluster_load_stat";
+---------------+-------------------------------------------------------------------------------------------------------------------+
| StorageMedium | ClusterDiskBalanceStat                                                                                            |
+---------------+-------------------------------------------------------------------------------------------------------------------+
| HDD           | {"balanced":false,"maxBeId":1,"minBeId":2,"maxUsedPercent":0.9,"minUsedPercent":0.1,"type":"CLUSTER_DISK"}        |
+---------------+-------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```

2. Add `BackendDiskBalanceStat` in show `cluster_load_stat/storage_medium` proc.
```
// Backend disk balance stat
mysql> show proc "/cluster_balance/cluster_load_stat/HDD";
+-------+-----------------+-----------+--------------+--------------+-------------+------------+----------+-----------+-------+-------+-----------------------------------------------------------------------------------------------------------------------------------------+
| BeId  | Cluster         | Available | UsedCapacity | Capacity     | UsedPercent | ReplicaNum | CapCoeff | ReplCoeff | Score | Class | BackendDiskBalanceStat                                                                                                                  |
+-------+-----------------+-----------+--------------+--------------+-------------+------------+----------+-----------+-------+-------+-----------------------------------------------------------------------------------------------------------------------------------------+
| 10004 | default_cluster | true      | 651509602    | 243695955810 | 0.267       | 339        | 0.5      | 0.5       | 1.0   | MID   | {"maxUsedPercent":0.9,"minUsedPercent":0.1,"beId":1,"maxPath":"/disk1","minPath":"/disk2","type":"BACKEND_DISK","balanced":false}       |
+-------+-----------------+-----------+--------------+--------------+-------------+------------+----------+-----------+-------+-------+-----------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)
```

https://github.com/StarRocks/starrocks/issues/61340

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
