### PR TITLE
[BugFix](starrocks-python-client) Correct reflection of server_default and generated columns

### DIFF
--- a/contrib/starrocks-python-client/starrocks/reflection.py
+++ b/contrib/starrocks-python-client/starrocks/reflection.py
@@ -107,17 +107,22 @@ class StarRocksTableDefinitionParser(object):
         Parse column from information_schema.columns table.
         It returns dictionary with column informations expected by sqlalchemy.
         """
-        return {
+        col_data = {
             "name": column["COLUMN_NAME"],
             "type": self._parse_column_type(column=column),
             "nullable": column["IS_NULLABLE"] == "YES",
             "default": column["COLUMN_DEFAULT"],
             "autoincrement": None,  # TODO: This is not specified
-            "computed": {
-                "sqltext": column["GENERATION_EXPRESSION"]
-            },
             "comment": column["COLUMN_COMMENT"],
         }
+
+        generation_expression = column.get("GENERATION_EXPRESSION")
+        if generation_expression:
+            col_data["computed"] = {
+                "sqltext": generation_expression
+            }
+
+        return col_data
 
     def _get_key_columns(self, columns: list[_DecodingRow]) -> list[str]:
         """


### PR DESCRIPTION
## Why I'm doing:
The current SQLAlchemy dialect for StarRocks has a bug in its reflection logic when using information_schema. It incorrectly identifies columns with a server_default (like DEFAULT CURRENT_TIMESTAMP) as "computed" columns.
This causes SQLAlchemy to raise an ArgumentError: A generated column cannot specify a server_default..., which breaks schema reflection tools like MetaData.reflect() and Alembic's autogenerate feature, making automated schema management for such tables impossible.

## What I'm doing:
This PR fixes the reflection logic in starrocks/reflection.py to correctly distinguish between true generated columns and columns that only have a server-side default value.

Fixes #61793

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
