### PR TITLE
[Doc] Add user documentation for format_bytes function (StarRocks#61597)

### DIFF
--- a/docs/en/sql-reference/sql-functions/string-functions/format_bytes.md
+++ b/docs/en/sql-reference/sql-functions/string-functions/format_bytes.md
@@ -1,0 +1,133 @@
+---
+displayed_sidebar: docs
+---
+
+# format_bytes
+
+Converts a byte count into a human-readable string with appropriate units (B, KB, MB, GB, TB, PB, EB).
+
+This function is useful for displaying file sizes, table sizes, memory usage, and other storage-related metrics in a user-friendly format. It uses 1024-based calculations (binary prefixes) but displays units as KB, MB, GB for simplicity and familiarity.
+
+This function is supported from v3.4.
+
+## Syntax
+
+```Haskell
+VARCHAR format_bytes(BIGINT bytes)
+```
+
+## Parameters
+
+- `bytes`: the number of bytes to format. BIGINT is supported. Must be a non-negative integer value.
+
+## Return value
+
+Returns a VARCHAR value representing the formatted byte size with appropriate units.
+
+- For values less than 1024: returns the exact number with "B" (bytes)
+- For larger values: returns a formatted string with 2 decimal places and the appropriate unit (KB, MB, GB, TB, PB, EB)
+- Returns NULL if the input is negative or NULL
+
+## Usage notes
+
+- The function uses 1024-based (binary) calculations internally (1 KB = 1024 bytes, 1 MB = 1024² bytes, etc.)
+- Units are displayed as KB, MB, GB, TB, PB, EB for user familiarity, though they represent binary prefixes (KiB, MiB, GiB, etc.)
+- Values greater than or equal to 1 KB are displayed with exactly 2 decimal places
+- Byte values (less than 1024) are displayed as whole numbers without decimal places
+- Negative values return NULL
+- Supports values up to 8 EB (exabytes), covering the full range of BIGINT
+
+## Examples
+
+Example 1: Format various byte sizes.
+
+```sql
+SELECT format_bytes(0);
+-- 0 B
+
+SELECT format_bytes(123);
+-- 123 B
+
+SELECT format_bytes(1024);
+-- 1.00 KB
+
+SELECT format_bytes(4096);
+-- 4.00 KB
+
+SELECT format_bytes(123456789);
+-- 117.74 MB
+
+SELECT format_bytes(10737418240);
+-- 10.00 GB
+```
+
+Example 2: Handle edge cases and null values.
+
+```sql
+SELECT format_bytes(-1);
+-- NULL
+
+SELECT format_bytes(NULL);
+-- NULL
+
+SELECT format_bytes(0);
+-- 0 B
+```
+
+Example 3: Practical usage for table size monitoring.
+
+```sql
+-- Create a sample table with size information
+CREATE TABLE storage_info (
+    table_name VARCHAR(64),
+    size_bytes BIGINT
+);
+
+INSERT INTO storage_info VALUES
+('user_profiles', 1073741824),
+('transaction_logs', 5368709120),
+('product_catalog', 524288000),
+('analytics_data', 2199023255552);
+
+-- Display table sizes in human-readable format
+SELECT 
+    table_name,
+    size_bytes,
+    format_bytes(size_bytes) as formatted_size
+FROM storage_info
+ORDER BY size_bytes DESC;
+
+-- Expected output:
+-- +------------------+---------------+----------------+
+-- | table_name       | size_bytes    | formatted_size |
+-- +------------------+---------------+----------------+
+-- | analytics_data   | 2199023255552 | 2.00 TB        |
+-- | transaction_logs | 5368709120    | 5.00 GB        |
+-- | user_profiles    | 1073741824    | 1.00 GB        |
+-- | product_catalog  | 524288000     | 500.00 MB      |
+-- +------------------+---------------+----------------+
+```
+
+Example 4: Precision and rounding behavior.
+
+```sql
+SELECT format_bytes(1536);       -- 1.50 KB (exactly 1.5 KB)
+SELECT format_bytes(1025);       -- 1.00 KB (rounded to 2 decimals)
+SELECT format_bytes(1048576 + 52429);  -- 1.05 MB (rounded to 2 decimals)
+```
+
+Example 5: Full range of supported units.
+
+```sql
+SELECT format_bytes(512);                    -- 512 B
+SELECT format_bytes(2048);                   -- 2.00 KB  
+SELECT format_bytes(1572864);                -- 1.50 MB
+SELECT format_bytes(2147483648);             -- 2.00 GB
+SELECT format_bytes(1099511627776);          -- 1.00 TB
+SELECT format_bytes(1125899906842624);       -- 1.00 PB
+SELECT format_bytes(1152921504606846976);    -- 1.00 EB
+```
+
+## keyword
+
+FORMAT_BYTES

--- a/docs/ja/sql-reference/sql-functions/string-functions/format_bytes.md
+++ b/docs/ja/sql-reference/sql-functions/string-functions/format_bytes.md
@@ -1,0 +1,133 @@
+---
+displayed_sidebar: docs
+---
+
+# format_bytes
+
+バイト数を適切な単位（B, KB, MB, GB, TB, PB, EB）で人間が読みやすい文字列に変換します。
+
+この関数は、ファイルサイズ、テーブルサイズ、メモリ使用量、その他のストレージ関連のメトリクスをユーザーフレンドリーな形式で表示するのに便利です。1024ベースの計算（バイナリプレフィックス）を使用しますが、単位は簡単で親しみやすいようにKB, MB, GBとして表示されます。
+
+この関数はv3.4からサポートされています。
+
+## 構文
+
+```Haskell
+VARCHAR format_bytes(BIGINT bytes)
+```
+
+## パラメータ
+
+- `bytes`: フォーマットするバイト数。BIGINTがサポートされています。非負の整数値である必要があります。
+
+## 戻り値
+
+適切な単位でフォーマットされたバイトサイズを表すVARCHAR値を返します。
+
+- 1024未満の値の場合: 正確な数値と"B"（バイト）を返します
+- より大きな値の場合: 2桁の小数点を持つフォーマットされた文字列と適切な単位（KB, MB, GB, TB, PB, EB）を返します
+- 入力が負またはNULLの場合はNULLを返します
+
+## 使用上の注意
+
+- 関数は内部的に1024ベース（バイナリ）の計算を使用します（1 KB = 1024バイト、1 MB = 1024²バイトなど）
+- 単位はユーザーの親しみやすさのためにKB, MB, GB, TB, PB, EBとして表示されますが、バイナリプレフィックス（KiB, MiB, GiBなど）を表します
+- 1 KB以上の値は正確に2桁の小数点で表示されます
+- バイト値（1024未満）は小数点なしの整数として表示されます
+- 負の値はNULLを返します
+- 8 EB（エクサバイト）までの値をサポートし、BIGINTの全範囲をカバーします
+
+## 例
+
+例1: 様々なバイトサイズをフォーマットします。
+
+```sql
+SELECT format_bytes(0);
+-- 0 B
+
+SELECT format_bytes(123);
+-- 123 B
+
+SELECT format_bytes(1024);
+-- 1.00 KB
+
+SELECT format_bytes(4096);
+-- 4.00 KB
+
+SELECT format_bytes(123456789);
+-- 117.74 MB
+
+SELECT format_bytes(10737418240);
+-- 10.00 GB
+```
+
+例2: エッジケースとNULL値を処理します。
+
+```sql
+SELECT format_bytes(-1);
+-- NULL
+
+SELECT format_bytes(NULL);
+-- NULL
+
+SELECT format_bytes(0);
+-- 0 B
+```
+
+例3: テーブルサイズの監視における実用的な使用法。
+
+```sql
+-- サイズ情報を持つサンプルテーブルを作成
+CREATE TABLE storage_info (
+    table_name VARCHAR(64),
+    size_bytes BIGINT
+);
+
+INSERT INTO storage_info VALUES
+('user_profiles', 1073741824),
+('transaction_logs', 5368709120),
+('product_catalog', 524288000),
+('analytics_data', 2199023255552);
+
+-- 人間が読みやすい形式でテーブルサイズを表示
+SELECT 
+    table_name,
+    size_bytes,
+    format_bytes(size_bytes) as formatted_size
+FROM storage_info
+ORDER BY size_bytes DESC;
+
+-- 期待される出力:
+-- +------------------+---------------+----------------+
+-- | table_name       | size_bytes    | formatted_size |
+-- +------------------+---------------+----------------+
+-- | analytics_data   | 2199023255552 | 2.00 TB        |
+-- | transaction_logs | 5368709120    | 5.00 GB        |
+-- | user_profiles    | 1073741824    | 1.00 GB        |
+-- | product_catalog  | 524288000     | 500.00 MB      |
+-- +------------------+---------------+----------------+
+```
+
+例4: 精度と丸めの動作。
+
+```sql
+SELECT format_bytes(1536);       -- 1.50 KB (正確に1.5 KB)
+SELECT format_bytes(1025);       -- 1.00 KB (2桁に丸め)
+SELECT format_bytes(1048576 + 52429);  -- 1.05 MB (2桁に丸め)
+```
+
+例5: サポートされる単位の全範囲。
+
+```sql
+SELECT format_bytes(512);                    -- 512 B
+SELECT format_bytes(2048);                   -- 2.00 KB  
+SELECT format_bytes(1572864);                -- 1.50 MB
+SELECT format_bytes(2147483648);             -- 2.00 GB
+SELECT format_bytes(1099511627776);          -- 1.00 TB
+SELECT format_bytes(1125899906842624);       -- 1.00 PB
+SELECT format_bytes(1152921504606846976);    -- 1.00 EB
+```
+
+## キーワード
+
+FORMAT_BYTES

--- a/docs/zh/sql-reference/sql-functions/string-functions/format_bytes.md
+++ b/docs/zh/sql-reference/sql-functions/string-functions/format_bytes.md
@@ -1,0 +1,133 @@
+---
+displayed_sidebar: docs
+---
+
+# format_bytes
+
+将字节数转换为带有适当单位（B、KB、MB、GB、TB、PB、EB）的易读字符串。
+
+此函数用于以用户友好的格式显示文件大小、表大小、内存使用情况和其他与存储相关的指标。它使用基于1024的计算（二进制前缀），但为了简单和习惯，显示单位为KB、MB、GB。
+
+此函数从v3.4开始支持。
+
+## 语法
+
+```Haskell
+VARCHAR format_bytes(BIGINT bytes)
+```
+
+## 参数
+
+- `bytes`：要格式化的字节数。支持BIGINT。必须是非负整数值。
+
+## 返回值
+
+返回一个VARCHAR值，表示带有适当单位的格式化字节大小。
+
+- 对于小于1024的值：返回带有“B”（字节）的确切数字
+- 对于较大的值：返回带有2位小数和适当单位（KB、MB、GB、TB、PB、EB）的格式化字符串
+- 如果输入为负或NULL，则返回NULL
+
+## 使用说明
+
+- 该函数内部使用基于1024的（二进制）计算（1 KB = 1024字节，1 MB = 1024²字节，等等）
+- 单位显示为KB、MB、GB、TB、PB、EB以迎合用户习惯，尽管它们代表二进制前缀（KiB、MiB、GiB等）
+- 大于或等于1 KB的值以精确到2位小数显示
+- 字节值（小于1024）以整数显示，不带小数位
+- 负值返回NULL
+- 支持的最大值为8 EB（艾字节），覆盖BIGINT的完整范围
+
+## 示例
+
+示例1：格式化各种字节大小。
+
+```sql
+SELECT format_bytes(0);
+-- 0 B
+
+SELECT format_bytes(123);
+-- 123 B
+
+SELECT format_bytes(1024);
+-- 1.00 KB
+
+SELECT format_bytes(4096);
+-- 4.00 KB
+
+SELECT format_bytes(123456789);
+-- 117.74 MB
+
+SELECT format_bytes(10737418240);
+-- 10.00 GB
+```
+
+示例2：处理边缘情况和空值。
+
+```sql
+SELECT format_bytes(-1);
+-- NULL
+
+SELECT format_bytes(NULL);
+-- NULL
+
+SELECT format_bytes(0);
+-- 0 B
+```
+
+示例3：用于表大小监控的实际应用。
+
+```sql
+-- 创建一个包含大小信息的示例表
+CREATE TABLE storage_info (
+    table_name VARCHAR(64),
+    size_bytes BIGINT
+);
+
+INSERT INTO storage_info VALUES
+('user_profiles', 1073741824),
+('transaction_logs', 5368709120),
+('product_catalog', 524288000),
+('analytics_data', 2199023255552);
+
+-- 以易读格式显示表大小
+SELECT 
+    table_name,
+    size_bytes,
+    format_bytes(size_bytes) as formatted_size
+FROM storage_info
+ORDER BY size_bytes DESC;
+
+-- 预期输出:
+-- +------------------+---------------+----------------+
+-- | table_name       | size_bytes    | formatted_size |
+-- +------------------+---------------+----------------+
+-- | analytics_data   | 2199023255552 | 2.00 TB        |
+-- | transaction_logs | 5368709120    | 5.00 GB        |
+-- | user_profiles    | 1073741824    | 1.00 GB        |
+-- | product_catalog  | 524288000     | 500.00 MB      |
+-- +------------------+---------------+----------------+
+```
+
+示例4：精度和舍入行为。
+
+```sql
+SELECT format_bytes(1536);       -- 1.50 KB (精确到1.5 KB)
+SELECT format_bytes(1025);       -- 1.00 KB (舍入到2位小数)
+SELECT format_bytes(1048576 + 52429);  -- 1.05 MB (舍入到2位小数)
+```
+
+示例5：支持单位的完整范围。
+
+```sql
+SELECT format_bytes(512);                    -- 512 B
+SELECT format_bytes(2048);                   -- 2.00 KB  
+SELECT format_bytes(1572864);                -- 1.50 MB
+SELECT format_bytes(2147483648);             -- 2.00 GB
+SELECT format_bytes(1099511627776);          -- 1.00 TB
+SELECT format_bytes(1125899906842624);       -- 1.00 PB
+SELECT format_bytes(1152921504606846976);    -- 1.00 EB
+```
+
+## Keyword
+
+FORMAT_BYTES


### PR DESCRIPTION
## Why I'm doing:

StarRocks users need a convenient way to display byte counts in human-readable formats for monitoring table sizes, disk usage, and storage metrics. Currently, users must manually calculate and format these values, which is cumbersome and error-prone. Adding comprehensive documentation ensures all users can discover and effectively use the new format_bytes function.

## What I'm doing:

This PR adds complete user documentation for the format_bytes function in the string functions section. The documentation includes:

  - Function overview and use cases
  - Syntax and parameter details
  - Return value behavior and edge cases
  - Usage notes about 1024-based calculations and display units
  - Comprehensive examples covering basic usage, edge cases, and practical scenarios
  - Real-world examples for table size monitoring that users can test immediately

The documentation follows StarRocks documentation standards and provides everything users need to understand and use this function effectively.

Fixes #61597

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
