### PR TITLE
[BugFix] Fix set_tablet_schema for partition_morsel_queue(split_morsel_queue)

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -312,10 +312,10 @@ void PhysicalSplitMorselQueue::set_key_ranges(const std::vector<std::unique_ptr<
     }
 }
 
-void PhysicalSplitMorselQueue::set_key_ranges(TabletReaderParams::RangeStartOperation range_start_op,
-                                              TabletReaderParams::RangeEndOperation range_end_op,
-                                              std::vector<OlapTuple> range_start_key,
-                                              std::vector<OlapTuple> range_end_key) {
+void PhysicalSplitMorselQueue::set_key_ranges(const TabletReaderParams::RangeStartOperation& range_start_op,
+                                              const TabletReaderParams::RangeEndOperation& range_end_op,
+                                              const std::vector<OlapTuple>& range_start_key,
+                                              const std::vector<OlapTuple>& range_end_key) {
     _range_start_op = range_start_op;
     _range_end_op = range_end_op;
     _range_start_key = range_start_key;
@@ -578,10 +578,10 @@ void LogicalSplitMorselQueue::set_key_ranges(const std::vector<std::unique_ptr<O
     }
 }
 
-void LogicalSplitMorselQueue::set_key_ranges(TabletReaderParams::RangeStartOperation range_start_op,
-                                             TabletReaderParams::RangeEndOperation range_end_op,
-                                             std::vector<OlapTuple> range_start_key,
-                                             std::vector<OlapTuple> range_end_key) {
+void LogicalSplitMorselQueue::set_key_ranges(const TabletReaderParams::RangeStartOperation& range_start_op,
+                                             const TabletReaderParams::RangeEndOperation& range_end_op,
+                                             const std::vector<OlapTuple>& range_start_key,
+                                             const std::vector<OlapTuple>& range_end_key) {
     _range_start_op = range_start_op;
     _range_end_op = range_end_op;
     _range_start_key = range_start_key;

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -251,6 +251,9 @@ StatusOr<MorselPtr> BucketSequenceMorselQueue::try_get() {
     }
     ASSIGN_OR_RETURN(auto morsel, _morsel_queue->try_get());
     auto* m = down_cast<ScanMorsel*>(morsel.get());
+    if (m == nullptr) {
+        return nullptr;
+    }
     DCHECK(m->has_owner_id());
     auto owner_id = m->owner_id();
     ASSIGN_OR_RETURN(int64_t next_owner_id, _peek_sequence_id());

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -361,7 +361,7 @@ public:
     virtual StatusOr<bool> ready_for_next() const { return true; }
     virtual Status append_morsels(Morsels&& morsels);
     virtual Type type() const = 0;
-    void set_tablet_schema(TabletSchemaCSPtr tablet_schema) {
+    virtual void set_tablet_schema(const TabletSchemaCSPtr& tablet_schema) {
         DCHECK(tablet_schema != nullptr);
         _tablet_schema = tablet_schema;
     }
@@ -421,6 +421,11 @@ public:
     StatusOr<bool> ready_for_next() const override;
     Status append_morsels(Morsels&& morsels) override { return _morsel_queue->append_morsels(std::move(morsels)); }
     Type type() const override { return BUCKET_SEQUENCE; }
+
+    void set_tablet_schema(const TabletSchemaCSPtr& tablet_schema) override {
+        MorselQueue::set_tablet_schema(tablet_schema);
+        _morsel_queue->set_tablet_schema(tablet_schema);
+    }
 
 private:
     StatusOr<int64_t> _peek_sequence_id() const;

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -345,9 +345,10 @@ public:
 
     virtual std::vector<TInternalScanRange*> prepare_olap_scan_ranges() const;
     virtual void set_key_ranges(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges) {}
-    virtual void set_key_ranges(TabletReaderParams::RangeStartOperation _range_start_op,
-                                TabletReaderParams::RangeEndOperation _range_end_op,
-                                std::vector<OlapTuple> _range_start_key, std::vector<OlapTuple> _range_end_key) {}
+    virtual void set_key_ranges(const TabletReaderParams::RangeStartOperation& range_start_op,
+                                const TabletReaderParams::RangeEndOperation& range_end_op,
+                                const std::vector<OlapTuple>& range_start_key,
+                                const std::vector<OlapTuple>& range_end_key) {}
     virtual void set_tablets(const std::vector<BaseTabletSharedPtr>& tablets) { _tablets = tablets; }
     virtual void set_tablet_rowsets(const std::vector<std::vector<BaseRowsetSharedPtr>>& tablet_rowsets) {
         _tablet_rowsets = tablet_rowsets;
@@ -405,11 +406,11 @@ public:
         _morsel_queue->set_key_ranges(key_ranges);
     }
 
-    void set_key_ranges(TabletReaderParams::RangeStartOperation _range_start_op,
-                        TabletReaderParams::RangeEndOperation _range_end_op, std::vector<OlapTuple> _range_start_key,
-                        std::vector<OlapTuple> _range_end_key) override {
-        _morsel_queue->set_key_ranges(_range_start_op, _range_end_op, std::move(_range_start_key),
-                                      std::move(_range_end_key));
+    void set_key_ranges(const TabletReaderParams::RangeStartOperation& range_start_op,
+                        const TabletReaderParams::RangeEndOperation& range_end_op,
+                        const std::vector<OlapTuple>& range_start_key,
+                        const std::vector<OlapTuple>& range_end_key) override {
+        _morsel_queue->set_key_ranges(range_start_op, range_end_op, range_start_key, range_end_key);
     }
 
     void set_tablets(const std::vector<BaseTabletSharedPtr>& tablets) override { _morsel_queue->set_tablets(tablets); }
@@ -485,9 +486,10 @@ public:
     ~PhysicalSplitMorselQueue() override = default;
 
     void set_key_ranges(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges) override;
-    void set_key_ranges(TabletReaderParams::RangeStartOperation _range_start_op,
-                        TabletReaderParams::RangeEndOperation _range_end_op, std::vector<OlapTuple> _range_start_key,
-                        std::vector<OlapTuple> _range_end_key) override;
+    void set_key_ranges(const TabletReaderParams::RangeStartOperation& range_start_op,
+                        const TabletReaderParams::RangeEndOperation& range_end_op,
+                        const std::vector<OlapTuple>& range_start_key,
+                        const std::vector<OlapTuple>& range_end_key) override;
     bool empty() const override { return _unget_morsel == nullptr && _tablet_idx >= _tablets.size(); }
     StatusOr<MorselPtr> try_get() override;
 
@@ -542,9 +544,10 @@ public:
     ~LogicalSplitMorselQueue() override = default;
 
     void set_key_ranges(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges) override;
-    void set_key_ranges(TabletReaderParams::RangeStartOperation range_start_op,
-                        TabletReaderParams::RangeEndOperation range_end_op, std::vector<OlapTuple> range_start_key,
-                        std::vector<OlapTuple> range_end_key) override;
+    void set_key_ranges(const TabletReaderParams::RangeStartOperation& range_start_op,
+                        const TabletReaderParams::RangeEndOperation& range_end_op,
+                        const std::vector<OlapTuple>& range_start_key,
+                        const std::vector<OlapTuple>& range_end_key) override;
     bool empty() const override { return _unget_morsel == nullptr && _tablet_idx >= _tablets.size(); }
     StatusOr<MorselPtr> try_get() override;
 

--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
@@ -83,9 +83,7 @@ StatusOr<ChunkPtr> OlapScanPrepareOperator::pull_chunk(RuntimeState* state) {
     }
     _morsel_queue->set_tablet_rowsets(std::move(tablet_rowsets));
 
-    if ((_morsel_queue->type() == MorselQueue::Type::LOGICAL_SPLIT ||
-         _morsel_queue->type() == MorselQueue::Type::PHYSICAL_SPLIT) &&
-        !tablets.empty()) {
+    if (!tablets.empty()) {
         _morsel_queue->set_tablet_schema(tablets[0]->tablet_schema());
     }
 

--- a/test/sql/test_per_bucket_optimize/R/test_per_bucket_optimize
+++ b/test/sql/test_per_bucket_optimize/R/test_per_bucket_optimize
@@ -25,6 +25,12 @@ select /*+ SET_VAR(enable_per_bucket_optimize=false,enable_query_cache=false) */
 2	5
 3	4
 -- !result
+select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false,tablet_internal_parallel_mode='force_split',pipeline_dop=2) */c2, count() from t0 group by c2 order by c2;
+-- result:
+1	5
+2	5
+3	4
+-- !result
 CREATE TABLE t1 (
     c1 int,
     c2 int
@@ -51,6 +57,12 @@ select /*+ SET_VAR(enable_per_bucket_optimize=false,enable_query_cache=false) */
 2	6
 3	4
 -- !result
+select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false,tablet_internal_parallel_mode='force_split',pipeline_dop=2) */c2, count() from t1 group by c2 order by c2;
+-- result:
+1	5
+2	6
+3	4
+-- !result
 CREATE TABLE t2 (
     c1 int,
     c2 int
@@ -72,6 +84,12 @@ select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false) */c
 3	4
 -- !result
 select /*+ SET_VAR(enable_per_bucket_optimize=false,enable_query_cache=false) */c2, count() from t2 group by c2 order by c2;
+-- result:
+1	5
+2	6
+3	4
+-- !result
+select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false,tablet_internal_parallel_mode='force_split',pipeline_dop=2) */c2, count() from t2 group by c2 order by c2;
 -- result:
 1	5
 2	6
@@ -105,6 +123,13 @@ select /*+ SET_VAR(enable_per_bucket_optimize=false,enable_query_cache=false) */
 3	4
 11	1
 -- !result
+select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false,tablet_internal_parallel_mode='force_split',pipeline_dop=2) */c2, count() from t3 group by c2 order by c2;
+-- result:
+1	5
+2	6
+3	4
+11	1
+-- !result
 CREATE TABLE t4 (
     c1 int, c2 int
 ) DUPLICATE KEY(c1, c2)
@@ -122,6 +147,12 @@ select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false) */c
 3	4
 -- !result
 select /*+ SET_VAR(enable_per_bucket_optimize=false,enable_query_cache=false) */c2, count() from t4 group by c2 order by c2;
+-- result:
+1	5
+2	6
+3	4
+-- !result
+select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false,tablet_internal_parallel_mode='force_split',pipeline_dop=2) */c2, count() from t4 group by c2 order by c2;
 -- result:
 1	5
 2	6

--- a/test/sql/test_per_bucket_optimize/T/test_per_bucket_optimize
+++ b/test/sql/test_per_bucket_optimize/T/test_per_bucket_optimize
@@ -12,6 +12,7 @@ PROPERTIES( "replication_num"="1", "colocate_with"="5a5fd327dsdb_2806" );
 insert into t0 (c1, c2) values (1, 1), (2, 1), (3, 1), (4, 1), (11, 1), (11, 2), (1, 2), (2, 2), (3, 2), (11, 2), (12, 2), (1, 3), (2, 3), (3, 3), (11, 3);
 select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false) */c2, count() from t0 group by c2 order by c2;
 select /*+ SET_VAR(enable_per_bucket_optimize=false,enable_query_cache=false) */c2, count() from t0 group by c2 order by c2;
+select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false,tablet_internal_parallel_mode='force_split',pipeline_dop=2) */c2, count() from t0 group by c2 order by c2;
 
 CREATE TABLE t1 (
     c1 int,
@@ -25,6 +26,7 @@ PROPERTIES( "replication_num"="1", "colocate_with"="5a5fd327dsdb_2806" );
 insert into t1 (c1, c2) values (1, 1), (2, 1), (3, 1), (4, 1), (11, 1), (11, 2), (1, 2), (2, 2), (3, 2), (11, 2), (12, 2), (1, 3), (2, 3), (3, 3), (11, 3);
 select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false) */c2, count() from t1 group by c2 order by c2;
 select /*+ SET_VAR(enable_per_bucket_optimize=false,enable_query_cache=false) */c2, count() from t1 group by c2 order by c2;
+select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false,tablet_internal_parallel_mode='force_split',pipeline_dop=2) */c2, count() from t1 group by c2 order by c2;
 
 
 CREATE TABLE t2 (
@@ -40,6 +42,7 @@ PROPERTIES( "replication_num"="1", "colocate_with"="5a5fd327dsdb_2806" );
 insert into t2 (c1, c2)values (1, 1), (2, 1), (3, 1), (4, 1), (11, 1), (11, 2), (1, 2), (2, 2), (3, 2), (11, 2), (12, 2), (1, 3), (2, 3), (3, 3), (11, 3);
 select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false) */c2, count() from t2 group by c2 order by c2;
 select /*+ SET_VAR(enable_per_bucket_optimize=false,enable_query_cache=false) */c2, count() from t2 group by c2 order by c2;
+select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false,tablet_internal_parallel_mode='force_split',pipeline_dop=2) */c2, count() from t2 group by c2 order by c2;
 
 
 CREATE TABLE t3 (
@@ -54,6 +57,7 @@ PROPERTIES( "replication_num"="1", "colocate_with"="5a5fd327dsdb_2806" );
 insert into t3 (c1, c2)values (1, 1), (2, 1), (3, 1), (4, 1), (11, 1), (11, 2), (1, 2), (2, 2), (3, 2), (11, 2), (12, 2), (1, 3), (2, 3), (3, 3), (11, 3),(1,11);
 select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false) */c2, count() from t3 group by c2 order by c2;
 select /*+ SET_VAR(enable_per_bucket_optimize=false,enable_query_cache=false) */c2, count() from t3 group by c2 order by c2;
+select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false,tablet_internal_parallel_mode='force_split',pipeline_dop=2) */c2, count() from t3 group by c2 order by c2;
 
 
 CREATE TABLE t4 (
@@ -64,3 +68,4 @@ PROPERTIES( "replication_num"="1", "colocate_with"="5a5fd327dsdb_2806" );
 insert into t4 (c1, c2)values (1, 1), (2, 1), (3, 1), (4, 1), (11, 1), (11, 2), (1, 2), (2, 2), (3, 2), (11, 2), (12, 2), (1, 3), (2, 3), (3, 3), (11, 3);
 select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false) */c2, count() from t4 group by c2 order by c2;
 select /*+ SET_VAR(enable_per_bucket_optimize=false,enable_query_cache=false) */c2, count() from t4 group by c2 order by c2;
+select /*+ SET_VAR(enable_per_bucket_optimize=true,enable_query_cache=false,tablet_internal_parallel_mode='force_split',pipeline_dop=2) */c2, count() from t4 group by c2 order by c2;


### PR DESCRIPTION
## Why I'm doing:

#55860 introduced a new `set_tablet_schema` API for `MorselQueue`, which is set when `morsel_queue.type` is `split_morsel_queue`.

However, a `partition_morsel_queue` nests a `split_morsel_queue`, and the `partition_morsel_queue` itself has type `BUCKET_SEQUENCE` rather than `split_morsel_queue`. As a result, the nested `split_morsel_queue` never has `set_tablet_schema` set.

```
*** SIGSEGV (@0xa0) received by PID 1328927 (TID 0x14f3e4c3a640) from PID 160; stack trace: ***
    @     0x14f509070ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xa37c049 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x14f509e7835d os::Linux::chained_handler(int, siginfo*, void*)
    @     0x14f509e7df5f JVM_handle_linux_signal
    @     0x14f509e6f968 signalHandler(int, siginfo*, void*)
    @     0x14f509019520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x6d622bc starrocks::TabletReader::_to_seek_tuple(std::shared_ptr<starrocks::TabletSchema const> const&, starrocks::OlapTuple const&, starrocks::SeekTuple*, starrocks::MemPool*)
    @          0x6d62ebe starrocks::TabletReader::parse_seek_range(std::shared_ptr<starrocks::TabletSchema const> const&, starrocks::TabletReaderParams::RangeStartOperation, starrocks::TabletReaderParams::RangeEndOperation, std::vector<starrocks::OlapTuple, std::allocator<starrockP^Y
    @          0x758ae83 starrocks::pipeline::PhysicalSplitMorselQueue::_init_segment()
    @          0x758b46f starrocks::pipeline::PhysicalSplitMorselQueue::_try_get_split_from_single_tablet()
    @          0x758bd67 starrocks::pipeline::PhysicalSplitMorselQueue::try_get()
    @          0x7587e53 starrocks::pipeline::BucketSequenceMorselQueue::try_get()
    @          0x5456ace starrocks::pipeline::ScanOperator::_pickup_morsel(starrocks::RuntimeState*, int)
    @          0x54555bc starrocks::pipeline::ScanOperator::_try_to_trigger_next_scan(starrocks::RuntimeState*)
    @          0x545584a starrocks::pipeline::ScanOperator::pull_chunk(starrocks::RuntimeState*)
    @          0x544c8b8 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x7ebce58 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x8c00b73 starrocks::ThreadPool::dispatch_thread()
    @          0x8bf81c9 starrocks::Thread::supervise_thread(void*)
    @     0x14f50906bac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x14f5090fd850 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x12684f)
```

## What I'm doing:


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
