### PR TITLE
[BugFix] avoid get file size in report tablet stat thread

### DIFF
--- a/be/src/storage/delta_column_group.cpp
+++ b/be/src/storage/delta_column_group.cpp
@@ -24,11 +24,12 @@ namespace starrocks {
 
 void DeltaColumnGroup::init(int64_t version, const std::vector<std::vector<ColumnUID>>& column_ids,
                             const std::vector<std::string>& column_files,
-                            const std::vector<std::string>& encryption_metas) {
+                            const std::vector<std::string>& encryption_metas, int64_t file_size) {
     _version = version;
     _column_uids = column_ids;
     _column_files = column_files;
     _encryption_metas = encryption_metas;
+    _file_size = file_size;
     _calc_memory_usage();
 }
 
@@ -128,6 +129,7 @@ Status DeltaColumnGroup::load(int64_t version, const char* data, size_t length) 
             _column_uids.back().push_back(cid);
         }
     }
+    _file_size = dcg_pb.file_size();
     _calc_memory_usage();
     return Status::OK();
 }
@@ -164,6 +166,7 @@ std::string DeltaColumnGroup::save() const {
             dcg_col_pb->add_column_ids(cid);
         }
     }
+    dcg_pb.set_file_size(_file_size);
     std::string result;
     dcg_pb.SerializeToString(&result);
     return result;
@@ -187,6 +190,7 @@ std::string DeltaColumnGroupListSerializer::serialize_delta_column_group_list(co
                 dcg_col_pb->add_column_ids(cid);
             }
         }
+        dcg_pb.set_file_size(dcg->file_size());
         dcgs_pb.add_dcgs()->CopyFrom(dcg_pb);
     }
 
@@ -232,7 +236,7 @@ Status DeltaColumnGroupListSerializer::_deserialize_delta_column_group_list(cons
                 encryption_metas.push_back(dcgs_pb.dcgs(i).encryption_metas(j));
             }
         }
-        dcg->init(dcgs_pb.versions(i), column_ids, column_files, encryption_metas);
+        dcg->init(dcgs_pb.versions(i), column_ids, column_files, encryption_metas, dcgs_pb.file_size());
         dcgs->push_back(dcg);
     }
     return Status::OK();

--- a/be/src/storage/delta_column_group.cpp
+++ b/be/src/storage/delta_column_group.cpp
@@ -236,7 +236,7 @@ Status DeltaColumnGroupListSerializer::_deserialize_delta_column_group_list(cons
                 encryption_metas.push_back(dcgs_pb.dcgs(i).encryption_metas(j));
             }
         }
-        dcg->init(dcgs_pb.versions(i), column_ids, column_files, encryption_metas, dcgs_pb.file_size());
+        dcg->init(dcgs_pb.versions(i), column_ids, column_files, encryption_metas, dcgs_pb.dcgs(i).file_size());
         dcgs->push_back(dcg);
     }
     return Status::OK();

--- a/be/src/storage/delta_column_group.h
+++ b/be/src/storage/delta_column_group.h
@@ -37,7 +37,8 @@ public:
     DeltaColumnGroup() {}
     ~DeltaColumnGroup() {}
     void init(int64_t version, const std::vector<std::vector<ColumnUID>>& column_ids,
-              const std::vector<std::string>& column_files, const std::vector<std::string>& encryption_metas = {});
+              const std::vector<std::string>& column_files, const std::vector<std::string>& encryption_metas = {},
+              int64_t file_size = 0);
     Status load(int64_t version, const char* data, size_t length);
     Status load(int64_t version, const DeltaColumnGroupVerPB& dcg_ver_pb);
     std::string save() const;
@@ -104,6 +105,8 @@ public:
 
     const std::vector<std::string>& encryption_metas() const { return _encryption_metas; }
 
+    int64_t file_size() const { return _file_size; }
+
 private:
     void _calc_memory_usage();
 
@@ -113,6 +116,7 @@ private:
     std::vector<std::string> _column_files;
     std::vector<std::string> _encryption_metas;
     size_t _memory_usage = 0;
+    int64_t _file_size = 0; // file size of all column files
 };
 
 class DeltaColumnGroupLoader {

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3706,6 +3706,7 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta, IOStat* stat) 
     }
     if (stat != nullptr) {
         stat->reload_meta_cost += watch.elapsed_time();
+        stat->total_file_size = (_l0 ? _l0->file_size() : 0) + _l1_l2_file_size();
     }
     _calc_memory_usage();
 

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -100,14 +100,16 @@ struct IOStat {
     uint64_t flush_or_wal_cost = 0;
     uint64_t compaction_cost = 0;
     uint64_t reload_meta_cost = 0;
+    uint64_t total_file_size = 0;
 
     std::string print_str() {
         return fmt::format(
                 "IOStat read_iops: {} filtered_kv_cnt: {} get_in_shard_cost: {} read_io_bytes: {} "
                 "l0_write_cost: {} "
-                "l1_l2_read_cost: {} flush_or_wal_cost: {} compaction_cost: {} reload_meta_cost: {}",
+                "l1_l2_read_cost: {} flush_or_wal_cost: {} compaction_cost: {} reload_meta_cost: {} total_file_size: "
+                "{}",
                 read_iops, filtered_kv_cnt, get_in_shard_cost, read_io_bytes, l0_write_cost, l1_l2_read_cost,
-                flush_or_wal_cost, compaction_cost, reload_meta_cost);
+                flush_or_wal_cost, compaction_cost, reload_meta_cost, total_file_size);
     }
 };
 

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1130,10 +1130,10 @@ Status PrimaryIndex::prepare(const EditVersion& version, size_t n) {
     return Status::OK();
 }
 
-Status PrimaryIndex::commit(PersistentIndexMetaPB* index_meta) {
+Status PrimaryIndex::commit(PersistentIndexMetaPB* index_meta, IOStat* stat) {
     auto scope = IOProfiler::scope(IOProfiler::TAG_PKINDEX, _tablet_id);
     if (_persistent_index != nullptr) {
-        return _persistent_index->commit(index_meta);
+        return _persistent_index->commit(index_meta, stat);
     }
     _calc_memory_usage();
     return Status::OK();

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -127,7 +127,7 @@ public:
 
     Status prepare(const EditVersion& version, size_t n);
 
-    Status commit(PersistentIndexMetaPB* index_meta);
+    Status commit(PersistentIndexMetaPB* index_meta, IOStat* stat = nullptr);
 
     Status on_commited();
 

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -755,13 +755,13 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
     int64_t total_do_update_time = 0;
     int64_t total_finalize_dcg_time = 0;
     int64_t handle_cnt = 0;
-    std::map<uint32_t, uint64_t> rssid_to_segment_file_size;
     // must record unique column id in delta column group
     // dcg_column_ids and dcg_column_files are mapped one to the other. E.g.
     // {{1,2}, {3,4}} -> {"aaa.cols", "bbb.cols"}
     // It means column_1 and column_2 are stored in aaa.cols, and column_3 and column_4 are stored in bbb.cols
     std::map<uint32_t, std::vector<std::vector<ColumnUID>>> dcg_column_ids;
     std::map<uint32_t, std::vector<std::string>> dcg_column_files;
+    std::map<uint32_t, int64_t> rssid_to_segment_file_size;
     // 3. read from raw segment file and update file, and generate `.col` files one by one
     int idx = 0; // It is used for generate different .cols filename
     for (uint32_t col_index = 0; col_index < update_column_ids.size(); col_index += BATCH_HANDLE_COLUMN_CNT) {

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -755,7 +755,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
     int64_t total_do_update_time = 0;
     int64_t total_finalize_dcg_time = 0;
     int64_t handle_cnt = 0;
-    int64_t total_segment_file_size = 0;
+    std::map<uint32_t, uint64_t> rssid_to_segment_file_size;
     // must record unique column id in delta column group
     // dcg_column_ids and dcg_column_files are mapped one to the other. E.g.
     // {{1,2}, {3,4}} -> {"aaa.cols", "bbb.cols"}
@@ -815,7 +815,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
             dcg_column_ids[each.first].push_back(selective_unique_update_column_ids);
             dcg_column_files[each.first].push_back(file_name(delta_column_group_writer->segment_path()));
             handle_cnt++;
-            total_segment_file_size += segment_file_size;
+            rssid_to_segment_file_size[each.first] += segment_file_size;
         }
         idx++;
     }
@@ -824,7 +824,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
         _rssid_to_delta_column_group[each.first] = std::make_shared<DeltaColumnGroup>();
         _rssid_to_delta_column_group[each.first]->init(latest_applied_version.major_number() + 1,
                                                        dcg_column_ids[each.first], dcg_column_files[each.first], {},
-                                                       total_segment_file_size);
+                                                       rssid_to_segment_file_size[each.first]);
     }
     cost_str << " [generate delta column group] " << watch.elapsed_time();
     watch.reset();

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -755,6 +755,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
     int64_t total_do_update_time = 0;
     int64_t total_finalize_dcg_time = 0;
     int64_t handle_cnt = 0;
+    int64_t total_segment_file_size = 0;
     // must record unique column id in delta column group
     // dcg_column_ids and dcg_column_files are mapped one to the other. E.g.
     // {{1,2}, {3,4}} -> {"aaa.cols", "bbb.cols"}
@@ -814,6 +815,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
             dcg_column_ids[each.first].push_back(selective_unique_update_column_ids);
             dcg_column_files[each.first].push_back(file_name(delta_column_group_writer->segment_path()));
             handle_cnt++;
+            total_segment_file_size += segment_file_size;
         }
         idx++;
     }
@@ -821,7 +823,8 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
     for (const auto& each : rss_upt_id_to_rowid_pairs) {
         _rssid_to_delta_column_group[each.first] = std::make_shared<DeltaColumnGroup>();
         _rssid_to_delta_column_group[each.first]->init(latest_applied_version.major_number() + 1,
-                                                       dcg_column_ids[each.first], dcg_column_files[each.first]);
+                                                       dcg_column_ids[each.first], dcg_column_files[each.first], {},
+                                                       total_segment_file_size);
     }
     cost_str << " [generate delta column group] " << watch.elapsed_time();
     watch.reset();

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1445,6 +1445,11 @@ void Tablet::get_compaction_status(std::string* json_result) {
 }
 
 void Tablet::do_tablet_meta_checkpoint() {
+    if (_updates) {
+        // pk tablet only need to calc extra file size. Ignore error.
+        (void)_updates->calc_extra_file_size();
+        return;
+    }
     std::unique_lock store_lock(_meta_store_lock);
     if (_will_be_force_replaced) {
         return;

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1445,11 +1445,6 @@ void Tablet::get_compaction_status(std::string* json_result) {
 }
 
 void Tablet::do_tablet_meta_checkpoint() {
-    if (_updates) {
-        // pk tablet only need to calc extra file size. Ignore error.
-        (void)_updates->calc_extra_file_size();
-        return;
-    }
     std::unique_lock store_lock(_meta_store_lock);
     if (_will_be_force_replaced) {
         return;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -277,6 +277,10 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& tablet_updates_pb) {
         }
     }
 
+    // load extra file size. Include persistent index files and delta column files.
+    _extra_file_size_cache.pindex_size = tablet_updates_pb.extra_file_size().pindex_size();
+    _extra_file_size_cache.col_size = tablet_updates_pb.extra_file_size().col_size();
+
     RETURN_IF_ERROR(_load_meta_and_log(tablet_updates_pb));
 
     {
@@ -412,16 +416,7 @@ size_t TabletUpdates::data_size() const {
         LOG_EVERY_N(WARNING, 10) << "data_size() some rowset stats not found tablet=" << _tablet.tablet_id()
                                  << " rowset=" << err_rowsets;
     }
-    auto size_st = _get_extra_file_size();
-    if (!size_st.ok()) {
-        // Ignore error status here, because we don't to break up tablet report because of get extra file size failure.
-        // So just print error log and keep going.
-        VLOG(2) << "get extra file size in primary table fail, tablet_id: " << _tablet.tablet_id()
-                << " status: " << size_st.status();
-        return total_size;
-    } else {
-        return total_size + (*size_st).pindex_size + (*size_st).col_size;
-    }
+    return total_size + _extra_file_size_cache.pindex_size + _extra_file_size_cache.col_size;
 }
 
 size_t TabletUpdates::num_rows() const {
@@ -477,16 +472,7 @@ std::pair<int64_t, int64_t> TabletUpdates::num_rows_and_data_size() const {
         LOG_EVERY_N(WARNING, 10) << "data_size() some rowset stats not found tablet=" << _tablet.tablet_id()
                                  << " rowset=" << err_rowsets;
     }
-    auto size_st = _get_extra_file_size();
-    if (!size_st.ok()) {
-        // Ignore error status here, because we don't to break up tablet report because of get extra file size failure.
-        // So just print error log and keep going.
-        VLOG(2) << "get extra file size in primary table fail, tablet_id: " << _tablet.tablet_id()
-                << " status: " << size_st.status();
-        return {total_row, total_size};
-    } else {
-        return {total_row, total_size + (*size_st).pindex_size + (*size_st).col_size};
-    }
+    return {total_row, total_size + _extra_file_size_cache.pindex_size + _extra_file_size_cache.col_size};
 }
 
 size_t TabletUpdates::num_rowsets() const {
@@ -3571,8 +3557,7 @@ size_t TabletUpdates::_get_rowset_num_deletes(const Rowset& rowset) {
     return num_dels;
 }
 
-StatusOr<ExtraFileSize> TabletUpdates::_get_extra_file_size() const {
-    ExtraFileSize ef_size;
+Status TabletUpdates::calc_extra_file_size() {
 #if !defined(ADDRESS_SANITIZER)
     std::string tablet_path_str = _tablet.schema_hash_path();
     std::filesystem::path tablet_path(tablet_path_str.c_str());
@@ -3582,10 +3567,10 @@ StatusOr<ExtraFileSize> TabletUpdates::_get_extra_file_size() const {
                 std::string filename = entry.path().filename().string();
 
                 if (filename.starts_with("index.l")) {
-                    ef_size.pindex_size += entry.file_size();
+                    _extra_file_size_cache.pindex_size.fetch_add(entry.file_size());
                 } else if (filename.ends_with(".cols")) {
                     // TODO skip the expired cols file
-                    ef_size.col_size += entry.file_size();
+                    _extra_file_size_cache.col_size.fetch_add(entry.file_size());
                 }
             }
         }
@@ -3600,7 +3585,7 @@ StatusOr<ExtraFileSize> TabletUpdates::_get_extra_file_size() const {
         return Status::InternalError(err_msg);
     }
 #endif
-    return ef_size;
+    return Status::OK();
 }
 
 void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
@@ -3646,16 +3631,7 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
         LOG_EVERY_N(WARNING, 10) << "get_tablet_info_extra() some rowset stats not found tablet=" << _tablet.tablet_id()
                                  << " rowset=" << err_rowsets;
     }
-    auto size_st = _get_extra_file_size();
-
-    if (!size_st.ok()) {
-        // Ignore error status here, because we don't to break up tablet report because of get extra file size failure.
-        // So just print error log and keep going.
-        VLOG(2) << "get extra file size in primary table fail, tablet_id: " << _tablet.tablet_id()
-                << " status: " << size_st.status();
-    } else {
-        total_size += (*size_st).pindex_size + (*size_st).col_size;
-    }
+    total_size += _extra_file_size_cache.pindex_size + _extra_file_size_cache.col_size;
     info->__set_version(version);
     info->__set_min_readable_version(min_readable_version);
     info->__set_max_readable_version(max_readable_version);
@@ -4785,15 +4761,7 @@ void TabletUpdates::get_basic_info_extra(TabletBasicInfo& info) {
         info.index_mem = index_entry->size();
         index_cache.release(index_entry);
     }
-    auto size_st = _get_extra_file_size();
-    if (!size_st.ok()) {
-        // Ignore error status here, because we don't to break up get basic info because of get pk index disk usage failure.
-        // So just print error log and keep going.
-        VLOG(2) << "get persistent index disk usage fail, tablet_id: " << _tablet.tablet_id()
-                << ", error: " << size_st.status();
-    } else {
-        info.index_disk_usage = (*size_st).pindex_size;
-    }
+    info.index_disk_usage = _extra_file_size_cache.pindex_size;
 }
 
 Status TabletUpdates::pk_index_major_compaction() {
@@ -4860,6 +4828,9 @@ void TabletUpdates::_to_updates_pb_unlocked(TabletUpdatesPB* updates_pb) const {
     }
     updates_pb->set_next_rowset_id(_next_rowset_id);
     updates_pb->set_next_log_id(_next_log_id);
+    // set extra file size
+    updates_pb->mutable_extra_file_size()->set_pindex_size(_extra_file_size_cache.pindex_size);
+    updates_pb->mutable_extra_file_size()->set_col_size(_extra_file_size_cache.col_size);
     if (_apply_version_idx < _edit_version_infos.size()) {
         const EditVersion& apply_version = _edit_version_infos[_apply_version_idx]->version;
         updates_pb->mutable_apply_version()->set_major_number(apply_version.major_number());

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -278,8 +278,13 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& tablet_updates_pb) {
     }
 
     // load extra file size. Include persistent index files and delta column files.
-    _extra_file_size_cache.pindex_size = tablet_updates_pb.extra_file_size().pindex_size();
-    _extra_file_size_cache.col_size = tablet_updates_pb.extra_file_size().col_size();
+    if (tablet_updates_pb.has_extra_file_size()) {
+        _extra_file_size_cache.pindex_size = tablet_updates_pb.extra_file_size().pindex_size();
+        _extra_file_size_cache.col_size = tablet_updates_pb.extra_file_size().col_size();
+    } else {
+        _extra_file_size_cache.pindex_size = 0;
+        _extra_file_size_cache.col_size = 0;
+    }
 
     RETURN_IF_ERROR(_load_meta_and_log(tablet_updates_pb));
 

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -73,8 +73,8 @@ struct CompactionInfo {
 };
 
 struct ExtraFileSize {
-    int64_t pindex_size = 0;
-    int64_t col_size = 0;
+    std::atomic<int64_t> pindex_size = 0;
+    std::atomic<int64_t> col_size = 0;
 };
 
 struct EditVersionInfo {
@@ -520,7 +520,7 @@ private:
 
     std::shared_timed_mutex* get_index_lock() { return &_index_lock; }
 
-    StatusOr<ExtraFileSize> _get_extra_file_size() const;
+    Status calc_extra_file_size();
 
     bool _use_light_apply_compaction(Rowset* rowset);
 
@@ -598,6 +598,9 @@ private:
 
     std::atomic<bool> _apply_schedule{false};
     size_t _apply_failed_time = 0;
+
+    // cache of latest ExtraFileSize
+    ExtraFileSize _extra_file_size_cache;
 };
 
 } // namespace starrocks

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -520,8 +520,6 @@ private:
 
     std::shared_timed_mutex* get_index_lock() { return &_index_lock; }
 
-    Status calc_extra_file_size();
-
     bool _use_light_apply_compaction(Rowset* rowset);
 
     Status _light_apply_compaction_commit(const EditVersion& version, Rowset* output_rowset, PrimaryIndex* index,

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -325,6 +325,17 @@ void UpdateManager::clear_cached_delta_column_group_by_tablet_id(int64_t tablet_
     }
 }
 
+int64_t UpdateManager::get_delta_column_group_file_size_by_tablet_id(int64_t tablet_id) const {
+    int64_t file_size = 0;
+    std::lock_guard<std::mutex> lg(_delta_column_group_cache_lock);
+    auto itr = _delta_column_group_cache.lower_bound(TabletSegmentId(tablet_id, 0));
+    while (itr != _delta_column_group_cache.end() && itr->first.tablet_id == tablet_id) {
+        file_size += itr->second[0]->file_size(); // only latest dcg file size.
+        itr++;
+    }
+    return file_size;
+}
+
 void UpdateManager::clear_cached_delta_column_group(const std::vector<TabletSegmentId>& tsids) {
     std::lock_guard<std::mutex> lg(_delta_column_group_cache_lock);
     for (const auto& tsid : tsids) {

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -330,7 +330,9 @@ int64_t UpdateManager::get_delta_column_group_file_size_by_tablet_id(int64_t tab
     std::lock_guard<std::mutex> lg(_delta_column_group_cache_lock);
     auto itr = _delta_column_group_cache.lower_bound(TabletSegmentId(tablet_id, 0));
     while (itr != _delta_column_group_cache.end() && itr->first.tablet_id == tablet_id) {
-        file_size += itr->second[0]->file_size(); // only latest dcg file size.
+        if (!itr->second.empty()) {
+            file_size += itr->second[0]->file_size(); // only latest dcg file size.
+        }
         itr++;
     }
     return file_size;

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -325,7 +325,7 @@ void UpdateManager::clear_cached_delta_column_group_by_tablet_id(int64_t tablet_
     }
 }
 
-int64_t UpdateManager::get_delta_column_group_file_size_by_tablet_id(int64_t tablet_id) const {
+int64_t UpdateManager::get_delta_column_group_file_size_by_tablet_id(int64_t tablet_id) {
     int64_t file_size = 0;
     std::lock_guard<std::mutex> lg(_delta_column_group_cache_lock);
     auto itr = _delta_column_group_cache.lower_bound(TabletSegmentId(tablet_id, 0));

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -124,6 +124,7 @@ public:
     void clear_cached_delta_column_group_by_tablet_id(int64_t tablet_id);
     void clear_cached_delta_column_group(const std::vector<TabletSegmentId>& tsids);
 
+    int64_t get_delta_column_group_file_size_by_tablet_id(int64_t tablet_id) const;
     StatusOr<size_t> clear_delta_column_group_before_version(KVStore* meta, const std::string& tablet_path,
                                                              int64_t tablet_id, int64_t min_readable_version);
 

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -124,7 +124,7 @@ public:
     void clear_cached_delta_column_group_by_tablet_id(int64_t tablet_id);
     void clear_cached_delta_column_group(const std::vector<TabletSegmentId>& tsids);
 
-    int64_t get_delta_column_group_file_size_by_tablet_id(int64_t tablet_id) const;
+    int64_t get_delta_column_group_file_size_by_tablet_id(int64_t tablet_id);
     StatusOr<size_t> clear_delta_column_group_before_version(KVStore* meta, const std::string& tablet_path,
                                                              int64_t tablet_id, int64_t min_readable_version);
 

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -631,6 +631,15 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_multi_segment_preload_and_c
     int64_t version = 1;
     int64_t version_before_partial_update = 1;
     prepare_tablet(this, tablet, version, version_before_partial_update, N);
+    // calc tablet update extra file size
+    ASSERT_TRUE(tablet->updates()->calc_extra_file_size().ok());
+    // get TabletUpdatesPB
+    TabletUpdatesPB updates_pb;
+    tablet->updates()->to_updates_pb(&updates_pb);
+// check extra file size exist.
+#if !defined(ADDRESS_SANITIZER)
+    ASSERT_TRUE(updates_pb.extra_file_size().col_size() > 0);
+#endif
 }
 
 TEST_P(RowsetColumnPartialUpdateTest, partial_update_index_lock_timeout) {

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -631,15 +631,6 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_multi_segment_preload_and_c
     int64_t version = 1;
     int64_t version_before_partial_update = 1;
     prepare_tablet(this, tablet, version, version_before_partial_update, N);
-    // calc tablet update extra file size
-    ASSERT_TRUE(tablet->updates()->calc_extra_file_size().ok());
-    // get TabletUpdatesPB
-    TabletUpdatesPB updates_pb;
-    tablet->updates()->to_updates_pb(&updates_pb);
-// check extra file size exist.
-#if !defined(ADDRESS_SANITIZER)
-    ASSERT_TRUE(updates_pb.extra_file_size().col_size() > 0);
-#endif
 }
 
 TEST_P(RowsetColumnPartialUpdateTest, partial_update_index_lock_timeout) {
@@ -1438,6 +1429,19 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_compaction_conflict_ch
     }));
 
     config::enable_light_pk_compaction_publish = true;
+}
+
+TEST_P(RowsetColumnPartialUpdateTest, test_dcg_file_size) {
+    const int N = 100;
+    auto tablet = create_tablet(rand(), rand());
+    ASSERT_EQ(1, tablet->updates()->version_history_count());
+    int64_t version = 1;
+    int64_t version_before_partial_update = 1;
+    prepare_tablet(this, tablet, version, version_before_partial_update, N);
+    // get dcg file size
+    int64_t dcg_file_size = StorageEngine::instance()->update_manager()->get_delta_column_group_file_size_by_tablet_id(
+            tablet->tablet_id());
+    ASSERT_GT(dcg_file_size, 0) << "dcg file size should be greater than 0";
 }
 
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -910,6 +910,20 @@ void TabletUpdatesTest::test_apply(bool enable_persistent_index, bool has_merge_
         ASSERT_EQ(N, read_tablet(_tablet, i));
     }
     test_pk_dump(rowsets.size());
+    // test extra file size;
+    // calc tablet update extra file size
+    ASSERT_TRUE(_tablet->updates()->calc_extra_file_size().ok());
+    // get TabletUpdatesPB
+    TabletUpdatesPB updates_pb;
+    _tablet->updates()->to_updates_pb(&updates_pb);
+// check extra file size exist.
+#if !defined(ADDRESS_SANITIZER)
+    if (enable_persistent_index) {
+        ASSERT_TRUE(updates_pb.extra_file_size().col_size() > 0);
+    } else {
+        ASSERT_TRUE(updates_pb.extra_file_size().col_size() == 0);
+    }
+#endif
 }
 
 TEST_F(TabletUpdatesTest, apply) {

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -911,19 +911,15 @@ void TabletUpdatesTest::test_apply(bool enable_persistent_index, bool has_merge_
     }
     test_pk_dump(rowsets.size());
     // test extra file size;
-    // calc tablet update extra file size
-    ASSERT_TRUE(_tablet->updates()->calc_extra_file_size().ok());
     // get TabletUpdatesPB
     TabletUpdatesPB updates_pb;
     _tablet->updates()->to_updates_pb(&updates_pb);
-// check extra file size exist.
-#if !defined(ADDRESS_SANITIZER)
+    // check extra file size exist.
     if (enable_persistent_index) {
-        ASSERT_TRUE(updates_pb.extra_file_size().col_size() > 0);
+        ASSERT_TRUE(updates_pb.extra_file_size().pindex_size() > 0);
     } else {
-        ASSERT_TRUE(updates_pb.extra_file_size().col_size() == 0);
+        ASSERT_TRUE(updates_pb.extra_file_size().pindex_size() == 0);
     }
-#endif
 }
 
 TEST_F(TabletUpdatesTest, apply) {

--- a/gensrc/proto/olap_common.proto
+++ b/gensrc/proto/olap_common.proto
@@ -61,6 +61,7 @@ message DeltaColumnGroupPB {
     repeated DeltaColumnGroupColumnIdsPB column_ids = 1;
     repeated string column_files = 2;
     repeated bytes encryption_metas = 3;
+    optional int64 file_size = 4;
 }
 
 message DeltaColumnGroupListPB {

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -257,11 +257,17 @@ message TabletMetaLogPB {
     repeated TabletMetaOpPB ops = 1;
 }
 
+message TabletUpdatesExtraFileSize {
+    optional int64 pindex_size = 1; // total file size of persistent index.
+    optional int64 col_size = 2;    // total file size of delta column files.
+}
+
 message TabletUpdatesPB {
     repeated EditVersionMetaPB versions = 1;
     optional EditVersionPB apply_version = 2;
     optional uint32 next_rowset_id = 3;
     optional uint64 next_log_id = 4;
+    optional TabletUpdatesExtraFileSize extra_file_size = 5;
 }
 
 message BinlogConfigPB {


### PR DESCRIPTION
## Why I'm doing:
High disk I/O load can slow down file size fetch operations. With a large number of tablets, this may cause delays in BE status report.

## What I'm doing:
This pull request introduces a new mechanism for accurately tracking and caching the file sizes of persistent index and delta column group files at the tablet level, replacing the previous on-demand directory scanning approach. The changes improve performance and reliability by maintaining up-to-date file size information in memory and updating it during relevant operations. The major updates are grouped below:

**Delta Column Group File Size Tracking:**

* Added a `_file_size` member to the `DeltaColumnGroup` class, updated its initialization, serialization, and deserialization logic to ensure file size is tracked and persisted with each delta column group. (`delta_column_group.h/cpp`) [[1]](diffhunk://#diff-8203a92c4ad505ff024665f02813735ec29a19d1c3498db557e84786f481ca18R119) [[2]](diffhunk://#diff-8203a92c4ad505ff024665f02813735ec29a19d1c3498db557e84786f481ca18L40-R41) [[3]](diffhunk://#diff-8203a92c4ad505ff024665f02813735ec29a19d1c3498db557e84786f481ca18R108-R109) [[4]](diffhunk://#diff-c4a57de893be51e268444bf9855770d8857942f17538eade52475e199ea2d3e3L27-R32) [[5]](diffhunk://#diff-c4a57de893be51e268444bf9855770d8857942f17538eade52475e199ea2d3e3R132) [[6]](diffhunk://#diff-c4a57de893be51e268444bf9855770d8857942f17538eade52475e199ea2d3e3R169) [[7]](diffhunk://#diff-c4a57de893be51e268444bf9855770d8857942f17538eade52475e199ea2d3e3R193) [[8]](diffhunk://#diff-c4a57de893be51e268444bf9855770d8857942f17538eade52475e199ea2d3e3L235-R239) [[9]](diffhunk://#diff-85b0ac4d8f9f775732a5786a0f9b9f84a41955bfe77ce6f23453beeaea299e67R758) [[10]](diffhunk://#diff-85b0ac4d8f9f775732a5786a0f9b9f84a41955bfe77ce6f23453beeaea299e67R818-R827)
* Updated `UpdateManager` to provide a method for retrieving the total delta column group file size for a given tablet from its cache. (`update_manager.cpp`)

**Persistent Index File Size Tracking:**

* Updated `PersistentIndex` and `IOStat` to track and report the total file size of persistent index files, and propagate this information during index commit operations. (`persistent_index.cpp/h`) [[1]](diffhunk://#diff-d3ea825657ade9c2ab9cc49583948c6e7599a94fedfd38a94dfe10e89b5203d5R3709) [[2]](diffhunk://#diff-da797af69ced87554b37fff696a558293c3ecda50ecca66a2c7ff4f6140d2d3eR103-R112)

**TabletUpdates File Size Caching and Reporting:**

* Introduced a cached `ExtraFileSize` struct (with atomic members) in `TabletUpdates` to store persistent index and delta column group file sizes, updating it during commit and version removal operations. (`tablet_updates.h/cpp`) [[1]](diffhunk://#diff-a8fa27b4cd659e8cffbb045edc0acb96165f25aea08b62ab9f5385c13c58956aL76-R77) [[2]](diffhunk://#diff-a8fa27b4cd659e8cffbb045edc0acb96165f25aea08b62ab9f5385c13c58956aR599-R601) [[3]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR280-R283) [[4]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cL415-R419) [[5]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cL480-R475) [[6]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cL1640-R1627) [[7]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR1636) [[8]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cL2510-R2499) [[9]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR2508-R2509) [[10]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR2799-R2803)
* Refactored all methods in `TabletUpdates` that previously called `_get_extra_file_size()` to use the new cache, removing the directory scanning logic for performance and reliability. (`tablet_updates.cpp/h`) [[1]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cL3574-L3605) [[2]](diffhunk://#diff-a8fa27b4cd659e8cffbb045edc0acb96165f25aea08b62ab9f5385c13c58956aL523-L524) [[3]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cL3649-R3613) [[4]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cL4788-R4743)
* Ensured the cached file size values are serialized and deserialized with `TabletUpdatesPB` for persistence across restarts. (`tablet_updates.cpp`)

These changes collectively make file size accounting for storage components more efficient and robust, and ensure that reporting and management operations have quick access to accurate file size data.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
