### PR TITLE
[UT] skip caching mv plan in the background

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -51,6 +51,7 @@ import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.ColumnRenameClause;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.MaterializedViewOptimizer;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.utframe.StarRocksAssert;
@@ -128,6 +129,14 @@ public class LocalMetaStoreTest {
             public MvPlanContext optimize(MaterializedView mv,
                                           ConnectContext connectContext) {
                 return null;
+            }
+        };
+
+        // Mock the cacheMaterializedView method to avoid actual caching in the background
+        new MockUp<CachingMvPlanContextBuilder>() {
+            @Mock
+            public void cacheMaterializedView(MaterializedView mv) {
+                // Do nothing to avoid actual caching
             }
         };
 


### PR DESCRIPTION
* avoid the background caching activity that interfers other unit tests in the same test suite.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
