### PR TITLE
[BugFix] fix the incorrect handling of flatjson table property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2346,13 +2346,23 @@ public class SchemaChangeHandler extends AlterHandler {
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
         }
+        // First check if flat_json.enable is being set to false
+        boolean flatJsonEnabled = newFlatJsonConfig.getFlatJsonEnable();
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE)) {
-            boolean flatJsonEnabled = PropertyAnalyzer.analyzeFlatJsonEnabled(properties);
+            flatJsonEnabled = PropertyAnalyzer.analyzeFlatJsonEnabled(properties);
             if (flatJsonEnabled != newFlatJsonConfig.getFlatJsonEnable()) {
                 newFlatJsonConfig.setFlatJsonEnable(flatJsonEnabled);
                 hasChanged = true;
             }
         }
+        
+        // Check if other flat JSON properties are set when flat_json.enable is false
+        if (!flatJsonEnabled && (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR) ||
+                properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR) ||
+                properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX))) {
+            throw new RuntimeException("flat JSON configuration must be set after enabling flat JSON.");
+        }
+        
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR)) {
             double flatJsonNullFactor = PropertyAnalyzer.analyzeFlatJsonNullFactor(properties);
             if (flatJsonNullFactor != newFlatJsonConfig.getFlatJsonNullFactor()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FlatJsonConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FlatJsonConfig.java
@@ -115,9 +115,14 @@ public class FlatJsonConfig implements Writable {
     public Map<String, String> toProperties() {
         Map<String, String> properties = new HashMap<>();
         properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, String.valueOf(flatJsonEnable));
-        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, String.valueOf(flatJsonNullFactor));
-        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, String.valueOf(flatJsonSparsityFactor));
-        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, String.valueOf(flatJsonColumnMax));
+
+        // Only include other flat JSON properties if flat JSON is enabled
+        if (flatJsonEnable) {
+            properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, String.valueOf(flatJsonNullFactor));
+            properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR,
+                    String.valueOf(flatJsonSparsityFactor));
+            properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, String.valueOf(flatJsonColumnMax));
+        }
         return properties;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3621,24 +3621,28 @@ public class OlapTable extends Table {
         String flatJsonEnable = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE);
         if (!Strings.isNullOrEmpty(flatJsonEnable)) {
             properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, flatJsonEnable);
-        }
 
-        // flat json null factor
-        String flatJsonNullFactor = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR);
-        if (!Strings.isNullOrEmpty(flatJsonNullFactor)) {
-            properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, flatJsonNullFactor);
-        }
+            // Only include other flat JSON properties if flat_json.enable is true
+            if (Boolean.parseBoolean(flatJsonEnable)) {
+                // flat json null factor
+                String flatJsonNullFactor = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR);
+                if (!Strings.isNullOrEmpty(flatJsonNullFactor)) {
+                    properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, flatJsonNullFactor);
+                }
 
-        // flat json sparsity factor
-        String flatJsonSparsityFactor = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR);
-        if (!Strings.isNullOrEmpty(flatJsonSparsityFactor)) {
-            properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, flatJsonSparsityFactor);
-        }
+                // flat json sparsity factor
+                String flatJsonSparsityFactor =
+                        tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR);
+                if (!Strings.isNullOrEmpty(flatJsonSparsityFactor)) {
+                    properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, flatJsonSparsityFactor);
+                }
 
-        // flat json column max
-        String flatJsonColumnMax = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX);
-        if (!Strings.isNullOrEmpty(flatJsonColumnMax)) {
-            properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, flatJsonColumnMax);
+                // flat json column max
+                String flatJsonColumnMax = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX);
+                if (!Strings.isNullOrEmpty(flatJsonColumnMax)) {
+                    properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, flatJsonColumnMax);
+                }
+            }
         }
 
         return properties;

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -848,9 +848,11 @@ public class OlapTableFactory implements AbstractTableFactory {
             boolean enableFlatJson = PropertyAnalyzer.analyzeBooleanProp(properties,
                     PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, false);
 
-            if (!enableFlatJson) {
-                throw new DdlException(
-                        "flat_json.enable must be set to true in order to set flat-json related configurations.");
+            // Check if other flat JSON properties are set when flat_json.enable is false
+            if (!enableFlatJson && (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR) ||
+                    properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR) ||
+                    properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX))) {
+                throw new DdlException("flat JSON configuration must be set after enabling flat JSON.");
             }
 
             double flatJsonNullFactor = PropertyAnalyzer.analyzerDoubleProp(properties,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -396,6 +396,7 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, e.getMessage());
             }
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE)) {
+            // Allow setting flat_json.enable to true or false
             PropertyAnalyzer.analyzeFlatJsonEnabled(properties);
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR) ||
                     properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR) ||
@@ -412,7 +413,7 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                     }
                 } else {
                     ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
-                            "Property " + PropertyAnalyzer.PROPERTIES_BINLOG_ENABLE +
+                            "Property " + PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE +
                                     " haven't been enabled");
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FlatJsonConfigValidationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FlatJsonConfigValidationTest.java
@@ -1,0 +1,219 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.util.PropertyAnalyzer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit test for flat JSON configuration validation logic.
+ * This test focuses on the validation methods that were fixed in the bug fix.
+ */
+public class FlatJsonConfigValidationTest {
+
+    @Test
+    public void testTablePropertyBuildFlatJsonConfig() {
+        // Test that TableProperty.buildFlatJsonConfig() works correctly with the fix
+        
+        // Test 1: Only flat_json.enable = false (should work)
+        Map<String, String> properties1 = new HashMap<>();
+        properties1.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "false");
+        
+        TableProperty tableProperty1 = new TableProperty(properties1);
+        tableProperty1.buildFlatJsonConfig();
+        
+        FlatJsonConfig config1 = tableProperty1.getFlatJsonConfig();
+        Assertions.assertNotNull(config1);
+        Assertions.assertFalse(config1.getFlatJsonEnable());
+        // Should use default values for other properties
+        Assertions.assertEquals(Config.flat_json_null_factor, config1.getFlatJsonNullFactor(), 0.001);
+        Assertions.assertEquals(Config.flat_json_sparsity_factory, config1.getFlatJsonSparsityFactor(), 0.001);
+        Assertions.assertEquals(Config.flat_json_column_max, config1.getFlatJsonColumnMax());
+
+        // Test 2: flat_json.enable = false with other properties (should throw exception)
+        Map<String, String> properties2 = new HashMap<>();
+        properties2.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "false");
+        properties2.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, "0.1");
+        
+        TableProperty tableProperty2 = new TableProperty(properties2);
+        
+        Exception exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            tableProperty2.buildFlatJsonConfig();
+        });
+        
+        // The exception should be our validation error, not an AnalysisException
+        Assertions.assertTrue(exception.getMessage().contains("flat JSON configuration must be set after enabling flat JSON"));
+
+        // Test 3: flat_json.enable = true with other properties (should work)
+        Map<String, String> properties3 = new HashMap<>();
+        properties3.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "true");
+        properties3.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, "0.1");
+        properties3.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, "0.8");
+        properties3.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, "50");
+        
+        TableProperty tableProperty3 = new TableProperty(properties3);
+        tableProperty3.buildFlatJsonConfig();
+        
+        FlatJsonConfig config3 = tableProperty3.getFlatJsonConfig();
+        Assertions.assertNotNull(config3);
+        Assertions.assertTrue(config3.getFlatJsonEnable());
+        Assertions.assertEquals(0.1, config3.getFlatJsonNullFactor(), 0.001);
+        Assertions.assertEquals(0.8, config3.getFlatJsonSparsityFactor(), 0.001);
+        Assertions.assertEquals(50, config3.getFlatJsonColumnMax());
+
+        // Test 4: flat_json.enable = true without other properties (should work with defaults)
+        Map<String, String> properties4 = new HashMap<>();
+        properties4.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "true");
+        
+        TableProperty tableProperty4 = new TableProperty(properties4);
+        tableProperty4.buildFlatJsonConfig();
+        
+        FlatJsonConfig config4 = tableProperty4.getFlatJsonConfig();
+        Assertions.assertNotNull(config4);
+        Assertions.assertTrue(config4.getFlatJsonEnable());
+        Assertions.assertEquals(Config.flat_json_null_factor, config4.getFlatJsonNullFactor(), 0.001);
+        Assertions.assertEquals(Config.flat_json_sparsity_factory, config4.getFlatJsonSparsityFactor(), 0.001);
+        Assertions.assertEquals(Config.flat_json_column_max, config4.getFlatJsonColumnMax());
+    }
+
+    @Test
+    public void testPropertyAnalyzerMethods() {
+        // Test PropertyAnalyzer methods that were affected by the fix
+        
+        // Test 1: analyzeFlatJsonEnabled with false
+        Map<String, String> properties1 = new HashMap<>();
+        properties1.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "false");
+        boolean result1 = PropertyAnalyzer.analyzeFlatJsonEnabled(properties1);
+        Assertions.assertFalse(result1);
+
+        // Test 2: analyzeFlatJsonEnabled with true
+        Map<String, String> properties2 = new HashMap<>();
+        properties2.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "true");
+        boolean result2 = PropertyAnalyzer.analyzeFlatJsonEnabled(properties2);
+        Assertions.assertTrue(result2);
+
+        // Test 3: analyzeFlatJsonEnabled with missing property (should return false)
+        Map<String, String> properties3 = new HashMap<>();
+        boolean result3 = PropertyAnalyzer.analyzeFlatJsonEnabled(properties3);
+        Assertions.assertFalse(result3);
+
+        // Test 4: analyzerDoubleProp with default value
+        Map<String, String> properties4 = new HashMap<>();
+        properties4.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "true");
+        double nullFactor = PropertyAnalyzer.analyzerDoubleProp(properties4,
+                PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, Config.flat_json_null_factor);
+        Assertions.assertEquals(Config.flat_json_null_factor, nullFactor, 0.001);
+
+        // Test 5: analyzeIntProp with default value
+        int columnMax = PropertyAnalyzer.analyzeIntProp(properties4,
+                PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, Config.flat_json_column_max);
+        Assertions.assertEquals(Config.flat_json_column_max, columnMax);
+    }
+
+    @Test
+    public void testFlatJsonConfigConstructor() {
+        // Test FlatJsonConfig constructor and methods
+        
+        // Test 1: Constructor with all parameters
+        FlatJsonConfig config1 = new FlatJsonConfig(true, 0.1, 0.8, 50);
+        Assertions.assertTrue(config1.getFlatJsonEnable());
+        Assertions.assertEquals(0.1, config1.getFlatJsonNullFactor(), 0.001);
+        Assertions.assertEquals(0.8, config1.getFlatJsonSparsityFactor(), 0.001);
+        Assertions.assertEquals(50, config1.getFlatJsonColumnMax());
+
+        // Test 2: Constructor with false enable
+        FlatJsonConfig config2 = new FlatJsonConfig(false, 0.2, 0.9, 100);
+        Assertions.assertFalse(config2.getFlatJsonEnable());
+        Assertions.assertEquals(0.2, config2.getFlatJsonNullFactor(), 0.001);
+        Assertions.assertEquals(0.9, config2.getFlatJsonSparsityFactor(), 0.001);
+        Assertions.assertEquals(100, config2.getFlatJsonColumnMax());
+
+        // Test 3: Default constructor
+        FlatJsonConfig config3 = new FlatJsonConfig();
+        Assertions.assertFalse(config3.getFlatJsonEnable());
+        Assertions.assertEquals(Config.flat_json_null_factor, config3.getFlatJsonNullFactor(), 0.001);
+        Assertions.assertEquals(Config.flat_json_sparsity_factory, config3.getFlatJsonSparsityFactor(), 0.001);
+        Assertions.assertEquals(Config.flat_json_column_max, config3.getFlatJsonColumnMax());
+
+        // Test 4: Copy constructor
+        FlatJsonConfig config4 = new FlatJsonConfig(config1);
+        Assertions.assertTrue(config4.getFlatJsonEnable());
+        Assertions.assertEquals(0.1, config4.getFlatJsonNullFactor(), 0.001);
+        Assertions.assertEquals(0.8, config4.getFlatJsonSparsityFactor(), 0.001);
+        Assertions.assertEquals(50, config4.getFlatJsonColumnMax());
+    }
+
+    @Test
+    public void testFlatJsonConfigBuildFromProperties() {
+        // Test FlatJsonConfig.buildFromProperties method
+        
+        FlatJsonConfig config = new FlatJsonConfig();
+        
+        // Test 1: Build with flat_json.enable = false
+        Map<String, String> properties1 = new HashMap<>();
+        properties1.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "false");
+        config.buildFromProperties(properties1);
+        Assertions.assertFalse(config.getFlatJsonEnable());
+
+        // Test 2: Build with flat_json.enable = true and other properties
+        Map<String, String> properties2 = new HashMap<>();
+        properties2.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "true");
+        properties2.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, "0.1");
+        properties2.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, "0.8");
+        properties2.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, "50");
+        config.buildFromProperties(properties2);
+        
+        Assertions.assertTrue(config.getFlatJsonEnable());
+        Assertions.assertEquals(0.1, config.getFlatJsonNullFactor(), 0.001);
+        Assertions.assertEquals(0.8, config.getFlatJsonSparsityFactor(), 0.001);
+        Assertions.assertEquals(50, config.getFlatJsonColumnMax());
+    }
+
+    @Test
+    public void testFlatJsonConfigSetters() {
+        // Test FlatJsonConfig setter methods
+        
+        FlatJsonConfig config = new FlatJsonConfig();
+        
+        // Test setters
+        config.setFlatJsonEnable(true);
+        config.setFlatJsonNullFactor(0.1);
+        config.setFlatJsonSparsityFactor(0.8);
+        config.setFlatJsonColumnMax(50);
+        
+        Assertions.assertTrue(config.getFlatJsonEnable());
+        Assertions.assertEquals(0.1, config.getFlatJsonNullFactor(), 0.001);
+        Assertions.assertEquals(0.8, config.getFlatJsonSparsityFactor(), 0.001);
+        Assertions.assertEquals(50, config.getFlatJsonColumnMax());
+    }
+
+    @Test
+    public void testFlatJsonConfigToProperties() {
+        // Test FlatJsonConfig.toProperties method
+        
+        FlatJsonConfig config = new FlatJsonConfig(true, 0.1, 0.8, 50);
+        Map<String, String> properties = config.toProperties();
+        
+        Assertions.assertEquals("true", properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE));
+        Assertions.assertEquals("0.1", properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+        Assertions.assertEquals("0.8", properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+        Assertions.assertEquals("50", properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FlatJsonConfigValidationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FlatJsonConfigValidationTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.catalog;
 
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.PropertyAnalyzer;
 import org.junit.jupiter.api.Assertions;
@@ -94,7 +95,7 @@ public class FlatJsonConfigValidationTest {
     }
 
     @Test
-    public void testPropertyAnalyzerMethods() {
+    public void testPropertyAnalyzerMethods() throws AnalysisException {
         // Test PropertyAnalyzer methods that were affected by the fix
         
         // Test 1: analyzeFlatJsonEnabled with false
@@ -207,13 +208,23 @@ public class FlatJsonConfigValidationTest {
     @Test
     public void testFlatJsonConfigToProperties() {
         // Test FlatJsonConfig.toProperties method
-        
-        FlatJsonConfig config = new FlatJsonConfig(true, 0.1, 0.8, 50);
-        Map<String, String> properties = config.toProperties();
-        
-        Assertions.assertEquals("true", properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE));
-        Assertions.assertEquals("0.1", properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
-        Assertions.assertEquals("0.8", properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
-        Assertions.assertEquals("50", properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
+
+        // Test 1: When flat_json.enable is true, all properties should be present
+        FlatJsonConfig config1 = new FlatJsonConfig(true, 0.1, 0.8, 50);
+        Map<String, String> properties1 = config1.toProperties();
+
+        Assertions.assertEquals("true", properties1.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE));
+        Assertions.assertEquals("0.1", properties1.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+        Assertions.assertEquals("0.8", properties1.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+        Assertions.assertEquals("50", properties1.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
+
+        // Test 2: When flat_json.enable is false, only the enable property should be present
+        FlatJsonConfig config2 = new FlatJsonConfig(false, 0.1, 0.8, 50);
+        Map<String, String> properties2 = config2.toProperties();
+
+        Assertions.assertEquals("false", properties2.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE));
+        Assertions.assertNull(properties2.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+        Assertions.assertNull(properties2.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+        Assertions.assertNull(properties2.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
@@ -43,6 +43,7 @@ import com.starrocks.catalog.Table.TableType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UnitTestUtil;
 import com.starrocks.server.GlobalStateMgr;
@@ -61,6 +62,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class OlapTableTest {
@@ -433,4 +435,84 @@ public class OlapTableTest {
         Assertions.assertTrue(result.get(0).getIndexName().equals("index1"));
         Assertions.assertTrue(result.get(1).getIndexName().equals("index2"));
     }
+
+    @Test
+    public void testGetUniquePropertiesWithFlatJsonConfig() {
+        // Test case 1: Flat JSON enabled with all properties set
+        OlapTable table1 = new OlapTable();
+        TableProperty tableProperty1 = new TableProperty();
+        Map<String, String> properties1 = new HashMap<>();
+        properties1.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "true");
+        properties1.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, "0.1");
+        properties1.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, "0.8");
+        properties1.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, "50");
+        tableProperty1.modifyTableProperties(properties1);
+        table1.setTableProperty(tableProperty1);
+
+        Map<String, String> result1 = table1.getUniqueProperties();
+        Assertions.assertEquals("true", result1.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE));
+        Assertions.assertEquals("0.1", result1.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+        Assertions.assertEquals("0.8", result1.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+        Assertions.assertEquals("50", result1.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
+
+        // Test case 2: Flat JSON enabled but only some properties set
+        OlapTable table2 = new OlapTable();
+        TableProperty tableProperty2 = new TableProperty();
+        Map<String, String> properties2 = new HashMap<>();
+        properties2.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "true");
+        properties2.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, "0.2");
+        // Don't set sparsity factor and column max
+        tableProperty2.modifyTableProperties(properties2);
+        table2.setTableProperty(tableProperty2);
+
+        Map<String, String> result2 = table2.getUniqueProperties();
+        Assertions.assertEquals("true", result2.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE));
+        Assertions.assertEquals("0.2", result2.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+        Assertions.assertNull(result2.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+        Assertions.assertNull(result2.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
+
+        // Test case 3: Flat JSON disabled - other properties should not be included
+        OlapTable table3 = new OlapTable();
+        TableProperty tableProperty3 = new TableProperty();
+        Map<String, String> properties3 = new HashMap<>();
+        properties3.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "false");
+        properties3.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, "0.3");
+        properties3.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, "0.9");
+        properties3.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, "100");
+        tableProperty3.modifyTableProperties(properties3);
+        table3.setTableProperty(tableProperty3);
+
+        Map<String, String> result3 = table3.getUniqueProperties();
+        Assertions.assertEquals("false", result3.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE));
+        Assertions.assertNull(result3.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+        Assertions.assertNull(result3.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+        Assertions.assertNull(result3.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
+
+        // Test case 4: No flat JSON properties set
+        OlapTable table4 = new OlapTable();
+        TableProperty tableProperty4 = new TableProperty();
+        table4.setTableProperty(tableProperty4);
+
+        Map<String, String> result4 = table4.getUniqueProperties();
+        Assertions.assertNull(result4.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE));
+        Assertions.assertNull(result4.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+        Assertions.assertNull(result4.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+        Assertions.assertNull(result4.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
+
+        // Test case 5: Flat JSON enabled with null/empty values
+        OlapTable table5 = new OlapTable();
+        TableProperty tableProperty5 = new TableProperty();
+        Map<String, String> properties5 = new HashMap<>();
+        properties5.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "true");
+        properties5.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, "");
+        properties5.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, null);
+        tableProperty5.modifyTableProperties(properties5);
+        table5.setTableProperty(tableProperty5);
+
+        Map<String, String> result5 = table5.getUniqueProperties();
+        Assertions.assertEquals("true", result5.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE));
+        Assertions.assertNull(result5.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+        Assertions.assertNull(result5.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


follow #57379

bug: `create table (....) properties('flat_json.enable'='false')` would always report exception: `(1064, 'flat JSON configuration must be set after enabling flat JSON.')`




Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
