### PR TITLE
[Enhancement] Improve error logs for loading and replication

### DIFF
--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -294,6 +294,7 @@ void LoadChannelMgr::get_load_replica_status(brpc::Controller* cntl, const PLoad
                                              PLoadReplicaStatusResult* response, google::protobuf::Closure* done) {
     ClosureGuard done_guard(done);
     UniqueId load_id(request->load_id());
+    auto start_time = MonotonicMillis();
     auto channel = _find_load_channel(load_id);
     if (channel == nullptr) {
         for (int64_t tablet_id : request->tablet_ids()) {
@@ -306,6 +307,9 @@ void LoadChannelMgr::get_load_replica_status(brpc::Controller* cntl, const PLoad
         std::string remote_ip = butil::ip2str(cntl->remote_side().ip).c_str();
         channel->get_load_replica_status(remote_ip, request, response);
     }
+    std::string remote_ip = butil::ip2str(cntl->remote_side().ip).c_str();
+    LOG(INFO) << "receive get_load_replica_status, load_id: " << load_id << ", txn_id: " << request->txn_id()
+              << ", remote: " << remote_ip << ", cost: " << (MonotonicMillis() - start_time) << "ms";
 }
 
 void LoadChannelMgr::load_diagnose(brpc::Controller* cntl, const PLoadDiagnoseRequest* request,

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -46,6 +46,7 @@
 #include "runtime/load_channel.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/tablets_channel.h"
+#include "service/backend_options.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/utils.h"
 #include "util/starrocks_metrics.h"
@@ -225,7 +226,9 @@ void LoadChannelMgr::add_chunk(const PTabletWriterAddChunkRequest& request, PTab
         channel->add_chunk(request, response);
     } else {
         response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
-        response->mutable_status()->add_error_msgs("no associated load channel " + print_id(request.id()));
+        response->mutable_status()->add_error_msgs(fmt::format("no associated load channel on host {}, load_id: {}",
+                                                               BackendOptions::get_localhost(),
+                                                               print_id(request.id())));
     }
 }
 
@@ -237,7 +240,9 @@ void LoadChannelMgr::add_chunks(const PTabletWriterAddChunksRequest& request, PT
         channel->add_chunks(request, response);
     } else {
         response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
-        response->mutable_status()->add_error_msgs("no associated load channel " + print_id(request.id()));
+        response->mutable_status()->add_error_msgs(fmt::format("no associated load channel on host {}, load_id: {}",
+                                                               BackendOptions::get_localhost(),
+                                                               print_id(request.id())));
     }
 }
 
@@ -251,7 +256,9 @@ void LoadChannelMgr::add_segment(brpc::Controller* cntl, const PTabletWriterAddS
         closure_guard.release();
     } else {
         response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
-        response->mutable_status()->add_error_msgs("no associated load channel " + print_id(request->id()));
+        response->mutable_status()->add_error_msgs(fmt::format("no associated load channel on host {}, load_id: {}",
+                                                               BackendOptions::get_localhost(),
+                                                               print_id(request->id())));
     }
 }
 

--- a/be/src/storage/segment_flush_executor.cpp
+++ b/be/src/storage/segment_flush_executor.cpp
@@ -25,6 +25,7 @@
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/internal_service.pb.h"
 #include "runtime/current_thread.h"
+#include "service/backend_options.h"
 #include "service/brpc.h"
 #include "storage/delta_writer.h"
 
@@ -178,7 +179,9 @@ Status SegmentFlushToken::submit(DeltaWriter* writer, brpc::Controller* cntl,
     ClosureGuard closure_guard(done);
     Status token_st = status();
     if (!token_st.ok()) {
-        Status st = Status::InternalError("Segment flush token is not ok. The status: " + token_st.to_string());
+        Status st = Status::InternalError(
+                fmt::format("Secondary replica on host {} failed to flush segment, tablet_id: {}. Reason: {}",
+                            BackendOptions::get_localhost(), writer->tablet()->tablet_id(), token_st.to_string()));
         st.to_protobuf(response->mutable_status());
         return st;
     }

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -21,10 +21,12 @@
 
 #include "fs/fs_posix.h"
 #include "gen_cpp/data.pb.h"
+#include "gutil/strings/join.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "runtime/load_fail_point.h"
 #include "runtime/mem_tracker.h"
+#include "service/backend_options.h"
 #include "storage/delta_writer.h"
 #include "util/brpc_stub_cache.h"
 #include "util/raw_container.h"
@@ -383,14 +385,26 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
         }
 
         if (_failed_node_id.size() > _max_fail_replica_num) {
-            LOG(WARNING) << "Failed to sync segment err " << st << " by " << debug_string() << " fail_num "
-                         << _failed_node_id.size() << " max_fail_num " << _max_fail_replica_num;
+            std::vector<const ReplicateChannel*> failed_channels;
             for (const auto& [_, channel] : _replicate_channels) {
                 if (_failed_node_id.count(channel->node_id()) == 0) {
                     channel->cancel(Status::InternalError("failed replica num exceed max fail num"));
+                } else {
+                    failed_channels.push_back(channel.get());
                 }
             }
-            return set_status(st);
+            std::string failed_replica_hosts = JoinMapped(
+                    failed_channels, [](const ReplicateChannel* ch) { return ch->host(); }, ",");
+
+            auto err_msg = fmt::format(
+                    "failed to sync segment to enough replicas. tablet_id={}, "
+                    "num_failed_replicas={}, max_allowed_failed_replicas={}, primary_replica={}, failed_replicas=[{}], "
+                    "last_error='{}'",
+                    _opt->tablet_id, _failed_node_id.size(), _max_fail_replica_num, BackendOptions::get_localhost(),
+                    failed_replica_hosts, st.to_string());
+
+            LOG(WARNING) << err_msg;
+            return set_status(Status::InternalError(err_msg));
         }
     }
 }

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -49,6 +49,8 @@ public:
 
     int64_t node_id() { return _node_id; }
 
+    const std::string& host() const { return _host; }
+
     std::string debug_string();
 
     Status get_status() {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
* Improve some error messages during the data loading and replication process for better diagnose
* Increase the default value of `load_diagnose_send_rpc_timeout_ms` to provide more tolerance

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [X] 4.0
  - [X] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improve error/status messages and diagnostics across load and replication paths with host/load_id context, timing logs, and detailed replica-failure reporting; add `ReplicateChannel::host()` accessor.
> 
> - **Runtime / Load**:
>   - Update error messages in `LoadChannelMgr::{add_chunk,add_chunks,add_segment}` to include `host` and `load_id` via `BackendOptions::get_localhost()`.
>   - Add timing/info log for `get_load_replica_status` requests.
> - **Tablets Channel**:
>   - Enhance RPC failure handling messages in `LocalTabletsChannel` secondary-replica wait path to include local host, primary host, `tablet_id`, retry count, and RPC error.
>   - Minor log text tweak: `fail num` -> `num retries`.
> - **Storage / Flush**:
>   - Improve `SegmentFlushToken::submit` failure message with local host and `tablet_id`.
> - **Storage / Replication**:
>   - When exceeding allowed failed replicas, log and return detailed error including `tablet_id`, counts, primary host, and failed replica hosts; cancel remaining channels accordingly.
>   - Add `ReplicateChannel::host()` accessor (exposed in header).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fb8dc52a6c2703cd0826c2407bb66eb03ebd81b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->