### PR TITLE
[Enhancement] Support standard bitmap32 without type code in bitmap_from_binary function

### DIFF
--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -751,8 +751,8 @@ bool BitmapValue::valid_and_deserialize(const char* src, size_t max_bytes) {
         _type = EMPTY;
         return true;
     }
-
-    if (*src < BitmapTypeCode::EMPTY || *src > BitmapTypeCode::BITMAP64_SERIV2) {
+    if ((*src < BitmapTypeCode::EMPTY || *src > BitmapTypeCode::BITMAP64_SERIV2) &&
+        *src != BitmapTypeCode::STANDARD_BITMAP32 && *src != BitmapTypeCode::STANDARD_BITMAP32_HAS_RUN) {
         return false;
     } else {
         bool valid = true;
@@ -778,6 +778,8 @@ bool BitmapValue::valid_and_deserialize(const char* src, size_t max_bytes) {
         case BitmapTypeCode::BITMAP64:
         case BitmapTypeCode::BITMAP32_SERIV2:
         case BitmapTypeCode::BITMAP64_SERIV2:
+        case BitmapTypeCode::STANDARD_BITMAP32:
+        case BitmapTypeCode::STANDARD_BITMAP32_HAS_RUN:
             _bitmap = std::make_shared<detail::Roaring64Map>(detail::Roaring64Map::read_safe(src, max_bytes, &valid));
             if (!valid) {
                 return false;


### PR DESCRIPTION
## Why I'm doing:
StarRocks cannot parse standard RoaringBitmap binary data during queries due to type encapsulation mismatch.

## What I'm doing:
Extend the RoaringBitmap type and implement read logic for correct parsing.

Reference standard:  https://github.com/RoaringBitmap/RoaringBitmap/blob/master/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java (In the serialization, BITMAP32 out.writeInt(Integer.reverseBytes("12346"),first char is 58)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3