### PR TITLE
[Enhancement] In the IN expression, date and string type casting are supported

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -156,6 +156,11 @@ public class TypeManager {
         Preconditions.checkState(!types.isEmpty());
         Type compatibleType = types.get(0);
 
+        //date_format(str_to_date('20241209','%Y%m%d'),'%Y-%m-%d 00:00:00') in (str_to_date('20241209','%Y%m%d'),str_to_date('20241208','%Y%m%d'))
+        //The above example needs to convert the string type to the date type
+        if (!isBetween && types.stream().skip(1).allMatch(e -> e == types.get(1))) {
+            return getCompatibleTypeForBinary(false, types.get(0), types.get(1));
+        }
         for (int i = 1; i < types.size(); i++) {
             compatibleType = getCompatibleTypeForBetweenAndIn(compatibleType, types.get(i), isBetween);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -156,14 +156,6 @@ public class TypeManager {
         Preconditions.checkState(!types.isEmpty());
         Type compatibleType = types.get(0);
 
-        // date_format(str_to_date('20241209','%Y%m%d'),'%Y-%m-%d 00:00:00') in (str_to_date('20241209','%Y%m%d'),str_to_date('20241208','%Y%m%d'))
-        // The above example needs to convert the string type to the date type
-        if (!isBetween && types.size() > 1 && types.stream().skip(1).allMatch(e -> e == types.get(1))) {
-            if (compatibleType.isVarchar() && types.get(1).isDateType() ||
-                    compatibleType.isDateType() && types.get(1).isVarchar()) {
-                return getCompatibleTypeForBinary(false, types.get(0), types.get(1));
-            }
-        }
         for (int i = 1; i < types.size(); i++) {
             compatibleType = getCompatibleTypeForBetweenAndIn(compatibleType, types.get(i), isBetween);
         }
@@ -171,6 +163,11 @@ public class TypeManager {
         if (VarcharType.VARCHAR.equals(compatibleType)) {
             if (types.get(0).isDateType()) {
                 return types.get(0);
+            }
+            //date_format(str_to_date('20241209','%Y%m%d'),'%Y-%m-%d 00:00:00') in (str_to_date('20241209','%Y%m%d'),str_to_date('20241208','%Y%m%d'))
+            if (!isBetween && types.size() > 1 && types.get(1).isDateType() &&
+                    types.stream().skip(1).allMatch(e -> e == types.get(1))) {
+                return types.get(1);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -156,8 +156,8 @@ public class TypeManager {
         Preconditions.checkState(!types.isEmpty());
         Type compatibleType = types.get(0);
 
-        //date_format(str_to_date('20241209','%Y%m%d'),'%Y-%m-%d 00:00:00') in (str_to_date('20241209','%Y%m%d'),str_to_date('20241208','%Y%m%d'))
-        //The above example needs to convert the string type to the date type
+        // date_format(str_to_date('20241209','%Y%m%d'),'%Y-%m-%d 00:00:00') in (str_to_date('20241209','%Y%m%d'),str_to_date('20241208','%Y%m%d'))
+        // The above example needs to convert the string type to the date type
         if (!isBetween && types.stream().skip(1).allMatch(e -> e == types.get(1))) {
             return getCompatibleTypeForBinary(false, types.get(0), types.get(1));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -158,8 +158,11 @@ public class TypeManager {
 
         // date_format(str_to_date('20241209','%Y%m%d'),'%Y-%m-%d 00:00:00') in (str_to_date('20241209','%Y%m%d'),str_to_date('20241208','%Y%m%d'))
         // The above example needs to convert the string type to the date type
-        if (!isBetween && types.stream().skip(1).allMatch(e -> e == types.get(1))) {
-            return getCompatibleTypeForBinary(false, types.get(0), types.get(1));
+        if (!isBetween && types.size() > 1 && types.stream().skip(1).allMatch(e -> e == types.get(1))) {
+            if (compatibleType.isVarchar() && types.get(1).isDateType() ||
+                    compatibleType.isDateType() && types.get(1).isVarchar()) {
+                return getCompatibleTypeForBinary(false, types.get(0), types.get(1));
+            }
         }
         for (int i = 1; i < types.size(); i++) {
             compatibleType = getCompatibleTypeForBetweenAndIn(compatibleType, types.get(i), isBetween);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRuleTest.java
@@ -221,9 +221,9 @@ public class ImplicitCastRuleTest {
                 ConstantOperator.createDate(LocalDate.of(2024, 12, 9).atStartOfDay()),
                 ConstantOperator.createDate(LocalDateTime.now()));
         ScalarOperator result1 = rule.apply(op1, null);
-        assertTrue(result1.getChild(0) instanceof CastOperator);
-        assertTrue(result1.getChild(1) instanceof CastOperator);
-        assertTrue(result1.getChild(2) instanceof CastOperator);
+        assertTrue(result1.getChild(0).getType().isDateType());
+        assertTrue(result1.getChild(1).getType().isDateType());
+        assertTrue(result1.getChild(2).getType().isDateType());
 
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRuleTest.java
@@ -40,6 +40,7 @@ import com.starrocks.type.VarcharType;
 import mockit.Expectations;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
 
@@ -214,6 +215,16 @@ public class ImplicitCastRuleTest {
 
         assertTrue(result.getChild(0).getChild(0).getType().isBigint());
         assertTrue(result.getChild(2).getChild(0).getType().isDate());
+
+        //date_format(str_to_date('20241209','%Y%m%d'),'%Y-%m-%d 00:00:00') in (str_to_date('20241209','%Y%m%d'),str_to_date('20241208','%Y%m%d'))
+        InPredicateOperator op1 = new InPredicateOperator(ConstantOperator.createVarchar("2024-12-09 00:00:00"),
+                ConstantOperator.createDate(LocalDate.of(2024, 12, 9).atStartOfDay()),
+                ConstantOperator.createDate(LocalDateTime.now()));
+        ScalarOperator result1 = rule.apply(op1, null);
+        assertTrue(result1.getChild(0) instanceof CastOperator);
+        assertTrue(result1.getChild(1) instanceof CastOperator);
+        assertTrue(result1.getChild(2) instanceof CastOperator);
+
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRuleTest.java
@@ -216,7 +216,7 @@ public class ImplicitCastRuleTest {
         assertTrue(result.getChild(0).getChild(0).getType().isBigint());
         assertTrue(result.getChild(2).getChild(0).getType().isDate());
 
-        //date_format(str_to_date('20241209','%Y%m%d'),'%Y-%m-%d 00:00:00') in (str_to_date('20241209','%Y%m%d'),str_to_date('20241208','%Y%m%d'))
+        // date_format(str_to_date('20241209','%Y%m%d'),'%Y-%m-%d 00:00:00') in (str_to_date('20241209','%Y%m%d'),str_to_date('20241208','%Y%m%d'))
         InPredicateOperator op1 = new InPredicateOperator(ConstantOperator.createVarchar("2024-12-09 00:00:00"),
                 ConstantOperator.createDate(LocalDate.of(2024, 12, 9).atStartOfDay()),
                 ConstantOperator.createDate(LocalDateTime.now()));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -877,8 +877,8 @@ public class ExpressionTest extends PlanTestBase {
                         "c5 IN ('292278994-08-17', '1970-02-01') AND " +
                         "c5 IN ('292278994-08-17', '1970-02-01')  " +
                         " FROM test_in_pred_norm",
-                "<slot 7> : (5: c4 IN (CAST('292278994-08-17' AS DATE), '1970-02-01')) AND " +
-                        "(6: c5 IN (CAST('292278994-08-17' AS DATE), '1970-02-01'))");
+                "<slot 7> : (CAST(5: c4 AS DATETIME) IN (CAST('292278994-08-17' AS DATETIME), '1970-02-01 00:00:00')) " +
+                        "AND (CAST(6: c5 AS DATETIME) IN (CAST('292278994-08-17' AS DATETIME), '1970-02-01 00:00:00'))");
 
         String plan = getFragmentPlan("SELECT " +
                 "c4 IN ('292278994-08-17', '1970-02-01') AND c4 IN ('292278994-08-18', '1970-02-01') AND " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -869,16 +869,13 @@ public class ExpressionTest extends PlanTestBase {
         testPlanContains("SELECT * FROM test_in_pred_norm WHERE c4 IN ('1970-01-01', '1970-01-01', '1970-02-01') ",
                 "c4 IN ('1970-01-01', '1970-01-01', '1970-02-01')");
         testPlanContains("SELECT * FROM test_in_pred_norm WHERE c4 IN ('292278994-08-17', '1970-01-01', '1970-02-01') ",
-                "CAST(5: c4 AS DATETIME) IN (CAST('292278994-08-17' AS DATETIME), '1970-01-01 00:00:00', '1970-02-01 00:00:00')");
-
+                "5: c4 IN (CAST('292278994-08-17' AS DATE), '1970-01-01', '1970-02-01')");
         // common expression
-        testPlanContains("SELECT " +
-                        "c4 IN ('292278994-08-17', '1970-02-01') AND " +
-                        "c5 IN ('292278994-08-17', '1970-02-01') AND " +
-                        "c5 IN ('292278994-08-17', '1970-02-01')  " +
-                        " FROM test_in_pred_norm",
-                "<slot 7> : (CAST(5: c4 AS DATETIME) IN (CAST('292278994-08-17' AS DATETIME), '1970-02-01 00:00:00')) " +
-                        "AND (CAST(6: c5 AS DATETIME) IN (CAST('292278994-08-17' AS DATETIME), '1970-02-01 00:00:00'))");
+        testPlanContains(
+                "SELECT " + "c4 IN ('292278994-08-17', '1970-02-01') AND " + "c5 IN ('292278994-08-17', '1970-02-01') AND " +
+                        "c5 IN ('292278994-08-17', '1970-02-01')  " + " FROM test_in_pred_norm",
+                "<slot 7> : (5: c4 IN (CAST('292278994-08-17' AS DATE), '1970-02-01')) AND " +
+                        "(6: c5 IN (CAST('292278994-08-17' AS DATE), '1970-02-01'))");
 
         String plan = getFragmentPlan("SELECT " +
                 "c4 IN ('292278994-08-17', '1970-02-01') AND c4 IN ('292278994-08-18', '1970-02-01') AND " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -869,7 +869,7 @@ public class ExpressionTest extends PlanTestBase {
         testPlanContains("SELECT * FROM test_in_pred_norm WHERE c4 IN ('1970-01-01', '1970-01-01', '1970-02-01') ",
                 "c4 IN ('1970-01-01', '1970-01-01', '1970-02-01')");
         testPlanContains("SELECT * FROM test_in_pred_norm WHERE c4 IN ('292278994-08-17', '1970-01-01', '1970-02-01') ",
-                "5: c4 IN (CAST('292278994-08-17' AS DATE), '1970-01-01', '1970-02-01')");
+                "CAST(5: c4 AS DATETIME) IN (CAST('292278994-08-17' AS DATETIME), '1970-01-01 00:00:00', '1970-02-01 00:00:00')");
 
         // common expression
         testPlanContains("SELECT " +


### PR DESCRIPTION
## Why I'm doing:
Currently, there is no support for date/string type casting in IN expressions.

## What I'm doing:
Implement multi-value conversion for IN expressions using equality-based logic.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces implicit coercion for `IN` predicates mixing `DATE/DATETIME` and `VARCHAR`.
> 
> - Enhances `TypeManager.getCompatibleTypeForBetweenAndIn` to detect uniform RHS types and pick a compatible type via `getCompatibleTypeForBinary` when LHS/RHS are `DATE` vs `VARCHAR`
> - Planner now casts sides of `IN` to `DATETIME` in cases like `DATE IN ('invalid-date', '1970-01-01', ...)`
> - Updates `ImplicitCastRuleTest` and `ExpressionTest` expectations to reflect new casting behavior and plan outputs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daf638c1f3be6e3b427ba670d8ae0fc72c135614. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->