### PR TITLE
[BugFix] Fix NullPoinitException when doesn't found column partition statis

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
@@ -67,7 +67,8 @@ public class Deployer {
 
     static {
         int threadPoolSize = Math.max(ThreadPoolManager.cpuCores(), Config.deploy_serialization_thread_pool_size);
-        int threadPoolQueueSize = Math.max(threadPoolSize * 2, Config.deploy_serialization_queue_size);
+        int threadPoolQueueSize = Config.deploy_serialization_queue_size > 0 ? Config.deploy_serialization_queue_size :
+                threadPoolSize * 2;
         EXECUTOR = ThreadPoolManager.newDaemonThreadPool(1, threadPoolSize, 60, TimeUnit.SECONDS,
                 new LinkedBlockingQueue<>(threadPoolQueueSize), new ThreadPoolExecutor.AbortPolicy(),
                 "deployer", true);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -419,12 +419,10 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
 
             if (resultFuture.isDone()) {
                 Map<ColumnStatsCacheKey, Optional<PartitionStats>> result = resultFuture.get();
+
                 Map<String, PartitionStats> columnStatistics = Maps.newHashMap();
-                for (String column : columns) {
-                    Optional<PartitionStats> columnStatistic =
-                            result.getOrDefault(new ColumnStatsCacheKey(table.getId(), column), Optional.empty());
-                    columnStatistics.put(column, columnStatistic.orElse(null));
-                }
+                result.forEach((k, v) ->
+                        v.ifPresent(partitionStats -> columnStatistics.put(k.column, partitionStats)));
                 return columnStatistics;
             }
             return Collections.emptyMap();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -419,13 +419,13 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
 
             if (resultFuture.isDone()) {
                 Map<ColumnStatsCacheKey, Optional<PartitionStats>> result = resultFuture.get();
-                return columns.stream()
-                        .collect(Collectors.toMap(
-                                column -> column,
-                                column -> result.getOrDefault(new ColumnStatsCacheKey(table.getId(), column),
-                                                Optional.empty())
-                                        .orElse(null)
-                        ));
+                Map<String, PartitionStats> columnStatistics = Maps.newHashMap();
+                for (String column : columns) {
+                    Optional<PartitionStats> columnStatistic =
+                            result.getOrDefault(new ColumnStatsCacheKey(table.getId(), column), Optional.empty());
+                    columnStatistics.put(column, columnStatistic.orElse(null));
+                }
+                return columnStatistics;
             }
             return Collections.emptyMap();
         } catch (InterruptedException e) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
@@ -396,7 +396,6 @@ public class CachedStatisticStorageTest {
         partitionStatsMap =
                 cachedStatisticStorage.getColumnNDVForPartitions(table, ImmutableList.of("c1"));
         Assertions.assertEquals(0, partitionStatsMap.size());
-
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
```
{"@timestamp":"2025-08-14 02:52:05.751Z","level":"WARN","thread.name":"starrocks-mysql-nio-pool-12585","thread.id":171969,"line":438,"file":"CachedStatisticStorage.java","method":"getColumnNDVForPartitions","message":"Get partition NDV failed","exception":"java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:222)
	at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:178)
	at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at com.starrocks.sql.optimizer.statistics.CachedStatisticStorage.getColumnNDVForPartitions(CachedStatisticStorage.java:424)
	at com.starrocks.sql.optimizer.statistics.CachedStatisticStorage.getColumnStatisticsOfPartitionLevel(CachedStatisticStorage.java:462)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalcUtils.getPartitionStatistics(StatisticsCalcUtils.java:111)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.adjustPredicateCardinality(StatisticsCalculator.java:404)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.computeOlapScanNode(StatisticsCalculator.java:358)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalOlapScan(StatisticsCalculator.java:300)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalOlapScan(StatisticsCalculator.java:179)
	at com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator.accept(LogicalOlapScanOperator.java:163)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.estimatorStats(StatisticsCalculator.java:202)
	at com.starrocks.sql.optimizer.rule.join.JoinOrder.calculateStatistics(JoinOrder.java:281)
	at com.starrocks.sql.optimizer.rule.join.JoinOrder.init(JoinOrder.java:194)
	at com.starrocks.sql.optimizer.rule.join.JoinOrder.reorder(JoinOrder.java:230)
	at com.starrocks.sql.optimizer.rule.join.ReorderJoinRule.enumerate(ReorderJoinRule.java:96)
	at com.starrocks.sql.optimizer.rule.join.ReorderJoinRule.transform(ReorderJoinRule.java:223)
	at com.starrocks.sql.optimizer.Optimizer.memoOptimize(Optimizer.java:861)
	at com.starrocks.sql.optimizer.Optimizer.optimizeByCost(Optimizer.java:272)
	at com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:196)
	at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:365)
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:141)
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:98)
	at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:580)
	at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:391)
	at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:600)
	at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:938)
	at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
"}
```

The collector implatation:
<img width="1509" height="439" alt="image" src="https://github.com/user-attachments/assets/faf014fb-3b83-4084-8ee3-39fe2c2114c6" />


## What I'm doing:
* Fix the partitions statistic put map
* Fix deploy_pool_queue_size config depend on deploy_pool_size

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
