### PR TITLE
[BugFix] support lazy delta column compact for size tiered compaction in pk table to reduce cost

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2117,6 +2117,9 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo, con
 // So we need `_check_conflict_with_partial_update` to detect this conflict and cancel this compaction.
 Status TabletUpdates::_check_conflict_with_partial_update(CompactionInfo* info) {
     TEST_SYNC_POINT_CALLBACK("TabletUpdates::_check_conflict_with_partial_update", &info->start_version);
+    if (info->is_empty) {
+        return Status::OK();
+    }
     // check if compaction's start version is too old to decide whether conflict happens
     if (info->start_version < _edit_version_infos[0]->version) {
         std::string msg = strings::Substitute(
@@ -2910,6 +2913,7 @@ struct CompactionEntry {
     size_t num_dels = 0;
     size_t bytes = 0;
     size_t num_segments = 0;
+    bool partial_update_by_column = false;
 
     bool operator<(const CompactionEntry& rhs) const { return score_per_row > rhs.score_per_row; }
 };
@@ -3012,6 +3016,7 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
         // delta column back to main segment file too soon, for save compaction IO cost.
         // Separate delta column won't affect query performance.
         if (info->inputs.size() > 1 && has_partial_update_by_column && config::enable_lazy_delta_column_compaction) {
+            info->is_empty = true;
             break;
         }
         info->inputs.push_back(e.rowsetid);
@@ -3080,6 +3085,7 @@ Status TabletUpdates::compaction_for_size_tiered(MemTracker* mem_tracker) {
 
     size_t total_valid_rowsets = 0;
     size_t total_valid_segments = 0;
+    bool has_partial_update_by_column = false;
     // level -1 keep empty rowsets and have no IO overhead, so we can merge them with any level
     std::map<int, vector<CompactionEntry>> candidates_by_level;
     {
@@ -3106,6 +3112,8 @@ Status TabletUpdates::compaction_for_size_tiered(MemTracker* mem_tracker) {
                 e.num_dels = stat.num_dels;
                 e.bytes = stat.byte_size;
                 e.num_segments = stat.num_segments;
+                e.partial_update_by_column = stat.partial_update_by_column;
+                has_partial_update_by_column |= stat.partial_update_by_column;
             }
         }
     }
@@ -3116,7 +3124,22 @@ Status TabletUpdates::compaction_for_size_tiered(MemTracker* mem_tracker) {
     int64_t max_score = 0;
     for (auto& [level, candidates] : candidates_by_level) {
         if (level == -1) {
-            continue;
+            // When we enable lazy delta column compaction, which means that we don't want to merge
+            // delta column back to main segment file too soon, for save compaction IO cost.
+            // Separate delta column won't affect query performance.
+            // check if there is rowset with column update and more than 1, trigger lazy compaction strategy.
+            if (has_partial_update_by_column && candidates.size() > 1 && config::enable_lazy_delta_column_compaction) {
+                for (auto& e : candidates) {
+                    info->inputs.emplace_back(e.rowsetid);
+                }
+                info->is_empty = true;
+                VLOG(1) << "trigger lazy compaction strategy for tablet:" << _tablet.tablet_id()
+                        << " because of column update rowset count:" << candidates.size();
+                // only merge empty rowsets, so no need to consider other level
+                break;
+            } else {
+                continue;
+            }
         }
         int64_t total_segments = 0;
         int64_t del_rows = 0;
@@ -3135,46 +3158,50 @@ Status TabletUpdates::compaction_for_size_tiered(MemTracker* mem_tracker) {
     int64_t total_merged_segments = 0;
     RowsetStats stat;
     std::set<int32_t> compaction_level_candidate;
-    max_score = 0;
-    do {
-        auto iter = candidates_by_level.find(compaction_level);
-        if (iter == candidates_by_level.end()) {
-            break;
-        }
-        for (auto& e : iter->second) {
-            size_t new_rows = stat.num_rows + e.num_rows - e.num_dels;
-            size_t new_bytes = stat.byte_size;
-            if (e.num_rows != 0) {
-                new_bytes += e.bytes * (e.num_rows - e.num_dels) / e.num_rows;
-            }
-            if ((stat.byte_size > 0 && new_bytes > config::update_compaction_result_bytes * 2) ||
-                info->inputs.size() >= config::max_update_compaction_num_singleton_deltas) {
+
+    if (info->inputs.empty()) {
+        // no trigger lazy compaction strategy, try to merge level by level
+        max_score = 0;
+        do {
+            auto iter = candidates_by_level.find(compaction_level);
+            if (iter == candidates_by_level.end()) {
                 break;
             }
-            max_score += e.score_per_row * (e.num_rows - e.num_dels);
-            info->inputs.emplace_back(e.rowsetid);
-            stat.num_rows = new_rows;
-            stat.byte_size = new_bytes;
-            total_rows += e.num_rows;
-            total_bytes += e.bytes;
-            total_merged_segments += e.num_segments;
-        }
-        compaction_level_candidate.insert(compaction_level);
-        compaction_level = _calc_compaction_level(&stat);
-        stat.num_segments = stat.byte_size > 0 ? (stat.byte_size - 1) / config::max_segment_file_size + 1 : 0;
-        _calc_compaction_score(&stat);
-    } while (stat.byte_size <= config::update_compaction_result_bytes * 2 &&
-             info->inputs.size() < config::max_update_compaction_num_singleton_deltas &&
-             compaction_level_candidate.find(compaction_level) == compaction_level_candidate.end() &&
-             candidates_by_level.find(compaction_level) != candidates_by_level.end() && stat.compaction_score > 0);
-
-    if (compaction_level_candidate.find(-1) == compaction_level_candidate.end()) {
-        if (candidates_by_level[-1].size() > 0) {
-            for (auto& e : candidates_by_level[-1]) {
+            for (auto& e : iter->second) {
+                size_t new_rows = stat.num_rows + e.num_rows - e.num_dels;
+                size_t new_bytes = stat.byte_size;
+                if (e.num_rows != 0) {
+                    new_bytes += e.bytes * (e.num_rows - e.num_dels) / e.num_rows;
+                }
+                if ((stat.byte_size > 0 && new_bytes > config::update_compaction_result_bytes * 2) ||
+                    info->inputs.size() >= config::max_update_compaction_num_singleton_deltas) {
+                    break;
+                }
+                max_score += e.score_per_row * (e.num_rows - e.num_dels);
                 info->inputs.emplace_back(e.rowsetid);
+                stat.num_rows = new_rows;
+                stat.byte_size = new_bytes;
+                total_rows += e.num_rows;
+                total_bytes += e.bytes;
                 total_merged_segments += e.num_segments;
             }
-            compaction_level_candidate.insert(-1);
+            compaction_level_candidate.insert(compaction_level);
+            compaction_level = _calc_compaction_level(&stat);
+            stat.num_segments = stat.byte_size > 0 ? (stat.byte_size - 1) / config::max_segment_file_size + 1 : 0;
+            _calc_compaction_score(&stat);
+        } while (stat.byte_size <= config::update_compaction_result_bytes * 2 &&
+                 info->inputs.size() < config::max_update_compaction_num_singleton_deltas &&
+                 compaction_level_candidate.find(compaction_level) == compaction_level_candidate.end() &&
+                 candidates_by_level.find(compaction_level) != candidates_by_level.end() && stat.compaction_score > 0);
+
+        if (compaction_level_candidate.find(-1) == compaction_level_candidate.end()) {
+            if (candidates_by_level[-1].size() > 0) {
+                for (auto& e : candidates_by_level[-1]) {
+                    info->inputs.emplace_back(e.rowsetid);
+                    total_merged_segments += e.num_segments;
+                }
+                compaction_level_candidate.insert(-1);
+            }
         }
     }
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2912,7 +2912,6 @@ struct CompactionEntry {
     size_t num_dels = 0;
     size_t bytes = 0;
     size_t num_segments = 0;
-    bool partial_update_by_column = false;
 
     bool operator<(const CompactionEntry& rhs) const { return score_per_row > rhs.score_per_row; }
 };
@@ -3110,7 +3109,6 @@ Status TabletUpdates::compaction_for_size_tiered(MemTracker* mem_tracker) {
                 e.num_dels = stat.num_dels;
                 e.bytes = stat.byte_size;
                 e.num_segments = stat.num_segments;
-                e.partial_update_by_column = stat.partial_update_by_column;
                 has_partial_update_by_column |= stat.partial_update_by_column;
             }
         }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2117,7 +2117,7 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo, con
 // So we need `_check_conflict_with_partial_update` to detect this conflict and cancel this compaction.
 Status TabletUpdates::_check_conflict_with_partial_update(CompactionInfo* info) {
     TEST_SYNC_POINT_CALLBACK("TabletUpdates::_check_conflict_with_partial_update", &info->start_version);
-    if (info->is_empty) {
+    if (info->is_empty_output) {
         return Status::OK();
     }
     // check if compaction's start version is too old to decide whether conflict happens
@@ -3016,7 +3016,7 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
         // delta column back to main segment file too soon, for save compaction IO cost.
         // Separate delta column won't affect query performance.
         if (info->inputs.size() > 1 && has_partial_update_by_column && config::enable_lazy_delta_column_compaction) {
-            info->is_empty = true;
+            info->is_empty_output = true;
             break;
         }
         info->inputs.push_back(e.rowsetid);
@@ -3132,7 +3132,7 @@ Status TabletUpdates::compaction_for_size_tiered(MemTracker* mem_tracker) {
                 for (auto& e : candidates) {
                     info->inputs.emplace_back(e.rowsetid);
                 }
-                info->is_empty = true;
+                info->is_empty_output = true;
                 VLOG(1) << "trigger lazy compaction strategy for tablet:" << _tablet.tablet_id()
                         << " because of column update rowset count:" << candidates.size();
                 // only merge empty rowsets, so no need to consider other level

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -70,8 +70,6 @@ struct CompactionInfo {
     EditVersion start_version;
     std::vector<uint32_t> inputs;
     uint32_t output = UINT32_MAX;
-    // All rowsets in inputs are empty, and then compaction will generate an empty rowset.
-    bool is_empty_output = false;
 };
 
 struct ExtraFileSize {

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -70,6 +70,8 @@ struct CompactionInfo {
     EditVersion start_version;
     std::vector<uint32_t> inputs;
     uint32_t output = UINT32_MAX;
+    // All rowsets in inputs are empty, and then compaction will generate an empty rowset.
+    bool is_empty_output = false;
 };
 
 struct ExtraFileSize {

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -1444,6 +1444,52 @@ TEST_P(RowsetColumnPartialUpdateTest, test_dcg_file_size) {
     ASSERT_GT(dcg_file_size, 0) << "dcg file size should be greater than 0";
 }
 
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_size_tier_compaction) {
+    const int N = 100;
+    auto tablet = create_tablet(rand(), rand());
+    ASSERT_EQ(1, tablet->updates()->version_history_count());
+
+    // create full rowsets first
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.emplace_back(create_rowset(tablet, keys));
+    int64_t version = 1;
+    commit_rowsets(tablet, rowsets, version);
+    // check data
+    ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2, int32_t v3) {
+        return (int16_t)(k1 % 100 + 1) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
+    }));
+
+    std::vector<int32_t> column_indexes = {0, 1};
+    auto v1_func = [](int64_t k1) { return (int16_t)(k1 % 100 + 3); };
+    auto v2_func = [](int64_t k1) { return (int32_t)(k1 % 1000 + 4); };
+    std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
+    for (int i = 0; i < 10; i++) {
+        // create partial rowset
+        RowsetSharedPtr partial_rowset =
+                create_partial_rowset(tablet, keys, column_indexes, v1_func, v2_func, partial_schema, 1);
+        // commit partial update
+        auto st = tablet->rowset_commit(++version, partial_rowset, 10000);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+    }
+    // check data
+    ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2, int32_t v3) {
+        return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
+    }));
+    // trigger size tiered compaction
+    config::enable_pk_size_tiered_compaction_strategy = true;
+    ASSERT_TRUE(tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
+    // check data
+    ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2, int32_t v3) {
+        return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
+    }));
+    // there will be two rowsets
+    ASSERT_TRUE(tablet->updates()->num_rowsets() == 2);
+}
+
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,
                          ::testing::Values(RowsetColumnPartialUpdateParam{1, false},
                                            RowsetColumnPartialUpdateParam{1024, true},


### PR DESCRIPTION
## Why I'm doing:
When we enable lazy delta column compaction (enable_lazy_delta_column_compaction), which means that we don't want to merge delta column back to main segment file too soon, for save compaction IO cost.

But currently it doesn't support on size tiered compaction, it will lead to two issues:
1. useless cost.
2. Too much conflict between compaction and partial column update.

## What I'm doing:
This pull request enhances the compaction logic for tablets with partial column updates, particularly when using the size-tiered compaction strategy. The main improvements involve introducing a "lazy delta column compaction" strategy to avoid unnecessary IO by not merging delta columns back to the main segment file too soon, and ensuring compaction logic correctly handles cases where only empty rowsets are merged. Additionally, a new unit test is added to verify the behavior. 

**Compaction logic improvements:**

* Added a check in `_check_conflict_with_partial_update` to immediately return OK if the compaction info is empty, preventing unnecessary conflict checks.
* Updated the compaction process to set `is_empty` (or `is_empty_output`) when the lazy delta column compaction strategy is triggered, ensuring that compaction can generate an empty rowset when appropriate. [[1]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR3019) [[2]](diffhunk://#diff-a8fa27b4cd659e8cffbb045edc0acb96165f25aea08b62ab9f5385c13c58956aR73-R74)
* Enhanced the size-tiered compaction logic to detect and handle cases where rowsets with partial column updates should be lazily compacted, and to skip merging non-empty rowsets in these cases. [[1]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR3088) [[2]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR3115-R3116) [[3]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR3127-R3143) [[4]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR3161-R3163) [[5]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR3206)
* Added a new `partial_update_by_column` flag to `CompactionEntry` to track rowsets with partial column updates.

**Testing:**

* Introduced a new unit test (`partial_update_with_size_tier_compaction`) to verify that the size-tiered compaction strategy works correctly with partial column updates and the lazy compaction strategy.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
