### PR TITLE
[BugFix] Fix min/max by crash when process literal inputs

### DIFF
--- a/be/src/exprs/agg/maxmin_by.h
+++ b/be/src/exprs/agg/maxmin_by.h
@@ -19,6 +19,7 @@
 
 #include "column/fixed_length_column.h"
 #include "column/type_traits.h"
+#include "column/vectorized_fwd.h"
 #include "exprs/agg/aggregate.h"
 #include "exprs/agg/aggregate_traits.h"
 #include "gutil/casts.h"
@@ -381,9 +382,14 @@ public:
             return;
         }
 
-        auto* data_col1 = ColumnHelper::get_data_column(columns[1]);
-        auto column1_value = down_cast<const InputColumnType*>(data_col1)->get_data()[row_num];
-        OP()(this->data(state), (Column*)columns[0], row_num, column1_value);
+        RunTimeCppType<LT> rhs;
+        auto* data_col1 = down_cast<const InputColumnType*>(ColumnHelper::get_data_column(columns[1]));
+        if (columns[1]->is_constant()) {
+            rhs = data_col1->get_data()[0];
+        } else {
+            rhs = data_col1->get_data()[row_num];
+        }
+        OP()(this->data(state), (Column*)columns[0], row_num, rhs);
     }
 
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
@@ -643,8 +649,14 @@ public:
         if (columns[1]->only_null() || columns[1]->is_null(row_num)) {
             return;
         }
-        Slice column1_value = ColumnHelper::get_data_column(columns[1])->get(row_num).get_slice();
-        OP()(this->data(state), (Column*)columns[0], row_num, column1_value);
+        Slice rhs;
+        auto* binary_column = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[1]));
+        if (columns[1]->is_constant()) {
+            rhs = binary_column->get_slice(0);
+        } else {
+            rhs = binary_column->get_slice(row_num);
+        }
+        OP()(this->data(state), (Column*)columns[0], row_num, rhs);
     }
 
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,

--- a/test/sql/test_max_min_by_not_filter_nulls_with_nulls/R/test_max_min_by_not_filter_nulls_with_nulls
+++ b/test/sql/test_max_min_by_not_filter_nulls_with_nulls/R/test_max_min_by_not_filter_nulls_with_nulls
@@ -1,4 +1,4 @@
--- name: test_max_min_by_not_filter_nulls_with_nulls @slow @sequential
+-- name: test_max_min_by_not_filter_nulls_with_nulls
 DROP TABLE if exists t0;
 -- result:
 -- !result
@@ -71,11 +71,11 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--19258865877
+-8717232615
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-25406211869
+20365175519
 -- !result
 SET new_planner_agg_stage=2;
 -- result:
@@ -117,11 +117,11 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--19258865877
+-8717232615
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-25406211869
+20365175519
 -- !result
 SET new_planner_agg_stage=2;
 -- result:
@@ -163,11 +163,11 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--19258865877
+-8717232615
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-25406211869
+20365175519
 -- !result
 SET new_planner_agg_stage=3;
 -- result:
@@ -209,11 +209,11 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--19258865877
+-8717232615
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-25406211869
+20365175519
 -- !result
 SET new_planner_agg_stage=3;
 -- result:
@@ -255,11 +255,11 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--19258865877
+-8717232615
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-25406211869
+20365175519
 -- !result
 SET new_planner_agg_stage=4;
 -- result:
@@ -301,11 +301,11 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--19258865877
+-8717232615
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-25406211869
+20365175519
 -- !result
 SET new_planner_agg_stage=4;
 -- result:
@@ -347,11 +347,11 @@ select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmu
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
 -- result:
--19258865877
+-8717232615
 -- !result
 select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
 -- result:
-25406211869
+20365175519
 -- !result
 -- name: test_max_min_by_support_window
 CREATE TABLE exam (
@@ -370,12 +370,20 @@ insert into exam values
     (6,'biology',null);
 -- result:
 -- !result
-SELECT max_by(subject, exam_result) over(partition by subject_id) FROM exam;
+SELECT max_by(subject, exam_result) over(partition by subject_id) FROM exam order by 1;
 -- result:
-english
 None
-physics
 chemistry
-music
+english
 math
+music
+physics
+-- !result
+select max_by(tag, tag) from (select 'literal' tag, subject_id from exam) t;
+-- result:
+literal
+-- !result
+select max_by(tag, tag) from (select 1 tag, subject_id from exam) t;
+-- result:
+1
 -- !result

--- a/test/sql/test_max_min_by_not_filter_nulls_with_nulls/T/test_max_min_by_not_filter_nulls_with_nulls
+++ b/test/sql/test_max_min_by_not_filter_nulls_with_nulls/T/test_max_min_by_not_filter_nulls_with_nulls
@@ -1,4 +1,4 @@
--- name: test_max_min_by_not_filter_nulls_with_nulls @slow @sequential
+-- name: test_max_min_by_not_filter_nulls_with_nulls
  DROP TABLE if exists t0;
 
  CREATE TABLE if not exists t0
@@ -129,4 +129,8 @@ insert into exam values
     (5,'music',95),
     (6,'biology',null);
 
-SELECT max_by(subject, exam_result) over(partition by subject_id) FROM exam;
+SELECT max_by(subject, exam_result) over(partition by subject_id) FROM exam order by 1;
+
+
+select max_by(tag, tag) from (select 'literal' tag, subject_id from exam) t;
+select max_by(tag, tag) from (select 1 tag, subject_id from exam) t;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
query_id:eee67f88-7287-11f0-aded-525400b2ecb4, fragment_instance:eee67f88-7287-11f0-aded-525400b2ecb6
tracker:process consumption: 9015288568
tracker:jemalloc_metadata consumption: 150819056
tracker:query_pool consumption: 4295371904
tracker:query_pool/connector_scan consumption: 0
tracker:load consumption: 16992
tracker:metadata consumption: 225520791
tracker:tablet_metadata consumption: 132729675
tracker:rowset_metadata consumption: 23813839
tracker:segment_metadata consumption: 14482950
tracker:column_metadata consumption: 54494327
tracker:tablet_schema consumption: 490171
tracker:segment_zonemap consumption: 5373951
tracker:short_key_index consumption: 7662098
tracker:column_zonemap_index consumption: 10610303
tracker:ordinal_index consumption: 21162408
tracker:bitmap_index consumption: 1139376
tracker:bloom_filter_index consumption: 35216
tracker:compaction consumption: 0
tracker:schema_change consumption: 0
tracker:column_pool consumption: 0
tracker:page_cache consumption: 3343651904
tracker:jit_cache consumption: 0
tracker:update consumption: 33425956
tracker:chunk_allocator consumption: 0
tracker:passthrough consumption: 0
tracker:clone consumption: 0
tracker:consistency consumption: 0
tracker:datacache consumption: 0
tracker:replication consumption: 0
*** Aborted at 1754458860 (unix time) try "date -d @1754458860" if you are using GNU date ***
PC: @     0x7f0ee04d5711 __memcpy_ssse3_back
*** SIGSEGV (@0x7f0e74196ff1) received by PID 16389 (TID 0x7f0e5895e700) from PID 1947824113; stack trace: ***
    @     0x7f0ee107b20b __pthread_once_slow
    @          0x7dc3dc0 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f0ee1f0935d os::Linux::chained_handler(int, siginfo*, void*)
    @     0x7f0ee1f0ef5f JVM_handle_linux_signal
    @     0x7f0ee1f00968 signalHandler(int, siginfo*, void*)
    @     0x7f0ee1084630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @     0x7f0ee04d5711 __memcpy_ssse3_back
    @          0x4ce607d starrocks::AggregateFunctionBatchHelper<starrocks::MinByAggregateData<(starrocks::LogicalType)17, true, int>, starrocks::MaxMinByAggregateFunction<(starrocks::LogicalType)17, starrocks::MinByAggregateData<(starrocks::LogicalType)17, true, int>, starrocks::��
    @          0x46200dc starrocks::Aggregator::compute_batch_agg_states(starrocks::Chunk*, unsigned long)
    @          0x451ffcd starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0x452f3e1 starrocks::pipeline::BucketProcessSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0x44f49d4 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x47b85e3 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x398e8e3 starrocks::ThreadPool::dispatch_thread()
    @          0x3985f66 starrocks::Thread::supervise_thread(void*)
    @     0x7f0ee107cea5 start_thread
    @     0x7f0ee047db0d __clone
[1754458860.656][thread:139699592488704] je_mallctl execute purge success
[1754458860.656][thread:139699592488704] je_mallctl execute dontdump success
start time: Wed Aug  6 13:41:32 CST 2025, server uptime:  13:41:32 up 228 days, 19:50,  0 users,  load average: 29.07, 8.45, 3.04
Duplicate assignment to config 'be_http_port', previous assignment will be ignored
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
