### PR TITLE
[BugFix] Fix the problem with the number of rebuild file counted.

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -692,7 +692,7 @@ size_t LakePersistentIndex::need_rebuild_file_cnt(const TabletMetadataPB& metada
         cnt += rowset.del_files_size();
         // rowset id + segment id < rebuild_rss_id can be skip.
         // so only some segments in this rowset need to rebuild
-        cnt += std::min(rowset.id() + rowset.segments_size() - rebuild_rss_id + 1, (uint32_t)rowset.segments_size());
+        cnt += std::min(rowset.id() + rowset.segments_size() - rebuild_rss_id, (uint32_t)rowset.segments_size());
     }
     return cnt;
 }


### PR DESCRIPTION
## Why I'm doing:
Fix the problem with the number of rebuild file counted.
## What I'm doing:

Fixes #issue

 If `rebuild_rss_id` is 12, and `id` = 10, `segments_size` = 3, we can't skip this rowset, because last segment's id
  is 12 which is equal to 12, it may not dump to sst yet.
so rebuild_file_cnt = rowset.id() + rowset.segments_size() - rebuild_rss_id.
rebuild_file_cnt=10+3-12=1.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
