### PR TITLE
[Enhancement] implement z-order encoding for multi-dimensional clustering

### DIFF
--- a/be/src/exprs/utility_functions.cpp
+++ b/be/src/exprs/utility_functions.cpp
@@ -566,9 +566,9 @@ StatusOr<ColumnPtr> UtilityFunctions::encode_sort_key(FunctionContext* context, 
 // - For each row, the bits from all encoded sequences are interleaved in z-order (Morton order).
 // - The resulting byte sequence forms the final Z-order encoded key for that row.
 // - The output is a VARBINARY column, where each entry is the Z-order encoded key for the corresponding row.
-StatusOr<ColumnPtr> UtilityFunctions::zorder_encode(FunctionContext* context, const Columns& columns) {
+StatusOr<ColumnPtr> UtilityFunctions::encode_zorder_key(FunctionContext* context, const Columns& columns) {
     int num_args = columns.size();
-    RETURN_IF(num_args < 1, Status::InvalidArgument("zorder_encode requires at least 1 argument"));
+    RETURN_IF(num_args < 1, Status::InvalidArgument("encode_zorder_key requires at least 1 argument"));
 
     size_t num_rows = columns[0]->size();
     for (int i = 1; i < num_args; ++i) {

--- a/be/src/exprs/utility_functions.cpp
+++ b/be/src/exprs/utility_functions.cpp
@@ -486,6 +486,92 @@ struct EncoderVisitor : public ColumnVisitorAdapter<EncoderVisitor> {
 };
 } // namespace detail
 
+// Visitor to collect order-preserving 64-bit values and null flags for Z-order encoding
+namespace detail {
+struct ZOrderVisitor : public ColumnVisitorAdapter<ZOrderVisitor> {
+    explicit ZOrderVisitor(std::vector<uint64_t>* values_, std::vector<uint8_t>* nulls_)
+            : ColumnVisitorAdapter(this), values(values_), nulls(nulls_) {}
+
+    std::vector<uint64_t>* values;
+    std::vector<uint8_t>* nulls;
+    const Buffer<uint8_t>* null_mask = nullptr;
+    int width_bits = 0;
+
+    Status do_visit(const NullableColumn& column) {
+        auto& nm = column.immutable_null_column_data();
+        // Merge null mask
+        for (size_t i = 0; i < column.size(); i++) {
+            if ((*nulls)[i] == 0 && nm[i]) (*nulls)[i] = 1;
+        }
+        const Buffer<uint8_t>* old = null_mask;
+        null_mask = &nm;
+        Status st = column.data_column()->accept(this);
+        null_mask = old;
+        return st;
+    }
+
+    Status do_visit(const ConstColumn& column) {
+        // Expand const by re-visiting the data column (ConstColumn::size() should equal row count)
+        for (size_t i = 0; i < column.size(); i++) {
+            RETURN_IF_ERROR(column.data_column()->accept(this));
+        }
+        return Status::OK();
+    }
+
+    template <typename T>
+    static inline uint64_t sign_flip(T v) {
+        using UT = std::make_unsigned_t<T>;
+        constexpr int B = sizeof(T) * 8;
+        UT uv = static_cast<UT>(v);
+        uv ^= static_cast<UT>(1) << (B - 1);
+        return static_cast<uint64_t>(uv);
+    }
+
+    static inline uint32_t encode_f32(float v) {
+        uint32_t u; memcpy(&u, &v, sizeof(u));
+        u ^= (u & 0x80000000u) ? 0xFFFFFFFFu : 0x80000000u;
+        return u;
+    }
+    static inline uint64_t encode_f64(double v) {
+        uint64_t u; memcpy(&u, &v, sizeof(u));
+        u ^= (u & 0x8000000000000000ull) ? 0xFFFFFFFFFFFFFFFFull : 0x8000000000000000ull;
+        return u;
+    }
+
+    template <typename T>
+    Status do_visit(const FixedLengthColumn<T>& column) {
+        const auto& data = column.get_data();
+        for (size_t i = 0; i < column.size(); i++) {
+            bool isnull = (null_mask && (*null_mask)[i]);
+            if (isnull) {
+                (*nulls)[i] = 1;
+                (*values)[i] = 0;
+            } else {
+                if constexpr (std::is_same_v<T, float>) {
+                    (*values)[i] = encode_f32(data[i]); width_bits = 32;
+                } else if constexpr (std::is_same_v<T, double>) {
+                    (*values)[i] = encode_f64(data[i]); width_bits = 64;
+                } else if constexpr (std::is_same_v<T, DateValue>) {
+                    (*values)[i] = static_cast<uint64_t>(data[i].julian()); width_bits = 32;
+                } else if constexpr (std::is_same_v<T, TimestampValue>) {
+                    (*values)[i] = static_cast<uint64_t>(data[i].timestamp()); width_bits = 64;
+                } else if constexpr (std::is_integral_v<T>) {
+                    if constexpr (std::is_signed_v<T>) { (*values)[i] = sign_flip(data[i]); }
+                    else { (*values)[i] = static_cast<uint64_t>(data[i]); }
+                    width_bits = static_cast<int>(sizeof(T) * 8);
+                } else {
+                    return Status::NotSupported("zorder_encode: unsupported argument type");
+                }
+            }
+        }
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(const T& /*column*/) { return Status::NotSupported("zorder_encode: unsupported argument type"); }
+};
+} // namespace detail
+
 // The encoding strategy of encode_sort_key is as follows:
 //
 // - For each input column, each row's value is encoded into a binary buffer
@@ -566,65 +652,26 @@ StatusOr<ColumnPtr> UtilityFunctions::zorder_encode(FunctionContext* context, co
         RETURN_IF(columns[i]->size() != num_rows, Status::InvalidArgument("all arguments must have the same number of rows"));
     }
 
-    struct DimAccessor {
-        std::function<uint64_t(size_t)> get_u64;
-        std::function<bool(size_t)> is_null;
-        int width_bits = 0;
-    };
-
-    auto sign_flip = [](auto v) -> uint64_t {
-        using T = decltype(v);
-        using UT = std::make_unsigned_t<T>;
-        constexpr int B = sizeof(T) * 8;
-        UT uv = static_cast<UT>(v);
-        uv ^= static_cast<UT>(1) << (B - 1);
-        return static_cast<uint64_t>(uv);
-    };
-    auto f32 = [](float v) -> uint32_t {
-        uint32_t u; memcpy(&u, &v, sizeof(u));
-        u ^= (u & 0x80000000u) ? 0xFFFFFFFFu : 0x80000000u; return u;
-    };
-    auto f64 = [](double v) -> uint64_t {
-        uint64_t u; memcpy(&u, &v, sizeof(u));
-        u ^= (u & 0x8000000000000000ull) ? 0xFFFFFFFFFFFFFFFFull : 0x8000000000000000ull; return u;
-    };
-
-    std::vector<DimAccessor> dims;
-    dims.reserve(num_args);
+    // Build per-dimension accessors with ColumnVisitor
+    struct Dim { std::vector<uint64_t> values; std::vector<uint8_t> nulls; int width_bits = 0; };
+    std::vector<Dim> dims; dims.reserve(num_args);
     for (int j = 0; j < num_args; ++j) {
-        const ColumnPtr& in_col = columns[j];
-        ColumnPtr data_col = FunctionHelper::get_data_column_of_const(in_col);
-        const NullableColumn* nullable = data_col->is_nullable() ? down_cast<const NullableColumn*>(data_col.get()) : nullptr;
-        const Column* raw = nullable ? nullable->data_column().get() : data_col.get();
-        DimAccessor acc;
-        if (nullable) { const auto* nulls = &nullable->immutable_null_column_data(); acc.is_null = [nulls](size_t i){ return (*nulls)[i] != 0; }; }
-        else { acc.is_null = [](size_t){ return false; }; }
-
-        if (auto p = dynamic_cast<const Int8Column*>(raw)) { const auto* b=&p->get_data(); acc.get_u64=[b,sign_flip](size_t i){return sign_flip((*b)[i]);}; acc.width_bits=8; }
-        else if (auto p = dynamic_cast<const Int16Column*>(raw)) { const auto* b=&p->get_data(); acc.get_u64=[b,sign_flip](size_t i){return sign_flip((*b)[i]);}; acc.width_bits=16; }
-        else if (auto p = dynamic_cast<const Int32Column*>(raw)) { const auto* b=&p->get_data(); acc.get_u64=[b,sign_flip](size_t i){return sign_flip((*b)[i]);}; acc.width_bits=32; }
-        else if (auto p = dynamic_cast<const Int64Column*>(raw)) { const auto* b=&p->get_data(); acc.get_u64=[b,sign_flip](size_t i){return sign_flip((*b)[i]);}; acc.width_bits=64; }
-        else if (auto p = dynamic_cast<const UInt8Column*>(raw)) { const auto* b=&p->get_data(); acc.get_u64=[b](size_t i){return static_cast<uint64_t>((*b)[i]);}; acc.width_bits=8; }
-        else if (auto p = dynamic_cast<const UInt16Column*>(raw)) { const auto* b=&p->get_data(); acc.get_u64=[b](size_t i){return static_cast<uint64_t>((*b)[i]);}; acc.width_bits=16; }
-        else if (auto p = dynamic_cast<const UInt32Column*>(raw)) { const auto* b=&p->get_data(); acc.get_u64=[b](size_t i){return static_cast<uint64_t>((*b)[i]);}; acc.width_bits=32; }
-        else if (auto p = dynamic_cast<const UInt64Column*>(raw)) { const auto* b=&p->get_data(); acc.get_u64=[b](size_t i){return static_cast<uint64_t>((*b)[i]);}; acc.width_bits=64; }
-        else if (auto p = dynamic_cast<const FloatColumn*>(raw)) { const auto* b=&p->get_data(); acc.get_u64=[b,f32](size_t i){return static_cast<uint64_t>(f32((*b)[i]));}; acc.width_bits=32; }
-        else if (auto p = dynamic_cast<const DoubleColumn*>(raw)) { const auto* b=&p->get_data(); acc.get_u64=[b,f64](size_t i){return f64((*b)[i]);}; acc.width_bits=64; }
-        else if (auto p = dynamic_cast<const DateColumn*>(raw)) { const auto* b=&p->get_data(); acc.get_u64=[b](size_t i){return static_cast<uint64_t>((*b)[i].julian());}; acc.width_bits=32; }
-        else if (auto p = dynamic_cast<const TimestampColumn*>(raw)) { const auto* b=&p->get_data(); acc.get_u64=[b](size_t i){return static_cast<uint64_t>((*b)[i].timestamp());}; acc.width_bits=64; }
-        else { return Status::NotSupported("zorder_encode: unsupported argument type"); }
-
-        dims.emplace_back(std::move(acc));
+        Dim d; d.values.assign(num_rows, 0); d.nulls.assign(num_rows, 0);
+        detail::ZOrderVisitor visitor_dim(&d.values, &d.nulls);
+        ColumnPtr col = FunctionHelper::get_data_column_of_const(columns[j]);
+        RETURN_IF_ERROR(col->accept(&visitor_dim));
+        d.width_bits = visitor_dim.width_bits;
+        dims.emplace_back(std::move(d));
     }
 
     int max_bits = 0; for (const auto& d : dims) max_bits = std::max(max_bits, d.width_bits);
     ColumnBuilder<TYPE_VARBINARY> builder(num_rows);
     std::string out; out.reserve(((size_t)max_bits*dims.size()+7)/8 + dims.size());
     for (size_t i = 0; i < num_rows; ++i) {
-        out.clear(); for (const auto& d : dims) out.push_back(d.is_null(i) ? *NULL_MARKER : *NOT_NULL_MARKER);
+        out.clear(); for (const auto& d : dims) out.push_back(d.nulls[i] ? *NULL_MARKER : *NOT_NULL_MARKER);
         const size_t total_bits = (size_t)max_bits*dims.size(); const size_t total_bytes = (total_bits+7)/8; size_t off = out.size(); out.resize(off+total_bytes, '\0');
         std::vector<uint64_t> aligned; aligned.reserve(dims.size());
-        for (const auto& d : dims) { uint64_t v = d.is_null(i) ? 0ULL : d.get_u64(i); int shift = max_bits - d.width_bits; uint64_t av = (d.width_bits>=64 || shift<=0) ? v : (v << shift); aligned.emplace_back(av); }
+        for (const auto& d : dims) { uint64_t v = d.nulls[i] ? 0ULL : d.values[i]; int shift = max_bits - d.width_bits; uint64_t av = (d.width_bits>=64 || shift<=0) ? v : (v << shift); aligned.emplace_back(av); }
         for (int g = 0; g < max_bits; ++g) { int idx = max_bits - 1 - g; for (size_t j = 0; j < dims.size(); ++j) { uint64_t bit = (aligned[j] >> idx) & 1ULL; size_t ob = (size_t)g*dims.size() + j; size_t byte = ob >> 3; int bit_in_byte = 7 - (ob & 7); out[off+byte] = static_cast<char>(out[off+byte] | (bit << bit_in_byte)); } }
         builder.append(out);
     }

--- a/be/src/exprs/utility_functions.h
+++ b/be/src/exprs/utility_functions.h
@@ -70,6 +70,9 @@ public:
 
     // Build an order-preserving composite binary key from heterogeneous arguments
     DEFINE_VECTORIZED_FN(encode_sort_key);
+
+    // Build a Morton(Z-order) encoded binary key from heterogeneous arguments
+    DEFINE_VECTORIZED_FN(zorder_encode);
 };
 
 } // namespace starrocks

--- a/be/src/exprs/utility_functions.h
+++ b/be/src/exprs/utility_functions.h
@@ -72,7 +72,7 @@ public:
     DEFINE_VECTORIZED_FN(encode_sort_key);
 
     // Build a Morton(Z-order) encoded binary key from heterogeneous arguments
-    DEFINE_VECTORIZED_FN(zorder_encode);
+    DEFINE_VECTORIZED_FN(encode_zorder_key);
 };
 
 } // namespace starrocks

--- a/be/test/exprs/utility_functions_test.cpp
+++ b/be/test/exprs/utility_functions_test.cpp
@@ -336,7 +336,7 @@ TEST_F(UtilityFunctionsTest, zorderEncodeSingleDimOrdering) {
     Columns cols;
     cols.emplace_back(c_int);
 
-    ASSIGN_OR_ASSERT_FAIL(ColumnPtr out, UtilityFunctions::zorder_encode(ctx, cols));
+    ASSIGN_OR_ASSERT_FAIL(ColumnPtr out, UtilityFunctions::encode_zorder_key(ctx, cols));
     auto* bin = ColumnHelper::cast_to_raw<TYPE_VARBINARY>(out);
     ASSERT_EQ(5, bin->size());
 
@@ -379,7 +379,7 @@ TEST_F(UtilityFunctionsTest, zorderEncodeTwoDimsBasicInterleaving) {
     cols.emplace_back(a);
     cols.emplace_back(b);
 
-    ASSIGN_OR_ASSERT_FAIL(ColumnPtr out, UtilityFunctions::zorder_encode(ctx, cols));
+    ASSIGN_OR_ASSERT_FAIL(ColumnPtr out, UtilityFunctions::encode_zorder_key(ctx, cols));
     auto* bin = ColumnHelper::cast_to_raw<TYPE_VARBINARY>(out);
     ASSERT_EQ(test_data.size(), bin->size());
 
@@ -424,7 +424,7 @@ TEST_F(UtilityFunctionsTest, zorderEncodeNullHandling) {
     cols.emplace_back(c1);
     cols.emplace_back(c2);
 
-    ASSIGN_OR_ASSERT_FAIL(ColumnPtr out, UtilityFunctions::zorder_encode(ctx, cols));
+    ASSIGN_OR_ASSERT_FAIL(ColumnPtr out, UtilityFunctions::encode_zorder_key(ctx, cols));
     auto* bin = ColumnHelper::cast_to_raw<TYPE_VARBINARY>(out);
     ASSERT_EQ(4, bin->size());
 
@@ -488,7 +488,7 @@ TEST_F(UtilityFunctionsTest, zorderEncodeMixedDataTypes) {
     cols.emplace_back(date_col);
     cols.emplace_back(timestamp_col);
 
-    ASSIGN_OR_ASSERT_FAIL(ColumnPtr out, UtilityFunctions::zorder_encode(ctx, cols));
+    ASSIGN_OR_ASSERT_FAIL(ColumnPtr out, UtilityFunctions::encode_zorder_key(ctx, cols));
     auto* bin = ColumnHelper::cast_to_raw<TYPE_VARBINARY>(out);
     ASSERT_EQ(5, bin->size());
 

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -826,6 +826,7 @@ vectorized_functions = [
     [100018, 'host_name', True, False, 'VARCHAR', [], "UtilityFunctions::host_name"],
     [100020, 'get_query_profile', True, False, 'VARCHAR', ['VARCHAR'], "UtilityFunctions::get_query_profile"],
     [100024, 'encode_sort_key', True, False, 'VARBINARY', ['ANY_ELEMENT', '...'], 'UtilityFunctions::encode_sort_key'],
+    [100025, 'zorder_encode', True, False, 'VARBINARY', ['ANY_ELEMENT', '...'], 'UtilityFunctions::zorder_encode'],
 
     # json string function
     [110022, "get_json_int", False, False, "BIGINT", ["VARCHAR", "VARCHAR"], "JsonFunctions::get_json_bigint",

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -826,7 +826,7 @@ vectorized_functions = [
     [100018, 'host_name', True, False, 'VARCHAR', [], "UtilityFunctions::host_name"],
     [100020, 'get_query_profile', True, False, 'VARCHAR', ['VARCHAR'], "UtilityFunctions::get_query_profile"],
     [100024, 'encode_sort_key', True, False, 'VARBINARY', ['ANY_ELEMENT', '...'], 'UtilityFunctions::encode_sort_key'],
-    [100025, 'zorder_encode', True, False, 'VARBINARY', ['ANY_ELEMENT', '...'], 'UtilityFunctions::zorder_encode'],
+    [100025, 'encode_zorder_key', True, False, 'VARBINARY', ['ANY_ELEMENT', '...'], 'UtilityFunctions::encode_zorder_key'],
 
     # json string function
     [110022, "get_json_int", False, False, "BIGINT", ["VARCHAR", "VARCHAR"], "JsonFunctions::get_json_bigint",

--- a/test/sql/test_zorder_encode/R/test_zorder_encode_basic
+++ b/test/sql/test_zorder_encode/R/test_zorder_encode_basic
@@ -1,0 +1,224 @@
+-- name: test_zorder_encode_basic
+CREATE DATABASE test_zorder_encode_basic;
+-- result:
+-- !result
+USE test_zorder_encode_basic;
+-- result:
+-- !result
+CREATE TABLE points2d (
+  id INT NOT NULL,
+  x  INT,
+  y  INT,
+  zkey VARBINARY(1024) AS (encode_zorder_key(x, y))
+) ENGINE=OLAP
+DISTRIBUTED BY HASH(id) BUCKETS 1
+ORDER BY (zkey)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+set enable_profile = true;
+-- result:
+-- !result
+set enable_async_profile = false;
+-- result:
+-- !result
+create view profile_filter_rows as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%FilterRows%'
+order by unnest;
+-- result:
+-- !result
+INSERT INTO points2d (id, x, y)
+SELECT 
+  row_number() OVER (ORDER BY rand()) as id,
+  100 + (row_number() OVER (ORDER BY rand()) % 200) as x,
+  100 + (row_number() OVER (ORDER BY rand()) % 200) as y
+FROM table(generate_series(1, 200000));
+-- result:
+-- !result
+INSERT INTO points2d (id, x, y)
+SELECT 
+  200000 + row_number() OVER (ORDER BY rand()) as id,
+  1000 + (row_number() OVER (ORDER BY rand()) % 200) as x,
+  1000 + (row_number() OVER (ORDER BY rand()) % 200) as y
+FROM table(generate_series(1, 200000));
+-- result:
+-- !result
+INSERT INTO points2d (id, x, y)
+SELECT 
+  400000 + row_number() OVER (ORDER BY rand()) as id,
+  5000 + (row_number() OVER (ORDER BY rand()) % 200) as x,
+  5000 + (row_number() OVER (ORDER BY rand()) % 200) as y
+FROM table(generate_series(1, 200000));
+-- result:
+-- !result
+INSERT INTO points2d (id, x, y)
+SELECT 
+  600000 + row_number() OVER (ORDER BY rand()) as id,
+  8000 + (row_number() OVER (ORDER BY rand()) % 200) as x,
+  8000 + (row_number() OVER (ORDER BY rand()) % 200) as y
+FROM table(generate_series(1, 200000));
+-- result:
+-- !result
+INSERT INTO points2d (id, x, y)
+SELECT 
+  800000 + row_number() OVER (ORDER BY rand()) as id,
+  100 + (row_number() OVER (ORDER BY rand()) % 9000) as x,
+  100 + (row_number() OVER (ORDER BY rand()) % 9000) as y
+FROM table(generate_series(1, 200000));
+-- result:
+-- !result
+SELECT count(*) FROM points2d WHERE x = 1000;
+-- result:
+1023
+-- !result
+select * from profile_filter_rows;
+-- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 587.008K (587008)
+- DelVecFilterRows: 0
+- PredFilterRows: 411.969K (411969)
+-- !result
+SELECT count(*) FROM points2d WHERE y = 1000;
+-- result:
+1023
+-- !result
+select * from profile_filter_rows;
+-- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 587.008K (587008)
+- DelVecFilterRows: 0
+- PredFilterRows: 411.969K (411969)
+-- !result
+SELECT count(*) FROM points2d WHERE x = 1000 and y = 1000;
+-- result:
+1
+-- !result
+select * from profile_filter_rows;
+-- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 587.008K (587008)
+- DelVecFilterRows: 0
+- PredFilterRows: 412.991K (412991)
+-- !result
+SELECT count(*) FROM points2d WHERE x BETWEEN 95 AND 105 AND y BETWEEN 95 AND 105;
+-- result:
+198
+-- !result
+select * from profile_filter_rows;
+-- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 587.008K (587008)
+- DelVecFilterRows: 0
+- PredFilterRows: 412.794K (412794)
+-- !result
+SELECT count(*) FROM points2d WHERE x BETWEEN 995 AND 1005 AND y BETWEEN 995 AND 1005;
+-- result:
+155
+-- !result
+select * from profile_filter_rows;
+-- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 587.008K (587008)
+- DelVecFilterRows: 0
+- PredFilterRows: 412.837K (412837)
+-- !result
+SELECT count(*) FROM points2d WHERE x BETWEEN 4995 AND 5005 AND y BETWEEN 4995 AND 5005;
+-- result:
+169
+-- !result
+select * from profile_filter_rows;
+-- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 587.008K (587008)
+- DelVecFilterRows: 0
+- PredFilterRows: 412.823K (412823)
+-- !result
+SELECT count(*) FROM points2d WHERE x BETWEEN 7995 AND 8005 AND y BETWEEN 7995 AND 8005;
+-- result:
+165
+-- !result
+select * from profile_filter_rows;
+-- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 589.824K (589824)
+- DelVecFilterRows: 0
+- PredFilterRows: 410.011K (410011)
+-- !result
+SELECT count(*) FROM points2d WHERE x BETWEEN 90 AND 210 AND y BETWEEN 90 AND 210;
+-- result:
+61474
+-- !result
+select * from profile_filter_rows;
+-- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 587.008K (587008)
+- DelVecFilterRows: 0
+- PredFilterRows: 351.518K (351518)
+-- !result
+SELECT count(*) FROM points2d WHERE x BETWEEN 990 AND 1110 AND y BETWEEN 990 AND 1110;
+-- result:
+61737
+-- !result
+select * from profile_filter_rows;
+-- result:
+- BitmapIndexFilterRows: 0
+- BloomFilterFilterRows: 0
+- GinFilterRows: 0
+- SegmentRuntimeZoneMapFilterRows: 0
+- SegmentZoneMapFilterRows: 0
+- ShortKeyFilterRows: 0
+- VectorIndexFilterRows: 0
+- ZoneMapIndexFilterRows: 587.008K (587008)
+- DelVecFilterRows: 0
+- PredFilterRows: 351.255K (351255)
+-- !result

--- a/test/sql/test_zorder_encode/T/test_zorder_encode_basic
+++ b/test/sql/test_zorder_encode/T/test_zorder_encode_basic
@@ -1,0 +1,67 @@
+-- name: test_zorder_encode_basic
+CREATE DATABASE test_zorder_encode_basic;
+USE test_zorder_encode_basic;
+
+-- Create a table with a generated Z-order key over two dimensions
+CREATE TABLE points2d (
+  id INT NOT NULL,
+  x  INT,
+  y  INT,
+  zkey VARBINARY(1024) AS (zorder_encode(x, y)) COMMENT "Z-order key for (x,y)"
+) ENGINE=OLAP
+DISTRIBUTED BY HASH(id) BUCKETS 2
+ORDER BY (zkey)
+PROPERTIES ("replication_num" = "1");
+
+-- Insert a small grid that demonstrates different orderings between lexicographic (x,y) and Z-order
+INSERT INTO points2d VALUES
+  (1, 0, 0),
+  (2, 0, 1),
+  (3, 1, 0),
+  (4, 1, 1),
+  (5, 2, 0),
+  (6, 0, 2),
+  (7, 2, 2),
+  (8, NULL, 1),
+  (9, 1, NULL);
+
+-- Compare lexicographic ordering and Z-order ordering
+SELECT id, x, y FROM points2d ORDER BY x, y, id;
+SELECT id, x, y FROM points2d ORDER BY zkey, id;
+
+-- Show the key length and a sample of the encoded key bytes for reference
+SELECT id, x, y, length(zkey) AS key_len FROM points2d ORDER BY id;
+
+-- Demonstrate range-style filtering using the generated Z-order key
+-- (In practice you'd compute a set of Z-order ranges for a multidimensional window.)
+SELECT id, x, y FROM points2d
+WHERE zkey > (SELECT zkey FROM points2d WHERE id = 1)
+ORDER BY zkey, id;
+
+-- Also demo with three dimensions
+CREATE TABLE points3d (
+  id INT NOT NULL,
+  x  INT,
+  y  INT,
+  t  BIGINT,
+  zkey VARBINARY(1024) AS (zorder_encode(x, y, t)) COMMENT "Z-order key for (x,y,t)"
+) ENGINE=OLAP
+DISTRIBUTED BY HASH(id) BUCKETS 2
+ORDER BY (zkey)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO points3d VALUES
+  (1, 0, 0,  0),
+  (2, 0, 1,  1),
+  (3, 1, 0,  1),
+  (4, 1, 1,  2),
+  (5, 2, 2, 10),
+  (6, NULL, 1, 5),
+  (7, 1, NULL, 5),
+  (8, 1, 1,  NULL);
+
+SELECT id, x, y, t FROM points3d ORDER BY zkey, id;
+
+-- Clean up
+DROP DATABASE test_zorder_encode_basic;
+

--- a/test/sql/test_zorder_encode/T/test_zorder_encode_basic
+++ b/test/sql/test_zorder_encode/T/test_zorder_encode_basic
@@ -7,61 +7,93 @@ CREATE TABLE points2d (
   id INT NOT NULL,
   x  INT,
   y  INT,
-  zkey VARBINARY(1024) AS (zorder_encode(x, y)) COMMENT "Z-order key for (x,y)"
+  zkey VARBINARY(1024) AS (encode_zorder_key(x, y))
 ) ENGINE=OLAP
-DISTRIBUTED BY HASH(id) BUCKETS 2
+DISTRIBUTED BY HASH(id) BUCKETS 1
 ORDER BY (zkey)
 PROPERTIES ("replication_num" = "1");
 
--- Insert a small grid that demonstrates different orderings between lexicographic (x,y) and Z-order
-INSERT INTO points2d VALUES
-  (1, 0, 0),
-  (2, 0, 1),
-  (3, 1, 0),
-  (4, 1, 1),
-  (5, 2, 0),
-  (6, 0, 2),
-  (7, 2, 2),
-  (8, NULL, 1),
-  (9, 1, NULL);
+set enable_profile = true;
+set enable_async_profile = false;
 
--- Compare lexicographic ordering and Z-order ordering
-SELECT id, x, y FROM points2d ORDER BY x, y, id;
-SELECT id, x, y FROM points2d ORDER BY zkey, id;
+create view profile_filter_rows as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%FilterRows%'
+order by unnest;
 
--- Show the key length and a sample of the encoded key bytes for reference
-SELECT id, x, y, length(zkey) AS key_len FROM points2d ORDER BY id;
+-- Insert data that demonstrates Z-order spatial locality
+-- This creates large clusters of points in different regions to show how Z-order
+-- improves query performance for spatial range queries
 
--- Demonstrate range-style filtering using the generated Z-order key
--- (In practice you'd compute a set of Z-order ranges for a multidimensional window.)
-SELECT id, x, y FROM points2d
-WHERE zkey > (SELECT zkey FROM points2d WHERE id = 1)
-ORDER BY zkey, id;
+-- Cluster 1: Large cluster around (100, 100) - 200K points
+INSERT INTO points2d (id, x, y)
+SELECT 
+  row_number() OVER (ORDER BY rand()) as id,
+  100 + (row_number() OVER (ORDER BY rand()) % 200) as x,
+  100 + (row_number() OVER (ORDER BY rand()) % 200) as y
+FROM table(generate_series(1, 200000));
 
--- Also demo with three dimensions
-CREATE TABLE points3d (
-  id INT NOT NULL,
-  x  INT,
-  y  INT,
-  t  BIGINT,
-  zkey VARBINARY(1024) AS (zorder_encode(x, y, t)) COMMENT "Z-order key for (x,y,t)"
-) ENGINE=OLAP
-DISTRIBUTED BY HASH(id) BUCKETS 2
-ORDER BY (zkey)
-PROPERTIES ("replication_num" = "1");
+-- Cluster 2: Large cluster around (1000, 1000) - 200K points
+INSERT INTO points2d (id, x, y)
+SELECT 
+  200000 + row_number() OVER (ORDER BY rand()) as id,
+  1000 + (row_number() OVER (ORDER BY rand()) % 200) as x,
+  1000 + (row_number() OVER (ORDER BY rand()) % 200) as y
+FROM table(generate_series(1, 200000));
 
-INSERT INTO points3d VALUES
-  (1, 0, 0,  0),
-  (2, 0, 1,  1),
-  (3, 1, 0,  1),
-  (4, 1, 1,  2),
-  (5, 2, 2, 10),
-  (6, NULL, 1, 5),
-  (7, 1, NULL, 5),
-  (8, 1, 1,  NULL);
+-- Cluster 3: Large cluster around (5000, 5000) - 200K points
+INSERT INTO points2d (id, x, y)
+SELECT 
+  400000 + row_number() OVER (ORDER BY rand()) as id,
+  5000 + (row_number() OVER (ORDER BY rand()) % 200) as x,
+  5000 + (row_number() OVER (ORDER BY rand()) % 200) as y
+FROM table(generate_series(1, 200000));
 
-SELECT id, x, y, t FROM points3d ORDER BY zkey, id;
+-- Cluster 4: Large cluster around (8000, 8000) - 200K points
+INSERT INTO points2d (id, x, y)
+SELECT 
+  600000 + row_number() OVER (ORDER BY rand()) as id,
+  8000 + (row_number() OVER (ORDER BY rand()) % 200) as x,
+  8000 + (row_number() OVER (ORDER BY rand()) % 200) as y
+FROM table(generate_series(1, 200000));
 
--- Clean up
-DROP DATABASE test_zorder_encode_basic;
+-- Scattered points to fill the space - 200K points
+INSERT INTO points2d (id, x, y)
+SELECT 
+  800000 + row_number() OVER (ORDER BY rand()) as id,
+  100 + (row_number() OVER (ORDER BY rand()) % 9000) as x,
+  100 + (row_number() OVER (ORDER BY rand()) % 9000) as y
+FROM table(generate_series(1, 200000));
+
+SELECT count(*) FROM points2d WHERE x = 1000;
+select * from profile_filter_rows;
+SELECT count(*) FROM points2d WHERE y = 1000;
+select * from profile_filter_rows;
+SELECT count(*) FROM points2d WHERE x = 1000 and y = 1000;
+select * from profile_filter_rows;
+
+-- Additional queries to demonstrate Z-order benefits
+-- Query points in a spatial range around cluster 1
+SELECT count(*) FROM points2d WHERE x BETWEEN 95 AND 105 AND y BETWEEN 95 AND 105;
+select * from profile_filter_rows;
+
+-- Query points in a spatial range around cluster 2  
+SELECT count(*) FROM points2d WHERE x BETWEEN 995 AND 1005 AND y BETWEEN 995 AND 1005;
+select * from profile_filter_rows;
+
+-- Query points in a spatial range around cluster 3
+SELECT count(*) FROM points2d WHERE x BETWEEN 4995 AND 5005 AND y BETWEEN 4995 AND 5005;
+select * from profile_filter_rows;
+
+-- Query points in a spatial range around cluster 4
+SELECT count(*) FROM points2d WHERE x BETWEEN 7995 AND 8005 AND y BETWEEN 7995 AND 8005;
+select * from profile_filter_rows;
+
+-- Large range queries to show Z-order effectiveness
+SELECT count(*) FROM points2d WHERE x BETWEEN 90 AND 210 AND y BETWEEN 90 AND 210;
+select * from profile_filter_rows;
+
+SELECT count(*) FROM points2d WHERE x BETWEEN 990 AND 1110 AND y BETWEEN 990 AND 1110;
+select * from profile_filter_rows;
 


### PR DESCRIPTION
## Why I'm doing:

To support Z-Order Encoding for Multi-Dimensional Clustering, which can improve query performance on multi-dimensional data.

## What I'm doing:

Introduced a new built-in function `encode_zorder_key(col1, col2, ...)` that computes a Morton (Z-order) interleaved `VARBINARY` key.
This function supports various numeric types (integers, floats, doubles), DATE, and TIMESTAMP, and correctly handles NULL values.
Users can leverage this by defining a generated column using `zorder_encode` and then applying `ORDER BY` on this generated column for multi-dimensional clustering.

Fixes #61769

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-8eadadac-3f0f-4de9-ae74-9c8fd084b077">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8eadadac-3f0f-4de9-ae74-9c8fd084b077">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>
