### PR TITLE
[Enhancement]Support show LakeAlterMetaJob

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -14,16 +14,22 @@
 
 package com.starrocks.alter;
 
+import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.lake.LakeTable;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.task.TabletMetadataUpdateAgentTask;
 import com.starrocks.task.TabletMetadataUpdateAgentTaskFactory;
 import com.starrocks.thrift.TTabletMetaType;
+import com.starrocks.warehouse.Warehouse;
 
+import java.util.List;
 import java.util.Set;
 
 public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
@@ -113,6 +119,41 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
             table.getTableProperty().modifyTableProperties(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY,
                     String.valueOf(compactionStrategy));
             table.getTableProperty().buildCompactionStrategy();
+        }
+    }
+
+    @Override
+    protected void getInfo(List<List<Comparable>> infos) {
+        String progress = FeConstants.NULL_STRING;
+        if (jobState == JobState.RUNNING && getBatchTask() != null) {
+            progress = getBatchTask().getFinishedTaskNum() + "/" + getBatchTask().getTaskNum();
+        }
+
+        for (MaterializedIndex index : getPhysicalPartitionIndexMap().values()) {
+            List<Comparable> info = Lists.newArrayList();
+            info.add(jobId);
+            info.add(tableName);
+            info.add(TimeUtils.longToTimeString(createTimeMs));
+            info.add(TimeUtils.longToTimeString(finishedTimeMs));
+            // here we just use index id as index name
+            info.add(index.getId());
+            info.add(index.getId());
+            info.add(index.getId());
+
+            // just set null
+            info.add("null"); // schema version and schema hash
+            info.add(getWatershedTxnId());
+            info.add(jobState.name());
+            info.add(errMsg);
+            info.add(progress);
+            info.add(timeoutMs / 1000);
+            Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouseAllowNull(warehouseId);
+            if (warehouse == null) {
+                info.add("null");
+            } else {
+                info.add(warehouse.getName());
+            }
+            infos.add(info);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -301,6 +301,10 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         physicalPartitionIndexMap.put(partitionId, indexId, index);
     }
 
+    protected Table<Long, Long, MaterializedIndex> getPhysicalPartitionIndexMap() {
+        return physicalPartitionIndexMap;
+    }
+
     public void updatePartitionTabletMeta(Database db, LakeTable table, Partition partition) throws DdlException {
         Collection<PhysicalPartition> physicalPartitions;
         Locker locker = new Locker();


### PR DESCRIPTION
## Why I'm doing:
we can show the LakeAlterMetaJob state by `show alter table column from db`;
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4