### PR TITLE
[BugFix] Fix create mv with case-when incompatible varchar type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1474,6 +1474,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "The interval of create partition batch, to avoid too frequent")
     public static long mv_create_partition_batch_interval_ms = 1000;
 
+    @ConfField(mutable = true, comment = "Whether to prefer string type for fixed length varchar column " +
+            "in materialized view creation/ctas")
+    public static boolean transform_type_prefer_string_for_varchar = false;
+
     /**
      * The number of query retries.
      * A query may retry if we encounter RPC exception and no result has been sent to user.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1254,11 +1254,16 @@ public class AnalyzerUtils {
                     PrimitiveType.CHAR == srcType.getPrimitiveType() ||
                     PrimitiveType.NULL_TYPE == srcType.getPrimitiveType()) {
                 int len = ScalarType.getOlapMaxVarcharLength();
-                if (!Config.transform_type_prefer_string_for_varchar && srcType instanceof ScalarType) {
+                if (srcType instanceof ScalarType) {
                     ScalarType scalarType = (ScalarType) srcType;
-                    if (scalarType.getLength() > 0) {
-                        // Catalog's varchar length may larger than olap's max varchar length
-                        len = Integer.min(scalarType.getLength(), ScalarType.getOlapMaxVarcharLength());
+                    if (Config.transform_type_prefer_string_for_varchar) {
+                        // always use max varchar length for varchar type if transform_type_prefer_string_for_varchar is set.
+                        len = ScalarType.getOlapMaxVarcharLength();
+                    } else {
+                        if (scalarType.getLength() > 0) {
+                            // Catalog's varchar length may larger than olap's max varchar length
+                            len = Integer.min(scalarType.getLength(), ScalarType.getOlapMaxVarcharLength());
+                        }
                     }
                 }
                 newType = ScalarType.createVarcharType(len);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1254,7 +1254,7 @@ public class AnalyzerUtils {
                     PrimitiveType.CHAR == srcType.getPrimitiveType() ||
                     PrimitiveType.NULL_TYPE == srcType.getPrimitiveType()) {
                 int len = ScalarType.getOlapMaxVarcharLength();
-                if (srcType instanceof ScalarType) {
+                if (!Config.transform_type_prefer_string_for_varchar && srcType instanceof ScalarType) {
                     ScalarType scalarType = (ScalarType) srcType;
                     if (scalarType.getLength() > 0) {
                         // Catalog's varchar length may larger than olap's max varchar length

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -319,9 +319,13 @@ public class TypeManager {
             }
         }
         if (compatibleType.isStringType()) {
-            return isContainVarcharWithoutLength
-                    ? ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength())
-                    : compatibleType;
+            ScalarType resultType = (ScalarType) compatibleType;
+            // If result type is varchar with length, it may cause the case when result type is not compatible.
+            if (isContainVarcharWithoutLength && resultType.getLength() > 0) {
+                return ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
+            } else {
+                return compatibleType;
+            }
         } else {
             return compatibleType;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -765,17 +765,16 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
 
     @Test
     public void testNestedViewWithCTE() throws Exception {
-
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/nested_view_with_cte"),
                         null, TExplainLevel.NORMAL);
-        Assertions.assertTrue(replayPair.second.contains("Project\n" +
-                "  |  <slot 7363> : 7363: count\n" +
-                "  |  limit: 100\n"), replayPair.second);
-        Assertions.assertTrue(replayPair.second.contains("AGGREGATE (merge finalize)\n" +
-                "  |  output: count(7363: count)\n" +
-                "  |  group by: 24: mock_038, 15: mock_003, 108: mock_109, 4: mock_005, 2: mock_110, 2133: case\n" +
-                "  |  limit: 100"), replayPair.second);
+        PlanTestBase.assertContains(replayPair.second, "Project\n" +
+                "  |  <slot 7368> : 7368: count\n" +
+                "  |  limit: 100");
+        PlanTestBase.assertContains(replayPair.second, "AGGREGATE (merge finalize)\n" +
+                "  |  output: count(7368: count)\n" +
+                "  |  group by: 24: mock_038, 15: mock_003, 108: mock_109, 4: mock_005, 2: mock_110, 2134: case\n" +
+                "  |  limit: 100");
     }
 
     @Test

--- a/test/sql/test_materialized_view/R/test_create_mv_with_type_incompatible
+++ b/test/sql/test_materialized_view/R/test_create_mv_with_type_incompatible
@@ -1,0 +1,37 @@
+-- name: test_create_mv_with_type_incompatible
+CREATE TABLE t1 (dt date, val int, col1 char(8), col2 varchar(8)) PARTITION BY date_trunc('day', dt);
+-- result:
+-- !result
+insert into t1 values 
+  ('2023-12-01', 100, 'a', 'b'),
+  ('2023-12-01', 200, 'c', 'd'),
+  ('2023-12-02', 300, 'e', 'f'),
+  ('2023-12-02', 400, 'g', 'h'),
+  ('2023-12-03', 500, 'i', 'j');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL 
+AS SELECT   CASE WHEN (`col1` = 'a') THEN '床前明月光'
+   WHEN (`col1` = 'b') THEN '疑是地上霜' 
+   WHEN (`col1` = 'c') THEN '举头望明月' 
+   WHEN (`col1` = 'd') THEN '低头思故乡' 
+   WHEN (`col1` = 'e') THEN '一二三四五六七八九十' 
+   WHEN (`col1` = 'f') THEN '百千万亿ABCDEFG'
+   ELSE col1 END AS new_col1, 
+   col1, col2, dt from t1;
+-- result:
+-- !result
+refresh materialized view test_mv1 with sync mode;
+select count(*) from test_mv1;
+-- result:
+5
+-- !result
+select * from test_mv1 order by dt, new_col1;
+-- result:
+举头望明月	c	d	2023-12-01
+床前明月光	a	b	2023-12-01
+g	g	h	2023-12-02
+一二三四五六七八九十	e	f	2023-12-02
+i	i	j	2023-12-03
+-- !result

--- a/test/sql/test_materialized_view/T/test_create_mv_with_type_incompatible
+++ b/test/sql/test_materialized_view/T/test_create_mv_with_type_incompatible
@@ -1,0 +1,25 @@
+-- name: test_create_mv_with_type_incompatible
+
+CREATE TABLE t1 (dt date, val int, col1 char(8), col2 varchar(8)) PARTITION BY date_trunc('day', dt);
+
+insert into t1 values 
+  ('2023-12-01', 100, 'a', 'b'),
+  ('2023-12-01', 200, 'c', 'd'),
+  ('2023-12-02', 300, 'e', 'f'),
+  ('2023-12-02', 400, 'g', 'h'),
+  ('2023-12-03', 500, 'i', 'j');
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL 
+AS SELECT   CASE WHEN (`col1` = 'a') THEN '床前明月光'
+   WHEN (`col1` = 'b') THEN '疑是地上霜' 
+   WHEN (`col1` = 'c') THEN '举头望明月' 
+   WHEN (`col1` = 'd') THEN '低头思故乡' 
+   WHEN (`col1` = 'e') THEN '一二三四五六七八九十' 
+   WHEN (`col1` = 'f') THEN '百千万亿ABCDEFG'
+   ELSE col1 END AS new_col1, 
+   col1, col2, dt from t1;
+
+refresh materialized view test_mv1 with sync mode;
+select count(*) from test_mv1;
+select * from test_mv1 order by dt, new_col1;


### PR DESCRIPTION
## Why I'm doing:

After refresh `test_mv1`, `test_mv1`'s result is empty in old version(throw exceptions in main), which is not equal to the result of direct querying.
```
CREATE TABLE t1 (dt date, val int, col1 char(8), col2 varchar(8)) PARTITION BY date_trunc('day', dt);

insert into t1 values 
  ('2023-12-01', 100, 'a', 'b'),
  ('2023-12-01', 200, 'c', 'd'),
  ('2023-12-02', 300, 'e', 'f'),
  ('2023-12-02', 400, 'g', 'h'),
  ('2023-12-03', 500, 'i', 'j');

CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
REFRESH DEFERRED MANUAL 
AS SELECT   CASE WHEN (`col1` = '01') THEN '本县区'
   WHEN (`col1` = '02') THEN '本市其它县区' 
   WHEN (`col1` = '03') THEN '本省其它地市' 
   WHEN (`col1` = '04') THEN '其他省' 
   WHEN (`col1` = '05') THEN '港澳台' 
   WHEN (`col1` = '06') THEN '外籍'
    ELSE cast(`col1` as string)
    END AS new_col1,  col1, col2, dt from t1;
```
This is because `case when`'s deduce type is `varchar(8)` but result's length is greater than 8 bytes:

```
mysql> desc test_mv1;
+----------+------------+------+-------+---------+-------+
| Field    | Type       | Null | Key   | Default | Extra |
+----------+------------+------+-------+---------+-------+
| new_col1 | varchar(8) | YES  | true  | NULL    |       |
| col1     | varchar(8) | YES  | false | NULL    | NONE  |
| col2     | varchar(8) | YES  | false | NULL    | NONE  |
| dt       | date       | YES  | false | NULL    | NONE  |
+----------+------------+------+-------+---------+-------+
4 rows in set (0.00 sec)

```
## What I'm doing:
- Use the max varchar length if case when 's `else` expr contains non fixed length varchar;
- Add `transform_type_prefer_string_for_varchar` config to use `string` rather than `varchar` in creating mv /ctas to avoid other type deduce bugs.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
