### PR TITLE
[BugFix] Fix now(precision) precision loss in Stream Load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -1105,7 +1105,7 @@ public class Load {
                 return funcExpr.getChild(0);
             } else if (funcName.equalsIgnoreCase(FunctionSet.NOW)) {
                 FunctionName nowFunctionName = new FunctionName(FunctionSet.NOW);
-                FunctionCallExpr newFunc = new FunctionCallExpr(nowFunctionName, new FunctionParams(null));
+                FunctionCallExpr newFunc = new FunctionCallExpr(nowFunctionName, funcExpr.getParams());
                 return newFunc;
             } else if (funcName.equalsIgnoreCase(FunctionSet.SUBSTITUTE)) {
                 return funcExpr.getChild(0);


### PR DESCRIPTION
## Why I'm doing:

Fix the issue where `now(precision)` function loses its precision parameter in Stream Load. When using `now(6)` or similar functions with precision parameters in Stream Load's `COLUMNS` expressions, the system incorrectly rewrites them as `now()`, causing the loss of user-specified precision parameters.

**Problem Example:**

When using Stream Load to import data, if the `COLUMNS` expression contains `now(6)` function, the system incorrectly processes it as `now()`, causing the loss of microsecond precision:

```bash
# Problem scenario: now(6) is incorrectly rewritten as now()
curl --location-trusted -u root: -X PUT \
    -H "Expect:100-continue" \
    -H "columns: id,create_time=now(6)" \
    -d '1' \
    http://localhost:8030/api/test_db/test_table/_stream_load
```

**Before fix:**
- `now(6)` was rewritten as `now()`, returning second-level precision time
- Example: `2023-12-08 13:46:45` (no microsecond part)

**After fix:**
- `now(6)` correctly preserves precision parameters, returning microsecond-level precision time
- Example: `2023-12-08 13:46:45.123456` (with 6-digit microseconds)

## What I'm doing:

Fix the `NOW` function processing logic in `fe/fe-core/src/main/java/com/starrocks/load/Load.java` to ensure that precision parameters in `now(precision)` are correctly preserved in Stream Load column mapping expressions.

**Key fix:**
```java
// Before: Force using empty parameters
FunctionCallExpr newFunc = new FunctionCallExpr(nowFunctionName, new FunctionParams(null));

// After: Reuse original expression parameters
FunctionCallExpr newFunc = new FunctionCallExpr(nowFunctionName, funcExpr.getParams());
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3