### PR TITLE
[Refactor] Remove PartitionType references from partition descriptor classes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfoBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfoBuilder.java
@@ -104,7 +104,7 @@ public class PartitionInfoBuilder {
         try {
             List<Column> partitionColumns = findPartitionColumns(listPartitionDesc.getPartitionColNames(), schema);
             Map<ColumnId, Column> idToColumn = MetaUtils.buildIdToColumn(schema);
-            ListPartitionInfo listPartitionInfo = new ListPartitionInfo(listPartitionDesc.getType(), partitionColumns);
+            ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST, partitionColumns);
 
             // Handle SingleItemListPartitionDesc
             for (SingleItemListPartitionDesc desc : listPartitionDesc.getSingleListPartitionDescs()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1398,7 +1398,8 @@ public class AnalyzerUtils {
             return getAddPartitionClauseForRangePartition(olapTable, partitionValues, isTemp, partitionNamePrefix, measure,
                     distributionDesc, (ExpressionRangePartitionInfo) partitionInfo);
         } else {
-            throw new AnalysisException("Unsupported partition type " + partitionDesc.getClass().getSimpleName());
+            PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+            throw new AnalysisException("Unsupported partition type " + partitionInfo.getType());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1398,7 +1398,7 @@ public class AnalyzerUtils {
             return getAddPartitionClauseForRangePartition(olapTable, partitionValues, isTemp, partitionNamePrefix, measure,
                     distributionDesc, (ExpressionRangePartitionInfo) partitionInfo);
         } else {
-            throw new AnalysisException("Unsupported partition type " + partitionDesc.getType());
+            throw new AnalysisException("Unsupported partition type " + partitionDesc.getClass().getSimpleName());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -61,8 +61,12 @@ import com.starrocks.sql.ast.Identifier;
 import com.starrocks.sql.ast.IndexDef;
 import com.starrocks.sql.ast.KeysDesc;
 import com.starrocks.sql.ast.ListPartitionDesc;
+import com.starrocks.sql.ast.MultiItemListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.RandomDistributionDesc;
+import com.starrocks.sql.ast.RangePartitionDesc;
+import com.starrocks.sql.ast.SingleItemListPartitionDesc;
+import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.sql.common.EngineType;
 import com.starrocks.sql.common.MetaUtils;
 import org.apache.commons.collections.CollectionUtils;
@@ -565,7 +569,12 @@ public class CreateTableAnalyzer {
         PartitionDesc partitionDesc = stmt.getPartitionDesc();
         if (stmt.isOlapEngine()) {
             if (partitionDesc != null) {
-                if (partitionDesc.getType() == PartitionType.RANGE || partitionDesc.getType() == PartitionType.LIST) {
+                if (partitionDesc instanceof ListPartitionDesc ||
+                        partitionDesc instanceof MultiItemListPartitionDesc ||
+                        partitionDesc instanceof RangePartitionDesc ||
+                        partitionDesc instanceof SingleItemListPartitionDesc ||
+                        partitionDesc instanceof SingleRangePartitionDesc) {
+                    //if (partitionDesc.getType() == PartitionType.RANGE || partitionDesc.getType() == PartitionType.LIST) {
                     try {
                         PartitionDescAnalyzer.analyze(partitionDesc);
                         partitionDesc.analyze(stmt.getColumnDefs(), stmt.getProperties());
@@ -597,7 +606,7 @@ public class CreateTableAnalyzer {
         } else {
             if (engineName.equalsIgnoreCase(Table.TableType.ELASTICSEARCH.name())) {
                 EsUtil.analyzePartitionDesc(partitionDesc);
-            } else if (engineName.equalsIgnoreCase(Table.TableType.ICEBERG.name()) 
+            } else if (engineName.equalsIgnoreCase(Table.TableType.ICEBERG.name())
                     || engineName.equalsIgnoreCase(Table.TableType.HIVE.name())) {
                 if (partitionDesc != null) {
                     ((ListPartitionDesc) partitionDesc).analyzeExternalPartitionColumns(stmt.getColumnDefs(), engineName);
@@ -645,8 +654,7 @@ public class CreateTableAnalyzer {
                 throw new SemanticException(keysDesc.getKeysType().toSql()
                         + " must use hash distribution", distributionDesc.getPos());
             }
-            if (distributionDesc.getBuckets() > Config.max_bucket_number_per_partition && stmt.isOlapEngine()
-                    && stmt.getPartitionDesc() != null && stmt.getPartitionDesc().getType() != PartitionType.UNPARTITIONED) {
+            if (distributionDesc.getBuckets() > Config.max_bucket_number_per_partition && stmt.isOlapEngine()) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_TOO_MANY_BUCKETS, Config.max_bucket_number_per_partition);
             }
             Set<String> columnSet = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
@@ -672,7 +680,7 @@ public class CreateTableAnalyzer {
     private static void analyzeGeneratedColumnForIceberg(CreateTableStmt stmt, ConnectContext context) {
         List<Column> columns = stmt.getColumns();
         ListPartitionDesc desc = (ListPartitionDesc) stmt.getPartitionDesc();
-        
+
         for (Column column : columns) {
             if (column.isGeneratedColumn()) {
                 if (!column.getName().startsWith(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {
@@ -701,7 +709,7 @@ public class CreateTableAnalyzer {
                             throw new SemanticException("Iceberg transform expression's parameter should be a column reference");
                         }
                     } else if (fnName.equalsIgnoreCase("truncate") ||
-                                fnName.equalsIgnoreCase("bucket")) {
+                            fnName.equalsIgnoreCase("bucket")) {
                         if (expr.getChildren().size() != 2) {
                             throw new SemanticException("Iceberg transform expression parameter's count not valid");
                         } else if (!(expr.getChild(0) instanceof SlotRef)) {
@@ -710,7 +718,7 @@ public class CreateTableAnalyzer {
                             throw new SemanticException("Iceberg transform expression's second parameter is not valid");
                         }
                     } else {
-                        throw new SemanticException("Iceberg partition column does not support " + fnName + 
+                        throw new SemanticException("Iceberg partition column does not support " + fnName +
                                 " transform expression");
                     }
                 } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -33,7 +33,6 @@ import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
-import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
@@ -574,7 +573,6 @@ public class CreateTableAnalyzer {
                         partitionDesc instanceof RangePartitionDesc ||
                         partitionDesc instanceof SingleItemListPartitionDesc ||
                         partitionDesc instanceof SingleRangePartitionDesc) {
-                    //if (partitionDesc.getType() == PartitionType.RANGE || partitionDesc.getType() == PartitionType.LIST) {
                     try {
                         PartitionDescAnalyzer.analyze(partitionDesc);
                         partitionDesc.analyze(stmt.getColumnDefs(), stmt.getProperties());
@@ -654,7 +652,8 @@ public class CreateTableAnalyzer {
                 throw new SemanticException(keysDesc.getKeysType().toSql()
                         + " must use hash distribution", distributionDesc.getPos());
             }
-            if (distributionDesc.getBuckets() > Config.max_bucket_number_per_partition && stmt.isOlapEngine()) {
+            if (distributionDesc.getBuckets() > Config.max_bucket_number_per_partition && stmt.isOlapEngine()
+                    && stmt.getPartitionDesc() != null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_TOO_MANY_BUCKETS, Config.max_bucket_number_per_partition);
             }
             Set<String> columnSet = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ListPartitionDesc.java
@@ -21,7 +21,6 @@ import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.catalog.AggregateType;
-import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
@@ -71,7 +70,6 @@ public class ListPartitionDesc extends PartitionDesc {
     public ListPartitionDesc(List<String> partitionColNames,
                              List<PartitionDesc> partitionDescs, NodePosition pos) {
         super(pos);
-        super.type = PartitionType.LIST;
         this.partitionColNames = partitionColNames;
         this.singleListPartitionDescs = Lists.newArrayList();
         this.multiListPartitionDescs = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiItemListPartitionDesc.java
@@ -15,7 +15,6 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.LiteralExpr;
-import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.PrintableMap;
@@ -46,7 +45,6 @@ public class MultiItemListPartitionDesc extends SinglePartitionDesc {
     public MultiItemListPartitionDesc(boolean ifNotExists, String partitionName, List<List<String>> multiValues,
                                       Map<String, String> properties, NodePosition pos) {
         super(ifNotExists, partitionName, properties, pos);
-        this.type = PartitionType.LIST;
         this.multiValues = multiValues;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionDesc.java
@@ -17,7 +17,6 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.catalog.DataProperty;
-import com.starrocks.catalog.PartitionType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.sql.parser.NodePosition;
@@ -29,8 +28,6 @@ import java.util.Map;
 
 public class PartitionDesc implements ParseNode {
 
-    protected PartitionType type;
-
     protected final NodePosition pos;
     protected boolean isSystem = false;
 
@@ -40,10 +37,6 @@ public class PartitionDesc implements ParseNode {
 
     protected PartitionDesc(NodePosition pos) {
         this.pos = pos;
-    }
-
-    public PartitionType getType() {
-        return type;
     }
 
     public void analyze(List<ColumnDef> columnDefs, Map<String, String> otherProperties) throws AnalysisException {
@@ -58,8 +51,6 @@ public class PartitionDesc implements ParseNode {
     public NodePosition getPos() {
         return pos;
     }
-
-
 
     public String getPartitionName() throws NotImplementedException {
         throw new NotImplementedException();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RangePartitionDesc.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.TimestampArithmeticExpr;
 import com.starrocks.catalog.AggregateType;
-import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.ast.PartitionKeyDesc.PartitionRangeType;
@@ -47,7 +46,6 @@ public class RangePartitionDesc extends PartitionDesc {
 
     public RangePartitionDesc(List<String> partitionColNames, List<PartitionDesc> partitionDescs, NodePosition pos) {
         super(pos);
-        type = PartitionType.RANGE;
         this.partitionColNames = partitionColNames;
 
         singleRangePartitionDescs = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleItemListPartitionDesc.java
@@ -18,7 +18,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.LiteralExpr;
-import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.PrintableMap;
@@ -52,7 +51,6 @@ public class SingleItemListPartitionDesc extends SinglePartitionDesc {
     public SingleItemListPartitionDesc(boolean ifNotExists, String partitionName, List<String> values,
                                        Map<String, String> properties, NodePosition pos) {
         super(ifNotExists, partitionName, properties, pos);
-        this.type = PartitionType.LIST;
         this.values = values;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.PartitionType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.PrintableMap;
 import com.starrocks.sql.analyzer.FeNameFormat;
@@ -33,7 +32,6 @@ public class SingleRangePartitionDesc extends SinglePartitionDesc {
     public SingleRangePartitionDesc(boolean ifNotExists, String partName, PartitionKeyDesc partitionKeyDesc,
                                     Map<String, String> properties, NodePosition pos) {
         super(ifNotExists, partName, properties, pos);
-        this.type = PartitionType.RANGE;
         this.partitionKeyDesc = partitionKeyDesc;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MultiListPartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MultiListPartitionDescTest.java
@@ -87,7 +87,6 @@ public class MultiListPartitionDescTest {
         partitionDesc.analyze(columnDefLists, null);
 
         Assertions.assertEquals(partitionName, partitionDesc.getPartitionName());
-        Assertions.assertEquals(PartitionType.LIST, partitionDesc.getType());
         Assertions.assertEquals(1, partitionDesc.getReplicationNum());
         Assertions.assertEquals(TTabletType.TABLET_TYPE_MEMORY, partitionDesc.getTabletType());
         Assertions.assertEquals(true, partitionDesc.isInMemory());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/SingleListPartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/SingleListPartitionDescTest.java
@@ -85,7 +85,6 @@ public class SingleListPartitionDescTest {
         partitionDesc.analyze(columnDefLists, null);
 
         Assertions.assertEquals(partitionName, partitionDesc.getPartitionName());
-        Assertions.assertEquals(PartitionType.LIST, partitionDesc.getType());
         Assertions.assertEquals(1, partitionDesc.getReplicationNum());
         Assertions.assertEquals(TTabletType.TABLET_TYPE_MEMORY, partitionDesc.getTabletType());
         Assertions.assertEquals(true, partitionDesc.isInMemory());


### PR DESCRIPTION
## Why I'm doing:
This change simplifies the partitioning logic, improves extensibility, and eliminates redundant code. 
## What I'm doing:
This pull request refactors how partition types are handled in the codebase, removing reliance on the `PartitionType` enum and shifting to class-based type checking for partition descriptors. 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
