### PR TITLE
[Feature] Add date function of weekday

### DIFF
--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -519,6 +519,13 @@ DEFINE_UNARY_FN_WITH_IMPL(day_of_week_isoImpl, v) {
 }
 DEFINE_TIME_UNARY_FN(day_of_week_iso, TYPE_DATETIME, TYPE_INT);
 
+// week_day
+DEFINE_UNARY_FN_WITH_IMPL(week_dayImpl, v) {
+    int day = ((DateValue)v).weekday();
+    return (day + 6) % 7;
+}
+DEFINE_TIME_UNARY_FN(week_day, TYPE_DATETIME, TYPE_INT);
+
 DEFINE_UNARY_FN_WITH_IMPL(time_to_secImpl, v) {
     return static_cast<int64_t>(v);
 }

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -121,6 +121,23 @@ public:
     DEFINE_VECTORIZED_FN(day_of_week_iso);
 
     /**
+     * Get day of week of the timestamp.
+     * syntax like select weekday("2023-01-03");
+     * result is 1
+     * @param context
+     * @param columns [TimestampColumn] Columns that hold timestamps.
+     * @return  IntColumn Day of the day_of_week_iso:
+     *  - 0: Monday
+     *  - 1: Tuesday
+     *  - 2: Wednesday
+     *  - 3: Thursday
+     *  - 4: Friday
+     *  - 5: Saturday
+     *  - 6: Sunday
+     */
+    DEFINE_VECTORIZED_FN(week_day);
+
+    /**
      * Get day of the timestamp.
      * @param context
      * @param columns [TimestampColumn] Columns that hold timestamps.

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -374,6 +374,25 @@ TEST_F(TimeFunctionsTest, dayofweekisoTest) {
     }
 }
 
+TEST_F(TimeFunctionsTest, weekdayTest) {
+    TimestampColumn::Ptr tc = TimestampColumn::create();
+    tc->append(TimestampValue::create(2023, 1, 1, 0, 5, 0));
+    tc->append(TimestampValue::create(2023, 1, 2, 0, 9, 0));
+    tc->append(TimestampValue::create(2023, 1, 3, 0, 2, 0));
+
+    int days[] = {6, 0, 1};
+
+    Columns columns;
+    columns.emplace_back(tc);
+
+    ColumnPtr result = TimeFunctions::week_day(_utils->get_fn_ctx(), columns).value();
+
+    auto ret = ColumnHelper::cast_to<TYPE_INT>(result);
+    for (size_t i = 0; i < sizeof(days) / sizeof(days[0]); ++i) {
+        ASSERT_EQ(days[i], ret->get_data()[i]);
+    }
+}
+
 TEST_F(TimeFunctionsTest, weekWithModeTest) {
     TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2007, 1, 1, 0, 0, 0));

--- a/docs/en/sql-reference/sql-functions/date-time-functions/weekday.md
+++ b/docs/en/sql-reference/sql-functions/date-time-functions/weekday.md
@@ -1,0 +1,32 @@
+---
+displayed_sidebar: docs
+---
+
+# weekday
+
+Returns the weekday index for a given date. For example, the index for Monday is 0, for Sunday is 6.
+
+## Syntax
+
+```Haskell
+INT WEEKDAY(DATETIME date)
+```
+
+## Parameters
+
+`date`: The `date` parameter must be of the DATE or DATETIME type, or a valid expression that can be cast into a DATE or DATETIME value.
+
+## Examples
+
+```Plain Text
+MySQL > select weekday('2023-01-01');
++-----------------------+
+| weekday('2023-01-01') |
++-----------------------+
+|                     6 |
++-----------------------+
+```
+
+## keyword
+
+WEEKDAY

--- a/docs/ja/sql-reference/sql-functions/date-time-functions/weekday.md
+++ b/docs/ja/sql-reference/sql-functions/date-time-functions/weekday.md
@@ -1,0 +1,32 @@
+---
+displayed_sidebar: docs
+---
+
+# weekday
+
+指定された日付の曜日インデックスを返します。例えば、月曜日は0、日曜日のインデックスは6。
+
+## Syntax
+
+```Haskell
+INT WEEKDAY(DATETIME date)
+```
+
+## Parameters
+
+`date`: パラメータは、DATE または DATETIME 型である必要があります。または、DATE または DATETIME 値にキャストできる有効な式である必要があります。
+
+## Examples
+
+```SQL
+MySQL > select weekday('2023-01-01');
++-----------------------+
+| weekday('2023-01-01') |
++-----------------------+
+|                     6 |
++-----------------------+
+```
+
+## Keywords
+
+WEEKDAY

--- a/docs/zh/sql-reference/sql-functions/date-time-functions/weekday.md
+++ b/docs/zh/sql-reference/sql-functions/date-time-functions/weekday.md
@@ -1,0 +1,32 @@
+---
+displayed_sidebar: docs
+---
+
+# weekday
+
+返回指定日期的工作日索引值，即星期一为 0，星期日为 6。
+
+## 语法
+
+```Haskell
+INT WEEKDAY(DATETIME date)
+```
+
+## 参数说明
+
+`date`：参数为 DATE 或 DATETIME 类型，或者为可以 CAST 成 DATE 或 DATETIME 类型的数字。
+
+## 示例
+
+```SQL
+MySQL > select weekday('2023-01-01');
++-----------------------+
+| weekday('2023-01-01') |
++-----------------------+
+|                     6 |
++-----------------------+
+```
+
+## 关键字
+
+WEEKDAY

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -486,6 +486,8 @@ vectorized_functions = [
     [50089, 'second', True, False, 'TINYINT', ['DATETIME'], 'TimeFunctions::secondV2'],
     [50090, 'second', True, False, 'INT', ['DATETIME'], 'TimeFunctions::second'],
 
+    [50100, 'weekday', True, False, 'INT', ['DATETIME'], 'TimeFunctions::week_day'],
+
     [50110, 'years_add', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::years_add'],
     [50111, 'years_sub', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::years_sub'],
     [50115, 'quarters_add', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::quarters_add'],

--- a/test/sql/test_time_fn/R/test_time_fn
+++ b/test/sql/test_time_fn/R/test_time_fn
@@ -761,6 +761,28 @@ select dayofweek_iso(NULL);
 None
 -- !result
 
+-- name: test_week_day
+select weekday("2023-01-01");
+-- result:
+6
+-- !result
+select weekday("2023-01-02");
+-- result:
+0
+-- !result
+select weekday("2023-01-03");
+-- result:
+1
+-- !result
+select weekday("");
+-- result:
+None
+-- !result
+select weekday(NULL);
+-- result:
+None
+-- !result
+
 -- name: test_makedate
 CREATE TABLE IF NOT EXISTS `makedate_test` (
   `id` int,

--- a/test/sql/test_time_fn/T/test_time_fn
+++ b/test/sql/test_time_fn/T/test_time_fn
@@ -213,6 +213,13 @@ select dayofweek_iso("2023-01-03");
 select dayofweek_iso("");
 select dayofweek_iso(NULL);
 
+-- name: test_week_day
+select weekday("2023-01-01");
+select weekday("2023-01-02");
+select weekday("2023-01-03");
+select weekday("");
+select weekday(NULL);
+
 -- name: test_makedate
 CREATE TABLE IF NOT EXISTS `makedate_test` (
   `id` int,


### PR DESCRIPTION
## Why I'm doing:
Fixes #61695 

## What I'm doing:

Fixes #61695 , add WEEKDAY function similar to the dayofweek_iso function, but it returns numbers from 0 to 6 (corresponding to Monday to Sunday)

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
