### PR TITLE
[BugFix] Fix too many disk io when check consistency

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1311,7 +1311,7 @@ public class Config extends ConfigBase {
      * tablet can be checked only one time on one day, to avoid too many disk io in be
      */
     @ConfField(mutable = true)
-    public static long consistency_check_cooldown_time_second = 24 * 3600; // every 1 day
+    public static long consistency_check_cooldown_time_second = 24 * 3600L; // every 1 day
 
     // Configurations for query engine
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1307,6 +1307,11 @@ public class Config extends ConfigBase {
     public static long check_consistency_default_timeout_second = 600; // 10 min
     @ConfField(mutable = true)
     public static long consistency_tablet_meta_check_interval_ms = 2 * 3600 * 1000L; // every 2 hours
+    /**
+     * tablet can be checked only one time on one day, to avoid too many disk io in be
+     */
+    @ConfField(mutable = true)
+    public static long consistency_check_cooldown_time_ms = 24 * 3600 * 1000L; // every 1 day
 
     // Configurations for query engine
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1311,7 +1311,7 @@ public class Config extends ConfigBase {
      * tablet can be checked only one time on one day, to avoid too many disk io in be
      */
     @ConfField(mutable = true)
-    public static long consistency_check_cooldown_time_ms = 24 * 3600 * 1000L; // every 1 day
+    public static long consistency_check_cooldown_time_second = 24 * 3600; // every 1 day
 
     // Configurations for query engine
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
@@ -525,9 +525,8 @@ public class ConsistencyChecker extends FrontendDaemon {
                                 // sort tablets
                                 Queue<MetaObject> tabletQueue =
                                         new PriorityQueue<>(Math.max(index.getTablets().size(), 1), COMPARATOR);
-                                // tablet can be checked only one time on one day, to avoid to many disk io in be
                                 List<Tablet> cooldownedTablets = index.getTablets().stream()
-                                        .filter(t -> startTime - t.getLastCheckTime() > 24 * 3600 * 1000)
+                                        .filter(t -> startTime - t.getLastCheckTime() > Config.consistency_check_cooldown_time_ms)
                                         .toList();
                                 tabletQueue.addAll(cooldownedTablets);
 

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
@@ -525,8 +525,9 @@ public class ConsistencyChecker extends FrontendDaemon {
                                 // sort tablets
                                 Queue<MetaObject> tabletQueue =
                                         new PriorityQueue<>(Math.max(index.getTablets().size(), 1), COMPARATOR);
+                                long cooldonwedTimeMs = startTime - Config.consistency_check_cooldown_time_second * 1000;
                                 List<Tablet> cooldownedTablets = index.getTablets().stream()
-                                        .filter(t -> startTime - t.getLastCheckTime() > Config.consistency_check_cooldown_time_ms)
+                                        .filter(t -> t.getLastCheckTime() < cooldonwedTimeMs)
                                         .toList();
                                 tabletQueue.addAll(cooldownedTablets);
 

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
@@ -525,7 +525,11 @@ public class ConsistencyChecker extends FrontendDaemon {
                                 // sort tablets
                                 Queue<MetaObject> tabletQueue =
                                         new PriorityQueue<>(Math.max(index.getTablets().size(), 1), COMPARATOR);
-                                tabletQueue.addAll(index.getTablets());
+                                // tablet can be checked only one time on one day, to avoid to many disk io in be
+                                List<Tablet> cooldownedTablets = index.getTablets().stream()
+                                        .filter(t -> startTime - t.getLastCheckTime() > 24 * 3600 * 1000)
+                                        .toList();
+                                tabletQueue.addAll(cooldownedTablets);
 
                                 while ((chosenOne = tabletQueue.poll()) != null) {
                                     LocalTablet tablet = (LocalTablet) chosenOne;

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
@@ -525,7 +525,7 @@ public class ConsistencyChecker extends FrontendDaemon {
                                 // sort tablets
                                 Queue<MetaObject> tabletQueue =
                                         new PriorityQueue<>(Math.max(index.getTablets().size(), 1), COMPARATOR);
-                                long cooldonwedTimeMs = startTime - Config.consistency_check_cooldown_time_second * 1000;
+                                long cooldownedTimeMs = startTime - Config.consistency_check_cooldown_time_second * 1000;
                                 List<Tablet> cooldownedTablets = index.getTablets().stream()
                                         .filter(t -> t.getLastCheckTime() < cooldonwedTimeMs)
                                         .toList();

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
@@ -525,7 +525,8 @@ public class ConsistencyChecker extends FrontendDaemon {
                                 // sort tablets
                                 Queue<MetaObject> tabletQueue =
                                         new PriorityQueue<>(Math.max(index.getTablets().size(), 1), COMPARATOR);
-                                long cooldownedTimeMs = startTime - Config.consistency_check_cooldown_time_second * 1000;
+                                long startCheckTime = System.currentTimeMillis();
+                                long cooldownedTimeMs = startCheckTime - Config.consistency_check_cooldown_time_second * 1000;
                                 List<Tablet> cooldownedTablets = index.getTablets().stream()
                                         .filter(t -> t.getLastCheckTime() < cooldownedTimeMs)
                                         .toList();

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
@@ -527,7 +527,7 @@ public class ConsistencyChecker extends FrontendDaemon {
                                         new PriorityQueue<>(Math.max(index.getTablets().size(), 1), COMPARATOR);
                                 long cooldownedTimeMs = startTime - Config.consistency_check_cooldown_time_second * 1000;
                                 List<Tablet> cooldownedTablets = index.getTablets().stream()
-                                        .filter(t -> t.getLastCheckTime() < cooldonwedTimeMs)
+                                        .filter(t -> t.getLastCheckTime() < cooldownedTimeMs)
                                         .toList();
                                 tabletQueue.addAll(cooldownedTablets);
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fix too many disk io when check consistency.
Since consistency checker, when you write to a table again and again, be will checksum the tablet again and again, and make too much disk io.
So added a cooldown time for tablet (default is 1day) to avoid it. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0 
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
