### PR TITLE
[Enhancement] optimize ngram bf's memory usage when case insensitive

### DIFF
--- a/be/src/storage/rowset/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_writer.cpp
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE/2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -185,7 +185,7 @@ public:
         return ((size >= x.size) && memequal(data + (size - x.size), x.size, x.data, x.size));
     }
 
-    Slice tolower(std::string& buf) {
+    Slice tolower(std::string& buf) const {
         // copy this slice into buf
         buf.assign(get_data(), get_size());
         std::transform(buf.begin(), buf.end(), buf.begin(), [](unsigned char c) { return std::tolower(c); });

--- a/test/sql/test_index/R/test_ngram_bloom_filter
+++ b/test/sql/test_index/R/test_ngram_bloom_filter
@@ -201,6 +201,9 @@ select * from ngram_index_case_in_sensitive order by ngram_search_case_insensiti
 2023-01-01 00:00:00	AaBAa	3
 2023-01-01 00:00:00	aAbac	3
 -- !result
+select * from ngram_index_case_in_sensitive order by ngram_search_case_insensitive(Username,"ddddd",4) desc;
+-- result:
+-- !result
 -- name: test_ngram_bloom_filter_char
 create database ngram_bloom_filter_db_3;
 -- result:

--- a/test/sql/test_index/T/test_ngram_bloom_filter
+++ b/test/sql/test_index/T/test_ngram_bloom_filter
@@ -106,8 +106,9 @@ function: wait_alter_table_finish()
 -- because tow rows all hit bloom filter if case insensitive, which is a bad case
 select * from ngram_index_case_in_sensitive order by ngram_search(Username,"aabaa",4) desc;
 
--- both are case insensitive, can't filter data 
+-- both are case insensitive
 select * from ngram_index_case_in_sensitive order by ngram_search_case_insensitive(Username,"aabaa",4) desc;
+select * from ngram_index_case_in_sensitive order by ngram_search_case_insensitive(Username,"ddddd",4) desc;
 
 -- name: test_ngram_bloom_filter_char
 create database ngram_bloom_filter_db_3;


### PR DESCRIPTION
## Why I'm doing:
fix https://github.com/StarRocks/starrocks/issues/61936

## What I'm doing:
when ngram bloom filter index is case insensitive, original implementation is to create a new string for every ngram, and transform this string to lowercase. Then insert this string into hashSet. which will cost extra memory

so i implement a case-insensitive hashset when ngram bloom filter index is case insensitive, only insert original slice into this hashset, which will not cost extra memory. when flush, I reuse a string buf for every distinct value in hashset, and transfrom distinct value into lowercase when writing to string buf.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3