### PR TITLE
[Enhancement] Converting intra FE calls into https when its enabled

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -313,8 +313,10 @@ public class StarRocksFE {
     }
 
     private static boolean isNewLeaderReady(String leaderHost) {
-        String accessibleHostPort = NetUtils.getHostPortInAccessibleFormat(leaderHost, Config.http_port);
-        String url = "http://" + accessibleHostPort
+        String protocol = Config.enable_https ? "https" : "http";
+        int port = Config.enable_https ? Config.https_port : Config.http_port;
+        String accessibleHostPort = NetUtils.getHostPortInAccessibleFormat(leaderHost, port);
+        String url = protocol + "://" + accessibleHostPort
                 + "/api/bootstrap"
                 + "?cluster_id=" + GlobalStateMgr.getCurrentState().getNodeMgr().getClusterId()
                 + "&token=" +  GlobalStateMgr.getCurrentState().getNodeMgr().getToken();

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -41,12 +41,12 @@ import com.starrocks.common.Config;
 import com.starrocks.common.Log4jConfig;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.Version;
-import com.starrocks.common.util.NetUtils;
 import com.starrocks.common.util.Util;
 import com.starrocks.failpoint.FailPoint;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.ha.StateChangeExecutor;
 import com.starrocks.http.HttpServer;
+import com.starrocks.http.WebUtils;
 import com.starrocks.http.rest.ActionStatus;
 import com.starrocks.http.rest.BootstrapFinishAction;
 import com.starrocks.journal.Journal;
@@ -313,13 +313,9 @@ public class StarRocksFE {
     }
 
     private static boolean isNewLeaderReady(String leaderHost) {
-        String protocol = Config.enable_https ? "https" : "http";
-        int port = Config.enable_https ? Config.https_port : Config.http_port;
-        String accessibleHostPort = NetUtils.getHostPortInAccessibleFormat(leaderHost, port);
-        String url = protocol + "://" + accessibleHostPort
-                + "/api/bootstrap"
-                + "?cluster_id=" + GlobalStateMgr.getCurrentState().getNodeMgr().getClusterId()
-                + "&token=" +  GlobalStateMgr.getCurrentState().getNodeMgr().getToken();
+        String url = WebUtils.buildEndpoint(leaderHost, "/api/bootstrap",
+                "cluster_id=" + GlobalStateMgr.getCurrentState().getNodeMgr().getClusterId(),
+                "token=" + GlobalStateMgr.getCurrentState().getNodeMgr().getToken());
         try {
             String resultStr = Util.getResultForUrl(url, null,
                     Config.heartbeat_timeout_second * 1000,

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/FrontendsProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/FrontendsProcNode.java
@@ -108,7 +108,7 @@ public class FrontendsProcNode implements ProcNodeInterface {
             info.add(fe.getHost());
 
             info.add(Integer.toString(fe.getEditLogPort()));
-            info.add(Integer.toString(Config.http_port));
+            info.add(Integer.toString(Config.enable_https ? Config.https_port : Config.http_port));
 
             if (fe.getHost().equals(globalStateMgr.getNodeMgr().getSelfNode().first)) {
                 info.add(Integer.toString(Config.query_port));

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/FrontendsProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/FrontendsProcNode.java
@@ -60,8 +60,8 @@ public class FrontendsProcNode implements ProcNodeInterface {
     private static final Logger LOG = LogManager.getLogger(FrontendsProcNode.class);
 
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("Id").add("Name").add("IP").add("EditLogPort").add("HttpPort").add("QueryPort").add("RpcPort")
-            .add("Role").add("ClusterId").add("Join").add("Alive").add("ReplayedJournalId")
+            .add("Id").add("Name").add("IP").add("EditLogPort").add("HttpPort").add("HttpsPort").add("QueryPort")
+            .add("RpcPort").add("Role").add("ClusterId").add("Join").add("Alive").add("ReplayedJournalId")
             .add("LastHeartbeat").add("IsHelper").add("ErrMsg").add("StartTime").add("Version")
             .build();
 
@@ -108,7 +108,8 @@ public class FrontendsProcNode implements ProcNodeInterface {
             info.add(fe.getHost());
 
             info.add(Integer.toString(fe.getEditLogPort()));
-            info.add(Integer.toString(Config.enable_https ? Config.https_port : Config.http_port));
+            info.add(Integer.toString(Config.http_port));
+            info.add(Integer.toString(Config.https_port));
 
             if (fe.getHost().equals(globalStateMgr.getNodeMgr().getSelfNode().first)) {
                 info.add(Integer.toString(Config.query_port));

--- a/fe/fe-core/src/main/java/com/starrocks/ha/LeaderInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/LeaderInfo.java
@@ -28,17 +28,28 @@ public class LeaderInfo implements Writable {
     private int httpPort;
     @SerializedName("rp")
     private int rpcPort;
+    @SerializedName("sp")
+    private int httpsPort;
 
     public LeaderInfo() {
         this.ip = "";
         this.httpPort = 0;
         this.rpcPort = 0;
+        this.httpsPort = 0;
     }
 
     public LeaderInfo(String ip, int httpPort, int rpcPort) {
         this.ip = ip;
         this.httpPort = httpPort;
         this.rpcPort = rpcPort;
+        this.httpsPort = Config.https_port;
+    }
+
+    public LeaderInfo(String ip, int httpPort, int rpcPort, int httpsPort) {
+        this.ip = ip;
+        this.httpPort = httpPort;
+        this.rpcPort = rpcPort;
+        this.httpsPort = httpsPort;
     }
 
     public String getIp() {
@@ -63,6 +74,14 @@ public class LeaderInfo implements Writable {
 
     public void setRpcPort(int rpcPort) {
         this.rpcPort = rpcPort;
+    }
+
+    public int getHttpsPort() {
+        return this.httpsPort;
+    }
+
+    public void setHttpsPort(int httpsPort) {
+        this.httpsPort = httpsPort;
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/ha/LeaderInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/LeaderInfo.java
@@ -18,6 +18,7 @@
 package com.starrocks.ha;
 
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Config;
 import com.starrocks.common.io.Writable;
 
 public class LeaderInfo implements Writable {

--- a/fe/fe-core/src/main/java/com/starrocks/http/WebUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/WebUtils.java
@@ -36,7 +36,9 @@ package com.starrocks.http;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
+import com.starrocks.common.Config;
 import com.starrocks.common.path.PathTrie;
+import com.starrocks.common.util.NetUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
@@ -214,5 +216,34 @@ public class WebUtils {
             queryMap.put(key, value);
         }
         return queryMap;
+    }
+
+    public static String buildEndpoint(String ip, String path, String... queryParams) {
+        int port = Config.enable_https ? Config.https_port : Config.http_port;
+        return buildEndpoint(ip, port, path, queryParams);
+    }
+
+    /**
+     * Builds a complete HTTP/HTTPS endpoint URL for a given IP address and port.
+     * Automatically selects the appropriate protocol based on configuration.
+     * 
+     * @param ip The IP address or hostname
+     * @param port The port number to use
+     * @param path The API path (e.g., "/api/bootstrap")
+     * @param queryParams Optional query parameters to append
+     * @return Complete endpoint URL
+     */
+    public static String buildEndpoint(String ip, int port, String path, String... queryParams) {
+        String protocol = Config.enable_https ? "https" : "http";
+        String accessibleHostPort = NetUtils.getHostPortInAccessibleFormat(ip, port);
+        
+        StringBuilder url = new StringBuilder();
+        url.append(protocol).append("://").append(accessibleHostPort).append(path);
+        
+        if (queryParams != null && queryParams.length > 0) {
+            url.append("?").append(String.join("&", queryParams));
+        }
+        
+        return url.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
@@ -36,13 +36,12 @@ package com.starrocks.http.meta;
 
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
-import com.starrocks.common.Config;
-import com.starrocks.common.util.NetUtils;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.http.WebUtils;
 import com.starrocks.leader.MetaHelper;
 import com.starrocks.persist.ImageFormatVersion;
 import com.starrocks.persist.MetaCleaner;
@@ -267,11 +266,10 @@ public class MetaService {
                 imageFormatVersion = ImageFormatVersion.valueOf(formatStr);
             }
 
-            String protocol = Config.enable_https ? "https" : "http";
-            String url = protocol + "://" + NetUtils.getHostPortInAccessibleFormat(machine, Integer.parseInt(portStr)) + 
-                    "/image?version=" + versionStr
-                    + "&subdir=" + subDirStr
-                    + "&image_format_version=" + imageFormatVersion;
+            String url = WebUtils.buildEndpoint(machine, Integer.parseInt(portStr), "/image",
+                    "version=" + versionStr,
+                    "subdir=" + subDirStr,
+                    "image_format_version=" + imageFormatVersion);
             String filename = Storage.IMAGE + "." + versionStr;
 
             String realDir = MetaHelper.getImageFileDir(subDirStr, imageFormatVersion);

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
@@ -266,7 +266,8 @@ public class MetaService {
                 imageFormatVersion = ImageFormatVersion.valueOf(formatStr);
             }
 
-            String url = "http://" + NetUtils.getHostPortInAccessibleFormat(machine, Integer.parseInt(portStr)) + 
+            String protocol = Config.enable_https ? "https" : "http";
+            String url = protocol + "://" + NetUtils.getHostPortInAccessibleFormat(machine, Integer.parseInt(portStr)) + 
                     "/image?version=" + versionStr
                     + "&subdir=" + subDirStr
                     + "&image_format_version=" + imageFormatVersion;

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
@@ -36,6 +36,7 @@ package com.starrocks.http.meta;
 
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.NetUtils;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.http.ActionController;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
@@ -63,8 +63,12 @@ public class OAuth2Action extends RestBaseAction {
         int fid = (int) ((connectionId >> 24) & 0xFF);
         Frontend frontend = GlobalStateMgr.getCurrentState().getNodeMgr().getFrontend(fid);
         if (!nodeMgr.getMySelf().getNodeName().equals(frontend.getNodeName())) {
+            // Use HTTPS only if request scheme is HTTPS and Config.enable_https is true
+            String scheme = request.getRequest().scheme();
+            boolean useHttps = "https".equals(scheme) && Config.enable_https;
+            int port = useHttps ? Config.https_port : Config.http_port;
             String responseContent =
-                    StarRocksHttpClient.redirect(frontend.getHost(), Config.http_port, request.getRequest());
+                    StarRocksHttpClient.redirect(frontend.getHost(), port, request.getRequest());
             response.appendContent(responseContent);
             sendResult(request, response);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
@@ -63,8 +63,7 @@ public class OAuth2Action extends RestBaseAction {
         int fid = (int) ((connectionId >> 24) & 0xFF);
         Frontend frontend = GlobalStateMgr.getCurrentState().getNodeMgr().getFrontend(fid);
         if (!nodeMgr.getMySelf().getNodeName().equals(frontend.getNodeName())) {
-            // Use HTTPS only if request scheme is HTTPS and Config.enable_https is true
-            String scheme = request.getRequest().scheme();
+            String scheme = getProtocolFromRequest(request);
             boolean useHttps = "https".equals(scheme) && Config.enable_https;
             int port = useHttps ? Config.https_port : Config.http_port;
             String responseContent =

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -242,10 +242,10 @@ public class RestBaseAction extends BaseAction {
         String originalProtocol = getProtocolFromRequest(request);
 
         // Choose the appropriate port and protocol based on the original request
-        Pair<String, Integer> leaderIpAndPort = ("https".equals(originalProtocol) && Config.enable_https) 
-            ? globalStateMgr.getNodeMgr().getLeaderIpAndHttpsPort()
-            : globalStateMgr.getNodeMgr().getLeaderIpAndHttpPort();
-        
+        Pair<String, Integer> leaderIpAndPort = ("https".equals(originalProtocol) && Config.enable_https)
+                ? globalStateMgr.getNodeMgr().getLeaderIpAndHttpsPort()
+                : globalStateMgr.getNodeMgr().getLeaderIpAndHttpPort();
+
         redirectTo(request, response,
                 new TNetworkAddress(leaderIpAndPort.first, leaderIpAndPort.second));
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -242,17 +242,9 @@ public class RestBaseAction extends BaseAction {
         String originalProtocol = getProtocolFromRequest(request);
 
         // Choose the appropriate port and protocol based on the original request
-        Pair<String, Integer> leaderIpAndPort;
-        String protocol;
-        if ("https".equals(originalProtocol) && Config.enable_https) {
-            // For HTTPS requests, use HTTPS port when enabled
-            leaderIpAndPort = globalStateMgr.getNodeMgr().getLeaderIpAndHttpsPort();
-            protocol = "https";
-        } else {
-            // For HTTP requests or when HTTPS is disabled, use HTTP port
-            leaderIpAndPort = globalStateMgr.getNodeMgr().getLeaderIpAndHttpPort();
-            protocol = "http";
-        }
+        Pair<String, Integer> leaderIpAndPort = ("https".equals(originalProtocol) && Config.enable_https) 
+            ? globalStateMgr.getNodeMgr().getLeaderIpAndHttpsPort()
+            : globalStateMgr.getNodeMgr().getLeaderIpAndHttpPort();
         
         redirectTo(request, response,
                 new TNetworkAddress(leaderIpAndPort.first, leaderIpAndPort.second));

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -39,6 +39,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.AuthorizationMgr;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.Pair;
@@ -56,7 +57,7 @@ import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.thrift.TNetworkAddress;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.apache.commons.lang3.StringUtils;
+import io.netty.handler.ssl.SslHandler;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -199,18 +200,15 @@ public class RestBaseAction extends BaseAction {
     }
 
     /**
-     * Get the protocol from the request, defaulting to "http" if scheme is null, empty, or not http/https
+     * Get the protocol from the request, defaulting to "http"
      * @param request the base request
      * @return the protocol string ("http" or "https")
      */
-    private String getProtocolFromRequest(BaseRequest request) {
-        String scheme = request.getRequest().scheme();
-        if (StringUtils.isEmpty(scheme)) {
-            return "http";
-        }
-        scheme = scheme.toLowerCase();
-        if ("http".equals(scheme) || "https".equals(scheme)) {
-            return scheme;
+    protected String getProtocolFromRequest(BaseRequest request) {
+        if (request.getContext() != null
+                && request.getContext().pipeline() != null
+                && request.getContext().pipeline().get(SslHandler.class) != null) {
+            return "https";
         }
         return "http";
     }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
@@ -270,7 +270,9 @@ public class CheckpointController extends FrontendDaemon {
             throw new IOException(errMessage);
         }
         File dir = new File(imageDir);
-        String url = "http://" + NetUtils.getHostPortInAccessibleFormat(frontend.getHost(), Config.http_port) +
+        String protocol = Config.enable_https ? "https" : "http";
+        int port = Config.enable_https ? Config.https_port : Config.http_port;
+        String url = protocol + "://" + NetUtils.getHostPortInAccessibleFormat(frontend.getHost(), port) +
                 "/image?version=" + journalId
                 + "&subdir=" + subDir
                 + "&image_format_version=" + imageFormatVersion;
@@ -407,9 +409,11 @@ public class CheckpointController extends FrontendDaemon {
 
             boolean pushSuccess = true;
             ImageFormatVersion formatVersion = belongToGlobalStateMgr ? ImageFormatVersion.v2 : ImageFormatVersion.v1;
-            String url = "http://" + NetUtils.getHostPortInAccessibleFormat(frontend.getHost(), Config.http_port)
+            String protocol = Config.enable_https ? "https" : "http";
+            int port = Config.enable_https ? Config.https_port : Config.http_port;
+            String url = protocol + "://" + NetUtils.getHostPortInAccessibleFormat(frontend.getHost(), port)
                     + "/put?version=" + imageVersion
-                    + "&port=" + Config.http_port
+                    + "&port=" + port
                     + "&subdir=" + subDir
                     + "&for_global_state=" + belongToGlobalStateMgr
                     + "&image_format_version=" + formatVersion.toString();
@@ -438,7 +442,8 @@ public class CheckpointController extends FrontendDaemon {
         long minReplayedJournalId = Long.MAX_VALUE;
         for (Frontend fe : GlobalStateMgr.getServingState().getNodeMgr().getOtherFrontends()) {
             String host = fe.getHost();
-            int port = Config.http_port;
+            String protocol = Config.enable_https ? "https" : "http";
+            int port = Config.enable_https ? Config.https_port : Config.http_port;
             URL idURL;
             HttpURLConnection conn = null;
             try {
@@ -448,7 +453,7 @@ public class CheckpointController extends FrontendDaemon {
                  * any non-master node's current replayed journal id. otherwise,
                  * this lagging node can never get the deleted journal.
                  */
-                idURL = new URL("http://" + NetUtils.getHostPortInAccessibleFormat(host, port) + "/journal_id?prefix=" + journal.getPrefix());
+                idURL = new URL(protocol + "://" + NetUtils.getHostPortInAccessibleFormat(host, port) + "/journal_id?prefix=" + journal.getPrefix());
                 conn = (HttpURLConnection) idURL.openConnection();
                 conn.setConnectTimeout(CONNECT_TIMEOUT_SECOND * 1000);
                 conn.setReadTimeout(READ_TIMEOUT_SECOND * 1000);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
@@ -40,10 +40,10 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
 import com.starrocks.common.proc.CurrentQueryInfoProvider;
 import com.starrocks.common.util.QueryStatisticsFormatter;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.http.WebUtils;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.thrift.TQueryStatisticsInfo;
 import org.apache.http.HttpStatus;
@@ -401,10 +401,7 @@ public class QueryStatisticsInfo {
     public static String getExecProgress(String feIp, String queryId, HttpClient httpClient) {
         String result = "";
         try {
-            String protocol = Config.enable_https ? "https" : "http";
-            int port = Config.enable_https ? Config.https_port : Config.http_port;
-            String url = String.format("%s://%s:%s/api/query/progress?query_id=%s",
-                    protocol, feIp, port, queryId);
+            String url = WebUtils.buildEndpoint(feIp, "/api/query/progress", "query_id=" + queryId);
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .GET()

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
@@ -401,8 +401,10 @@ public class QueryStatisticsInfo {
     public static String getExecProgress(String feIp, String queryId, HttpClient httpClient) {
         String result = "";
         try {
-            String url = String.format("http://%s:%s/api/query/progress?query_id=%s",
-                    feIp, Config.http_port, queryId);
+            String protocol = Config.enable_https ? "https" : "http";
+            int port = Config.enable_https ? Config.https_port : Config.http_port;
+            String url = String.format("%s://%s:%s/api/query/progress?query_id=%s",
+                    protocol, feIp, port, queryId);
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .GET()

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -1137,15 +1137,6 @@ public class NodeMgr {
         return new Pair<>(getLeaderIp(), Config.https_port);
     }
 
-    public String getLeaderIp() {
-        if (GlobalStateMgr.getServingState().isReady()) {
-            return this.leaderIp;
-        } else {
-            String leaderNodeName = GlobalStateMgr.getServingState().getHaProtocol().getLeaderNodeName();
-            return frontends.get(leaderNodeName).getHost();
-        }
-    }
-
     public void setLeader(LeaderInfo info) {
         this.leaderIp = info.getIp();
         this.leaderHttpPort = info.getHttpPort();

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -47,6 +47,7 @@ import com.starrocks.common.util.MachineInfo;
 import com.starrocks.common.util.NetUtils;
 import com.starrocks.common.util.Util;
 import com.starrocks.encryption.KeyMgr;
+import com.starrocks.http.WebUtils;
 import com.starrocks.http.rest.ActionStatus;
 import com.starrocks.http.rest.BootstrapFinishAction.BootstrapResult;
 import com.starrocks.monitor.jvm.JvmStats;
@@ -367,11 +368,8 @@ public class HeartbeatMgr extends FrontendDaemon {
                 }
             }
 
-            String protocol = Config.enable_https ? "https" : "http";
-            int port = Config.enable_https ? Config.https_port : Config.http_port;
-            String accessibleHostPort = NetUtils.getHostPortInAccessibleFormat(fe.getHost(), port);
-            String url = protocol + "://" + accessibleHostPort
-                    + "/api/bootstrap?cluster_id=" + clusterId + "&token=" + token;
+            String url = WebUtils.buildEndpoint(fe.getHost(), "/api/bootstrap",
+                    "cluster_id=" + clusterId, "token=" + token);
             try {
                 String resultStr = Util.getResultForUrl(url, null,
                         Config.heartbeat_timeout_second * 1000, Config.heartbeat_timeout_second * 1000);

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -367,8 +367,10 @@ public class HeartbeatMgr extends FrontendDaemon {
                 }
             }
 
-            String accessibleHostPort = NetUtils.getHostPortInAccessibleFormat(fe.getHost(), Config.http_port);
-            String url = "http://" + accessibleHostPort
+            String protocol = Config.enable_https ? "https" : "http";
+            int port = Config.enable_https ? Config.https_port : Config.http_port;
+            String accessibleHostPort = NetUtils.getHostPortInAccessibleFormat(fe.getHost(), port);
+            String url = protocol + "://" + accessibleHostPort
                     + "/api/bootstrap?cluster_id=" + clusterId + "&token=" + token;
             try {
                 String resultStr = Util.getResultForUrl(url, null,


### PR DESCRIPTION
## Why I'm doing:
Currently HTTP and HTTPs are both enabled when enable_https flag is true. Intra FE calls are still HTTP which will be made HTTPs in this patch when its enabled.

## What I'm doing:
Intra FE calls are still HTTP which will be made HTTPs in this patch when enable_https is true.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3