### PR TITLE
[BugFix] Fix maxmin_by window function primitive type output cause unmatched length chunk

### DIFF
--- a/be/src/exprs/agg/maxmin_by.h
+++ b/be/src/exprs/agg/maxmin_by.h
@@ -592,6 +592,7 @@ public:
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                     size_t end) const override {
+        dst->resize(start);
         if constexpr (State::not_filter_nulls_flag) {
             if (this->data(state).null_result) {
                 DCHECK(dst->is_nullable());
@@ -831,6 +832,7 @@ public:
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                     size_t end) const override {
+        dst->resize(start);
         if constexpr (State::not_filter_nulls_flag) {
             if (this->data(state).null_result) {
                 DCHECK(dst->is_nullable());

--- a/test/sql/test_max_min_by_not_filter_nulls_without_nulls/R/test_max_min_by_not_filter_nulls_without_nulls
+++ b/test/sql/test_max_min_by_not_filter_nulls_without_nulls/R/test_max_min_by_not_filter_nulls_without_nulls
@@ -71,11 +71,11 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--30649812568
+-8744363242
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-21366473853
+-13399679587
 -- !result
 SET new_planner_agg_stage=2;
 -- result:
@@ -117,11 +117,11 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--30649812568
+-8744363242
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-21366473853
+-13399679587
 -- !result
 SET new_planner_agg_stage=2;
 -- result:
@@ -163,11 +163,11 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--30649812568
+-8744363242
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-21366473853
+-13399679587
 -- !result
 SET new_planner_agg_stage=3;
 -- result:
@@ -209,11 +209,11 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--30649812568
+-8744363242
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-21366473853
+-13399679587
 -- !result
 SET new_planner_agg_stage=3;
 -- result:
@@ -255,11 +255,11 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--30649812568
+-8744363242
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-21366473853
+-13399679587
 -- !result
 SET new_planner_agg_stage=4;
 -- result:
@@ -301,11 +301,11 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--30649812568
+-8744363242
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-21366473853
+-13399679587
 -- !result
 SET new_planner_agg_stage=4;
 -- result:
@@ -347,9 +347,9 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--30649812568
+-8744363242
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-21366473853
+-13399679587
 -- !result

--- a/test/sql/test_window_function/R/test_minmax_by_window_function
+++ b/test/sql/test_window_function/R/test_minmax_by_window_function
@@ -1,0 +1,79 @@
+-- name: test_minmax_by_window_function
+CREATE TABLE `t1_nulls` (
+  `v1` int NULL,
+  `v2` bigint NULL,
+  `v3` largeint NULL,
+  `v4` string NULL,
+  `v5` json NULL,
+  `v6` map<int, string> NULL,
+  `v7` array<int> NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1_nulls SELECT generate_series, generate_series, generate_series, generate_series, generate_series, map(generate_series, generate_series), [generate_series] FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+select count(mb), sum(mb) from (select min_by(v1, v1) over (partition by v1) mb from t1_nulls) t;
+-- result:
+40960	838881280
+-- !result
+select count(mb), sum(mb) from (select min_by(v2, v2) over (partition by v1) mb from t1_nulls) t;
+-- result:
+40960	838881280
+-- !result
+select count(mb), sum(mb) from (select min_by(v3, v3) over (partition by v1) mb from t1_nulls) t;
+-- result:
+40960	838881280
+-- !result
+select count(mb), max(mb) from (select min_by(v4, v4) over (partition by v1) mb from t1_nulls) t;
+-- result:
+40960	9999
+-- !result
+select count(mb), max(get_json_int(mb, "$")) from (select min_by(v5, v1) over (partition by v1) mb from t1_nulls) t;
+-- result:
+40960	40960
+-- !result
+CREATE TABLE `t1_not_nulls` (
+  `v1` int,
+  `v2` bigint,
+  `v3` largeint,
+  `v4` string,
+  `v5` json,
+  `v6` map<int, string>,
+  `v7` array<int>
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1_not_nulls SELECT generate_series, generate_series, generate_series, generate_series, generate_series, map(generate_series, generate_series), [generate_series] FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+select count(mb), sum(mb) from (select min_by(v1, v1) over (partition by v1) mb from t1_not_nulls) t;
+-- result:
+40960	838881280
+-- !result
+select count(mb), sum(mb) from (select min_by(v2, v2) over (partition by v1) mb from t1_not_nulls) t;
+-- result:
+40960	838881280
+-- !result
+select count(mb), sum(mb) from (select min_by(v3, v3) over (partition by v1) mb from t1_not_nulls) t;
+-- result:
+40960	838881280
+-- !result
+select count(mb), max(mb) from (select min_by(v4, v4) over (partition by v1) mb from t1_not_nulls) t;
+-- result:
+40960	9999
+-- !result
+select count(mb), max(get_json_int(mb, "$")) from (select min_by(v5, v1) over (partition by v1) mb from t1_not_nulls) t;
+-- result:
+40960	40960
+-- !result

--- a/test/sql/test_window_function/T/test_minmax_by_window_function
+++ b/test/sql/test_window_function/T/test_minmax_by_window_function
@@ -1,0 +1,45 @@
+-- name: test_minmax_by_window_function
+
+CREATE TABLE `t1_nulls` (
+  `v1` int NULL,
+  `v2` bigint NULL,
+  `v3` largeint NULL,
+  `v4` string NULL,
+  `v5` json NULL,
+  `v6` map<int, string> NULL,
+  `v7` array<int> NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+insert into t1_nulls SELECT generate_series, generate_series, generate_series, generate_series, generate_series, map(generate_series, generate_series), [generate_series] FROM TABLE(generate_series(1,  40960));
+
+select count(mb), sum(mb) from (select min_by(v1, v1) over (partition by v1) mb from t1_nulls) t;
+select count(mb), sum(mb) from (select min_by(v2, v2) over (partition by v1) mb from t1_nulls) t;
+select count(mb), sum(mb) from (select min_by(v3, v3) over (partition by v1) mb from t1_nulls) t;
+select count(mb), max(mb) from (select min_by(v4, v4) over (partition by v1) mb from t1_nulls) t;
+select count(mb), max(get_json_int(mb, "$")) from (select min_by(v5, v1) over (partition by v1) mb from t1_nulls) t;
+
+CREATE TABLE `t1_not_nulls` (
+  `v1` int,
+  `v2` bigint,
+  `v3` largeint,
+  `v4` string,
+  `v5` json,
+  `v6` map<int, string>,
+  `v7` array<int>
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+insert into t1_not_nulls SELECT generate_series, generate_series, generate_series, generate_series, generate_series, map(generate_series, generate_series), [generate_series] FROM TABLE(generate_series(1,  40960));
+
+select count(mb), sum(mb) from (select min_by(v1, v1) over (partition by v1) mb from t1_not_nulls) t;
+select count(mb), sum(mb) from (select min_by(v2, v2) over (partition by v1) mb from t1_not_nulls) t;
+select count(mb), sum(mb) from (select min_by(v3, v3) over (partition by v1) mb from t1_not_nulls) t;
+select count(mb), max(mb) from (select min_by(v4, v4) over (partition by v1) mb from t1_not_nulls) t;
+select count(mb), max(get_json_int(mb, "$")) from (select min_by(v5, v1) over (partition by v1) mb from t1_not_nulls) t;


### PR DESCRIPTION
## Why I'm doing:


we will call resize for primitive type output before window function.
```
        if (_agg_fn_types[i].result_type.type == LogicalType::TYPE_CHAR ||
            _agg_fn_types[i].result_type.type == LogicalType::TYPE_VARCHAR ||
            _agg_fn_types[i].result_type.type == LogicalType::TYPE_JSON ||
            _agg_fn_types[i].result_type.type == LogicalType::TYPE_ARRAY ||
            _agg_fn_types[i].result_type.type == LogicalType::TYPE_MAP ||
            _agg_fn_types[i].result_type.type == LogicalType::TYPE_STRUCT) {
            _result_window_columns[i]->reserve(chunk_size);
        } else {
            _result_window_columns[i]->resize(chunk_size);
        }
```
So we must call resize before calling get_values to avoid duplicate append data

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
