### PR TITLE
[BugFix] notify should be call after setting streaming_all_states

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -106,6 +106,7 @@ Status AggregateStreamingSourceOperator::_output_chunk_from_hash_map(ChunkPtr* c
 
     // TODO: notify sink here
     if (need_reset_aggregator) {
+        auto notify = _aggregator->defer_notify_sink();
         if (!_aggregator->is_sink_complete()) {
             RETURN_IF_ERROR(_aggregator->reset_state(state, {}, nullptr, false));
         }


### PR DESCRIPTION
## Why I'm doing:

This patch will solve test_spill_random timeout.

## What I'm doing:

reproduce case:
```
set enable_spill=true;
set spill_mode="random";

CREATE TABLE t1 (
    k1 INT,
    k2 VARCHAR(20))
DUPLICATE KEY(k1)
DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');

insert into t1 values (1,"1");
CREATE TABLE t2 (
    k1 INT,
    k2 VARCHAR(20))
DUPLICATE KEY(k1)
DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');

-- run multi times.
insert into t2 select sum(k1),k2 from t1 group by k2;
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
