### PR TITLE
[BugFix]Fix high memory usage in CatalogRecycleBin

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -683,6 +683,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
 
             if (finished) {
                 iterator.remove();
+                asyncDeleteForPartitions.remove(partitionInfo);
                 removeRecycleMarkers(partitionId);
 
                 GlobalStateMgr.getCurrentState().getEditLog().logErasePartition(partitionId);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -618,6 +618,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             Preconditions.checkState(!info.isRecoverable());
             if (finished) {
                 finishedTables.add(info.table.getId());
+                asyncDeleteForTables.remove(info);
             } else if (asyncDeleteForTables.get(info) == null) {
                 // treated as error if task is not running
                 setNextEraseMinTime(info.table.getId(), System.currentTimeMillis() + FAIL_RETRY_INTERVAL);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
@@ -155,6 +157,22 @@ public class CatalogRecycleBinLakeTableTest {
             } catch (Exception ignore) {
             }
         }
+    }
+
+    private static boolean containsAsyncDeleteTable(Object recycleBin, long id) {
+        Map<?, CompletableFuture<Boolean>> asyncDeleteForTables =
+                Deencapsulation.getField(recycleBin, "asyncDeleteForTables");
+
+        return asyncDeleteForTables.entrySet().stream()
+                .anyMatch(e -> ((CatalogRecycleBin.RecycleTableInfo) e.getKey()).getTable().getId() == id);
+    }
+
+    private static boolean containsAsyncDeletePartition(Object recycleBin, long id) {
+        Map<?, CompletableFuture<Boolean>> asyncDeleteForPartitions =
+                Deencapsulation.getField(recycleBin, "asyncDeleteForPartitions");
+
+        return asyncDeleteForPartitions.entrySet().stream()
+                .anyMatch(e -> ((RecyclePartitionInfo) e.getKey()).getPartition().getId() == id);
     }
 
     @Test
@@ -297,6 +315,7 @@ public class CatalogRecycleBinLakeTableTest {
 
         recycleBin.replayEraseTable(Lists.newArrayList(table1.getId()));
         Assertions.assertNull(recycleBin.getTable(db.getId(), table1.getId()));
+        Assertions.assertFalse(containsAsyncDeleteTable(recycleBin, table1.getId()));
     }
 
     @Test
@@ -481,7 +500,9 @@ public class CatalogRecycleBinLakeTableTest {
         waitPartitionClearFinished(recycleBin, p1.getId(), System.currentTimeMillis() + delay);
         waitPartitionClearFinished(recycleBin, p2.getId(), System.currentTimeMillis() + delay);
         Assertions.assertNull(recycleBin.getPartition(p1.getId()));
+        Assertions.assertFalse(containsAsyncDeletePartition(recycleBin, p1.getId()));
         Assertions.assertNull(recycleBin.getPartition(p2.getId()));
+        Assertions.assertFalse(containsAsyncDeletePartition(recycleBin, p2.getId()));
         checkPartitionTablet(p1, false);
         checkPartitionTablet(p2, false);
 
@@ -523,6 +544,7 @@ public class CatalogRecycleBinLakeTableTest {
         recycleBin.erasePartition(System.currentTimeMillis() + delay);
         waitPartitionClearFinished(recycleBin, p1.getId(), System.currentTimeMillis() + delay);
         Assertions.assertNull(recycleBin.getPartition(p1.getId()));
+        Assertions.assertFalse(containsAsyncDeletePartition(recycleBin, p1.getId()));
         checkPartitionTablet(p1, false);
     }
 


### PR DESCRIPTION
## Why I'm doing:
`asyncDeleteForPartitions` may cause significant memory usage. Once a partition has been successfully deleted, it's unnecessary to retain its information. It should be removed along with `idToPartition`.

## What I'm doing:
`asyncDeleteForPartitions` may cause significant memory usage. Once a partition has been successfully deleted, it's unnecessary to retain its information. It should be removed along with `idToPartition`.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
