### PR TITLE
[Enhancement] Emit routine load lag time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2483,7 +2483,7 @@ public class Config extends ConfigBase {
      * Whether to collect routine load latency metrics.
      */
     @ConfField(mutable = true)
-    public static boolean enable_routine_load_lag_time_metrics = true;
+    public static boolean enable_routine_load_lag_time_metrics = false;
 
     @ConfField(mutable = true)
     public static boolean enable_collect_query_detail_info = false;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2479,6 +2479,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_routine_load_lag_metrics = false;
 
+    /**
+     * Whether to collect routine load latency metrics.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_routine_load_lag_time_metrics = true;
+
     @ConfField(mutable = true)
     public static boolean enable_collect_query_detail_info = false;
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -502,9 +502,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                 Long.valueOf((totalRows - errorRows - unselectedRows) * 1000 / totalTaskExcutionTimeMs));
         summary.put("committedTaskNum", Long.valueOf(committedTaskNum));
         summary.put("abortedTaskNum", Long.valueOf(abortedTaskNum));
-        if (Config.enable_routine_load_lag_time_metrics) {
-            summary.put("routineLoadLagTime", getRoutineLoadLagTime());
-        }
+        summary.put("routineLoadLagTime", getRoutineLoadLagTime());
         Gson gson = new GsonBuilder().disableHtmlEscaping().create();
         return gson.toJson(summary);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -68,6 +68,7 @@ import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.load.Load;
 import com.starrocks.load.RoutineLoadDesc;
+import com.starrocks.metric.RoutineLoadLagTimeMetricMgr;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -501,6 +502,9 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                 Long.valueOf((totalRows - errorRows - unselectedRows) * 1000 / totalTaskExcutionTimeMs));
         summary.put("committedTaskNum", Long.valueOf(committedTaskNum));
         summary.put("abortedTaskNum", Long.valueOf(abortedTaskNum));
+        if (Config.enable_routine_load_lag_time_metrics) {
+            summary.put("routineLoadLagTime", getRoutineLoadLagTime());
+        }
         Gson gson = new GsonBuilder().disableHtmlEscaping().create();
         return gson.toJson(summary);
     }
@@ -879,5 +883,65 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
             }
         }
         updateSubstate(JobSubstate.STABLE, null);
+    }
+
+    @Override
+    public void afterVisible(TransactionState txnState, boolean txnOperated) {
+        super.afterVisible(txnState, txnOperated);
+        // Update lag time metrics when Kafka transaction becomes visible
+        if (Config.enable_routine_load_lag_time_metrics) {
+            updateLagTimeMetricsFromProgress();
+        }
+    }
+
+    /**
+     * Update lag time metrics using current Kafka progress
+     */
+    private void updateLagTimeMetricsFromProgress() {
+        try {
+            KafkaProgress progress = (KafkaProgress) getTimestampProgress();
+            Map<Integer, Long> partitionTimestamps = progress.getPartitionIdToOffset();
+            Map<Integer, Long> partitionLagTimes = Maps.newHashMap();
+            
+            long now = System.currentTimeMillis();
+            for (Map.Entry<Integer, Long> entry : partitionTimestamps.entrySet()) {
+                int partition = entry.getKey();
+                Long timestampValue = entry.getValue();
+                long lag = 0L;
+                //   Check for clock drift (future timestamps)
+                if (timestampValue > now) {
+                    long clockDrift = timestampValue - now;
+                    LOG.warn("Clock drift detected for job {} ({}) partition {}: " +
+                            "timestamp {}ms is {}ms ahead of current time {}ms. ",
+                            id, name, partition, timestampValue, clockDrift, now);
+                } else {
+                    lag = (now - timestampValue) / 1000; // convert to seconds
+                } 
+                partitionLagTimes.put(partition, lag);
+            }
+            
+            if (!partitionLagTimes.isEmpty()) {
+                RoutineLoadLagTimeMetricMgr.getInstance().updateRoutineLoadLagTimeMetric(this, partitionLagTimes);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to update lag time metrics for Kafka job {} ({}): {}", id, name, e.getMessage(), e);
+        }
+    }
+
+    private Map<Integer, Long> getRoutineLoadLagTime() {
+        try {
+            RoutineLoadLagTimeMetricMgr metricMgr = RoutineLoadLagTimeMetricMgr.getInstance();
+            Map<Integer, Long> lagTimes = metricMgr.getPartitionLagTimes(this);
+            if (lagTimes != null && !lagTimes.isEmpty()) {
+                LOG.info("Retrieved lag times from metrics manager for job {} ({}): {} partitions", 
+                            id, name, lagTimes.size());
+                return lagTimes;
+            }
+            return Maps.newHashMap();
+        } catch (Exception e) {
+            LOG.warn("Failed to get routine load lag time for job {} ({}): {}", id, name, e.getMessage(), e);
+            // Return empty map as fallback
+            return Maps.newHashMap();
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -182,6 +182,11 @@ public class MetricCalculator extends TimerTask {
             MetricRepo.updateMemoryUsageMetrics();
         }
 
+        // Clean up stale routine load lag time metrics
+        if (Config.enable_routine_load_lag_time_metrics) {
+            RoutineLoadLagTimeMetricMgr.getInstance().cleanupStaleMetrics();
+        }
+
         MetricRepo.GAUGE_SAFE_MODE.setValue(GlobalStateMgr.getCurrentState().isSafeMode() ? 1 : 0);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -65,6 +65,7 @@ import com.starrocks.load.routineload.RoutineLoadMgr;
 import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.metric.Metric.MetricType;
 import com.starrocks.metric.Metric.MetricUnit;
+import com.starrocks.metric.RoutineLoadLagTimeMetricMgr;
 import com.starrocks.monitor.jvm.JvmStatCollector;
 import com.starrocks.monitor.jvm.JvmStats;
 import com.starrocks.proto.PKafkaOffsetProxyRequest;
@@ -879,6 +880,13 @@ public final class MetricRepo {
         // collect routine load process metrics
         if (Config.enable_routine_load_lag_metrics) {
             collectRoutineLoadProcessMetrics(visitor);
+        }
+
+        // ADD: Collect Kafka routine load lag metrics
+        try {
+            RoutineLoadLagTimeMetricMgr.getInstance().collectRoutineLoadLagTimeMetrics(visitor);
+        } catch (Exception e) {
+            LOG.warn("Failed to collect routine load lag metrics", e);
         }
 
         if (Config.memory_tracker_enable) {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/RoutineLoadLagTimeMetricMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/RoutineLoadLagTimeMetricMgr.java
@@ -1,0 +1,238 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+
+//   http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.   
+
+package com.starrocks.metric;
+
+import com.google.common.collect.Maps;
+import com.starrocks.common.Config;
+import com.starrocks.load.routineload.KafkaRoutineLoadJob;
+import com.starrocks.metric.Metric.MetricUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Manager for Routine Load Lag Time Metrics
+ * Handles collection and emission of lag metrics for Kafka routine load jobs
+ */
+public class RoutineLoadLagTimeMetricMgr {
+    private static final Logger LOG = LogManager.getLogger(RoutineLoadLagTimeMetricMgr.class);
+    
+    private static volatile RoutineLoadLagTimeMetricMgr instance;
+    
+    // Use composite key (dbId_jobName) to uniquely identify jobs
+    private final Map<String, RoutineLoadLagTimeMetric> jobLagTimeMap = Maps.newConcurrentMap();
+    
+    private RoutineLoadLagTimeMetricMgr() {}
+    
+    public static RoutineLoadLagTimeMetricMgr getInstance() {
+        if (instance == null) {
+            synchronized (RoutineLoadLagTimeMetricMgr.class) {
+                if (instance == null) {
+                    instance = new RoutineLoadLagTimeMetricMgr();
+                }
+            }
+        }
+        return instance;
+    }
+
+    private String getJobKey(KafkaRoutineLoadJob job) {
+        return job.getDbId() + "." + job.getName();
+    }
+
+    private static class RoutineLoadLagTimeMetric {
+        private long updateTimestamp;
+        private final String jobName;
+        
+        private final Map<Integer, GaugeMetricImpl<Long>> partitionMetrics;
+        private final GaugeMetricImpl<Long> maxLagTimeMetric;
+        
+        public RoutineLoadLagTimeMetric(String jobName) {
+            this.updateTimestamp = -1;
+            this.jobName = jobName;
+            this.partitionMetrics = Maps.newHashMap();
+            this.maxLagTimeMetric = new GaugeMetricImpl<>(
+                    "routine_load_lag_time_seconds_max",
+                    MetricUnit.SECONDS,
+                    "Maximum lag time across all partitions for routine load job"
+            );
+            this.maxLagTimeMetric.addLabel(new MetricLabel("job_name", jobName));
+            
+            LOG.debug("Initialized empty lag time metric structure for job {}", jobName);
+        }
+        
+        public void updateMetrics(Map<Integer, Long> newPartitionLagTimes, long newUpdateTimestamp) {
+            this.updateTimestamp = newUpdateTimestamp;
+            this.partitionMetrics.clear();
+
+            // Calculate max lag time from partition lag times
+            long newMaxLagTime = newPartitionLagTimes.values().stream()
+                    .mapToLong(Long::longValue)
+                    .max()
+                    .orElse(0L);
+
+            for (Map.Entry<Integer, Long> entry : newPartitionLagTimes.entrySet()) {
+                int partition = entry.getKey();
+                long lagTime = entry.getValue();
+                
+                GaugeMetricImpl<Long> partitionMetric = new GaugeMetricImpl<>(
+                        "routine_load_lag_time_seconds_partition",
+                        MetricUnit.SECONDS,
+                        "Kafka partition lag time in seconds"
+                );
+                partitionMetric.addLabel(new MetricLabel("job_name", jobName));
+                partitionMetric.addLabel(new MetricLabel("partition", String.valueOf(partition)));
+                partitionMetric.setValue(lagTime);
+                
+                this.partitionMetrics.put(partition, partitionMetric);
+            }
+
+            this.maxLagTimeMetric.setValue(newMaxLagTime);
+            
+            LOG.debug("Updated metrics for job {}: max_lag_time={}s, partitions={}", 
+                     jobName, newMaxLagTime, newPartitionLagTimes.size());
+        }
+
+        public Map<Integer, GaugeMetricImpl<Long>> getPartitionMetrics() { 
+            return Collections.unmodifiableMap(partitionMetrics);
+        }
+
+        public Map<Integer, Long> getPartitionLagTimes() {
+            Map<Integer, Long> lagTimes = Maps.newHashMap();
+            partitionMetrics.forEach((partition, metric) -> 
+                    lagTimes.put(partition, metric.getValue())
+            );
+            return lagTimes;
+        }
+
+        public GaugeMetricImpl<Long> getMaxLagTimeMetric() {
+            return maxLagTimeMetric;
+        }
+        
+        public boolean isStale(long currentTime, long staleThresholdMs) {
+            return (currentTime - updateTimestamp) > staleThresholdMs;
+        }
+        
+        public boolean hasData() {
+            return !partitionMetrics.isEmpty() && updateTimestamp > 0;
+        }
+    }
+
+    public void updateRoutineLoadLagTimeMetric(KafkaRoutineLoadJob job, Map<Integer, Long> partitionLagTimes) {
+        try {
+            if (partitionLagTimes.isEmpty()) {
+                LOG.debug("No partition lag times available for job {}", job.getName());
+                return;
+            }
+            
+            // Get or create the metric structure using composite key
+            String jobKey = getJobKey(job);
+            RoutineLoadLagTimeMetric lagTimeMetric =
+                    jobLagTimeMap.computeIfAbsent(jobKey, RoutineLoadLagTimeMetric::new);
+            
+            // Update the metric with new values
+            long now = System.currentTimeMillis();
+            lagTimeMetric.updateMetrics(partitionLagTimes, now);
+            
+            LOG.debug("Updated lag time data for Kafka job {}: partitions={}", 
+                     jobKey, partitionLagTimes.size());
+            
+        } catch (Exception e) {
+            LOG.warn("Failed to update lag time data for Kafka job {}: {}", getJobKey(job), e.getMessage());
+        }
+    }
+    
+    /**
+     * Collect routine load lag time metrics - now uses stored data instead of calculating on-demand
+     */
+    public void collectRoutineLoadLagTimeMetrics(MetricVisitor visitor) {
+        if (!Config.enable_routine_load_lag_time_metrics) {
+            return;
+        }
+        
+        try {
+            long now = System.currentTimeMillis();
+            long staleThresholdMs = 5 * 60 * 1000; // 5 minutes; to prevent memory leaks
+            
+            // Clean up stale data and emit metrics
+            Iterator<Map.Entry<String, RoutineLoadLagTimeMetric>> jobLagTimeIterator = jobLagTimeMap.entrySet().iterator();
+            while (jobLagTimeIterator.hasNext()) {
+                Map.Entry<String, RoutineLoadLagTimeMetric> entry = jobLagTimeIterator.next();
+                String jobKey = entry.getKey();
+                RoutineLoadLagTimeMetric lagTimeMetric = entry.getValue();
+                
+                // Skip metrics that don't have data yet
+                if (!lagTimeMetric.hasData()) {
+                    LOG.debug("Skipping job {} - no data available yet", jobKey);
+                    continue;
+                }
+                
+                // Remove stale data
+                if (lagTimeMetric.isStale(now, staleThresholdMs)) {
+                    LOG.debug("Removing stale lag time data for job {}", jobKey);
+                    jobLagTimeIterator.remove();
+                    continue;
+                }
+                
+                // Emit metrics for this job
+                emitJobMetrics(jobKey, lagTimeMetric, visitor);
+            }
+            
+        } catch (Exception e) {
+            LOG.warn("Failed to collect routine load lag time metrics", e);
+        }
+    }
+    
+    private void emitJobMetrics(String jobKey, RoutineLoadLagTimeMetric lagTimeMetric, MetricVisitor visitor) {
+        try {            
+            if (lagTimeMetric.hasData()) {
+                Map<Integer, GaugeMetricImpl<Long>> partitionMetrics = lagTimeMetric.getPartitionMetrics();
+                for (GaugeMetricImpl<Long> partitionMetric : partitionMetrics.values()) {
+                    visitor.visit(partitionMetric);
+                }
+                visitor.visit(lagTimeMetric.getMaxLagTimeMetric());
+            }            
+        } catch (Exception e) {
+            LOG.warn("Failed to emit metrics for job {}: {}", jobKey, e.getMessage());
+        }
+    }
+
+    public Map<Integer, Long> getPartitionLagTimes(KafkaRoutineLoadJob job) {
+        try {
+            String jobKey = getJobKey(job);
+            RoutineLoadLagTimeMetric lagTimeMetric = jobLagTimeMap.get(jobKey);
+            
+            if (lagTimeMetric == null || !lagTimeMetric.hasData()) {
+                LOG.info("No lag time metric found for job {} ({})", jobKey, job.getName());
+                return Collections.emptyMap();
+            }
+            
+            Map<Integer, Long> lagTimes = lagTimeMetric.getPartitionLagTimes();
+            LOG.info("Retrieved {} partition lag times for job {} ({})", 
+                     lagTimes.size(), jobKey, job.getName());
+            return lagTimes;
+            
+        } catch (Exception e) {
+            LOG.warn("Failed to get partition lag times for job {} ({}): {}", 
+                     getJobKey(job), job.getName(), e.getMessage());
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/metric/RoutineLoadLagTimeMetricMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/RoutineLoadLagTimeMetricMgrTest.java
@@ -1,0 +1,186 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+
+//   http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License. 
+
+package com.starrocks.metric;
+
+import com.google.common.collect.Maps;
+import com.starrocks.load.routineload.KafkaRoutineLoadJob;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RoutineLoadLagTimeMetricMgrTest {
+
+    private RoutineLoadLagTimeMetricMgr metricMgr;
+    
+    @Mock
+    private MetricVisitor mockVisitor;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        metricMgr = RoutineLoadLagTimeMetricMgr.getInstance();
+    }
+
+    // Helper method to create mock jobs with unique names
+    private KafkaRoutineLoadJob createMockJob(String jobName, long dbId, long jobId) {
+        KafkaRoutineLoadJob mockJob = mock(KafkaRoutineLoadJob.class);
+        when(mockJob.getDbId()).thenReturn(dbId);
+        when(mockJob.getName()).thenReturn(jobName);
+        when(mockJob.getId()).thenReturn(jobId);
+        return mockJob;
+    }
+
+    @Test
+    public void testMultipleJobsMetrics() {
+        // Setup: Create two jobs with unique names
+        KafkaRoutineLoadJob mockJob1 = createMockJob("test_multiple_job1", 1L, 103L);
+        KafkaRoutineLoadJob mockJob2 = createMockJob("test_multiple_job2", 2L, 104L);
+
+        // Setup: Different lag times for each job
+        Map<Integer, Long> job1LagTimes = Maps.newHashMap();
+        job1LagTimes.put(0, 30L);
+        job1LagTimes.put(1, 45L);
+
+        Map<Integer, Long> job2LagTimes = Maps.newHashMap();
+        job2LagTimes.put(0, 60L);
+        job2LagTimes.put(1, 75L);
+        job2LagTimes.put(2, 90L);
+
+        // Execute: Update metrics for both jobs
+        metricMgr.updateRoutineLoadLagTimeMetric(mockJob1, job1LagTimes);
+        metricMgr.updateRoutineLoadLagTimeMetric(mockJob2, job2LagTimes);
+
+        // Verify: Each job has its own metrics
+        Map<Integer, Long> retrieved1 = metricMgr.getPartitionLagTimes(mockJob1);
+        Map<Integer, Long> retrieved2 = metricMgr.getPartitionLagTimes(mockJob2);
+
+        Assert.assertEquals("Job 1 should have 2 partitions", 2, retrieved1.size());
+        Assert.assertEquals("Job 2 should have 3 partitions", 3, retrieved2.size());
+        Assert.assertEquals("Job 1 partition 0", Long.valueOf(30L), retrieved1.get(0));
+        Assert.assertEquals("Job 2 partition 0", Long.valueOf(60L), retrieved2.get(0));
+    }
+
+    @Test
+    public void testUpdateRoutineLoadLagTimeMetricWithEmptyPartitions() {
+        // Setup: Create job with unique name for this test
+        KafkaRoutineLoadJob mockJob = createMockJob("test_empty_job", 1L, 101L);
+        
+        // Setup: Empty partition lag times
+        Map<Integer, Long> partitionLagTimes = Maps.newHashMap();
+
+        // Execute: Update metrics with empty map
+        metricMgr.updateRoutineLoadLagTimeMetric(mockJob, partitionLagTimes);
+
+        // Verify: No metrics stored
+        Map<Integer, Long> retrievedLagTimes = metricMgr.getPartitionLagTimes(mockJob);
+        Assert.assertTrue("Should return empty map for empty input", retrievedLagTimes.isEmpty());
+    }
+
+    @Test
+    public void testUpdateRoutineLoadLagTimeMetricOverwrite() {
+        // Setup: Create job with unique name for this test
+        KafkaRoutineLoadJob mockJob = createMockJob("test_overwrite_job", 1L, 102L);
+        
+        // Setup: Initial partition lag times
+        Map<Integer, Long> initialLagTimes = Maps.newHashMap();
+        initialLagTimes.put(0, 30L);
+        initialLagTimes.put(1, 45L);
+
+        // Execute: First update
+        metricMgr.updateRoutineLoadLagTimeMetric(mockJob, initialLagTimes);
+
+        // Setup: Updated partition lag times
+        Map<Integer, Long> updatedLagTimes = Maps.newHashMap();
+        updatedLagTimes.put(0, 35L); // Updated lag for partition 0
+        updatedLagTimes.put(1, 50L); // Updated lag for partition 1
+        updatedLagTimes.put(2, 25L); // New partition 2
+
+        // Execute: Second update
+        metricMgr.updateRoutineLoadLagTimeMetric(mockJob, updatedLagTimes);
+
+        // Verify: Metrics were updated, old partitions removed
+        Map<Integer, Long> retrievedLagTimes = metricMgr.getPartitionLagTimes(mockJob);
+        Assert.assertEquals("Should have 3 partitions after update", 3, retrievedLagTimes.size());
+        Assert.assertEquals("Partition 0 lag time updated", Long.valueOf(35L), retrievedLagTimes.get(0));
+        Assert.assertEquals("Partition 1 lag time updated", Long.valueOf(50L), retrievedLagTimes.get(1));
+        Assert.assertEquals("Partition 2 lag time added", Long.valueOf(25L), retrievedLagTimes.get(2));
+    }
+
+    @Test
+    public void testGetPartitionLagTimesForNonExistentJob() {
+        // Setup: Create job that was never added to metrics
+        KafkaRoutineLoadJob nonExistentJob = createMockJob("test_nonexistent_job", 999L, 999L);
+
+        // Execute: Try to get lag times for non-existent job
+        Map<Integer, Long> retrievedLagTimes = metricMgr.getPartitionLagTimes(nonExistentJob);
+
+        // Verify: Returns empty map
+        Assert.assertTrue("Should return empty map for non-existent job", retrievedLagTimes.isEmpty());
+    }
+
+    @Test
+    public void testCollectMetrics() throws Exception {
+        // Setup: Create job with unique name for this test
+        KafkaRoutineLoadJob mockJob = createMockJob("test_collect_job", 1L, 105L);
+        
+        // Setup: Add metrics
+        Map<Integer, Long> partitionLagTimes = Maps.newHashMap();
+        partitionLagTimes.put(0, 30L);
+        partitionLagTimes.put(1, 45L);
+        metricMgr.updateRoutineLoadLagTimeMetric(mockJob, partitionLagTimes);
+
+        // Execute: Collect metrics
+        metricMgr.collectRoutineLoadLagTimeMetrics(mockVisitor);
+
+        // Verify: Visitor was called for partition metrics and max metric
+        verify(mockVisitor, atLeast(1)).visit(any());
+    }
+
+    @Test
+    public void testMaxLagTimeCalculation() {
+        // Setup: Create job with unique name for this test
+        KafkaRoutineLoadJob mockJob = createMockJob("test_maxlag_job", 1L, 108L);
+        
+        // Setup: Partition lag times with different values
+        Map<Integer, Long> partitionLagTimes = Maps.newHashMap();
+        partitionLagTimes.put(0, 30L);  // min
+        partitionLagTimes.put(1, 75L);  // max
+        partitionLagTimes.put(2, 45L);  // middle
+
+        // Execute: Update metrics
+        metricMgr.updateRoutineLoadLagTimeMetric(mockJob, partitionLagTimes);
+
+        // Verify: Max lag time is calculated correctly
+        Map<Integer, Long> retrieved = metricMgr.getPartitionLagTimes(mockJob);
+        Assert.assertEquals("Should maintain all partition data", 3, retrieved.size());
+        
+        // Verify max value is among the retrieved values
+        Long maxValue = retrieved.values().stream().max(Long::compareTo).orElse(0L);
+        Assert.assertEquals("Max lag time should be 75", Long.valueOf(75L), maxValue);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Measuring the lag in time for routine Kafka loads is essential for real-time and near–real-time analytics at scale. Existing metrics may track lag in terms of Kafka offsets or rows, but they don’t reflect how far behind the system is in actual wall-clock time. Without this metric, operators and developers cannot easily assess whether data ingestion is keeping up with data production, identify performance bottlenecks, or promptly detect incidents causing ingest delays. This metric addresses an important gap in observability for production data pipelines using StarRocks routine load.

## What I'm doing:

This PR introduces a new time-based metric that measures the end-to-end lag of StarRocks’ routine load jobs from Kafka. The metric is calculated by comparing the timestamp of the latest processed Kafka record against the current system time, providing a real-time view of the ingestion delay. This value is exported as an observable metric, allowing users to monitor it through StarRocks’ metrics systems. With this addition, users can track how stale the ingested data is and respond quickly to unexpected increases in load lag.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [x] 3.3

