### PR TITLE
[Enhancement] revise cache mem size limit for iceberg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2497,10 +2497,10 @@ public class Config extends ConfigBase {
     public static String iceberg_metadata_cache_disk_path = StarRocksFE.STARROCKS_HOME_DIR + "/caches/iceberg";
 
     /**
-     * iceberg metadata memory cache total size, default 512MB
+     * iceberg metadata memory cache total size, default 0MB (turn off)
      */
     @ConfField(mutable = true)
-    public static long iceberg_metadata_memory_cache_capacity = 536870912L;
+    public static long iceberg_metadata_memory_cache_capacity = 0L;
 
     /**
      * iceberg metadata memory cache expiration time, default 86500s
@@ -2527,10 +2527,10 @@ public class Config extends ConfigBase {
     public static long iceberg_metadata_disk_cache_expiration_seconds = 7L * 24L * 60L * 60L;
 
     /**
-     * iceberg metadata cache max entry size, default 8MB
+     * iceberg metadata cache max entry size, default 0L (turn off)
      */
     @ConfField(mutable = true)
-    public static long iceberg_metadata_cache_max_entry_size = 8388608L;
+    public static long iceberg_metadata_cache_max_entry_size = 0L;
 
     /**
      * paimon metadata cache preheat, default false

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -14,6 +14,9 @@
 
 package com.starrocks.connector.iceberg;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.Weigher;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -47,6 +50,7 @@ import org.apache.iceberg.view.View;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.parquet.Strings;
+import org.apache.spark.util.SizeEstimator;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -74,8 +78,8 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     private final ExecutorService backgroundExecutor;
 
     private final IcebergCatalogProperties icebergProperties;
-    private final Cache<String, Set<DataFile>> dataFileCache;
-    private final Cache<String, Set<DeleteFile>> deleteFileCache;
+    private final com.github.benmanes.caffeine.cache.Cache<String, Set<DataFile>> dataFileCache;
+    private final com.github.benmanes.caffeine.cache.Cache<String, Set<DeleteFile>> deleteFileCache;
     private final Map<IcebergTableName, Long> tableLatestAccessTime = new ConcurrentHashMap<>();
     private final Map<IcebergTableName, Long> tableLatestRefreshTime = new ConcurrentHashMap<>();
 
@@ -100,14 +104,49 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                                     .setNativeTable(nativeTable).build();
                     return delegate.getPartitions(icebergTable, key.snapshotId, null);
                 }));
-        this.dataFileCache = enableCache ?
-                newCacheBuilder(
-                        icebergProperties.getIcebergMetaCacheTtlSec(), icebergProperties.getIcebergManifestCacheMaxNum()).build()
-                : null;
-        this.deleteFileCache = enableCache ?
-                newCacheBuilder(
-                        icebergProperties.getIcebergMetaCacheTtlSec(), icebergProperties.getIcebergManifestCacheMaxNum()).build()
-                : null;
+
+        long dataFileCacheSize = Math.round(Runtime.getRuntime().maxMemory() *
+                icebergProperties.getIcebergDataFileCacheMemoryUsageRatio());
+        long deleteFileCacheSize = Math.round(Runtime.getRuntime().maxMemory() *
+                icebergProperties.getIcebergDeleteFileCacheMemoryUsageRatio());
+
+        this.dataFileCache = enableCache ? Caffeine.newBuilder()
+                .executor(executorService)
+                .expireAfterWrite(icebergProperties.getIcebergMetaCacheTtlSec(), SECONDS)
+                .weigher((Weigher<String, Set<DataFile>>) (String key, Set<DataFile> files) -> {
+                    long size = SizeEstimator.estimate(key);
+                    if (!files.isEmpty()) {
+                        size += 1L * SizeEstimator.estimate(files.iterator().next()) * files.size();
+                    }
+                    return (size > Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int) size;
+                })
+                .maximumWeight(dataFileCacheSize)
+                .removalListener((String key, Set<DataFile> value, RemovalCause cause) -> {
+                    LOG.debug(String.format("Key=%s, Value.size=%d, Cause=%s",
+                            key,
+                            value != null ? value.size() : 0,
+                            cause));
+                })
+                .build() : null;
+        this.deleteFileCache = enableCache ? Caffeine.newBuilder()
+                .executor(executorService)
+                .expireAfterWrite(icebergProperties.getIcebergMetaCacheTtlSec(), SECONDS)
+                .weigher((Weigher<String, Set<DeleteFile>>) (String key, Set<DeleteFile> files) -> {
+                    long size = SizeEstimator.estimate(key);
+                    if (!files.isEmpty()) {
+                        size += 1L * SizeEstimator.estimate(files.iterator().next()) * files.size();
+                    }
+                    return (size > Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int) size;
+                })
+                .maximumWeight(deleteFileCacheSize)
+                .removalListener((String key, Set<DeleteFile> value, RemovalCause cause) -> {
+                    LOG.debug(String.format("Key=%s, Value.size=%d, Cause=%s",
+                            key,
+                            value != null ? value.size() : 0,
+                            cause));
+                })
+                .build() : null;
+
         this.backgroundExecutor = executorService;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
@@ -39,6 +39,8 @@ public class IcebergCatalogProperties {
     public static final String BACKGROUND_ICEBERG_JOB_PLANNING_THREAD_NUM = "background_iceberg_job_planning_thread_num";
     public static final String ICEBERG_MANIFEST_CACHE_WITH_COLUMN_STATISTICS = "iceberg_manifest_cache_with_column_statistics";
     public static final String ICEBERG_MANIFEST_CACHE_MAX_NUM = "iceberg_manifest_cache_max_num";
+    public static final String ICEBERG_DATA_FILE_CACHE_MEMORY_SIZE_RATIO = "iceberg_data_file_cache_memory_usage_ratio";
+    public static final String ICEBERG_DELETE_FILE_CACHE_MEMORY_SIZE_RATIO = "iceberg_delete_file_cache_memory_usage_ratio";
 
     // internal config
     public static final String ICEBERG_TABLE_CACHE_TTL = "iceberg_table_cache_ttl_sec";
@@ -58,11 +60,13 @@ public class IcebergCatalogProperties {
     private int refreshOtherFeIcebergCacheThreadNum;
     private boolean icebergManifestCacheWithColumnStatistics;
     private long icebergTableCacheTtlSec;
-    private long icebergManifestCacheMaxNum;
+    private long icebergManifestCacheMaxNum; // Deprecated
     private long refreshIcebergManifestMinLength;
     private long localPlanningMaxSlotBytes;
     private boolean enableDistributedPlanLoadColumnStatsWithEqDelete;
     private boolean enableCacheDataFileIdentifierColumnStatistics;
+    private double icebergDataFileCacheMemoryUsageRatio;
+    private double icebergDeleteFileCacheMemoryUsageRatio;
 
     public IcebergCatalogProperties(Map<String, String> catalogProperties) {
         this.properties = catalogProperties;
@@ -91,9 +95,13 @@ public class IcebergCatalogProperties {
     private void initIcebergMetadataCache() {
         this.enableIcebergMetadataCache = PropertyUtil.propertyAsBoolean(properties, ENABLE_ICEBERG_METADATA_CACHE, true);
 
-        this.icebergMetaCacheTtlSec = PropertyUtil.propertyAsLong(properties, ICEBERG_META_CACHE_TTL, 48 * 60 * 60);
-        this.icebergTableCacheTtlSec = PropertyUtil.propertyAsLong(properties, ICEBERG_TABLE_CACHE_TTL, 1800L);
-        this.icebergManifestCacheMaxNum = PropertyUtil.propertyAsLong(properties, ICEBERG_MANIFEST_CACHE_MAX_NUM, 100000);
+        this.icebergMetaCacheTtlSec = PropertyUtil.propertyAsLong(properties, ICEBERG_META_CACHE_TTL, 2L * 60 * 60); // 2 hours
+        this.icebergTableCacheTtlSec = PropertyUtil.propertyAsLong(properties, ICEBERG_TABLE_CACHE_TTL, 1800L); // 30 min
+        this.icebergManifestCacheMaxNum = PropertyUtil.propertyAsLong(properties, ICEBERG_MANIFEST_CACHE_MAX_NUM, 100000); //deprcated, use memory ratio instead
+        this.icebergDataFileCacheMemoryUsageRatio = PropertyUtil.propertyAsDouble(
+                    properties, ICEBERG_DATA_FILE_CACHE_MEMORY_SIZE_RATIO, 0.1);
+        this.icebergDeleteFileCacheMemoryUsageRatio = PropertyUtil.propertyAsDouble(
+                    properties, ICEBERG_DELETE_FILE_CACHE_MEMORY_SIZE_RATIO, 0.1);
         this.icebergManifestCacheWithColumnStatistics = PropertyUtil.propertyAsBoolean(
                 properties, ICEBERG_MANIFEST_CACHE_WITH_COLUMN_STATISTICS, false);
         this.refreshIcebergManifestMinLength = PropertyUtil.propertyAsLong(properties, REFRESH_ICEBERG_MANIFEST_MIN_LENGTH,
@@ -158,6 +166,14 @@ public class IcebergCatalogProperties {
 
     public long getIcebergManifestCacheMaxNum() {
         return icebergManifestCacheMaxNum;
+    }
+
+    public double getIcebergDataFileCacheMemoryUsageRatio() {
+        return icebergDataFileCacheMemoryUsageRatio;
+    }
+
+    public double getIcebergDeleteFileCacheMemoryUsageRatio() {
+        return icebergDeleteFileCacheMemoryUsageRatio;
     }
 
     public long getRefreshIcebergManifestMinLength() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.connector.iceberg;
 
-import com.google.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import com.starrocks.connector.PlanMode;
 import com.starrocks.qe.ConnectContext;
 import org.apache.iceberg.DataFile;

--- a/fe/fe-core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -18,9 +18,9 @@
  */
 package org.apache.iceberg;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.google.common.cache.Cache;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;

--- a/fe/fe-core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -18,9 +18,9 @@
  */
 package org.apache.iceberg;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.google.common.cache.Cache;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -327,7 +327,6 @@ class ManifestGroup {
 
         matchingManifests =
                 CloseableIterable.count(scanMetrics.scannedDataManifests(), matchingManifests);
-
         return Iterables.transform(
                 matchingManifests,
                 manifest ->

--- a/fe/fe-core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -19,7 +19,8 @@
 
 package org.apache.iceberg;
 
-import com.google.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.starrocks.connector.iceberg.DataFileWrapper;
 import com.starrocks.connector.iceberg.DeleteFileWrapper;
 import org.apache.iceberg.avro.AvroIterable;
@@ -281,11 +282,15 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
 
     // when the identifier field ids is null, it will copy all metrics.
     private CloseableIterable<ManifestEntry<F>> fillCacheIfNeeded(CloseableIterable<ManifestEntry<F>> entries) {
+        Set<DataFile> tmpDataFiles = Sets.newHashSet();
+        Set<DeleteFile> tmpDeleteFiles = Sets.newHashSet();
         if (dataFileCache != null && content == FileType.DATA_FILES) {
             entries = CloseableIterable.transform(entries,
                     entry -> {
-                        Set<DataFile> dataFiles = dataFileCache.getIfPresent(file.location());
-                        if (dataFiles != null && entry.isLive()) {
+                        // Could not use the getIfpresent result Set to add items, because here is thread-unsafe.
+                        // Be careful to not corrupt the cache.
+                        Set<DataFile> keyExisted = dataFileCache.getIfPresent(file.location());
+                        if (keyExisted != null && entry.isLive()) {
                             Set<Integer> requestedColumnIds = null;
                             if (identifierFieldIds != null && !identifierFieldIds.isEmpty()) {
                                 requestedColumnIds = identifierFieldIds;
@@ -295,24 +300,41 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
                             DataFile copiedDataFile = dataFileCacheWithMetrics ?
                                     dataFile.copyWithStats(requestedColumnIds) :
                                     dataFile.copyWithoutStats();
-                            dataFiles.add(DataFileWrapper.wrap(copiedDataFile));
+                            tmpDataFiles.add(DataFileWrapper.wrap(copiedDataFile));
                         }
                         return entry;
                     });
-        }
-
+                }
+                
         if (content == FileType.DELETE_FILES && deleteFileCache != null) {
             entries = CloseableIterable.transform(entries,
                     entry -> {
-                        Set<DeleteFile> deleteFiles = deleteFileCache.getIfPresent(file.location());
-                        if (deleteFiles != null && entry.isLive()) {
-                            deleteFiles.add(DeleteFileWrapper.wrap((DeleteFile) entry.file().copy()));
+                        Set<DeleteFile> keyExisted = deleteFileCache.getIfPresent(file.location());
+                        if (keyExisted != null && entry.isLive()) {
+                            tmpDeleteFiles.add(DeleteFileWrapper.wrap((DeleteFile) entry.file().copy()));
                         }
                         return entry;
                     });
         }
 
-        return entries;
+        final CloseableIterable<ManifestEntry<F>> transformedEntries = entries;
+        return new CloseableIterable<ManifestEntry<F>>() {
+            @Override
+            public CloseableIterator<ManifestEntry<F>> iterator() {
+                return transformedEntries.iterator();
+            }
+        
+            @Override
+            public void close() throws IOException {
+                if (!tmpDataFiles.isEmpty()) {
+                    dataFileCache.put(file.location(), tmpDataFiles); // to recalculate the weight
+                }
+                if (!tmpDeleteFiles.isEmpty()) {
+                    deleteFileCache.put(file.location(), tmpDeleteFiles); // to recalculate the weight
+                }
+                transformedEntries.close();
+            }
+        };
     }
 
     private boolean hasRowFilter() {

--- a/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
@@ -14,7 +14,7 @@
 
 package org.apache.iceberg;
 
-import com.google.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.common.profile.Tracers;


### PR DESCRIPTION
## Why I'm doing:

Cache num can not limit the mem size well. Instead, add the cache size limit for iceberg manifest cache. 

## What I'm doing:

Add two iceberg catalog properties:
iceberg_data_file_cache_memory_usage_ratio
iceberg_delete_file_cache_memory_usage_ratio

and deprecate the iceberg_manifest_cache_max_num.

This pull request introduces significant improvements to the Iceberg metadata caching mechanism, focusing on memory management and cache safety. The main changes include switching cache limits from fixed sizes to memory usage ratios, updating configuration defaults to disable old cache mechanisms, and refactoring cache usage for thread safety and accurate weight calculation.

**Iceberg metadata cache configuration changes:**

* The default memory cache capacity (`iceberg_metadata_memory_cache_capacity`) and max entry size (`iceberg_metadata_cache_max_entry_size`) are now set to zero, effectively disabling the old memory cache by default. [[1]](diffhunk://#diff-c4dd949472990c944bb229f17a8fda3b329551819852735b5a7d7ae75aab1e18L2500-R2503) [[2]](diffhunk://#diff-c4dd949472990c944bb229f17a8fda3b329551819852735b5a7d7ae75aab1e18L2530-R2533)
* New configuration properties were added to control the cache size by specifying memory usage ratios: `iceberg_data_file_cache_memory_usage_ratio` and `iceberg_delete_file_cache_memory_usage_ratio`. [[1]](diffhunk://#diff-416084b70c43dd1a84ecc1319f66fe12dd9cc00d5e5317e9511cfc82f3480ce7R42-R43) [[2]](diffhunk://#diff-416084b70c43dd1a84ecc1319f66fe12dd9cc00d5e5317e9511cfc82f3480ce7L61-R69) [[3]](diffhunk://#diff-416084b70c43dd1a84ecc1319f66fe12dd9cc00d5e5317e9511cfc82f3480ce7L94-R104) [[4]](diffhunk://#diff-416084b70c43dd1a84ecc1319f66fe12dd9cc00d5e5317e9511cfc82f3480ce7R171-R178)

**Caching logic and implementation updates:**

* The cache builders for data and delete files now use memory usage ratios to set their maximum weights, leveraging `SizeEstimator` for accurate cache sizing. This replaces the previous fixed entry count limit. [[1]](diffhunk://#diff-6ddd453bb810191565c31c5966e5473a9ea0673e9a487d1ed5577a34f109ce90R50) [[2]](diffhunk://#diff-6ddd453bb810191565c31c5966e5473a9ea0673e9a487d1ed5577a34f109ce90L103-R120)
* The cache fill logic in `ManifestReader` was refactored to avoid thread-unsafe operations and ensure cache weights are recalculated correctly when updating entries. Temporary sets are used to collect new cache entries before updating the cache. [[1]](diffhunk://#diff-2b5b0eb57905982906814766957f9ccf106e057f7dd2bd9b9586306dd870d026R285-R291) [[2]](diffhunk://#diff-2b5b0eb57905982906814766957f9ccf106e057f7dd2bd9b9586306dd870d026L298-R322)


# Test Report

## Environment
Test results on local cluster:
- 1 FE, 4 BE (each 8G memory)

---

## Experiments

### 1. Continuous Insert and Query with Cache

The catalog is created by SQL:
```sql
CREATE EXTERNAL CATALOG 'iceberg'  
COMMENT "External catalog to Apache Iceberg on MinIO"  
PROPERTIES (  
  "type" = "iceberg",  
  ...  
  "iceberg_data_file_cache_memory_usage_ratio" = "0.02"  
);
```
The debug level log:
```
2025-08-25 13:19:18.031+08:00 DEBUG (iceberg-background-iceberg-worker-pool-3|179) [CachingIcebergCatalog.lambda$new$2():124] Key=s3://warehouse/test/test_manifest_cache/metadata/dec99555-2602-4ca3-9df2-d75ffb97df1f-m1.avro, Value.size=325030, Cause=SIZE
2025-08-25 13:19:18.382+08:00 DEBUG (iceberg-background-iceberg-worker-pool-1|173) [CachingIcebergCatalog.lambda$new$2():124] Key=s3://warehouse/test/test_manifest_cache/metadata/c780103f-8120-47aa-9922-cad975a23ae8-m1.avro, Value.size=394854, Cause=SIZE
2025-08-25 13:19:37.101+08:00 DEBUG (iceberg-background-iceberg-worker-pool-3|179) [CachingIcebergCatalog.lambda$new$2():124] Key=s3://warehouse/test/test_manifest_cache/metadata/dec99555-2602-4ca3-9df2-d75ffb97df1f-m1.avro, Value.size=325030, Cause=SIZE
2025-08-25 13:19:38.330+08:00 DEBUG (iceberg-background-iceberg-worker-pool-1|173) [CachingIcebergCatalog.lambda$new$2():124] Key=s3://warehouse/test/test_manifest_cache/metadata/c780103f-8120-47aa-9922-cad975a23ae8-m1.avro, Value.size=394854, Cause=SIZE
2025-08-25 13:19:57.699+08:00 DEBUG (iceberg-background-iceberg-worker-pool-3|179) [CachingIcebergCatalog.lambda$new$2():124] Key=s3://warehouse/test/test_manifest_cache/metadata/dec99555-2602-4ca3-9df2-d75ffb97df1f-m1.avro, Value.size=325030, Cause=SIZE
2025-08-25 13:19:58.271+08:00 DEBUG (iceberg-background-iceberg-worker-pool-3|179) [CachingIcebergCatalog.lambda$new$2():124] Key=s3://warehouse/test/test_manifest_cache/metadata/c780103f-8120-47aa-9922-cad975a23ae8-m1.avro, Value.size=394854, Cause=SIZE
2025-08-25 13:20:19.865+08:00 DEBUG (iceberg-background-iceberg-worker-pool-3|179) [CachingIcebergCatalog.lambda$new$2():124] Key=s3://warehouse/test/test_manifest_cache/metadata/dec99555-2602-4ca3-9df2-d75ffb97df1f-m1.avro, Value.size=325030, Cause=SIZE
2025-08-25 13:20:19.966+08:00 DEBUG (iceberg-background-iceberg-worker-pool-2|174) [CachingIcebergCatalog.lambda$new$2():124] Key=s3://warehouse/test/test_manifest_cache/metadata/c780103f-8120-47aa-9922-cad975a23ae8-m1.avro, Value.size=394854, Cause=SIZE
2025-08-25 13:20:41.827+08:00 DEBUG (iceberg-background-iceberg-worker-pool-3|179) [CachingIcebergCatalog.lambda$new$2():124] Key=s3://warehouse/test/test_manifest_cache/metadata/dec99555-2602-4ca3-9df2-d75ffb97df1f-m1.avro, Value.size=325030, Cause=SIZE
2025-08-25 13:20:42.707+08:00 DEBUG (iceberg-background-iceberg-worker-pool-3|179) [CachingIcebergCatalog.lambda$new$2():124] Key=s3://warehouse/test/test_manifest_cache/metadata/c780103f-8120-47aa-9922-cad975a23ae8-m1.avro, Value.size=394854, Cause=SIZE
2025-08-25 13:21:05.336+08:00 DEBUG (iceberg-background-iceberg-worker-pool-3|179) [CachingIcebergCatalog.lambda$new$2():124] Key=s3://warehouse/test/test_manifest_cache/metadata/dec99555-2602-4ca3-9df2-d75ffb97df1f-m1.avro, Value.size=325030, Cause=SIZE
2025-08-25 13:21:05.964+08:00 DEBUG (iceberg-background-iceberg-worker-pool-3|179) [CachingIcebergCatalog.lambda$new$2():124] Key=s3://warehouse/test/test_manifest_cache/metadata/c780103f-8120-47aa-9922-cad975a23ae8-m1.avro, Value.size=394854, Cause=SIZE
```
jmap result:
```
sr@iZ8vbeqpp8b4q6q4i1shflZ:~$ jmap -histo:live 58832 | head -n 50
 num     #instances         #bytes  class name (module)
-------------------------------------------------------
   1:        377711      130245760  [B (java.base@17.0.13)
   2:        118381       15152768  org.apache.iceberg.GenericDataFile
   3:         14902       13451672  [I (java.base@17.0.13)
   4:        366990        8807760  java.lang.String (java.base@17.0.13)
   5:        157573        5964992  [Ljava.lang.Object; (java.base@17.0.13)
   6:        160376        5132032  java.util.HashMap$Node (java.base@17.0.13)
   7:        118381        3788192  org.apache.iceberg.PartitionData
   8:        118879        3084040  [J (java.base@17.0.13)
   9:         22052        2660248  java.lang.Class (java.base@17.0.13)
  10:         77877        2492064  java.util.concurrent.ConcurrentHashMap$Node (java.base@17.0.13)
  11:         19143        2437344  [Ljava.util.HashMap$Node; (java.base@17.0.13)
  12:        119428        1910848  java.lang.Integer (java.base@17.0.13)
  13:        118381        1894096  com.starrocks.connector.iceberg.DataFileWrapper
...

sr@iZ8vbeqpp8b4q6q4i1shflZ:~$ jcmd 58832 GC.heap_info
58832:
 garbage-first heap   total 835584K, used 345679K [0x0000000666400000, 0x0000000800000000)
  region size 4096K, 26 young (106496K), 0 survivors (0K)
 Metaspace       used 133895K, committed 134848K, reserved 1179648K
  class space    used 14311K, committed 14784K, reserved 1048576K

```
Memory watcher:
The two horizontal lines before and after indicate the start and end of the test.
<img width="706" height="297" alt="image" src="https://github.com/user-attachments/assets/7aea5edf-c365-4784-af89-0bee01e1f579" />


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
