### PR TITLE
[Tool] separate gen_build_version.py, only build java for fe and cpp for be

### DIFF
--- a/build-support/gen_build_version.py
+++ b/build-support/gen_build_version.py
@@ -19,6 +19,7 @@ import os
 import platform
 import re
 import subprocess
+import sys
 
 from datetime import datetime
 
@@ -199,9 +200,13 @@ const char* STARROCKS_BUILD_ARCH = "{BUILD_ARCH}";
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--cpp", dest='cpp_path', default="./version.cpp", help="Path of generated cpp file", type=str)
-    parser.add_argument("--java", dest='java_path', default="./Version.java", help="Path of generated java file", type=str)
+    parser.add_argument("--cpp", dest='cpp_path', default="", help="Path of generated cpp file", type=str)
+    parser.add_argument("--java", dest='java_path', default="", help="Path of generated java file", type=str)
     args = parser.parse_args()
+
+    if not args.cpp_path and not args.java_path:
+        print("Neither --cpp nor --java provided, do nothing!", file=sys.stderr)
+        return False
 
     version = get_version()
     commit_hash = get_commit_hash()
@@ -217,8 +222,10 @@ def main():
 
     java_version = get_java_version()
 
-    generate_cpp_file(args.cpp_path, version, commit_hash, build_type, build_time, user, hostname, build_distro_id, build_arch)
-    generate_java_file(args.java_path, version, commit_hash, build_type, build_time, user, hostname, java_version, build_distro_id, build_arch)
+    if args.cpp_path:
+        generate_cpp_file(args.cpp_path, version, commit_hash, build_type, build_time, user, hostname, build_distro_id, build_arch)
+    if args.java_path:
+        generate_java_file(args.java_path, version, commit_hash, build_type, build_time, user, hostname, java_version, build_distro_id, build_arch)
 
 if __name__ == '__main__':
     main()

--- a/build.sh
+++ b/build.sh
@@ -373,14 +373,15 @@ do
 done
 
 # Clean and build generated code
-echo "Build generated code"
-cd ${STARROCKS_HOME}/gensrc
-if [ ${CLEAN} -eq 1 ]; then
-   make clean
-   rm -rf ${STARROCKS_HOME}/fe/fe-core/target
+if [ ${BUILD_BE} -eq 1 ] || [ ${BUILD_FORMAT_LIB} -eq 1 ] ; then
+    echo "Build generated code"
+    cd ${STARROCKS_HOME}/gensrc
+    if [ ${CLEAN} -eq 1 ]; then
+       make clean
+    fi
+    # DO NOT using parallel make(-j) for gensrc
+    make
 fi
-# DO NOT using parallel make(-j) for gensrc
-make
 cd ${STARROCKS_HOME}
 
 if [[ "${MACHINE_TYPE}" == "aarch64" ]]; then
@@ -521,7 +522,8 @@ if [ ${FE_MODULES}x != ""x ]; then
     if [ ${CLEAN} -eq 1 ]; then
         ${MVN_CMD} clean
     fi
-    ${MVN_CMD} $addon_mvn_opts package -am -pl ${FE_MODULES} -DskipTests -T ${PARALLEL}
+    # clean phase is explicited by `--clean` option, don't bother doing clean again.
+    ${MVN_CMD} $addon_mvn_opts package -am -pl ${FE_MODULES} -DskipTests -Dmaven.clean.skip=true -T ${PARALLEL}
     cd ${STARROCKS_HOME}/java-extensions
     ${MVN_CMD} $addon_mvn_opts package -am -pl hadoop-ext -DskipTests -T ${PARALLEL}
     cd ${STARROCKS_HOME}

--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -408,7 +408,6 @@ tasks.register<Task>("generateByScripts") {
             commandLine(
                 "python3",
                 "${project.rootProject.projectDir}/../build-support/gen_build_version.py",
-                "--cpp", outputDir.toString(),
                 "--java", outputDir.toString()
             )
         }

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -1073,8 +1073,6 @@ under the License.
                                 <exec executable="${ant.python}">
                                     <env key="JAVA_HOME" value="${java.home}"/>
                                     <arg value="${starrocks.home}/build-support/gen_build_version.py"/>
-                                    <arg value="--cpp"/>
-                                    <arg value="${starrocks.home}/fe/fe-core/target/generated-sources/build"/>
                                     <arg value="--java"/>
                                     <arg value="${starrocks.home}/fe/fe-core/target/generated-sources/build"/>
                                 </exec>

--- a/gensrc/script/Makefile
+++ b/gensrc/script/Makefile
@@ -56,7 +56,7 @@ gen_functions: ${GEN_FUNCTIONS_OUTPUT}
 
 # generate version info
 gen_version:
-	${PYTHON} ${CURDIR}/../../build-support/gen_build_version.py --cpp ${BUILD_DIR}/gen_cpp --java ${FE_TARGET_DIR}
+	${PYTHON} ${CURDIR}/../../build-support/gen_build_version.py --cpp ${BUILD_DIR}/gen_cpp
 .PHONY: gen_version
 
 


### PR DESCRIPTION
* gen_build_version.py allows generating only java or cpp code
* skip `maven clean` phase in fe build

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
