### PR TITLE
[BugFix] fix query id not found when cancelled

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -982,7 +982,9 @@ Status FragmentExecutor::append_incremental_scan_ranges(ExecEnv* exec_env, const
 
     QueryContextPtr query_ctx = exec_env->query_context_mgr()->get(query_id);
     if (query_ctx == nullptr) {
-        return Status::InternalError(fmt::format("QueryContext not found for query_id: {}", print_id(query_id)));
+        // query can be cancelled because of timeout or short-circuited query like `limit`.
+        // return Status::InternalError(fmt::format("QueryContext not found for query_id: {}", print_id(query_id)));
+        return Status::OK();
     }
     FragmentContextPtr fragment_ctx = query_ctx->fragment_mgr()->get(instance_id);
     if (fragment_ctx == nullptr) {


### PR DESCRIPTION
## Why I'm doing:

this bug is introduceded in this pr https://github.com/StarRocks/starrocks/pull/61562

if you run `select * from table limit 10`,  query can be cancelled if enough rows returned.

## What I'm doing:

Ignore queryid not found this case.

Fixes https://github.com/StarRocks/StarRocksTest/issues/10070

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
