### PR TITLE
[Enhancement] Optimize journal log writing for replica add/update in tablet report and clone

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -1565,8 +1565,16 @@ public class EditLog {
         logJsonObject(OperationType.OP_ADD_REPLICA_V2, info);
     }
 
+    public JournalTask logAddReplicaNoWait(ReplicaPersistInfo info) {
+        return logJsonObjectNoWait(OperationType.OP_ADD_REPLICA_V2, info);
+    }
+
     public void logUpdateReplica(ReplicaPersistInfo info) {
         logJsonObject(OperationType.OP_UPDATE_REPLICA_V2, info);
+    }
+
+    public JournalTask logUpdateReplicaNoWait(ReplicaPersistInfo info) {
+        return logJsonObjectNoWait(OperationType.OP_UPDATE_REPLICA_V2, info);
     }
 
     public void logDeleteReplica(ReplicaPersistInfo info) {
@@ -2101,6 +2109,15 @@ public class EditLog {
                 Text.writeString(out, GsonUtils.GSON.toJson(obj));
             }
         });
+    }
+
+    public JournalTask logJsonObjectNoWait(short op, Object obj) {
+        return submitLog(op, new Writable() {
+            @Override
+            public void write(DataOutput out) throws IOException {
+                Text.writeString(out, GsonUtils.GSON.toJson(obj));
+            }
+        }, -1);
     }
 
     public void logModifyTableAddOrDrop(TableAddOrDropColumnsInfo info) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
In tablet report and clone, there may be a large number of replica add or update operations, which can generate a large number of journal log writes. These writes will hold the database lock for a long time, causing slow locks.

Wait for the journal logs writing to finish outside the database lock.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
