### PR TITLE
[BugFix] Handling partition col name with special symbols while savin…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
@@ -109,19 +109,19 @@ public class SlotRef extends Expr {
         this.qualifiedName = QualifiedName.of(qualifiedName.getParts(), qualifiedName.getPos());
         if (parts.size() == 1) {
             this.colName = parts.get(0);
-            this.label = parts.get(0);
+            this.label = "`" + parts.get(0) + "`";
         } else if (parts.size() == 2) {
             this.tblName = new TableName(null, null, parts.get(0), qualifiedName.getPos());
             this.colName = parts.get(1);
-            this.label = parts.get(1);
+            this.label = "`" + parts.get(1) + "`";
         } else if (parts.size() == 3) {
             this.tblName = new TableName(null, parts.get(0), parts.get(1), qualifiedName.getPos());
             this.colName = parts.get(2);
-            this.label = parts.get(2);
+            this.label = "`" + parts.get(2) + "`";
         } else if (parts.size() == 4) {
             this.tblName = new TableName(parts.get(0), parts.get(1), parts.get(2), qualifiedName.getPos());
             this.colName = parts.get(3);
-            this.label = parts.get(3);
+            this.label = "`" + parts.get(3) + "`";
         } else {
             // If parts.size() > 4, it must refer to a struct subfield name, so we set SlotRef's TableName null value,
             // set col, label a qualified name here[Of course it's a wrong value].


### PR DESCRIPTION
…g partition info to edit log

## Why I'm doing:
Handling partition col name with special symbols while saving partition info to edit log. While saving the column name with special symbols, escape sequence is missed and causing issue while replaying the statement after restarting the FE. 

## What I'm doing:
Adding escape sequence to label, which is used mainly for sql conversion purpose

Fixes #issue


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3