### PR TITLE
[Enhancement]local-exchange support bucket-aware execution

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -157,6 +157,7 @@ public:
     virtual Status init(ObjectPool* pool, RuntimeState* state) { return Status::OK(); }
 
     const std::vector<ExprContext*>& partition_exprs() const { return _partition_exprs; }
+    const std::vector<TBucketProperty>& get_bucket_properties() const { return _bucket_properties; }
 
     virtual const TupleDescriptor* tuple_descriptor(RuntimeState* state) const = 0;
 
@@ -184,6 +185,7 @@ public:
 
 protected:
     std::vector<ExprContext*> _partition_exprs;
+    std::vector<TBucketProperty> _bucket_properties;
     int64_t scan_dop = 0;
 };
 using DataSourceProviderPtr = std::unique_ptr<DataSourceProvider>;

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -44,7 +44,11 @@ std::unique_ptr<ConnectorChunkSinkProvider> HiveConnector::create_data_sink_prov
 // ================================
 
 HiveDataSourceProvider::HiveDataSourceProvider(ConnectorScanNode* scan_node, const TPlanNode& plan_node)
-        : _scan_node(scan_node), _hdfs_scan_node(plan_node.hdfs_scan_node) {}
+        : _scan_node(scan_node), _hdfs_scan_node(plan_node.hdfs_scan_node) {
+    if (_hdfs_scan_node.__isset.bucket_properties) {
+        _bucket_properties = _hdfs_scan_node.bucket_properties;
+    }
+}
 
 DataSourcePtr HiveDataSourceProvider::create_data_source(const TScanRange& scan_range) {
     return std::make_unique<HiveDataSource>(this, scan_range);

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -77,8 +77,12 @@ protected:
 class ShufflePartitioner final : public Partitioner {
 public:
     ShufflePartitioner(LocalExchangeSourceOperatorFactory* source, const TPartitionType::type part_type,
-                       const std::vector<ExprContext*>& partition_expr_ctxs)
-            : Partitioner(source), _part_type(part_type), _partition_expr_ctxs(partition_expr_ctxs) {
+                       const std::vector<ExprContext*>& partition_expr_ctxs,
+                       const std::vector<TBucketProperty>& bucket_properties)
+            : Partitioner(source),
+              _part_type(part_type),
+              _partition_expr_ctxs(partition_expr_ctxs),
+              _bucket_properties(bucket_properties) {
         _partitions_columns.resize(partition_expr_ctxs.size());
         _hash_values.reserve(source->runtime_state()->chunk_size());
     }
@@ -90,8 +94,10 @@ private:
     const TPartitionType::type _part_type;
     // Compute per-row partition values.
     const std::vector<ExprContext*>& _partition_expr_ctxs;
+    const std::vector<TBucketProperty>& _bucket_properties;
     Columns _partitions_columns;
     std::vector<uint32_t> _hash_values;
+    std::vector<uint32_t> _round_hashes;
     std::unique_ptr<Shuffler> _shuffler;
 };
 
@@ -191,7 +197,8 @@ class PartitionExchanger final : public LocalExchanger {
 public:
     PartitionExchanger(const std::shared_ptr<ChunkBufferMemoryManager>& memory_manager,
                        LocalExchangeSourceOperatorFactory* source, const TPartitionType::type part_type,
-                       std::vector<ExprContext*> _partition_expr_ctxs);
+                       std::vector<ExprContext*> _partition_expr_ctxs,
+                       std::vector<TBucketProperty> bucket_properties);
 
     ~PartitionExchanger() override = default;
 
@@ -208,6 +215,7 @@ private:
     // TODO(lzh): limit the size of _partitioners, because it will cost too much memory when dop is high.
     TPartitionType::type _part_type;
     std::vector<ExprContext*> _partition_exprs;
+    std::vector<TBucketProperty> _bucket_properties;
     std::vector<std::unique_ptr<ShufflePartitioner>> _partitioners;
 };
 

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -197,8 +197,7 @@ class PartitionExchanger final : public LocalExchanger {
 public:
     PartitionExchanger(const std::shared_ptr<ChunkBufferMemoryManager>& memory_manager,
                        LocalExchangeSourceOperatorFactory* source, const TPartitionType::type part_type,
-                       std::vector<ExprContext*> _partition_expr_ctxs,
-                       std::vector<TBucketProperty> bucket_properties);
+                       std::vector<ExprContext*> _partition_expr_ctxs, std::vector<TBucketProperty> bucket_properties);
 
     ~PartitionExchanger() override = default;
 

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -194,7 +194,8 @@ private:
     OpFactories _do_maybe_interpolate_local_shuffle_exchange(
             RuntimeState* state, int32_t plan_node_id, OpFactories& pred_operators,
             const std::vector<ExprContext*>& partition_expr_ctxs,
-            const TPartitionType::type part_type = TPartitionType::type::HASH_PARTITIONED);
+            const TPartitionType::type part_type = TPartitionType::type::HASH_PARTITIONED,
+            const std::vector<TBucketProperty>& bucket_properties = std::vector<TBucketProperty>());
 
     static constexpr int kLocalExchangeBufferChunks = 8;
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -159,6 +159,12 @@ const std::vector<ExprContext*>& ConnectorScanOperatorFactory::partition_exprs()
     return provider->partition_exprs();
 }
 
+const std::vector<TBucketProperty>& ConnectorScanOperatorFactory::get_bucket_properties() const {
+    auto* connector_scan_node = down_cast<ConnectorScanNode*>(_scan_node);
+    auto* provider = connector_scan_node->data_source_provider();
+    return provider->get_bucket_properties();
+}
+
 void ConnectorScanOperatorFactory::set_chunk_source_mem_bytes(int64_t value) {
     _io_tasks_mem_limiter->update_chunk_source_mem_bytes(value);
     _io_tasks_mem_limiter->update_arb_chunk_source_mem_bytes(value);

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -67,6 +67,7 @@ public:
 
     TPartitionType::type partition_type() const override { return TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED; }
     const std::vector<ExprContext*>& partition_exprs() const override;
+    const std::vector<TBucketProperty>& get_bucket_properties() const override;
     void set_chunk_source_mem_bytes(int64_t mem_bytes);
     void set_scan_mem_limit(int64_t scan_mem_limit);
     void set_mem_share_arb(ConnectorScanOperatorMemShareArbitrator* arb);

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -69,6 +69,7 @@ public:
     void set_partition_type(TPartitionType::type partition_type) { _partition_type = partition_type; }
     virtual const std::vector<ExprContext*>& partition_exprs() const { return _partition_exprs; }
     void set_partition_exprs(const std::vector<ExprContext*>& partition_exprs) { _partition_exprs = partition_exprs; }
+    virtual const std::vector<TBucketProperty>& get_bucket_properties() const { return _bucket_properties; }
 
     /// The pipelines of a fragment instance are organized by groups.
     /// - The operator tree is broken into several groups by CollectStatsSourceOperator (CsSource)
@@ -128,6 +129,7 @@ protected:
     MorselQueueFactory* _morsel_queue_factory = nullptr;
 
     std::vector<ExprContext*> _partition_exprs;
+    std::vector<TBucketProperty> _bucket_properties;
 
     std::vector<SourceOperatorFactory*> _upstream_sources;
     mutable SourceOperatorFactory* _group_parent = this;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -69,6 +69,7 @@ set(EXEC_FILES
         ./exec/pipeline/sink/memory_scratch_sink_operator_test.cpp
         ./exec/pipeline/exchange_pass_through_test.cpp
         ./exec/pipeline/limit_operator_test.cpp
+        ./exec/pipeline/local_bucket_shuffle_test.cpp
         ./exec/pipeline/mem_limited_chunk_queue_test.cpp
         ./exec/query_cache/query_cache_test.cpp
         ./exec/query_cache/transform_operator.cpp

--- a/be/test/exec/pipeline/local_bucket_shuffle_test.cpp
+++ b/be/test/exec/pipeline/local_bucket_shuffle_test.cpp
@@ -1,0 +1,132 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "exec/chunk_buffer_memory_manager.h"
+#include "exec/pipeline/exchange/local_exchange.h"
+#include "exec/pipeline/exchange/local_exchange_source_operator.h"
+#include "exec/pipeline/query_context.h"
+#include "runtime/types.h"
+#include "testutil/assert.h"
+#include "types/logical_type.h"
+
+namespace starrocks::pipeline {
+
+class LocalBucketShuffleTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _exec_env = ExecEnv::GetInstance();
+
+        _query_context = std::make_shared<QueryContext>();
+        _query_context->set_exec_env(_exec_env);
+        _query_context->init_mem_tracker(-1, GlobalEnv::GetInstance()->process_mem_tracker());
+
+        TQueryOptions query_options;
+        query_options.batch_size = 4096;
+        TQueryGlobals query_globals;
+        _runtime_state = std::make_shared<RuntimeState>(_fragment_id, query_options, query_globals, _exec_env);
+        _runtime_state->set_query_ctx(_query_context.get());
+        _runtime_state->init_instance_mem_tracker();
+
+        _chunk_buffer_memory_manager = std::make_shared<ChunkBufferMemoryManager>(4, 1024 * 1024);
+        _source_op_factory = std::make_unique<LocalExchangeSourceOperatorFactory>(0, 1, _chunk_buffer_memory_manager);
+        _source_op_factory->set_runtime_state(_runtime_state.get());
+        for (size_t i = 0; i < _dop; i++) {
+            _sources.emplace_back(_source_op_factory->create(_dop, i));
+        }
+    }
+
+protected:
+    TExpr _create_slot_ref_expr(int slot_id) {
+        std::vector<TExprNode> nodes;
+        TExprNode node1;
+        node1.node_type = TExprNodeType::SLOT_REF;
+        node1.type = gen_type_desc(TPrimitiveType::INT);
+        node1.num_children = 0;
+        TSlotRef t_slot_ref = TSlotRef();
+        t_slot_ref.slot_id = slot_id;
+        t_slot_ref.tuple_id = 0;
+        node1.__set_slot_ref(t_slot_ref);
+        node1.is_nullable = true;
+        nodes.emplace_back(node1);
+
+        TExpr t_expr;
+        t_expr.nodes = nodes;
+        return t_expr;
+    }
+
+    std::shared_ptr<ChunkBufferMemoryManager> _chunk_buffer_memory_manager;
+    std::unique_ptr<LocalExchangeSourceOperatorFactory> _source_op_factory;
+    TUniqueId _fragment_id;
+    ExecEnv* _exec_env;
+    std::shared_ptr<QueryContext> _query_context;
+    std::shared_ptr<RuntimeState> _runtime_state;
+    ObjectPool _object_pool;
+    std::vector<OperatorPtr> _sources;
+    size_t _dop = 3;
+};
+
+TEST_F(LocalBucketShuffleTest, test_local_bucket_shuffle) {
+    std::vector<TExpr> t_conjuncts;
+    t_conjuncts.emplace_back(_create_slot_ref_expr(1));
+    t_conjuncts.emplace_back(_create_slot_ref_expr(2));
+
+    std::vector<ExprContext*> partition_exprs;
+    Expr::create_expr_trees(&_object_pool, t_conjuncts, &partition_exprs, nullptr);
+    Expr::prepare(partition_exprs, _runtime_state.get());
+    Expr::open(partition_exprs, _runtime_state.get());
+
+    TBucketProperty bucket_property = TBucketProperty();
+    bucket_property.bucket_func = TBucketFunction::MURMUR3_X86_32;
+    bucket_property.bucket_num = 2;
+    auto bucket_properies = std::vector<TBucketProperty>();
+    bucket_properies.emplace_back(bucket_property);
+    bucket_properies.emplace_back(bucket_property);
+
+    auto partitioner =
+            make_unique<ShufflePartitioner>(_source_op_factory.get(), TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED,
+                                            partition_exprs, bucket_properies);
+    auto chunk = std::make_shared<Chunk>();
+
+    auto col = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
+    col->append_datum(Datum(1));
+    col->append_datum(Datum(2));
+    col->append_datum(Datum(3));
+    col->append_nulls(1);
+    col->append_datum(Datum(4));
+    col->append_nulls(1);
+    chunk->append_column(std::move(col), 1);
+
+    auto col_s = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true);
+    std::vector<Slice> strings{{"a"}, {"b"}, {"c"}, {"d"}, {"e"}};
+    col_s->append_strings(strings.data(), strings.size());
+    col_s->append_nulls(1);
+    chunk->append_column(std::move(col_s), 2);
+
+    std::vector<uint32_t> partition_indexes(chunk->num_rows());
+    ASSERT_OK(partitioner->partition_chunk(chunk, _dop, partition_indexes));
+    std::vector<uint32_t> indexes{5, 0, 3, 1, 2, 4};
+    for (size_t i = 0; i < partition_indexes.size(); i++) {
+        ASSERT_EQ(indexes[i], partition_indexes[i]);
+    }
+    std::vector<uint32_t> part_len{1, 2, 3};
+    for (size_t i = 0; i < _dop; i++) {
+        ASSERT_EQ(part_len[i], partitioner->partition_end_offset(i) - partitioner->partition_begin_offset(i));
+    }
+}
+
+} // namespace starrocks::pipeline


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
follow #61554 local exchange needs to calc hash values as what exchange node does.

Fixes #issue
#61287 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
