### PR TITLE
[Enhancement] avoid pow regression in glibc-2.34

### DIFF
--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -160,10 +160,6 @@ DEFINE_UNARY_FN_WITH_IMPL(ZeroCheck, value) {
     DEFINE_BINARY_FUNCTION(NAME##Impl, FN);                                                        \
     DEFINE_MATH_BINARY_WITH_OUTPUT_NAN_CHECK_FN(NAME, LTYPE, RTYPE, RESULT_TYPE);
 
-#define DEFINE_MATH_BINARY_WITH_OUTPUT_INF_NAN_CHECK_FN_WITH_IMPL(NAME, LTYPE, RTYPE, RESULT_TYPE, FN) \
-    DEFINE_BINARY_FUNCTION(NAME##Impl, FN);                                                            \
-    DEFINE_MATH_BINARY_WITH_OUTPUT_INF_NAN_CHECK_FN(NAME, LTYPE, RTYPE, RESULT_TYPE);
-
 // ============ math function impl ==========
 StatusOr<ColumnPtr> MathFunctions::pi(FunctionContext* context, const Columns& columns) {
     return ColumnHelper::create_const_column<TYPE_DOUBLE>(M_PI, 1);
@@ -308,10 +304,24 @@ DEFINE_BINARY_FUNCTION_WITH_IMPL(round_up_toImpl, l, r) {
     return MathFunctions::double_round(l, r, false, false);
 }
 
+DEFINE_BINARY_FUNCTION_WITH_IMPL(powImpl, l, r) {
+    // fast path
+    if (r == 1.0) {
+        return l;
+    } else if (r == 2.0) {
+        return l * l;
+    } else if (r == -1.0) {
+        return 1.0 / l;
+    } else if (r == 0) {
+        return 1.0;
+    }
+    return std::pow(l, r);
+}
+DEFINE_MATH_BINARY_WITH_OUTPUT_INF_NAN_CHECK_FN(pow, TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE);
+
 // binary math
 DEFINE_MATH_BINARY_FN_WITH_NAN_CHECK(truncate, TYPE_DOUBLE, TYPE_INT, TYPE_DOUBLE);
 DEFINE_MATH_BINARY_FN(round_up_to, TYPE_DOUBLE, TYPE_INT, TYPE_DOUBLE);
-DEFINE_MATH_BINARY_WITH_OUTPUT_INF_NAN_CHECK_FN_WITH_IMPL(pow, TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE, std::pow);
 DEFINE_MATH_BINARY_WITH_OUTPUT_NAN_CHECK_FN_WITH_IMPL(atan2, TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE, std::atan2);
 
 template <LogicalType Type>

--- a/be/test/exprs/math_functions_test.cpp
+++ b/be/test/exprs/math_functions_test.cpp
@@ -1008,6 +1008,10 @@ TEST_F(VecMathFunctionsTest, InfNanTest) {
         Columns binary_columns;
         auto tc1 = DoubleColumn::create();
         tc1->append(-0.9);
+        tc1->append(2);
+        tc1->append(2);
+        tc1->append(2);
+        tc1->append(2);
         tc1->append(0.2);
         tc1->append(0.3);
         tc1->append(4.0);
@@ -1015,12 +1019,16 @@ TEST_F(VecMathFunctionsTest, InfNanTest) {
 
         auto tc2 = DoubleColumn::create();
         tc2->append(0.8);
+        tc2->append(1);
+        tc2->append(2);
+        tc2->append(-1);
+        tc2->append(0);
         tc2->append(0.2);
         tc2->append(0.3);
         tc2->append(1024.0);
         binary_columns.emplace_back(std::move(tc2));
 
-        std::vector<bool> null_expect = {true, false, false, true};
+        std::vector<bool> null_expect = {true, false, false, false, false, false, false, true};
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::pow(ctx.get(), binary_columns).value();
         auto nullable = ColumnHelper::as_raw_column<NullableColumn>(result);


### PR DESCRIPTION
## Why I'm doing:

![img_v3_02p5_98fd1d86-f6f2-4efe-8315-763d4548ba3g](https://github.com/user-attachments/assets/618308e7-d9b5-481e-8d30-071448c6bbeb)

glibc 2.17 has fast path on pow when y is 0/1/-1/2.

## What I'm doing:

implements fast path for function pow

Fixes https://github.com/StarRocks/StarRocksTest/issues/10099

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
