### PR TITLE
[Feature] Support automatic creating split tablet job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -556,6 +556,8 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_LABELS_LOCATION)) {
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
+                    } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_DYNAMIC_TABLET)) {
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else {
                         schemaChangeHandler.process(Lists.newArrayList(clause), db, olapTable);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTabletUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTabletUtils.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.alter.dynamictablet;
 
+import com.starrocks.common.Config;
+
 public class DynamicTabletUtils {
 
     public static boolean isPowerOfTwo(long n) {
@@ -22,9 +24,12 @@ public class DynamicTabletUtils {
 
     public static int calcSplitCount(long dataSize, long splitSize) {
         int splitCount = 1;
-        while (dataSize > splitCount) {
-            splitCount *= 2;
-            dataSize /= splitCount;
+        for (long size = dataSize; size >= splitSize; size /= 2) {
+            int newSplitCount = splitCount * 2;
+            if (newSplitCount > Config.dynamic_tablet_max_split_count) {
+                break;
+            }
+            splitCount = newSplitCount;
         }
         return splitCount;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3198,6 +3198,39 @@ public class OlapTable extends Table {
         tableProperty.buildUseFastSchemaEvolution();
     }
 
+    public Boolean getEnableDynamicTablet() {
+        if (tableProperty != null) {
+            return tableProperty.getEnableDynamicTablet();
+        }
+        return null;
+    }
+
+    public boolean isEnableDynamicTablet() {
+        if (!isCloudNativeTableOrMaterializedView()) {
+            return false;
+        }
+
+        if (defaultDistributionInfo.getType() != DistributionInfoType.HASH) {
+            return false;
+        }
+
+        Boolean enableDynamicTablet = getEnableDynamicTablet();
+        if (enableDynamicTablet == null) {
+            return false;
+        }
+
+        return enableDynamicTablet;
+    }
+
+    public void setEnableDynamicTablet(Boolean enableDynamicTablet) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_DYNAMIC_TABLET,
+                enableDynamicTablet != null ? enableDynamicTablet.toString() : "");
+        tableProperty.buildEnableDynamicTablet();
+    }
+
     public void setSessionId(UUID sessionId) {
         this.sessionId = sessionId;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -327,6 +327,8 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     private TCompactionStrategy compactionStrategy = TCompactionStrategy.DEFAULT;
 
+    private Boolean enableDynamicTablet = null;
+
     public TableProperty() {
         this(Maps.newLinkedHashMap());
     }
@@ -413,6 +415,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 buildDataCachePartitionDuration();
                 buildLocation();
                 buildStorageCoolDownTTL();
+                buildEnableDynamicTablet();
                 break;
             case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY:
                 buildConstraint();
@@ -903,6 +906,19 @@ public class TableProperty implements Writable, GsonPostProcessable {
         }
     }
 
+    public TableProperty buildEnableDynamicTablet() {
+        String value = properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_DYNAMIC_TABLET);
+        if (value == null) {
+            enableDynamicTablet = null;
+        } else if (value.isEmpty()) {
+            enableDynamicTablet = null;
+            properties.remove(PropertyAnalyzer.PROPERTIES_ENABLE_DYNAMIC_TABLET);
+        } else {
+            enableDynamicTablet = Boolean.parseBoolean(value);
+        }
+        return this;
+    }
+
     public void modifyTableProperties(Map<String, String> modifyProperties) {
         properties.putAll(modifyProperties);
     }
@@ -1199,6 +1215,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return useFastSchemaEvolution;
     }
 
+    public Boolean getEnableDynamicTablet() {
+        return enableDynamicTablet;
+    }
+
     @Override
     public void gsonPostProcess() throws IOException {
         try {
@@ -1233,5 +1253,6 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildFileBundling();
         buildMutableBucketNum();
         buildCompactionStrategy();
+        buildEnableDynamicTablet();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -41,6 +41,7 @@ import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.Pair;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -56,6 +57,7 @@ import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.SplitTabletClause;
 import com.starrocks.statistic.BasicStatsMeta;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
@@ -118,24 +120,24 @@ public class TabletStatMgr extends FrontendDaemon {
 
         // after update replica in all backends, update index row num
         long start = System.currentTimeMillis();
-        List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds();
-        for (Long dbId : dbIds) {
+        for (Long dbId : GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds()) {
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 continue;
             }
             Locker locker = new Locker();
             for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
-                long totalRowCount = 0L;
                 if (!table.isNativeTableOrMaterializedView()) {
                     continue;
                 }
 
-                // NOTE: calculate the row first with read lock, then update the stats with write lock
-                locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+                long totalRowCount = 0L;
+                long maxTabletSize = 0L;
                 Map<Pair<Long, Long>, Long> indexRowCountMap = Maps.newHashMap();
+                // NOTE: calculate the row first with read lock, then update the stats with write lock
+                OlapTable olapTable = (OlapTable) table;
+                locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
                 try {
-                    OlapTable olapTable = (OlapTable) table;
                     for (Partition partition : olapTable.getAllPartitions()) {
                         for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                             long version = physicalPartition.getVisibleVersion();
@@ -145,6 +147,7 @@ public class TabletStatMgr extends FrontendDaemon {
                                 // NOTE: can take a rather long time to iterate lots of tablets
                                 for (Tablet tablet : index.getTablets()) {
                                     indexRowCount += tablet.getRowCount(version);
+                                    maxTabletSize = Math.max(maxTabletSize, tablet.getDataSize(true));
                                 } // end for tablets
                                 indexRowCountMap.put(Pair.create(physicalPartition.getId(), index.getId()),
                                         indexRowCount);
@@ -163,7 +166,6 @@ public class TabletStatMgr extends FrontendDaemon {
                 // update
                 locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.WRITE);
                 try {
-                    OlapTable olapTable = (OlapTable) table;
                     for (Partition partition : olapTable.getAllPartitions()) {
                         for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                             for (MaterializedIndex index :
@@ -180,11 +182,31 @@ public class TabletStatMgr extends FrontendDaemon {
                 } finally {
                     locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.WRITE);
                 }
+
+                // Trigger dynamic tablet splitting
+                if (GlobalStateMgr.getCurrentState().isLeader()) {
+                    triggerDynamicTablet(db, olapTable, maxTabletSize);
+                }
             }
         }
         LOG.info("finished to update index row num of all databases. cost: {} ms",
                 (System.currentTimeMillis() - start));
         lastWorkTimestamp = LocalDateTime.now();
+    }
+
+    private void triggerDynamicTablet(Database db, OlapTable table, long maxTabletSize) {
+        if (maxTabletSize >= Config.dynamic_tablet_split_size && table.isEnableDynamicTablet()) {
+            try {
+                GlobalStateMgr.getCurrentState().getDynamicTabletJobMgr().createDynamicTabletJob(
+                        db, table, new SplitTabletClause());
+            } catch (StarRocksException e) {
+                LOG.info("Failed to create split tablet job for table {}.{}. ",
+                        db.getFullName(), table.getName(), e);
+            } catch (Exception e) {
+                LOG.warn("Failed to create split tablet job for table {}.{}. ",
+                        db.getFullName(), table.getName(), e);
+            }
+        }
     }
 
     private void updateLocalTabletStat() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3797,6 +3797,12 @@ public class Config extends ConfigBase {
     public static long default_statistics_output_row_count = 1L * 1000 * 1000 * 1000;
 
     /**
+     * Whether enable dynamic tablet.
+     */
+    @ConfField(mutable = true, comment = "Whether enable dynamic tablet.")
+    public static boolean enable_dynamic_tablet = false;
+
+    /**
      * The default scheduler interval for dynamic tablet jobs.
      */
     @ConfField(mutable = false, comment = "The default scheduler interval for dynamic tablet jobs.")
@@ -3824,7 +3830,7 @@ public class Config extends ConfigBase {
      * The max number of new tablets that an old tablet can be split into.
      */
     @ConfField(mutable = true, comment = "The max number of new tablets that an old tablet can be split into.")
-    public static int dynamic_tablet_max_split_count = 1024;
+    public static int dynamic_tablet_max_split_count = 8;
 
     /**
      * Whether to enable tracing historical nodes when cluster scale

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -262,6 +262,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_COMPACTION_STRATEGY = "compaction_strategy";
 
+    public static final String PROPERTIES_ENABLE_DYNAMIC_TABLET = "enable_dynamic_tablet";
+
     public static final String PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE = "dynamic_tablet_split_size";
 
     /**
@@ -1571,6 +1573,42 @@ public class PropertyAnalyzer {
         return TCompactionStrategy.DEFAULT;
     }
 
+    public static Boolean analyzeEnableDynamicTablet(Map<String, String> properties, boolean removeProperties)
+            throws AnalysisException {
+        Boolean enableDynamicTablet = Config.enable_dynamic_tablet;
+        if (properties != null) {
+            String value = removeProperties ? properties.remove(PROPERTIES_ENABLE_DYNAMIC_TABLET)
+                    : properties.get(PROPERTIES_ENABLE_DYNAMIC_TABLET);
+            if (value != null) {
+                try {
+                    enableDynamicTablet = parseBoolean(value);
+                } catch (Exception e) {
+                    ErrorReport.reportAnalysisException(ErrorCode.ERR_INVALID_VALUE,
+                            PROPERTIES_ENABLE_DYNAMIC_TABLET, value, "`true` or `false`");
+                }
+            }
+        }
+        return enableDynamicTablet;
+    }
+
+    public static long analyzeDynamicTabletSplitSize(Map<String, String> properties, boolean removeProperties)
+            throws AnalysisException {
+        long dynamicTabletSplitSize = Config.dynamic_tablet_split_size;
+        if (properties != null) {
+            String value = removeProperties ? properties.remove(PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE)
+                    : properties.get(PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE);
+            if (value != null) {
+                try {
+                    dynamicTabletSplitSize = Long.parseLong(value);
+                } catch (Exception e) {
+                    ErrorReport.reportAnalysisException(ErrorCode.ERR_INVALID_VALUE,
+                            PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE, value, "a positive integer");
+                }
+            }
+        }
+        return dynamicTabletSplitSize;
+    }
+
     public static PeriodDuration analyzeStorageCoolDownTTL(Map<String, String> properties,
                                                            boolean removeProperties) throws AnalysisException {
         String text = properties.get(PROPERTIES_STORAGE_COOLDOWN_TTL);
@@ -1957,5 +1995,15 @@ public class PropertyAnalyzer {
         }
         sb.append(")");
         return sb.toString();
+    }
+
+    public static boolean parseBoolean(String value) {
+        if (value.equalsIgnoreCase("true")) {
+            return true;
+        }
+        if (value.equalsIgnoreCase("false")) {
+            return false;
+        }
+        throw new IllegalArgumentException("Illegal boolean value: " + value);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
@@ -140,6 +140,11 @@ public class LakeMaterializedView extends MaterializedView {
                 properties.put(PropertyAnalyzer.PROPERTIES_ENABLE_ASYNC_WRITE_BACK,
                         String.valueOf(storageInfo.isEnableAsyncWriteBack()));
             }
+
+            Boolean enableDynamicTablet = getEnableDynamicTablet();
+            if (enableDynamicTablet != null && enableDynamicTablet) {
+                properties.put(PropertyAnalyzer.PROPERTIES_ENABLE_DYNAMIC_TABLET, enableDynamicTablet.toString());
+            }
         }
         return properties;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -168,6 +168,11 @@ public class LakeTable extends OlapTable {
             properties.put(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE, getPersistentIndexTypeString());
         }
 
+        Boolean enableDynamicTablet = getEnableDynamicTablet();
+        if (enableDynamicTablet != null && enableDynamicTablet) {
+            properties.put(PropertyAnalyzer.PROPERTIES_ENABLE_DYNAMIC_TABLET, enableDynamicTablet.toString());
+        }
+
         return properties;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3751,6 +3751,14 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         ImmutableMap.of(key, propertiesToPersist.get(key)));
                 GlobalStateMgr.getCurrentState().getEditLog().logAlterTableProperties(info);
             }
+            if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_DYNAMIC_TABLET)) {
+                String enableDynamicTablet = propertiesToPersist.get(PropertyAnalyzer.PROPERTIES_ENABLE_DYNAMIC_TABLET);
+                tableProperty.getProperties().put(PropertyAnalyzer.PROPERTIES_ENABLE_DYNAMIC_TABLET, enableDynamicTablet);
+                tableProperty.buildEnableDynamicTablet();
+                ModifyTablePropertyOperationLog info = new ModifyTablePropertyOperationLog(db.getId(), table.getId(),
+                        ImmutableMap.of(key, propertiesToPersist.get(key)));
+                GlobalStateMgr.getCurrentState().getEditLog().logAlterTableProperties(info);
+            }
         }
     }
 
@@ -3830,6 +3838,14 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             }
             String locations = PropertyAnalyzer.analyzeLocation(properties, true);
             results.put(PropertyAnalyzer.PROPERTIES_LABELS_LOCATION, locations);
+        }
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_DYNAMIC_TABLET)) {
+            try {
+                Boolean enableDynamicTablet = PropertyAnalyzer.analyzeEnableDynamicTablet(properties, true);
+                results.put(PropertyAnalyzer.PROPERTIES_ENABLE_DYNAMIC_TABLET, enableDynamicTablet);
+            } catch (AnalysisException e) {
+                throw new RuntimeException(e.getMessage());
+            }
         }
         if (!properties.isEmpty()) {
             throw new DdlException("Modify failed because unknown properties: " + properties);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -494,6 +494,13 @@ public class OlapTableFactory implements AbstractTableFactory {
                 throw new DdlException(e.getMessage());
             }
 
+            try {
+                Boolean enableDynamicTablet = PropertyAnalyzer.analyzeEnableDynamicTablet(properties, true);
+                table.setEnableDynamicTablet(enableDynamicTablet);
+            } catch (Exception e) {
+                throw new DdlException(e.getMessage());
+            }
+
             // write quorum
             try {
                 table.setWriteQuorum(PropertyAnalyzer.analyzeWriteQuorum(properties));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SplitTabletClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SplitTabletClause.java
@@ -14,11 +14,8 @@
 
 package com.starrocks.sql.ast;
 
-import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
-import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.PrintableMap;
-import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Map;
@@ -32,6 +29,11 @@ public class SplitTabletClause extends AlterTableClause {
     private final Map<String, String> properties;
 
     private long dynamicTabletSplitSize;
+
+    public SplitTabletClause() {
+        this(null, null, null);
+        this.dynamicTabletSplitSize = Config.dynamic_tablet_split_size;
+    }
 
     public SplitTabletClause(
             PartitionNames partitionNames,
@@ -67,41 +69,8 @@ public class SplitTabletClause extends AlterTableClause {
         return dynamicTabletSplitSize;
     }
 
-    public void analyze() throws StarRocksException {
-        if (partitionNames != null && tabletList != null) {
-            throw new StarRocksException("Partitions and tablets cannot be specified at the same time");
-        }
-
-        if (partitionNames != null) {
-            if (partitionNames.isTemp()) {
-                throw new StarRocksException("Cannot split tablet in temp partition");
-            }
-            if (partitionNames.getPartitionNames().isEmpty()) {
-                throw new StarRocksException("Empty partitions");
-            }
-        }
-
-        if (tabletList != null && tabletList.getTabletIds().isEmpty()) {
-            throw new StarRocksException("Empty tablets");
-        }
-
-        if (properties == null) {
-            dynamicTabletSplitSize = Config.dynamic_tablet_split_size;
-            return;
-        }
-
-        String splitSize = properties.get(PropertyAnalyzer.PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE);
-        try {
-            dynamicTabletSplitSize = Long.parseLong(splitSize);
-        } catch (Exception e) {
-            throw new StarRocksException("Invalid property value: " + splitSize);
-        }
-
-        Map<String, String> copiedProperties = Maps.newHashMap(properties);
-        copiedProperties.remove(PropertyAnalyzer.PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE);
-        if (!copiedProperties.isEmpty()) {
-            throw new StarRocksException("Unknown properties: " + copiedProperties);
-        }
+    public void setDynamicTabletSplitSize(long dynamicTabletSplitSize) {
+        this.dynamicTabletSplitSize = dynamicTabletSplitSize;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/AutomaticDynamicTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/AutomaticDynamicTabletTest.java
@@ -1,0 +1,140 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.dynamictablet;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.TabletStatMgr;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AutomaticDynamicTabletTest {
+    protected static ConnectContext connectContext;
+    protected static StarRocksAssert starRocksAssert;
+    private static Database db;
+    private static OlapTable table;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        starRocksAssert.withDatabase("test").useDatabase("test");
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+
+        String sql = "create table test_table (key1 int, key2 varchar(10))\n" +
+                "distributed by hash(key1) buckets 1\n" +
+                "properties('replication_num' = '1', 'enable_dynamic_tablet' = 'false'); ";
+        starRocksAssert.withTable(sql);
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "test_table");
+    }
+
+    @Test
+    public void testEnableDynamicTablet() throws Exception {
+        {
+            Assertions.assertFalse(table.getEnableDynamicTablet());
+            Assertions.assertFalse(table.isEnableDynamicTablet());
+        }
+
+        {
+            table.setEnableDynamicTablet(null);
+            Assertions.assertNull(table.getEnableDynamicTablet());
+            Assertions.assertEquals(Config.enable_dynamic_tablet, table.isEnableDynamicTablet());
+        }
+
+        {
+            String sql = "alter table test_table set ('enable_dynamic_tablet' = 'true')";
+            starRocksAssert.alterTableProperties(sql);
+            Assertions.assertTrue(table.getEnableDynamicTablet());
+            Assertions.assertTrue(table.isEnableDynamicTablet());
+            Assertions.assertTrue(table.getUniqueProperties().containsKey("enable_dynamic_tablet"));
+
+            TabletStatMgr tabletStatMgr = new TabletStatMgr();
+            Deencapsulation.invoke(tabletStatMgr, "triggerDynamicTablet", db, table, Config.dynamic_tablet_split_size);
+        }
+
+        {
+            Assertions.assertThrows(AnalysisException.class,
+                    () -> starRocksAssert.alterTable("alter table test_table split tablet temporary partitions (tp1)"));
+
+            Assertions.assertThrows(AnalysisException.class,
+                    () -> starRocksAssert.alterTable("alter table test_table split tablet partitions ()"));
+
+            Assertions.assertThrows(AnalysisException.class,
+                    () -> starRocksAssert.alterTable("alter table test_table split tablet ()"));
+
+            Assertions.assertThrows(AnalysisException.class, () -> starRocksAssert.alterTable(
+                    "alter table test_table split tablet properties ('dynamic_tablet_split_size' = 'true')"));
+
+            Assertions.assertThrows(AnalysisException.class, () -> starRocksAssert.alterTable(
+                    "alter table test_table split tablet properties ('dynamic_tablet_split_size_xxx' = 'true')"));
+
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> starRocksAssert.alterTable("alter table test_table split tablet"));
+        }
+
+        {
+            Config.dynamic_tablet_max_split_count = 8;
+            Assertions.assertEquals(8, DynamicTabletUtils.calcSplitCount(100, 20));
+            Assertions.assertEquals(8, DynamicTabletUtils.calcSplitCount(100, 10));
+        }
+
+        {
+            Map<String, String> properties = new HashMap<>();
+            properties.put("enable_dynamic_tablet", "100");
+            properties.put("dynamic_tablet_split_size", "true");
+
+            Assertions.assertThrows(AnalysisException.class,
+                    () -> PropertyAnalyzer.analyzeEnableDynamicTablet(properties, false));
+            Assertions.assertThrows(AnalysisException.class,
+                    () -> PropertyAnalyzer.analyzeDynamicTabletSplitSize(properties, false));
+        }
+
+        {
+            Map<String, String> properties = new HashMap<>();
+            properties.put("enable_dynamic_tablet", "true");
+            properties.put("dynamic_tablet_split_size", "100");
+
+            Assertions.assertEquals(true, PropertyAnalyzer.analyzeEnableDynamicTablet(properties, true));
+            Assertions.assertEquals(100, PropertyAnalyzer.analyzeDynamicTabletSplitSize(properties, true));
+            Assertions.assertTrue(properties.isEmpty());
+        }
+
+        {
+            Map<String, String> properties = new HashMap<>();
+            properties.put("enable_dynamic_tablet", "false");
+            properties.put("dynamic_tablet_split_size", "-4");
+
+            Assertions.assertEquals(false, PropertyAnalyzer.analyzeEnableDynamicTablet(properties, true));
+            Assertions.assertEquals(-4, PropertyAnalyzer.analyzeDynamicTabletSplitSize(properties, true));
+            Assertions.assertTrue(properties.isEmpty());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/DynamicTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/DynamicTabletJobTest.java
@@ -190,7 +190,7 @@ public class DynamicTabletJobTest {
 
         Map<String, String> properties = Map.of(PropertyAnalyzer.PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE, "-2");
         SplitTabletClause clause = new SplitTabletClause(null, tabletList, properties);
-        clause.analyze();
+        clause.setDynamicTabletSplitSize(-2);
 
         DynamicTabletJobFactory factory = new SplitTabletJobFactory(db, table, clause);
         return factory.createDynamicTabletJob();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/SplitTabletJobFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/dynamictablet/SplitTabletJobFactoryTest.java
@@ -62,7 +62,7 @@ public class SplitTabletJobFactoryTest {
         {
             Map<String, String> properties = Map.of(PropertyAnalyzer.PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE, "-1");
             SplitTabletClause clause = new SplitTabletClause(null, null, properties);
-            clause.analyze();
+            clause.setDynamicTabletSplitSize(-1);
 
             DynamicTabletJobFactory factory = new SplitTabletJobFactory(db, table, clause);
             Assertions.assertThrows(IllegalStateException.class, () -> factory.createDynamicTabletJob());
@@ -71,7 +71,7 @@ public class SplitTabletJobFactoryTest {
         {
             Map<String, String> properties = Map.of(PropertyAnalyzer.PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE, "1");
             SplitTabletClause clause = new SplitTabletClause(null, null, properties);
-            clause.analyze();
+            clause.setDynamicTabletSplitSize(1);
 
             DynamicTabletJobFactory factory = new SplitTabletJobFactory(db, table, clause);
             Assertions.assertThrows(StarRocksException.class, () -> factory.createDynamicTabletJob());
@@ -85,7 +85,7 @@ public class SplitTabletJobFactoryTest {
 
             Map<String, String> properties = Map.of(PropertyAnalyzer.PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE, "-2");
             SplitTabletClause clause = new SplitTabletClause(null, tabletList, properties);
-            clause.analyze();
+            clause.setDynamicTabletSplitSize(-2);
 
             DynamicTabletJobFactory factory = new SplitTabletJobFactory(db, table, clause);
             DynamicTabletJob dynamicTabletJob = factory.createDynamicTabletJob();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. Add a FE config enable_dynamic_tablet, default false.
2. Add a table property enable_dynamic_tablet.
3. Add a check in tablet stat mgr to automatically create dynamic tablet job.

Fixes https://github.com/StarRocks/starrocks/issues/59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
