### PR TITLE
[Enhancement] Reorder TabletBalanceStat column in show index proc for better compatibility

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
@@ -59,7 +59,7 @@ import java.util.List;
 public class IndicesProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("IndexId").add("IndexName").add("State").add("LastConsistencyCheckTime")
-            .add("VirtualBuckets").add("Tablets").add("TabletBalanceStat")
+            .add("TabletBalanceStat").add("VirtualBuckets").add("Tablets")
             .build();
 
     private Database db;
@@ -90,9 +90,9 @@ public class IndicesProcDir implements ProcDirInterface {
                 indexInfo.add(olapTable.getIndexNameById(materializedIndex.getId()));
                 indexInfo.add(materializedIndex.getState());
                 indexInfo.add(TimeUtils.longToTimeString(materializedIndex.getLastCheckTime()));
+                indexInfo.add(materializedIndex.getBalanceStat().toString());
                 indexInfo.add(materializedIndex.getVirtualBuckets().size());
                 indexInfo.add(materializedIndex.getTablets().size());
-                indexInfo.add(materializedIndex.getBalanceStat().toString());
 
                 indexInfos.add(indexInfo);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/IndicesProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/IndicesProcDirTest.java
@@ -72,11 +72,11 @@ public class IndicesProcDirTest {
         Assertions.assertEquals("index1", row.get(1));
         Assertions.assertEquals("NORMAL", row.get(2));
         Assertions.assertEquals("\\N", row.get(3)); // last consistency check time
-        Assertions.assertEquals("2", row.get(4)); // virtual buckets
-        Assertions.assertEquals("2", row.get(5)); // tablets
         Assertions.assertEquals(
                 "{\"maxTabletNum\":9,\"minTabletNum\":1,\"maxBeId\":1,\"minBeId\":2,\"type\":\"CLUSTER_TABLET\"," +
                         "\"balanced\":false}",
-                row.get(6)); // tablet balance stat
+                row.get(4)); // tablet balance stat
+        Assertions.assertEquals("2", row.get(5)); // virtual buckets
+        Assertions.assertEquals("2", row.get(6)); // tablets
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
`VirtualBuckets and Tablets` are not merged into branch 3.5 yet, so i put them at the end.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
