### PR TITLE
[BugFix] forbidden statistics collect generate expr column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -438,7 +438,8 @@ public class StatisticUtils {
         List<String> columns = new ArrayList<>();
         for (Column column : table.getBaseSchema()) {
             // disable stats collection for auto generated columns, see SelectAnalyzer#analyzeSelect
-            if (column.isGeneratedColumn() && column.getName().startsWith(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {
+            // generated column doesn't support cross DB use
+            if (column.isGeneratedColumn()) {
                 continue;
             }
             if (!column.isAggregated()) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -438,9 +438,16 @@ public class StatisticUtils {
         List<String> columns = new ArrayList<>();
         for (Column column : table.getBaseSchema()) {
             // disable stats collection for auto generated columns, see SelectAnalyzer#analyzeSelect
-            // generated column doesn't support cross DB use
-            if (column.isGeneratedColumn()) {
+            if (column.isGeneratedColumn() && column.getName()
+                    .startsWith(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {
                 continue;
+            }
+            // generated column doesn't support cross DB use
+            if (column.isGeneratedColumn() && column.generatedColumnExprToString() != null) {
+                String expr = column.generatedColumnExprToString().toLowerCase();
+                if (expr.contains("dict_mapping") || expr.contains("dictionary_get")) {
+                    continue;
+                }
             }
             if (!column.isAggregated()) {
                 columns.add(column.getName());


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Forbidden statistics collect on generate expr column，because GEC doesn't support cross db use

e.g:

```
use test;
CREATE TABLE dict_table(    
   key_varchar VARCHAR NOT NULL,
   key_dt DATETIME NOT NULL,
   value BIGINT(20) NOT NULL AUTO_INCREMENT    
) ENGINE=OLAP 
PRIMARY KEY(`key_varchar`, `key_dt`)
DISTRIBUTED BY HASH(`key_varchar`) BUCKETS 12
PROPERTIES (
    "replication_num" = "1",
    "enable_persistent_index" = "true",
    "replicated_storage" = "true"
);

CREATE TABLE `dd0` (
  `k1` int(11) NOT NULL,
  `k2` BIGINT(11) NULL AS dict_mapping('dict_table', `k1`, TRUE)
) ENGINE=OLAP
DUPLICATE KEY(`k1`)
PROPERTIES (
"replication_num" = "1"
);

-- insert data

use td;
select k2 from test.dd0; -- error
```

Fixes https://github.com/StarRocks/StarRocksTest/issues/10063

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
