### PR TITLE
[BugFix] support print error msg when delete tablet failed in StarMgrMetaSync

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -188,9 +188,14 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                 DeleteTabletResponse response = future.get();
                 Set<Long> shards = shardIdsByBeMap.get(entry.getKey());
                 if (response != null && response.failedTablets != null && !response.failedTablets.isEmpty()) {
+                    String errorMsg = "";
+                    if (response.status != null && response.status.errorMsgs != null &&
+                            !response.status.errorMsgs.isEmpty()) {
+                        errorMsg = response.status.errorMsgs.get(0);
+                    }
                     TStatusCode stCode = TStatusCode.findByValue(response.status.statusCode);
-                    LOG.info("Fail to delete tablet from node: {}. StatusCode: {}, failedTablets: {}", nodeId, stCode,
-                            response.failedTablets);
+                    LOG.info("Fail to delete tablet from node: {}. StatusCode: {}, Error: {}, failedTablets: {}",
+                            nodeId, stCode, errorMsg, response.failedTablets);
 
                     // ignore INVALID_ARGUMENT error, treat it as success
                     if (stCode != TStatusCode.INVALID_ARGUMENT) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```Fail to delete tablet from node: 10011. StatusCode: INTERNAL_ERROR, Error: on purpose, failedTablets: [10029, 10030]```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
