### PR TITLE
[BugFix] fix incorrect bucket size check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -186,8 +186,7 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_ENABLE_LOAD_PROFILE = "enable_load_profile";
 
-    public static final String PROPERTIES_BASE_COMPACTION_FORBIDDEN_TIME_RANGES =
-            "base_compaction_forbidden_time_ranges";
+    public static final String PROPERTIES_BASE_COMPACTION_FORBIDDEN_TIME_RANGES = "base_compaction_forbidden_time_ranges";
 
     public static final String PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC = "primary_index_cache_expire_sec";
 
@@ -407,8 +406,7 @@ public class PropertyAnalyzer {
         return partitionTimeToLive;
     }
 
-    public static Pair<String, PeriodDuration> analyzePartitionTTL(Map<String, String> properties,
-                                                                   boolean removeProperties) {
+    public static Pair<String, PeriodDuration> analyzePartitionTTL(Map<String, String> properties, boolean removeProperties) {
         if (properties != null && properties.containsKey(PROPERTIES_PARTITION_TTL)) {
             String ttlStr = properties.get(PROPERTIES_PARTITION_TTL);
             PeriodDuration duration;
@@ -469,12 +467,10 @@ public class PropertyAnalyzer {
             }
             // validate retention condition
             TableName tableName = new TableName(db.getFullName(), olapTable.getName());
-            ConnectContext connectContext =
-                    ConnectContext.get() == null ? new ConnectContext(null) : ConnectContext.get();
+            ConnectContext connectContext = ConnectContext.get() == null ? new ConnectContext(null) : ConnectContext.get();
 
             try {
-                PartitionSelector.getPartitionIdsByExpr(connectContext, tableName, olapTable, whereExpr, false,
-                        exprToAdjustMap);
+                PartitionSelector.getPartitionIdsByExpr(connectContext, tableName, olapTable, whereExpr, false, exprToAdjustMap);
             } catch (Exception e) {
                 throw new SemanticException("Failed to validate retention condition: " + e.getMessage());
             }
@@ -760,8 +756,7 @@ public class PropertyAnalyzer {
 
         List<Long> backendIds = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAvailableBackendIds();
         if (RunMode.isSharedDataMode()) {
-            backendIds.addAll(
-                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAvailableComputeNodeIds());
+            backendIds.addAll(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAvailableComputeNodeIds());
             if (RunMode.defaultReplicationNum() > backendIds.size()) {
                 throw new SemanticException("Number of available CN nodes is " + backendIds.size()
                         + ", less than " + RunMode.defaultReplicationNum());
@@ -804,8 +799,7 @@ public class PropertyAnalyzer {
                 tStorageType = TStorageType.COLUMN;
             } else if (olapTable.supportsUpdate() && storageType.equalsIgnoreCase(TStorageType.ROW.name())) {
                 tStorageType = TStorageType.ROW;
-            } else if (olapTable.supportsUpdate() &&
-                    storageType.equalsIgnoreCase(TStorageType.COLUMN_WITH_ROW.name())) {
+            } else if (olapTable.supportsUpdate() && storageType.equalsIgnoreCase(TStorageType.COLUMN_WITH_ROW.name())) {
                 tStorageType = TStorageType.COLUMN_WITH_ROW;
                 if (olapTable.getColumns().stream().filter(column -> !column.isKey()).count() == 0) {
                     throw new AnalysisException("column_with_row storage type must have some non-key columns");

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -111,6 +111,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -185,7 +186,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_ENABLE_LOAD_PROFILE = "enable_load_profile";
 
-    public static final String PROPERTIES_BASE_COMPACTION_FORBIDDEN_TIME_RANGES = "base_compaction_forbidden_time_ranges";
+    public static final String PROPERTIES_BASE_COMPACTION_FORBIDDEN_TIME_RANGES =
+            "base_compaction_forbidden_time_ranges";
 
     public static final String PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC = "primary_index_cache_expire_sec";
 
@@ -405,7 +407,8 @@ public class PropertyAnalyzer {
         return partitionTimeToLive;
     }
 
-    public static Pair<String, PeriodDuration> analyzePartitionTTL(Map<String, String> properties, boolean removeProperties) {
+    public static Pair<String, PeriodDuration> analyzePartitionTTL(Map<String, String> properties,
+                                                                   boolean removeProperties) {
         if (properties != null && properties.containsKey(PROPERTIES_PARTITION_TTL)) {
             String ttlStr = properties.get(PROPERTIES_PARTITION_TTL);
             PeriodDuration duration;
@@ -466,10 +469,12 @@ public class PropertyAnalyzer {
             }
             // validate retention condition
             TableName tableName = new TableName(db.getFullName(), olapTable.getName());
-            ConnectContext connectContext = ConnectContext.get() == null ? new ConnectContext(null) : ConnectContext.get();
+            ConnectContext connectContext =
+                    ConnectContext.get() == null ? new ConnectContext(null) : ConnectContext.get();
 
             try {
-                PartitionSelector.getPartitionIdsByExpr(connectContext, tableName, olapTable, whereExpr, false, exprToAdjustMap);
+                PartitionSelector.getPartitionIdsByExpr(connectContext, tableName, olapTable, whereExpr, false,
+                        exprToAdjustMap);
             } catch (Exception e) {
                 throw new SemanticException("Failed to validate retention condition: " + e.getMessage());
             }
@@ -755,7 +760,8 @@ public class PropertyAnalyzer {
 
         List<Long> backendIds = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAvailableBackendIds();
         if (RunMode.isSharedDataMode()) {
-            backendIds.addAll(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAvailableComputeNodeIds());
+            backendIds.addAll(
+                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAvailableComputeNodeIds());
             if (RunMode.defaultReplicationNum() > backendIds.size()) {
                 throw new SemanticException("Number of available CN nodes is " + backendIds.size()
                         + ", less than " + RunMode.defaultReplicationNum());
@@ -798,7 +804,8 @@ public class PropertyAnalyzer {
                 tStorageType = TStorageType.COLUMN;
             } else if (olapTable.supportsUpdate() && storageType.equalsIgnoreCase(TStorageType.ROW.name())) {
                 tStorageType = TStorageType.ROW;
-            } else if (olapTable.supportsUpdate() && storageType.equalsIgnoreCase(TStorageType.COLUMN_WITH_ROW.name())) {
+            } else if (olapTable.supportsUpdate() &&
+                    storageType.equalsIgnoreCase(TStorageType.COLUMN_WITH_ROW.name())) {
                 tStorageType = TStorageType.COLUMN_WITH_ROW;
                 if (olapTable.getColumns().stream().filter(column -> !column.isKey()).count() == 0) {
                     throw new AnalysisException("column_with_row storage type must have some non-key columns");
@@ -1241,6 +1248,14 @@ public class PropertyAnalyzer {
             properties.remove(propKey);
         }
         return val;
+    }
+
+    public static Optional<Long> analyzeLongProp(Map<String, String> properties, String propKey)
+            throws AnalysisException {
+        if (properties == null || !properties.containsKey(propKey)) {
+            return Optional.empty();
+        }
+        return Optional.of(analyzeLongProp(properties, propKey, 0L));
     }
 
     public static long analyzeLongProp(Map<String, String> properties, String propKey, long defaultVal)

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -450,13 +450,18 @@ public class OlapTableFactory implements AbstractTableFactory {
 
             try {
                 long bucketSize = PropertyAnalyzer.analyzeLongProp(properties,
-                        PropertyAnalyzer.PROPERTIES_BUCKET_SIZE, Config.default_automatic_bucket_size);
+                        PropertyAnalyzer.PROPERTIES_BUCKET_SIZE, -1);
                 if (bucketSize >= 0) {
                     if (!table.allowBucketSizeSetting()) {
-                        throw new DdlException("Setting bucket size is not allowed: only supported for tables with RANDOM " +
-                                "distribution and when 'enable_automatic_bucket' is enabled.");
+                        throw new DdlException(
+                                "Setting bucket size is not allowed: only supported for tables with RANDOM " +
+                                        "distribution and when 'enable_automatic_bucket' is enabled.");
                     }
                     table.setAutomaticBucketSize(bucketSize);
+                } else if (bucketSize == -1) {
+                    if (table.allowBucketSizeSetting()) {
+                        table.setAutomaticBucketSize(Config.default_automatic_bucket_size);
+                    }
                 } else {
                     throw new DdlException("Illegal bucket size: " + bucketSize);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -83,6 +83,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -449,21 +450,21 @@ public class OlapTableFactory implements AbstractTableFactory {
             }
 
             try {
-                long bucketSize = PropertyAnalyzer.analyzeLongProp(properties,
-                        PropertyAnalyzer.PROPERTIES_BUCKET_SIZE, -1);
-                if (bucketSize >= 0) {
+                Optional<Long> bucketSize = PropertyAnalyzer.analyzeLongProp(properties,
+                        PropertyAnalyzer.PROPERTIES_BUCKET_SIZE);
+                if (bucketSize.isPresent() && bucketSize.get() >= 0) {
                     if (!table.allowBucketSizeSetting()) {
                         throw new DdlException(
                                 "Setting bucket size is not allowed: only supported for tables with RANDOM " +
                                         "distribution and when 'enable_automatic_bucket' is enabled.");
                     }
-                    table.setAutomaticBucketSize(bucketSize);
-                } else if (bucketSize == -1) {
+                    table.setAutomaticBucketSize(bucketSize.get());
+                } else if (bucketSize.isEmpty()) {
                     if (table.allowBucketSizeSetting()) {
                         table.setAutomaticBucketSize(Config.default_automatic_bucket_size);
                     }
                 } else {
-                    throw new DdlException("Illegal bucket size: " + bucketSize);
+                    throw new DdlException("Illegal bucket size: " + bucketSize.get());
                 }
             } catch (AnalysisException e) {
                 throw new DdlException(e.getMessage());

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -467,7 +467,6 @@ COMMENT "OLAP"
 DISTRIBUTED BY HASH(`rowkey`) BUCKETS 64
 PROPERTIES (
     "replication_num" = "1",
-    "bucket_size" = "4294967296",
     "storage_volume" = "builtin_storage_volume",
     "enable_persistent_index" = "true",
     "compression" = "LZ4"

--- a/test/sql/test_string_functions/T/test_string_functions
+++ b/test/sql/test_string_functions/T/test_string_functions
@@ -169,7 +169,6 @@ COMMENT "OLAP"
 DISTRIBUTED BY HASH(`rowkey`) BUCKETS 64
 PROPERTIES (
     "replication_num" = "1",
-    "bucket_size" = "4294967296",
     "storage_volume" = "builtin_storage_volume",
     "enable_persistent_index" = "true",
     "compression" = "LZ4"


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Introduced by #60523.

The `PropertyAnalyzer.analyzeLongProp` uses a default value, which causes it to return `default_automatic_bucket_size` when omitted. This behavior can lead to a conflict with the subsequent table type validation.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
