### PR TITLE
[BugFix] Avoid double precission issue while displaying resource group

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -22,6 +22,8 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.thrift.TWorkGroupType;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.Collections;
 import java.util.List;
@@ -98,7 +100,13 @@ public class ResourceGroup {
                     (rg, classifier) -> "" + rg.getNormalizedExclusiveCpuCores()),
             new ColumnMeta(
                     new Column(MEM_LIMIT, ScalarType.createVarchar(200)),
-                    (rg, classifier) -> (rg.getMemLimit() * 100) + "%"),
+                    (rg, classifier) -> {
+                        // Avoid double pression issue
+                        BigDecimal memLimit = BigDecimal.valueOf(rg.getMemLimit())
+                                .multiply(BigDecimal.valueOf(100))
+                                .setScale(2, RoundingMode.HALF_UP);
+                        return memLimit.toPlainString() + "%";
+                    }),
             new ColumnMeta(
                     new Column(MAX_CPU_CORES, ScalarType.createVarchar(200)),
                     (rg, classifier) -> "" + rg.getMaxCpuCores(), false),


### PR DESCRIPTION

## Why I'm doing:
Precission issue while dispaying resource group info, ex: when mem limit is set to 0.55, 0.54, 0.56 etc

## What I'm doing:
Using Big decimal API to resolve precission issue and to match with create resource command. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3