### PR TITLE
[BugFix] fix parquet array write when split null string

### DIFF
--- a/be/src/exprs/split.cpp
+++ b/be/src/exprs/split.cpp
@@ -155,6 +155,9 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
             array_binary_column->reserve(row_nums * 5, haystack_columns->get_bytes().size());
             for (int row = 0; row < row_nums; ++row) {
                 array_offsets->append(offset);
+                if (string_viewer.is_null(row)) {
+                    continue;
+                }
                 Slice haystack = string_viewer.value(row);
                 int32_t haystack_offset = 0;
                 int splits_size = 0;

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -457,8 +457,16 @@ Status LevelBuilder::_write_array_column_chunk(const LevelBuilderContext& ctx, c
             continue;
         }
 
+        auto array_size = offsets[offset + 1] - offsets[offset];
+        auto array_is_null = (def_level < ctx._max_def_level || (null_col != nullptr && null_col[offset]));
+
         // null in current array_column
-        if (def_level < ctx._max_def_level || (null_col != nullptr && null_col[offset])) {
+        if (array_is_null) {
+            if (array_size > 0) {
+                return Status::DataQualityError(
+                        fmt::format("Array column ({}) has null element at offset {}, but array size is {}",
+                                    type_desc.debug_string(), offset, array_size));
+            }
             (*def_levels)[num_levels] = def_level;
             (*rep_levels)[num_levels] = rep_level;
 
@@ -467,7 +475,6 @@ Status LevelBuilder::_write_array_column_chunk(const LevelBuilderContext& ctx, c
             continue;
         }
 
-        auto array_size = offsets[offset + 1] - offsets[offset];
         // not null but empty array
         if (array_size == 0) {
             (*def_levels)[num_levels] = def_level + node->is_optional();

--- a/test/sql/test_external_file/R/test_parquet_arrary_check
+++ b/test/sql/test_external_file/R/test_parquet_arrary_check
@@ -1,0 +1,28 @@
+-- name: test_parquet_array_check
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_array_check/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+insert into files
+(
+"path" = "oss://${oss_bucket}/test_parquet_array_check/${uuid0}/000/",
+"format" = "parquet"
+) 
+with tt  (tme_mv_id, fid,  fsinger_id_max) as ((select 10, "10", null) union all (select 20, "20", "aaa")),
+tt2 (tme_mv_id, fid, fsinger_ids, fsinger_id_max) as (select tme_mv_id, fid, split(fsinger_id_max, '|') as fsinger_ids, fsinger_id_max from tt)
+select * from tt2;
+-- result:
+-- !result
+select * from 
+files("path" = "oss://${oss_bucket}/test_parquet_array_check/${uuid0}/000/*",
+"format" = "parquet") order by tme_mv_id;
+-- result:
+10	10	None	None
+20	20	["aaa"]	aaa
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_array_check/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_external_file/T/test_parquet_arrary_check
+++ b/test/sql/test_external_file/T/test_parquet_arrary_check
@@ -1,0 +1,19 @@
+-- name: test_parquet_array_check
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_array_check/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+
+insert into files
+(
+"path" = "oss://${oss_bucket}/test_parquet_array_check/${uuid0}/000/",
+"format" = "parquet"
+) 
+with tt  (tme_mv_id, fid,  fsinger_id_max) as ((select 10, "10", null) union all (select 20, "20", "aaa")),
+tt2 (tme_mv_id, fid, fsinger_ids, fsinger_id_max) as (select tme_mv_id, fid, split(fsinger_id_max, '|') as fsinger_ids, fsinger_id_max from tt)
+select * from tt2;
+
+-- expect [10, nul], [20, ["aaa"]]
+select * from 
+files("path" = "oss://${oss_bucket}/test_parquet_array_check/${uuid0}/000/*",
+"format" = "parquet") order by tme_mv_id;
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_array_check/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why
This PR addresses two critical issues:
1. **Parquet Array Write Issue**: When writing Parquet files, arrays marked as `NULL` but containing placeholder elements caused inconsistencies. Specifically, the system failed to handle cases where `array_size > 0` for `NULL` arrays, leading to potential data quality issues or crashes.
2. **Split Function Null Handling**: The `split` function did not properly handle `NULL` input strings, resulting in incorrect array outputs or skipped rows.

## What
1. **Parquet Array Write Fix**:
   - Added a check in `level_builder.cpp` to ensure that `NULL` arrays with non-zero `array_size` throw a `DataQualityError`.
   - Improved error messaging to provide clear context about the issue.

2. **Split Function Fix**:
   - Updated `split.cpp` to skip processing rows where the input string is `NULL`.
   - Ensured that `NULL` rows are properly represented in the output array column.

3. **Test Cases**:
   - Added `TestWriteArrayNullWithOffset` to validate the handling of `NULL` arrays with offsets in Parquet files.
   - Added SQL-based integration tests to verify the behavior of the `split` function with `NULL` inputs.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
