### PR TITLE
[BugFix] fix corner case failing to clean expired stream load tasks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.load.streamload;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
@@ -993,7 +992,9 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         } finally {
             readUnlock();
         }
-        Preconditions.checkState(endTimeMs != -1, endTimeMs);
+        if (endTimeMs == -1) {
+            return false;
+        }
         if (isForce || ((currentMs - endTimeMs) > Config.stream_load_task_keep_max_second * 1000L)) {
             return true;
         }


### PR DESCRIPTION
## Why I'm doing:
`checkNeedRemove` is called inside a loop.
Exception will be thrown when `endTimeMs == -1`, this will break the loop causing `cleanOldStreamLoadTasks` failed to clean other expired tasks, causing memory leak.
```java
Preconditions.checkState(endTimeMs != -1, endTimeMs);
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [x] 3.4
  - [x] 3.3
