### PR TITLE
[Enhancement] Optimize update replica lock in tablet report and clone

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -1054,14 +1054,14 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             throw new SchedException(Status.UNRECOVERABLE, "db does not exist");
         }
 
-        OlapTable olapTable = (OlapTable) globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(db, tblId);
-        if (olapTable == null) {
-            throw new SchedException(Status.UNRECOVERABLE, "table does not exist");
-        }
-
         Locker locker = new Locker();
         locker.lockTableWithIntensiveDbLock(dbId, tblId, LockType.WRITE);
         try {
+            OlapTable olapTable = (OlapTable) globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(db, tblId);
+            if (olapTable == null) {
+                throw new SchedException(Status.UNRECOVERABLE, "table does not exist");
+            }
+
             PhysicalPartition partition = globalStateMgr.getLocalMetastore()
                     .getPhysicalPartitionIncludeRecycleBin(olapTable, physicalPartitionId);
             if (partition == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1064,8 +1064,8 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 } finally {
                     locker.unLockTableWithIntensiveDbLock(dbId, tableId, LockType.WRITE);
                 }
-                LOG.info("sync {} update {} in {} tablets in db[{}]. backend[{}]", syncCounter, logSyncCounter,
-                        offset, dbId, backendId);
+                LOG.info("sync {} update {} in {} tablets in db[{}], table[{}]. backend[{}]", syncCounter, logSyncCounter,
+                        offset, dbId, tableId, backendId);
             }
         } // end for dbs
     }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -940,6 +940,12 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 Locker locker = new Locker();
                 locker.lockTableWithIntensiveDbLock(dbId, tableId, LockType.WRITE);
                 try {
+                    // Get the table by tableId again, ensure it still exists under the lock.
+                    olapTable = (OlapTable) globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(db, tableId);
+                    if (olapTable == null) {
+                        break;
+                    }
+
                     List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
                     for (int i = 0; i < tabletMetaList.size(); i++) {
                         offset++;

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -463,8 +463,8 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
         HashMap<Long, TStorageMedium> storageMediumMap =
                 GlobalStateMgr.getCurrentState().getLocalMetastore().getPartitionIdToStorageMediumMap();
 
-        // db id -> tablet id
-        ListMultimap<Long, Long> tabletSyncMap = ArrayListMultimap.create();
+        // (db id, table id) -> tablet id
+        ListMultimap<Pair<Long, Long>, Long> tabletSyncMap = ArrayListMultimap.create();
         // db id -> tablet id
         ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
         // tablet ids which schema hash is valid
@@ -550,7 +550,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
 
     public static void tabletReport(long backendId, Map<Long, TTablet> backendTablets,
                                     final HashMap<Long, TStorageMedium> storageMediumMap,
-                                    ListMultimap<Long, Long> tabletSyncMap,
+                                    ListMultimap<Pair<Long, Long>, Long> tabletSyncMap,
                                     ListMultimap<Long, Long> tabletDeleteFromMeta,
                                     Set<Long> foundTabletsWithValidSchema,
                                     ListMultimap<TStorageMedium, Long> tabletMigrationMap,
@@ -605,7 +605,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                         // 1. (intersection)
                         if (needSync(replica, backendTabletInfo)) {
                             // need sync
-                            tabletSyncMap.put(tabletMeta.getDbId(), tabletId);
+                            tabletSyncMap.put(Pair.create(tabletMeta.getDbId(), tabletMeta.getTableId()), tabletId);
                         }
 
                         // check and set path,
@@ -910,26 +910,35 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 .updateDataCacheMetrics(backendId, DataCacheMetrics.buildFromThrift(metrics));
     }
 
-    private static void sync(Map<Long, TTablet> backendTablets, ListMultimap<Long, Long> tabletSyncMap,
+    private static void sync(Map<Long, TTablet> backendTablets, ListMultimap<Pair<Long, Long>, Long> tabletSyncMap,
                              long backendId, long backendReportVersion) {
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        for (Long dbId : tabletSyncMap.keySet()) {
+        for (Pair<Long, Long> dbTableId : tabletSyncMap.keySet()) {
+            long dbId = dbTableId.first;
+            long tableId = dbTableId.second;
+
             Database db = globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(dbId);
             if (db == null) {
                 continue;
             }
-            List<Long> allTabletIds = tabletSyncMap.get(dbId);
+
+            OlapTable olapTable = (OlapTable) globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(db, tableId);
+            if (olapTable == null) {
+                continue;
+            }
+
+            List<Long> allTabletIds = tabletSyncMap.get(dbTableId);
             int offset = 0;
 
-            LOG.info("before sync tablets in db[{}]. report num: {}. backend[{}]",
-                    dbId, allTabletIds.size(), backendId);
+            LOG.info("before sync tablets in db[{}], table[{}]. report num: {}. backend[{}]",
+                    dbId, tableId, allTabletIds.size(), backendId);
             while (offset < allTabletIds.size()) {
                 int syncCounter = 0;
                 int logSyncCounter = 0;
                 List<Long> tabletIds = allTabletIds.subList(offset, allTabletIds.size());
                 Locker locker = new Locker();
-                locker.lockDatabase(db.getId(), LockType.WRITE);
+                locker.lockTableWithIntensiveDbLock(dbId, tableId, LockType.WRITE);
                 try {
                     List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
                     for (int i = 0; i < tabletMetaList.size(); i++) {
@@ -939,17 +948,10 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                             continue;
                         }
                         long tabletId = tabletIds.get(i);
-                        long tableId = tabletMeta.getTableId();
                         long physicalPartitionId = tabletMeta.getPhysicalPartitionId();
 
                         LOG.debug("sync tablet {} partition {} in db[{}]. backend[{}]",
                                 tabletId, physicalPartitionId, dbId, backendId);
-
-                        OlapTable olapTable =
-                                (OlapTable) globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(db, tableId);
-                        if (olapTable == null) {
-                            continue;
-                        }
 
                         PhysicalPartition partition = globalStateMgr.getLocalMetastore()
                                 .getPhysicalPartitionIncludeRecycleBin(olapTable, physicalPartitionId);
@@ -1048,13 +1050,13 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                                         backendVersion);
                             }
                         }
-                        // update replica operation is heavy, couldn't do much in db write lock
+                        // update replica operation is heavy, couldn't do much in table write lock
                         if (logSyncCounter > 10) {
                             break;
                         }
                     } // end for tabletMetaSyncMap
                 } finally {
-                    locker.unLockDatabase(db.getId(), LockType.WRITE);
+                    locker.unLockTableWithIntensiveDbLock(dbId, tableId, LockType.WRITE);
                 }
                 LOG.info("sync {} update {} in {} tablets in db[{}]. backend[{}]", syncCounter, logSyncCounter,
                         offset, dbId, backendId);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR refactors the tablet report logic to improve locking granularity, shifting from database-level to table-level lock.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches tablet report sync and clone finalize paths from database-level to table-level locking and groups tablet sync by (dbId, tableId).
> 
> - **Locking granularity**:
>   - Replace database write locks with `locker.lockTableWithIntensiveDbLock(..., LockType.WRITE)` in `TabletSchedCtx.finishCloneTask` and `ReportHandler.sync`, with corresponding unlocks.
>   - Adjust comments/logs to reflect table-level locks.
> - **Tablet report sync refactor**:
>   - Change `tabletSyncMap` key from `dbId` to `Pair<dbId, tableId>`; update method signatures/usages (`tabletReport`, `sync`).
>   - Pre-validate and re-fetch `OlapTable` under lock; update sync loop to operate per-table and improve logging context.
> - **Minor**:
>   - Error text tweak: "tbl does not exist" -> "table does not exist".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 276a4adb7311067fdf96c400e02979a6492072e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->