### PR TITLE
[UT] Fix unstable cluster load stat UT

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/ClusterLoadStatByMediumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/ClusterLoadStatByMediumTest.java
@@ -85,16 +85,21 @@ public class ClusterLoadStatByMediumTest {
         List<List<String>> rows = result.getRows();
         Assertions.assertEquals(2, rows.size());
 
-        List<String> row0 = rows.get(0);
-        Assertions.assertEquals(2, row0.size());
-        Assertions.assertEquals("HDD", row0.get(0));
-        Assertions.assertEquals(
-                "{\"maxUsedPercent\":0.9,\"minUsedPercent\":0.1,\"maxBeId\":1,\"minBeId\":2,\"type\":\"CLUSTER_DISK\"," +
-                        "\"balanced\":false}",
-                row0.get(1));
-
-        List<String> row1 = rows.get(1);
-        Assertions.assertEquals("SSD", row1.get(0));
-        Assertions.assertEquals("{\"balanced\":true}", row1.get(1));
+        for (int i = 0; i < rows.size(); ++i) {
+            List<String> row = rows.get(i);
+            Assertions.assertEquals(2, row.size());
+            String medium = row.get(0);
+            String balanceStat = row.get(1);
+            if (medium.equals("HDD")) {
+                Assertions.assertEquals(
+                        "{\"maxUsedPercent\":0.9,\"minUsedPercent\":0.1,\"maxBeId\":1,\"minBeId\":2,\"type\":\"CLUSTER_DISK\"," +
+                                "\"balanced\":false}",
+                        balanceStat);
+            } else if (medium.equals("SSD")) {
+                Assertions.assertEquals("{\"balanced\":true}", balanceStat);
+            } else {
+                Assertions.fail(String.format("Unknown storage medium: %s", medium));
+            }
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/ClusterLoadStatisticProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/ClusterLoadStatisticProcDirTest.java
@@ -120,6 +120,8 @@ public class ClusterLoadStatisticProcDirTest {
                         row.get(11));
             } else if (beId.equals("10002")) {
                 Assertions.assertEquals("{\"balanced\":true}", row.get(11));
+            } else {
+                Assertions.fail(String.format("Unknown backend id: %s", beId));
             }
         }
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Unstable UT:
```
     🧪 - fe/fe-core/src/test/java/com/starrocks/common/proc/ClusterLoadStatByMediumTest.java | expected: <HDD> but was: <SSD>
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
