### PR TITLE
[BugFix] Fix NPE in TaskRunScheduler.getAllRunnableTaskCount

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunFIFOQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunFIFOQueue.java
@@ -252,6 +252,9 @@ public class TaskRunFIFOQueue {
         try {
             for (Set<TaskRun> taskRuns : gIdToTaskRunsMap.values()) {
                 for (TaskRun taskRun : taskRuns) {
+                    if (taskRun.getRunCtx() == null) {
+                        continue;
+                    }
                     result.compute(taskRun.getRunCtx().getCurrentWarehouseId(),
                             (key, value) -> value == null ? 1 : value + 1);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
@@ -225,10 +225,16 @@ public class TaskRunScheduler {
     public Map<Long, Long> getAllRunnableTaskCount() {
         Map<Long, Long> result = new HashMap<>();
         for (TaskRun taskRun : runningTaskRunMap.values()) {
+            if (taskRun.getRunCtx() == null) {
+                continue;
+            }
             result.compute(taskRun.getRunCtx().getCurrentWarehouseId(),
                     (key, value) -> value == null ? 1L : value + 1);
         }
         for (TaskRun taskRun : runningSyncTaskRunMap.values()) {
+            if (taskRun.getRunCtx() == null) {
+                continue;
+            }
             result.compute(taskRun.getRunCtx().getCurrentWarehouseId(),
                     (key, value) -> value == null ? 1L : value + 1);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
@@ -322,6 +322,10 @@ public class TaskRunSchedulerTest {
         run3.setRunCtx(context3);
         run3.setTaskId(3L);
         taskRunScheduler.addPendingTaskRun(run3);
+        TaskRun runNull = new TaskRun();
+        runNull.setRunCtx(null);
+        runNull.setTaskId(4L);
+        taskRunScheduler.addPendingTaskRun(runNull);
 
         TaskRun run4 = new TaskRun();
         run4.setRunCtx(context1);
@@ -335,6 +339,10 @@ public class TaskRunSchedulerTest {
         run6.setRunCtx(context3);
         run6.setTaskId(6L);
         taskRunScheduler.addRunningTaskRun(run6);
+        TaskRun runNull2 = new TaskRun();
+        runNull2.setRunCtx(null);
+        runNull2.setTaskId(7L);
+        taskRunScheduler.addRunningTaskRun(runNull2);
 
         TaskRun run7 = new TaskRun();
         run7.setRunCtx(context1);
@@ -348,6 +356,10 @@ public class TaskRunSchedulerTest {
         run9.setRunCtx(context3);
         run9.setTaskId(9L);
         taskRunScheduler.addSyncRunningTaskRun(run9);
+        TaskRun runNull3 = new TaskRun();
+        runNull3.setRunCtx(null);
+        runNull3.setTaskId(10L);
+        taskRunScheduler.addSyncRunningTaskRun(runNull3);
 
         Map<Long, Long> result = taskRunScheduler.getAllRunnableTaskCount();
         Assertions.assertEquals(3, result.size());


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes 
```
{"@timestamp":"2025-08-08 07:39:04.318Z","level":"ERROR","thread.name":"WarehouseIdleChecker","[thread.id](http://thread.id/)":76,"line":111,"file":"Daemon.java","method":"run","message":"daemon thread got exception. name: WarehouseIdleChecker","exception":"java.lang.NullPointerException\n\tat com.starrocks.scheduler.TaskRunScheduler.getAllRunnableTaskCount(TaskRunScheduler.java:228)\n\tat com.starrocks.warehouse.WarehouseIdleChecker.runAfterCatalogReady(WarehouseIdleChecker.java:63)\n\tat com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72)\n\tat com.starrocks.common.util.Daemon.run(Daemon.java:109)\n"}
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
