### PR TITLE
[BugFix] Respect enable_simplify_case_when in PushDownPredicateScanRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
@@ -76,7 +76,9 @@ public class PushDownPredicateScanRule extends TransformationRule {
         ScalarOperatorRewriter scalarOperatorRewriter = new ScalarOperatorRewriter();
         ScalarOperator predicates = Utils.compoundAnd(lfo.getPredicate(), logicalScanOperator.getPredicate());
 
-        predicates = ScalarOperatorRewriter.simplifyCaseWhen(predicates);
+        if (context.getSessionVariable().isEnableSimplifyCaseWhen()) {
+            predicates = ScalarOperatorRewriter.simplifyCaseWhen(predicates);
+        }
 
         ScalarRangePredicateExtractor rangeExtractor = new ScalarRangePredicateExtractor();
         predicates = rangeExtractor.rewriteOnlyColumn(Utils.compoundAnd(Utils.extractConjuncts(predicates)


### PR DESCRIPTION
## Why I'm doing:
In the below example, CASE-WHEN simplification isn't making things simpler so we want to disable it.

Data Prep:
```sql
CREATE TABLE IF NOT EXISTS tbl01(
  id BIGINT,
  col_arr ARRAY<VARCHAR(100)>
)
PROPERTIES ("replication_num" = "1");

INSERT INTO tbl01 VALUES
                    (1, ["A"]),
                    (2, ["A", "B"]),
                    (3, ["A", "B", "C"]),
                    (4, ["A", "B", "C", "D"]),
                    (5, ["A", "B", "C", "D", "E"]),
                    (6, ["A", "B", "C", "D", "E", "F"]),
                    (7, ["A", "B", "C", "D", "E", "F", "G"]),
                    (8, ["A", "B", "C", "D", "E", "F", "G", "H"]),
                    (9, ["A", "B", "C", "D", "E", "F", "G", "H", "I"]),
                    (10, ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]),
                    (11, ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K"]),
                    (12, NULL),
                    (13, NULL),
                    (14, NULL),
                    (15, NULL),
                    (16, NULL);
```

Query:
```sql
WITH cte01 AS (
  SELECT
    id,
    (
      CASE
        WHEN (ARRAY_LENGTH(col_arr) < 8) THEN " 1.0 - 7 "
        WHEN ((ARRAY_LENGTH(col_arr) >= 8) AND (ARRAY_LENGTH(col_arr) < 16)) THEN " 2.8 -15 "
        ELSE NULL
        END
      ) AS len_bucket
  FROM
    tbl01
)
SELECT id, len_bucket
FROM cte01
WHERE len_bucket IS NOT NULL;
```

With CASE-WHEN simplification, the scan predicate becomes
```
PREDICATES: (((array_length(2: col_arr) < 8) AND (array_length(2: col_arr) IS NOT NULL)) OR (((array_length(2: col_arr) >= 8) AND (array_length(2: col_arr) < 16)) AND ((array_length(2: col_arr) >= 8) AND (array_length(2: col_arr) < 16) IS NOT NULL))) OR (((array_length(2: col_arr) >= 8) OR (array_length(2: col_arr) IS NULL)) AND (((array_length(2: col_arr) < 8) OR (array_length(2: col_arr) >= 16)) OR ((array_length(2: col_arr) >= 8) AND (array_length(2: col_arr) < 16) IS NULL)) IS NULL)
```

Without it, the scan predicate is simpler:
```
PREDICATES: CASE WHEN array_length(2: col_arr) < 8 THEN ' 1.0 - 7 ' WHEN (array_length(2: col_arr) >= 8) AND (array_length(2: col_arr) < 16) THEN ' 2.8 -15 ' ELSE NULL END IS NOT NULL
```

## What I'm doing:

Respect `enable_simplify_case_when` session property in `PushDownPredicateScanRule`

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.
- [x] This PR doesn't result in a change in terms of query results. It does result in a change in terms of query planning, if the session variable is used.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3