### PR TITLE
[Enhancement] Add show balance statistic proc

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/BalanceStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BalanceStat.java
@@ -18,10 +18,10 @@ import com.google.gson.Gson;
 
 public abstract class BalanceStat {
     public enum BalanceType {
-        CLUSTER_DISK("cluster disk"),
-        CLUSTER_TABLET("cluster tablet"),
-        BACKEND_DISK("backend disk"),
-        BACKEND_TABLET("backend tablet");
+        CLUSTER_DISK("inter-node disk usage"),
+        CLUSTER_TABLET("inter-node tablet distribution"),
+        BACKEND_DISK("intra-node disk usage"),
+        BACKEND_TABLET("intra-node tablet distribution");
 
         private final String label;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BalanceStatProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BalanceStatProcNode.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.proc;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.clone.TabletScheduler;
+import com.starrocks.common.AnalysisException;
+
+public class BalanceStatProcNode implements ProcNodeInterface {
+    public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
+            .add("StorageMedium").add("BalanceType").add("Balanced").add("PendingTablets").add("RunningTablets").build();
+
+    private final TabletScheduler tabletScheduler;
+
+    public BalanceStatProcNode(TabletScheduler tabletScheduler) {
+        this.tabletScheduler = tabletScheduler;
+    }
+
+    @Override
+    public ProcResult fetchResult() throws AnalysisException {
+        BaseProcResult result = new BaseProcResult();
+        result.setNames(TITLE_NAMES);
+        result.setRows(tabletScheduler.getClusterBalanceStats());
+        return result;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ClusterBalanceProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ClusterBalanceProcDir.java
@@ -49,6 +49,7 @@ public class ClusterBalanceProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("Item").add("Number").build();
 
+    public static final String BALANCE_STAT = "balance_stat";
     public static final String CLUSTER_LOAD = "cluster_load_stat";
     public static final String WORKING_SLOTS = "working_slots";
     public static final String SCHED_STAT = "sched_stat";
@@ -66,7 +67,9 @@ public class ClusterBalanceProcDir implements ProcDirInterface {
 
     @Override
     public ProcNodeInterface lookup(String name) throws AnalysisException {
-        if (name.equals(CLUSTER_LOAD)) {
+        if (name.equals(BALANCE_STAT)) {
+            return new BalanceStatProcNode(GlobalStateMgr.getCurrentState().getTabletScheduler());
+        } else if (name.equals(CLUSTER_LOAD)) {
             return new ClusterLoadStatByMedium(GlobalStateMgr.getCurrentState().getTabletScheduler());
         } else if (name.equals(WORKING_SLOTS)) {
             return new SchedulerWorkingSlotsProcDir();
@@ -86,6 +89,7 @@ public class ClusterBalanceProcDir implements ProcDirInterface {
 
         TabletScheduler tabletScheduler = GlobalStateMgr.getCurrentState().getTabletScheduler();
         TabletChecker tabletChecker = GlobalStateMgr.getCurrentState().getTabletChecker();
+        result.addRow(Lists.newArrayList(BALANCE_STAT, "1"));
         result.addRow(Lists.newArrayList(CLUSTER_LOAD, "1"));
         result.addRow(Lists.newArrayList(WORKING_SLOTS,
                 String.valueOf(tabletScheduler.getBackendsWorkingSlots().size())));

--- a/fe/fe-core/src/test/java/com/starrocks/clone/BalanceStatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/BalanceStatTest.java
@@ -33,7 +33,7 @@ public class BalanceStatTest {
             BalanceStat stat = BalanceStat.createClusterDiskBalanceStat(1L, 2L, 0.9, 0.1);
             Assertions.assertFalse(stat.isBalanced());
             Assertions.assertEquals(BalanceType.CLUSTER_DISK, stat.getBalanceType());
-            Assertions.assertEquals("cluster disk", stat.getBalanceType().label());
+            Assertions.assertEquals("inter-node disk usage", stat.getBalanceType().label());
             Assertions.assertEquals(
                     "{\"maxUsedPercent\":0.9,\"minUsedPercent\":0.1,\"maxBeId\":1,\"minBeId\":2,\"type\":\"CLUSTER_DISK\"," +
                             "\"balanced\":false}",
@@ -44,7 +44,7 @@ public class BalanceStatTest {
             BalanceStat stat = BalanceStat.createClusterTabletBalanceStat(1L, 2L, 9L, 1L);
             Assertions.assertFalse(stat.isBalanced());
             Assertions.assertEquals(BalanceType.CLUSTER_TABLET, stat.getBalanceType());
-            Assertions.assertEquals("cluster tablet", stat.getBalanceType().label());
+            Assertions.assertEquals("inter-node tablet distribution", stat.getBalanceType().label());
             Assertions.assertEquals(
                     "{\"maxTabletNum\":9,\"minTabletNum\":1,\"maxBeId\":1,\"minBeId\":2,\"type\":\"CLUSTER_TABLET\"," +
                             "\"balanced\":false}",
@@ -55,7 +55,7 @@ public class BalanceStatTest {
             BalanceStat stat = BalanceStat.createBackendDiskBalanceStat(1L, "disk1", "disk2", 0.9, 0.1);
             Assertions.assertFalse(stat.isBalanced());
             Assertions.assertEquals(BalanceType.BACKEND_DISK, stat.getBalanceType());
-            Assertions.assertEquals("backend disk", stat.getBalanceType().label());
+            Assertions.assertEquals("intra-node disk usage", stat.getBalanceType().label());
             Assertions.assertEquals(
                     "{\"maxUsedPercent\":0.9,\"minUsedPercent\":0.1,\"beId\":1,\"maxPath\":\"disk1\",\"minPath\":\"disk2\"," +
                             "\"type\":\"BACKEND_DISK\",\"balanced\":false}",
@@ -66,7 +66,7 @@ public class BalanceStatTest {
             BalanceStat stat = BalanceStat.createBackendTabletBalanceStat(1L, "disk1", "disk2",  9L, 1L);
             Assertions.assertFalse(stat.isBalanced());
             Assertions.assertEquals(BalanceType.BACKEND_TABLET, stat.getBalanceType());
-            Assertions.assertEquals("backend tablet", stat.getBalanceType().label());
+            Assertions.assertEquals("intra-node tablet distribution", stat.getBalanceType().label());
             Assertions.assertEquals(
                     "{\"maxTabletNum\":9,\"minTabletNum\":1,\"beId\":1,\"maxPath\":\"disk1\",\"minPath\":\"disk2\"," +
                             "\"type\":\"BACKEND_TABLET\",\"balanced\":false}",

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/BalanceStatProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/BalanceStatProcNodeTest.java
@@ -1,0 +1,192 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.proc;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.CatalogRecycleBin;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DiskInfo;
+import com.starrocks.catalog.ListPartitionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.RandomDistributionInfo;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.Type;
+import com.starrocks.clone.BalanceStat;
+import com.starrocks.clone.BalanceStat.BalanceType;
+import com.starrocks.clone.ClusterLoadStatistic;
+import com.starrocks.clone.TabletSchedCtx;
+import com.starrocks.clone.TabletScheduler;
+import com.starrocks.clone.TabletSchedulerStat;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Pair;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TStorageMedium;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class BalanceStatProcNodeTest {
+
+    @Test
+    public void testFetchResult(@Mocked GlobalStateMgr globalStateMgr) throws AnalysisException {
+        // 0. backend disk balance
+        // system info service
+        // be1
+        Backend be1 = new Backend(10001L, "192.168.0.1", 9051);
+        Map<String, DiskInfo> disks = Maps.newHashMap();
+        DiskInfo diskInfo1 = new DiskInfo("/path1");
+        diskInfo1.setTotalCapacityB(1000000L);
+        diskInfo1.setAvailableCapacityB(100000L);
+        diskInfo1.setDataUsedCapacityB(880000L);
+        diskInfo1.setStorageMedium(TStorageMedium.HDD);
+        disks.put(diskInfo1.getRootPath(), diskInfo1);
+        DiskInfo diskInfo2 = new DiskInfo("/path2");
+        diskInfo2.setTotalCapacityB(1000000L);
+        diskInfo2.setAvailableCapacityB(900000L);
+        diskInfo2.setDataUsedCapacityB(80000L);
+        diskInfo2.setStorageMedium(TStorageMedium.HDD);
+        disks.put(diskInfo2.getRootPath(), diskInfo2);
+        be1.setDisks(ImmutableMap.copyOf(disks));
+        be1.setAlive(true);
+
+        // be2
+        Backend be2 = new Backend(10002L, "192.168.0.2", 9051);
+        disks = Maps.newHashMap();
+        diskInfo1 = new DiskInfo("/path1");
+        diskInfo1.setTotalCapacityB(1000000L);
+        diskInfo1.setAvailableCapacityB(500000L);
+        diskInfo1.setDataUsedCapacityB(480000L);
+        diskInfo1.setStorageMedium(TStorageMedium.HDD);
+        disks.put(diskInfo1.getRootPath(), diskInfo1);
+        diskInfo2 = new DiskInfo("/path2");
+        diskInfo2.setTotalCapacityB(1000000L);
+        diskInfo2.setAvailableCapacityB(500000L);
+        diskInfo2.setDataUsedCapacityB(480000L);
+        diskInfo2.setStorageMedium(TStorageMedium.HDD);
+        disks.put(diskInfo2.getRootPath(), diskInfo2);
+        be2.setDisks(ImmutableMap.copyOf(disks));
+        be2.setAlive(true);
+
+        SystemInfoService systemInfoService = new SystemInfoService();
+        systemInfoService.addBackend(be1);
+        systemInfoService.addBackend(be2);
+
+        // tablet inverted index
+        TabletInvertedIndex invertedIndex = new TabletInvertedIndex();
+
+        invertedIndex.addTablet(50000L, new TabletMeta(1L, 2L, 3L, 4L, TStorageMedium.HDD));
+        invertedIndex.addReplica(50000L, new Replica(50001L, be1.getId(), 0, Replica.ReplicaState.NORMAL));
+
+        invertedIndex.addTablet(60000L, new TabletMeta(1L, 2L, 3L, 4L, TStorageMedium.HDD));
+        invertedIndex.addReplica(60000L, new Replica(60002L, be2.getId(), 0, Replica.ReplicaState.NORMAL));
+
+        // cluster load statistic
+        ClusterLoadStatistic clusterLoadStat = new ClusterLoadStatistic(systemInfoService, invertedIndex);
+        clusterLoadStat.init();
+        clusterLoadStat.updateBackendDiskBalanceStat(Pair.create(TStorageMedium.HDD, be1.getId()),
+                BalanceStat.createBackendDiskBalanceStat(be1.getId(), "/path1", "/path2", 0.9, 0.1));
+
+        // tablet scheduler
+        TabletScheduler tabletScheduler = new TabletScheduler(new TabletSchedulerStat());
+        tabletScheduler.setClusterLoadStatistic(clusterLoadStat);
+
+        // 2 pending tablet
+        TabletSchedCtx ctx1 = new TabletSchedCtx(TabletSchedCtx.Type.BALANCE, 1L, 2L, 3L, 4L, 1001L, System.currentTimeMillis());
+        ctx1.setOrigPriority(TabletSchedCtx.Priority.NORMAL);
+        ctx1.setBalanceType(BalanceType.BACKEND_DISK);
+        ctx1.setStorageMedium(TStorageMedium.HDD);
+        Deencapsulation.invoke(tabletScheduler, "addToPendingTablets", ctx1);
+
+        TabletSchedCtx ctx2 = new TabletSchedCtx(TabletSchedCtx.Type.BALANCE, 1L, 2L, 3L, 4L, 1002L, System.currentTimeMillis());
+        ctx2.setOrigPriority(TabletSchedCtx.Priority.NORMAL);
+        ctx2.setBalanceType(BalanceType.BACKEND_DISK);
+        ctx2.setStorageMedium(TStorageMedium.HDD);
+        Deencapsulation.invoke(tabletScheduler, "addToPendingTablets", ctx2);
+
+        // 1. cluster tablet balance
+        // local meta store
+        LocalMetastore localMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), new CatalogRecycleBin(), null);
+
+        Database db = new Database(10000L, "BalanceStatProcTestDB");
+        localMetastore.unprotectCreateDb(db);
+
+        List<Column> col = Lists.newArrayList(new Column("province", Type.VARCHAR));
+        PartitionInfo listPartition = new ListPartitionInfo(PartitionType.LIST, col);
+        long partitionId = 1025;
+        listPartition.setDataProperty(partitionId, DataProperty.DEFAULT_DATA_PROPERTY);
+        listPartition.setIsInMemory(partitionId, false);
+        listPartition.setReplicationNum(partitionId, (short) 1);
+        OlapTable olapTable = new OlapTable(1024L, "olap_table", col, null, listPartition, null);
+        MaterializedIndex index = new MaterializedIndex(1000L, MaterializedIndex.IndexState.NORMAL);
+        index.setBalanceStat(BalanceStat.createClusterTabletBalanceStat(10001L, 10002L, 9L, 1L));
+        Map<String, Long> indexNameToId = olapTable.getIndexNameToId();
+        indexNameToId.put("index1", index.getId());
+        TabletMeta tabletMeta = new TabletMeta(db.getId(), olapTable.getId(), partitionId, index.getId(), TStorageMedium.HDD);
+        index.addTablet(new LocalTablet(1010L), tabletMeta);
+        index.addTablet(new LocalTablet(1011L), tabletMeta);
+        Partition partition = new Partition(partitionId, 1035, "p1", index, new RandomDistributionInfo(2));
+        olapTable.addPartition(partition);
+
+        db.registerTableUnlocked(olapTable);
+
+        // 1 running tablet
+        TabletSchedCtx ctx3 = new TabletSchedCtx(TabletSchedCtx.Type.BALANCE, 1L, 2L, 3L, 4L, 1002L, System.currentTimeMillis());
+        ctx3.setOrigPriority(TabletSchedCtx.Priority.NORMAL);
+        ctx3.setBalanceType(BalanceType.CLUSTER_TABLET);
+        ctx3.setStorageMedium(TStorageMedium.HDD);
+        Deencapsulation.invoke(tabletScheduler, "addToRunningTablets", ctx3);
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getLocalMetastore();
+                result = localMetastore;
+            }
+        };
+
+        // test
+        BalanceStatProcNode proc = new BalanceStatProcNode(tabletScheduler);
+        BaseProcResult result = (BaseProcResult) proc.fetchResult();
+        List<List<String>> rows = result.getRows();
+        Assertions.assertEquals(4, rows.size());
+
+        // cluster disk balanced
+        Assertions.assertEquals("[HDD, cluster disk, true, 0, 0]", rows.get(0).toString());
+        // cluster tablet not balanced, 1 running tablet
+        Assertions.assertEquals("[HDD, cluster tablet, false, 0, 1]", rows.get(1).toString());
+        // backend disk not balanced, 2 pending tablets
+        Assertions.assertEquals("[HDD, backend disk, false, 2, 0]", rows.get(2).toString());
+        // backend tablet balanced
+        Assertions.assertEquals("[HDD, backend tablet, true, 0, 0]", rows.get(3).toString());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Show the balance status of the cluster, identify which types are unbalanced, and how many balancing tasks are currently pending or running.

```
// Cluster balance overview
mysql> show proc "/cluster_balance/balance_stat";
+---------------+--------------------------------+-----------+----------------+----------------+
| StorageMedium | BalanceType                    | Balanced  | PendingTablets | RunningTablets |
+---------------+--------------------------------+-----------+----------------+----------------+
| HDD           | inter-node disk usage          | true      | 0              | 0              |
| HDD           | inter-node tablet distribution | false     | 9              | 8              |
| HDD           | intra-node disk usage          | true      | 0              | 0              |
| HDD           | intra-node tablet distribution | true      | 0              | 0              |
+---------------+--------------------------------+-----------+----------------+----------------+
4 rows in set (0.00 sec)
```

https://github.com/StarRocks/starrocks/issues/61340

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
