### PR TITLE
[Enhancement] create string column zonemap with prefix truncation

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -323,6 +323,11 @@ CONF_mBool(enable_zonemap_index_memory_page_cache, "true");
 // whether to enable the ordinal index memory cache
 CONF_mBool(enable_ordinal_index_memory_page_cache, "true");
 
+// Enable ZoneMap for string (CHAR/VARCHAR) columns using prefix-based min/max
+CONF_mBool(enable_string_prefix_zonemap, "true");
+// Prefix length used for string ZoneMap min/max when enabled
+CONF_mInt32(string_prefix_zonemap_prefix_len, "16");
+
 CONF_mInt32(base_compaction_check_interval_seconds, "60");
 CONF_mInt64(min_base_compaction_num_singleton_deltas, "5");
 CONF_mInt64(max_base_compaction_num_singleton_deltas, "100");

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -394,6 +394,9 @@ Status ScalarColumnWriter::init() {
     if (_opts.need_zone_map) {
         _has_index_builder = true;
         _zone_map_index_builder = ZoneMapIndexWriter::create(type_info());
+        if (_opts.zone_map_truncate_string) {
+            _zone_map_index_builder->enable_truncate_string();
+        }
     }
     if (_opts.need_bitmap_index) {
         _has_index_builder = true;

--- a/be/src/storage/rowset/column_writer.h
+++ b/be/src/storage/rowset/column_writer.h
@@ -73,6 +73,7 @@ struct ColumnWriterOptions {
     // space saving = 1 - compressed_size / uncompressed_size
     double compression_min_space_saving = 0.1;
     bool need_zone_map = false;
+    bool zone_map_truncate_string = false; // truncate string at write time to reduce comparison/metadata overhead.
     bool need_bitmap_index = false;
     bool need_bloom_filter = false;
     bool need_vector_index = false;

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -195,6 +195,7 @@ Status FlatJsonColumnWriter::_init_flat_writers() {
         opts.need_flat = false;
         opts.need_zone_map = config::json_flat_create_zonemap && is_zone_map_key_type(_flat_types[i]);
         opts.need_zone_map |= config::enable_string_prefix_zonemap && is_string_type(_flat_types[i]);
+        opts.zone_map_truncate_string = config::enable_string_prefix_zonemap && is_string_type(_flat_types[i]);
 
         // Set global dict for sub-columns that support it
         if (is_string_type(_flat_types[i])) {

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -194,6 +194,7 @@ Status FlatJsonColumnWriter::_init_flat_writers() {
         opts.meta->set_name(_flat_paths[i]);
         opts.need_flat = false;
         opts.need_zone_map = config::json_flat_create_zonemap && is_zone_map_key_type(_flat_types[i]);
+        opts.need_zone_map |= config::enable_string_prefix_zonemap && is_string_type(_flat_types[i]);
 
         // Set global dict for sub-columns that support it
         if (is_string_type(_flat_types[i])) {

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -169,8 +169,10 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
         const bool enable_dup_zone_map =
                 _tablet_schema->keys_type() == KeysType::DUP_KEYS && is_zone_map_key_type(column.type());
         opts.need_zone_map = column.is_key() || enable_pk_zone_map || enable_dup_zone_map || column.is_sort_key();
-        // Create prefix zonemap for string type
+        // Create prefix zonemap for string type, but only truncate it for non-key columns
         opts.need_zone_map |= config::enable_string_prefix_zonemap && is_string_type(column.type());
+        opts.zone_map_truncate_string =
+                config::enable_string_prefix_zonemap && is_string_type(column.type()) && !column.is_key();
         if (column.type() == LogicalType::TYPE_ARRAY) {
             opts.need_zone_map = false;
         }

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -169,6 +169,10 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
         const bool enable_dup_zone_map =
                 _tablet_schema->keys_type() == KeysType::DUP_KEYS && is_zone_map_key_type(column.type());
         opts.need_zone_map = column.is_key() || enable_pk_zone_map || enable_dup_zone_map || column.is_sort_key();
+        if (config::enable_string_prefix_zonemap &&
+            (column.type() == LogicalType::TYPE_CHAR || column.type() == LogicalType::TYPE_VARCHAR)) {
+            opts.need_zone_map = true;
+        }
         if (column.type() == LogicalType::TYPE_ARRAY) {
             opts.need_zone_map = false;
         }

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -170,9 +170,7 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
                 _tablet_schema->keys_type() == KeysType::DUP_KEYS && is_zone_map_key_type(column.type());
         opts.need_zone_map = column.is_key() || enable_pk_zone_map || enable_dup_zone_map || column.is_sort_key();
         // Create prefix zonemap for string type
-        if (!opts.need_zone_map && config::enable_string_prefix_zonemap && is_string_type(column.type())) {
-            opts.need_zone_map = true;
-        }
+        opts.need_zone_map |= config::enable_string_prefix_zonemap && is_string_type(column.type());
         if (column.type() == LogicalType::TYPE_ARRAY) {
             opts.need_zone_map = false;
         }

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -169,8 +169,8 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
         const bool enable_dup_zone_map =
                 _tablet_schema->keys_type() == KeysType::DUP_KEYS && is_zone_map_key_type(column.type());
         opts.need_zone_map = column.is_key() || enable_pk_zone_map || enable_dup_zone_map || column.is_sort_key();
-        if (config::enable_string_prefix_zonemap &&
-            (column.type() == LogicalType::TYPE_CHAR || column.type() == LogicalType::TYPE_VARCHAR)) {
+        // Create prefix zonemap for string type
+        if (!opts.need_zone_map && config::enable_string_prefix_zonemap && is_string_type(column.type())) {
             opts.need_zone_map = true;
         }
         if (column.type() == LogicalType::TYPE_ARRAY) {

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -52,29 +52,6 @@
 
 namespace starrocks {
 
-// Truncate string min/max values at write time to reduce comparison/metadata overhead.
-// For max values that are truncated, append 0xFF to preserve an upper bound.
-template <LogicalType LT>
-static inline void _truncate_string_minmax_if_needed(ZoneMap<LT>* zm) {
-    if (!config::enable_string_prefix_zonemap) return;
-    const size_t kPrefixLen = std::max<int32_t>(0, config::string_prefix_zonemap_prefix_len);
-    if constexpr (LT == TYPE_CHAR || LT == TYPE_VARCHAR) {
-        auto& min_slice = zm->min_value.value;
-        auto& max_slice = zm->max_value.value;
-        if (min_slice.size > kPrefixLen) {
-            min_slice.size = kPrefixLen;
-        }
-        if (max_slice.size > kPrefixLen) {
-            // Safe, original buffer has length > kPrefixLen
-            // Ensure buffer has room for 0xFF; if exactly kPrefixLen length, keep as is.
-            if (max_slice.size > kPrefixLen) {
-                max_slice.data[kPrefixLen] = static_cast<char>(0xFF);
-                max_slice.size = kPrefixLen + 1;
-            }
-        }
-    }
-}
-
 template <LogicalType type>
 struct ZoneMapDatumBase {
     using CppType = typename TypeTraits<type>::CppType;
@@ -227,6 +204,25 @@ template <LogicalType type>
 ZoneMapIndexWriterImpl<type>::ZoneMapIndexWriterImpl(TypeInfo* type_info) : _type_info(type_info) {
     _reset_zone_map(&_page_zone_map);
     _reset_zone_map(&_segment_zone_map);
+}
+
+// Truncate string min/max values at write time to reduce comparison/metadata overhead.
+// For max values that are truncated, append 0xFF to preserve an upper bound.
+template <LogicalType LT>
+static inline void _truncate_string_minmax_if_needed(ZoneMap<LT>* zm) {
+    const size_t kPrefixLen = std::max<int32_t>(8, config::string_prefix_zonemap_prefix_len);
+    if constexpr (LT == TYPE_CHAR || LT == TYPE_VARCHAR) {
+        auto& min_slice = zm->min_value.value;
+        auto& max_slice = zm->max_value.value;
+        if (min_slice.size > kPrefixLen) {
+            min_slice.size = kPrefixLen;
+        }
+        if (max_slice.size > kPrefixLen) {
+            // Safe, original buffer has length > kPrefixLen, ensure buffer has room for 0xFF
+            max_slice.data[kPrefixLen] = static_cast<char>(0xFF);
+            max_slice.size = kPrefixLen + 1;
+        }
+    }
 }
 
 template <LogicalType type>

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -51,6 +51,19 @@
 
 namespace starrocks {
 
+// Limit the serialized string length of ZoneMap's min/max to avoid excessive metadata.
+// If max is truncated, append 0xFF to make sure it is still an upper bound.
+static inline std::string _zonemap_truncate_and_pad(const std::string& input, size_t prefix_len, bool is_max_side) {
+    if (prefix_len == 0 || input.size() <= prefix_len) {
+        return input;
+    }
+    std::string out = input.substr(0, prefix_len);
+    if (is_max_side) {
+        out.push_back(static_cast<char>(0xFF));
+    }
+    return out;
+}
+
 template <LogicalType type>
 struct ZoneMapDatumBase {
     using CppType = typename TypeTraits<type>::CppType;
@@ -153,8 +166,27 @@ struct ZoneMap {
     bool has_not_null = false;
 
     void to_proto(ZoneMapPB* dst, TypeInfo* type_info) const {
-        dst->set_min(min_value.to_zone_map_string(type_info));
-        dst->set_max(max_value.to_zone_map_string(type_info));
+        // For string-like types, serialize only a fixed-length prefix to reduce memory footprint.
+        // Truncate both min and max to kPrefixLen; if max is truncated, append 0xFF for safety.
+        constexpr size_t kPrefixLen = 64;
+        const auto lt = delegate_type(type_info->type());
+        if (is_string_type(lt)) {
+            std::string min_str = min_value.to_zone_map_string(type_info);
+            std::string max_str = max_value.to_zone_map_string(type_info);
+            min_str = _zonemap_truncate_and_pad(min_str, kPrefixLen, /*is_max_side=*/false);
+            bool truncated_max = max_str.size() > kPrefixLen;
+            max_str = _zonemap_truncate_and_pad(max_str, kPrefixLen, /*is_max_side=*/true);
+            // If not truncated, keep original to avoid unnecessary 0xFF suffix.
+            if (!truncated_max) {
+                // ensure we didn't add 0xFF when not truncated
+                // (helper only adds when size > kPrefixLen)
+            }
+            dst->set_min(min_str);
+            dst->set_max(max_str);
+        } else {
+            dst->set_min(min_value.to_zone_map_string(type_info));
+            dst->set_max(max_value.to_zone_map_string(type_info));
+        }
         dst->set_has_null(has_null);
         dst->set_has_not_null(has_not_null);
     }

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -211,7 +211,7 @@ ZoneMapIndexWriterImpl<type>::ZoneMapIndexWriterImpl(TypeInfo* type_info) : _typ
 template <LogicalType LT>
 static inline void _truncate_string_minmax_if_needed(ZoneMap<LT>* zm) {
     const size_t kPrefixLen = std::max<int32_t>(8, config::string_prefix_zonemap_prefix_len);
-    if constexpr (LT == TYPE_CHAR || LT == TYPE_VARCHAR) {
+    if constexpr (is_string_type(LT) || is_binary_type(LT)) {
         auto& min_slice = zm->min_value.value;
         auto& max_slice = zm->max_value.value;
         if (min_slice.size > kPrefixLen) {

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -38,6 +38,7 @@
 
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
+#include "common/config.h"
 #include "storage/chunk_helper.h"
 #include "storage/decimal_type_info.h"
 #include "storage/olap_define.h"
@@ -48,7 +49,6 @@
 #include "storage/type_traits.h"
 #include "storage/types.h"
 #include "util/unaligned_access.h"
-#include "common/config.h"
 
 namespace starrocks {
 

--- a/be/src/storage/rowset/zone_map_index.h
+++ b/be/src/storage/rowset/zone_map_index.h
@@ -62,6 +62,8 @@ public:
 
     virtual ~ZoneMapIndexWriter() = default;
 
+    virtual void enable_truncate_string() = 0;
+
     virtual void add_values(const void* values, size_t count) = 0;
 
     virtual void add_nulls(uint32_t count) = 0;

--- a/be/src/types/logical_type.h
+++ b/be/src/types/logical_type.h
@@ -143,14 +143,8 @@ inline bool is_decimalv3_field_type(LogicalType type) {
 LogicalType string_to_logical_type(const std::string& type_str);
 const char* logical_type_to_string(LogicalType type);
 
-inline bool is_binary_type(LogicalType type) {
-    switch (type) {
-    case TYPE_BINARY:
-    case TYPE_VARBINARY:
-        return true;
-    default:
-        return false;
-    }
+constexpr bool is_binary_type(LogicalType type) {
+    return type == TYPE_BINARY || type == TYPE_VARBINARY;
 }
 
 inline bool is_scalar_field_type(LogicalType type) {

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -464,4 +464,62 @@ TEST_F(ColumnZoneMapTest, VarbinaryWithBinaryData) {
                  true, true);
 }
 
+TEST_F(ColumnZoneMapTest, StringPrefixZonemapVariants) {
+    // Enable string prefix zonemap for this test context
+    bool old_switch = config::enable_string_prefix_zonemap;
+    int old_len = config::string_prefix_zonemap_prefix_len;
+    config::enable_string_prefix_zonemap = true;
+    config::string_prefix_zonemap_prefix_len = 16;
+
+    // Build a segment with various string lengths and patterns
+    std::string filename = kTestDir + "/StringPrefixZonemapVariants";
+
+    TabletColumn varchar_column = create_varchar_key(0);
+    TypeInfoPtr type_info = get_type_info(varchar_column);
+
+    auto writer = ZoneMapIndexWriter::create(type_info.get());
+
+    // Short strings
+    std::vector<Slice> shorts = {{"a", 1}, {"b", 1}, {"c", 1}};
+    writer->add_values(shorts.data(), shorts.size());
+    writer->flush();
+
+    // Common prefix strings
+    std::vector<std::string> cp = {"prefix_0001", "prefix_0002", "prefix_9999"};
+    std::vector<Slice> cp_slices;
+    for (auto& s : cp) cp_slices.push_back({s.data(), s.size()});
+    writer->add_values(cp_slices.data(), cp_slices.size());
+    writer->flush();
+
+    // Random long strings (> 64 to ensure truncation even if config changes)
+    std::string long1(80, 'X');
+    std::string long2(120, 'Y');
+    std::vector<Slice> longs = {{long1.data(), long1.size()}, {long2.data(), long2.size()}};
+    writer->add_values(longs.data(), longs.size());
+    writer->flush();
+
+    // Write index out
+    ColumnIndexMetaPB index_meta;
+    write_file(*writer, index_meta, filename);
+
+    // Read back
+    ZoneMapIndexReader reader;
+    load_zone_map(reader, index_meta, filename);
+
+    ASSERT_EQ(3, reader.num_pages());
+    const auto& zone_maps = reader.page_zone_maps();
+    size_t pfx = (size_t)config::string_prefix_zonemap_prefix_len;
+
+    // Page 0: shorts
+    check_result_prefix(zone_maps[0], true, true, "a", "c", false, true, pfx);
+    // Page 1: common prefix
+    check_result_prefix(zone_maps[1], true, true, cp.front(), cp.back(), false, true, pfx);
+    // Page 2: long strings
+    check_result_prefix(zone_maps[2], true, true, long1, long2, false, true, pfx);
+
+    // Restore config
+    config::enable_string_prefix_zonemap = old_switch;
+    config::string_prefix_zonemap_prefix_len = old_len;
+}
+
 } // namespace starrocks

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -128,7 +128,6 @@ protected:
         }
         if (has_max) {
             auto zmax = zone_map.max();
-            // Allow writer to append 0xFF when original was truncated
             if (max.size() > prefix_len) {
                 std::string expect = max.substr(0, prefix_len);
                 std::string allow = expect;

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -43,6 +43,7 @@
 #include "fs/fs_memory.h"
 #include "storage/tablet_schema_helper.h"
 #include "testutil/assert.h"
+#include "common/config.h"
 
 namespace starrocks {
 
@@ -100,11 +101,12 @@ protected:
         ASSERT_EQ(3, column_zone_map.num_pages());
         const std::vector<ZoneMapPB>& zone_maps = column_zone_map.page_zone_maps();
         ASSERT_EQ(3, zone_maps.size());
-        check_result_prefix(zone_maps[0], true, true, "aaaa", "ffff", false, true);
+        size_t pfx = config::enable_string_prefix_zonemap ? (size_t)config::string_prefix_zonemap_prefix_len : 64;
+        check_result_prefix(zone_maps[0], true, true, "aaaa", "ffff", false, true, pfx);
         ASSERT_EQ(false, zone_maps[0].has_null());
         ASSERT_EQ(true, zone_maps[0].has_not_null());
 
-        check_result_prefix(zone_maps[1], true, true, "aaaaa", "fffff", true, true);
+        check_result_prefix(zone_maps[1], true, true, "aaaaa", "fffff", true, true, pfx);
         ASSERT_EQ(true, zone_maps[1].has_null());
         ASSERT_EQ(true, zone_maps[1].has_not_null());
 
@@ -290,12 +292,13 @@ TEST_F(ColumnZoneMapTest, StringResize) {
     const auto& zone_maps = reader.page_zone_maps();
     ASSERT_EQ(2, zone_maps.size());
 
-    check_result_prefix(zone_maps[0], true, true, str1, str2, false, true);
-    check_result_prefix(zone_maps[1], true, true, str3, str4, false, true);
+    size_t pfx = config::enable_string_prefix_zonemap ? (size_t)config::string_prefix_zonemap_prefix_len : 64;
+    check_result_prefix(zone_maps[0], true, true, str1, str2, false, true, pfx);
+    check_result_prefix(zone_maps[1], true, true, str3, str4, false, true, pfx);
 
     // segment zonemap
     const auto& segment_zonemap = index_meta.zone_map_index().segment_zone_map();
-    check_result_prefix(segment_zonemap, true, true, str1, str4, false, true);
+    check_result_prefix(segment_zonemap, true, true, str1, str4, false, true, pfx);
 }
 
 TEST_F(ColumnZoneMapTest, AllNullPage) {

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -40,10 +40,10 @@
 #include <string>
 
 #include "cache/object_cache/page_cache.h"
+#include "common/config.h"
 #include "fs/fs_memory.h"
 #include "storage/tablet_schema_helper.h"
 #include "testutil/assert.h"
-#include "common/config.h"
 
 namespace starrocks {
 
@@ -125,19 +125,12 @@ protected:
         ASSERT_EQ(has_min, zone_map.has_min());
         ASSERT_EQ(has_max, zone_map.has_max());
         if (has_min) {
-            auto zmin = zone_map.min();
+            const auto& zmin = zone_map.min();
             ASSERT_TRUE(min.rfind(zmin, 0) == 0 || zmin == min.substr(0, std::min(prefix_len, min.size())));
+            ASSERT_TRUE(zmin <= min);
         }
         if (has_max) {
-            auto zmax = zone_map.max();
-            if (max.size() > prefix_len) {
-                std::string expect = max.substr(0, prefix_len);
-                std::string allow = expect;
-                allow.push_back(static_cast<char>(0xFF));
-                ASSERT_TRUE(zmax == expect || zmax == allow);
-            } else {
-                ASSERT_EQ(max, zmax);
-            }
+            ASSERT_TRUE(zone_map.max() >= max);
         }
         ASSERT_EQ(has_null, zone_map.has_null());
         ASSERT_EQ(has_not_null, zone_map.has_not_null());


### PR DESCRIPTION
## Why I'm doing:

To optimize the storage footprint of ZoneMap metadata for string columns by reducing the serialized size of min/max values, addressing issue #61967.

## What I'm doing:

-   Implemented prefix truncation (to 16 bytes) for string min/max values during ZoneMap serialization.
-   For truncated max values, a `0xFF` byte is appended to ensure the value remains a valid upper bound for pruning.
-   Updated existing string ZoneMap tests to reflect and validate the new prefix truncation and padding behavior.

Fixes #61967

## What type of PR is this:

-   [ ] BugFix
-   [ ] Feature
-   [x] Enhancement
-   [ ] Refactor
-   [ ] UT
-   [ ] Doc
-   [ ] Tool

Does this PR entail a change in behavior?

-   [ ] Yes, this PR will result in a change in behavior.
-   [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

-   [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
-   [ ] Parameter changes: default values, similar parameters but with different default values
-   [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
-   [ ] Feature removed
-   [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

-   [x] I have added test cases for my bug fix or my new feature
-   [ ] This pr needs user documentation (for new or modified features or behaviors)
    -   [ ] I have added documentation for my new feature or new function
-   [ ] This is a backport pr

## Bugfix cherry-pick branch check:
-   [x] I have checked the version labels which the pr will be auto-backported to the target branch
    -   [x] 4.0
    -   [ ] 3.5
    -   [ ] 3.4
    -   [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-eeef66af-38ad-4c18-8f36-afad98e4b775">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eeef66af-38ad-4c18-8f36-afad98e4b775">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

