### PR TITLE
[BugFix]Fix java.time.LocalDate type check.

### DIFF
--- a/be/src/types/checker/type_checker.cpp
+++ b/be/src/types/checker/type_checker.cpp
@@ -245,6 +245,17 @@ StatusOr<LogicalType> LocalDateTimeTypeChecker::check(const std::string& java_cl
     return TYPE_VARCHAR;
 }
 
+StatusOr<LogicalType> LocalDateTypeChecker::check(const std::string& java_class,
+                                                  const SlotDescriptor* slot_desc) const {
+    auto type = slot_desc->type().type;
+    if (type != TYPE_DATE) {
+        return Status::NotSupported(
+                fmt::format("Type mismatches on column[{}], JDBC result type is LocalDate, please set the type to date",
+                            slot_desc->col_name()));
+    }
+    return TYPE_VARCHAR;
+}
+
 StatusOr<LogicalType> BigDecimalTypeChecker::check(const std::string& java_class,
                                                    const SlotDescriptor* slot_desc) const {
     auto type = slot_desc->type().type;

--- a/be/src/types/checker/type_checker.h
+++ b/be/src/types/checker/type_checker.h
@@ -84,6 +84,9 @@ DEFINE_TYPE_CHECKER(TimeTypeChecker)
 // Define type checker for java.time.LocalDateTime
 DEFINE_TYPE_CHECKER(LocalDateTimeTypeChecker)
 
+// Define type checker for java.time.LocalDate
+DEFINE_TYPE_CHECKER(LocalDateTypeChecker)
+
 // Define type checker for java.math.BigDecimal
 DEFINE_TYPE_CHECKER(BigDecimalTypeChecker)
 

--- a/be/src/types/type_checker_manager.cpp
+++ b/be/src/types/type_checker_manager.cpp
@@ -38,6 +38,7 @@ TypeCheckerManager::TypeCheckerManager() {
     registerChecker("java.sql.Date", std::make_unique<DateTypeChecker>());
     registerChecker("java.sql.Time", std::make_unique<TimeTypeChecker>());
     registerChecker("java.time.LocalDateTime", std::make_unique<LocalDateTimeTypeChecker>());
+    registerChecker("java.time.LocalDate", std::make_unique<LocalDateTypeChecker>());
     registerChecker("java.math.BigDecimal", std::make_unique<BigDecimalTypeChecker>());
     registerChecker("oracle.sql.TIMESTAMP", std::make_unique<OracleTimestampClassTypeChecker>());
     registerChecker("oracle.sql.TIMESTAMPLTZ", std::make_unique<OracleTimestampClassTypeChecker>());

--- a/be/test/types/type_checker_test.cpp
+++ b/be/test/types/type_checker_test.cpp
@@ -355,6 +355,19 @@ TEST_F(TypeCheckerTest, NotSupportLocalDateTimeType) {
     ASSERT_FALSE(status_or_type.ok());
 }
 
+// Define unit test for java.time.LocalDate
+TEST_F(TypeCheckerTest, SupportLocalDateType) {
+    SlotDescriptor localdate_type_slot(0, "localdate_type_slot", TypeDescriptor(TYPE_DATE));
+    auto status_or_type = type_checker_manager_.checkType("java.time.LocalDate", &localdate_type_slot);
+    ASSERT_TRUE(status_or_type.ok());
+    ASSERT_EQ(status_or_type.value(), LogicalType::TYPE_VARCHAR);
+}
+TEST_F(TypeCheckerTest, NotSupportLocalDateType) {
+    SlotDescriptor unknown_type_slot(0, "unknown_type_slot", TypeDescriptor(TYPE_TINYINT));
+    auto status_or_type = type_checker_manager_.checkType("java.time.LocalDate", &unknown_type_slot);
+    ASSERT_FALSE(status_or_type.ok());
+}
+
 // Define unit test for java.math.BigDecimal
 TEST_F(TypeCheckerTest, SupporBigDecimalType) {
     SlotDescriptor decimal32_type_slot(0, "decimal32_type_slot", TypeDescriptor(TYPE_DECIMAL32));


### PR DESCRIPTION
## Why I'm doing:
#47729 Refactoring jdbc_scanner's type checking misses type checking for java.time.LocalDate
## What I'm doing:

Fixes #61686

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
