### PR TITLE
[Refactor] Add new AST User to replace UserIdentity in parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
@@ -48,6 +48,7 @@ import com.starrocks.sql.ast.GrantPrivilegeStmt;
 import com.starrocks.sql.ast.GrantRoleStmt;
 import com.starrocks.sql.ast.RevokePrivilegeStmt;
 import com.starrocks.sql.ast.RevokeRoleStmt;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.parser.NodePosition;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -403,12 +404,14 @@ public class AuthorizationMgr {
                         stmt.isWithGrantOption(),
                         stmt.getRole());
             } else {
+                UserRef user = stmt.getUser();
+                UserIdentity userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
                 grantToUser(
                         stmt.getObjectType(),
                         stmt.getPrivilegeTypes(),
                         stmt.getObjectList(),
                         stmt.isWithGrantOption(),
-                        stmt.getUserIdentity());
+                        userIdentity);
             }
         } catch (PrivilegeException e) {
             throw new DdlException("failed to grant: " + e.getMessage(), e);
@@ -423,6 +426,7 @@ public class AuthorizationMgr {
             UserIdentity userIdentity) throws PrivilegeException {
         userWriteLock();
         try {
+
             UserPrivilegeCollectionV2 collection = getUserPrivilegeCollectionUnlocked(userIdentity);
             collection.grant(type, privilegeTypes, objects, isGrant);
             GlobalStateMgr.getCurrentState().getEditLog().logUpdateUserPrivilege(
@@ -469,7 +473,7 @@ public class AuthorizationMgr {
                         stmt.getObjectType(),
                         stmt.getPrivilegeTypes(),
                         stmt.getObjectList(),
-                        stmt.getUserIdentity());
+                        stmt.getUser());
             }
         } catch (PrivilegeException e) {
             throw new DdlException(e.getMessage());
@@ -480,9 +484,10 @@ public class AuthorizationMgr {
             ObjectType objectType,
             List<PrivilegeType> privilegeTypes,
             List<PEntryObject> objects,
-            UserIdentity userIdentity) throws PrivilegeException {
+            UserRef user) throws PrivilegeException {
         userWriteLock();
         try {
+            UserIdentity userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
             UserPrivilegeCollectionV2 collection = getUserPrivilegeCollectionUnlocked(userIdentity);
             collection.revoke(objectType, privilegeTypes, objects);
             GlobalStateMgr.getCurrentState().getEditLog().logUpdateUserPrivilege(
@@ -518,7 +523,7 @@ public class AuthorizationMgr {
     public void grantRole(GrantRoleStmt stmt) throws DdlException {
         try {
             switch (stmt.getGrantType()) {
-                case USER -> grantRoleToUser(stmt.getGranteeRole(), stmt.getUserIdentity());
+                case USER -> grantRoleToUser(stmt.getGranteeRole(), stmt.getUser());
                 case ROLE -> grantRoleToRole(stmt.getGranteeRole(), stmt.getRoleOrGroup());
             }
         } catch (PrivilegeException e) {
@@ -526,10 +531,12 @@ public class AuthorizationMgr {
         }
     }
 
-    protected void grantRoleToUser(List<String> parentRoleName, UserIdentity user) throws PrivilegeException {
+    protected void grantRoleToUser(List<String> parentRoleName, UserRef user) throws PrivilegeException {
         userWriteLock();
         try {
-            UserPrivilegeCollectionV2 userPrivilegeCollection = getUserPrivilegeCollectionUnlocked(user);
+            UserIdentity userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+
+            UserPrivilegeCollectionV2 userPrivilegeCollection = getUserPrivilegeCollectionUnlocked(userIdentity);
 
             roleReadLock();
             try {
@@ -548,10 +555,10 @@ public class AuthorizationMgr {
                     try {
                         Set<Long> result = getAllPredecessorRoleIdsUnlocked(userPrivilegeCollection);
                         if (result.size() > Config.privilege_max_total_roles_per_user) {
-                            LOG.warn("too many predecessor roles {} for user {}", result, user);
+                            LOG.warn("too many predecessor roles {} for user {}", result, userIdentity);
                             throw new PrivilegeException(String.format(
                                     "%s has total %d predecessor roles > %d!",
-                                    user, result.size(), Config.privilege_max_total_roles_per_user));
+                                    userIdentity, result.size(), Config.privilege_max_total_roles_per_user));
                         }
                         verifyDone = true;
                     } finally {
@@ -565,8 +572,8 @@ public class AuthorizationMgr {
             }
 
             GlobalStateMgr.getCurrentState().getEditLog().logUpdateUserPrivilege(
-                    user, userPrivilegeCollection, provider.getPluginId(), provider.getPluginVersion());
-            invalidateUserInCache(user);
+                    userIdentity, userPrivilegeCollection, provider.getPluginId(), provider.getPluginVersion());
+            invalidateUserInCache(userIdentity);
             LOG.info("grant role {} to user {}", Joiner.on(", ").join(parentRoleName), user);
         } finally {
             userWriteUnlock();
@@ -650,7 +657,7 @@ public class AuthorizationMgr {
     public void revokeRole(RevokeRoleStmt stmt) throws DdlException {
         try {
             switch (stmt.getGrantType()) {
-                case USER -> revokeRoleFromUser(stmt.getGranteeRole(), stmt.getUserIdentity());
+                case USER -> revokeRoleFromUser(stmt.getGranteeRole(), stmt.getUser());
                 case ROLE -> revokeRoleFromRole(stmt.getGranteeRole(), stmt.getRoleOrGroup());
             }
         } catch (PrivilegeException e) {
@@ -658,10 +665,12 @@ public class AuthorizationMgr {
         }
     }
 
-    protected void revokeRoleFromUser(List<String> roleNameList, UserIdentity user) throws PrivilegeException {
+    protected void revokeRoleFromUser(List<String> roleNameList, UserRef user) throws PrivilegeException {
         userWriteLock();
         try {
-            UserPrivilegeCollectionV2 collection = getUserPrivilegeCollectionUnlocked(user);
+            UserIdentity userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+
+            UserPrivilegeCollectionV2 collection = getUserPrivilegeCollectionUnlocked(userIdentity);
             roleReadLock();
             try {
                 for (String roleName : roleNameList) {
@@ -677,9 +686,9 @@ public class AuthorizationMgr {
                 roleReadUnlock();
             }
             GlobalStateMgr.getCurrentState().getEditLog().logUpdateUserPrivilege(
-                    user, collection, provider.getPluginId(), provider.getPluginVersion());
-            invalidateUserInCache(user);
-            LOG.info("revoke role {} from user {}", roleNameList.toString(), user);
+                    userIdentity, collection, provider.getPluginId(), provider.getPluginVersion());
+            invalidateUserInCache(userIdentity);
+            LOG.info("revoke role {} from user {}", roleNameList.toString(), userIdentity);
         } finally {
             userWriteUnlock();
         }
@@ -1138,7 +1147,9 @@ public class AuthorizationMgr {
 
                 if (!parentRoleNameList.isEmpty()) {
                     return Lists.newArrayList(userIdentity.toString(), null,
-                            AstToSQLBuilder.toSQL(new GrantRoleStmt(parentRoleNameList, userIdentity, NodePosition.ZERO)));
+                            AstToSQLBuilder.toSQL(new GrantRoleStmt(parentRoleNameList,
+                                    new UserRef(userIdentity.getUser(), userIdentity.getHost(), userIdentity.isDomain()),
+                                    NodePosition.ZERO)));
                 }
                 return null;
             } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -21,6 +21,7 @@ import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ConfigBase;
@@ -139,6 +140,7 @@ import com.starrocks.sql.ast.SubmitTaskStmt;
 import com.starrocks.sql.ast.SyncStmt;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.ast.UninstallPluginStmt;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.ast.group.CreateGroupProviderStmt;
 import com.starrocks.sql.ast.group.DropGroupProviderStmt;
 import com.starrocks.sql.ast.integration.AlterSecurityIntegrationStatement;
@@ -543,8 +545,10 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitAlterUserStatement(AlterUserStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
+                UserRef user = stmt.getUser();
+                UserIdentity userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
                 context.getGlobalStateMgr().getAuthenticationMgr()
-                        .alterUser(stmt.getUserIdentity(), stmt.getAuthenticationInfo(), stmt.getProperties());
+                        .alterUser(userIdentity, stmt.getAuthenticationInfo(), stmt.getProperties());
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteAsExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteAsExecutor.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.starrocks.authentication.UserProperty;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.ast.ExecuteAsStmt;
+import com.starrocks.sql.ast.UserRef;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -40,11 +41,12 @@ public class ExecuteAsExecutor {
         Preconditions.checkArgument(!stmt.isAllowRevert());
         LOG.info("{} EXEC AS {} from now on", ctx.getCurrentUserIdentity(), stmt.getToUser());
 
-        UserIdentity user = stmt.getToUser();
-        ctx.setCurrentUserIdentity(user);
-        ctx.setCurrentRoleIds(user);
+        UserRef user = stmt.getToUser();
+        UserIdentity userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+        ctx.setCurrentUserIdentity(userIdentity);
+        ctx.setCurrentRoleIds(userIdentity);
 
-        if (!user.isEphemeral()) {
+        if (!userIdentity.isEphemeral()) {
             UserProperty userProperty = ctx.getGlobalStateMgr().getAuthenticationMgr()
                     .getUserProperty(user.getUser());
             ctx.updateByUserProperty(userProperty);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SetDefaultRoleExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SetDefaultRoleExecutor.java
@@ -20,6 +20,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.SetDefaultRoleStmt;
 import com.starrocks.sql.ast.SetRoleType;
+import com.starrocks.sql.ast.UserRef;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,8 +28,10 @@ import java.util.Set;
 public class SetDefaultRoleExecutor {
     public static void execute(SetDefaultRoleStmt stmt, ConnectContext context) throws StarRocksException, PrivilegeException {
         AuthorizationMgr manager = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
-        UserIdentity user = stmt.getUserIdentity();
-        Set<Long> roleIdsForUser = manager.getRoleIdsByUser(user);
+
+        UserRef user = stmt.getUser();
+        UserIdentity userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+        Set<Long> roleIdsForUser = manager.getRoleIdsByUser(userIdentity);
         Set<Long> roleIds;
 
         if (stmt.getSetRoleType().equals(SetRoleType.NONE)) {
@@ -46,6 +49,6 @@ public class SetDefaultRoleExecutor {
             }
         }
 
-        manager.setUserDefaultRole(roleIds, user);
+        manager.setUserDefaultRole(roleIds, userIdentity);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SetExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SetExecutor.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.qe;
 
+import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.DdlException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SetStmtAnalyzer;
@@ -41,6 +42,7 @@ import com.starrocks.sql.ast.SetListItem;
 import com.starrocks.sql.ast.SetPassVar;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.SystemVariable;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.ast.UserVariable;
 
 import java.util.Map;
@@ -70,8 +72,10 @@ public class SetExecutor {
             ctx.modifyUserVariableCopyInWrite(userVariable);
         } else if (var instanceof SetPassVar setPassVar) {
             // Set password
+            UserRef user = setPassVar.getUser();
+            UserIdentity userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
             GlobalStateMgr.getCurrentState().getAuthenticationMgr()
-                    .alterUser(setPassVar.getUserIdent(), setPassVar.getUserAuthenticationInfo(), null);
+                    .alterUser(userIdentity, setPassVar.getUserAuthenticationInfo(), null);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -81,7 +81,6 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.View;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.ParseUtil;
@@ -141,6 +140,7 @@ import com.starrocks.sql.ast.TableFunctionRelation;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.UnionRelation;
 import com.starrocks.sql.ast.UserAuthOption;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.ast.UserVariable;
 import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.ast.ViewRelation;
@@ -212,7 +212,7 @@ public class AstToStringBuilder {
         @Override
         public String visitCreateUserStatement(CreateUserStmt stmt, Void context) {
             StringBuilder sb = new StringBuilder();
-            sb.append("CREATE USER ").append(stmt.getUserIdentity());
+            sb.append("CREATE USER ").append(stmt.getUser());
             sb.append(buildAuthOptionSql(stmt.getAuthOption()));
 
             if (!stmt.getDefaultRoles().isEmpty()) {
@@ -227,7 +227,7 @@ public class AstToStringBuilder {
         @Override
         public String visitAlterUserStatement(AlterUserStmt stmt, Void context) {
             StringBuilder sb = new StringBuilder();
-            sb.append("ALTER USER ").append(stmt.getUserIdentity());
+            sb.append("ALTER USER ").append(stmt.getUser());
             sb.append(buildAuthOptionSql(stmt.getAuthOption()));
 
             return sb.toString();
@@ -297,8 +297,8 @@ public class AstToStringBuilder {
             } else {
                 sb.append(" FROM ");
             }
-            if (stmt.getUserIdentity() != null) {
-                sb.append("USER ").append(stmt.getUserIdentity());
+            if (stmt.getUser() != null) {
+                sb.append("USER ").append(stmt.getUser());
             } else {
                 sb.append("ROLE '").append(stmt.getRole()).append("'");
             }
@@ -330,7 +330,7 @@ public class AstToStringBuilder {
             if (statement.getGrantType().equals(GrantType.ROLE)) {
                 sqlBuilder.append("ROLE ").append(statement.getRoleOrGroup());
             } else {
-                sqlBuilder.append(statement.getUserIdentity());
+                sqlBuilder.append(statement.getUser());
             }
 
             return sqlBuilder.toString();
@@ -368,7 +368,7 @@ public class AstToStringBuilder {
                     setVarList.add(setVarSql);
                 } else if (setVar instanceof SetPassVar) {
                     SetPassVar setPassVar = (SetPassVar) setVar;
-                    UserIdentity userIdentity = setPassVar.getUserIdent();
+                    UserRef userIdentity = setPassVar.getUser();
                     String setPassSql = "";
                     if (userIdentity == null) {
                         setPassSql += "PASSWORD";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthenticationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthenticationAnalyzer.java
@@ -14,11 +14,14 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.google.common.base.Strings;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.authentication.UserAuthenticationInfo;
 import com.starrocks.authorization.AuthorizationMgr;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.CaseSensibility;
 import com.starrocks.common.Config;
+import com.starrocks.common.PatternMatcher;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterUserStmt;
@@ -28,32 +31,55 @@ import com.starrocks.sql.ast.DropUserStmt;
 import com.starrocks.sql.ast.ExecuteAsStmt;
 import com.starrocks.sql.ast.ShowAuthenticationStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UserRef;
 
 public class AuthenticationAnalyzer {
     public static void analyze(StatementBase statement, ConnectContext session) {
         new AuthenticationAnalyzerVisitor().analyze(statement, session);
     }
 
+    public static void analyzeUser(UserRef userIdent) {
+        String user = userIdent.getUser();
+        String host = userIdent.getHost();
+
+        if (Strings.isNullOrEmpty(user)) {
+            throw new SemanticException("Does not support anonymous user");
+        }
+
+        FeNameFormat.checkUserName(user);
+
+        // reuse createMysqlPattern to validate host pattern
+        PatternMatcher.createMysqlPattern(host, CaseSensibility.HOST.getCaseSensibility());
+    }
+
+    public static void checkUserExist(UserRef user, boolean checkExist) {
+        AuthenticationMgr authenticationManager = GlobalStateMgr.getCurrentState().getAuthenticationMgr();
+        UserIdentity userIdent = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+        if (checkExist && !authenticationManager.doesUserExist(userIdent)) {
+            throw new SemanticException("cannot find user " + userIdent + "!");
+        }
+    }
+
+    public static void checkUserNotExist(UserRef user, boolean checkNotExist) {
+        AuthenticationMgr authenticationManager = GlobalStateMgr.getCurrentState().getAuthenticationMgr();
+        UserIdentity userIdent = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+        if (!checkNotExist && authenticationManager.doesUserExist(userIdent)) {
+            throw new SemanticException("user " + userIdent + " already exists!");
+        }
+    }
+
+    public static boolean needProtectAdminUser(UserRef user, ConnectContext context) {
+        return Config.authorization_enable_admin_user_protection &&
+                user.getUser().equalsIgnoreCase("admin") &&
+                !context.getCurrentUserIdentity().equals(UserIdentity.ROOT);
+    }
+
     public static class AuthenticationAnalyzerVisitor implements AstVisitor<Void, ConnectContext> {
-        private AuthenticationMgr authenticationManager = null;
         private AuthorizationMgr authorizationManager = null;
 
         public void analyze(StatementBase statement, ConnectContext session) {
-            authenticationManager = GlobalStateMgr.getCurrentState().getAuthenticationMgr();
             authorizationManager = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
             visit(statement, session);
-        }
-
-        /**
-         * analyse user identity + check if user exists in UserPrivTable
-         */
-        private void analyseUser(UserIdentity userIdent, boolean checkExist) {
-            userIdent.analyze();
-
-            // check if user exists
-            if (checkExist && !authenticationManager.doesUserExist(userIdent)) {
-                throw new SemanticException("cannot find user " + userIdent + "!");
-            }
         }
 
         /**
@@ -70,56 +96,41 @@ public class AuthenticationAnalyzer {
 
         @Override
         public Void visitCreateUserStatement(CreateUserStmt stmt, ConnectContext context) {
-            stmt.getUserIdentity().analyze();
-            if (authenticationManager.doesUserExist(stmt.getUserIdentity()) && !stmt.isIfNotExists()) {
-                throw new SemanticException("Operation CREATE USER failed for " + stmt.getUserIdentity()
-                        + " : user already exists");
-            }
+            analyzeUser(stmt.getUser());
+            checkUserNotExist(stmt.getUser(), stmt.isIfNotExists());
             if (!stmt.getDefaultRoles().isEmpty()) {
                 stmt.getDefaultRoles().forEach(r -> validRoleName(r, "Valid role name fail", true));
             }
 
             UserAuthenticationInfo userAuthenticationInfo =
-                    UserAuthOptionAnalyzer.analyzeAuthOption(stmt.getUserIdentity(), stmt.getAuthOption());
+                    UserAuthOptionAnalyzer.analyzeAuthOption(stmt.getUser(), stmt.getAuthOption());
             stmt.setAuthenticationInfo(userAuthenticationInfo);
             return null;
         }
 
         @Override
         public Void visitAlterUserStatement(AlterUserStmt stmt, ConnectContext context) {
-            stmt.getUserIdentity().analyze();
-            if (!authenticationManager.doesUserExist(stmt.getUserIdentity()) && !stmt.isIfExists()) {
-                throw new SemanticException("Operation ALTER USER failed for " + stmt.getUserIdentity()
-                        + " : user not exists");
-            }
+            analyzeUser(stmt.getUser());
+            checkUserExist(stmt.getUser(), !stmt.isIfExists());
 
             UserAuthenticationInfo userAuthenticationInfo =
-                    UserAuthOptionAnalyzer.analyzeAuthOption(stmt.getUserIdentity(), stmt.getAuthOption());
+                    UserAuthOptionAnalyzer.analyzeAuthOption(stmt.getUser(), stmt.getAuthOption());
             stmt.setAuthenticationInfo(userAuthenticationInfo);
             return null;
         }
 
-        private boolean needProtectAdminUser(UserIdentity userIdentity, ConnectContext context) {
-            return Config.authorization_enable_admin_user_protection &&
-                    userIdentity.getUser().equalsIgnoreCase("admin") &&
-                    !context.getCurrentUserIdentity().equals(UserIdentity.ROOT);
-        }
-
         @Override
         public Void visitDropUserStatement(DropUserStmt stmt, ConnectContext session) {
-            UserIdentity userIdentity = stmt.getUserIdentity();
-            userIdentity.analyze();
+            UserRef user = stmt.getUser();
+            analyzeUser(user);
+            checkUserExist(user, !stmt.isIfExists());
 
-            if (needProtectAdminUser(userIdentity, session)) {
+            if (needProtectAdminUser(user, session)) {
                 throw new SemanticException("'admin' user cannot be dropped because of " +
                         "'authorization_enable_admin_user_protection' configuration is enabled");
             }
 
-            if (!authenticationManager.doesUserExist(userIdentity) && !stmt.isIfExists()) {
-                throw new SemanticException("Operation DROP USER failed for " + userIdentity + " : user not exists");
-            }
-
-            if (stmt.getUserIdentity().equals(UserIdentity.ROOT)) {
+            if (stmt.getUser().equals(UserRef.ROOT)) {
                 throw new SemanticException("Operation DROP USER failed for " + UserIdentity.ROOT +
                         " : cannot drop user " + UserIdentity.ROOT);
             }
@@ -128,11 +139,14 @@ public class AuthenticationAnalyzer {
 
         @Override
         public Void visitShowAuthenticationStatement(ShowAuthenticationStmt statement, ConnectContext context) {
-            UserIdentity user = statement.getUserIdent();
+            UserRef user = statement.getUser();
             if (user != null) {
-                analyseUser(user, true);
+                analyzeUser(user);
+                checkUserExist(user, true);
             } else if (!statement.isAll()) {
-                statement.setUserIdent(context.getCurrentUserIdentity());
+                statement.setUser(new UserRef(context.getCurrentUserIdentity().getUser(),
+                        context.getCurrentUserIdentity().getHost(),
+                        context.getCurrentUserIdentity().isDomain()));
             }
             return null;
         }
@@ -142,7 +156,8 @@ public class AuthenticationAnalyzer {
             if (stmt.isAllowRevert()) {
                 throw new SemanticException("`EXECUTE AS` must use with `WITH NO REVERT` for now!");
             }
-            analyseUser(stmt.getToUser(), true);
+            analyzeUser(stmt.getToUser());
+            checkUserExist(stmt.getToUser(), true);
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizationAnalyzer.java
@@ -18,7 +18,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.TableName;
-import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.authorization.AuthorizationMgr;
 import com.starrocks.authorization.ObjectType;
 import com.starrocks.authorization.PEntryObject;
@@ -30,7 +29,6 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSearchDesc;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -44,6 +42,7 @@ import com.starrocks.sql.ast.SetDefaultRoleStmt;
 import com.starrocks.sql.ast.SetRoleStmt;
 import com.starrocks.sql.ast.ShowGrantsStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.ast.pipe.PipeName;
 
 import java.util.ArrayList;
@@ -57,25 +56,11 @@ public class AuthorizationAnalyzer {
     }
 
     public static class AuthorizationAnalyzerVisitor implements AstVisitor<Void, ConnectContext> {
-        private AuthenticationMgr authenticationManager = null;
         private AuthorizationMgr authorizationManager = null;
 
         public void analyze(StatementBase statement, ConnectContext session) {
-            authenticationManager = GlobalStateMgr.getCurrentState().getAuthenticationMgr();
             authorizationManager = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
             visit(statement, session);
-        }
-
-        /**
-         * analyse user identity + check if user exists in UserPrivTable
-         */
-        private void analyseUser(UserIdentity userIdent, boolean checkExist) {
-            userIdent.analyze();
-
-            // check if user exists
-            if (checkExist && !authenticationManager.doesUserExist(userIdent)) {
-                throw new SemanticException("cannot find user " + userIdent + "!");
-            }
         }
 
         /**
@@ -133,8 +118,9 @@ public class AuthorizationAnalyzer {
         @Override
         public Void visitGrantRevokePrivilegeStatement(BaseGrantRevokePrivilegeStmt stmt, ConnectContext session) {
             // validate user/role
-            if (stmt.getUserIdentity() != null) {
-                analyseUser(stmt.getUserIdentity(), true);
+            if (stmt.getUser() != null) {
+                AuthenticationAnalyzer.analyzeUser(stmt.getUser());
+                AuthenticationAnalyzer.checkUserExist(stmt.getUser(), true);
             } else {
                 validRoleName(stmt.getRole(), "Can not grant/revoke to role", true);
             }
@@ -145,8 +131,12 @@ public class AuthorizationAnalyzer {
 
                 List<PEntryObject> objectList = new ArrayList<>();
                 if (objectType.equals(ObjectType.USER)) {
-                    List<UserIdentity> userIdentities = analyzeUserPrivToken(stmt);
-                    for (UserIdentity userIdentity : userIdentities) {
+                    List<UserRef> users = analyzeUserPrivToken(stmt);
+                    for (UserRef user : users) {
+                        UserIdentity userIdentity = null;
+                        if (user != null) {
+                            userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+                        }
                         objectList.add(authorizationManager.generateUserObject(ObjectType.USER, userIdentity));
                     }
                 } else if (objectType.equals(ObjectType.FUNCTION) || objectType.equals(ObjectType.GLOBAL_FUNCTION)) {
@@ -188,8 +178,8 @@ public class AuthorizationAnalyzer {
             return null;
         }
 
-        public List<UserIdentity> analyzeUserPrivToken(BaseGrantRevokePrivilegeStmt stmt) {
-            List<UserIdentity> userIdentities = new ArrayList<>();
+        public List<UserRef> analyzeUserPrivToken(BaseGrantRevokePrivilegeStmt stmt) {
+            List<UserRef> userIdentities = new ArrayList<>();
             if (stmt.isGrantOnALL()) {
                 Preconditions.checkArgument(stmt.getPrivilegeObjectNameTokensList() != null);
                 Preconditions.checkArgument(stmt.getPrivilegeObjectNameTokensList().size() == 1);
@@ -201,9 +191,10 @@ public class AuthorizationAnalyzer {
                 }
                 userIdentities.add(null);
             } else {
-                for (UserIdentity userIdentity : stmt.getUserPrivilegeObjectList()) {
-                    analyseUser(userIdentity, true);
-                    userIdentities.add(userIdentity);
+                for (UserRef userRef : stmt.getUserPrivilegeObjectList()) {
+                    AuthenticationAnalyzer.analyzeUser(userRef);
+                    AuthenticationAnalyzer.checkUserExist(userRef, true);
+                    userIdentities.add(userRef);
                 }
             }
             return userIdentities;
@@ -445,16 +436,20 @@ public class AuthorizationAnalyzer {
                         "set default role statement is not supported for ephemeral user " + currentUser);
             }
 
-            analyseUser(stmt.getUserIdentity(), true);
+            AuthenticationAnalyzer.analyzeUser(stmt.getUser());
+            AuthenticationAnalyzer.checkUserExist(stmt.getUser(), true);
+
+            UserIdentity userIdentity = new UserIdentity(stmt.getUser().getUser(), stmt.getUser().getHost(),
+                    stmt.getUser().isDomain());
             try {
                 for (String roleName : stmt.getRoles()) {
                     validRoleName(roleName, "Cannot set role", true);
 
                     Long roleId = authorizationManager.getRoleIdByNameAllowNull(roleName);
-                    Set<Long> roleIdsForUser = authorizationManager.getRoleIdsByUser(stmt.getUserIdentity());
+                    Set<Long> roleIdsForUser = authorizationManager.getRoleIdsByUser(userIdentity);
                     if (roleId == null || !roleIdsForUser.contains(roleId)) {
                         throw new SemanticException("Role " + roleName + " is not granted to " +
-                                stmt.getUserIdentity().toString());
+                                stmt.getUser().toString());
                     }
                 }
             } catch (PrivilegeException e) {
@@ -472,9 +467,10 @@ public class AuthorizationAnalyzer {
          */
         @Override
         public Void visitGrantRevokeRoleStatement(BaseGrantRevokeRoleStmt stmt, ConnectContext session) {
-            if (stmt.getUserIdentity() != null) {
-                analyseUser(stmt.getUserIdentity(), true);
-                if (needProtectAdminUser(stmt.getUserIdentity(), session)) {
+            if (stmt.getUser() != null) {
+                AuthenticationAnalyzer.analyzeUser(stmt.getUser());
+                AuthenticationAnalyzer.checkUserExist(stmt.getUser(), true);
+                if (AuthenticationAnalyzer.needProtectAdminUser(stmt.getUser(), session)) {
                     throw new SemanticException("roles of 'admin' user cannot be changed because of " +
                             "'authorization_enable_admin_user_protection' configuration is enabled");
                 }
@@ -490,21 +486,18 @@ public class AuthorizationAnalyzer {
 
         @Override
         public Void visitShowGrantsStatement(ShowGrantsStmt stmt, ConnectContext session) {
-            if (stmt.getUserIdent() != null) {
-                analyseUser(stmt.getUserIdent(), true);
+            if (stmt.getUser() != null) {
+                AuthenticationAnalyzer.analyzeUser(stmt.getUser());
+                AuthenticationAnalyzer.checkUserExist(stmt.getUser(), true);
             } else if (stmt.getGroupOrRole() != null) {
                 validRoleName(stmt.getGroupOrRole(), "There is no such grant defined for role " + stmt.getGroupOrRole(), true);
             } else {
-                stmt.setUserIdent(session.getCurrentUserIdentity());
+                UserIdentity userIdentity = session.getCurrentUserIdentity();
+                UserRef user = new UserRef(userIdentity.getUser(), userIdentity.getHost(), userIdentity.isDomain());
+                stmt.setUser(user);
             }
 
             return null;
-        }
-
-        private boolean needProtectAdminUser(UserIdentity userIdentity, ConnectContext context) {
-            return Config.authorization_enable_admin_user_protection &&
-                    userIdentity.getUser().equalsIgnoreCase("admin") &&
-                    !context.getCurrentUserIdentity().equals(UserIdentity.ROOT);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -212,6 +212,7 @@ import com.starrocks.sql.ast.UninstallPluginStmt;
 import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.ast.UseCatalogStmt;
 import com.starrocks.sql.ast.UseDbStmt;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.ast.group.CreateGroupProviderStmt;
 import com.starrocks.sql.ast.group.DropGroupProviderStmt;
 import com.starrocks.sql.ast.group.ShowCreateGroupProviderStmt;
@@ -1191,7 +1192,7 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
     @Override
     public Void visitBaseCreateAlterUserStmt(BaseCreateAlterUserStmt statement, ConnectContext context) {
         try {
-            if (statement.getUserIdentity().equals(UserIdentity.ROOT)
+            if (statement.getUser().equals(UserRef.ROOT)
                     && !context.getCurrentUserIdentity().equals(UserIdentity.ROOT)) {
                 throw new SemanticException("Can not modify root user, except root itself");
             }
@@ -1236,8 +1237,13 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
 
     @Override
     public Void visitShowAuthenticationStatement(ShowAuthenticationStmt statement, ConnectContext context) {
-        UserIdentity user = statement.getUserIdent();
-        if (user != null && !user.equals(context.getCurrentUserIdentity()) || statement.isAll()) {
+        UserRef user = statement.getUser();
+        UserRef contextUser = new UserRef(
+                context.getCurrentUserIdentity().getUser(),
+                context.getCurrentUserIdentity().getHost(),
+                context.getCurrentUserIdentity().isDomain());
+
+        if (user != null && !user.equals(contextUser) || statement.isAll()) {
             try {
                 Authorizer.checkSystemAction(context, PrivilegeType.GRANT);
             } catch (AccessDeniedException e) {
@@ -1253,8 +1259,9 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
     @Override
     public Void visitExecuteAsStatement(ExecuteAsStmt statement, ConnectContext context) {
         try {
-            Authorizer.checkUserAction(context, statement.getToUser(),
-                    PrivilegeType.IMPERSONATE);
+            UserRef user = statement.getToUser();
+            UserIdentity userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+            Authorizer.checkUserAction(context, userIdentity, PrivilegeType.IMPERSONATE);
         } catch (AccessDeniedException e) {
             AccessDeniedException.reportAccessDenied(
                     InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
@@ -1361,7 +1368,7 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
         }
 
         if (statement.getGranteeRole().stream().anyMatch(r -> r.equals(PrivilegeBuiltinConstants.ROOT_ROLE_NAME))) {
-            if (statement.getUserIdentity() != null && statement.getUserIdentity().equals(UserIdentity.ROOT)) {
+            if (statement.getUser() != null && statement.getUser().equals(UserRef.ROOT)) {
                 throw new SemanticException("Can not revoke root role from root user");
             }
         }
@@ -1379,8 +1386,13 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
 
     @Override
     public Void visitSetDefaultRoleStatement(SetDefaultRoleStmt statement, ConnectContext context) {
-        UserIdentity user = statement.getUserIdentity();
-        if (user != null && !user.equals(context.getCurrentUserIdentity())) {
+        UserRef user = statement.getUser();
+        if (user == null) {
+            return null;
+        }
+
+        UserIdentity userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+        if (!userIdentity.equals(context.getCurrentUserIdentity())) {
             try {
                 Authorizer.checkSystemAction(context, PrivilegeType.GRANT);
             } catch (AccessDeniedException e) {
@@ -1413,10 +1425,13 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
 
     @Override
     public Void visitShowGrantsStatement(ShowGrantsStmt statement, ConnectContext context) {
-        UserIdentity user = statement.getUserIdent();
+        UserRef user = statement.getUser();
         try {
-            if (user != null && !user.equals(context.getCurrentUserIdentity())) {
-                Authorizer.checkSystemAction(context, PrivilegeType.GRANT);
+            if (user != null) {
+                UserIdentity userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+                if (!userIdentity.equals(context.getCurrentUserIdentity())) {
+                    Authorizer.checkSystemAction(context, PrivilegeType.GRANT);
+                }
             } else if (statement.getGroupOrRole() != null) {
                 AuthorizationMgr authorizationManager = context.getGlobalStateMgr().getAuthorizationMgr();
                 Set<String> roleNames =
@@ -2152,7 +2167,8 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
         List<SetListItem> varList = statement.getSetListItems();
         varList.forEach(setVar -> {
             if ((setVar instanceof SetPassVar)) {
-                UserIdentity prepareChangeUser = ((SetPassVar) setVar).getUserIdent();
+                UserRef user = ((SetPassVar) setVar).getUser();
+                UserIdentity prepareChangeUser = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
                 if (!context.getCurrentUserIdentity().equals(prepareChangeUser)) {
                     if (prepareChangeUser.equals(UserIdentity.ROOT)) {
                         throw new SemanticException("Can not set password for root user, except root itself");
@@ -2376,7 +2392,7 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
         AbstractJob job = null;
         try {
             job = GlobalStateMgr.getCurrentState().getBackupHandler().getAbstractJob(statement.isExternalCatalog(),
-                                                                                     statement.getDbName());
+                    statement.getDbName());
         } catch (DdlException e) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, statement.getDbName());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -56,6 +56,7 @@ import com.starrocks.sql.ast.SetPassVar;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.SetUserPropertyVar;
 import com.starrocks.sql.ast.SystemVariable;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.ast.UserVariable;
 import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.common.QueryDebugOptions;
@@ -442,12 +443,15 @@ public class SetStmtAnalyzer {
     }
 
     private static void analyzeSetPassVar(SetPassVar var, ConnectContext session) {
-        UserIdentity userIdentity = var.getUserIdent();
-        if (userIdentity == null) {
+        UserRef user = var.getUser();
+        UserIdentity userIdentity;
+        if (user == null) {
             userIdentity = session.getCurrentUserIdentity();
+            var.setUser(new UserRef(userIdentity.getUser(), userIdentity.getHost(), userIdentity.isDomain()));
+        } else {
+            userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+            AuthenticationAnalyzer.analyzeUser(user);
         }
-        userIdentity.analyze();
-        var.setUserIdent(userIdentity);
 
         UserAuthenticationInfo userAuthenticationInfo =
                 GlobalStateMgr.getCurrentState().getAuthenticationMgr().getUserAuthenticationInfoByUserIdentity(userIdentity);
@@ -461,7 +465,7 @@ public class SetStmtAnalyzer {
                     userIdentity + ", AuthPlugin: " + userAuthenticationInfo.getAuthPlugin());
         }
 
-        var.setUserAuthenticationInfo(UserAuthOptionAnalyzer.analyzeAuthOption(userIdentity, var.getAuthOption()));
+        var.setUserAuthenticationInfo(UserAuthOptionAnalyzer.analyzeAuthOption(var.getUser(), var.getAuthOption()));
     }
 
     private static boolean checkUserVariableType(Type type) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UserAuthOptionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UserAuthOptionAnalyzer.java
@@ -17,15 +17,15 @@ package com.starrocks.sql.analyzer;
 import com.google.common.base.Strings;
 import com.starrocks.authentication.AuthenticationException;
 import com.starrocks.authentication.UserAuthenticationInfo;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.mysql.MysqlPassword;
 import com.starrocks.mysql.privilege.AuthPlugin;
 import com.starrocks.sql.ast.UserAuthOption;
+import com.starrocks.sql.ast.UserRef;
 
 import java.util.Arrays;
 
 public class UserAuthOptionAnalyzer {
-    public static UserAuthenticationInfo analyzeAuthOption(UserIdentity userIdentity, UserAuthOption userAuthOption) {
+    public static UserAuthenticationInfo analyzeAuthOption(UserRef user, UserAuthOption userAuthOption) {
         try {
             String authPluginUsing;
             if (userAuthOption == null || userAuthOption.getAuthPlugin() == null) {
@@ -55,7 +55,7 @@ public class UserAuthOptionAnalyzer {
                 info.setAuthString(userAuthOption == null ? null : userAuthOption.getAuthString());
             }
 
-            info.setOrigUserHost(userIdentity.getUser(), userIdentity.getHost());
+            info.setOrigUserHost(user.getUser(), user.getHost());
 
             return info;
         } catch (AuthenticationException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterUserStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterUserStmt.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Map;
@@ -22,9 +21,9 @@ import java.util.Map;
 public class AlterUserStmt extends BaseCreateAlterUserStmt {
     private final boolean ifExists;
 
-    public AlterUserStmt(UserIdentity userIdentity, boolean ifExists, UserAuthOption userAuthOption,
+    public AlterUserStmt(UserRef user, boolean ifExists, UserAuthOption userAuthOption,
                          Map<String, String> properties, NodePosition pos) {
-        super(userIdentity, userAuthOption, properties, pos);
+        super(user, userAuthOption, properties, pos);
         this.ifExists = ifExists;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseCreateAlterUserStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseCreateAlterUserStmt.java
@@ -15,14 +15,13 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.authentication.UserAuthenticationInfo;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Map;
 
 // CreateUserStmt and AlterUserStmt share the same parameter and check logic
 public abstract class BaseCreateAlterUserStmt extends DdlStmt {
-    protected UserIdentity userIdentity;
+    protected UserRef user;
     protected UserAuthOption authOption;
 
     // used in new RBAC privilege framework
@@ -30,17 +29,17 @@ public abstract class BaseCreateAlterUserStmt extends DdlStmt {
 
     private final Map<String, String> properties;
 
-    public BaseCreateAlterUserStmt(UserIdentity userIdentity, UserAuthOption authOption,
+    public BaseCreateAlterUserStmt(UserRef user, UserAuthOption authOption,
                                    Map<String, String> properties, NodePosition pos) {
         super(pos);
 
-        this.userIdentity = userIdentity;
+        this.user = user;
         this.authOption = authOption;
         this.properties = properties;
     }
 
-    public UserIdentity getUserIdentity() {
-        return userIdentity;
+    public UserRef getUser() {
+        return user;
     }
 
     public UserAuthOption getAuthOption() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseGrantRevokePrivilegeStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseGrantRevokePrivilegeStmt.java
@@ -19,7 +19,6 @@ import com.starrocks.analysis.FunctionName;
 import com.starrocks.authorization.ObjectType;
 import com.starrocks.authorization.PEntryObject;
 import com.starrocks.authorization.PrivilegeType;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.parser.NodePosition;
 
@@ -65,7 +64,7 @@ public class BaseGrantRevokePrivilegeStmt extends DdlStmt {
     /**
      * old privilege framework only support grant/revoke on one single object
      */
-    public UserIdentity getUserPrivilegeObject() {
+    public UserRef getUserPrivilegeObject() {
         return objectsUnResolved.getUserPrivilegeObjectList().get(0);
     }
 
@@ -73,7 +72,7 @@ public class BaseGrantRevokePrivilegeStmt extends DdlStmt {
         return objectsUnResolved.getPrivilegeObjectNameTokensList();
     }
 
-    public List<UserIdentity> getUserPrivilegeObjectList() {
+    public List<UserRef> getUserPrivilegeObjectList() {
         return objectsUnResolved.getUserPrivilegeObjectList();
     }
 
@@ -97,8 +96,8 @@ public class BaseGrantRevokePrivilegeStmt extends DdlStmt {
         return role;
     }
 
-    public UserIdentity getUserIdentity() {
-        return clause.getUserIdentity();
+    public UserRef getUser() {
+        return clause.getUser();
     }
 
     public String getObjectTypeUnResolved() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseGrantRevokeRoleStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseGrantRevokeRoleStmt.java
@@ -15,7 +15,6 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.authorization.GrantType;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
@@ -23,14 +22,14 @@ import java.util.List;
 // GrantRoleStmt and RevokeRoleStmt share the same parameter and check logic with GrantRoleStmt
 public abstract class BaseGrantRevokeRoleStmt extends DdlStmt {
     protected List<String> granteeRole;
-    protected UserIdentity userIdentity;
+    protected UserRef user;
     protected String roleOrGroup;
     protected GrantType grantType;
 
-    protected BaseGrantRevokeRoleStmt(List<String> granteeRole, UserIdentity userIdentity, NodePosition pos) {
+    protected BaseGrantRevokeRoleStmt(List<String> granteeRole, UserRef user, NodePosition pos) {
         super(pos);
         this.granteeRole = granteeRole;
-        this.userIdentity = userIdentity;
+        this.user = user;
         this.roleOrGroup = null;
         this.grantType = GrantType.USER;
     }
@@ -38,13 +37,13 @@ public abstract class BaseGrantRevokeRoleStmt extends DdlStmt {
     protected BaseGrantRevokeRoleStmt(List<String> granteeRole, String roleOrGroup, GrantType grantType, NodePosition pos) {
         super(pos);
         this.granteeRole = granteeRole;
-        this.userIdentity = null;
+        this.user = null;
         this.roleOrGroup = roleOrGroup;
         this.grantType = grantType;
     }
 
-    public UserIdentity getUserIdentity() {
-        return userIdentity;
+    public UserRef getUser() {
+        return user;
     }
 
     public List<String> getGranteeRole() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateUserStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateUserStmt.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
@@ -39,12 +38,12 @@ public class CreateUserStmt extends BaseCreateAlterUserStmt {
     protected SetRoleType setRoleType;
     protected List<String> defaultRoles;
 
-    public CreateUserStmt(UserIdentity userIdentity, boolean ifNotExists,
+    public CreateUserStmt(UserRef user, boolean ifNotExists,
                           UserAuthOption authOption,
                           List<String> defaultRoles,
                           Map<String, String> properties,
                           NodePosition pos) {
-        super(userIdentity, authOption, properties, pos);
+        super(user, authOption, properties, pos);
         this.ifNotExists = ifNotExists;
         this.setRoleType = SetRoleType.ROLE;
         this.defaultRoles = defaultRoles;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropUserStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropUserStmt.java
@@ -14,25 +14,24 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 public class DropUserStmt extends DdlStmt {
-    private final UserIdentity userIdent;
+    private final UserRef user;
     private final boolean ifExists;
 
-    public DropUserStmt(UserIdentity userIdent, boolean ifExists) {
-        this(userIdent, ifExists, NodePosition.ZERO);
+    public DropUserStmt(UserRef user, boolean ifExists) {
+        this(user, ifExists, NodePosition.ZERO);
     }
 
-    public DropUserStmt(UserIdentity userIdent, boolean ifExists, NodePosition pos) {
+    public DropUserStmt(UserRef user, boolean ifExists, NodePosition pos) {
         super(pos);
-        this.userIdent = userIdent;
+        this.user = user;
         this.ifExists = ifExists;
     }
 
-    public UserIdentity getUserIdentity() {
-        return userIdent;
+    public UserRef getUser() {
+        return user;
     }
 
     public boolean isIfExists() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExecuteAsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExecuteAsStmt.java
@@ -15,25 +15,24 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 // EXECUTE AS XX WITH NO REVERT
 public class ExecuteAsStmt extends StatementBase {
-    protected UserIdentity toUser;
+    protected UserRef toUser;
     protected boolean allowRevert;
 
-    public ExecuteAsStmt(UserIdentity toUser, boolean allowRevert) {
+    public ExecuteAsStmt(UserRef toUser, boolean allowRevert) {
         this(toUser, allowRevert, NodePosition.ZERO);
     }
 
-    public ExecuteAsStmt(UserIdentity toUser, boolean allowRevert, NodePosition pos) {
+    public ExecuteAsStmt(UserRef toUser, boolean allowRevert, NodePosition pos) {
         super(pos);
         this.toUser = toUser;
         this.allowRevert = allowRevert;
     }
 
-    public UserIdentity getToUser() {
+    public UserRef getToUser() {
         return toUser;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/GrantPrivilegeStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/GrantPrivilegeStmt.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
@@ -47,9 +46,9 @@ public class GrantPrivilegeStmt extends BaseGrantRevokePrivilegeStmt {
     /**
      * The following functions is used to generate sql when excuting `show grants` in old privilege framework
      */
-    public GrantPrivilegeStmt(List<String> privilegeTypeUnResolved, String objectTypeUnResolved, UserIdentity userIdentity,
+    public GrantPrivilegeStmt(List<String> privilegeTypeUnResolved, String objectTypeUnResolved, UserRef user,
                               boolean withGrantOption) {
-        super(privilegeTypeUnResolved, objectTypeUnResolved, new GrantRevokeClause(userIdentity, null),
+        super(privilegeTypeUnResolved, objectTypeUnResolved, new GrantRevokeClause(user, null),
                 new GrantRevokePrivilegeObjects());
         this.withGrantOption = withGrantOption;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/GrantRevokeClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/GrantRevokeClause.java
@@ -16,7 +16,6 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.ParseNode;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 /**
@@ -25,23 +24,23 @@ import com.starrocks.sql.parser.NodePosition;
  * ;
  */
 public class GrantRevokeClause implements ParseNode {
-    private final UserIdentity userIdentity;
+    private final UserRef user;
     private final String roleName;
 
     private final NodePosition pos;
 
-    public GrantRevokeClause(UserIdentity userIdentifier, String roleName) {
-        this(userIdentifier, roleName, NodePosition.ZERO);
+    public GrantRevokeClause(UserRef user, String roleName) {
+        this(user, roleName, NodePosition.ZERO);
     }
 
-    public GrantRevokeClause(UserIdentity userIdentifier, String roleName, NodePosition pos) {
+    public GrantRevokeClause(UserRef user, String roleName, NodePosition pos) {
         this.pos = pos;
-        this.userIdentity = userIdentifier;
+        this.user = user;
         this.roleName = roleName;
     }
 
-    public UserIdentity getUserIdentity() {
-        return userIdentity;
+    public UserRef getUser() {
+        return user;
     }
 
     public String getRoleName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/GrantRevokePrivilegeObjects.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/GrantRevokePrivilegeObjects.java
@@ -17,7 +17,6 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.ParseNode;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.parser.NodePosition;
 
@@ -28,7 +27,7 @@ public class GrantRevokePrivilegeObjects implements ParseNode {
     private List<List<String>> privilegeObjectNameTokensList;
 
     //UnResolved AST used in syntax grantImpersonate
-    private List<UserIdentity> userPrivilegeObjectList;
+    private List<UserRef> userPrivilegeObjectList;
 
     //UnResolved AST used in syntax grantPrivWithFunc
     private List<Pair<FunctionName, FunctionArgsDef>> functions;
@@ -52,11 +51,11 @@ public class GrantRevokePrivilegeObjects implements ParseNode {
         this.privilegeObjectNameTokensList = privilegeObjectNameTokensList;
     }
 
-    public List<UserIdentity> getUserPrivilegeObjectList() {
+    public List<UserRef> getUserPrivilegeObjectList() {
         return userPrivilegeObjectList;
     }
 
-    public void setUserPrivilegeObjectList(List<UserIdentity> userPrivilegeObjectList) {
+    public void setUserPrivilegeObjectList(List<UserRef> userPrivilegeObjectList) {
         this.userPrivilegeObjectList = userPrivilegeObjectList;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/GrantRoleStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/GrantRoleStmt.java
@@ -15,15 +15,14 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.authorization.GrantType;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 
 public class GrantRoleStmt extends BaseGrantRevokeRoleStmt {
 
-    public GrantRoleStmt(List<String> granteeRole, UserIdentity userIdent, NodePosition pos) {
-        super(granteeRole, userIdent, pos);
+    public GrantRoleStmt(List<String> granteeRole, UserRef user, NodePosition pos) {
+        super(granteeRole, user, pos);
     }
     public GrantRoleStmt(List<String> granteeRole, String group, GrantType grantType, NodePosition pos) {
         super(granteeRole, group, grantType, pos);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RevokeRoleStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RevokeRoleStmt.java
@@ -15,14 +15,13 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.authorization.GrantType;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 
 public class RevokeRoleStmt extends BaseGrantRevokeRoleStmt {
-    public RevokeRoleStmt(List<String> granteeRole, UserIdentity userIdent, NodePosition pos) {
-        super(granteeRole, userIdent, pos);
+    public RevokeRoleStmt(List<String> granteeRole, UserRef user, NodePosition pos) {
+        super(granteeRole, user, pos);
     }
 
     public RevokeRoleStmt(List<String> granteeRole, String group, GrantType grantType, NodePosition pos) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetDefaultRoleStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetDefaultRoleStmt.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.ArrayList;
@@ -22,23 +21,23 @@ import java.util.List;
 
 public class SetDefaultRoleStmt extends StatementBase {
 
-    private final UserIdentity userIdentity;
+    private final UserRef user;
     private final List<String> roles = new ArrayList<>();
     private final SetRoleType setRoleType;
 
-    public SetDefaultRoleStmt(UserIdentity userIdentity, SetRoleType setRoleType, List<String> roles) {
-        this(userIdentity, setRoleType, roles, NodePosition.ZERO);
+    public SetDefaultRoleStmt(UserRef user, SetRoleType setRoleType, List<String> roles) {
+        this(user, setRoleType, roles, NodePosition.ZERO);
     }
 
-    public SetDefaultRoleStmt(UserIdentity userIdentity, SetRoleType setRoleType, List<String> roles, NodePosition pos) {
+    public SetDefaultRoleStmt(UserRef user, SetRoleType setRoleType, List<String> roles, NodePosition pos) {
         super(pos);
-        this.userIdentity = userIdentity;
+        this.user = user;
         this.roles.addAll(roles);
         this.setRoleType = setRoleType;
     }
 
-    public UserIdentity getUserIdentity() {
-        return userIdentity;
+    public UserRef getUser() {
+        return user;
     }
 
     public SetRoleType getSetRoleType() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetPassVar.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetPassVar.java
@@ -15,26 +15,25 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.authentication.UserAuthenticationInfo;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 public class SetPassVar extends SetListItem {
-    private UserIdentity userIdent;
+    private UserRef user;
     private final UserAuthOption authOption;
     private UserAuthenticationInfo userAuthenticationInfo;
 
-    public SetPassVar(UserIdentity userIdentity, UserAuthOption authOption, NodePosition pos) {
+    public SetPassVar(UserRef user, UserAuthOption authOption, NodePosition pos) {
         super(pos);
-        this.userIdent = userIdentity;
+        this.user = user;
         this.authOption = authOption;
     }
 
-    public UserIdentity getUserIdent() {
-        return userIdent;
+    public UserRef getUser() {
+        return user;
     }
 
-    public void setUserIdent(UserIdentity userIdent) {
-        this.userIdent = userIdent;
+    public void setUser(UserRef user) {
+        this.user = user;
     }
 
     public UserAuthOption getAuthOption() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAuthenticationStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAuthenticationStmt.java
@@ -12,39 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 public class ShowAuthenticationStmt extends ShowStmt {
     private final boolean isAll;
-    private UserIdentity userIdent;
+    private UserRef user;
 
     // SHOW AUTHENTICATION -> (null, false)
     // SHOW ALL AUTHENTICATION -> (null, true)
     // SHOW AUTHENTICATION FOR xx -> (xx, false)
-    public ShowAuthenticationStmt(UserIdentity userIdent, boolean isAll) {
-        this(userIdent, isAll, NodePosition.ZERO);
+    public ShowAuthenticationStmt(UserRef user, boolean isAll) {
+        this(user, isAll, NodePosition.ZERO);
     }
 
-    public ShowAuthenticationStmt(UserIdentity userIdent, boolean isAll, NodePosition pos) {
+    public ShowAuthenticationStmt(UserRef user, boolean isAll, NodePosition pos) {
         super(pos);
-        this.userIdent = userIdent;
+        this.user = user;
         this.isAll = isAll;
     }
 
-    public UserIdentity getUserIdent() {
-        return userIdent;
+    public UserRef getUser() {
+        return user;
     }
 
     public boolean isAll() {
         return isAll;
     }
 
-    public void setUserIdent(UserIdentity userIdent) {
-        this.userIdent = userIdent;
+    public void setUser(UserRef user) {
+        this.user = user;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowGrantsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowGrantsStmt.java
@@ -15,38 +15,37 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.authorization.GrantType;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.parser.NodePosition;
 
 public class ShowGrantsStmt extends ShowStmt {
-    private UserIdentity userIdent;
+    private UserRef user;
     private final String groupOrRole;
     private final GrantType grantType;
 
-    public ShowGrantsStmt(UserIdentity userIdent, NodePosition pos) {
+    public ShowGrantsStmt(UserRef user, NodePosition pos) {
         super(pos);
-        this.userIdent = userIdent;
+        this.user = user;
         this.groupOrRole = null;
         grantType = GrantType.USER;
     }
 
     public ShowGrantsStmt(String groupOrRole, GrantType grantType, NodePosition pos) {
         super(pos);
-        this.userIdent = null;
+        this.user = null;
         this.groupOrRole = groupOrRole;
         this.grantType = grantType;
     }
 
-    public UserIdentity getUserIdent() {
-        return userIdent;
+    public UserRef getUser() {
+        return user;
     }
 
     public String getGroupOrRole() {
         return groupOrRole;
     }
 
-    public void setUserIdent(UserIdentity userIdent) {
-        this.userIdent = userIdent;
+    public void setUser(UserRef user) {
+        this.user = user;
     }
 
     public GrantType getGrantType() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UserRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UserRef.java
@@ -1,0 +1,100 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.google.common.base.Strings;
+import com.starrocks.analysis.ParseNode;
+import com.starrocks.sql.parser.NodePosition;
+
+import java.util.Objects;
+
+public class UserRef implements ParseNode {
+    public static final UserRef ROOT;
+
+    static {
+        ROOT = new UserRef("root", "%");
+    }
+
+    private final String user;
+    private final String host;
+    private final boolean isDomain;
+    private final NodePosition pos;
+
+    public UserRef(String user, String host) {
+        this(user, host, false);
+    }
+
+    public UserRef(String user, String host, boolean isDomain) {
+        this(user, host, isDomain, NodePosition.ZERO);
+    }
+
+    public UserRef(String user, String host, boolean isDomain, NodePosition pos) {
+        this.user = user;
+        this.host = Strings.emptyToNull(host);
+        this.isDomain = isDomain;
+        this.pos = pos;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public boolean isDomain() {
+        return isDomain;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("'");
+        if (!Strings.isNullOrEmpty(user)) {
+            sb.append(user);
+        }
+        sb.append("'@");
+        if (!Strings.isNullOrEmpty(host)) {
+            if (isDomain) {
+                sb.append("['").append(host).append("']");
+            } else {
+                sb.append("'").append(host).append("'");
+            }
+        } else {
+            sb.append("%");
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public NodePosition getPos() {
+        return pos;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        UserRef user1 = (UserRef) object;
+        return isDomain == user1.isDomain && Objects.equals(user, user1.user) && Objects.equals(host, user1.host);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(user, host, isDomain);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -98,7 +98,6 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.StructField;
 import com.starrocks.catalog.StructType;
 import com.starrocks.catalog.Type;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.combinator.AggStateDesc;
 import com.starrocks.catalog.combinator.AggStateUtils;
 import com.starrocks.common.AnalysisException;
@@ -477,6 +476,7 @@ import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.ast.UseCatalogStmt;
 import com.starrocks.sql.ast.UseDbStmt;
 import com.starrocks.sql.ast.UserAuthOption;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.ast.UserVariable;
 import com.starrocks.sql.ast.ValueList;
 import com.starrocks.sql.ast.ValuesRelation;
@@ -4275,7 +4275,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 stringLiteral.getStringValue(), isPlainPassword, pos);
 
         if (context.user() != null) {
-            return new SetPassVar((UserIdentity) visit(context.user()), authOption, pos);
+            return new SetPassVar((UserRef) visit(context.user()), authOption, pos);
         } else {
             return new SetPassVar(null, authOption, pos);
         }
@@ -6452,7 +6452,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitCreateUserStatement(StarRocksParser.CreateUserStatementContext context) {
-        UserIdentity user = (UserIdentity) visit(context.user());
+        UserRef user = (UserRef) visit(context.user());
         UserAuthOption authOption = (UserAuthOption) visitIfPresent(context.authOption());
         boolean ifNotExists = context.IF() != null;
 
@@ -6474,13 +6474,13 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitDropUserStatement(StarRocksParser.DropUserStatementContext context) {
-        UserIdentity user = (UserIdentity) visit(context.user());
+        UserRef user = (UserRef) visit(context.user());
         return new DropUserStmt(user, context.EXISTS() != null, createPos(context));
     }
 
     @Override
     public ParseNode visitAlterUserStatement(StarRocksParser.AlterUserStatementContext context) {
-        UserIdentity user = (UserIdentity) visit(context.user());
+        UserRef user = (UserRef) visit(context.user());
 
         if (context.ROLE() != null) {
             List<String> roles = new ArrayList<>();
@@ -6541,7 +6541,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     public ParseNode visitShowAuthenticationForUser(StarRocksParser.ShowAuthenticationForUserContext context) {
         NodePosition pos = createPos(context);
         if (context.user() != null) {
-            return new ShowAuthenticationStmt((UserIdentity) visit(context.user()), false, pos);
+            return new ShowAuthenticationStmt((UserRef) visit(context.user()), false, pos);
         } else {
             return new ShowAuthenticationStmt(null, false, pos);
         }
@@ -6551,7 +6551,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     public ParseNode visitExecuteAsStatement(StarRocksParser.ExecuteAsStatementContext context) {
         boolean allowRevert = context.WITH() == null;
         // we only support WITH NO REVERT for now
-        return new ExecuteAsStmt((UserIdentity) visit(context.user()), allowRevert, createPos(context));
+        return new ExecuteAsStmt((UserRef) visit(context.user()), allowRevert, createPos(context));
     }
 
     @Override
@@ -6593,7 +6593,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             roleNameList.add(((Identifier) visit(oneContext)).getValue());
         }
 
-        return new GrantRoleStmt(roleNameList, (UserIdentity) visit(context.user()), createPos(context));
+        return new GrantRoleStmt(roleNameList, (UserRef) visit(context.user()), createPos(context));
     }
 
     @Override
@@ -6616,7 +6616,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             roleNameList.add(((Identifier) visit(oneContext)).getValue());
         }
 
-        return new RevokeRoleStmt(roleNameList, (UserIdentity) visit(context.user()), createPos(context));
+        return new RevokeRoleStmt(roleNameList, (UserRef) visit(context.user()), createPos(context));
     }
 
     @Override
@@ -6672,7 +6672,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             setRoleType = SetRoleType.ROLE;
         }
 
-        return new SetDefaultRoleStmt((UserIdentity) visit(context.user()), setRoleType, roles, createPos(context));
+        return new SetDefaultRoleStmt((UserRef) visit(context.user()), setRoleType, roles, createPos(context));
     }
 
     @Override
@@ -6682,7 +6682,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             Identifier role = (Identifier) visit(context.identifierOrString());
             return new ShowGrantsStmt(role.getValue(), GrantType.ROLE, pos);
         } else {
-            UserIdentity userId = context.user() == null ? null : (UserIdentity) visit(context.user());
+            UserRef userId = context.user() == null ? null : (UserRef) visit(context.user());
             return new ShowGrantsStmt(userId, pos);
         }
     }
@@ -6708,7 +6708,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     public ParseNode visitGrantRevokeClause(StarRocksParser.GrantRevokeClauseContext context) {
         NodePosition pos = createPos(context);
         if (context.user() != null) {
-            UserIdentity user = (UserIdentity) visit(context.user());
+            UserRef user = (UserRef) visit(context.user());
             return new GrantRevokeClause(user, null, pos);
         } else {
             String roleName = ((Identifier) visit(context.identifierOrString())).getValue();
@@ -6720,8 +6720,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     public ParseNode visitGrantOnUser(StarRocksParser.GrantOnUserContext context) {
         List<String> privList = Collections.singletonList("IMPERSONATE");
         GrantRevokeClause clause = (GrantRevokeClause) visit(context.grantRevokeClause());
-        List<UserIdentity> users = context.user().stream()
-                .map(user -> (UserIdentity) visit(user)).collect(toList());
+        List<UserRef> users = context.user().stream()
+                .map(user -> (UserRef) visit(user)).collect(toList());
         GrantRevokePrivilegeObjects objects = new GrantRevokePrivilegeObjects();
         objects.setUserPrivilegeObjectList(users);
         return new GrantPrivilegeStmt(privList, "USER", clause, objects,
@@ -6732,8 +6732,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     public ParseNode visitRevokeOnUser(StarRocksParser.RevokeOnUserContext context) {
         List<String> privList = Collections.singletonList("IMPERSONATE");
         GrantRevokeClause clause = (GrantRevokeClause) visit(context.grantRevokeClause());
-        List<UserIdentity> users = context.user().stream()
-                .map(user -> (UserIdentity) visit(user)).collect(toList());
+        List<UserRef> users = context.user().stream()
+                .map(user -> (UserRef) visit(user)).collect(toList());
         GrantRevokePrivilegeObjects objects = new GrantRevokePrivilegeObjects();
         objects.setUserPrivilegeObjectList(users);
         return new RevokePrivilegeStmt(privList, "USER", clause, objects, createPos(context));
@@ -8631,20 +8631,20 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     public ParseNode visitUserWithHostAndBlanket(StarRocksParser.UserWithHostAndBlanketContext context) {
         Identifier user = (Identifier) visit(context.identifierOrString(0));
         Identifier host = (Identifier) visit(context.identifierOrString(1));
-        return new UserIdentity(user.getValue(), host.getValue(), true, false, createPos(context));
+        return new UserRef(user.getValue(), host.getValue(), true, createPos(context));
     }
 
     @Override
     public ParseNode visitUserWithHost(StarRocksParser.UserWithHostContext context) {
         Identifier user = (Identifier) visit(context.identifierOrString(0));
         Identifier host = (Identifier) visit(context.identifierOrString(1));
-        return new UserIdentity(user.getValue(), host.getValue(), false, false, createPos(context));
+        return new UserRef(user.getValue(), host.getValue(), false, createPos(context));
     }
 
     @Override
     public ParseNode visitUserWithoutHost(StarRocksParser.UserWithoutHostContext context) {
         Identifier user = (Identifier) visit(context.identifierOrString());
-        return new UserIdentity(user.getValue(), "%", false, false, createPos(context));
+        return new UserRef(user.getValue(), "%", false, createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterUserStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterUserStmtTest.java
@@ -63,7 +63,7 @@ public class AlterUserStmtTest {
 
         sql = "ALTER USER 'user' IDENTIFIED BY PASSWORD '*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0'";
         stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assertions.assertEquals("user", stmt.getUserIdentity().getUser());
+        Assertions.assertEquals("user", stmt.getUser().getUser());
         Assertions.assertEquals("ALTER USER 'user'@'%' IDENTIFIED BY PASSWORD '*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0'",
                 AstToSQLBuilder.toSQL(stmt));
         Assertions.assertEquals(new String(stmt.getAuthenticationInfo().getPassword(), StandardCharsets.UTF_8),

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateUserStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateUserStmtTest.java
@@ -73,7 +73,7 @@ public class CreateUserStmtTest {
 
         sql = "CREATE USER 'user' IDENTIFIED BY PASSWORD '*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0'";
         stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assertions.assertEquals("user", stmt.getUserIdentity().getUser());
+        Assertions.assertEquals("user", stmt.getUser().getUser());
         Assertions.assertEquals(
                 "CREATE USER 'user'@'%' IDENTIFIED BY PASSWORD '*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0'",
                 AstToSQLBuilder.toSQL(stmt));

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetPassVarTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetPassVarTest.java
@@ -53,6 +53,7 @@ import com.starrocks.sql.ast.SetPassVar;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SystemVariable;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.ast.UserAuthOption;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.parser.SqlParser;
@@ -99,17 +100,17 @@ public class SetPassVarTest {
         //  mode: SET PASSWORD FOR 'testUser' = 'testPass';
         UserAuthOption userAuthOption =
                 new UserAuthOption(null, "*88EEBA7D913688E7278E2AD071FDB5E76D76D34B", false, NodePosition.ZERO);
-        stmt = new SetPassVar(new UserIdentity("test", "%"), userAuthOption, NodePosition.ZERO);
+        stmt = new SetPassVar(new UserRef("test", "%"), userAuthOption, NodePosition.ZERO);
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(stmt)), null);
-        Assertions.assertEquals("test", stmt.getUserIdent().getUser());
+        Assertions.assertEquals("test", stmt.getUser().getUser());
         Assertions.assertEquals("*88EEBA7D913688E7278E2AD071FDB5E76D76D34B", stmt.getAuthOption().getAuthString());
-        Assertions.assertEquals("'test'@'%'", stmt.getUserIdent().toString());
+        Assertions.assertEquals("'test'@'%'", stmt.getUser().toString());
 
         // empty user
         ctxToRoot();
         stmt = new SetPassVar(null, userAuthOption, NodePosition.ZERO);
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(stmt)), ctx);
-        Assertions.assertEquals("'root'@'%'", stmt.getUserIdent().toString());
+        Assertions.assertEquals("'root'@'%'", stmt.getUser().toString());
     }
 
     @Test
@@ -118,7 +119,7 @@ public class SetPassVarTest {
         SetStmt setStmt = (SetStmt) SqlParser.parse(sql, ctx.getSessionVariable()).get(0);
         Analyzer.analyze(setStmt, ctx);
         SetPassVar setPassVar = (SetPassVar) setStmt.getSetListItems().get(0);
-        Assertions.assertEquals("test", setPassVar.getUserIdent().getUser());
+        Assertions.assertEquals("test", setPassVar.getUser().getUser());
 
         sql = "SET PASSWORD = PASSWORD('testPass')";
         setStmt = (SetStmt) SqlParser.parse(sql, ctx.getSessionVariable()).get(0);
@@ -191,7 +192,7 @@ public class SetPassVarTest {
             //  mode: SET PASSWORD FOR 'testUser' = 'testPass';
             UserAuthOption userAuthOption =
                     new UserAuthOption(null, "*88EEBAHD913688E7278E2AD071FDB5E76D76D34B", false, NodePosition.ZERO);
-            stmt = new SetPassVar(new UserIdentity("test", "%"), userAuthOption, NodePosition.ZERO);
+            stmt = new SetPassVar(new UserRef("test", "%"), userAuthOption, NodePosition.ZERO);
             SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(stmt)), null);
             Assertions.fail("No exception throws.");
         });
@@ -215,7 +216,8 @@ public class SetPassVarTest {
         AuthenticationMgr authenticationManager =
                 starRocksAssert.getCtx().getGlobalStateMgr().getAuthenticationMgr();
         authenticationManager.createUser(createUserStmt);
-        return createUserStmt.getUserIdentity();
+        UserRef user = createUserStmt.getUser();
+        return new UserIdentity(user.getUser(), user.getHost());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationManagerTest.java
@@ -502,7 +502,8 @@ public class AuthenticationManagerTest {
         // 3. alter user
         sql = "alter user test identified by 'abc'";
         AlterUserStmt alterUserStmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        masterManager.alterUser(alterUserStmt.getUserIdentity(), alterUserStmt.getAuthenticationInfo(), null);
+        UserIdentity userIdentity = new UserIdentity(alterUserStmt.getUser().getUser(), alterUserStmt.getUser().getHost());
+        masterManager.alterUser(userIdentity, alterUserStmt.getAuthenticationInfo(), null);
         Assertions.assertEquals(testUser, AuthenticationHandler.authenticate(ctx,
                 testUser.getUser(), "10.1.1.1", scramble));
 

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/OpenIdConnectAuthenticationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/OpenIdConnectAuthenticationTest.java
@@ -21,6 +21,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.UserAuthOptionAnalyzer;
 import com.starrocks.sql.ast.UserAuthOption;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.parser.NodePosition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,7 @@ public class OpenIdConnectAuthenticationTest {
 
         JWTAuthenticationProvider provider =
                 new JWTAuthenticationProvider("jwks.json", "preferred_username", emptyIssuer, emptyAudience);
-        UserAuthOptionAnalyzer.analyzeAuthOption(new UserIdentity("harbor", "%"),
+        UserAuthOptionAnalyzer.analyzeAuthOption(new UserRef("harbor", "%"),
                 new UserAuthOption(null, "", true, NodePosition.ZERO));
         String openIdConnectJson = mockTokenUtils.generateTestOIDCToken(3600 * 1000);
 

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/AuthorizationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/AuthorizationMgrTest.java
@@ -57,6 +57,7 @@ import com.starrocks.sql.ast.ShowDbStmt;
 import com.starrocks.sql.ast.ShowGrantsStmt;
 import com.starrocks.sql.ast.ShowTableStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
@@ -902,7 +903,10 @@ public class AuthorizationMgrTest {
         CreateUserStmt createUserStmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(
                 "create user test_role_user", ctx);
         ctx.getGlobalStateMgr().getAuthenticationMgr().createUser(createUserStmt);
-        UserIdentity testUser = createUserStmt.getUserIdentity();
+
+        UserRef user = createUserStmt.getUser();
+        UserIdentity testUser = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+
         AuthorizationMgr manager = ctx.getGlobalStateMgr().getAuthorizationMgr();
         setCurrentUserAndRoles(ctx, UserIdentity.ROOT);
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RBACExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RBACExecutorTest.java
@@ -42,6 +42,7 @@ import com.starrocks.sql.ast.ShowGrantsStmt;
 import com.starrocks.sql.ast.ShowRolesStmt;
 import com.starrocks.sql.ast.ShowUserStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.thrift.TFunctionBinaryType;
 import com.starrocks.utframe.StarRocksAssert;
@@ -99,7 +100,7 @@ public class RBACExecutorTest {
         GrantPrivilegeStmt grantPrivilegeStmt = (GrantPrivilegeStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         DDLStmtExecutor.execute(grantPrivilegeStmt, ctx);
 
-        ShowGrantsStmt stmt = new ShowGrantsStmt(new UserIdentity("u1", "%"), NodePosition.ZERO);
+        ShowGrantsStmt stmt = new ShowGrantsStmt(new UserRef("u1", "%"), NodePosition.ZERO);
 
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
         Assertions.assertEquals("[['u1'@'%', default_catalog, GRANT USAGE, CREATE DATABASE, DROP, ALTER " +

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
@@ -21,7 +21,6 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TaskName;
 import com.starrocks.analysis.TypeDef;
 import com.starrocks.catalog.PrimitiveType;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.sql.ast.AddBackendBlackListStmt;
 import com.starrocks.sql.ast.AddComputeNodeBlackListStmt;
 import com.starrocks.sql.ast.AddSqlBlackListStmt;
@@ -235,6 +234,7 @@ import com.starrocks.sql.ast.UpdateFailPointStatusStatement;
 import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.ast.UseCatalogStmt;
 import com.starrocks.sql.ast.UseDbStmt;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.ast.feedback.AddPlanAdvisorStmt;
 import com.starrocks.sql.ast.feedback.ClearPlanAdvisorStmt;
@@ -1012,8 +1012,8 @@ public class RedirectStatusTest {
 
     @Test
     public void testRevokePrivilegeStmt() {
-        RevokePrivilegeStmt stmt = new RevokePrivilegeStmt(null, null, new GrantRevokeClause(new UserIdentity("", ""), ""),
-                null, null);
+        RevokePrivilegeStmt stmt =
+                new RevokePrivilegeStmt(null, null, new GrantRevokeClause(new UserRef("", ""), ""), null, null);
         Assertions.assertEquals(RedirectStatus.FORWARD_WITH_SYNC, RedirectStatus.getRedirectStatus(stmt));
     }
 
@@ -1606,8 +1606,8 @@ public class RedirectStatusTest {
 
     @Test
     public void testGrantPrivilegeStmt() {
-        GrantPrivilegeStmt stmt = new GrantPrivilegeStmt(null, null, new GrantRevokeClause(new UserIdentity("", ""), ""), null,
-                false);
+        GrantPrivilegeStmt stmt =
+                new GrantPrivilegeStmt(null, null, new GrantRevokeClause(new UserRef("", ""), ""), null, false);
         Assertions.assertEquals(RedirectStatus.FORWARD_WITH_SYNC, RedirectStatus.getRedirectStatus(stmt));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SetExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SetExecutorTest.java
@@ -41,6 +41,7 @@ import com.starrocks.sql.ast.SetPassVar;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.UserAuthOption;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.ast.UserVariable;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.thrift.TExplainLevel;
@@ -70,7 +71,8 @@ public class SetExecutorTest {
         AuthenticationMgr authenticationManager =
                 starRocksAssert.getCtx().getGlobalStateMgr().getAuthenticationMgr();
         authenticationManager.createUser(createUserStmt);
-        testUser = createUserStmt.getUserIdentity();
+        UserRef user = createUserStmt.getUser();
+        testUser = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
     }
 
     private static void ctxToTestUser() {
@@ -87,7 +89,7 @@ public class SetExecutorTest {
     public void testNormal() throws StarRocksException {
         List<SetListItem> vars = Lists.newArrayList();
 
-        new SetPassVar(new UserIdentity("testUser", "%"),
+        new SetPassVar(new UserRef("testUser", "%"),
                 new UserAuthOption(null, "*88EEBA7D913688E7278E2AD071FDB5E76D76D34B", false, NodePosition.ZERO),
                 NodePosition.ZERO);
         vars.add(new SetNamesVar("utf8"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
@@ -131,12 +131,12 @@ public class AnalyzeShowTest {
         String sql = "SHOW AUTHENTICATION;";
         ShowAuthenticationStmt stmt = (ShowAuthenticationStmt) analyzeSuccess(sql);
         Assertions.assertFalse(stmt.isAll());
-        Assertions.assertEquals("root", stmt.getUserIdent().getUser());
+        Assertions.assertEquals("root", stmt.getUser().getUser());
 
         sql = "SHOW ALL AUTHENTICATION;";
         stmt = (ShowAuthenticationStmt) analyzeSuccess(sql);
         Assertions.assertTrue(stmt.isAll());
-        Assertions.assertNull(stmt.getUserIdent());
+        Assertions.assertNull(stmt.getUser());
 
         sql = "SHOW AUTHENTICATION FOR xx";
         analyzeFail(sql, "cannot find user 'xx'@'%'!");
@@ -149,7 +149,7 @@ public class AnalyzeShowTest {
         sql = "SHOW AUTHENTICATION FOR u1";
         stmt = (ShowAuthenticationStmt) analyzeSuccess(sql);
         Assertions.assertFalse(stmt.isAll());
-        Assertions.assertEquals("u1", stmt.getUserIdent().getUser());
+        Assertions.assertEquals("u1", stmt.getUser().getUser());
 
         DropUserStmt dropUserStmt = (DropUserStmt) UtFrameUtils.parseStmtWithNewParser(
                 "drop user u1", context);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExternalDbTablePrivTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExternalDbTablePrivTest.java
@@ -29,6 +29,7 @@ import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.CreateUserStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -45,6 +46,7 @@ import java.util.ArrayList;
 public class ExternalDbTablePrivTest {
     private static StarRocksAssert starRocksAssert;
     private static UserIdentity testUser;
+    private static UserRef user;
 
     private void mockHiveMeta() {
         new MockUp<MetadataMgr>() {
@@ -138,7 +140,9 @@ public class ExternalDbTablePrivTest {
         AuthenticationMgr authenticationManager =
                 starRocksAssert.getCtx().getGlobalStateMgr().getAuthenticationMgr();
         authenticationManager.createUser(createUserStmt);
-        testUser = createUserStmt.getUserIdentity();
+
+        user = createUserStmt.getUser();
+        testUser = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
     }
 
     @BeforeEach


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request refactors the handling of user identity throughout the authentication and authorization codebase. The main change is to consistently use the `User` class (which contains username, host, and domain information) as the primary input for user-related operations, rather than passing around a `UserIdentity` directly. This improves clarity and maintainability, and ensures a single source of truth for user attributes.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
