### PR TITLE
[Feature] Remove table path after clear table

### DIFF
--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -59,6 +59,10 @@ public:
     void drop_table(::google::protobuf::RpcController* controller, const ::starrocks::DropTableRequest* request,
                     ::starrocks::DropTableResponse* response, ::google::protobuf::Closure* done) override;
 
+    void remove_table_path(::google::protobuf::RpcController* controller,
+                           const ::starrocks::RemoveTablePathRequest* request,
+                           ::starrocks::RemoveTablePathResponse* response, ::google::protobuf::Closure* done) override;
+
     void delete_data(::google::protobuf::RpcController* controller, const ::starrocks::DeleteDataRequest* request,
                      ::starrocks::DeleteDataResponse* response, ::google::protobuf::Closure* done) override;
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableCleaner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableCleaner.java
@@ -58,6 +58,29 @@ class LakeTableCleaner {
                 allRemoved = false;
             }
         }
+
+        if (allRemoved) {
+            removeTablePath();
+        }
+
         return allRemoved;
+    }
+
+    public boolean removeTablePath() {
+        try {
+            String tablePath = table.getDefaultFilePathInfo().getFullPath();
+            if (tablePath == null || tablePath.isEmpty()) {
+                LOG.warn("Fail to remove table path of table {}, full path is empty.", table.getName());
+                return false;
+            }
+
+            if (!tablePath.endsWith("/")) {
+                tablePath = tablePath + "/";
+            }
+            return LakeTableHelper.removeTablePath(tablePath);
+        } catch (Exception e) {
+            LOG.warn("Fail to remove table path of table {}: {}", table.getName(), e.getMessage());
+            return false;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -29,7 +29,6 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
-import com.starrocks.common.UserException;
 import com.starrocks.proto.DeleteTabletCacheRequest;
 import com.starrocks.proto.DeleteTabletCacheResponse;
 import com.starrocks.proto.DropTableRequest;
@@ -127,7 +126,7 @@ public class LakeTableHelper {
         try {
             nodeId = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
                     .getNodeSelector().seqChooseBackendOrComputeId();
-        } catch (UserException e) {
+        } catch (Exception e) {
             LOG.warn("Fail to remove table path {}: no alive node", path);
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -39,6 +39,8 @@ import com.starrocks.proto.PublishLogVersionRequest;
 import com.starrocks.proto.PublishLogVersionResponse;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
+import com.starrocks.proto.RemoveTablePathRequest;
+import com.starrocks.proto.RemoveTablePathResponse;
 import com.starrocks.proto.RestoreSnapshotsRequest;
 import com.starrocks.proto.RestoreSnapshotsResponse;
 import com.starrocks.proto.TabletStatRequest;
@@ -96,6 +98,9 @@ public interface LakeService {
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "drop_table", onceTalkTimeout = TIMEOUT_DROP_TABLE)
     Future<DropTableResponse> dropTable(DropTableRequest request);
+
+    @ProtobufRPC(serviceName = "LakeService", methodName = "remove_table_path", onceTalkTimeout = TIMEOUT_DROP_TABLE)
+    Future<RemoveTablePathResponse> removeTablePath(RemoveTablePathRequest request);
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "publish_log_version", onceTalkTimeout = TIMEOUT_PUBLISH_LOG_VERSION)
     Future<PublishLogVersionResponse> publishLogVersion(PublishLogVersionRequest request);

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -83,6 +83,8 @@ import com.starrocks.proto.PublishLogVersionRequest;
 import com.starrocks.proto.PublishLogVersionResponse;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
+import com.starrocks.proto.RemoveTablePathRequest;
+import com.starrocks.proto.RemoveTablePathResponse;
 import com.starrocks.proto.RestoreSnapshotsRequest;
 import com.starrocks.proto.RestoreSnapshotsResponse;
 import com.starrocks.proto.StatusPB;
@@ -1159,6 +1161,11 @@ public class PseudoBackend {
 
         @Override
         public Future<DropTableResponse> dropTable(DropTableRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<RemoveTablePathResponse> removeTablePath(RemoveTablePathRequest request) {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -69,6 +69,8 @@ import com.starrocks.proto.PublishLogVersionRequest;
 import com.starrocks.proto.PublishLogVersionResponse;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
+import com.starrocks.proto.RemoveTablePathRequest;
+import com.starrocks.proto.RemoveTablePathResponse;
 import com.starrocks.proto.RestoreSnapshotsRequest;
 import com.starrocks.proto.RestoreSnapshotsResponse;
 import com.starrocks.proto.StatusPB;
@@ -634,6 +636,11 @@ public class MockedBackend {
 
         @Override
         public Future<DropTableResponse> dropTable(DropTableRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<RemoveTablePathResponse> removeTablePath(RemoveTablePathRequest request) {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -170,6 +170,16 @@ message DropTableResponse {
     optional StatusPB status = 2;
 }
 
+message RemoveTablePathRequest {
+    optional string path = 1;
+}
+
+message RemoveTablePathResponse {
+    // unused, just for preventing jprotobuf error "no field use annotation @com.baidu.bjf.remoting.protobuf.annotation.Protobuf ..."
+    optional int32 pad = 1;
+    optional StatusPB status = 2;
+}
+
 message DeleteDataRequest {
     repeated int64 tablet_ids = 1;
     optional int64 txn_id = 2;
@@ -354,6 +364,7 @@ service LakeService {
     rpc compact(CompactRequest) returns (CompactResponse);
     rpc delete_tablet(DeleteTabletRequest) returns (DeleteTabletResponse);
     rpc drop_table(DropTableRequest) returns (DropTableResponse);
+    rpc remove_table_path(RemoveTablePathRequest) returns (RemoveTablePathResponse);
     rpc delete_data(DeleteDataRequest) returns (DeleteDataResponse);
     rpc get_tablet_stats(TabletStatRequest) returns (TabletStatResponse);
     rpc lock_tablet_metadata(LockTabletMetadataRequest) returns (LockTabletMetadataResponse);


### PR DESCRIPTION
## Why I'm doing:
Currently, after executing a clear table, the system does not physically delete the underlying files or directories. This leads to an excessive number of subdirectories in real-business scenarios, which impacts metadata read performance in distributed storage systems

## What I'm doing:
I'm implementing physical deletion logic for files and directories after a  clear table operation. This ensures that all associated data and directory structures are removed, preventing unnecessary metadata accumulation and improving distributed storage performance.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
