### PR TITLE
[Feature] Support iceberg register table procedure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -253,6 +253,11 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public Procedure getProcedure(DatabaseTableName procedureName) {
+        return normal.getProcedure(procedureName);
+    }
+
+    @Override
     public void finishSink(String dbName, String table, List<TSinkCommitInfo> commitInfos, String branch) {
         normal.finishSink(dbName, table, commitInfos, branch);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -215,6 +215,11 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         return delegate.dropView(connectContext, dbName, viewName);
     }
 
+    @Override
+    public boolean registerTable(ConnectContext context, String dbName, String tableName, String metadataFileLocation) {
+        return delegate.registerTable(context, dbName, tableName, metadataFileLocation);
+    }
+
     public View getView(ConnectContext connectContext, String dbName, String viewName) {
         return delegate.getView(connectContext, dbName, viewName);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -207,6 +207,19 @@ public interface IcebergCatalog extends MemoryTrackable {
         throw new StarRocksConnectorException("This catalog doesn't loading iceberg view");
     }
 
+    /**
+     * Register an existing table in the catalog using the given metadata file location.
+     * 
+     * @param context The connect context
+     * @param dbName The database name
+     * @param tableName The table name
+     * @param metadataFileLocation The location of the metadata file
+     * @return true if the table was successfully registered, false otherwise
+     */
+    default boolean registerTable(ConnectContext context, String dbName, String tableName, String metadataFileLocation) {
+        throw new StarRocksConnectorException("This catalog doesn't support registering tables");
+    }
+
     default void deleteUncommittedDataFiles(List<String> fileLocations) {
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -143,7 +143,7 @@ public class IcebergConnector implements Connector {
     }
 
     private void registerProcedures() {
-        this.procedureRegistry.register(RegisterTableProcedure.getInstance());
+        this.procedureRegistry.register(new RegisterTableProcedure(catalogName, getNativeCatalog()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
@@ -207,6 +207,20 @@ public class IcebergGlueCatalog implements IcebergCatalog {
         }
     }
 
+    @Override
+    public boolean registerTable(ConnectContext context, String dbName, String tableName, 
+                                 String metadataFileLocation) {
+        try {
+            TableIdentifier tableIdentifier = TableIdentifier.of(dbName, tableName);
+            Table table = delegate.registerTable(tableIdentifier, metadataFileLocation);
+            return table != null;
+        } catch (Exception e) {
+            LOG.error("Failed to register table {}.{} with metadata file location {}", 
+                    dbName, tableName, metadataFileLocation, e);
+            throw new StarRocksConnectorException("Failed to register table: " + e.getMessage(), e);
+        }
+    }
+
     public String toString() {
         return delegate.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hadoop/IcebergHadoopCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hadoop/IcebergHadoopCatalog.java
@@ -213,6 +213,20 @@ public class IcebergHadoopCatalog implements IcebergCatalog {
         }
     }
 
+    @Override
+    public boolean registerTable(ConnectContext context, String dbName, String tableName, 
+                                 String metadataFileLocation) {
+        try {
+            TableIdentifier tableIdentifier = TableIdentifier.of(dbName, tableName);
+            Table table = delegate.registerTable(tableIdentifier, metadataFileLocation);
+            return table != null;
+        } catch (Exception e) {
+            LOG.error("Failed to register table {}.{} with metadata file location {}", 
+                    dbName, tableName, metadataFileLocation, e);
+            throw new StarRocksConnectorException("Failed to register table: " + e.getMessage(), e);
+        }
+    }
+
     public String toString() {
         return delegate.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
@@ -255,6 +255,20 @@ public class IcebergHiveCatalog implements IcebergCatalog {
         }
     }
 
+    @Override
+    public boolean registerTable(ConnectContext context, String dbName, String tableName, 
+                                 String metadataFileLocation) {
+        try {
+            TableIdentifier tableIdentifier = TableIdentifier.of(dbName, tableName);
+            Table table = delegate.registerTable(tableIdentifier, metadataFileLocation);
+            return table != null;
+        } catch (Exception e) {
+            LOG.error("Failed to register table {}.{} with metadata file location {}", 
+                    dbName, tableName, metadataFileLocation, e);
+            throw new StarRocksConnectorException("Failed to register table: " + e.getMessage(), e);
+        }
+    }
+
     public String toString() {
         return delegate.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalog.java
@@ -224,6 +224,20 @@ public class IcebergJdbcCatalog implements IcebergCatalog {
         }
     }
 
+    @Override
+    public boolean registerTable(ConnectContext context, String dbName, String tableName, 
+                                 String metadataFileLocation) {
+        try {
+            TableIdentifier tableIdentifier = TableIdentifier.of(dbName, tableName);
+            Table table = delegate.registerTable(tableIdentifier, metadataFileLocation);
+            return table != null;
+        } catch (Exception e) {
+            LOG.error("Failed to register table {}.{} with metadata file location {}", 
+                    dbName, tableName, metadataFileLocation, e);
+            throw new StarRocksConnectorException("Failed to register table: " + e.getMessage(), e);
+        }
+    }
+
     public String toString() {
         return delegate.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RegisterTableProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RegisterTableProcedure.java
@@ -15,12 +15,17 @@
 package com.starrocks.connector.iceberg.procedure;
 
 import com.starrocks.catalog.Type;
+import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.Procedure;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergCatalog;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 
 public class RegisterTableProcedure extends Procedure {
     private static final String PROCEDURE_NAME = "register_table";
@@ -28,28 +33,83 @@ public class RegisterTableProcedure extends Procedure {
 
     private static final String DATABASE_NAME = "database_name";
     private static final String TABLE_NAME = "table_name";
-    private static final String TABLE_LOCATION = "table_location";
+    private static final String METADATA_FILE = "metadata_file";
 
-    private static final RegisterTableProcedure INSTANCE = new RegisterTableProcedure();
+    private final String catalogName;
+    private final IcebergCatalog icebergCatalog;
 
-    public static RegisterTableProcedure getInstance() {
-        return INSTANCE;
-    }
-
-    private RegisterTableProcedure() {
+    public RegisterTableProcedure(String catalogName, IcebergCatalog icebergCatalog) {
         super(
                 SYSTEM_DATABASE,
                 PROCEDURE_NAME,
                 Arrays.asList(
-                        new Argument(DATABASE_NAME, Type.VARCHAR, true),
+                        new Argument(DATABASE_NAME, Type.VARCHAR, false),
                         new Argument(TABLE_NAME, Type.VARCHAR, true),
-                        new Argument(TABLE_LOCATION, Type.VARCHAR, true)
+                        new Argument(METADATA_FILE, Type.VARCHAR, true)
                 )
         );
+        this.catalogName = catalogName;
+        this.icebergCatalog = icebergCatalog;
     }
 
     @Override
     public void execute(ConnectContext context, Map<String, ConstantOperator> args) {
-        // todo: Implement the logic to register an Iceberg table
+        // Validate required arguments
+        if (!args.containsKey(TABLE_NAME) || !args.containsKey(METADATA_FILE)) {
+            throw new IllegalArgumentException("Missing required arguments: table_name, metadata_file");
+        }
+
+        // Get database name from argument or use current database as default
+        String databaseName = args.containsKey(DATABASE_NAME) ?
+                args.get(DATABASE_NAME).getVarchar() : context.getDatabase();
+        String tableName = args.get(TABLE_NAME).getVarchar();
+        String metadataFile = args.get(METADATA_FILE).getVarchar();
+        
+        // Validate argument values
+        if (databaseName == null || databaseName.trim().isEmpty()) {
+            throw new IllegalArgumentException("database_name cannot be null or empty");
+        }
+        if (tableName == null || tableName.trim().isEmpty()) {
+            throw new IllegalArgumentException("table_name cannot be null or empty");
+        }
+        if (metadataFile == null || metadataFile.trim().isEmpty()) {
+            throw new IllegalArgumentException("metadata_file cannot be null or empty");
+        }
+
+        // Validate metadata file format
+        if (!metadataFile.endsWith("metadata.json") && !metadataFile.contains("/metadata/")) {
+            throw new IllegalArgumentException("metadata_file should be a valid Iceberg table metadata file path");
+        }
+
+        // Get catalog metadata
+        Optional<ConnectorMetadata> metadata = GlobalStateMgr.getCurrentState()
+                .getMetadataMgr()
+                .getOptionalMetadata(java.util.Optional.empty(), catalogName);
+
+        if (metadata.isEmpty()) {
+            throw new StarRocksConnectorException("Failed to get metadata for catalog '%s'", catalogName);
+        }
+        ConnectorMetadata icebergMetadata = metadata.get();
+
+        // Validate database exists
+        if (!icebergMetadata.dbExists(context, databaseName)) {
+            throw new StarRocksConnectorException("Database '%s' does not exist in catalog '%s'",
+                    databaseName, catalogName);
+        }
+
+        // Check if table already exists
+        if (icebergMetadata.tableExists(context, databaseName, tableName)) {
+            throw new StarRocksConnectorException("Table '%s.%s' already exists in catalog '%s'",
+                    databaseName, tableName, catalogName);
+        }
+
+        try {
+            // Register the table using Iceberg catalog
+            icebergCatalog.registerTable(context, databaseName, tableName, metadataFile);
+        } catch (Exception e) {
+            // Wrap other exceptions
+            throw new StarRocksConnectorException("Failed to register table '%s.%s' with metadata file '%s': %s",
+                    databaseName, tableName, metadataFile, e.getMessage());
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -389,6 +389,20 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         }
     }
 
+    @Override
+    public boolean registerTable(ConnectContext context, String dbName, String tableName, String metadataFileLocation) {
+        try {
+            TableIdentifier tableIdentifier = TableIdentifier.of(convertDbNameToNamespace(dbName), tableName);
+            Table table = delegate.registerTable(buildContext(context), tableIdentifier, metadataFileLocation);
+            return table != null;
+        } catch (RESTException re) {
+            LOG.error("Failed to register table using REST Catalog, for dbName {} tableName {} metadataFileLocation {}", 
+                    dbName, tableName, metadataFileLocation, re);
+            throw new StarRocksConnectorException("Failed to register table using REST Catalog",
+                    new RuntimeException("Failed to register table using REST Catalog, exception: " + re.getMessage(), re));
+        }
+    }
+
     public String toString() {
         return delegate.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CallProcedureStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CallProcedureStatement.java
@@ -23,7 +23,7 @@ import com.starrocks.sql.parser.NodePosition;
 import java.util.List;
 import java.util.Map;
 
-public class CallProcedureStatement extends StatementBase {
+public class CallProcedureStatement extends DdlStmt {
     private QualifiedName qualifiedName;
     private final List<ProcedureArgument> arguments;
     private Procedure procedure;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1791,11 +1791,11 @@ grantRevokeClause
 
 grantPrivilegeStatement
     : GRANT IMPERSONATE ON USER user (',' user)* TO grantRevokeClause (WITH GRANT OPTION)?              #grantOnUser
+    | GRANT privilegeTypeList ON SYSTEM TO grantRevokeClause (WITH GRANT OPTION)?                       #grantOnSystem
     | GRANT privilegeTypeList ON privObjectNameList TO grantRevokeClause (WITH GRANT OPTION)?           #grantOnTableBrief
 
     | GRANT privilegeTypeList ON GLOBAL? FUNCTION privFunctionObjectNameList
         TO grantRevokeClause (WITH GRANT OPTION)?                                                       #grantOnFunc
-    | GRANT privilegeTypeList ON SYSTEM TO grantRevokeClause (WITH GRANT OPTION)?                       #grantOnSystem
     | GRANT privilegeTypeList ON privObjectType privObjectNameList
         TO grantRevokeClause (WITH GRANT OPTION)?                                                       #grantOnPrimaryObj
     | GRANT privilegeTypeList ON ALL privObjectTypePlural
@@ -1805,10 +1805,10 @@ grantPrivilegeStatement
 
 revokePrivilegeStatement
     : REVOKE IMPERSONATE ON USER user (',' user)* FROM grantRevokeClause                                #revokeOnUser
+    | REVOKE privilegeTypeList ON SYSTEM FROM grantRevokeClause                                         #revokeOnSystem
     | REVOKE privilegeTypeList ON privObjectNameList FROM grantRevokeClause                             #revokeOnTableBrief
     | REVOKE privilegeTypeList ON GLOBAL? FUNCTION privFunctionObjectNameList
         FROM grantRevokeClause                                                                          #revokeOnFunc
-    | REVOKE privilegeTypeList ON SYSTEM FROM grantRevokeClause                                         #revokeOnSystem
     | REVOKE privilegeTypeList ON privObjectType privObjectNameList
         FROM grantRevokeClause                                                                          #revokeOnPrimaryObj
     | REVOKE privilegeTypeList ON ALL privObjectTypePlural
@@ -3167,7 +3167,7 @@ nonReserved
     | RESOURCE | RESOURCES | RESTORE | RESUME | RETAIN | RETENTION | RETURNS | RETRY | REVERT | ROLE | ROLES | ROLLUP | ROLLBACK | ROUTINE | ROW | RUNNING | RULE | RULES
     | SAMPLE | SCHEDULE | SCHEDULER | SECOND | SECURITY | SEPARATOR | SERIALIZABLE |SEMI | SESSION | SETS | SIGNED | SNAPSHOT | SNAPSHOTS | SPLIT | SQLBLACKLIST | START | STARROCKS
     | STREAM | SUM | STATUS | STOP | SKIP_HEADER | SWAP
-    | STORAGE| STRING | STRUCT | STATS | SUBMIT | SUSPEND | SYNC | SYSTEM_TIME
+    | STORAGE| STRING | STRUCT | STATS | SUBMIT | SUSPEND | SYNC | SYSTEM | SYSTEM_TIME
     | TABLES | TABLET | TABLETS | TAG | TASK | TEMPORARY | TIMESTAMP | TIMESTAMPADD | TIMESTAMPDIFF | THAN | TIME | TIMES | TRANSACTION | TRACE | TRANSLATE
     | TRIM_SPACE
     | TRIGGERS | TRUNCATE | TYPE | TYPES

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/AuthorizationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/AuthorizationMgrTest.java
@@ -25,6 +25,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.OperationType;
 import com.starrocks.persist.RolePrivilegeCollectionInfo;
@@ -61,6 +62,7 @@ import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
+import mockit.Mocked;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -1559,7 +1561,7 @@ public class AuthorizationMgrTest {
     }
 
     @Test
-    public void testGrantOnCatalog() throws Exception {
+    public void testGrantOnCatalog(@Mocked IcebergHiveCatalog hiveCatalog) throws Exception {
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
                 "create external catalog test_catalog properties (" +
                         "\"type\"=\"iceberg\", \"iceberg.catalog.type\"=\"hive\")", ctx), ctx);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalogRegisterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalogRegisterTableTest.java
@@ -1,0 +1,107 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.glue;
+
+import com.starrocks.qe.ConnectContext;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.aws.glue.GlueCatalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class IcebergGlueCatalogRegisterTableTest {
+    @Mocked
+    private GlueCatalog glueCatalog;
+
+    @Injectable
+    private Table mockTable;
+
+    private IcebergGlueCatalog icebergGlueCatalog;
+    private ConnectContext connectContext;
+
+    @BeforeEach
+    public void setUp() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("aws.region", "us-east-1");
+        icebergGlueCatalog = new IcebergGlueCatalog("test_catalog", new Configuration(), properties);
+        connectContext = new ConnectContext();
+    }
+
+    @Test
+    public void testRegisterTableSuccess() {
+        // Test successful table registration
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/path/to/table/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                glueCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = mockTable;
+            }
+        };
+
+        boolean result = icebergGlueCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation);
+        Assertions.assertTrue(result);
+    }
+
+    @Test
+    public void testRegisterTableFailure() {
+        // Test table registration failure when underlying catalog throws exception
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/path/to/table/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                glueCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = new RuntimeException("Registration failed");
+            }
+        };
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> icebergGlueCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation));
+        Assertions.assertTrue(exception.getMessage().contains("Failed to register table"));
+    }
+
+    @Test
+    public void testRegisterTableReturnsFalseWhenTableIsNull() {
+        // Test when registerTable returns null table
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/path/to/table/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                glueCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = null;
+            }
+        };
+
+        boolean result = icebergGlueCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation);
+        Assertions.assertFalse(result);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/hadoop/IcebergHadoopCatalogRegisterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/hadoop/IcebergHadoopCatalogRegisterTableTest.java
@@ -1,0 +1,126 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.hadoop;
+
+import com.starrocks.qe.ConnectContext;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class IcebergHadoopCatalogRegisterTableTest {
+    @Mocked
+    private HadoopCatalog hadoopCatalog;
+
+    @Injectable
+    private Table mockTable;
+
+    private IcebergHadoopCatalog icebergHadoopCatalog;
+    private ConnectContext connectContext;
+
+    @BeforeEach
+    public void setUp() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("warehouse", "/tmp/iceberg-warehouse");
+        icebergHadoopCatalog = new IcebergHadoopCatalog("test_catalog", new Configuration(), properties);
+        connectContext = new ConnectContext();
+    }
+
+    @Test
+    public void testRegisterTableSuccess() {
+        // Test successful table registration with Hadoop catalog
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/tmp/iceberg-warehouse/test_db/test_table/metadata/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                hadoopCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = mockTable;
+            }
+        };
+
+        boolean result = icebergHadoopCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation);
+        Assertions.assertTrue(result);
+    }
+
+    @Test
+    public void testRegisterTableFailureWithHadoopException() {
+        // Test table registration failure when Hadoop catalog throws exception
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/tmp/iceberg-warehouse/test_db/test_table/metadata/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                hadoopCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = new RuntimeException("Hadoop filesystem access failed");
+            }
+        };
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> icebergHadoopCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation));
+        Assertions.assertTrue(exception.getMessage().contains("Failed to register table"));
+    }
+
+    @Test
+    public void testRegisterTableReturnsFalseWhenTableIsNull() {
+        // Test when Hadoop catalog returns null table
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/tmp/iceberg-warehouse/test_db/test_table/metadata/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                hadoopCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = null;
+            }
+        };
+
+        boolean result = icebergHadoopCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation);
+        Assertions.assertFalse(result);
+    }
+
+    @Test
+    public void testRegisterTableWithHDFSWarehouseLocation() {
+        // Test table registration with HDFS warehouse location
+        String dbName = "production";
+        String tableName = "orders";
+        String metadataFileLocation = "hdfs://namenode:8020/warehouse/production/orders/metadata/v1.metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations(icebergHadoopCatalog) {
+            {
+                hadoopCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = mockTable;
+            }
+        };
+
+        boolean result = icebergHadoopCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation);
+        Assertions.assertTrue(result);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalogRegisterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalogRegisterTableTest.java
@@ -1,0 +1,126 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.hive;
+
+import com.starrocks.qe.ConnectContext;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hive.HiveCatalog;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class IcebergHiveCatalogRegisterTableTest {
+    @Mocked
+    private HiveCatalog hiveCatalog;
+
+    @Injectable
+    private Table mockTable;
+
+    private IcebergHiveCatalog icebergHiveCatalog;
+    private ConnectContext connectContext;
+
+    @BeforeEach
+    public void setUp() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("hive.metastore.uris", "thrift://localhost:9083");
+        icebergHiveCatalog = new IcebergHiveCatalog("test_catalog", new Configuration(), properties);
+        connectContext = new ConnectContext();
+    }
+
+    @Test
+    public void testRegisterTableSuccess() {
+        // Test successful table registration with Hive metastore
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/warehouse/test_db/test_table/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                hiveCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = mockTable;
+            }
+        };
+
+        boolean result = icebergHiveCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation);
+        Assertions.assertTrue(result);
+    }
+
+    @Test
+    public void testRegisterTableFailureWithHiveException() {
+        // Test table registration failure when Hive catalog throws exception
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/warehouse/test_db/test_table/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                hiveCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = new RuntimeException("Hive metastore connection failed");
+            }
+        };
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> icebergHiveCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation));
+        Assertions.assertTrue(exception.getMessage().contains("Failed to register table"));
+    }
+
+    @Test
+    public void testRegisterTableReturnsFalseWhenTableIsNull() {
+        // Test when Hive catalog returns null table
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/warehouse/test_db/test_table/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                hiveCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = null;
+            }
+        };
+
+        boolean result = icebergHiveCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation);
+        Assertions.assertFalse(result);
+    }
+
+    @Test
+    public void testRegisterTableWithHDFSLocation() {
+        // Test table registration with HDFS metadata file location
+        String dbName = "warehouse_db";
+        String tableName = "sales_data";
+        String metadataFileLocation = "hdfs://cluster/warehouse/sales_data/metadata/00001-abc123.metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                hiveCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = mockTable;
+            }
+        };
+
+        boolean result = icebergHiveCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation);
+        Assertions.assertTrue(result);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalogRegisterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalogRegisterTableTest.java
@@ -1,0 +1,110 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.jdbc;
+
+import com.starrocks.qe.ConnectContext;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class IcebergJdbcCatalogRegisterTableTest {
+    @Mocked
+    private JdbcCatalog jdbcCatalog;
+
+    @Injectable
+    private Table mockTable;
+
+    private IcebergJdbcCatalog icebergJdbcCatalog;
+    private ConnectContext connectContext;
+
+    @BeforeEach
+    public void setUp() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("iceberg.catalog.uri", "jdbc:postgresql://localhost:5432/iceberg_catalog");
+        properties.put("iceberg.catalog.jdbc.user", "iceberg");
+        properties.put("iceberg.catalog.jdbc.password", "password");
+        properties.put("iceberg.catalog.warehouse", "s3://my_bucket/warehouse_location");
+        icebergJdbcCatalog = new IcebergJdbcCatalog("test_catalog", new Configuration(), properties);
+        connectContext = new ConnectContext();
+    }
+
+    @Test
+    public void testRegisterTableSuccess() {
+        // Test successful table registration with JDBC catalog
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/warehouse/test_db/test_table/metadata/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                jdbcCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = mockTable;
+            }
+        };
+
+        boolean result = icebergJdbcCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation);
+        Assertions.assertTrue(result);
+    }
+
+    @Test
+    public void testRegisterTableFailureWithJdbcException() {
+        // Test table registration failure when JDBC catalog throws exception
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/warehouse/test_db/test_table/metadata/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                jdbcCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = new RuntimeException("Database connection failed");
+            }
+        };
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> icebergJdbcCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation));
+        Assertions.assertTrue(exception.getMessage().contains("Failed to register table"));
+    }
+
+    @Test
+    public void testRegisterTableReturnsFalseWhenTableIsNull() {
+        // Test when JDBC catalog returns null table
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/warehouse/test_db/test_table/metadata/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                jdbcCatalog.registerTable(expectedTableId, metadataFileLocation);
+                result = null;
+            }
+        };
+
+        boolean result = icebergJdbcCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation);
+        Assertions.assertFalse(result);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RegisterTableProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RegisterTableProcedureTest.java
@@ -14,43 +14,328 @@
 
 package com.starrocks.connector.iceberg.procedure;
 
+import com.starrocks.catalog.Type;
+import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.Procedure;
+import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
-import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.hive.HiveCatalog;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class RegisterTableProcedureTest {
-    @BeforeAll
-    public static void beforeClass() throws Exception {
-        UtFrameUtils.createMinStarRocksCluster();
+    @Mocked
+    private HiveCatalog hiveCatalog;
+
+    private IcebergHiveCatalog icebergCatalog;
+    private Procedure registerTableProcedure;
+    private static final String CATALOG_NAME = "iceberg_catalog";
+
+    @BeforeEach
+    public void setUp() {
+        icebergCatalog = new IcebergHiveCatalog(hiveCatalog, new Configuration());
+        registerTableProcedure = new RegisterTableProcedure(CATALOG_NAME, icebergCatalog);
     }
 
     @Test
     public void testRegisterTableProcedureRegistry() {
         // Test that RegisterTableProcedure can be registered and found in IcebergProcedureRegistry
         IcebergProcedureRegistry registry = new IcebergProcedureRegistry();
-        Procedure proc = RegisterTableProcedure.getInstance();
-        registry.register(proc);
-        Procedure found = registry.find(DatabaseTableName.of(proc.getDatabaseName(), proc.getProcedureName()));
+        registry.register(registerTableProcedure);
+        Procedure found = registry.find(DatabaseTableName.of(registerTableProcedure.getDatabaseName(),
+                registerTableProcedure.getProcedureName()));
         Assertions.assertNotNull(found);
-        Assertions.assertEquals(proc.getProcedureName(), found.getProcedureName());
+        Assertions.assertEquals(registerTableProcedure.getProcedureName(), found.getProcedureName());
     }
 
     @Test
-    public void testRegisterTableProcedureExecute() {
-        // Test that RegisterTableProcedure execute method works with valid arguments
-        Procedure proc = RegisterTableProcedure.getInstance();
+    public void testRegisterTableProcedureExecuteSuccess(@Mocked ConnectContext context,
+                                                         @Mocked GlobalStateMgr globalStateMgr,
+                                                         @Mocked MetadataMgr metadataMgr,
+                                                         @Mocked ConnectorMetadata connectorMetadata) {
+        // Test successful table registration with all required arguments
         Map<String, ConstantOperator> args = new HashMap<>();
-        args.put("database_name", ConstantOperator.createVarchar("db1"));
-        args.put("table_name", ConstantOperator.createVarchar("tbl1"));
-        args.put("table_location", ConstantOperator.createVarchar("/path/to/table"));
-        proc.execute(null, args);
-        // No exception means success
+        args.put("database_name", ConstantOperator.createVarchar("test_db"));
+        args.put("table_name", ConstantOperator.createVarchar("test_table"));
+        args.put("metadata_file", ConstantOperator.createVarchar("/path/to/table/metadata.json"));
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.getOptionalMetadata((Optional<String>) any, CATALOG_NAME);
+                result = Optional.of(connectorMetadata);
+                minTimes = 0;
+
+                connectorMetadata.dbExists(context, "test_db");
+                result = true;
+                minTimes = 0;
+
+                connectorMetadata.tableExists(context, "test_db", "test_table");
+                result = false;
+                minTimes = 0;
+
+                icebergCatalog.registerTable(context, "test_db", "test_table", "/path/to/table/metadata.json");
+                result = null;
+                minTimes = 0;
+            }
+        };
+
+        Assertions.assertDoesNotThrow(() -> registerTableProcedure.execute(context, args));
+    }
+
+    @Test
+    public void testRegisterTableProcedureWithoutDatabaseName(@Mocked ConnectContext context) {
+        // Test using current database when database_name is not provided
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put("table_name", ConstantOperator.createVarchar("test_table"));
+        args.put("metadata_file", ConstantOperator.createVarchar("/path/to/table/metadata.json"));
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> registerTableProcedure.execute(context, args));
+    }
+
+    @Test
+    public void testRegisterTableProcedureMissingTableName(@Mocked ConnectContext context) {
+        // Test exception when table_name is missing
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put("database_name", ConstantOperator.createVarchar("test_db"));
+        args.put("metadata_file", ConstantOperator.createVarchar("/path/to/table/metadata.json"));
+
+        Exception exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> registerTableProcedure.execute(context, args));
+        Assertions.assertTrue(exception.getMessage().contains("Missing required arguments"));
+    }
+
+    @Test
+    public void testRegisterTableProcedureMissingMetadataFile(@Mocked ConnectContext context) {
+        // Test exception when metadata_file is missing
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put("database_name", ConstantOperator.createVarchar("test_db"));
+        args.put("table_name", ConstantOperator.createVarchar("test_table"));
+
+        Exception exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> registerTableProcedure.execute(context, args));
+        Assertions.assertTrue(exception.getMessage().contains("Missing required arguments"));
+    }
+
+    @Test
+    public void testRegisterTableProcedureEmptyDatabaseName(@Mocked ConnectContext context) {
+        // Test exception when database_name is empty
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put("database_name", ConstantOperator.createVarchar(""));
+        args.put("table_name", ConstantOperator.createVarchar("test_table"));
+        args.put("metadata_file", ConstantOperator.createVarchar("/path/to/table/metadata.json"));
+
+        Exception exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> registerTableProcedure.execute(context, args));
+        Assertions.assertTrue(exception.getMessage().contains("database_name cannot be null or empty"));
+    }
+
+    @Test
+    public void testRegisterTableProcedureEmptyTableName(@Mocked ConnectContext context) {
+        // Test exception when table_name is empty
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put("database_name", ConstantOperator.createVarchar("test_db"));
+        args.put("table_name", ConstantOperator.createVarchar(""));
+        args.put("metadata_file", ConstantOperator.createVarchar("/path/to/table/metadata.json"));
+
+        Exception exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> registerTableProcedure.execute(context, args));
+        Assertions.assertTrue(exception.getMessage().contains("table_name cannot be null or empty"));
+    }
+
+    @Test
+    public void testRegisterTableProcedureInvalidMetadataFile(@Mocked ConnectContext context) {
+        // Test exception when metadata_file has invalid format
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put("database_name", ConstantOperator.createVarchar("test_db"));
+        args.put("table_name", ConstantOperator.createVarchar("test_table"));
+        args.put("metadata_file", ConstantOperator.createVarchar("invalid_file.txt"));
+
+        Exception exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> registerTableProcedure.execute(context, args));
+        Assertions.assertTrue(exception.getMessage().contains("should be a valid Iceberg table metadata file path"));
+    }
+
+    @Test
+    public void testRegisterTableProcedureCatalogNotFound(@Mocked ConnectContext context,
+                                                          @Mocked GlobalStateMgr globalStateMgr,
+                                                          @Mocked MetadataMgr metadataMgr) {
+        // Test exception when catalog metadata is not found
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put("database_name", ConstantOperator.createVarchar("test_db"));
+        args.put("table_name", ConstantOperator.createVarchar("test_table"));
+        args.put("metadata_file", ConstantOperator.createVarchar("/path/to/table/metadata.json"));
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.getOptionalMetadata((Optional<String>) any, CATALOG_NAME);
+                result = Optional.empty();
+                minTimes = 0;
+            }
+        };
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> registerTableProcedure.execute(context, args));
+        Assertions.assertTrue(exception.getMessage().contains("Failed to get metadata for catalog"));
+    }
+
+    @Test
+    public void testRegisterTableProcedureDatabaseNotExists(@Mocked ConnectContext context,
+                                                            @Mocked GlobalStateMgr globalStateMgr,
+                                                            @Mocked MetadataMgr metadataMgr,
+                                                            @Mocked ConnectorMetadata connectorMetadata) {
+        // Test exception when database does not exist
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put("database_name", ConstantOperator.createVarchar("nonexistent_db"));
+        args.put("table_name", ConstantOperator.createVarchar("test_table"));
+        args.put("metadata_file", ConstantOperator.createVarchar("/path/to/table/metadata.json"));
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.getOptionalMetadata((Optional<String>) any, CATALOG_NAME);
+                result = Optional.of(connectorMetadata);
+                minTimes = 0;
+
+                connectorMetadata.dbExists(context, "nonexistent_db");
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> registerTableProcedure.execute(context, args));
+        Assertions.assertTrue(exception.getMessage().contains("does not exist in catalog"));
+    }
+
+    @Test
+    public void testRegisterTableProcedureTableAlreadyExists(@Mocked ConnectContext context,
+                                                             @Mocked GlobalStateMgr globalStateMgr,
+                                                             @Mocked MetadataMgr metadataMgr,
+                                                             @Mocked ConnectorMetadata connectorMetadata) {
+        // Test exception when table already exists
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put("database_name", ConstantOperator.createVarchar("test_db"));
+        args.put("table_name", ConstantOperator.createVarchar("existing_table"));
+        args.put("metadata_file", ConstantOperator.createVarchar("/path/to/table/metadata.json"));
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.getOptionalMetadata((Optional<String>) any, CATALOG_NAME);
+                result = Optional.of(connectorMetadata);
+                minTimes = 0;
+
+                connectorMetadata.dbExists(context, "test_db");
+                result = true;
+                minTimes = 0;
+
+                connectorMetadata.tableExists(context, "test_db", "existing_table");
+                result = true;
+                minTimes = 0;
+            }
+        };
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> registerTableProcedure.execute(context, args));
+        Assertions.assertTrue(exception.getMessage().contains("already exists in catalog"));
+    }
+
+    @Test
+    public void testRegisterTableProcedureRegistrationFailure(@Mocked ConnectContext context,
+                                                              @Mocked GlobalStateMgr globalStateMgr,
+                                                              @Mocked MetadataMgr metadataMgr,
+                                                              @Mocked ConnectorMetadata connectorMetadata) {
+        // Test exception when table registration fails
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put("database_name", ConstantOperator.createVarchar("test_db"));
+        args.put("table_name", ConstantOperator.createVarchar("test_table"));
+        args.put("metadata_file", ConstantOperator.createVarchar("/path/to/table/metadata.json"));
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.getOptionalMetadata((Optional<String>) any, CATALOG_NAME);
+                result = Optional.of(connectorMetadata);
+                minTimes = 0;
+
+                connectorMetadata.dbExists(context, "test_db");
+                result = true;
+                minTimes = 0;
+
+                connectorMetadata.tableExists(context, "test_db", "test_table");
+                result = false;
+                minTimes = 0;
+
+                icebergCatalog.registerTable(context, "test_db", "test_table", "/path/to/table/metadata.json");
+                result = new RuntimeException("Registration failed");
+                minTimes = 0;
+            }
+        };
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> registerTableProcedure.execute(context, args));
+        Assertions.assertTrue(exception.getMessage().contains("Failed to register table"));
+    }
+
+    @Test
+    public void testRegisterTableProcedureNullArguments(@Mocked ConnectContext context) {
+        // Test exception when arguments contain null values
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put("database_name", ConstantOperator.createNull(Type.VARCHAR));
+        args.put("table_name", ConstantOperator.createVarchar("test_table"));
+        args.put("metadata_file", ConstantOperator.createVarchar("/path/to/table/metadata.json"));
+
+        Exception exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> registerTableProcedure.execute(context, args));
+        Assertions.assertTrue(exception.getMessage().contains("cannot be null or empty"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogRegisterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogRegisterTableTest.java
@@ -1,0 +1,105 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.rest;
+
+import com.starrocks.qe.ConnectContext;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.rest.RESTSessionCatalog;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+public class IcebergRESTCatalogRegisterTableTest {
+    @Mocked
+    private RESTSessionCatalog restCatalog;
+
+    @Injectable
+    private Table mockTable;
+
+    private IcebergRESTCatalog icebergRESTCatalog;
+    private ConnectContext connectContext;
+
+    @BeforeEach
+    public void setUp() {
+        icebergRESTCatalog = new IcebergRESTCatalog(restCatalog, new Configuration());
+        connectContext = new ConnectContext();
+    }
+
+    @Test
+    public void testRegisterTableSuccess() {
+        // Test successful table registration via REST catalog
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/path/to/table/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                restCatalog.registerTable((SessionCatalog.SessionContext) any, expectedTableId, metadataFileLocation);
+                result = mockTable;
+            }
+        };
+
+        boolean result = icebergRESTCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation);
+        Assertions.assertTrue(result);
+    }
+
+    @Test
+    public void testRegisterTableFailureWithRESTException() {
+        // Test table registration failure when REST catalog throws exception
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/path/to/table/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                restCatalog.registerTable((SessionCatalog.SessionContext) any, expectedTableId, metadataFileLocation);
+                result = new RESTException("REST API error");
+            }
+        };
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> icebergRESTCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation));
+        Assertions.assertTrue(exception.getMessage().contains("Failed to register table"));
+    }
+
+    @Test
+    public void testRegisterTableReturnsFalseWhenTableIsNull() {
+        // Test when REST catalog returns null table
+        String dbName = "test_db";
+        String tableName = "test_table";
+        String metadataFileLocation = "/path/to/table/metadata.json";
+        TableIdentifier expectedTableId = TableIdentifier.of(dbName, tableName);
+
+        new Expectations() {
+            {
+                restCatalog.registerTable((SessionCatalog.SessionContext) any, expectedTableId, metadataFileLocation);
+                result = null;
+            }
+        };
+
+        boolean result = icebergRESTCatalog.registerTable(connectContext, dbName, tableName, metadataFileLocation);
+        Assertions.assertFalse(result);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -54,6 +54,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.proc.ReplicasProcNode;
 import com.starrocks.common.util.KafkaUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
 import com.starrocks.http.rest.RestBaseAction;
 import com.starrocks.load.pipe.PipeManagerTest;
 import com.starrocks.load.routineload.RoutineLoadMgr;
@@ -499,7 +500,7 @@ public class PrivilegeCheckerTest {
     }
 
     @Test
-    public void testCatalogStatement() throws Exception {
+    public void testCatalogStatement(@Mocked IcebergHiveCatalog hiveCatalog) throws Exception {
         starRocksAssert.withCatalog("create external catalog test_ex_catalog properties (" +
                 "\"type\"=\"iceberg\", \"iceberg.catalog.type\"=\"hive\")");
         ConnectContext ctx = starRocksAssert.getCtx();
@@ -553,7 +554,7 @@ public class PrivilegeCheckerTest {
     }
 
     @Test
-    public void testExternalDBAndTablePEntryObject() throws Exception {
+    public void testExternalDBAndTablePEntryObject(@Mocked IcebergHiveCatalog hiveCatalog) throws Exception {
         starRocksAssert.withCatalog("create external catalog test_iceberg properties (" +
                 "\"type\"=\"iceberg\", \"iceberg.catalog.type\"=\"hive\")");
         DbPEntryObject dbPEntryObject =

--- a/test/sql/test_iceberg/R/test_iceberg_register_table
+++ b/test/sql/test_iceberg/R/test_iceberg_register_table
@@ -1,0 +1,147 @@
+-- name: test_iceberg_register_table
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+call iceberg_sql_test_${uuid0}.system.register_table("iceberg_db_${uuid0}", "iceberg_register_table", "oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+-- result:
+1	1
+2	2
+3	3
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+-- result:
+-- !result
+call iceberg_sql_test_${uuid0}.system.register_table(database_name="iceberg_db_${uuid0}",table_name="iceberg_register_table", metadata_file="oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+-- result:
+1	1
+2	2
+3	3
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+-- result:
+-- !result
+call iceberg_sql_test_${uuid0}.system.register_table(database_name=>"iceberg_db_${uuid0}",table_name=>"iceberg_register_table", metadata_file=>"oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+-- result:
+1	1
+2	2
+3	3
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+-- result:
+-- !result
+call iceberg_sql_test_${uuid0}.system.register_table(table_name=>"iceberg_register_table", database_name=>"iceberg_db_${uuid0}", metadata_file=>"oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+-- result:
+1	1
+2	2
+3	3
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+-- result:
+-- !result
+call iceberg_sql_test_${uuid0}.system.register_table(metadata_file="oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json", table_name="iceberg_register_table", database_name="iceberg_db_${uuid0}");
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+-- result:
+1	1
+2	2
+3	3
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+-- result:
+-- !result
+call iceberg_sql_test_${uuid0}.system.register_table("iceberg_db_${uuid0}", "iceberg_register_table", "oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00001-ce5998c2-b755-478f-94d1-bcd6c57bfbe0.metadata.json");
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+-- result:
+1	1
+2	2
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+-- result:
+-- !result
+set catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result
+call system.register_table("iceberg_db_${uuid0}", "iceberg_register_table", "oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+-- result:
+1	1
+2	2
+3	3
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+-- result:
+-- !result
+set catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result
+call register_table("iceberg_db_${uuid0}", "iceberg_register_table", "oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+-- result:
+1	1
+2	2
+3	3
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+-- result:
+-- !result
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+call register_table(table_name="iceberg_register_table", metadata_file="oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+-- result:
+1	1
+2	2
+3	3
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+-- result:
+-- !result
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+call register_table("iceberg_db_${uuid0}", "iceberg_register_table");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Missing required argument: metadata_file.')
+-- !result
+call register_table("iceberg_db_${uuid0}", "iceberg_register_table", "oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00003-xxxxxx.metadata.json");
+-- result:
+[REGEX].*Failed to register table: File does not exist: oss://starrocks-ci-test/iceberg_ci_db/iceberg_register_table/metadata/00003-xxxxxx.metadata.json.*
+-- !result
+call register_table(database_name="iceberg_db_${uuid0}", metadata_file="oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Missing required argument: table_name.')
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_register_table
+++ b/test/sql/test_iceberg/T/test_iceberg_register_table
@@ -1,0 +1,59 @@
+-- name: test_iceberg_register_table
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+
+-- Register Iceberg table with metadata file
+call iceberg_sql_test_${uuid0}.system.register_table("iceberg_db_${uuid0}", "iceberg_register_table", "oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+
+call iceberg_sql_test_${uuid0}.system.register_table(database_name="iceberg_db_${uuid0}",table_name="iceberg_register_table", metadata_file="oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+
+call iceberg_sql_test_${uuid0}.system.register_table(database_name=>"iceberg_db_${uuid0}",table_name=>"iceberg_register_table", metadata_file=>"oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+
+call iceberg_sql_test_${uuid0}.system.register_table(table_name=>"iceberg_register_table", database_name=>"iceberg_db_${uuid0}", metadata_file=>"oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+
+call iceberg_sql_test_${uuid0}.system.register_table(metadata_file="oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json", table_name="iceberg_register_table", database_name="iceberg_db_${uuid0}");
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+
+-- Register Iceberg table with old snapshot metadata file
+call iceberg_sql_test_${uuid0}.system.register_table("iceberg_db_${uuid0}", "iceberg_register_table", "oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00001-ce5998c2-b755-478f-94d1-bcd6c57bfbe0.metadata.json");
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+
+-- Register Iceberg table without catalog name
+set catalog iceberg_sql_test_${uuid0};
+call system.register_table("iceberg_db_${uuid0}", "iceberg_register_table", "oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+
+-- Register Iceberg table without database name
+set catalog iceberg_sql_test_${uuid0};
+call register_table("iceberg_db_${uuid0}", "iceberg_register_table", "oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+call register_table(table_name="iceberg_register_table", metadata_file="oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table order by k1;
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_register_table;
+
+-- error cases
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- missing metadata_file
+call register_table("iceberg_db_${uuid0}", "iceberg_register_table");
+-- invalid metadata_file
+call register_table("iceberg_db_${uuid0}", "iceberg_register_table", "oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00003-xxxxxx.metadata.json");
+-- missing table_name
+call register_table(database_name="iceberg_db_${uuid0}", metadata_file="oss://${oss_bucket}/iceberg_ci_db/iceberg_register_table/metadata/00002-c1b32f52-4f2b-42cc-b251-1b2909a52ea6.metadata.json");
+
+set catalog default_catalog;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
#61855 
https://github.com/StarRocks/StarRocksTest/pull/10111
## What I'm doing:
This pull request introduces support for registering existing Iceberg tables using metadata files via a new procedure, along with the necessary API and implementation changes across multiple catalog connectors. The main focus is on adding the `registerTable` method to the Iceberg catalog interface and its implementations, and providing a new procedure for users to invoke this functionality.

### Iceberg Table Registration Feature

* Added a new `registerTable` method to the `IcebergCatalog` interface, with default and per-catalog implementations (`IcebergGlueCatalog`, `IcebergHadoopCatalog`, `IcebergHiveCatalog`, `IcebergJdbcCatalog`, `IcebergRESTCatalog`). This enables registering an Iceberg table using its metadata file path, with error handling and logging.

* Updated `CachingIcebergCatalog` to delegate the new `registerTable` method to its underlying catalog implementation.

### Procedure and API Changes

* Implemented the new `RegisterTableProcedure`, including argument validation, metadata checks, and invoking the Iceberg catalog's `registerTable` method. The procedure now requires `database_name`, `table_name`, and `metadata_file` arguments.

* Changed procedure registration in `IcebergConnector` to instantiate `RegisterTableProcedure` with the appropriate catalog and native catalog objects.

### Metadata and Connector Updates

* Added the `registerTable` method to `CatalogConnectorMetadata`, delegating to the normal connector metadata implementation.

### Parser and Statement Changes

* Updated the SQL parser grammar to recognize `SYSTEM` as a non-reserved keyword, allowing its use in procedure names.
* Changed `CallProcedureStatement` to extend `DdlStmt` instead of `StatementBase` for better alignment with DDL operations.
Fixes #issue

### How to use 
```
call  <iceberg_catalog>.system.register_table(database_name="<db_name>",table_name="<table_name>", metadata_file="s3://path/to/iceberg_table/00002-xxxx.metadata.json");
```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
