### PR TITLE
[Refactor] Centralize partition info creation using PartitionInfoBuilder

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfoBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfoBuilder.java
@@ -1,0 +1,253 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.DdlException;
+import com.starrocks.persist.ColumnIdExpr;
+import com.starrocks.sql.ast.ExpressionPartitionDesc;
+import com.starrocks.sql.ast.ListPartitionDesc;
+import com.starrocks.sql.ast.MultiItemListPartitionDesc;
+import com.starrocks.sql.ast.PartitionDesc;
+import com.starrocks.sql.ast.RangePartitionDesc;
+import com.starrocks.sql.ast.SingleItemListPartitionDesc;
+import com.starrocks.sql.ast.SinglePartitionDesc;
+import com.starrocks.sql.ast.SingleRangePartitionDesc;
+import com.starrocks.sql.common.MetaUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builder class to centralize the creation of PartitionInfo from various PartitionDesc types.
+ */
+public class PartitionInfoBuilder {
+
+    /**
+     * Build PartitionInfo from a PartitionDesc
+     */
+    public static PartitionInfo build(PartitionDesc partitionDesc, List<Column> schema,
+                                      Map<String, Long> partitionNameToId, boolean isTemp) throws DdlException {
+        if (partitionDesc instanceof RangePartitionDesc) {
+            return buildRangePartitionInfo((RangePartitionDesc) partitionDesc, schema, partitionNameToId, isTemp);
+        } else if (partitionDesc instanceof ListPartitionDesc) {
+            return buildListPartitionInfo((ListPartitionDesc) partitionDesc, schema, partitionNameToId, isTemp);
+        } else if (partitionDesc instanceof ExpressionPartitionDesc) {
+            return buildExpressionPartitionInfo((ExpressionPartitionDesc) partitionDesc, schema, partitionNameToId, isTemp);
+        } else {
+            throw new DdlException("Unsupported partition type: " + partitionDesc.getClass().getSimpleName());
+        }
+    }
+
+    /**
+     * Build RangePartitionInfo from RangePartitionDesc
+     */
+    private static PartitionInfo buildRangePartitionInfo(RangePartitionDesc rangePartitionDesc,
+                                                         List<Column> schema,
+                                                         Map<String, Long> partitionNameToId,
+                                                         boolean isTemp) throws DdlException {
+        List<Column> partitionColumns = Lists.newArrayList();
+
+        // check and get partition column
+        for (String colName : rangePartitionDesc.getPartitionColNames()) {
+            findRangePartitionColumn(schema, partitionColumns, colName);
+            for (Column column : partitionColumns) {
+                try {
+                    RangePartitionInfo.checkRangeColumnType(column);
+                } catch (AnalysisException e) {
+                    throw new DdlException(e.getMessage());
+                }
+            }
+        }
+
+        /*
+         * validate key range
+         * eg.
+         * VALUE LESS THEN (10, 100, 1000)
+         * VALUE LESS THEN (50, 500)
+         * VALUE LESS THEN (80)
+         *
+         * key range is:
+         * ( {MIN, MIN, MIN},     {10,  100, 1000} )
+         * [ {10,  100, 1000},    {50,  500, MIN } )
+         * [ {50,  500, MIN },    {80,  MIN, MIN } )
+         */
+        RangePartitionInfo rangePartitionInfo = new RangePartitionInfo(partitionColumns);
+        for (SingleRangePartitionDesc desc : rangePartitionDesc.getSingleRangePartitionDescs()) {
+            long partitionId = partitionNameToId.get(desc.getPartitionName());
+            rangePartitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), desc, partitionId, isTemp);
+        }
+        return rangePartitionInfo;
+    }
+
+    /**
+     * Build ListPartitionInfo from ListPartitionDesc
+     */
+    private static PartitionInfo buildListPartitionInfo(ListPartitionDesc listPartitionDesc,
+                                                        List<Column> schema,
+                                                        Map<String, Long> partitionNameToId,
+                                                        boolean isTemp) throws DdlException {
+        try {
+            List<Column> partitionColumns = findPartitionColumns(listPartitionDesc.getPartitionColNames(), schema);
+            Map<ColumnId, Column> idToColumn = MetaUtils.buildIdToColumn(schema);
+            ListPartitionInfo listPartitionInfo = new ListPartitionInfo(listPartitionDesc.getType(), partitionColumns);
+
+            // Handle SingleItemListPartitionDesc
+            for (SingleItemListPartitionDesc desc : listPartitionDesc.getSingleListPartitionDescs()) {
+                long partitionId = partitionNameToId.get(desc.getPartitionName());
+                setPartitionProperties(listPartitionInfo, desc, partitionId, isTemp);
+                listPartitionInfo.setValues(partitionId, desc.getValues());
+                listPartitionInfo.setLiteralExprValues(idToColumn, partitionId, desc.getValues());
+            }
+
+            // Handle MultiItemListPartitionDesc
+            for (MultiItemListPartitionDesc desc : listPartitionDesc.getMultiListPartitionDescs()) {
+                long partitionId = partitionNameToId.get(desc.getPartitionName());
+                setPartitionProperties(listPartitionInfo, desc, partitionId, isTemp);
+                listPartitionInfo.setMultiValues(partitionId, desc.getMultiValues());
+                listPartitionInfo.setMultiLiteralExprValues(idToColumn, partitionId, desc.getMultiValues());
+            }
+
+            listPartitionInfo.setAutomaticPartition(listPartitionDesc.isAutoPartitionTable());
+            return listPartitionInfo;
+        } catch (AnalysisException e) {
+            throw new DdlException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Build ExpressionRangePartitionInfo from ExpressionPartitionDesc
+     */
+    private static PartitionInfo buildExpressionPartitionInfo(ExpressionPartitionDesc expressionPartitionDesc,
+                                                              List<Column> schema,
+                                                              Map<String, Long> partitionNameToId,
+                                                              boolean isTemp) throws DdlException {
+        // for materialized view express partition.
+        if (expressionPartitionDesc.getRangePartitionDesc() == null) {
+            return new ExpressionRangePartitionInfo(
+                    Collections.singletonList(ColumnIdExpr.create(schema, expressionPartitionDesc.getExpr())),
+                    schema,
+                    PartitionType.RANGE);
+        }
+
+        RangePartitionDesc rangePartitionDesc = expressionPartitionDesc.getRangePartitionDesc();
+        List<Column> partitionColumns = Lists.newArrayList();
+
+        // check and get partition column
+        for (String colName : rangePartitionDesc.getPartitionColNames()) {
+            findRangePartitionColumn(schema, partitionColumns, colName);
+        }
+
+        // automatic partition / partition expr only support one partition column
+        Column sourcePartitionColumn = partitionColumns.get(0);
+        if (expressionPartitionDesc.getPartitionType() != null) {
+            Column newTypePartitionColumn = new Column(sourcePartitionColumn);
+            newTypePartitionColumn.setType(expressionPartitionDesc.getPartitionType());
+            partitionColumns = Lists.newArrayList(newTypePartitionColumn);
+        }
+
+        for (Column column : partitionColumns) {
+            try {
+                RangePartitionInfo.checkExpressionRangeColumnType(column, expressionPartitionDesc.getExpr());
+            } catch (AnalysisException e) {
+                throw new DdlException(e.getMessage());
+            }
+        }
+
+        // Recreate a partition column type bypass check
+        RangePartitionInfo partitionInfo;
+        if (rangePartitionDesc.isAutoPartitionTable()) {
+            // for automatic partition table
+            partitionInfo = new ExpressionRangePartitionInfo(
+                    Collections.singletonList(ColumnIdExpr.create(schema, expressionPartitionDesc.getExpr())),
+                    partitionColumns,
+                    PartitionType.EXPR_RANGE);
+        } else {
+            // for partition by range expr
+            ExpressionRangePartitionInfoV2 expressionRangePartitionInfoV2 =
+                    new ExpressionRangePartitionInfoV2(
+                            Collections.singletonList(ColumnIdExpr.create(schema, expressionPartitionDesc.getExpr())),
+                            partitionColumns);
+            expressionRangePartitionInfoV2.setSourcePartitionTypes(
+                    Collections.singletonList(sourcePartitionColumn.getType()));
+            partitionInfo = expressionRangePartitionInfoV2;
+        }
+
+        for (SingleRangePartitionDesc desc : rangePartitionDesc.getSingleRangePartitionDescs()) {
+            long partitionId = partitionNameToId.get(desc.getPartitionName());
+            partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), desc, partitionId, isTemp);
+        }
+
+        return partitionInfo;
+    }
+
+    /**
+     * Helper method to find partition columns from schema
+     */
+    private static List<Column> findPartitionColumns(List<String> partitionColNames, List<Column> schema) {
+        List<Column> partitionColumns = Lists.newArrayList();
+        for (String colName : partitionColNames) {
+            for (Column column : schema) {
+                if (column.getName().equalsIgnoreCase(colName)) {
+                    partitionColumns.add(column);
+                    break;
+                }
+            }
+        }
+        return partitionColumns;
+    }
+
+    private static void findRangePartitionColumn(List<Column> schema, List<Column> partitionColumns, String colName)
+            throws DdlException {
+        boolean find = false;
+        for (Column column : schema) {
+            if (column.getName().equalsIgnoreCase(colName)) {
+                if (!column.isKey() && column.getAggregationType() != AggregateType.NONE) {
+                    throw new DdlException("The partition column could not be aggregated column"
+                            + " and unique table's partition column must be key column");
+                }
+
+                if (column.getType().isFloatingPointType() || column.getType().isComplexType()) {
+                    throw new DdlException(String.format("Invalid partition column '%s': %s",
+                            column.getName(), "invalid data type " + column.getType()));
+                }
+
+                partitionColumns.add(column);
+                find = true;
+                break;
+            }
+        }
+        if (!find) {
+            throw new DdlException("Partition column[" + colName + "] does not found");
+        }
+    }
+
+    /**
+     * Helper method to set common partition properties
+     */
+    private static void setPartitionProperties(ListPartitionInfo listPartitionInfo,
+                                               SinglePartitionDesc desc,
+                                               long partitionId,
+                                               boolean isTemp) {
+        listPartitionInfo.setDataProperty(partitionId, desc.getPartitionDataProperty());
+        listPartitionInfo.setIsInMemory(partitionId, desc.isInMemory());
+        listPartitionInfo.setTabletType(partitionId, desc.getTabletType());
+        listPartitionInfo.setReplicationNum(partitionId, desc.getReplicationNum());
+        listPartitionInfo.setIdToIsTempPartition(partitionId, isTemp);
+        listPartitionInfo.setDataCacheInfo(partitionId, desc.getDataCacheInfo());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/server/ElasticSearchTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/ElasticSearchTableFactory.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.EsTable;
 import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionInfoBuilder;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.DdlException;
@@ -63,7 +64,7 @@ public class ElasticSearchTableFactory implements AbstractTableFactory {
         PartitionInfo partitionInfo = null;
         Map<String, Long> partitionNameToId = Maps.newHashMap();
         if (partitionDesc != null) {
-            partitionInfo = partitionDesc.toPartitionInfo(baseSchema, partitionNameToId, false);
+            partitionInfo = PartitionInfoBuilder.build(partitionDesc, baseSchema, partitionNameToId, false);
         } else if (null != metastore) {
             long partitionId = metastore.getNextId();
             // use table name as single partition name

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -86,6 +86,7 @@ import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionInfoBuilder;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.PhysicalPartition;
@@ -3185,7 +3186,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
                 Expr partitionByExpr = partitionByExprs.get(0);
                 ExpressionPartitionDesc expressionPartitionDesc = new ExpressionPartitionDesc(partitionByExpr);
-                return expressionPartitionDesc.toPartitionInfo(mvPartitionColumns, Maps.newHashMap(), false);
+                return PartitionInfoBuilder.build(expressionPartitionDesc, mvPartitionColumns, Maps.newHashMap(), false);
             }
         } else {
             if (partitionType != PartitionType.UNPARTITIONED && partitionType != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -35,6 +35,7 @@ import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionInfoBuilder;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
@@ -146,7 +147,7 @@ public class OlapTableFactory implements AbstractTableFactory {
             } else {
                 throw new DdlException("Currently only support range or list partition with engine type olap");
             }
-            partitionInfo = partitionDesc.toPartitionInfo(baseSchema, partitionNameToId, false);
+            partitionInfo = PartitionInfoBuilder.build(partitionDesc, baseSchema, partitionNameToId, false);
 
             // Automatic partitioning needs to ensure that at least one tablet is opened.
             if (partitionInfo.isAutomaticPartition()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
@@ -55,7 +55,10 @@ public class ColumnDefAnalyzer {
         final String name = columnDef.getName();
         final TypeDef typeDef = columnDef.getTypeDef();
         final Boolean isPartitionColumn = columnDef.isPartitionColumn();
+
+        columnDef.setCharsetName(columnDef.getCharsetName().toLowerCase());
         final String charsetName = columnDef.getCharsetName();
+
         final AggregateType aggregateType = columnDef.getAggregateType();
         final AggStateDesc aggStateDesc = columnDef.getAggStateDesc();
         final boolean isKey = columnDef.isKey();
@@ -83,8 +86,6 @@ public class ColumnDefAnalyzer {
                 }
             }
         }
-
-        columnDef.setCharsetName(charsetName.toLowerCase());
 
         if (!CHARSET_NAMES.contains(charsetName)) {
             throw new AnalysisException("Unknown charset name: " + charsetName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionDesc.java
@@ -16,12 +16,9 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.ParseNode;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
-import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.DdlException;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.thrift.TTabletType;
@@ -62,12 +59,7 @@ public class PartitionDesc implements ParseNode {
         return pos;
     }
 
-    // Currently, RANGE is used for materialized view ExpressionRangePartitionInfo, which is isExprPartition=false,
-    // and EXPR_RANGE is used for ordinary table ExpressionRangePartitionInfo, which is isExprPartition=true
-    public PartitionInfo toPartitionInfo(List<Column> columns, Map<String, Long> partitionNameToId, boolean isTemp)
-            throws DdlException {
-        throw new NotImplementedException();
-    }
+
 
     public String getPartitionName() throws NotImplementedException {
         throw new NotImplementedException();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RangePartitionDesc.java
@@ -20,15 +20,10 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.TimestampArithmeticExpr;
 import com.starrocks.catalog.AggregateType;
-import com.starrocks.catalog.Column;
-import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
-import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.DdlException;
 import com.starrocks.sql.ast.PartitionKeyDesc.PartitionRangeType;
-import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
@@ -168,42 +163,11 @@ public class RangePartitionDesc extends PartitionDesc {
         this.isAutoPartitionTable = autoPartitionTable;
     }
 
-    @Override
-    public PartitionInfo toPartitionInfo(List<Column> schema, Map<String, Long> partitionNameToId, boolean isTemp)
-            throws DdlException {
-        List<Column> partitionColumns = Lists.newArrayList();
-
-        // check and get partition column
-        for (String colName : partitionColNames) {
-            ExpressionPartitionDesc.findRangePartitionColumn(schema, partitionColumns, colName);
-            for (Column column : partitionColumns) {
-                try {
-                    RangePartitionInfo.checkRangeColumnType(column);
-                } catch (AnalysisException e) {
-                    throw new DdlException(e.getMessage());
-                }
-            }
-        }
-
-        /*
-         * validate key range
-         * eg.
-         * VALUE LESS THEN (10, 100, 1000)
-         * VALUE LESS THEN (50, 500)
-         * VALUE LESS THEN (80)
-         *
-         * key range is:
-         * ( {MIN, MIN, MIN},     {10,  100, 1000} )
-         * [ {10,  100, 1000},    {50,  500, MIN } )
-         * [ {50,  500, MIN },    {80,  MIN, MIN } )
-         */
-        RangePartitionInfo rangePartitionInfo = new RangePartitionInfo(partitionColumns);
-        for (SingleRangePartitionDesc desc : singleRangePartitionDescs) {
-            long partitionId = partitionNameToId.get(desc.getPartitionName());
-            rangePartitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), desc, partitionId, isTemp);
-        }
-        return rangePartitionInfo;
+    public boolean isAutoPartitionTable() {
+        return isAutoPartitionTable;
     }
+
+
 
     @Override
     public String toString() {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionDescTest.java
@@ -127,7 +127,8 @@ public class ListPartitionDescTest {
         Map<String, Long> partitionNameToId = new HashMap<>();
         partitionNameToId.put("p1", 10001L);
         partitionNameToId.put("p2", 10002L);
-        return (ListPartitionInfo) listPartitionDesc.toPartitionInfo(this.findColumnList(), partitionNameToId, false);
+        return (ListPartitionInfo) PartitionInfoBuilder.build(listPartitionDesc, this.findColumnList(),
+                partitionNameToId, false);
     }
 
     public ListPartitionInfo findMultiListPartitionInfo() throws AnalysisException, DdlException {
@@ -138,7 +139,8 @@ public class ListPartitionDescTest {
         Map<String, Long> partitionNameToId = new HashMap<>();
         partitionNameToId.put("p1", 10001L);
         partitionNameToId.put("p2", 10002L);
-        return (ListPartitionInfo) listPartitionDesc.toPartitionInfo(this.findColumnList(), partitionNameToId, false);
+        return (ListPartitionInfo) PartitionInfoBuilder.build(listPartitionDesc, this.findColumnList(),
+                partitionNameToId, false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PartitionDescTest.java
@@ -18,6 +18,7 @@ package com.starrocks.catalog;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.TypeDef;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.DdlException;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.PartitionDesc;
 import org.apache.commons.lang.NotImplementedException;
@@ -63,14 +64,16 @@ public class PartitionDescTest {
     }
 
     @Test
-    public void testToPartitionInfo() {
-        assertThrows(NotImplementedException.class, () -> {
+    public void testPartitionInfoBuilder() {
+        // Since toPartitionInfo method was removed, we now use PartitionInfoBuilder directly
+        // We expect DdlException for unsupported partition types
+        assertThrows(DdlException.class, () -> {
             Column id = new Column("id", Type.BIGINT);
             List<Column> columns = Lists.newArrayList(id);
             Map<String, Long> partitionNameToId = new HashMap<>();
             partitionNameToId.put("p1", 1003L);
-            this.partitionDesc.toPartitionInfo(columns, partitionNameToId, false);
-            throw new NotImplementedException();
+            // Use PartitionInfoBuilder directly instead of toPartitionInfo
+            PartitionInfoBuilder.build(this.partitionDesc, columns, partitionNameToId, false);
         });
     }
 


### PR DESCRIPTION
## Why I'm doing:
The main themes are codebase simplification and improved maintainability.
## What I'm doing:
This pull request refactors the partition information creation logic in the StarRocks codebase by introducing a new centralized builder, `PartitionInfoBuilder`, and updating usages throughout the code. It also makes a small adjustment to charset handling in column definitions. 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
