### PR TITLE
[BugFix] fix min/max optimization on iceberg on partition columns

### DIFF
--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -237,8 +237,9 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     // short circuit for min/max optimization.
     if (_scanner_ctx.can_use_min_max_optimization()) {
         // 3 means we output 3 values: min, max, and null
-        _scanner_ctx.append_or_update_min_max_column_to_chunk(chunk, 3);
-        size_t row_count = (*chunk)->num_rows();
+        const size_t row_count = 3;
+        (*chunk)->set_num_rows(row_count);
+        _scanner_ctx.append_or_update_min_max_column_to_chunk(chunk, row_count);
         _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, row_count);
         _scanner_ctx.append_or_update_extended_column_to_chunk(chunk, row_count);
         _scanner_ctx.no_more_chunks = true;

--- a/test/sql/test_iceberg/R/test_iceberg_min_max_opt
+++ b/test/sql/test_iceberg/R/test_iceberg_min_max_opt
@@ -324,15 +324,28 @@ None	None	None	None
 drop table ice_tbl_${uuid1} force;
 -- result:
 -- !result
+create external table ice_tbl_${uuid2}(
+    c_int int,
+    dt datetime
+) partition by (dt);
+-- result:
+-- !result
+INSERT INTO ice_tbl_${uuid2} (    
+       c_int, dt
+) VALUES
+(10, '2021-01-01 13:00:00'),
+(20, '2022-01-01 14:00:00');
+-- result:
+-- !result
+select min(dt), max(dt) from ice_tbl_${uuid2};
+-- result:
+2021-01-01 13:00:00	2022-01-01 14:00:00
+-- !result
+drop table ice_tbl_${uuid2} force;
+-- result:
+-- !result
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 -- result:
--- !result
-use iceberg_sql_test_${uuid0}.iceberg_partitioned_tpcds_1g_sql_test_db;
--- result:
--- !result
-select min(ss_sold_date_sk), max(ss_sold_date_sk) from store_sales;
--- result:
-2450816	2452642
 -- !result
 set catalog default_catalog;
 -- result:

--- a/test/sql/test_iceberg/R/test_iceberg_min_max_opt
+++ b/test/sql/test_iceberg/R/test_iceberg_min_max_opt
@@ -327,6 +327,13 @@ drop table ice_tbl_${uuid1} force;
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 -- result:
 -- !result
+use iceberg_sql_test_${uuid0}.iceberg_partitioned_tpcds_1g_sql_test_db;
+-- result:
+-- !result
+select min(ss_sold_date_sk), max(ss_sold_date_sk) from store_sales;
+-- result:
+2450816	2452642
+-- !result
 set catalog default_catalog;
 -- result:
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_min_max_opt
+++ b/test/sql/test_iceberg/T/test_iceberg_min_max_opt
@@ -286,5 +286,9 @@ select min(c_int), max(c_int), max(c_bigint), max(c_bigint) from ice_tbl_${uuid1
 drop table ice_tbl_${uuid1} force;
 
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+
+use iceberg_sql_test_${uuid0}.iceberg_partitioned_tpcds_1g_sql_test_db;
+select min(ss_sold_date_sk), max(ss_sold_date_sk) from store_sales;
+
 set catalog default_catalog;
 drop catalog iceberg_sql_test_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_min_max_opt
+++ b/test/sql/test_iceberg/T/test_iceberg_min_max_opt
@@ -285,10 +285,21 @@ select min(c_int), max(c_int), max(c_bigint), max(c_bigint) from ice_tbl_${uuid1
 
 drop table ice_tbl_${uuid1} force;
 
+create external table ice_tbl_${uuid2}(
+    c_int int,
+    dt datetime
+) partition by (dt);
+
+INSERT INTO ice_tbl_${uuid2} (    
+       c_int, dt
+) VALUES
+(10, '2021-01-01 13:00:00'),
+(20, '2022-01-01 14:00:00');
+
+select min(dt), max(dt) from ice_tbl_${uuid2};
+
+drop table ice_tbl_${uuid2} force;
+
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
-
-use iceberg_sql_test_${uuid0}.iceberg_partitioned_tpcds_1g_sql_test_db;
-select min(ss_sold_date_sk), max(ss_sold_date_sk) from store_sales;
-
 set catalog default_catalog;
 drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

when I select `store_sales` of tpcds table, when `ss_sold_date_sk` is partition column.
> select min(ss_sold_date_sk), max(ss_sold_date_sk) from store_sales;

it outputs null/null.

And I find the reason is
- then plan outputs two slots: ss_sold_date_sk and ss_quantity
- and `ss_quantity` has min/max, but `ss_sold_date_sk` does not.
- by default, chunk row count is zero, and fill `ss_quantity` column first
- but when calling `chunk->row_count()`, it uses `ss_sold_date_sk` column to get row count which is zero, and it's not expected.

## What I'm doing:

This PR is to:
- force chunk row count to be 3 at first,
- then fill columns

Fixes https://github.com/StarRocks/starrocks/pull/60385

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
