### PR TITLE
[BugFix] avoid two-stage distinct aggregation when no grouping key in the query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -123,9 +123,13 @@ public abstract class SplitAggregateRule extends TransformationRule {
             return true;
         }
 
+        // 1. Only single node in the cluster
+        // 2. With GROUP-BY clause, otherwise the second-stage cannot be parallelized
+        // 3. CBO_ENABLE_SINGLE_NODE_PREFER_TWO_STAGE_AGGREGATE is enabled
         if (aggMode == AUTO.ordinal()
                 && isSingleNodeExecution(ConnectContext.get())
                 && !FeConstants.runningUnitTest
+                && CollectionUtils.isNotEmpty(operator.getGroupingKeys())
                 && ConnectContext.get().getSessionVariable().isCboEnableSingleNodePreferTwoStageAggregate()) {
             return true;
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


follow #60029

Without grouping key the second stage cannot be parallelized, it can be slower than a three-stage plan.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
