### PR TITLE
[BugFix] starrocks-python-client: Correct DDL generation for ARRAY type in SQLAlchemy dialect

### DIFF
--- a/contrib/starrocks-python-client/starrocks/datatype.py
+++ b/contrib/starrocks-python-client/starrocks/datatype.py
@@ -54,6 +54,10 @@ class PERCENTILE(sqltypes.Numeric):
 class ARRAY(TypeEngine):
     __visit_name__ = "ARRAY"
 
+    def __init__(self, item_type, **kwargs):
+        self.item_type = item_type
+        super().__init__(**kwargs)
+
     @property
     def python_type(self) -> Optional[Type[List[Any]]]:
         return list

--- a/contrib/starrocks-python-client/starrocks/dialect.py
+++ b/contrib/starrocks-python-client/starrocks/dialect.py
@@ -106,7 +106,9 @@ class StarRocksTypeCompiler(MySQLTypeCompiler):
         return "LARGEINT"
 
     def visit_ARRAY(self, type_, **kw):
-        return "ARRAY<type>"
+        """Compiles the ARRAY type into the correct StarRocks syntax."""
+        inner_type_sql = self.process(type_.item_type, **kw)
+        return f"ARRAY<{inner_type_sql}>"
 
     def visit_MAP(self, type_, **kw):
         return "MAP<keytype,valuetype>"


### PR DESCRIPTION
The SQLAlchemy dialect was generating incorrect DDL for ARRAY types, using a literal `ARRAY<type>` instead of compiling the inner type (e.g., `ARRAY<VARCHAR(20)>`).

This was caused by an incomplete ARRAY type definition and a hardcoded `visit_ARRAY` compiler method.

## Why I'm doing:

The current implementation of the SQLAlchemy dialect for StarRocks does not support the `ARRAY` type correctly. When trying to generate DDL for a table containing an `ARRAY` column (e.g., `ARRAY(String(20))`), the dialect produces invalid SQL syntax (`ARRAY<type>`).

This bug makes it impossible to use SQLAlchemy's schema management features or Alembic's `autogenerate` functionality for any models that include array columns, leading to `ProgrammingError (1064)` syntax errors.

## What I'm doing:

This PR fixes the DDL compilation for the `ARRAY` type by making two key changes:

1.  **In `starrocks/datatype.py`**: The `ARRAY` type class is updated with an `__init__` method to properly accept and store its inner item type (e.g., `String(20)`).
2.  **In `starrocks/dialect.py`**: The `StarRocksTypeCompiler.visit_ARRAY` method is implemented to correctly process the stored `item_type` using the compiler, generating the proper SQL syntax (e.g., `ARRAY<VARCHAR(20)>`).

With these changes, DDL for tables with `ARRAY` columns is now generated correctly, enabling full support for this type in SQLAlchemy and Alembic.

Fixes #61737

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
*(Bitte diesen Abschnitt den Maintainern überlassen)*
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4