### PR TITLE
[Enhancement]Add disk and memory datacache metrics

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
@@ -134,9 +134,9 @@ public class DataCacheSelectMetricsTest {
 
         prometheusMetricVisitor.getNodeInfo();
         String metricsInfo = prometheusMetricVisitor.build();
-        Assert.assertTrue(metricsInfo.contains("node_info{type=\"datacache_disk_quota\", backend=\"127.0.0.3\"} 2000"));
-        Assert.assertTrue(metricsInfo.contains("node_info{type=\"datacache_disk_used\", backend=\"127.0.0.3\"} 200"));
-        Assert.assertTrue(metricsInfo.contains("node_info{type=\"datacache_mem_quota\", backend=\"127.0.0.3\"} 1000"));
-        Assert.assertTrue(metricsInfo.contains("node_info{type=\"datacache_mem_used\", backend=\"127.0.0.3\"} 100"));
+        Assertions.assertTrue(metricsInfo.contains("node_info{type=\"datacache_disk_quota\", backend=\"127.0.0.3\"} 2000"));
+        Assertions.assertTrue(metricsInfo.contains("node_info{type=\"datacache_disk_used\", backend=\"127.0.0.3\"} 200"));
+        Assertions.assertTrue(metricsInfo.contains("node_info{type=\"datacache_mem_quota\", backend=\"127.0.0.3\"} 1000"));
+        Assertions.assertTrue(metricsInfo.contains("node_info{type=\"datacache_mem_used\", backend=\"127.0.0.3\"} 100"));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Users want to view datacache disk and memory metrics with grafana. They want add some alerts base on metrics.
But these metrics only can be viewed by `show backends`, as shown in the figure below

<img width="1200" height="559" alt="image" src="https://github.com/user-attachments/assets/473d3563-d1b0-42ea-beaf-6ebf8abe3cb2" />


## What I'm doing:
Add disk and memory datacache metrics.

<img width="1293" height="432" alt="image" src="https://github.com/user-attachments/assets/a83091c5-d354-44d8-a913-a794e9269981" />

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
