### PR TITLE
[BugFix] Fix the error in calculating the memory size of the low cardinality dictionary.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
@@ -129,7 +129,8 @@ public class CacheDictManager implements IDictManager, MemoryTrackable {
             int dictDataSize = 0;
             for (int i = 0; i < dictSize; i++) {
                 // a UTF-8 code may take up to 3 bytes
-                dictDataSize += tGlobalDict.strings.get(i).limit();
+                ByteBuffer buf = tGlobalDict.strings.get(i);
+                dictDataSize += buf.limit() - buf.position();
                 // string offsets
                 dictDataSize += 4;
             }

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_size_threshold
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_size_threshold
@@ -1,0 +1,19 @@
+-- name: test_low_cardinality
+CREATE TABLE t1(c1 int, c2 varchar(65536)) duplicate key(c1) distributed by hash(c1) buckets 1 properties("replication_num"="1");
+-- result:
+-- !result
+insert into t1 SELECT generate_series, concat(repeat("1234567890", 300), generate_series) FROM TABLE(generate_series(1,  200));
+-- result:
+-- !result
+[UC] analyze table t1;
+-- result:
+test_db_d366f57af3944281a68c9468213b8a92.t1     analyze status  OK
+-- !result
+function: wait_global_dict_ready('c2', 't1')
+-- result:
+
+-- !result
+function: assert_explain_contains('select c2, count(*) from t1 group by c2;', 'Decode')
+-- result:
+None
+-- !result

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_size_threshold
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_size_threshold
@@ -1,0 +1,9 @@
+-- name: test_low_cardinality
+
+CREATE TABLE t1(c1 int, c2 varchar(65536)) duplicate key(c1) distributed by hash(c1) buckets 1 properties("replication_num"="1");
+
+insert into t1 SELECT generate_series, concat(repeat("1234567890", 300), generate_series) FROM TABLE(generate_series(1,  200));
+
+[UC] analyze table t1;
+function: wait_global_dict_ready('c2', 't1')
+function: assert_explain_contains('select c2, count(*) from t1 group by c2;', 'Decode')


### PR DESCRIPTION
## Why I'm doing:

A `ByteBuffer` has three components: position, limit, and capacity. The actual size is (limit - position), not the limit itself.

// For values with a size of approximately 3000–3100 bytes
```
2025-08-05 11:06:56.953+08:00 WARN (cache-stats-25|683) [CacheDictManager.deserializeColumnDict():134]: SIZE: (dict)0, (size-pos)3001, (size)3008
2025-08-05 11:06:56.955+08:00 WARN (cache-stats-25|683) [CacheDictManager.deserializeColumnDict():134]: SIZE: (dict)1, (size-pos)3002, (size)6012
2025-08-05 11:06:56.955+08:00 WARN (cache-stats-25|683) [CacheDictManager.deserializeColumnDict():134]: SIZE: (dict)2, (size-pos)3003, (size)9017
2025-08-05 11:06:56.955+08:00 WARN (cache-stats-25|683) [CacheDictManager.deserializeColumnDict():134]: SIZE: (dict)3, (size-pos)3003, (size)12022
2025-08-05 11:06:56.955+08:00 WARN (cache-stats-25|683) [CacheDictManager.deserializeColumnDict():134]: SIZE: (dict)4, (size-pos)3003, (size)15027
```

## What I'm doing:

Fix the error in calculating the memory size of the low cardinality dictionary.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
