### PR TITLE
[BugFix] Fix group by compressed key cause wrong result on decimal

### DIFF
--- a/be/src/exec/aggregate/compress_serializer.cpp
+++ b/be/src/exec/aggregate/compress_serializer.cpp
@@ -229,7 +229,7 @@ public:
     }
 
     template <typename T>
-    Status do_visit(const DecimalV3Column<T>& column) {
+    Status do_visit(DecimalV3Column<T>* column) {
         bit_decompress<DecimalV3Column<T>, T>(column);
         return Status::OK();
     }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -116,6 +116,7 @@ set(EXEC_FILES
         ./exprs/agg/data_sketch/ds_theta_test.cpp
         ./exprs/agg/json_each_test.cpp
         ./exprs/agg/aggregate_test.cpp
+        ./exprs/agg/agg_compressed_key_test.cpp
         ./exprs/arithmetic_expr_test.cpp
         ./exprs/arithmetic_operation_test.cpp
         ./exprs/array_element_expr_test.cpp

--- a/be/test/exprs/agg/agg_compressed_key_test.cpp
+++ b/be/test/exprs/agg/agg_compressed_key_test.cpp
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/column_helper.h"
+#include "common/object_pool.h"
+#include "exec/aggregator.h"
+#include "exprs/literal.h"
+#include "runtime/types.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+bool could_apply_bitcompress_opt(
+        const std::vector<ColumnType>& group_by_types,
+        const std::vector<std::optional<std::pair<VectorizedLiteral*, VectorizedLiteral*>>>& ranges,
+        std::vector<std::any>& base, std::vector<int>& used_bytes, size_t* max_size, bool* has_null);
+
+TEST(AggCompressedKey, could_bound) {
+    // group by 1 columns
+    {
+        ObjectPool pool;
+
+        std::vector<ColumnType> groupby;
+        std::optional<std::pair<VectorizedLiteral*, VectorizedLiteral*>> range;
+        std::vector<std::any> bases;
+        std::vector<int> used_bytes;
+        size_t max_size;
+        bool has_null;
+
+        bases.resize(1);
+        used_bytes.resize(1);
+
+        auto type1 = TypeDescriptor(TYPE_INT);
+        groupby.emplace_back(type1, false);
+        std::vector<std::optional<std::pair<VectorizedLiteral*, VectorizedLiteral*>>> ranges;
+        auto* min = pool.add(new VectorizedLiteral(ColumnHelper::create_const_column<TYPE_INT>(0, 1), type1));
+        auto* max = pool.add(new VectorizedLiteral(ColumnHelper::create_const_column<TYPE_INT>(100, 1), type1));
+        range = {min, max};
+        ranges.emplace_back(range);
+
+        bool res = could_apply_bitcompress_opt(groupby, ranges, bases, used_bytes, &max_size, &has_null);
+        EXPECT_EQ(max_size, 7);
+        ASSERT_EQ(res, true);
+    }
+    // group by 2 columns
+    {
+        ObjectPool pool;
+
+        std::vector<ColumnType> groupby;
+        std::optional<std::pair<VectorizedLiteral*, VectorizedLiteral*>> range;
+        std::vector<std::any> bases;
+        std::vector<int> used_bytes;
+        size_t max_size;
+        bool has_null;
+
+        bases.resize(2);
+        used_bytes.resize(2);
+
+        auto type1 = TypeDescriptor(TYPE_INT);
+        groupby.emplace_back(type1, false);
+        groupby.emplace_back(type1, true);
+        std::vector<std::optional<std::pair<VectorizedLiteral*, VectorizedLiteral*>>> ranges;
+        auto* min = pool.add(new VectorizedLiteral(ColumnHelper::create_const_column<TYPE_INT>(0, 1), type1));
+        auto* max = pool.add(new VectorizedLiteral(ColumnHelper::create_const_column<TYPE_INT>(100, 1), type1));
+        range = {min, max};
+        ranges.emplace_back(range);
+        ranges.emplace_back(range);
+
+        bool res = could_apply_bitcompress_opt(groupby, ranges, bases, used_bytes, &max_size, &has_null);
+        EXPECT_EQ(max_size, 15);
+        ASSERT_EQ(res, true);
+    }
+    // group by decimal columns
+    {
+        ObjectPool pool;
+
+        std::vector<ColumnType> groupby;
+        std::optional<std::pair<VectorizedLiteral*, VectorizedLiteral*>> range;
+        std::vector<std::any> bases;
+        std::vector<int> used_bytes;
+        size_t max_size;
+        bool has_null;
+
+        bases.resize(2);
+        used_bytes.resize(2);
+
+        auto type1 = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 8, 4);
+        groupby.emplace_back(type1, false);
+        groupby.emplace_back(type1, true);
+        std::vector<std::optional<std::pair<VectorizedLiteral*, VectorizedLiteral*>>> ranges;
+        auto* min = pool.add(
+                new VectorizedLiteral(ColumnHelper::create_const_decimal_column<TYPE_DECIMAL128>(0, 8, 4, 1), type1));
+        auto* max = pool.add(
+                new VectorizedLiteral(ColumnHelper::create_const_decimal_column<TYPE_DECIMAL128>(100, 8, 4, 1), type1));
+        range = {min, max};
+        ranges.emplace_back(range);
+        ranges.emplace_back(range);
+
+        bool res = could_apply_bitcompress_opt(groupby, ranges, bases, used_bytes, &max_size, &has_null);
+        EXPECT_EQ(max_size, 15);
+        ASSERT_EQ(res, true);
+    }
+}
+} // namespace starrocks

--- a/test/sql/test_agg/R/test_agg_compressed_key
+++ b/test/sql/test_agg/R/test_agg_compressed_key
@@ -348,6 +348,46 @@ select c4, sum(c1) from all_decimal group by 1 order by 1, 2 limit 1;
 -- result:
 0.00000	0.00
 -- !result
+select c1, c2, sum(c1) from all_decimal group by 1,2 order by 1,2,3 limit 1;
+-- result:
+0.00	0.00	0.00
+-- !result
+select c1, c3, sum(c1) from all_decimal group by 1,2 order by 1,2,3 limit 1;
+-- result:
+0.00	0E-9	0.00
+-- !result
+select c1, c4, sum(c1) from all_decimal group by 1,2 order by 1,2,3 limit 1;
+-- result:
+0.00	0.00000	0.00
+-- !result
+select c2, c3, sum(c1) from all_decimal group by 1,2 order by 1,2,3 limit 1;
+-- result:
+0.00	0E-9	0.00
+-- !result
+select c2, c4, sum(c1) from all_decimal group by 1,2 order by 1,2,3 limit 1;
+-- result:
+0.00	0.00000	0.00
+-- !result
+select c3, c4, sum(c1) from all_decimal group by 1,2 order by 1,2,3 limit 1;
+-- result:
+0E-9	0.00000	0.00
+-- !result
+select c1, c2, c3, sum(c1) from all_decimal group by 1,2,3 order by 1,2,3,4 limit 1;
+-- result:
+0.00	0.00	0E-9	0.00
+-- !result
+select c1, c2, c4, sum(c1) from all_decimal group by 1,2,3 order by 1,2,3,4 limit 1;
+-- result:
+0.00	0.00	0.00000	0.00
+-- !result
+select c2, c3, c4, sum(c1) from all_decimal group by 1,2,3 order by 1,2,3,4 limit 1;
+-- result:
+0.00	0E-9	0.00000	0.00
+-- !result
+select c1, c2, c3, c4, sum(c1) from all_decimal group by 1,2,3,4 order by 1,2,3,4,5 limit 1;
+-- result:
+0.00	0.00	0E-9	0.00000	0.00
+-- !result
 create table all_numbers_t0 (
     c1 tinyint,
     c2 smallint,

--- a/test/sql/test_agg/T/test_agg_compressed_key
+++ b/test/sql/test_agg/T/test_agg_compressed_key
@@ -127,6 +127,17 @@ select c2, sum(c1) from all_decimal group by 1 order by 1, 2 limit 1;
 select c3, sum(c1) from all_decimal group by 1 order by 1, 2 limit 1;
 select c4, sum(c1) from all_decimal group by 1 order by 1, 2 limit 1;
 
+select c1, c2, sum(c1) from all_decimal group by 1,2 order by 1,2,3 limit 1;
+select c1, c3, sum(c1) from all_decimal group by 1,2 order by 1,2,3 limit 1;
+select c1, c4, sum(c1) from all_decimal group by 1,2 order by 1,2,3 limit 1;
+select c2, c3, sum(c1) from all_decimal group by 1,2 order by 1,2,3 limit 1;
+select c2, c4, sum(c1) from all_decimal group by 1,2 order by 1,2,3 limit 1;
+select c3, c4, sum(c1) from all_decimal group by 1,2 order by 1,2,3 limit 1;
+select c1, c2, c3, sum(c1) from all_decimal group by 1,2,3 order by 1,2,3,4 limit 1;
+select c1, c2, c4, sum(c1) from all_decimal group by 1,2,3 order by 1,2,3,4 limit 1;
+select c2, c3, c4, sum(c1) from all_decimal group by 1,2,3 order by 1,2,3,4 limit 1;
+select c1, c2, c3, c4, sum(c1) from all_decimal group by 1,2,3,4 order by 1,2,3,4,5 limit 1;
+
 -- int overflow
 create table all_numbers_t0 (
     c1 tinyint,


### PR DESCRIPTION
## Why I'm doing:


## What I'm doing:

1. Fixed an issue where decimal columns could not be matched.
2. Updated the group by compressed key strategy so that optimization is only attempted in good cases.
3. Added cases for group by multiple decimal columns.

Fixes https://github.com/StarRocks/StarRocksTest/issues/10103

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
