### PR TITLE
[Enhancement] Separate path id from physical partition id

### DIFF
--- a/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
@@ -57,6 +57,7 @@ SchemaScanner::ColumnDesc SchemaPartitionsMetaScanner::_s_columns[] = {
         {"STORAGE_SIZE", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
         {"TABLET_BALANCED", TypeDescriptor::from_logical_type(TYPE_BOOLEAN), sizeof(bool), false},
         {"METADATA_SWITCH_VERSION", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
+        {"PATH_ID", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
 };
 
 SchemaPartitionsMetaScanner::SchemaPartitionsMetaScanner()
@@ -311,6 +312,11 @@ Status SchemaPartitionsMetaScanner::fill_chunk(ChunkPtr* chunk) {
         case 31: {
             // METADATA_SWITCH_VERSION
             fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.metadata_switch_version);
+            break;
+        }
+        case 32: {
+            // PATH_ID
+            fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.path_id);
             break;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
@@ -98,7 +98,7 @@ public class LakeTableRollupBuilder extends AlterJobV2Builder {
                         .collect(Collectors.toList());
                 List<Long> shadowTabletIds = GlobalStateMgr.getCurrentState().getStarOSAgent().createShards(
                         originTablets.size(),
-                        olapTable.getPartitionFilePathInfo(physicalPartitionId),
+                        olapTable.getPartitionFilePathInfo(physicalPartition.getPathId()),
                         olapTable.getPartitionFileCacheInfo(physicalPartitionId),
                         shardGroupId, originTableIds, shardProperties, computeResource);
                 Preconditions.checkState(originTablets.size() == shadowTabletIds.size());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplitTabletJobFactory.java
@@ -367,7 +367,7 @@ public class SplitTabletJobFactory implements DynamicTabletJobFactory {
                 properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(indexId));
 
                 GlobalStateMgr.getCurrentState().getStarOSAgent().createShards(oldToNewTabletIds,
-                        table.getPartitionFilePathInfo(physicalPartitionId),
+                        table.getPartitionFilePathInfo(physicalPartitionId), // TODO(TackY): use path id
                         table.getPartitionFileCacheInfo(physicalPartitionId),
                         indexContext.getMaterializedIndex().getShardGroupId(),
                         properties, WarehouseManager.DEFAULT_RESOURCE);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3670,10 +3670,10 @@ public class OlapTable extends Table {
     }
 
     @Nullable
-    public FilePathInfo getPartitionFilePathInfo(long physicalPartitionId) {
+    public FilePathInfo getPartitionFilePathInfo(long physicalPartitionPathId) {
         FilePathInfo pathInfo = getDefaultFilePathInfo();
         if (pathInfo != null) {
-            return StarOSAgent.allocatePartitionFilePathInfo(pathInfo, physicalPartitionId);
+            return StarOSAgent.allocatePartitionFilePathInfo(pathInfo, physicalPartitionPathId);
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -60,6 +60,14 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
     @SerializedName(value = "shardGroupId")
     private long shardGroupId = INVALID_SHARD_GROUP_ID;
 
+    // Path id is only for shared-data mode, used to construct storage path.
+    // Default value is physical partition id, but in tablet splitting or merging,
+    // a new physical partition will replace the old physical partition,
+    // the new physical partition will share the same path id with the old one,
+    // and the path id is no longer the same as physical partition id.
+    @SerializedName(value = "pathId")
+    private long pathId;
+
     /* Physical Partition Member */
     @SerializedName(value = "isImmutable")
     private AtomicBoolean isImmutable = new AtomicBoolean(false);
@@ -142,6 +150,7 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
         this.id = id;
         this.name = name;
         this.parentId = parentId;
+        this.pathId = id;
         this.baseIndex = baseIndex;
         this.visibleVersion = PARTITION_INIT_VERSION;
         this.visibleVersionTime = System.currentTimeMillis();
@@ -167,6 +176,7 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
     public void setIdForRestore(long id) {
         this.beforeRestoreId = this.id;
         this.id = id;
+        this.pathId = id;
     }
 
     public long getBeforeRestoreId() {
@@ -183,6 +193,10 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     public long getShardGroupId() {
         return this.shardGroupId;
+    }
+
+    public long getPathId() {
+        return this.pathId;
     }
 
     public List<Long> getShardGroupIds() {
@@ -568,6 +582,9 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
     }
 
     public void gsonPostProcess() throws IOException {
+        if (pathId == 0) {
+            pathId = id;
+        }
         if (dataVersion == 0) {
             dataVersion = visibleVersion;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
@@ -63,6 +63,7 @@ public class PartitionsMetaSystemTable {
                         .column("STORAGE_SIZE", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("TABLET_BALANCED", ScalarType.createType(PrimitiveType.BOOLEAN))
                         .column("METADATA_SWITCH_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("PATH_ID", ScalarType.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_PARTITIONS_META);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -131,7 +131,8 @@ public class PartitionsProcDir implements ProcDirInterface {
                     .add("DataVersion")
                     .add("VersionEpoch")
                     .add("VersionTxnType")
-                    .add("MetaSwitchVersion");
+                    .add("MetaSwitchVersion")
+                    .add("PathId");
             this.titleNames = builder.build();
         } else {
             ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
@@ -418,6 +419,7 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(physicalPartition.getVersionEpoch()); // VersionEpoch
         partitionInfo.add(physicalPartition.getVersionTxnType()); // VersionTxnType
         partitionInfo.add(physicalPartition.getMetadataSwitchVersion()); // MetaSwitchVersion
+        partitionInfo.add(physicalPartition.getPathId()); // PathId
         return partitionInfo;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -175,6 +175,7 @@ public class LakeTable extends OlapTable {
     public Status createTabletsForRestore(int tabletNum, MaterializedIndex index, GlobalStateMgr globalStateMgr,
                                           int replicationNum, long version, int schemaHash,
                                           long physicalPartitionId, Database db) {
+        // Use physical partition id as path id when creating a new physical partition
         FilePathInfo fsInfo = getPartitionFilePathInfo(physicalPartitionId);
         FileCacheInfo cacheInfo = getPartitionFileCacheInfo(physicalPartitionId);
         Map<String, String> properties = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -956,8 +956,10 @@ public class StarOSAgent {
         return shardInfos;
     }
 
-    public static FilePathInfo allocatePartitionFilePathInfo(FilePathInfo tableFilePathInfo, long physicalPartitionId) {
-        String allocPath = StarClient.allocateFilePath(tableFilePathInfo, Long.hashCode(physicalPartitionId));
-        return tableFilePathInfo.toBuilder().setFullPath(String.format("%s/%d", allocPath, physicalPartitionId)).build();
+    public static FilePathInfo allocatePartitionFilePathInfo(FilePathInfo tableFilePathInfo,
+                                                            long physicalPartitionPathId) {
+        String allocPath = StarClient.allocateFilePath(tableFilePathInfo, Long.hashCode(physicalPartitionPathId));
+        return tableFilePathInfo.toBuilder().setFullPath(String.format("%s/%d", allocPath, physicalPartitionPathId))
+                .build();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2051,6 +2051,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             Warehouse warehouse = warehouseManager.getWarehouse(warehouseId);
             throw ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, warehouse.getName());
         }
+        // Use physical partition id as path id when creating a new physical partition
         List<Long> shardIds = stateMgr.getStarOSAgent().createShards(bucketNum,
                 table.getPartitionFilePathInfo(physicalPartitionId),
                 table.getPartitionFileCacheInfo(physicalPartitionId),

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -490,9 +490,11 @@ public class InformationSchemaDataSource {
             partitionMetaInfo.setMax_cs(compactionScore != null ? compactionScore.getMax() : 0.0);
             // STORAGE_PATH
             partitionMetaInfo.setStorage_path(
-                    table.getPartitionFilePathInfo(physicalPartition.getId()).getFullPath());
+                    table.getPartitionFilePathInfo(physicalPartition.getPathId()).getFullPath());
             // METADATA_SWITCH_VERSION
             partitionMetaInfo.setMetadata_switch_version(physicalPartition.getMetadataSwitchVersion());
+            // PATH_ID
+            partitionMetaInfo.setPath_id(physicalPartition.getPathId());
         }
 
         partitionMetaInfo.setData_version(physicalPartition.getDataVersion());

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1522,6 +1522,7 @@ struct TPartitionMetaInfo {
     29: optional i64 storage_size
     30: optional bool tablet_balanced
     31: optional i64 metadata_switch_version
+    32: optional i64 path_id
 }
 
 struct TGetPartitionsMetaResponse {


### PR DESCRIPTION
## Why I'm doing:
Physical partition id is used as path id to construct storage path in shared-data mode.
In tablet splitting and merging, a new physical partition will replace the old physical partition,
and the new physical partition will share the same path id with the old one.
So we need to separate path id from physical partition id.

## What I'm doing:
Introduce path id and separate it from physical partition id for physical partition.
Path id is the same as physical partition id when a new physical partition is created, 
but after tablet splitting or merging, path id is no longer the same as physical partition id.

Note that path id is different from physical partition id only after a tablet splitting.
Tablet splitting does not support downgrading cluster to an unsupported version.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
