### PR TITLE
[BugFix] Fix NPE for JoinHashTable::mem_usage

### DIFF
--- a/be/src/exec/join/join_hash_map.cpp
+++ b/be/src/exec/join/join_hash_map.cpp
@@ -488,8 +488,8 @@ int64_t JoinHashTable::mem_usage() const {
     // cases where `_table_items` was unexpectedly cleared or left uninitialized.
     // To prevent potential null pointer exceptions, we add a defensive check here.
     if (_table_items == nullptr) {
-        DCHECK(false);
         LOG(WARNING) << "table_items is nullptr in mem_usage, stack:" << get_stack_trace();
+        DCHECK(false);
         return 0;
     }
 

--- a/be/src/exec/join/join_hash_map.cpp
+++ b/be/src/exec/join/join_hash_map.cpp
@@ -488,6 +488,7 @@ int64_t JoinHashTable::mem_usage() const {
     // cases where `_table_items` was unexpectedly cleared or left uninitialized.
     // To prevent potential null pointer exceptions, we add a defensive check here.
     if (_table_items == nullptr) {
+        DCHECK(false);
         LOG(WARNING) << "table_items is nullptr in mem_usage, stack:" << get_stack_trace();
         return 0;
     }

--- a/be/src/exec/join/join_hash_map.cpp
+++ b/be/src/exec/join/join_hash_map.cpp
@@ -487,6 +487,7 @@ int64_t JoinHashTable::mem_usage() const {
     // cases where `_table_items` was unexpectedly cleared or left uninitialized.
     // To prevent potential null pointer exceptions, we add a defensive check here.
     if (_table_items == nullptr) {
+        LOG(WARNING) << "table_items is nullptr, returning 0 for memory usage";
         return 0;
     }
 

--- a/be/src/exec/join/join_hash_map.cpp
+++ b/be/src/exec/join/join_hash_map.cpp
@@ -483,6 +483,10 @@ void JoinHashTable::_init_join_keys() {
 }
 
 int64_t JoinHashTable::mem_usage() const {
+    if (_table_items == nullptr) {
+        return 0;
+    }
+
     int64_t usage = 0;
     if (_table_items->build_chunk != nullptr) {
         usage += _table_items->build_chunk->memory_usage();

--- a/be/src/exec/join/join_hash_map.cpp
+++ b/be/src/exec/join/join_hash_map.cpp
@@ -483,6 +483,9 @@ void JoinHashTable::_init_join_keys() {
 }
 
 int64_t JoinHashTable::mem_usage() const {
+    // Theoretically, `_table_items` may be a nullptr after a cancel, even though in practice we haven’t observed any
+    // cases where `_table_items` was unexpectedly cleared or left uninitialized.
+    // To prevent potential null pointer exceptions, we add a defensive check here.
     if (_table_items == nullptr) {
         return 0;
     }

--- a/be/src/exec/join/join_hash_map.cpp
+++ b/be/src/exec/join/join_hash_map.cpp
@@ -26,6 +26,7 @@
 #include "simd/simd.h"
 #include "types/logical_type_infra.h"
 #include "util/runtime_profile.h"
+#include "util/stack_util.h"
 
 namespace starrocks {
 
@@ -487,7 +488,7 @@ int64_t JoinHashTable::mem_usage() const {
     // cases where `_table_items` was unexpectedly cleared or left uninitialized.
     // To prevent potential null pointer exceptions, we add a defensive check here.
     if (_table_items == nullptr) {
-        LOG(WARNING) << "table_items is nullptr, returning 0 for memory usage";
+        LOG(WARNING) << "table_items is nullptr in mem_usage, stack:" << get_stack_trace();
         return 0;
     }
 


### PR DESCRIPTION
## Why I'm doing:

After executing a cancel query, a crash occurred when closing `HashJoinBuildOperator` due to `JoinHashTable::mem_usage` accessing `_table_items`, which was a nullptr.

In theory, this indicates that `_table_items` was either unexpectedly cleared or not initialized after the cancel. However, this issue couldn't be reproduced locally, and no such possibility was identified upon reviewing the code.

As a temporary workaround, we are adding a safeguard in `JoinHashTable::mem_usage`.  

Additionally, there is no risk of a null pointer exception after calling `JoinHashTable::mem_usage` within `HashJoinBuildOperator::close`.


```
*** Aborted at 1752872848 (unix time) try "date -d @1752872848" if you are using GNU date ***
PC: @          0x4182ec3 starrocks::JoinHashTable::mem_usage() const
*** SIGSEGV (@0x0) received by PID 49521 (TID 0x148ee8bf6640) from PID 0; stack trace: ***
    @     0x14952768ee18 __pthread_once_slow
    @          0x7dbe140 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x14952862b9b9 os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x149528631c7a JVM_handle_linux_signal
    @     0x149528623a4c signalHandler(int, siginfo_t*, void*)
    @     0x14952763e6f0 (/usr/lib64/libc.so.6+0x3e6ef)
    @          0x4182ec3 starrocks::JoinHashTable::mem_usage() const
    @          0x453475a starrocks::pipeline::HashJoinBuildOperator::close(starrocks::RuntimeState*)
    @          0x44ed7e6 starrocks::pipeline::PipelineDriver::_mark_operator_closed(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)
    @          0x44ee605 starrocks::pipeline::PipelineDriver::_close_operators(starrocks::RuntimeState*)
    @          0x44eeaf9 starrocks::pipeline::PipelineDriver::finalize(starrocks::RuntimeState*, starrocks::pipeline::DriverState, long, long)
    @          0x47b3c2e starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x398b053 starrocks::ThreadPool::dispatch_thread()
    @          0x3983296 starrocks::Thread::supervise_thread(void*)
    @     0x149527689c02 start_thread
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
