### PR TITLE
[Enhancement] Reorder tablet_balanced column of partitions_meta system table for better compatibility

### DIFF
--- a/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
@@ -55,8 +55,8 @@ SchemaScanner::ColumnDesc SchemaPartitionsMetaScanner::_s_columns[] = {
         {"MAX_CS", TypeDescriptor::from_logical_type(TYPE_DOUBLE), sizeof(double), false},
         {"STORAGE_PATH", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
         {"STORAGE_SIZE", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
-        {"METADATA_SWITCH_VERSION", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
         {"TABLET_BALANCED", TypeDescriptor::from_logical_type(TYPE_BOOLEAN), sizeof(bool), false},
+        {"METADATA_SWITCH_VERSION", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
 };
 
 SchemaPartitionsMetaScanner::SchemaPartitionsMetaScanner()
@@ -304,13 +304,13 @@ Status SchemaPartitionsMetaScanner::fill_chunk(ChunkPtr* chunk) {
             break;
         }
         case 30: {
-            // METADATA_SWITCH_VERSION
-            fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.metadata_switch_version);
+            // TABLET_BALANCED
+            fill_column_with_slot<TYPE_BOOLEAN>(column.get(), (void*)&info.tablet_balanced);
             break;
         }
         case 31: {
-            // TABLET_BALANCED
-            fill_column_with_slot<TYPE_BOOLEAN>(column.get(), (void*)&info.tablet_balanced);
+            // METADATA_SWITCH_VERSION
+            fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.metadata_switch_version);
             break;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
@@ -61,8 +61,8 @@ public class PartitionsMetaSystemTable {
                         .column("MAX_CS", ScalarType.createType(PrimitiveType.DOUBLE))
                         .column("STORAGE_PATH", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("STORAGE_SIZE", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("METADATA_SWITCH_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("TABLET_BALANCED", ScalarType.createType(PrimitiveType.BOOLEAN))
+                        .column("METADATA_SWITCH_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_PARTITIONS_META);
     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1518,8 +1518,8 @@ struct TPartitionMetaInfo {
     27: optional i64 version_epoch
     28: optional Types.TTxnType version_txn_type = Types.TTxnType.TXN_NORMAL
     29: optional i64 storage_size
-    30: optional i64 metadata_switch_version
-    31: optional bool tablet_balanced
+    30: optional bool tablet_balanced
+    31: optional i64 metadata_switch_version
 }
 
 struct TGetPartitionsMetaResponse {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

`metadata_switch_version` is not merged into branch 3.5 yet, so i put it at the end.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
