### PR TITLE
[Enhancement] support optimistic copy for LakeTable

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
@@ -14,14 +14,20 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.StringLiteral;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.lake.LakeMaterializedView;
+import com.starrocks.lake.LakeTable;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.operator.ColumnFilterConverter;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -30,6 +36,8 @@ import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.Set;
 
 public class AnalyzerUtilsTest {
 
@@ -40,7 +48,7 @@ public class AnalyzerUtilsTest {
     public static void beforeClass() throws Exception {
         FeConstants.runningUnitTest = true;
         Config.dynamic_partition_enable = false;
-        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
@@ -54,7 +62,9 @@ public class AnalyzerUtilsTest {
                         "DISTRIBUTED BY HASH(`bill_code`) BUCKETS 10 \n" +
                         "PROPERTIES (\n" +
                         "\"replication_num\" = \"1\"\n" +
-                        ");");
+                        ");")
+                .withMaterializedView("CREATE MATERIALIZED VIEW mv1 REFRESH ASYNC AS " +
+                        "SELECT * FROM bill_detail;");
     }
 
     @Test
@@ -85,4 +95,24 @@ public class AnalyzerUtilsTest {
         Assertions.assertEquals(ScalarType.getOlapMaxVarcharLength(), convertedString.getLength());
     }
 
+    @Test
+    public void testCopyOlapTable() throws Exception {
+        {
+            String sql = "select count(*) from bill_detail;";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+            Set<OlapTable> tables = Sets.newHashSet();
+            AnalyzerUtils.copyOlapTable(stmt, tables);
+            Assertions.assertEquals(1, tables.size());
+            Assertions.assertInstanceOf(LakeTable.class, tables.iterator().next());
+        }
+
+        {
+            String sql = "select count(*) from mv1;";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+            Set<OlapTable> tables = Sets.newHashSet();
+            AnalyzerUtils.copyOlapTable(stmt, tables);
+            Assertions.assertEquals(1, tables.size());
+            Assertions.assertInstanceOf(LakeMaterializedView.class, tables.iterator().next());
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
@@ -104,6 +104,8 @@ public class AnalyzerUtilsTest {
             AnalyzerUtils.copyOlapTable(stmt, tables);
             Assertions.assertEquals(1, tables.size());
             Assertions.assertInstanceOf(LakeTable.class, tables.iterator().next());
+            Assertions.assertSame(starRocksAssert.getTable("test", "bill_detail"), tables.iterator().next());
+            Assertions.assertTrue(AnalyzerUtils.areTablesCopySafe(stmt));
         }
 
         {
@@ -113,6 +115,8 @@ public class AnalyzerUtilsTest {
             AnalyzerUtils.copyOlapTable(stmt, tables);
             Assertions.assertEquals(1, tables.size());
             Assertions.assertInstanceOf(LakeMaterializedView.class, tables.iterator().next());
+            Assertions.assertSame(starRocksAssert.getTable("test", "mv1"), tables.iterator().next());
+            Assertions.assertTrue(AnalyzerUtils.areTablesCopySafe(stmt));
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Optimistic copying minimizes lock contention during queries by duplicating the table during query planning and releasing the lock, ensuring other lock requests remain unaffected.

Previously it only supports the `OlapTable` and `MaterializedView`, now we extend the support to `LakeTable` and `LakeMaterializedView`.



Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
