### PR TITLE
[Enhancement] VacuumFull Implementation

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -320,7 +320,6 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_limited_memory(const Chunk
 
 Status AggregateStreamingSinkOperator::reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) {
     _is_finished = false;
-    // TODO(cbrennan): Add this back once it doesn't break test compilation
     ONCE_RESET(_set_finishing_once);
     return _aggregator->reset_state(state, refill_chunks, this);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -320,6 +320,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_limited_memory(const Chunk
 
 Status AggregateStreamingSinkOperator::reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) {
     _is_finished = false;
+    // TODO(cbrennan): Add this back once it doesn't break test compilation
     ONCE_RESET(_set_finishing_once);
     return _aggregator->reset_state(state, refill_chunks, this);
 }

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -35,6 +35,7 @@
 #include "storage/lake/tablet.h"
 #include "storage/lake/transactions.h"
 #include "storage/lake/vacuum.h"
+#include "storage/lake/vacuum_full.h"
 #include "testutil/sync_point.h"
 #include "util/brpc_stub_cache.h"
 #include "util/countdown_latch.h"

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -191,6 +191,7 @@ set(STORAGE_FILES
     lake/horizontal_compaction_task.cpp
     lake/delta_writer.cpp
     lake/vacuum.cpp
+    lake/vacuum_full.cpp
     lake/general_tablet_writer.cpp
     lake/pk_tablet_writer.cpp
     lake/primary_key_compaction_policy.cpp

--- a/be/src/storage/lake/async_file_deleter.h
+++ b/be/src/storage/lake/async_file_deleter.h
@@ -1,0 +1,129 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <future>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "common/config.h"
+#include "common/status.h"
+
+namespace starrocks::lake {
+std::future<Status> delete_files_callable(std::vector<std::string> files_to_delete);
+
+// AsyncFileDeleter
+// A class for asynchronously deleting files in batches.
+//
+// The AsyncFileDeleter class provides a mechanism to delete files in batches in an asynchronous manner.
+// It allows specifying the batch size, which determines the number of files to be deleted in each batch.
+class AsyncFileDeleter {
+public:
+    using DeleteCallback = std::function<void(const std::vector<std::string>&)>;
+
+    explicit AsyncFileDeleter(int64_t batch_size) : _batch_size(batch_size) {}
+    explicit AsyncFileDeleter(int64_t batch_size, DeleteCallback cb) : _batch_size(batch_size), _cb(std::move(cb)) {}
+    virtual ~AsyncFileDeleter() = default;
+
+    virtual Status delete_file(std::string path) {
+        _batch.emplace_back(std::move(path));
+        if (_batch.size() < _batch_size) {
+            return Status::OK();
+        }
+        return submit(&_batch);
+    }
+
+    virtual Status finish() {
+        if (!_batch.empty()) {
+            RETURN_IF_ERROR(submit(&_batch));
+        }
+        return wait();
+    }
+
+    int64_t delete_count() const { return _delete_count; }
+
+private:
+    // Wait for all submitted deletion tasks to finish and return task execution results.
+    Status wait() {
+        if (_prev_task_status.valid()) {
+            try {
+                return _prev_task_status.get();
+            } catch (const std::exception& e) {
+                return Status::InternalError(e.what());
+            }
+        } else {
+            return Status::OK();
+        }
+    }
+
+    Status submit(std::vector<std::string>* files_to_delete) {
+        // Await previous task completion before submitting a new deletion.
+        RETURN_IF_ERROR(wait());
+        _delete_count += files_to_delete->size();
+        if (_cb) {
+            _cb(*files_to_delete);
+        }
+        _prev_task_status = delete_files_callable(std::move(*files_to_delete));
+        files_to_delete->clear();
+        DCHECK(_prev_task_status.valid());
+        return Status::OK();
+    }
+
+    int64_t _batch_size;
+    int64_t _delete_count = 0;
+    std::vector<std::string> _batch;
+    std::future<Status> _prev_task_status;
+    DeleteCallback _cb;
+};
+
+// Used for delete files which are shared by multiple tablets, so we can't delete them at first.
+// We need to wait for all tablets to finish and decide whether to delete them.
+class AsyncBundleFileDeleter : public AsyncFileDeleter {
+public:
+    explicit AsyncBundleFileDeleter(int64_t batch_size) : AsyncFileDeleter(batch_size) {}
+
+    Status delete_file(std::string path) override {
+        _pending_files[path]++;
+        return Status::OK();
+    }
+
+    Status delay_delete(std::string path) {
+        _delay_delete_files.insert(std::move(path));
+        return Status::OK();
+    }
+
+    Status finish() override {
+        for (auto& [path, count] : _pending_files) {
+            if (_delay_delete_files.count(path) == 0) {
+                if (config::lake_print_delete_log) {
+                    LOG(INFO) << "Deleting bundle file: " << path << " ref count: " << count;
+                }
+                RETURN_IF_ERROR(AsyncFileDeleter::delete_file(path));
+            }
+        }
+        return AsyncFileDeleter::finish();
+    }
+
+    bool is_empty() const { return _pending_files.empty(); }
+
+private:
+    // file to shared count.
+    std::unordered_map<std::string, uint32_t> _pending_files;
+    std::unordered_set<std::string> _delay_delete_files;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -502,6 +502,45 @@ StatusOr<BundleTabletMetadataPtr> TabletManager::parse_bundle_tablet_metadata(co
     return bundle_metadata;
 }
 
+StatusOr<MutableTabletMetadataPtrs> TabletManager::get_metas_from_bundle_tablet_metadata(const std::string& location,
+                                                                                         FileSystem* input_fs) {
+    std::unique_ptr<RandomAccessFile> input_file;
+    RandomAccessFileOptions opts{.skip_fill_local_cache = true};
+    if (input_fs == nullptr) {
+        ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(location));
+        ASSIGN_OR_RETURN(input_file, fs->new_random_access_file(opts, location));
+    } else {
+        ASSIGN_OR_RETURN(input_file, input_fs->new_random_access_file(opts, location));
+    }
+    ASSIGN_OR_RETURN(auto serialized_string, input_file->read_all());
+
+    auto file_size = serialized_string.size();
+    ASSIGN_OR_RETURN(auto bundle_metadata, TabletManager::parse_bundle_tablet_metadata(location, serialized_string));
+    MutableTabletMetadataPtrs metadatas;
+    metadatas.reserve(bundle_metadata->tablet_meta_pages().size());
+    for (const auto& tablet_page : bundle_metadata->tablet_meta_pages()) {
+        const PagePointerPB& page_pointer = tablet_page.second;
+        auto offset = page_pointer.offset();
+        auto size = page_pointer.size();
+        RETURN_IF(offset + size > file_size,
+                  Status::InternalError(
+                          fmt::format("Invalid page pointer for tablet {}, offset: {}, size: {}, file size: {}",
+                                      tablet_page.first, offset, size, file_size)));
+
+        auto metadata = std::make_shared<starrocks::TabletMetadataPB>();
+        std::string_view metadata_str = std::string_view(serialized_string.data() + offset);
+        RETURN_IF(
+                !metadata->ParseFromArray(metadata_str.data(), size),
+                Status::InternalError(fmt::format("Failed to parse tablet metadata for tablet {}, offset: {}, size: {}",
+                                                  tablet_page.first, offset, size)));
+        RETURN_IF(metadata->id() != tablet_page.first,
+                  Status::InternalError(fmt::format("Tablet ID mismatch in bundle metadata, expected: {}, found: {}",
+                                                    tablet_page.first, metadata->id())));
+        metadatas.push_back(std::move(metadata));
+    }
+    return metadatas;
+}
+
 DEFINE_FAIL_POINT(tablet_schema_not_found_in_bundle_metadata);
 StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t tablet_id, int64_t version,
                                                                       bool fill_cache, int64_t expected_gtid,

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -502,8 +502,8 @@ StatusOr<BundleTabletMetadataPtr> TabletManager::parse_bundle_tablet_metadata(co
     return bundle_metadata;
 }
 
-StatusOr<MutableTabletMetadataPtrs> TabletManager::get_metas_from_bundle_tablet_metadata(const std::string& location,
-                                                                                         FileSystem* input_fs) {
+StatusOr<ImmutableTabletMetadataPtrs> TabletManager::get_metas_from_bundle_tablet_metadata(const std::string& location,
+                                                                                           FileSystem* input_fs) {
     std::unique_ptr<RandomAccessFile> input_file;
     RandomAccessFileOptions opts{.skip_fill_local_cache = true};
     if (input_fs == nullptr) {
@@ -516,7 +516,7 @@ StatusOr<MutableTabletMetadataPtrs> TabletManager::get_metas_from_bundle_tablet_
 
     auto file_size = serialized_string.size();
     ASSIGN_OR_RETURN(auto bundle_metadata, TabletManager::parse_bundle_tablet_metadata(location, serialized_string));
-    MutableTabletMetadataPtrs metadatas;
+    ImmutableTabletMetadataPtrs metadatas;
     metadatas.reserve(bundle_metadata->tablet_meta_pages().size());
     for (const auto& tablet_page : bundle_metadata->tablet_meta_pages()) {
         const PagePointerPB& page_pointer = tablet_page.second;

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -502,8 +502,8 @@ StatusOr<BundleTabletMetadataPtr> TabletManager::parse_bundle_tablet_metadata(co
     return bundle_metadata;
 }
 
-StatusOr<ImmutableTabletMetadataPtrs> TabletManager::get_metas_from_bundle_tablet_metadata(const std::string& location,
-                                                                                           FileSystem* input_fs) {
+StatusOr<TabletMetadataPtrs> TabletManager::get_metas_from_bundle_tablet_metadata(const std::string& location,
+                                                                                  FileSystem* input_fs) {
     std::unique_ptr<RandomAccessFile> input_file;
     RandomAccessFileOptions opts{.skip_fill_local_cache = true};
     if (input_fs == nullptr) {
@@ -516,7 +516,7 @@ StatusOr<ImmutableTabletMetadataPtrs> TabletManager::get_metas_from_bundle_table
 
     auto file_size = serialized_string.size();
     ASSIGN_OR_RETURN(auto bundle_metadata, TabletManager::parse_bundle_tablet_metadata(location, serialized_string));
-    ImmutableTabletMetadataPtrs metadatas;
+    TabletMetadataPtrs metadatas;
     metadatas.reserve(bundle_metadata->tablet_meta_pages().size());
     for (const auto& tablet_page : bundle_metadata->tablet_meta_pages()) {
         const PagePointerPB& page_pointer = tablet_page.second;

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -102,8 +102,8 @@ public:
     static StatusOr<BundleTabletMetadataPtr> parse_bundle_tablet_metadata(const std::string& path,
                                                                           const std::string& serialized_string);
 
-    static StatusOr<ImmutableTabletMetadataPtrs> get_metas_from_bundle_tablet_metadata(const std::string& location,
-                                                                                       FileSystem* input_fs = nullptr);
+    static StatusOr<TabletMetadataPtrs> get_metas_from_bundle_tablet_metadata(const std::string& location,
+                                                                              FileSystem* input_fs = nullptr);
 
     TabletMetadataPtr get_latest_cached_tablet_metadata(int64_t tablet_id);
 

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -102,8 +102,8 @@ public:
     static StatusOr<BundleTabletMetadataPtr> parse_bundle_tablet_metadata(const std::string& path,
                                                                           const std::string& serialized_string);
 
-    static StatusOr<MutableTabletMetadataPtrs> get_metas_from_bundle_tablet_metadata(const std::string& location,
-                                                                                     FileSystem* input_fs = nullptr);
+    static StatusOr<ImmutableTabletMetadataPtrs> get_metas_from_bundle_tablet_metadata(const std::string& location,
+                                                                                       FileSystem* input_fs = nullptr);
 
     TabletMetadataPtr get_latest_cached_tablet_metadata(int64_t tablet_id);
 

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -102,6 +102,9 @@ public:
     static StatusOr<BundleTabletMetadataPtr> parse_bundle_tablet_metadata(const std::string& path,
                                                                           const std::string& serialized_string);
 
+    static StatusOr<MutableTabletMetadataPtrs> get_metas_from_bundle_tablet_metadata(const std::string& location,
+                                                                                     FileSystem* input_fs = nullptr);
+
     TabletMetadataPtr get_latest_cached_tablet_metadata(int64_t tablet_id);
 
     StatusOr<TabletMetadataIter> list_tablet_metadata(int64_t tablet_id);

--- a/be/src/storage/lake/tablet_metadata.h
+++ b/be/src/storage/lake/tablet_metadata.h
@@ -24,6 +24,6 @@ using TabletMetadata = TabletMetadataPB;
 using TabletMetadataPtr = std::shared_ptr<const TabletMetadata>;
 using MutableTabletMetadataPtr = std::shared_ptr<TabletMetadata>;
 using BundleTabletMetadataPtr = std::shared_ptr<BundleTabletMetadataPB>;
-using MutableTabletMetadataPtrs = std::vector<MutableTabletMetadataPtr>;
+using ImmutableTabletMetadataPtrs = std::vector<TabletMetadataPtr>;
 
 } // namespace starrocks

--- a/be/src/storage/lake/tablet_metadata.h
+++ b/be/src/storage/lake/tablet_metadata.h
@@ -24,6 +24,6 @@ using TabletMetadata = TabletMetadataPB;
 using TabletMetadataPtr = std::shared_ptr<const TabletMetadata>;
 using MutableTabletMetadataPtr = std::shared_ptr<TabletMetadata>;
 using BundleTabletMetadataPtr = std::shared_ptr<BundleTabletMetadataPB>;
-using ImmutableTabletMetadataPtrs = std::vector<TabletMetadataPtr>;
+using TabletMetadataPtrs = std::vector<TabletMetadataPtr>;
 
 } // namespace starrocks

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1165,7 +1165,7 @@ static StatusOr<std::map<std::string, DirEntry>> list_data_files(FileSystem* fs,
                                                   return true;
                                               })),
             "Failed to list " + segment_root_location);
-    LOG(INFO) << "Listed all data files, total files: " << total_files << ", total bytes: " << total_bytes
+    LOG(INFO) << segment_root_location << ": Listed all data files, total files: " << total_files << ", total bytes: " << total_bytes
               << ", candidate files: " << data_files.size();
     return data_files;
 }
@@ -1444,13 +1444,13 @@ StatusOr<int64_t> garbage_file_check(std::string_view root_location) {
 }
 
 static Status vacuum_unspecified_tablet_metadata(
-    TabletManager* tablet_mgr, const std::string& partition_directory, int64_t partition_id, const std::set<int64_t>& tablet_ids,
+    TabletManager* tablet_mgr, const std::string& root_loc, int64_t partition_id, const std::set<int64_t>& tablet_ids,
     int64_t* vacuumed_files) {
     DCHECK(tablet_mgr != nullptr);
     DCHECK(vacuumed_files != nullptr);
 
-    const auto metadata_root_location = join_path(partition_directory, kMetadataDirectoryName);
-    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(partition_directory));
+    const auto metadata_root_location = join_path(root_loc, kMetadataDirectoryName);
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_loc));
     ASSIGN_OR_RETURN(auto meta_files, list_meta_files(fs.get(), metadata_root_location));
     auto metafile_delete_cb = [=](const std::vector<std::string>& files) {
         erase_tablet_metadata_from_metacache(tablet_mgr, files);
@@ -1459,7 +1459,9 @@ static Status vacuum_unspecified_tablet_metadata(
     for (const auto& name : meta_files) {
         auto [tablet_id, version] = parse_tablet_metadata_filename(name);
         if (!tablet_ids.contains(tablet_id)) {
-            RETURN_IF_ERROR(metafile_deleter.delete_file(join_path(metadata_root_location, name)));
+            const string path = join_path(metadata_root_location, name);
+            LOG(INFO) << "Try delete for full vacuum: " << path;
+            RETURN_IF_ERROR(metafile_deleter.delete_file(path));
         }
     }
 
@@ -1473,12 +1475,12 @@ static Status vacuum_unspecified_tablet_metadata(
 // Returns the number of files vacuumed and their total size
 static StatusOr<std::pair<int64_t, int64_t>> vacuum_orphaned_datafiles(
     TabletManager* tablet_mgr,
-    std::string_view partition_directory,
+    std::string_view root_loc,
     int64_t max_check_version,
     int64_t min_active_txn_id) {
-    const auto metadata_root_location = join_path(partition_directory, kMetadataDirectoryName);
-    const auto segment_root_location = join_path(partition_directory, kSegmentDirectoryName);
-    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(partition_directory));
+    const auto metadata_root_location = join_path(root_loc, kMetadataDirectoryName);
+    const auto segment_root_location = join_path(root_loc, kSegmentDirectoryName);
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_loc));
 
     LOG(INFO) << "Listing files at " << segment_root_location << " to look for orphaned files";
     ASSIGN_OR_RETURN(auto data_files_to_vacuum, list_data_files(fs.get(), segment_root_location, /*expired_seconds=*/0));
@@ -1488,14 +1490,14 @@ static StatusOr<std::pair<int64_t, int64_t>> vacuum_orphaned_datafiles(
         return std::pair(0, 0);
     }
 
-    LOG(INFO) << "Starting to filter out files created by txn >= " << min_active_txn_id;
+    LOG(INFO) << segment_root_location << ": " << "Starting to filter out files at created by txn >= " << min_active_txn_id;
     const auto original_size = data_files_to_vacuum.size();
     std::erase_if(data_files_to_vacuum, [&](const auto& elem) {
         const auto& name = elem.first;
         const auto txn_id = extract_txn_id_prefix(name).value_or(0);
         return txn_id >= min_active_txn_id;
     });
-    LOG(INFO) << "Removed " << original_size - data_files_to_vacuum.size() << " data files from consideration as orphans based on txn id";
+    LOG(INFO) << segment_root_location << ": " << "Removed " << original_size - data_files_to_vacuum.size() << " data files from consideration as orphans based on txn id";
 
     ASSIGN_OR_RETURN(auto meta_files, list_meta_files(fs.get(), metadata_root_location));
 
@@ -1513,7 +1515,7 @@ static StatusOr<std::pair<int64_t, int64_t>> vacuum_orphaned_datafiles(
         }
     };
 
-    LOG(INFO) << "Start to filter with metadatas, count: " << meta_files.size();
+    LOG(INFO) << segment_root_location << ": " << "Start to filter with metadatas, count: " << meta_files.size();
 
     int64_t progress = 0;
     for (const auto& name : meta_files) {
@@ -1536,11 +1538,11 @@ static StatusOr<std::pair<int64_t, int64_t>> vacuum_orphaned_datafiles(
         for (const auto& rowset : metadata->rowsets()) {
             check_rowset(rowset);
         }
-        check_sst_meta(metadata->sstable_meta());\
+        check_sst_meta(metadata->sstable_meta());
         LOG(INFO) << "Filtered with meta file: " << name << " (" << progress << '/' << meta_files.size() << ')';
     }
 
-    LOG(INFO) << "Found " << data_files_to_vacuum.size() << " orphaned files to delete";
+    LOG(INFO) << segment_root_location << ": " << "Found " << data_files_to_vacuum.size() << " orphaned files to delete";
 
     int64_t bytes_to_delete = 0;
     std::vector<std::string> files_to_delete;
@@ -1549,7 +1551,7 @@ static StatusOr<std::pair<int64_t, int64_t>> vacuum_orphaned_datafiles(
         bytes_to_delete += dir_entry.size.value_or(0);
         files_to_delete.push_back(join_path(segment_root_location, name));
     }
-    LOG(INFO) << "Start to delete orphan data files: " << data_files_to_vacuum.size()
+    LOG(INFO) << segment_root_location << ": " << "Start to delete orphan data files: " << data_files_to_vacuum.size()
               << ", total size: " << bytes_to_delete;
 
     RETURN_IF_ERROR(do_delete_files(fs.get(), files_to_delete));
@@ -1585,18 +1587,13 @@ Status vacuum_full_impl(TabletManager* tablet_mgr, const VacuumFullRequest& requ
     auto tablet_infos = std::vector<TabletInfoPB>();
     tablet_infos.reserve(request.tablet_ids_size());
     std::set<int64_t> tablet_ids_set;
-    std::set<std::string> root_locations;
     for (const auto& tablet_id : request.tablet_ids()) {
         auto& tablet_info = tablet_infos.emplace_back();
         tablet_info.set_tablet_id(tablet_id);
         tablet_info.set_min_version(0);
         tablet_ids_set.insert(tablet_id);
-        root_locations.insert(tablet_mgr->tablet_root_location(tablet_id));
     }
-    if (UNLIKELY(root_locations.size() != 1)) {
-        return Status::InvalidArgument("tablet_ids are not in the same partition");
-    }
-    const std::string partition_directory = *(root_locations.begin());
+    const std::string root_loc = tablet_mgr->tablet_root_location(request.tablet_ids().at(0));
     const auto min_check_version = request.min_check_version();
     const auto max_check_version = request.max_check_version();
     const auto min_active_txn_id = request.min_active_txn_id();
@@ -1611,17 +1608,17 @@ Status vacuum_full_impl(TabletManager* tablet_mgr, const VacuumFullRequest& requ
     // (tablet_id not in request.tablet_ids OR version < min_check_version)
 
     // 1a. Delete all metadata files associated with the given partition which are not in the list of tablet_ids
-    RETURN_IF_ERROR(vacuum_unspecified_tablet_metadata(tablet_mgr, partition_directory, partition_id, tablet_ids_set, &vacuumed_files));
+    RETURN_IF_ERROR(vacuum_unspecified_tablet_metadata(tablet_mgr, root_loc, partition_id, tablet_ids_set, &vacuumed_files));
 
     // 1b. Delete all metadata files associated with the given partition which have version < min_check_version
     int64_t unused_tablet_version;
-    RETURN_IF_ERROR(vacuum_tablet_metadata(tablet_mgr, partition_directory, tablet_infos, min_check_version, /*grace_timestamp=*/0,
+    RETURN_IF_ERROR(vacuum_tablet_metadata(tablet_mgr, root_loc, tablet_infos, min_check_version, /*grace_timestamp=*/0,
                                            &vacuumed_files, &vacuumed_file_size, &unused_tablet_version));
-    RETURN_IF_ERROR(vacuum_txn_log(partition_directory, min_active_txn_id, &vacuumed_files, &vacuumed_file_size));
+    RETURN_IF_ERROR(vacuum_txn_log(root_loc, min_active_txn_id, &vacuumed_files, &vacuumed_file_size));
 
     // 2. Determine and delete orphaned data files. We use min_active_txn_id to filter out new data files, then we open
     // any remaining metadata files with version <= max_check_version and note that the data files referenced are not orphans.
-    ASSIGN_OR_RETURN(auto count_and_size, vacuum_orphaned_datafiles(tablet_mgr, partition_directory, max_check_version, min_active_txn_id));
+    ASSIGN_OR_RETURN(auto count_and_size, vacuum_orphaned_datafiles(tablet_mgr, root_loc, max_check_version, min_active_txn_id));
     vacuumed_files += count_and_size.first;
     vacuumed_file_size += count_and_size.second;
 

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -402,6 +402,10 @@ static size_t collect_extra_files_size(const TabletMetadataPB& metadata, int64_t
     return extra_file_size;
 }
 
+// Tablet metadata files with version numbers greater than or equal to min_retain_version will NOT be vacuumed.
+// grace_timestamp marks the point after which created tablet metadata files will not be vacuumed.
+// In addition to retaining all versions after grace_timestamp, retain the last version before
+// grace_timestamp. Set to 0 to not use
 static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_view root_dir, TabletInfoPB& tablet_info,
                                       int64_t grace_timestamp, int64_t min_retain_version,
                                       VacuumTabletMetaVerionRange* vacuum_version_range,
@@ -523,6 +527,10 @@ static void erase_tablet_metadata_from_metacache(TabletManager* tablet_mgr, cons
     }
 }
 
+// Tablet metadata files with version numbers greater than or equal to min_retain_version will NOT be vacuumed.
+// grace_timestamp marks the point after which created tablet metadata files will not be vacuumed.
+// In addition to retaining all versions after grace_timestamp, retain the last version before
+// grace_timestamp. Set to 0 to not use
 static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view root_dir,
                                      std::vector<TabletInfoPB>& tablet_infos, int64_t min_retain_version,
                                      int64_t grace_timestamp, bool enable_file_bundling, int64_t* vacuumed_files,
@@ -715,14 +723,6 @@ void vacuum(TabletManager* tablet_mgr, const VacuumRequest& request, VacuumRespo
     st.to_protobuf(response->mutable_status());
 }
 
-Status vacuum_full_impl(TabletManager* tablet_mgr, const VacuumFullRequest& request, VacuumFullResponse* response) {
-    return Status::NotSupported("vacuum_full not implemented yet");
-}
-
-void vacuum_full(TabletManager* tablet_mgr, const VacuumFullRequest& request, VacuumFullResponse* response) {
-    auto st = vacuum_full_impl(tablet_mgr, request, response);
-    st.to_protobuf(response->mutable_status());
-}
 
 // The state of the bundle tablet meta, used to determine whether the bundle file can be deleted.
 // ALL_TABLETS_TO_BE_DELETED means all tablets in this bundle tablet meta are going to be deleted,
@@ -1441,6 +1441,198 @@ StatusOr<int64_t> datafile_gc(std::string_view root_location, std::string_view a
 
 StatusOr<int64_t> garbage_file_check(std::string_view root_location) {
     return datafile_gc(root_location, "", 0, false);
+}
+
+static Status vacuum_unspecified_tablet_metadata(
+    TabletManager* tablet_mgr, const std::string& partition_directory, int64_t partition_id, const std::set<int64_t>& tablet_ids,
+    int64_t* vacuumed_files) {
+    DCHECK(tablet_mgr != nullptr);
+    DCHECK(vacuumed_files != nullptr);
+
+    const auto metadata_root_location = join_path(partition_directory, kMetadataDirectoryName);
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(partition_directory));
+    ASSIGN_OR_RETURN(auto meta_files, list_meta_files(fs.get(), metadata_root_location));
+    auto metafile_delete_cb = [=](const std::vector<std::string>& files) {
+        erase_tablet_metadata_from_metacache(tablet_mgr, files);
+    };
+    AsyncFileDeleter metafile_deleter(INT64_MAX, metafile_delete_cb);
+    for (const auto& name : meta_files) {
+        auto [tablet_id, version] = parse_tablet_metadata_filename(name);
+        if (!tablet_ids.contains(tablet_id)) {
+            RETURN_IF_ERROR(metafile_deleter.delete_file(join_path(metadata_root_location, name)));
+        }
+    }
+
+    RETURN_IF_ERROR(metafile_deleter.finish());
+    (*vacuumed_files) += metafile_deleter.delete_count();
+    return Status::OK();
+} 
+// Deletes orphaned data files (data files which are not referenced by "relevant" metadata files)
+// A relevant metadata file has a version <= max_check_version
+// Data files written by transactions with txn_id >= min_active_txn_id will NOT be vacuumed
+// Returns the number of files vacuumed and their total size
+static StatusOr<std::pair<int64_t, int64_t>> vacuum_orphaned_datafiles(
+    TabletManager* tablet_mgr,
+    std::string_view partition_directory,
+    int64_t max_check_version,
+    int64_t min_active_txn_id) {
+    const auto metadata_root_location = join_path(partition_directory, kMetadataDirectoryName);
+    const auto segment_root_location = join_path(partition_directory, kSegmentDirectoryName);
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(partition_directory));
+
+    LOG(INFO) << "Listing files at " << segment_root_location << " to look for orphaned files";
+    ASSIGN_OR_RETURN(auto data_files_to_vacuum, list_data_files(fs.get(), segment_root_location, /*expired_seconds=*/0));
+
+    if (data_files_to_vacuum.empty()) {
+        LOG(INFO) << "Found no files at " << segment_root_location;
+        return std::pair(0, 0);
+    }
+
+    LOG(INFO) << "Starting to filter out files created by txn >= " << min_active_txn_id;
+    const auto original_size = data_files_to_vacuum.size();
+    std::erase_if(data_files_to_vacuum, [&](const auto& elem) {
+        const auto& name = elem.first;
+        const auto txn_id = extract_txn_id_prefix(name).value_or(0);
+        return txn_id >= min_active_txn_id;
+    });
+    LOG(INFO) << "Removed " << original_size - data_files_to_vacuum.size() << " data files from consideration as orphans based on txn id";
+
+    ASSIGN_OR_RETURN(auto meta_files, list_meta_files(fs.get(), metadata_root_location));
+
+    std::set<std::string> data_files_in_metadatas;
+    auto check_rowset = [&](const RowsetMetadata& rowset) {
+        for (const auto& segment : rowset.segments()) {
+            data_files_to_vacuum.erase(segment);
+            data_files_in_metadatas.emplace(segment);
+        }
+    };
+    auto check_sst_meta = [&](const PersistentIndexSstableMetaPB& sst_meta) {
+        for (const auto& sst : sst_meta.sstables()) {
+            data_files_to_vacuum.erase(sst.filename());
+            data_files_in_metadatas.emplace(sst.filename());
+        }
+    };
+
+    LOG(INFO) << "Start to filter with metadatas, count: " << meta_files.size();
+
+    int64_t progress = 0;
+    for (const auto& name : meta_files) {
+        ++progress;
+        auto location = join_path(metadata_root_location, name);
+        auto res = get_tablet_metadata(location, false);
+        if (res.status().is_not_found()) { // This metadata file was deleted by another node
+            LOG(INFO) << location << " is deleted by other node";
+            continue;
+        } else if (!res.ok()) {
+            LOG(WARNING) << "Failed to get meta file: " << location << ", status: " << res.status();
+            continue;
+        }
+        const auto& metadata = res.value();
+        const auto& version = metadata->version();
+        if (version > max_check_version) {
+            LOG(INFO) << "Skipping use of " << name << " to see which data files it references.";
+            continue;
+        }
+        for (const auto& rowset : metadata->rowsets()) {
+            check_rowset(rowset);
+        }
+        check_sst_meta(metadata->sstable_meta());\
+        LOG(INFO) << "Filtered with meta file: " << name << " (" << progress << '/' << meta_files.size() << ')';
+    }
+
+    LOG(INFO) << "Found " << data_files_to_vacuum.size() << " orphaned files to delete";
+
+    int64_t bytes_to_delete = 0;
+    std::vector<std::string> files_to_delete;
+    files_to_delete.reserve(data_files_to_vacuum.size());
+    for (const auto& [name, dir_entry] : data_files_to_vacuum) {
+        bytes_to_delete += dir_entry.size.value_or(0);
+        files_to_delete.push_back(join_path(segment_root_location, name));
+    }
+    LOG(INFO) << "Start to delete orphan data files: " << data_files_to_vacuum.size()
+              << ", total size: " << bytes_to_delete;
+
+    RETURN_IF_ERROR(do_delete_files(fs.get(), files_to_delete));
+
+    return std::pair<int64_t, int64_t>(files_to_delete.size(), bytes_to_delete);
+}
+
+Status vacuum_full_impl(TabletManager* tablet_mgr, const VacuumFullRequest& request, VacuumFullResponse* response) {
+    if (UNLIKELY(tablet_mgr == nullptr)) {
+        return Status::InvalidArgument("tablet_mgr is null");
+    }
+    if (UNLIKELY(request.partition_id() == 0)) {
+        return Status::InvalidArgument("partition_id is unset");
+    }
+    if (UNLIKELY(request.tablet_ids_size() == 0)) {
+        return Status::InvalidArgument("tablet_ids is empty");
+    }
+    // min_check_version should be set to 1 if we want to check all versions, never 0
+    if (UNLIKELY(request.min_check_version() <= 0)) {
+        return Status::InvalidArgument("value of min_check_version is unset or negative");
+    }
+    if (UNLIKELY(request.max_check_version() <= 0)) {
+        return Status::InvalidArgument("value of max_check_version is unset or negative");
+    }
+    if (UNLIKELY(request.max_check_version() <= request.min_check_version())) {
+        return Status::InvalidArgument("value of max_check_version is less than or equal to min_check_version");
+    }
+    if (UNLIKELY(request.min_active_txn_id() <= 0)) {
+        return Status::InvalidArgument("value of min_active_txn_id is unset or nagative");
+    }
+    
+    const auto partition_id = request.partition_id();
+    auto tablet_infos = std::vector<TabletInfoPB>();
+    tablet_infos.reserve(request.tablet_ids_size());
+    std::set<int64_t> tablet_ids_set;
+    std::set<std::string> root_locations;
+    for (const auto& tablet_id : request.tablet_ids()) {
+        auto& tablet_info = tablet_infos.emplace_back();
+        tablet_info.set_tablet_id(tablet_id);
+        tablet_info.set_min_version(0);
+        tablet_ids_set.insert(tablet_id);
+        root_locations.insert(tablet_mgr->tablet_root_location(tablet_id));
+    }
+    if (UNLIKELY(root_locations.size() != 1)) {
+        return Status::InvalidArgument("tablet_ids are not in the same partition");
+    }
+    const std::string partition_directory = *(root_locations.begin());
+    const auto min_check_version = request.min_check_version();
+    const auto max_check_version = request.max_check_version();
+    const auto min_active_txn_id = request.min_active_txn_id();
+
+    int64_t vacuumed_files = 0;
+    int64_t vacuumed_file_size = 0;
+
+    std::sort(tablet_infos.begin(), tablet_infos.end(),
+              [](const auto& a, const auto& b) { return a.tablet_id() < b.tablet_id(); });
+
+    // 1. Before the orphaned data file cleanup even starts, delete metadata files which satisfy the following:
+    // (tablet_id not in request.tablet_ids OR version < min_check_version)
+
+    // 1a. Delete all metadata files associated with the given partition which are not in the list of tablet_ids
+    RETURN_IF_ERROR(vacuum_unspecified_tablet_metadata(tablet_mgr, partition_directory, partition_id, tablet_ids_set, &vacuumed_files));
+
+    // 1b. Delete all metadata files associated with the given partition which have version < min_check_version
+    int64_t unused_tablet_version;
+    RETURN_IF_ERROR(vacuum_tablet_metadata(tablet_mgr, partition_directory, tablet_infos, min_check_version, /*grace_timestamp=*/0,
+                                           &vacuumed_files, &vacuumed_file_size, &unused_tablet_version));
+    RETURN_IF_ERROR(vacuum_txn_log(partition_directory, min_active_txn_id, &vacuumed_files, &vacuumed_file_size));
+
+    // 2. Determine and delete orphaned data files. We use min_active_txn_id to filter out new data files, then we open
+    // any remaining metadata files with version <= max_check_version and note that the data files referenced are not orphans.
+    ASSIGN_OR_RETURN(auto count_and_size, vacuum_orphaned_datafiles(tablet_mgr, partition_directory, max_check_version, min_active_txn_id));
+    vacuumed_files += count_and_size.first;
+    vacuumed_file_size += count_and_size.second;
+
+    response->set_vacuumed_files(vacuumed_files);
+    response->set_vacuumed_file_size(vacuumed_file_size);
+    return Status::OK();
+}
+
+void vacuum_full(TabletManager* tablet_mgr, const VacuumFullRequest& request, VacuumFullResponse* response) {
+    auto st = vacuum_full_impl(tablet_mgr, request, response);
+    st.to_protobuf(response->mutable_status());
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/vacuum_full.cpp
+++ b/be/src/storage/lake/vacuum_full.cpp
@@ -1,0 +1,292 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/vacuum_full.h"
+
+#include <set>
+#include <string_view>
+
+#include "common/status.h"
+#include "fs/fs.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/metacache.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_metadata.h"
+#include "storage/lake/vacuum.h"
+#include "storage/protobuf_file.h"
+
+namespace starrocks::lake {
+
+static Status vacuum_unspecified_tablet_metadata(TabletManager* tablet_mgr, std::string_view root_loc,
+                                                 const std::set<int64_t>& tablet_ids, int64_t* vacuumed_files,
+                                                 std::list<std::string>* meta_files,
+                                                 std::list<std::string>* bundle_meta_files) {
+    DCHECK(tablet_mgr != nullptr);
+    DCHECK(vacuumed_files != nullptr);
+    DCHECK(meta_files != nullptr);
+    DCHECK(bundle_meta_files != nullptr);
+
+    auto metafile_delete_cb = [=](const std::vector<std::string>& files) {
+        auto cache = tablet_mgr->metacache();
+        DCHECK(cache != nullptr);
+        for (const auto& path : files) {
+            cache->erase(path);
+        }
+    };
+    AsyncFileDeleter metafile_deleter(INT64_MAX, metafile_delete_cb);
+    std::vector<std::string> unspecified_metas;
+    std::vector<std::string> bundle_unspecified_metas;
+    const auto metadata_root_location = join_path(root_loc, kMetadataDirectoryName);
+    for (const auto& name : *meta_files) {
+        auto [tablet_id, version] = parse_tablet_metadata_filename(name);
+        const string path = join_path(metadata_root_location, name);
+        ASSIGN_OR_RETURN(auto metadata, tablet_mgr->get_tablet_metadata(tablet_id, version, false));
+        if (!tablet_ids.contains(tablet_id) &&
+            metadata->version() != kInitialVersion /* filtered out meta created from alter job */) {
+            LOG(INFO) << "Try delete for full vacuum: " << path;
+            RETURN_IF_ERROR(metafile_deleter.delete_file(path));
+            unspecified_metas.push_back(name);
+        }
+    }
+    for (const auto& unspecified_meta : unspecified_metas) {
+        meta_files->remove(unspecified_meta);
+    }
+
+    std::vector<int64_t> tablet_ids_vec(tablet_ids.begin(), tablet_ids.end());
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_loc));
+    for (const auto& name : *bundle_meta_files) {
+        auto path = join_path(metadata_root_location, name);
+        bool need_clear = true;
+        ASSIGN_OR_RETURN(auto metadatas, TabletManager::get_metas_from_bundle_tablet_metadata(path, fs.get()));
+        for (const auto& metadata : metadatas) {
+            DCHECK(metadata->version() != kInitialVersion);
+            // make sure all reserved tablet ids should not existed in metadata
+            if (tablet_ids.contains(metadata->id())) {
+                need_clear = false;
+                break;
+            }
+        }
+        if (need_clear) {
+            LOG(INFO) << "Try delete for full vacuum: " << path;
+            RETURN_IF_ERROR(metafile_deleter.delete_file(path));
+            bundle_unspecified_metas.push_back(name);
+        }
+    }
+    for (const auto& bundle_unspecified_meta : bundle_unspecified_metas) {
+        bundle_meta_files->remove(bundle_unspecified_meta);
+    }
+
+    RETURN_IF_ERROR(metafile_deleter.finish());
+    (*vacuumed_files) += metafile_deleter.delete_count();
+    return Status::OK();
+}
+
+static Status vacuum_expired_tablet_metadata(TabletManager* tablet_mgr, std::string_view root_loc,
+                                             int64_t grace_timestamp, int64_t* vacuumed_files,
+                                             std::list<std::string>* meta_files,
+                                             std::list<std::string>* bundle_meta_files,
+                                             const std::unordered_set<int64_t>& retain_versions) {
+    DCHECK(tablet_mgr != nullptr);
+    DCHECK(meta_files != nullptr);
+    DCHECK(bundle_meta_files != nullptr);
+    if (grace_timestamp == 0) {
+        // no expired metadata to be vacuumed
+        return Status::OK();
+    }
+
+    auto metafile_delete_cb = [=](const std::vector<std::string>& files) {
+        auto cache = tablet_mgr->metacache();
+        DCHECK(cache != nullptr);
+        for (const auto& path : files) {
+            cache->erase(path);
+        }
+    };
+    AsyncFileDeleter metafile_deleter(INT64_MAX, metafile_delete_cb);
+    std::vector<std::string> expired_metas;
+    std::vector<std::string> bundle_expired_metas;
+    const auto metadata_root_location = join_path(root_loc, kMetadataDirectoryName);
+    for (const auto& name : *meta_files) {
+        auto [tablet_id, version] = parse_tablet_metadata_filename(name);
+        if (retain_versions.contains(version)) {
+            continue;
+        }
+        const string path = join_path(metadata_root_location, name);
+        ASSIGN_OR_RETURN(auto metadata, tablet_mgr->get_tablet_metadata(tablet_id, version, false));
+        if (metadata->commit_time() <= grace_timestamp) {
+            LOG(INFO) << "Try delete for full vacuum: " << path;
+            RETURN_IF_ERROR(metafile_deleter.delete_file(path));
+            expired_metas.push_back(name);
+        }
+    }
+    for (const auto& expired_meta : expired_metas) {
+        meta_files->remove(expired_meta);
+    }
+
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_loc));
+    for (const auto& name : *bundle_meta_files) {
+        auto [tablet_id, version] = parse_tablet_metadata_filename(name);
+        if (retain_versions.contains(version)) {
+            continue;
+        }
+        auto path = join_path(metadata_root_location, name);
+        bool need_clear = true;
+        ASSIGN_OR_RETURN(auto metadatas, TabletManager::get_metas_from_bundle_tablet_metadata(path, fs.get()));
+        for (const auto& metadata : metadatas) {
+            if (metadata->commit_time() > grace_timestamp) {
+                need_clear = false;
+                break;
+            }
+        }
+        if (need_clear) {
+            LOG(INFO) << "Try delete for full vacuum: " << path;
+            RETURN_IF_ERROR(metafile_deleter.delete_file(path));
+            bundle_expired_metas.push_back(name);
+        }
+    }
+    for (const auto& bundle_expired_meta : bundle_expired_metas) {
+        bundle_meta_files->remove(bundle_expired_meta);
+    }
+
+    RETURN_IF_ERROR(metafile_deleter.finish());
+    (*vacuumed_files) += metafile_deleter.delete_count();
+    return Status::OK();
+}
+
+// Deletes orphaned data files (data files which are not referenced by "relevant" metadata files)
+// Data files written by transactions with txn_id >= min_active_txn_id will NOT be vacuumed
+// Returns the number of files vacuumed and their total size
+static StatusOr<std::pair<int64_t, int64_t>> vacuum_orphaned_datafiles(
+        TabletManager* tablet_mgr, std::string_view root_loc, int64_t min_active_txn_id,
+        const std::list<std::string>& meta_files, const std::list<std::string>& bundle_meta_files) {
+    DCHECK(tablet_mgr != nullptr);
+    const auto segment_root_location = join_path(root_loc, kSegmentDirectoryName);
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_loc));
+    ASSIGN_OR_RETURN(auto data_files_to_vacuum,
+                     find_orphan_data_files(fs.get(), root_loc, 0, meta_files, bundle_meta_files, nullptr));
+    const auto original_size = data_files_to_vacuum.size();
+    std::erase_if(data_files_to_vacuum, [&](const auto& elem) {
+        const auto& name = elem.first;
+        const auto txn_id = extract_txn_id_prefix(name).value_or(0);
+        return txn_id == 0 || txn_id >= min_active_txn_id;
+    });
+    LOG(INFO) << segment_root_location << ": "
+              << "Removed " << original_size - data_files_to_vacuum.size()
+              << " data files from consideration as orphans based on txn id";
+
+    int64_t bytes_to_delete = 0;
+    std::vector<std::string> files_to_delete;
+    files_to_delete.reserve(data_files_to_vacuum.size());
+    for (const auto& [name, dir_entry] : data_files_to_vacuum) {
+        bytes_to_delete += dir_entry.size.value_or(0);
+        files_to_delete.push_back(join_path(segment_root_location, name));
+    }
+    LOG(INFO) << segment_root_location << ": "
+              << "Start to delete orphan data files: " << data_files_to_vacuum.size()
+              << ", total size: " << bytes_to_delete;
+
+    RETURN_IF_ERROR(do_delete_files(fs.get(), files_to_delete));
+
+    return std::pair<int64_t, int64_t>(files_to_delete.size(), bytes_to_delete);
+}
+
+Status vacuum_full_impl(TabletManager* tablet_mgr, const VacuumFullRequest& request, VacuumFullResponse* response) {
+    if (UNLIKELY(tablet_mgr == nullptr)) {
+        return Status::InvalidArgument("tablet_mgr is null");
+    }
+    if (UNLIKELY(request.partition_id() == 0)) {
+        return Status::InvalidArgument("partition_id is unset");
+    }
+    if (UNLIKELY(request.tablet_ids_size() == 0)) {
+        return Status::InvalidArgument("tablet_ids is empty");
+    }
+    if (UNLIKELY(request.min_active_txn_id() <= 0)) {
+        return Status::InvalidArgument("value of min_active_txn_id is unset or negative");
+    }
+    if (UNLIKELY(request.grace_timestamp() < 0)) {
+        return Status::InvalidArgument("value of grace_timestamp is unset or negative");
+    }
+    if (UNLIKELY(request.min_check_version() < 0)) {
+        return Status::InvalidArgument("value of min_check_version is unset or negative");
+    }
+    if (UNLIKELY(request.max_check_version() < 0)) {
+        return Status::InvalidArgument("value of max_check_version is unset or negative");
+    }
+
+    // init all relative request context
+    std::set<int64_t> tablet_ids_set;
+    for (const auto& tablet_id : request.tablet_ids()) {
+        tablet_ids_set.insert(tablet_id);
+    }
+    const auto grace_timestamp = request.grace_timestamp();
+    const auto min_active_txn_id = request.min_active_txn_id();
+    std::unordered_set<int64_t> retain_versions;
+    if (request.retain_versions_size() > 0) {
+        retain_versions.insert(request.retain_versions().begin(), request.retain_versions().end());
+    }
+    int64_t min_check_version = request.min_check_version();
+    int64_t max_check_version = request.max_check_version();
+    // protect the max check version
+    retain_versions.insert(max_check_version);
+
+    int64_t vacuumed_files = 0;
+    int64_t vacuumed_file_size = 0;
+
+    const std::string root_loc = tablet_mgr->tablet_root_location(request.tablet_ids().at(0));
+    const auto metadata_root_location = join_path(root_loc, kMetadataDirectoryName);
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_loc));
+    ASSIGN_OR_RETURN(auto meta_files_and_bundle_files, list_meta_files(fs.get(), metadata_root_location));
+    auto& meta_files = meta_files_and_bundle_files.first;
+    auto& bundle_meta_files = meta_files_and_bundle_files.second;
+    // filter metas by check version interval
+    auto meta_filter = [min_check_version, max_check_version](auto& metas) {
+        std::erase_if(metas, [&](auto& meta_file) {
+            const auto& [_, version] = parse_tablet_metadata_filename(meta_file);
+            return version < min_check_version || version > max_check_version;
+        });
+    };
+    meta_filter(meta_files);
+    meta_filter(bundle_meta_files);
+
+    // 1. Before the orphaned data file cleanup even starts, delete metadata files which satisfy the following:
+    // (tablet_id not in request.tablet_ids OR tabletmeta.commit_time < grace_timestamp)
+
+    // 1a. Delete all metadata files associated with the given partition which are not in the list of tablet_ids
+    RETURN_IF_ERROR(vacuum_unspecified_tablet_metadata(tablet_mgr, root_loc, tablet_ids_set, &vacuumed_files,
+                                                       &meta_files, &bundle_meta_files));
+    // 1b. Delete all metadata files associated with the given partition which have tabletmeta.commit_time < grace_timestamp
+    // and the version of tablet meta should not be found in retain_versions
+    RETURN_IF_ERROR(vacuum_expired_tablet_metadata(tablet_mgr, root_loc, grace_timestamp, &vacuumed_files, &meta_files,
+                                                   &bundle_meta_files, retain_versions));
+
+    // 2. Determine and delete orphaned data files. We use min_active_txn_id to filter out new data files, then we open
+    // any remaining metadata files and note that the data files referenced are not orphans.
+    ASSIGN_OR_RETURN(auto count_and_size,
+                     vacuum_orphaned_datafiles(tablet_mgr, root_loc, min_active_txn_id, meta_files, bundle_meta_files));
+    vacuumed_files += count_and_size.first;
+    vacuumed_file_size += count_and_size.second;
+
+    // 3. deleted txn log which have txn id < min_active_txn_id
+    RETURN_IF_ERROR(vacuum_txn_log(root_loc, min_active_txn_id, &vacuumed_files, &vacuumed_file_size));
+
+    response->set_vacuumed_files(vacuumed_files);
+    response->set_vacuumed_file_size(vacuumed_file_size);
+    return Status::OK();
+}
+
+void vacuum_full(TabletManager* tablet_mgr, const VacuumFullRequest& request, VacuumFullResponse* response) {
+    auto st = vacuum_full_impl(tablet_mgr, request, response);
+    st.to_protobuf(response->mutable_status());
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/vacuum_full.cpp
+++ b/be/src/storage/lake/vacuum_full.cpp
@@ -59,7 +59,7 @@ static Status vacuum_expired_tablet_metadata(TabletManager* tablet_mgr, std::str
         }
         const string path = join_path(metadata_root_location, name);
         ASSIGN_OR_RETURN(auto metadata, tablet_mgr->get_tablet_metadata(tablet_id, version, false));
-        if (metadata->commit_time() <= grace_timestamp) {
+        if (metadata->commit_time() < grace_timestamp) {
             LOG(INFO) << "Try delete for full vacuum: " << path;
             RETURN_IF_ERROR(metafile_deleter.delete_file(path));
             expired_metas.push_back(name);
@@ -79,7 +79,7 @@ static Status vacuum_expired_tablet_metadata(TabletManager* tablet_mgr, std::str
         bool need_clear = true;
         ASSIGN_OR_RETURN(auto metadatas, TabletManager::get_metas_from_bundle_tablet_metadata(path, fs.get()));
         for (const auto& metadata : metadatas) {
-            if (metadata->commit_time() > grace_timestamp) {
+            if (metadata->commit_time() >= grace_timestamp) {
                 need_clear = false;
                 break;
             }

--- a/be/src/storage/lake/vacuum_full.cpp
+++ b/be/src/storage/lake/vacuum_full.cpp
@@ -43,7 +43,7 @@ static Status vacuum_expired_tablet_metadata(TabletManager* tablet_mgr, std::str
     }
 
     auto meta_ver_checker = [&](const auto& version) {
-        return version >= min_check_version && version <= max_check_version && !retain_versions.contains(version);
+        return version >= min_check_version && version < max_check_version && !retain_versions.contains(version);
     };
 
     auto metafile_delete_cb = [=](const std::vector<std::string>& files) {
@@ -184,7 +184,7 @@ Status vacuum_full_impl(TabletManager* tablet_mgr, const VacuumFullRequest& requ
     auto& bundle_meta_files = meta_files_and_bundle_files.second;
 
     // 1. Delete all metadata files associated with the given partition which have tabletmeta.commit_time < grace_timestamp
-    // and the checked version of tablet meta should not be found in retain_versions and should in [min_check_version, max_check_version]
+    // and the checked version of tablet meta should not be found in retain_versions and should in [min_check_version, max_check_version)
     RETURN_IF_ERROR(vacuum_expired_tablet_metadata(tablet_mgr, root_loc, grace_timestamp, &vacuumed_files, &meta_files,
                                                    &bundle_meta_files, retain_versions, min_check_version,
                                                    max_check_version));

--- a/be/src/storage/lake/vacuum_full.cpp
+++ b/be/src/storage/lake/vacuum_full.cpp
@@ -186,7 +186,8 @@ Status vacuum_full_impl(TabletManager* tablet_mgr, const VacuumFullRequest& requ
     // 1. Delete all metadata files associated with the given partition which have tabletmeta.commit_time < grace_timestamp
     // and the checked version of tablet meta should not be found in retain_versions and should in [min_check_version, max_check_version]
     RETURN_IF_ERROR(vacuum_expired_tablet_metadata(tablet_mgr, root_loc, grace_timestamp, &vacuumed_files, &meta_files,
-                                                   &bundle_meta_files, retain_versions, min_check_version, max_check_version));
+                                                   &bundle_meta_files, retain_versions, min_check_version,
+                                                   max_check_version));
 
     // 2. Determine and delete orphaned data files. We use min_active_txn_id to filter out new data files, then we open
     // any remaining metadata files and note that the data files referenced are not orphans.

--- a/be/src/storage/lake/vacuum_full.cpp
+++ b/be/src/storage/lake/vacuum_full.cpp
@@ -167,8 +167,6 @@ Status vacuum_full_impl(TabletManager* tablet_mgr, const VacuumFullRequest& requ
     }
     int64_t min_check_version = request.min_check_version();
     int64_t max_check_version = request.max_check_version();
-    // protect the max check version
-    retain_versions.insert(max_check_version);
 
     int64_t vacuumed_files = 0;
     int64_t vacuumed_file_size = 0;

--- a/be/src/storage/lake/vacuum_full.h
+++ b/be/src/storage/lake/vacuum_full.h
@@ -14,16 +14,12 @@
 
 #pragma once
 
-#include <memory>
+#include "gen_cpp/lake_service.pb.h"
 
-#include "gen_cpp/lake_types.pb.h"
+namespace starrocks::lake {
 
-namespace starrocks {
+class TabletManager;
 
-using TabletMetadata = TabletMetadataPB;
-using TabletMetadataPtr = std::shared_ptr<const TabletMetadata>;
-using MutableTabletMetadataPtr = std::shared_ptr<TabletMetadata>;
-using BundleTabletMetadataPtr = std::shared_ptr<BundleTabletMetadataPB>;
-using MutableTabletMetadataPtrs = std::vector<MutableTabletMetadataPtr>;
+void vacuum_full(TabletManager* tablet_mgr, const VacuumFullRequest& request, VacuumFullResponse* response);
 
-} // namespace starrocks
+} // namespace starrocks::lake

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1970,7 +1970,7 @@ TEST_F(LakeServiceTest, test_vacuum_full_null_thread_pool) {
     brpc::Controller cntl;
     VacuumFullRequest request;
     VacuumFullResponse response;
-    request.add_tablet_ids(_tablet_id);
+    request.set_tablet_id(_tablet_id);
     _lake_service.vacuum_full(&cntl, &request, &response, nullptr);
     ASSERT_EQ("full vacuum thread pool is null", cntl.ErrorText());
 }
@@ -1986,7 +1986,7 @@ TEST_F(LakeServiceTest, test_vacuum_full_thread_pool_full) {
     brpc::Controller cntl;
     VacuumFullRequest request;
     VacuumFullResponse response;
-    request.add_tablet_ids(_tablet_id);
+    request.set_tablet_id(_tablet_id);
     _lake_service.vacuum_full(&cntl, &request, &response, nullptr);
     EXPECT_FALSE(cntl.Failed()) << cntl.ErrorText();
     EXPECT_EQ(TStatusCode::SERVICE_UNAVAILABLE, response.status().status_code()) << response.status().status_code();

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -28,6 +28,7 @@
 #include "storage/lake/metacache.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
+#include "storage/lake/vacuum_full.h"
 #include "test_util.h"
 #include "testutil/assert.h"
 #include "testutil/sync_point.h"
@@ -151,132 +152,245 @@ TEST_P(LakeVacuumTest, test_vacuum_1) {
     }
 }
 
-
 // Check that vacuum_full cleans up the expected metadata files
 // NOLINTNEXTLINE
 TEST_P(LakeVacuumTest, test_vacuum_full) {
+    create_data_file("0000000000000001_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat");
+    create_data_file("0000000000000001_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat");
+    create_data_file("000000000000FFFF_a542f95a-bff5-48a7-a3a7-2ed05691b58c.dat");
+    create_data_file("0000000000000002_a542ff5a-bff5-48a7-a3a7-2ed05691b58c.dat");
+
     VacuumFullRequest request;
     request.set_partition_id(1);
-    request.add_tablet_ids(600);
-    request.set_min_check_version(3);
-    request.set_max_check_version(5);
-    
-    // Check that it cleans up metadata files when their tablet id isn't in the request,
-    // and leaves the metadata files where the tablet id is in the request
-    
-    // tablet id is in the request -> should not be cleaned up
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
-        {
-        "id": 600,
-        "version": 4,
-        "rowsets": [],
-        "prev_garbage_version": 3
-        }
-        )DEL")));
+    request.add_tablet_ids(66600);
+    request.set_min_active_txn_id(10);
+    request.set_grace_timestamp(100);
+    request.add_retain_versions(4);
+    request.set_min_check_version(0);
+    request.set_max_check_version(6);
 
-    // tablet id is not in the request -> should be cleaned up
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
         {
-        "id": 601,
+        "id": 66601,
         "version": 5,
         "rowsets": []
         }
         )DEL")));
-    // Check that it cleans up the metadata files where version is less than min_check_version
-    // and leaves the metadata files where version is greater than or equal to min_check_version
 
-    // version 2 is less than min_check_version -> should be cleaned up
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
         {
-        "id": 600,
-        "version": 2,
-        "rowsets": [],
-        "prev_garbage_version": 1
-        }
-        )DEL")));
-    // version 3 is equal to min_check_version -> should not be cleaned up
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
-        {
-        "id": 600,
-        "version": 3,
-        "rowsets": [
-            {
-                "segments": [
-                    "00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
-                ],
-                "data_size": 4096
-            }
-        ],
-        "prev_garbage_version": 2
-        }
-        )DEL")));
-    // version 6 is greater than min_check_version -> should not be cleaned up
-    // But it's greater than max_check_version, so its data file may be cleaned up
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
-        {
-        "id": 600,
+        "id": 66600,
         "version": 6,
         "rowsets": [
             {
                 "segments": [
-                    "00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1f.dat"
+                    "0000000000000001_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
                 ],
                 "data_size": 4096
             }
         ],
-        "prev_garbage_version": 5
+        "commit_time": 99,
+        "prev_garbage_version": 3
         }
         )DEL")));
 
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 4)));
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 3)));
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(601, 5)));
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 2)));
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 6)));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 66600,
+        "version": 5,
+        "rowsets": [],
+        "commit_time": 99,
+        "prev_garbage_version": 3
+        }
+        )DEL")));
 
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 66600,
+        "version": 4,
+        "rowsets": [
+            {
+                "segments": [
+                    "0000000000000001_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"
+                ],
+                "data_size": 4096
+            }
+        ],
+        "commit_time": 98,
+        "prev_garbage_version": 3
+        }
+        )DEL")));
 
-    // Set up some data files which will be vacuumed, and some that won't.
-    // Data files with txn_id >= min_active_txn_id will not be vacuumed
-    const int64_t kTxnId1 = extract_txn_id_prefix("00000000000159e4_").value_or(-1);
-    const int64_t kRequestTxnId = kTxnId1;
-    request.set_min_active_txn_id(kRequestTxnId);
-    // These files will not be vacuumed because they're too new based on txn id (prefix of filename)
-    create_data_file("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat");
-    create_data_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat");
-    // Data files referenced by metadata files with version <= max_check_version will not be vacuumed
-    // This file was created by an older txn id (by 1),
-    // but it was referenced by a metadata file with version 3, so it will not be vacuumed
-    create_data_file("00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat");
-    // This file was created by an older txn id (by 1),
-    // and it was not referenced by any metadata file so it will be vacuumed. 
-    create_data_file("00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat");
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 66600,
+        "version": 3,
+        "rowsets": [],
+        "commit_time": 97,
+        "prev_garbage_version": 3
+        }
+        )DEL")));
 
-    // This file was created by an older txn id (by 1),
-    // and it was only referenced by a metadata file with version 6 (grea+ter than max_check_version),
-    // so it will be vacuumed.
-    create_data_file("00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1f.dat");
-    
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(66601, 5)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(66600, 6)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(66600, 5)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(66600, 4)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(66600, 3)));
+
     VacuumFullResponse response;
     vacuum_full(_tablet_mgr.get(), request, &response);
 
     ASSERT_TRUE(response.has_status());
     EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-    EXPECT_EQ(2 + 2, response.vacuumed_files()); // 2 metadata, 2 data
-    // The size of deleted metadata files is not counted in vacuumed_file_size.
-    // Each data file happens to be 4 bytes.
-    EXPECT_EQ(2*4, response.vacuumed_file_size());
+    EXPECT_EQ(3 + 1, response.vacuumed_files()); // 3 metadata, 1 data
 
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 4)));
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 3)));
-    EXPECT_FALSE(file_exist(tablet_metadata_filename(601, 5)));
-    EXPECT_FALSE(file_exist(tablet_metadata_filename(600, 2)));
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 6)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(66601, 5)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(66600, 6)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(66600, 5)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(66600, 4)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(66600, 3)));
 
-    EXPECT_TRUE(file_exist("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
-    EXPECT_TRUE(file_exist("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
-    EXPECT_TRUE(file_exist("00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
-    EXPECT_FALSE(file_exist("00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat"));
-    EXPECT_FALSE(file_exist("00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1f.dat"));
+    EXPECT_TRUE(file_exist("0000000000000001_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+    EXPECT_TRUE(file_exist("0000000000000001_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+    EXPECT_TRUE(file_exist("000000000000FFFF_a542f95a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+    EXPECT_FALSE(file_exist("0000000000000002_a542ff5a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+}
+
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_vacuum_full_with_bundle) {
+    create_data_file("0000000000000005_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat");
+    create_data_file("0000000000000005_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat");
+    create_data_file("0000000000000004_a542f95a-bff5-48a7-a3a7-2ed05691b58c.dat");
+    create_data_file("0000000000000004_a542ff5a-bff5-48a7-a3a7-2ed05691b58c.dat");
+
+    VacuumFullRequest request;
+    request.set_partition_id(1);
+    request.add_tablet_ids(66600);
+    request.set_min_active_txn_id(10);
+    request.set_grace_timestamp(100);
+    request.set_min_check_version(0);
+    request.set_max_check_version(8);
+
+    auto tablet_66601_v8 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 66601,
+        "version": 8,
+        "rowsets": [],
+        "commit_time": 10010
+        }
+        )DEL");
+
+    auto tablet_66600_v8 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 66600,
+        "version": 8,
+        "rowsets": [],
+        "commit_time": 10010
+        }
+        )DEL");
+
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v8;
+    tablet_metas_v8[66601] = *tablet_66601_v8;
+    tablet_metas_v8[66600] = *tablet_66600_v8;
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v8));
+
+    auto tablet_66601_v7 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 66601,
+        "version": 7,
+        "rowsets": [
+            {
+                "segments": [
+                    "0000000000000005_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
+                ],
+                "data_size": 4096
+            }
+        ],
+        "commit_time": 10000,
+        "prev_garbage_version": 3
+        }
+        )DEL");
+
+    auto tablet_66600_v7 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 66600,
+        "version": 7,
+        "rowsets": [
+            {
+                "segments": [
+                    "0000000000000005_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"
+                ],
+                "data_size": 4096
+            }
+        ],
+        "commit_time": 10000,
+        "prev_garbage_version": 3
+        }
+        )DEL");
+
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v7;
+    tablet_metas_v7[66601] = *tablet_66601_v7;
+    tablet_metas_v7[66600] = *tablet_66600_v7;
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v7));
+
+    auto tablet_66601_v6 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 66601,
+        "version": 6,
+        "rowsets": [
+            {
+                "segments": [
+                    "0000000000000004_a542f95a-bff5-48a7-a3a7-2ed05691b58c.dat"
+                ],
+                "data_size": 4096
+            }
+        ],
+        "commit_time": 10,
+        "prev_garbage_version": 3
+        }
+        )DEL");
+
+    auto tablet_66600_v6 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 66600,
+        "version": 6,
+        "rowsets": [
+            {
+                "segments": [
+                    "0000000000000004_a542ff5a-bff5-48a7-a3a7-2ed05691b58c.dat"
+                ],
+                "data_size": 4096
+            }
+        ],
+        "commit_time": 10,
+        "prev_garbage_version": 3
+        }
+        )DEL");
+
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v6;
+    tablet_metas_v6[66601] = *tablet_66601_v6;
+    tablet_metas_v6[66600] = *tablet_66600_v6;
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v6));
+
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 6)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 7)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 8)));
+
+    VacuumFullResponse response;
+    vacuum_full(_tablet_mgr.get(), request, &response);
+
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    EXPECT_EQ(3, response.vacuumed_files()); // 1 metadata, 2 data
+
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 6)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 7)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 8)));
+
+    EXPECT_TRUE(file_exist("0000000000000005_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+    EXPECT_TRUE(file_exist("0000000000000005_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+    EXPECT_FALSE(file_exist("0000000000000004_a542f95a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+    EXPECT_FALSE(file_exist("0000000000000004_a542ff5a-bff5-48a7-a3a7-2ed05691b58c.dat"));
 }
 
 // NOLINTNEXTLINE

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -162,7 +162,7 @@ TEST_P(LakeVacuumTest, test_vacuum_full) {
 
     VacuumFullRequest request;
     request.set_partition_id(1);
-    request.add_tablet_ids(66600);
+    request.set_tablet_id(66600);
     request.set_min_active_txn_id(10);
     request.set_grace_timestamp(100);
     request.add_retain_versions(4);
@@ -173,7 +173,8 @@ TEST_P(LakeVacuumTest, test_vacuum_full) {
         {
         "id": 66601,
         "version": 5,
-        "rowsets": []
+        "rowsets": [],
+        "commit_time": 1
         }
         )DEL")));
 
@@ -265,7 +266,7 @@ TEST_P(LakeVacuumTest, test_vacuum_full_with_bundle) {
 
     VacuumFullRequest request;
     request.set_partition_id(1);
-    request.add_tablet_ids(66600);
+    request.set_tablet_id(66600);
     request.set_min_active_txn_id(10);
     request.set_grace_timestamp(100);
     request.set_min_check_version(0);

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -151,6 +151,134 @@ TEST_P(LakeVacuumTest, test_vacuum_1) {
     }
 }
 
+
+// Check that vacuum_full cleans up the expected metadata files
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_vacuum_full) {
+    VacuumFullRequest request;
+    request.set_partition_id(1);
+    request.add_tablet_ids(600);
+    request.set_min_check_version(3);
+    request.set_max_check_version(5);
+    
+    // Check that it cleans up metadata files when their tablet id isn't in the request,
+    // and leaves the metadata files where the tablet id is in the request
+    
+    // tablet id is in the request -> should not be cleaned up
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 600,
+        "version": 4,
+        "rowsets": [],
+        "prev_garbage_version": 3
+        }
+        )DEL")));
+
+    // tablet id is not in the request -> should be cleaned up
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 601,
+        "version": 5,
+        "rowsets": []
+        }
+        )DEL")));
+    // Check that it cleans up the metadata files where version is less than min_check_version
+    // and leaves the metadata files where version is greater than or equal to min_check_version
+
+    // version 2 is less than min_check_version -> should be cleaned up
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 600,
+        "version": 2,
+        "rowsets": [],
+        "prev_garbage_version": 1
+        }
+        )DEL")));
+    // version 3 is equal to min_check_version -> should not be cleaned up
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 600,
+        "version": 3,
+        "rowsets": [
+            {
+                "segments": [
+                    "00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
+                ],
+                "data_size": 4096
+            }
+        ],
+        "prev_garbage_version": 2
+        }
+        )DEL")));
+    // version 6 is greater than min_check_version -> should not be cleaned up
+    // But it's greater than max_check_version, so its data file may be cleaned up
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 600,
+        "version": 6,
+        "rowsets": [
+            {
+                "segments": [
+                    "00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1f.dat"
+                ],
+                "data_size": 4096
+            }
+        ],
+        "prev_garbage_version": 5
+        }
+        )DEL")));
+
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 4)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 3)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(601, 5)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 2)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 6)));
+
+
+    // Set up some data files which will be vacuumed, and some that won't.
+    // Data files with txn_id >= min_active_txn_id will not be vacuumed
+    const int64_t kTxnId1 = extract_txn_id_prefix("00000000000159e4_").value_or(-1);
+    const int64_t kRequestTxnId = kTxnId1;
+    request.set_min_active_txn_id(kRequestTxnId);
+    // These files will not be vacuumed because they're too new based on txn id (prefix of filename)
+    create_data_file("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat");
+    create_data_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat");
+    // Data files referenced by metadata files with version <= max_check_version will not be vacuumed
+    // This file was created by an older txn id (by 1),
+    // but it was referenced by a metadata file with version 3, so it will not be vacuumed
+    create_data_file("00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat");
+    // This file was created by an older txn id (by 1),
+    // and it was not referenced by any metadata file so it will be vacuumed. 
+    create_data_file("00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat");
+
+    // This file was created by an older txn id (by 1),
+    // and it was only referenced by a metadata file with version 6 (grea+ter than max_check_version),
+    // so it will be vacuumed.
+    create_data_file("00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1f.dat");
+    
+    VacuumFullResponse response;
+    vacuum_full(_tablet_mgr.get(), request, &response);
+
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    EXPECT_EQ(2 + 2, response.vacuumed_files()); // 2 metadata, 2 data
+    // The size of deleted metadata files is not counted in vacuumed_file_size.
+    // Each data file happens to be 4 bytes.
+    EXPECT_EQ(2*4, response.vacuumed_file_size());
+
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 4)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 3)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(601, 5)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(600, 2)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(600, 6)));
+
+    EXPECT_TRUE(file_exist("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+    EXPECT_TRUE(file_exist("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+    EXPECT_TRUE(file_exist("00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+    EXPECT_FALSE(file_exist("00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat"));
+    EXPECT_FALSE(file_exist("00000000000159e3_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1f.dat"));
+}
+
 // NOLINTNEXTLINE
 TEST_P(LakeVacuumTest, test_vacuum_2) {
     create_data_file("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat");

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -167,7 +167,7 @@ TEST_P(LakeVacuumTest, test_vacuum_full) {
     request.set_grace_timestamp(100);
     request.add_retain_versions(3);
     request.set_min_check_version(0);
-    request.set_max_check_version(4);
+    request.set_max_check_version(5);
 
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
         {
@@ -270,7 +270,7 @@ TEST_P(LakeVacuumTest, test_vacuum_full_with_bundle) {
     request.set_min_active_txn_id(10);
     request.set_grace_timestamp(100);
     request.set_min_check_version(0);
-    request.set_max_check_version(6);
+    request.set_max_check_version(7);
 
     auto tablet_66601_v8 = json_to_pb<TabletMetadataPB>(R"DEL(
         {

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -165,9 +165,9 @@ TEST_P(LakeVacuumTest, test_vacuum_full) {
     request.set_tablet_id(66600);
     request.set_min_active_txn_id(10);
     request.set_grace_timestamp(100);
-    request.add_retain_versions(4);
+    request.add_retain_versions(3);
     request.set_min_check_version(0);
-    request.set_max_check_version(6);
+    request.set_max_check_version(4);
 
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
         {
@@ -243,16 +243,16 @@ TEST_P(LakeVacuumTest, test_vacuum_full) {
 
     ASSERT_TRUE(response.has_status());
     EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-    EXPECT_EQ(3 + 1, response.vacuumed_files()); // 3 metadata, 1 data
+    EXPECT_EQ(1 + 2, response.vacuumed_files()); // 1 metadata, 2 data
 
-    EXPECT_FALSE(file_exist(tablet_metadata_filename(66601, 5)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(66601, 5)));
     EXPECT_TRUE(file_exist(tablet_metadata_filename(66600, 6)));
-    EXPECT_FALSE(file_exist(tablet_metadata_filename(66600, 5)));
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(66600, 4)));
-    EXPECT_FALSE(file_exist(tablet_metadata_filename(66600, 3)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(66600, 5)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(66600, 4)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(66600, 3)));
 
     EXPECT_TRUE(file_exist("0000000000000001_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
-    EXPECT_TRUE(file_exist("0000000000000001_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+    EXPECT_FALSE(file_exist("0000000000000001_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
     EXPECT_TRUE(file_exist("000000000000FFFF_a542f95a-bff5-48a7-a3a7-2ed05691b58c.dat"));
     EXPECT_FALSE(file_exist("0000000000000002_a542ff5a-bff5-48a7-a3a7-2ed05691b58c.dat"));
 }
@@ -270,7 +270,7 @@ TEST_P(LakeVacuumTest, test_vacuum_full_with_bundle) {
     request.set_min_active_txn_id(10);
     request.set_grace_timestamp(100);
     request.set_min_check_version(0);
-    request.set_max_check_version(8);
+    request.set_max_check_version(6);
 
     auto tablet_66601_v8 = json_to_pb<TabletMetadataPB>(R"DEL(
         {
@@ -307,7 +307,7 @@ TEST_P(LakeVacuumTest, test_vacuum_full_with_bundle) {
                 "data_size": 4096
             }
         ],
-        "commit_time": 10000,
+        "commit_time": 11,
         "prev_garbage_version": 3
         }
         )DEL");
@@ -324,7 +324,7 @@ TEST_P(LakeVacuumTest, test_vacuum_full_with_bundle) {
                 "data_size": 4096
             }
         ],
-        "commit_time": 10000,
+        "commit_time": 11,
         "prev_garbage_version": 3
         }
         )DEL");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -125,6 +125,11 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     private final AtomicLong lastVacuumTime = new AtomicLong(0);
 
+    // Autovacuum
+    private volatile long lastVacuumTime = 0;
+    // Full vacuum (orphan data files and redundant db/table/partition)
+    private volatile long lastFullVacuumTime;
+
     private final AtomicLong minRetainVersion = new AtomicLong(0);
 
     private final AtomicLong lastSuccVacuumVersion = new AtomicLong(0);
@@ -211,6 +216,14 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     public void setLastVacuumTime(long lastVacuumTime) {
         this.lastVacuumTime.set(lastVacuumTime);
+    }
+
+    public long getLastFullVacuumTime() {
+        return lastFullVacuumTime;
+    }
+
+    public void setLastFullVacuumTime(long lastVacuumTime) {
+        this.lastFullVacuumTime = lastVacuumTime;
     }
 
     public long getMinRetainVersion() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -123,10 +123,9 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
      */
     private long visibleTxnId = -1;
 
+    // Autovacuum
     private final AtomicLong lastVacuumTime = new AtomicLong(0);
 
-    // Autovacuum
-    private volatile long lastVacuumTime = 0;
     // Full vacuum (orphan data files and redundant db/table/partition)
     private volatile long lastFullVacuumTime;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2990,7 +2990,7 @@ public class Config extends ConfigBase {
     public static int lake_autovacuum_parallel_partitions = 8;
 
     @ConfField(comment = "how many partitions can fullvacuum execute simultaneously at most")
-    public static int lake_fullvacuum_parallel_partitions = 128;
+    public static int lake_fullvacuum_parallel_partitions = 16;
 
     @ConfField(mutable = true, comment = "the minimum delay between autovacuum runs on any given partition")
     public static long lake_autovacuum_partition_naptime_seconds = 180;
@@ -3013,7 +3013,10 @@ public class Config extends ConfigBase {
     public static boolean lake_autovacuum_detect_vaccumed_version = true;
 
     @ConfField(mutable = true, comment = "the minimum delay between full vacuum runs on any given partition")
-    public static long lake_fullvacuum_partition_naptime_seconds = 3600 * 24;
+    public static long lake_fullvacuum_partition_naptime_seconds = 3600L * 24L;
+
+    @ConfField(mutable = true, comment = "metadata expired time from full vacuum begin running")
+    public static long lake_fullvacuum_meta_expired_seconds = 3600L * 24L * 2L;
 
     @ConfField(mutable = true, comment =
             "Whether enable throttling ingestion speed when compaction score exceeds the threshold.\n" +

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2989,6 +2989,9 @@ public class Config extends ConfigBase {
     @ConfField(comment = "how many partitions can autovacuum be executed simultaneously at most")
     public static int lake_autovacuum_parallel_partitions = 8;
 
+    @ConfField(comment = "how many partitions can fullvacuum execute simultaneously at most")
+    public static int lake_fullvacuum_parallel_partitions = 128;
+
     @ConfField(mutable = true, comment = "the minimum delay between autovacuum runs on any given partition")
     public static long lake_autovacuum_partition_naptime_seconds = 180;
 
@@ -3008,6 +3011,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = 
             "Determine whether a vacuum operation needs to be initiated based on the vacuum version.\n")
     public static boolean lake_autovacuum_detect_vaccumed_version = true;
+
+    @ConfField(mutable = true, comment = "the minimum delay between full vacuum runs on any given partition")
+    public static long lake_fullvacuum_partition_naptime_seconds = 3600 * 24;
 
     @ConfField(mutable = true, comment =
             "Whether enable throttling ingestion speed when compaction score exceeds the threshold.\n" +

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
@@ -1,0 +1,282 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.lake.vacuum;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.io.Writable;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.proto.VacuumFullRequest;
+import com.starrocks.proto.VacuumFullResponse;
+import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.LakeService;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.warehouse.Warehouse;
+import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static com.starrocks.rpc.LakeService.TIMEOUT_VACUUM_FULL;
+
+public class FullVacuumDaemon extends FrontendDaemon implements Writable {
+    private static final Logger LOG = LogManager.getLogger(FullVacuumDaemon.class);
+
+    private final Set<Long> vacuumingPartitions = Sets.newConcurrentHashSet();
+
+    private final Map<Long, AtomicInteger> cnIdToRunningFullVacuum = new ConcurrentHashMap<>();
+
+    private final BlockingThreadPoolExecutorService executorService =
+            BlockingThreadPoolExecutorService.newInstance(Config.lake_fullvacuum_parallel_partitions, 0, TIMEOUT_VACUUM_FULL,
+                    TimeUnit.MILLISECONDS, "fullvacuum");
+
+    public FullVacuumDaemon() {
+        // Check every minute if we should run a full vacuum
+        super("FullVacuumDaemon", 1000 * 60);
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        if (FeConstants.runningUnitTest) {
+            return;
+        }
+        List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds();
+        for (Long dbId : dbIds) {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+            if (db == null) {
+                continue;
+            }
+
+            List<Table> tables = new ArrayList<>();
+            for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
+                if (table.isCloudNativeTableOrMaterializedView()) {
+                    tables.add(table);
+                }
+            }
+
+            // Full vacuum cleans up two types of data (orphan data files and redundant db/table/partition)
+            // 1. Cleanup Orphan Data Files: Data files not referenced by tablet metadata.
+            for (Table table : tables) {
+                vacuumTable(db, table);
+            }
+            //  2. Redundant db/table/partition: Dbs, tables, or partitions that have been deleted in FE but not in the object storage.
+            // TODO Implement
+
+        }
+    }
+
+    public boolean shouldVacuum(PhysicalPartition partition) {
+        long current = System.currentTimeMillis();
+        // prevent vacuum too frequent
+        return current >= partition.getLastFullVacuumTime() + Config.lake_fullvacuum_partition_naptime_seconds * 1000;
+    }
+
+    private void vacuumTable(Database db, Table baseTable) {
+        OlapTable table = (OlapTable) baseTable;
+        List<PhysicalPartition> partitions;
+
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(baseTable.getId()), LockType.READ);
+        try {
+            partitions = table.getPhysicalPartitions().stream().filter(this::shouldVacuum).toList();
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(baseTable.getId()), LockType.READ);
+        }
+
+        for (PhysicalPartition partition : partitions) {
+            if (vacuumingPartitions.add(partition.getId())) {
+                executorService.execute(() -> vacuumPartition(db, table, partition));
+            }
+        }
+    }
+
+    private void vacuumPartition(Database db, OlapTable table, PhysicalPartition partition) {
+        try {
+            vacuumPartitionImpl(db, table, partition);
+        } finally {
+            vacuumingPartitions.remove(partition.getId());
+        }
+    }
+
+    private ComputeNode selectNodeWithMinVacuum(Collection<ComputeNode> involvedNodes) {
+        ComputeNode chosenNode = null;
+        int minRunning = Integer.MAX_VALUE;
+
+        for (ComputeNode node : involvedNodes) {
+            AtomicInteger currentlyRunningFullVacuum =
+                    cnIdToRunningFullVacuum.computeIfAbsent(node.getId(), id -> new AtomicInteger(0));
+
+            int currentRunning = currentlyRunningFullVacuum.get();
+            if (currentRunning < minRunning) {
+                minRunning = currentRunning;
+                chosenNode = node;
+            }
+        }
+
+        if (chosenNode == null || chosenNode.getHost() == null) {
+            LOG.error("Could not find usable ComputeNode to send full vacuum. Problem: {}",
+                    chosenNode == null ? "ComputeNode is null" : "Host is null");
+            return null;
+        } else {
+            cnIdToRunningFullVacuum.get(chosenNode.getId()).incrementAndGet();
+        }
+
+        return chosenNode;
+    }
+
+    private void vacuumPartitionImpl(Database db, OlapTable table, PhysicalPartition partition) {
+        LOG.info("Running orphan file deletion task for table={}, partition={}.", table.getName(), partition.getId());
+        List<Tablet> tablets = new ArrayList<>();
+        long visibleVersion;
+        long startTime = System.currentTimeMillis();
+        long minActiveTxnId = computeMinActiveTxnId(db, table);
+
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        try {
+            for (MaterializedIndex index : partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
+                tablets.addAll(index.getTablets());
+            }
+            visibleVersion = partition.getVisibleVersion();
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        }
+
+        if (visibleVersion <= 1) {
+            LOG.info("skipping full vacuum of partition={} because its visible version is {}", partition.getId(), visibleVersion);
+            partition.setLastFullVacuumTime(startTime);
+            return;
+        }
+
+        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        Warehouse warehouse = warehouseManager.getBackgroundWarehouse();
+        List<Long> allTabletIds = new ArrayList<>(tablets.size());
+        Set<ComputeNode> involvedNodes = new HashSet<>();
+
+        for (Tablet tablet : tablets) {
+            LakeTablet lakeTablet = (LakeTablet) tablet;
+            ComputeNode node = warehouseManager.getComputeNodeAssignedToTablet(warehouse.getId(), lakeTablet);
+
+            if (node == null) {
+                LOG.error("Could not get CN for tablet={}, returning early.", tablet.getId());
+                return;
+            }
+            allTabletIds.add(tablet.getId());
+            involvedNodes.add(node);
+        }
+        VacuumFullRequest vacuumFullRequest = new VacuumFullRequest();
+        vacuumFullRequest.setPartitionId(partition.getId());
+        // All tablet ids must be part of the request, since the CN will delete any + all tablets unspecified by the request.
+        vacuumFullRequest.setTabletIds(allTabletIds);
+        // TODO(cbrennan) min check version is an optimization to save compute on deleting metadata, but at some point this
+        //  should be something other than the default of 1.
+        vacuumFullRequest.setMinCheckVersion(1L);
+        vacuumFullRequest.setMaxCheckVersion(visibleVersion);
+        vacuumFullRequest.setMinActiveTxnId(minActiveTxnId);
+
+        ComputeNode chosenNode = selectNodeWithMinVacuum(involvedNodes);
+        if (chosenNode == null) {
+            return;
+        }
+
+        LOG.info(
+                "Sending full vacuum request to cn={}: table={}, partition={}, tablet_ids={}, max_check_version={}, " +
+                        "min_active_txn_id={}",
+                chosenNode.getHost(), table.getName(), vacuumFullRequest.getPartitionId(), vacuumFullRequest.getTabletIds(),
+                vacuumFullRequest.maxCheckVersion, vacuumFullRequest.minActiveTxnId);
+
+
+        boolean hasError = false;
+        long vacuumedFiles = 0;
+        long vacuumedFileSize = 0;
+        long vacuumedVersion = Long.MAX_VALUE;
+        Future<VacuumFullResponse> responseFuture = null;
+        try {
+            LakeService service = BrpcProxy.getLakeService(chosenNode.getHost(), chosenNode.getBrpcPort());
+            responseFuture = service.vacuumFull(vacuumFullRequest);
+        } catch (RpcException e) {
+            LOG.error("failed to send full vacuum request for partition {}.{}.{}", db.getFullName(), table.getName(),
+                    partition.getId(), e);
+            hasError = true;
+        }
+
+        try {
+            VacuumFullResponse response = responseFuture.get();
+            if (response.status.statusCode != 0) {
+                hasError = true;
+                LOG.warn("Vacuumed {}.{}.{} with error: {}", db.getFullName(), table.getName(), partition.getId(),
+                        response.status.errorMsgs.get(0));
+            } else {
+                vacuumedFiles += response.vacuumedFiles;
+                vacuumedFileSize += response.vacuumedFileSize;
+            }
+        } catch (InterruptedException e) {
+            LOG.warn("thread interrupted");
+            Thread.currentThread().interrupt();
+            hasError = true;
+        } catch (ExecutionException e) {
+            LOG.error("failed to full vacuum {}.{}.{}: {}", db.getFullName(), table.getName(), partition.getId(),
+                    e.getMessage());
+            hasError = true;
+        } finally {
+            cnIdToRunningFullVacuum.get(chosenNode.getId()).decrementAndGet();
+        }
+
+        partition.setLastFullVacuumTime(startTime);
+
+        LOG.info("Full vacuumed {}.{}.{} hasError={} vacuumedFiles={} vacuumedFileSize={} " +
+                        "visibleVersion={} minActiveTxnId={} vacuumVersion={} cost={}ms", db.getFullName(), table.getName(),
+                partition.getId(), hasError, vacuumedFiles, vacuumedFileSize, visibleVersion, minActiveTxnId, vacuumedVersion,
+                System.currentTimeMillis() - startTime);
+    }
+
+    @VisibleForTesting
+    public static long computeMinActiveTxnId(Database db, Table table) {
+        long a = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getMinActiveTxnIdOfDatabase(db.getId());
+        Optional<Long> b = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getActiveTxnIdOfTable(table.getId());
+        return Math.min(a, b.orElse(Long.MAX_VALUE));
+    }
+
+    public void testVacuumPartitionImpl(Database db, OlapTable table, PhysicalPartition partition) {
+        vacuumPartitionImpl(db, table, partition);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
@@ -42,12 +42,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -186,8 +186,8 @@ public class FullVacuumDaemon extends FrontendDaemon implements Writable {
 
         // choose a node for full vacuum by random
         List<ComputeNode> involvedNodesList = involvedNodes.stream().collect(Collectors.toList());
-        Collections.shuffle(involvedNodesList);
-        ComputeNode chosenNode = involvedNodesList.get(0);
+        Random random = new Random();
+        ComputeNode chosenNode = involvedNodesList.get(random.nextInt(involvedNodesList.size()));
 
         VacuumFullRequest vacuumFullRequest = new VacuumFullRequest();
         vacuumFullRequest.setPartitionId(partition.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
@@ -205,7 +205,7 @@ public class FullVacuumDaemon extends FrontendDaemon implements Writable {
             retainVersions.add(visibleVersion); // current visibleVersion should be retained 
         }
         long minCheckVersion = 0;
-        long maxCheckVersion = visibleVersion - 1; // always should be inited by current visibleVersion - 1
+        long maxCheckVersion = visibleVersion; // always should be inited by current visibleVersion
         vacuumFullRequest.setMinCheckVersion(minCheckVersion);
         vacuumFullRequest.setMaxCheckVersion(maxCheckVersion);
         vacuumFullRequest.setRetainVersions(retainVersions);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
@@ -212,10 +212,9 @@ public class FullVacuumDaemon extends FrontendDaemon implements Writable {
         vacuumFullRequest.setTabletId(nodeToTablet.get(chosenNode).getId());
 
         LOG.info(
-                "Sending full vacuum request to cn={}: table={}, partition={}, tablet_ids={}, max_check_version={}, " +
-                        "min_active_txn_id={}",
-                chosenNode.getHost(), table.getName(), vacuumFullRequest.getPartitionId(), vacuumFullRequest.getTabletIds(),
-                vacuumFullRequest.maxCheckVersion, vacuumFullRequest.minActiveTxnId);
+                "Sending full vacuum request to cn={}: table={}, partition={}, max_check_version={}, " + "min_active_txn_id={}",
+                chosenNode.getHost(), table.getName(), vacuumFullRequest.getPartitionId(), vacuumFullRequest.maxCheckVersion,
+                vacuumFullRequest.minActiveTxnId);
 
 
         boolean hasError = false;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
@@ -42,18 +42,16 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.starrocks.rpc.LakeService.TIMEOUT_VACUUM_FULL;
@@ -203,6 +201,9 @@ public class FullVacuumDaemon extends FrontendDaemon implements Writable {
         List<Long> retainVersions = new ArrayList<>();
         retainVersions.addAll(clusterSnapshotMgr.getVacuumRetainVersions(
                               db.getId(), table.getId(), partition.getParentId(), partition.getId()));
+        if (!retainVersions.contains(visibleVersion)) {
+            retainVersions.add(visibleVersion); // current visibleVersion should be retained 
+        }
         long minCheckVersion = 0;
         long maxCheckVersion = visibleVersion - 1; // always should be inited by current visibleVersion - 1
         vacuumFullRequest.setMinCheckVersion(minCheckVersion);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
@@ -204,7 +204,7 @@ public class FullVacuumDaemon extends FrontendDaemon implements Writable {
         retainVersions.addAll(clusterSnapshotMgr.getVacuumRetainVersions(
                               db.getId(), table.getId(), partition.getParentId(), partition.getId()));
         long minCheckVersion = 0;
-        long maxCheckVersion = visibleVersion; // always should be inited by current visibleVersion
+        long maxCheckVersion = visibleVersion - 1; // always should be inited by current visibleVersion - 1
         vacuumFullRequest.setMinCheckVersion(minCheckVersion);
         vacuumFullRequest.setMaxCheckVersion(maxCheckVersion);
         vacuumFullRequest.setRetainVersions(retainVersions);

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -47,6 +47,8 @@ import com.starrocks.proto.UnlockTabletMetadataRequest;
 import com.starrocks.proto.UnlockTabletMetadataResponse;
 import com.starrocks.proto.UploadSnapshotsRequest;
 import com.starrocks.proto.UploadSnapshotsResponse;
+import com.starrocks.proto.VacuumFullRequest;
+import com.starrocks.proto.VacuumFullResponse;
 import com.starrocks.proto.VacuumRequest;
 import com.starrocks.proto.VacuumResponse;
 
@@ -69,6 +71,7 @@ public interface LakeService {
     long TIMEOUT_PUBLISH_LOG_VERSION_BATCH = MILLIS_PER_MINUTE;
     long TIMEOUT_ABORT_COMPACTION = 5 * MILLIS_PER_SECOND;
     long TIMEOUT_VACUUM = MILLIS_PER_HOUR;
+    long TIMEOUT_VACUUM_FULL = MILLIS_PER_HOUR * 4;
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "publish_version", onceTalkTimeout = TIMEOUT_PUBLISH_VERSION)
     Future<PublishVersionResponse> publishVersion(PublishVersionRequest request);
@@ -124,5 +127,8 @@ public interface LakeService {
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "aggregate_publish_version", onceTalkTimeout = TIMEOUT_PUBLISH_VERSION)
     Future<PublishVersionResponse> aggregatePublishVersion(AggregatePublishVersionRequest request);
+
+    @ProtobufRPC(serviceName = "LakeService", methodName = "vacuum_full", onceTalkTimeout = TIMEOUT_VACUUM_FULL)
+    Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request);
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -71,7 +71,7 @@ public interface LakeService {
     long TIMEOUT_PUBLISH_LOG_VERSION_BATCH = MILLIS_PER_MINUTE;
     long TIMEOUT_ABORT_COMPACTION = 5 * MILLIS_PER_SECOND;
     long TIMEOUT_VACUUM = MILLIS_PER_HOUR;
-    long TIMEOUT_VACUUM_FULL = MILLIS_PER_HOUR * 4;
+    long TIMEOUT_VACUUM_FULL = MILLIS_PER_HOUR * 24;
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "publish_version", onceTalkTimeout = TIMEOUT_PUBLISH_VERSION)
     Future<PublishVersionResponse> publishVersion(PublishVersionRequest request);

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
@@ -45,6 +45,8 @@ import com.starrocks.proto.UnlockTabletMetadataRequest;
 import com.starrocks.proto.UnlockTabletMetadataResponse;
 import com.starrocks.proto.UploadSnapshotsRequest;
 import com.starrocks.proto.UploadSnapshotsResponse;
+import com.starrocks.proto.VacuumFullRequest;
+import com.starrocks.proto.VacuumFullResponse;
 import com.starrocks.proto.VacuumRequest;
 import com.starrocks.proto.VacuumResponse;
 
@@ -168,5 +170,11 @@ public class LakeServiceWithMetrics implements LakeService {
     public Future<PublishVersionResponse> aggregatePublishVersion(AggregatePublishVersionRequest request) {
         increaseMetrics();
         return lakeService.aggregatePublishVersion(request);
+    }
+
+    @Override
+    public Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request) {
+        increaseMetrics();
+        return lakeService.vacuumFull(request);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -143,6 +143,7 @@ import com.starrocks.lake.compaction.CompactionControlScheduler;
 import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
 import com.starrocks.lake.vacuum.AutovacuumDaemon;
+import com.starrocks.lake.vacuum.FullVacuumDaemon;
 import com.starrocks.leader.CheckpointController;
 import com.starrocks.leader.ReportHandler;
 import com.starrocks.leader.TabletCollector;
@@ -481,6 +482,7 @@ public class GlobalStateMgr {
     private final StorageVolumeMgr storageVolumeMgr;
 
     private AutovacuumDaemon autovacuumDaemon;
+    private FullVacuumDaemon fullVacuumDaemon;
 
     private final PipeManager pipeManager;
     private final PipeListener pipeListener;
@@ -781,6 +783,7 @@ public class GlobalStateMgr {
             this.storageVolumeMgr = new SharedDataStorageVolumeMgr();
             this.autovacuumDaemon = new AutovacuumDaemon();
             this.slotManager = new SlotManager(resourceUsageMonitor);
+            this.fullVacuumDaemon = new FullVacuumDaemon();
         } else {
             this.storageVolumeMgr = new SharedNothingStorageVolumeMgr();
             this.slotManager = new SlotManager(resourceUsageMonitor);
@@ -1461,6 +1464,7 @@ public class GlobalStateMgr {
 
             starMgrMetaSyncer.start();
             autovacuumDaemon.start();
+            fullVacuumDaemon.start();
         }
 
         if (Config.enable_safe_mode) {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -16,12 +16,17 @@ package com.starrocks.lake;
 
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.GlobalStateMgrTestUtil;
+import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.lake.vacuum.AutovacuumDaemon;
+import com.starrocks.lake.vacuum.FullVacuumDaemon;
 import com.starrocks.proto.StatusPB;
+import com.starrocks.proto.VacuumFullRequest;
+import com.starrocks.proto.VacuumFullResponse;
 import com.starrocks.proto.VacuumRequest;
 import com.starrocks.proto.VacuumResponse;
 import com.starrocks.qe.ConnectContext;
@@ -43,9 +48,13 @@ import org.mockito.MockedStatic;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.anyLong;
+import static com.starrocks.lake.vacuum.FullVacuumDaemon.computeMinActiveTxnId;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -116,7 +125,7 @@ public class VacuumTest {
 
         warehouseManager = mock(WarehouseManager.class);
         computeNode = mock(ComputeNode.class);
-        
+
 
         when(warehouseManager.getBackgroundWarehouse()).thenReturn(mock(Warehouse.class));
         when(warehouseManager.getComputeNodeAssignedToTablet((ComputeResource) any(), anyLong()))
@@ -124,7 +133,7 @@ public class VacuumTest {
 
         when(computeNode.getHost()).thenReturn("localhost");
         when(computeNode.getBrpcPort()).thenReturn(8080);
-        
+
     }
 
     @AfterAll
@@ -203,7 +212,7 @@ public class VacuumTest {
             mockBrpcProxyStatic.when(() -> BrpcProxy.getLakeService(anyString(), anyInt())).thenReturn(lakeService);
             autovacuumDaemon.testVacuumPartitionImpl(db, olapTable2, partition);
         }
-        
+
         Assertions.assertEquals(5L, partition.getLastSuccVacuumVersion());
 
         mockResponse.vacuumedVersion = 7L;
@@ -254,6 +263,44 @@ public class VacuumTest {
         }
         Assertions.assertEquals(7L, partition.getLastSuccVacuumVersion());
         Assertions.assertEquals(0L, partition.getMetadataSwitchVersion());
+    }
+
+    @Test
+    public void testFullVacuum() throws Exception {
+        partition = olapTable.getPhysicalPartitions().stream().findFirst().orElse(null);
+        partition.setVisibleVersion(10L, System.currentTimeMillis());
+        partition.setMinRetainVersion(10L);
+        partition.setLastSuccVacuumVersion(4L);
+
+        FullVacuumDaemon fullVacuumDaemon = new FullVacuumDaemon();
+
+        VacuumFullResponse mockResponse = new VacuumFullResponse();
+        mockResponse.status = new StatusPB();
+        mockResponse.status.statusCode = 0;
+        mockResponse.vacuumedFiles = 10L;
+        mockResponse.vacuumedFileSize = 1024L;
+
+        Future<VacuumFullResponse> mockFuture = mock(Future.class);
+        when(mockFuture.get()).thenReturn(mockResponse);
+
+        VacuumFullRequest expectedReq = new VacuumFullRequest();
+        expectedReq.setPartitionId(partition.getId());
+        expectedReq.setTabletIds(partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE).stream()
+                .map(MaterializedIndex::getTablets).flatMap(List::stream).map(Tablet::getId).collect(Collectors.toList()));
+        expectedReq.setMinCheckVersion(1L);
+        expectedReq.setMaxCheckVersion(partition.getVisibleVersion());
+        expectedReq.setMinActiveTxnId(computeMinActiveTxnId(db, olapTable));
+        long startTs;
+        lakeService = mock(LakeService.class);
+        when(lakeService.vacuumFull(refEq(expectedReq))).thenReturn(mockFuture);
+        try (MockedStatic<BrpcProxy> mockBrpcProxyStatic = mockStatic(BrpcProxy.class)) {
+            mockBrpcProxyStatic.when(() -> BrpcProxy.getLakeService(anyString(), anyInt())).thenReturn(lakeService);
+            startTs = System.currentTimeMillis();
+            fullVacuumDaemon.testVacuumPartitionImpl(db, olapTable, partition);
+        }
+
+        Assert.assertTrue(String.format("Last full vacuum time is %d but it should be geq to %d",
+                partition.getLastFullVacuumTime(), startTs), partition.getLastFullVacuumTime() >= startTs);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -37,7 +37,6 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.rpc.LakeServiceWithMetrics;
-import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.RunMode;
@@ -353,7 +352,7 @@ public class VacuumTest {
 
         new MockUp<BrpcProxy>() {
             @Mock
-            public LakeService getLakeService(String host, int port) throws RpcException {
+            public LakeService getLakeService(String host, int port) {
                 return new LakeServiceWithMetrics(null);
             }
         };
@@ -403,7 +402,7 @@ public class VacuumTest {
         new MockUp<VacuumFullRequest>() {
             @Mock
             public void setRetainVersions(List<Long> retainVersions) {
-                Assertions.assertEquals(retainVersions.size(), 0);
+                Assertions.assertEquals(0, retainVersions.size());
                 return;
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -375,7 +375,7 @@ public class VacuumTest {
         new MockUp<VacuumFullRequest>() {
             @Mock
             public void setRetainVersions(List<Long> retainVersions) {
-                Assertions.assertEquals(0, retainVersions.size());
+                Assertions.assertEquals(1, retainVersions.size());
                 return;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -92,6 +92,8 @@ import com.starrocks.proto.UnlockTabletMetadataRequest;
 import com.starrocks.proto.UnlockTabletMetadataResponse;
 import com.starrocks.proto.UploadSnapshotsRequest;
 import com.starrocks.proto.UploadSnapshotsResponse;
+import com.starrocks.proto.VacuumFullRequest;
+import com.starrocks.proto.VacuumFullResponse;
 import com.starrocks.proto.VacuumRequest;
 import com.starrocks.proto.VacuumResponse;
 import com.starrocks.rpc.LakeService;
@@ -1204,6 +1206,11 @@ public class PseudoBackend {
 
         @Override
         public Future<PublishVersionResponse> aggregatePublishVersion(AggregatePublishVersionRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request) {
             return CompletableFuture.completedFuture(null);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -78,6 +78,8 @@ import com.starrocks.proto.UnlockTabletMetadataRequest;
 import com.starrocks.proto.UnlockTabletMetadataResponse;
 import com.starrocks.proto.UploadSnapshotsRequest;
 import com.starrocks.proto.UploadSnapshotsResponse;
+import com.starrocks.proto.VacuumFullRequest;
+import com.starrocks.proto.VacuumFullResponse;
 import com.starrocks.proto.VacuumRequest;
 import com.starrocks.proto.VacuumResponse;
 import com.starrocks.rpc.BrpcProxy;
@@ -684,6 +686,11 @@ public class MockedBackend {
 
         @Override
         public Future<PublishVersionResponse> aggregatePublishVersion(AggregatePublishVersionRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request) {
             return CompletableFuture.completedFuture(null);
         }
     }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -328,15 +328,14 @@ message VacuumResponse {
 }
 
 // 1. Before the orphaned data file cleanup starts, VacuumFull will delete metadata files which satisfy the following:
-// (tablet_id not in request.tablet_ids OR commit_time < grace_timestamp)
+// (commit_time < grace_timestamp)
 // 2. Then, orphaned data files will be determined. We use min_active_txn_id to filter out new data files, then we open
 // any remaining metadata files and note that the data files referenced are not orphans.
 // 3. all tabletMetadata with versions in retain_versions should be retained when try to vaccum to meta which have
-// commit_time < grace_timestamp
+// commit_time < grace_timestamp. retain_versions must contains the lastest visible version.
 // 4. all tabletMetadata with versions NOT in [min_check_version, max_check_version] should not be checked.
 message VacuumFullRequest {
-    // The ids of the tablets to consider, delete metadata for other tablets
-    repeated int64 tablet_ids = 1;
+    repeated int64 tablet_ids = 1; // Full vacuum do not depends on this field now.
     optional int64 min_check_version = 2;
     optional int64 max_check_version = 3;
     // Don't delete files with txn_id >= min_active_txn_id
@@ -351,6 +350,8 @@ message VacuumFullRequest {
     // All tablet metadata and their data files of these verisons should be retained and can not be
     // vaccummed.
     repeated int64 retain_versions = 7;
+    // tablet_id can be the id of any of the tablet belongs to the table to be dropped.
+    optional int64 tablet_id = 8;
 }
 
 message VacuumFullResponse {

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -328,10 +328,11 @@ message VacuumResponse {
 }
 
 message VacuumFullRequest {
-    repeated int64 tablet_ids = 1;
-    optional int64 min_check_version = 2;
-    optional int64 max_check_version = 3;
-    optional int64 min_active_txn_id = 4;
+    optional int64 partition_id = 5; // The id of the partition to vacuum
+    repeated int64 tablet_ids = 1; // The ids of the tablets, ignore other tablets
+    optional int64 min_check_version = 2; // Ignore version < min_check_version, default 1 (set by FE)
+    optional int64 max_check_version = 3; // Ignore version >= max_check_version, default visible version
+    optional int64 min_active_txn_id = 4; // Delete txn log files with txn IDs less than min_active_txn_id
 }
 
 message VacuumFullResponse {

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -335,13 +335,14 @@ message VacuumResponse {
 // commit_time < grace_timestamp. retain_versions must contains the lastest visible version.
 // 4. all tabletMetadata with versions NOT in [min_check_version, max_check_version) should not be vacuumed.
 message VacuumFullRequest {
-    repeated int64 tablet_ids = 1; // Full vacuum do not depends on this field now.
-    optional int64 min_check_version = 2;
-    optional int64 max_check_version = 3;
-    // Don't delete files with txn_id >= min_active_txn_id
-    optional int64 min_active_txn_id = 4;
     // The id of the partition to vacuum
-    optional int64 partition_id = 5;
+    optional int64 partition_id = 1;
+    // tablet_id can be the id of any of the tablet belongs to the table to be dropped.
+    optional int64 tablet_id = 2;
+    optional int64 min_check_version = 3;
+    optional int64 max_check_version = 4;
+    // Don't delete files with txn_id >= min_active_txn_id
+    optional int64 min_active_txn_id = 5;
     // Delete metadata files with commit_time < grace_timestamp (set by FE)
     optional int64 grace_timestamp = 6;
     // retain version info of tablet metadata
@@ -350,8 +351,6 @@ message VacuumFullRequest {
     // All tablet metadata and their data files of these verisons should be retained and can not be
     // vaccummed.
     repeated int64 retain_versions = 7;
-    // tablet_id can be the id of any of the tablet belongs to the table to be dropped.
-    optional int64 tablet_id = 8;
 }
 
 message VacuumFullResponse {

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -328,20 +328,29 @@ message VacuumResponse {
 }
 
 // 1. Before the orphaned data file cleanup starts, VacuumFull will delete metadata files which satisfy the following:
-// (tablet_id not in request.tablet_ids OR version < min_check_version)
+// (tablet_id not in request.tablet_ids OR commit_time < grace_timestamp)
 // 2. Then, orphaned data files will be determined. We use min_active_txn_id to filter out new data files, then we open
-// any remaining metadata files with version <= max_check_version and note that the data files referenced are not orphans.
+// any remaining metadata files and note that the data files referenced are not orphans.
+// 3. all tabletMetadata with versions in retain_versions should be retained when try to vaccum to meta which have
+// commit_time < grace_timestamp
+// 4. all tabletMetadata with versions NOT in [min_check_version, max_check_version] should not be checked.
 message VacuumFullRequest {
-    // The id of the partition to vacuum
-    optional int64 partition_id = 5; 
     // The ids of the tablets to consider, delete metadata for other tablets
-    repeated int64 tablet_ids = 1; 
-     // Delete metadata files with version < min_check_version, default 1 (set by FE)
+    repeated int64 tablet_ids = 1;
     optional int64 min_check_version = 2;
-    // Ignore metadata files with version >= max_check_version, default visible version
     optional int64 max_check_version = 3;
     // Don't delete files with txn_id >= min_active_txn_id
     optional int64 min_active_txn_id = 4;
+    // The id of the partition to vacuum
+    optional int64 partition_id = 5;
+    // Delete metadata files with commit_time < grace_timestamp (set by FE)
+    optional int64 grace_timestamp = 6;
+    // retain version info of tablet metadata
+    // The version here means the version of tablet metadata or the physical partition version
+    // (because vacuun request is send by <node, physical partition>)
+    // All tablet metadata and their data files of these verisons should be retained and can not be
+    // vaccummed.
+    repeated int64 retain_versions = 7;
 }
 
 message VacuumFullResponse {

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -333,7 +333,7 @@ message VacuumResponse {
 // any remaining metadata files and note that the data files referenced are not orphans.
 // 3. all tabletMetadata with versions in retain_versions should be retained when try to vaccum to meta which have
 // commit_time < grace_timestamp. retain_versions must contains the lastest visible version.
-// 4. all tabletMetadata with versions NOT in [min_check_version, max_check_version] should not be checked.
+// 4. all tabletMetadata with versions NOT in [min_check_version, max_check_version] should not be vacuumed.
 message VacuumFullRequest {
     repeated int64 tablet_ids = 1; // Full vacuum do not depends on this field now.
     optional int64 min_check_version = 2;

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -327,12 +327,16 @@ message VacuumResponse {
     optional int64 extra_file_size = 6;
 }
 
+// 1. Before the orphaned data file cleanup starts, VacuumFull will delete metadata files which satisfy the following:
+// (tablet_id not in request.tablet_ids OR version < min_check_version)
+// 2. Then, orphaned data files will be determined. We use min_active_txn_id to filter out new data files, then we open
+// any remaining metadata files with version <= max_check_version and note that the data files referenced are not orphans.
 message VacuumFullRequest {
     optional int64 partition_id = 5; // The id of the partition to vacuum
     repeated int64 tablet_ids = 1; // The ids of the tablets, ignore other tablets
-    optional int64 min_check_version = 2; // Ignore version < min_check_version, default 1 (set by FE)
-    optional int64 max_check_version = 3; // Ignore version >= max_check_version, default visible version
-    optional int64 min_active_txn_id = 4; // Delete txn log files with txn IDs less than min_active_txn_id
+    optional int64 min_check_version = 2; // Delete metadata files with version < min_check_version, default 1 (set by FE)
+    optional int64 max_check_version = 3; // Ignore metadata files with version >= max_check_version, default visible version
+    optional int64 min_active_txn_id = 4;
 }
 
 message VacuumFullResponse {

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -333,7 +333,7 @@ message VacuumResponse {
 // any remaining metadata files and note that the data files referenced are not orphans.
 // 3. all tabletMetadata with versions in retain_versions should be retained when try to vaccum to meta which have
 // commit_time < grace_timestamp. retain_versions must contains the lastest visible version.
-// 4. all tabletMetadata with versions NOT in [min_check_version, max_check_version] should not be vacuumed.
+// 4. all tabletMetadata with versions NOT in [min_check_version, max_check_version) should not be vacuumed.
 message VacuumFullRequest {
     repeated int64 tablet_ids = 1; // Full vacuum do not depends on this field now.
     optional int64 min_check_version = 2;

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -332,10 +332,15 @@ message VacuumResponse {
 // 2. Then, orphaned data files will be determined. We use min_active_txn_id to filter out new data files, then we open
 // any remaining metadata files with version <= max_check_version and note that the data files referenced are not orphans.
 message VacuumFullRequest {
-    optional int64 partition_id = 5; // The id of the partition to vacuum
-    repeated int64 tablet_ids = 1; // The ids of the tablets, ignore other tablets
-    optional int64 min_check_version = 2; // Delete metadata files with version < min_check_version, default 1 (set by FE)
-    optional int64 max_check_version = 3; // Ignore metadata files with version >= max_check_version, default visible version
+    // The id of the partition to vacuum
+    optional int64 partition_id = 5; 
+    // The ids of the tablets to consider, delete metadata for other tablets
+    repeated int64 tablet_ids = 1; 
+     // Delete metadata files with version < min_check_version, default 1 (set by FE)
+    optional int64 min_check_version = 2;
+    // Ignore metadata files with version >= max_check_version, default visible version
+    optional int64 max_check_version = 3;
+    // Don't delete files with txn_id >= min_active_txn_id
     optional int64 min_active_txn_id = 4;
 }
 


### PR DESCRIPTION
This is the subsequent update based on this PR #58055

## Why I'm doing:

Disaster recovery based on cluster snapshot is implemented in StarRocks shared-data mode. The data in a cluster snapshot may be newer than the metadata version, potentially containing additional data files written after the metadata version. When a cluster is restored from a cluster snapshot, it needs to align the data with the metadata. To speed up the recovery process, only necessary data alignment is performed during the restoration. After the cluster is restored, some useless data might be left on the object storage. These useless data do not affect the normal operation of the cluster but occupy storage space unnecessarily, leading to storage waste. Full vacuum is used to delete these useless data to reclaim storage space.

## What I'm doing:

FullVacuum RPC implementation on backend
1. Before the orphaned data file cleanup starts, VacuumFull will delete metadata files which satisfy the following: (meta commit time < grace timestamp AND not in retain version list AND min_check_version <= ver < max_check_version)
2. Then, orphaned data files will be determined. We use min_active_txn_id to filter out new data files, then we open any remaining metadata files and note that the data files referenced are not orphans.

New Daemon on the frontend which triggers full vacuum on each partition every 24 hours (configurable)
1. Basically a copy of the AutoVacuumDaemon, except it triggers a different RPC and has different frequency
2. Unlike AutoVacuum, we don't broadcast requests based on tablet owners, since each RPC is handled by just a single CN (it's doing work for an entire partition, not just a set of tablets). Because it's not obvious to which CN a given request should be sent, this just choose a CN by random.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
