### PR TITLE
[BugFix] Fix the bug in JDBC's processing of the TIME type

### DIFF
--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -563,6 +563,7 @@ set(EXEC_FILES
         ./util/thrift_client_test.cpp
         ./udf/java/java_native_method_test.cpp
         ./udf/java/java_data_converter_test.cpp
+        ./udf/java/java_udf_test.cpp
         ./util/table_metrics_mgr_test.cpp
         )
 

--- a/be/test/udf/java/java_udf_test.cpp
+++ b/be/test/udf/java/java_udf_test.cpp
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "udf/java/java_udf.h"
 

--- a/be/test/udf/java/java_udf_test.cpp
+++ b/be/test/udf/java/java_udf_test.cpp
@@ -1,0 +1,117 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "udf/java/java_udf.h"
+
+#include <gtest/gtest.h>
+
+#include "column/column_helper.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+class JavaUDFTest : public testing::Test {
+public:
+    void SetUp() override;
+    void TearDown() override;
+
+protected:
+    void _set_timezone(const std::string& timezone);
+    jstring _get_timezone();
+
+    JNIEnv* _env = nullptr;
+    jstring _timezone;
+};
+
+void JavaUDFTest::SetUp() {
+    _env = getJNIEnv();
+    _timezone = _get_timezone();
+    _set_timezone("Asia/Singapore");
+}
+
+void JavaUDFTest::TearDown() {
+    _set_timezone(std::string(_env->GetStringUTFChars(_timezone, nullptr)));
+}
+
+jstring JavaUDFTest::_get_timezone() {
+    jclass time_zone_cls = _env->FindClass("java/util/TimeZone");
+    EXPECT_TRUE(time_zone_cls != nullptr);
+
+    jmethodID get_method = _env->GetStaticMethodID(time_zone_cls, "getDefault", "()Ljava/util/TimeZone;");
+    EXPECT_TRUE(get_method != nullptr);
+
+    jobject time_zone_obj = _env->CallStaticObjectMethod(time_zone_cls, get_method);
+    EXPECT_TRUE(time_zone_obj != nullptr);
+
+    jmethodID get_id_method = _env->GetMethodID(time_zone_cls, "getID", "()Ljava/lang/String;");
+    EXPECT_TRUE(get_id_method != nullptr);
+
+    jstring time_zone_id = (jstring)_env->CallObjectMethod(time_zone_obj, get_id_method);
+
+    _env->DeleteLocalRef(time_zone_obj);
+    _env->DeleteLocalRef(time_zone_cls);
+
+    return time_zone_id;
+}
+
+void JavaUDFTest::_set_timezone(const std::string& timezone) {
+    jclass tz_class = _env->FindClass("java/util/TimeZone");
+
+    jmethodID get_time_zone_mid =
+            _env->GetStaticMethodID(tz_class, "getTimeZone", "(Ljava/lang/String;)Ljava/util/TimeZone;");
+
+    jstring j_tz_id = _env->NewStringUTF(timezone.c_str());
+
+    jobject tz_obj = _env->CallStaticObjectMethod(tz_class, get_time_zone_mid, j_tz_id);
+
+    jmethodID set_default_mid = _env->GetStaticMethodID(tz_class, "setDefault", "(Ljava/util/TimeZone;)V");
+
+    _env->CallStaticVoidMethod(tz_class, set_default_mid, tz_obj);
+
+    _env->DeleteLocalRef(tz_obj);
+    _env->DeleteLocalRef(j_tz_id);
+    _env->DeleteLocalRef(tz_class);
+}
+
+TEST_F(JavaUDFTest, test_time_convert) {
+    jclass time_class = _env->FindClass("java/sql/Time");
+    ASSERT_TRUE(time_class != NULL);
+
+    jmethodID constructor = _env->GetMethodID(time_class, "<init>", "(III)V");
+    ASSERT_TRUE(constructor != NULL);
+
+    jobjectArray time_array = _env->NewObjectArray(1, time_class, NULL);
+    ASSERT_TRUE(time_array != NULL);
+
+    jint hour = 1;
+    jint minute = 10;
+    jint seconds = 20;
+    jobject time_obj = _env->NewObject(time_class, constructor, hour, minute, seconds);
+    _env->SetObjectArrayElement(time_array, 0, time_obj);
+
+    TypeDescriptor time_desc(TYPE_TIME);
+    auto result_column = ColumnHelper::create_column(time_desc, true);
+
+    auto& helper = JVMFunctionHelper::getInstance();
+    ASSERT_OK(helper.get_result_from_boxed_array(TYPE_TIME, result_column.get(), time_array, 1));
+    // 1 * 3600 + 10 * 60 + 20 = 4220
+    ASSERT_EQ(result_column->debug_string(), "[4220]");
+
+    _env->DeleteLocalRef(time_obj);
+    _env->DeleteLocalRef(time_array);
+    _env->DeleteLocalRef(time_class);
+}
+} // namespace starrocks

--- a/be/test/udf/java/java_udf_test.cpp
+++ b/be/test/udf/java/java_udf_test.cpp
@@ -40,7 +40,11 @@ void JavaUDFTest::SetUp() {
 }
 
 void JavaUDFTest::TearDown() {
-    _set_timezone(std::string(_env->GetStringUTFChars(_timezone, nullptr)));
+    const char* cstr = _env->GetStringUTFChars(_timezone, nullptr);
+    if (cstr != nullptr) {
+        _set_timezone(std::string(cstr));
+        _env->ReleaseStringUTFChars(_timezone, cstr);
+    }
 }
 
 jstring JavaUDFTest::_get_timezone() {

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
@@ -86,6 +86,7 @@ public class UDFHelper {
     private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
+    // TODO: Use the time zone set by session variables?
     private static final TimeZone timeZone = TimeZone.getDefault();
 
     private static void getBooleanBoxedResult(int numRows, Boolean[] boxedArr, long columnAddr) {
@@ -234,7 +235,8 @@ public class UDFHelper {
                 nulls[i] = 1;
             } else {
                 // Note: add the timezone offset back because Time#getTime() returns the GMT timestamp
-                dataArr[i] = (boxedArr[i].getTime() + timeZone.getRawOffset()) / 1000;
+                long v = boxedArr[i].getTime();
+                dataArr[i] = (v + timeZone.getOffset(v)) / 1000;
             }
         }
 

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
@@ -227,6 +227,7 @@ public class UDFHelper {
         Platform.copyMemory(dataArr, Platform.DOUBLE_ARRAY_OFFSET, null, addrs[1], numRows * 8L);
     }
 
+    // TODO: Why not use BigInt instead of double?
     private static void getDoubleTimeResult(int numRows, Time[] boxedArr, long columnAddr) {
         byte[] nulls = new byte[numRows];
         double[] dataArr = new double[numRows];


### PR DESCRIPTION
## Why I'm doing:

The Time type has no concept of time zones. Here is how StarRocks processes Time: 
1. the JDBC Driver will fill in a default date of 1970-01-01 with timezone
2. and then StarRocks converts it to one timestamp(Double Type),
```
                // Note: add the timezone offset back because Time#getTime() returns the GMT timestamp
                dataArr[i] = (boxedArr[i].getTime() + timeZone.getRawOffset()) / 1000;
```
4. and then transfer the double value to string using UTC timezone. 
```
std::string time_str_from_double(double time) {
    std::stringstream time_ss;
    if (time < 0) {
        time_ss << "-";
        time = -time;
    }
    int64_t hour = time / 60 / 60;
    int minute = ((int64_t)(time / 60)) % 60;
    int second = ((int64_t)time) % 60;

    time_ss << std::setw(2) << std::setfill('0') << hour << ":" << std::setw(2) << std::setfill('0') << minute << ":"
            << std::setw(2) << std::setfill('0') << second;
    return time_ss.str();
}
```

Take 09:40:20 as an example.

From 1945-09-13 ~ 1981-12-31, Singapore use the time zone (07:30)
From 1982-01-01 ~ now, Signapore use the time zone (08:00)

1. `09:40:20` --> (JDBC Driver) --> `1970-01-01 09:40:20+07:30`
2. (StarRocks) --> ((9-7)×3600 + (40-30)×60 + 20) × 1000 = 7820 × 1000 = 7,820,000 ms
3. (StarRocks) --> 7,820,000 + (timezone_offset) * 3600 * 1000 
4. (StarRocks) --> Use UTC Timezone to transfer double value to string

The reason for the error is that we should not use the TimeZoneOffset of the current time, but rather the TimeZoneOffset as it was in 1970.

If use the current timezone: 7,820,000 + 8 * 3600 * 1000 = 36,620,000, UTC TIME IS: 1970-01-01 10:10:20
If use the timezone of 1970: 7,820,000 + 7 * 3600 * 1000 + 30 * 60 * 1000 = 34, 820,000, UTC TIME IS: 1970-01-01 09:40:20

## What I'm doing:

Fix the bug of jdbc processing time type

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
