### PR TITLE
[BugFix]  Fix error base version in schema change job with lake rollup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -843,8 +843,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                 }
 
                 if (!isFileBundling) {
-                    Utils.publishVersion(allOtherPartitionTablets, originTxnInfo, 1, commitVersion, computeResource,
-                            isFileBundling);
+                    Utils.publishVersion(allOtherPartitionTablets, originTxnInfo, commitVersion - 1, commitVersion, 
+                            computeResource, isFileBundling);
                 } else {
                     Utils.createSubRequestForAggregatePublish(allOtherPartitionTablets, Lists.newArrayList(originTxnInfo),
                             commitVersion - 1, commitVersion, null, computeResource, request);

--- a/test/sql/test_rollup/R/test_lake_rollup
+++ b/test/sql/test_rollup/R/test_lake_rollup
@@ -50,3 +50,56 @@ SELECT v1 FROM rollup1 [_SYNC_MV_] ORDER BY v1;
 100
 300
 -- !result
+
+-- name: test_lake_rollup2 @cloud
+CREATE TABLE tbl2 (
+    k1 date,
+    k2 int,
+    v1 int sum
+) PARTITION BY RANGE(k1) (
+    PARTITION p1 values [('2020-01-01'),('2020-02-01')),
+    PARTITION p2 values [('2020-02-01'),('2020-03-01')))
+    DISTRIBUTED BY HASH(k1) BUCKETS 3
+    PROPERTIES('replication_num' = '1', 'file_bundling' = 'false');
+-- result:
+-- !result
+
+INSERT INTO tbl2
+VALUES
+    ("2020-01-12",4,100),
+    ("2020-01-11",5,100),
+    ("2020-01-11",4,100);
+-- result:
+-- !result
+
+ALTER TABLE tbl2 ADD ROLLUP rollup2 (k1, v1) FROM tbl2;
+-- result:
+-- !result
+function: wait_alter_table_finish("ROLLUP")
+-- result:
+None
+-- !result
+
+INSERT INTO tbl2 VALUES("2020-01-11",6,100);
+-- result:
+-- !result
+
+SELECT v1 FROM rollup2 [_SYNC_MV_] ORDER BY v1;
+-- result:
+100
+300
+-- !result
+
+ALTER TABLE tbl2 MODIFY COLUMN k2 BIGINT;
+-- result:
+-- !result
+function: wait_alter_table_finish("COLUMN")
+-- result:
+None
+-- !result
+
+SELECT v1 FROM rollup2 [_SYNC_MV_] ORDER BY v1;
+-- result:
+100
+300
+-- !result

--- a/test/sql/test_rollup/T/test_lake_rollup
+++ b/test/sql/test_rollup/T/test_lake_rollup
@@ -26,3 +26,33 @@ ALTER TABLE tbl1 MODIFY COLUMN k2 BIGINT;
 function: wait_alter_table_finish("COLUMN")
 
 SELECT v1 FROM rollup1 [_SYNC_MV_] ORDER BY v1;
+drop table tbl1;
+
+-- name: test_lake_rollup_2 @cloud
+CREATE TABLE tbl2 (
+    k1 date,
+    k2 int,
+    v1 int sum
+) PARTITION BY RANGE(k1) (
+    PARTITION p1 values [('2020-01-01'),('2020-02-01')),
+    PARTITION p2 values [('2020-02-01'),('2020-03-01')))
+    DISTRIBUTED BY HASH(k1) BUCKETS 3
+    PROPERTIES('replication_num' = '1', 'file_bundling' = 'false');
+
+INSERT INTO tbl2
+VALUES
+    ("2020-01-12",4,100),
+    ("2020-01-11",5,100),
+    ("2020-01-11",4,100);
+
+ALTER TABLE tbl2 ADD ROLLUP rollup2 (k1, v1) FROM tbl2;
+function: wait_alter_table_finish("ROLLUP")
+
+INSERT INTO tbl2 VALUES("2020-01-11",6,100);
+
+SELECT v1 FROM rollup2 [_SYNC_MV_] ORDER BY v1;
+
+ALTER TABLE tbl2 MODIFY COLUMN k2 BIGINT;
+function: wait_alter_table_finish("COLUMN")
+
+SELECT v1 FROM rollup2 [_SYNC_MV_] ORDER BY v1;


### PR DESCRIPTION
## Why I'm doing:
When we do alter job for lake rollup, the base version of rollup's shadow tablet is `1` and other tablets is not `1`.

## What I'm doing:
Fix the bug

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
