### PR TITLE
[BugFix] Fix mv refresh bug in the case of multiple tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -78,9 +78,6 @@ import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.system.SnapshotsTable;
-import org.apache.paimon.table.system.PartitionsTable;
-import org.apache.paimon.table.system.SchemasTable;
-import org.apache.paimon.table.system.SnapshotsTable;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeChecks;
@@ -179,14 +176,13 @@ public class PaimonMetadata implements ConnectorMetadata {
 
         try {
             List<org.apache.paimon.partition.Partition> partitions = paimonNativeCatalog.listPartitions(identifier);
-            boolean partitionLegacyName = getPartitionLegacyName(paimonTable);for (org.apache.paimon.partition.Partition partition : partitions) {
+            boolean partitionLegacyName = getPartitionLegacyName(paimonTable);
+            for (org.apache.paimon.partition.Partition partition : partitions) {
                 String partitionPath = PartitionPathUtils.generatePartitionPath(partition.spec(), dataTableRowType);
-                String[] partitionValues = Arrays.stream(partitionPath.split("/"))
-                        .map(part -> part.split("=")[1])
-                        .toArray(String[]::new);
-                Partition srPartition = getPartition(partition,
-                        partitionColumnNames, partitionColumnTypes,
-                        partitionValues, partitionLegacyName);
+                String[] partitionValues =
+                        Arrays.stream(partitionPath.split("/")).map(part -> part.split("=")[1]).toArray(String[]::new);
+                Partition srPartition =
+                        getPartition(partition, partitionColumnNames, partitionColumnTypes, partitionValues, partitionLegacyName);
                 this.partitionInfos.get(identifier).put(srPartition.getPartitionName(), srPartition);
             }
         } catch (Catalog.TableNotExistException e) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -1087,7 +1087,7 @@ public class PaimonMetadataTest {
         List<String> result2 = newMetadata.listPartitionNames("db2", "tbl2", null);
 
         // Before fix, if the key does not contain "db" and "table", it will return 2. After fix, it will return 3.
-        assertEquals(2, result2.size());
+        assertEquals(3, result2.size());
 
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -72,6 +72,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.CachingCatalog;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
@@ -84,6 +85,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.predicate.Predicate;
@@ -131,6 +133,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1016,5 +1019,73 @@ public class PaimonMetadataTest {
         catalog.dropTable(identifier, true);
         catalog.dropDatabase("test_db", true, true);
         Files.delete(tmpDir);
+    }
+
+    @Test
+    public void testListPartitionNamesIsolationAcrossTables(@Mocked FileStoreTable mockPaimonTable1,
+                                                            @Mocked FileStoreTable mockPaimonTable2)
+            throws Catalog.TableNotExistException {
+
+        Options options = new Options();
+        options.set(CatalogOptions.CACHE_ENABLED, true);
+        Catalog cachingCatalog = CachingCatalog.tryToCreate(paimonNativeCatalog, options);
+        PaimonMetadata newMetadata = new PaimonMetadata("test_catalog", new HdfsEnvironment(), cachingCatalog,
+                new ConnectorProperties(ConnectorType.PAIMON));
+
+        Identifier tblIdentifier1 = new Identifier("db1", "tbl1");
+        List<String> partitionKeys1 = Lists.newArrayList("year", "month");
+        Identifier tblIdentifier2 = new Identifier("db2", "tbl2");
+        List<String> partitionKeys2 = Lists.newArrayList("year", "month");
+
+        RowType tblRowType1 = RowType.of(new DataType[] {new IntType(true), new IntType(true)}, new String[] {"year", "month"});
+        RowType tblRowType2 = RowType.of(new DataType[] {new IntType(true), new IntType(true)}, new String[] {"year", "month"});
+
+        org.apache.paimon.partition.Partition db1PaimonPartition1 =
+                new org.apache.paimon.partition.Partition(new LinkedHashMap<String, String>() {{
+                    put("year", "2020");
+                    put("month", "1");
+                }}, 100L, 2048L, 2L, System.currentTimeMillis(), false);
+        org.apache.paimon.partition.Partition db2PaimonPartition1 =
+                new org.apache.paimon.partition.Partition(new LinkedHashMap<String, String>() {{
+                    put("year", "2021");
+                    put("month", "1");
+                }}, 100L, 2048L, 2L, System.currentTimeMillis(), false);
+        org.apache.paimon.partition.Partition db2PaimonPartition2 =
+                new org.apache.paimon.partition.Partition(new LinkedHashMap<String, String>() {{
+                    put("year", "2022");
+                    put("month", "1");
+                }}, 100L, 2048L, 2L, System.currentTimeMillis(), false);
+
+        new Expectations() {
+            {
+                // Table 1
+                paimonNativeCatalog.getTable(tblIdentifier1);
+                result = mockPaimonTable1;
+                paimonNativeCatalog.listPartitions(tblIdentifier1);
+                result = Lists.newArrayList(db1PaimonPartition1);
+                mockPaimonTable1.partitionKeys();
+                result = partitionKeys1;
+                mockPaimonTable1.rowType();
+                result = tblRowType1;
+
+                // Table 2
+                paimonNativeCatalog.getTable(tblIdentifier2);
+                result = mockPaimonTable2;
+                paimonNativeCatalog.listPartitions(tblIdentifier2);
+                result = Lists.newArrayList(db2PaimonPartition1, db2PaimonPartition2);
+                mockPaimonTable2.partitionKeys();
+                result = partitionKeys2;
+                mockPaimonTable2.rowType();
+                result = tblRowType2;
+
+            }
+        };
+
+        List<String> result1 = newMetadata.listPartitionNames("db1", "tbl1", null);
+        List<String> result2 = newMetadata.listPartitionNames("db2", "tbl2", null);
+
+        // Before fix, if the key does not contain "db" and "table", it will return 2. After fix, it will return 3.
+        assertEquals(2, result2.size());
+
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -1040,21 +1040,23 @@ public class PaimonMetadataTest {
         RowType tblRowType1 = RowType.of(new DataType[] {new IntType(true), new IntType(true)}, new String[] {"year", "month"});
         RowType tblRowType2 = RowType.of(new DataType[] {new IntType(true), new IntType(true)}, new String[] {"year", "month"});
 
+        Map<String, String> spec1 = new LinkedHashMap<>();
+        spec1.put("year", "2020");
+        spec1.put("month", "1");
         org.apache.paimon.partition.Partition db1PaimonPartition1 =
-                new org.apache.paimon.partition.Partition(new LinkedHashMap<String, String>() {{
-                    put("year", "2020");
-                    put("month", "1");
-                }}, 100L, 2048L, 2L, System.currentTimeMillis(), false);
+                new org.apache.paimon.partition.Partition(spec1, 100L, 2048L, 2L, System.currentTimeMillis(), false);
+
+        Map<String, String> spec2 = new LinkedHashMap<>();
+        spec2.put("year", "2021");
+        spec2.put("month", "1");
         org.apache.paimon.partition.Partition db2PaimonPartition1 =
-                new org.apache.paimon.partition.Partition(new LinkedHashMap<String, String>() {{
-                    put("year", "2021");
-                    put("month", "1");
-                }}, 100L, 2048L, 2L, System.currentTimeMillis(), false);
+                new org.apache.paimon.partition.Partition(spec2, 100L, 2048L, 2L, System.currentTimeMillis(), false);
+
+        Map<String, String> spec3 = new LinkedHashMap<>();
+        spec2.put("year", "2022");
+        spec2.put("month", "1");
         org.apache.paimon.partition.Partition db2PaimonPartition2 =
-                new org.apache.paimon.partition.Partition(new LinkedHashMap<String, String>() {{
-                    put("year", "2022");
-                    put("month", "1");
-                }}, 100L, 2048L, 2L, System.currentTimeMillis(), false);
+                new org.apache.paimon.partition.Partition(spec2, 100L, 2048L, 2L, System.currentTimeMillis(), false);
 
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -1047,16 +1047,16 @@ public class PaimonMetadataTest {
                 new org.apache.paimon.partition.Partition(spec1, 100L, 2048L, 2L, System.currentTimeMillis(), false);
 
         Map<String, String> spec2 = new LinkedHashMap<>();
-        spec2.put("year", "2021");
+        spec2.put("year", "2020");
         spec2.put("month", "1");
         org.apache.paimon.partition.Partition db2PaimonPartition1 =
                 new org.apache.paimon.partition.Partition(spec2, 100L, 2048L, 2L, System.currentTimeMillis(), false);
 
         Map<String, String> spec3 = new LinkedHashMap<>();
-        spec2.put("year", "2022");
-        spec2.put("month", "1");
+        spec3.put("year", "2022");
+        spec3.put("month", "1");
         org.apache.paimon.partition.Partition db2PaimonPartition2 =
-                new org.apache.paimon.partition.Partition(spec2, 100L, 2048L, 2L, System.currentTimeMillis(), false);
+                new org.apache.paimon.partition.Partition(spec3, 100L, 2048L, 2L, System.currentTimeMillis(), false);
 
         new Expectations() {
             {
@@ -1087,7 +1087,7 @@ public class PaimonMetadataTest {
         List<String> result2 = newMetadata.listPartitionNames("db2", "tbl2", null);
 
         // Before fix, if the key does not contain "db" and "table", it will return 2. After fix, it will return 3.
-        assertEquals(3, result2.size());
+        assertEquals(3, result1.size() + result2.size());
 
     }
 }


### PR DESCRIPTION
## Why I'm doing:
I found a bug, partition cache in Paimon does not distinguish tables, causing value overwrites in multi-table queries.

## What I'm doing:
Extend `partitionInfos` map key with table identifier to avoid conflicts.

The same MV refresh task refreshes two tables：
<db1,table1,20250808>
<db1,table2,20250908>

Current（Map<String, Partition> partitionInfos）：
first  refresh：<20250808,Partition Obj>
second refresh：<20250908,Partition Obj>

The key only contains partition information.

After the fix（Map<Identifier, Map<String, Partition>> partitionInfos）：
first  refresh：<db1+table1,<20250808,Partition Obj>
second refresh：<db1+table2,<20250908,Partition Obj>

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Bug fix: partition cache isolation**
> 
> - Changes `partitionInfos` to `Map<Identifier, Map<String, Partition>>`, scoping cached partitions per table
> - Updates `updatePartitionInfo`, `listPartitionNames`, and `getPartitions` to read/write partitions via table `Identifier` and handle empty/null maps
> - Adds `testListPartitionNamesIsolationAcrossTables` verifying partition name isolation across different tables (uses `CachingCatalog`); minor imports added
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db811baba713888c12bd4d8e2127ab6f5f58ac8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->