### PR TITLE
[BugFix] fail to calculate nested cte's statistics outside memo in table pruning

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningCTETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningCTETest.java
@@ -359,4 +359,47 @@ public class TablePruningCTETest extends TablePruningTestBase {
             Assertions.assertFalse(plan.contains("NESTLOOP"));
         }
     }
+
+    @Test
+    public void testNestedCte() {
+        String sql = "with cte0 as(\n" +
+                "select distinct l_orderkey,l_quantity, l_partkey, l_suppkey, l_linenumber\n" +
+                "from lineitem\n" +
+                "),\n" +
+                "cte1 as(\n" +
+                "select count(distinct l_linenumber) as n, l_orderkey, l_partkey, l_suppkey\n" +
+                "from cte0\n" +
+                "group by l_orderkey, l_partkey, l_suppkey\n" +
+                "),\n" +
+                "cte2 as(\n" +
+                "select count(distinct l_quantity) as n, l_orderkey, l_partkey, l_suppkey\n" +
+                "from cte0\n" +
+                "group by l_orderkey, l_partkey, l_suppkey\n" +
+                "),\n" +
+                "cte3 as(\n" +
+                "select l_orderkey,l_partkey, l_suppkey, sum(n) over(partition by l_orderkey,l_partkey) as sum0\n" +
+                "from cte1\n" +
+                "),\n" +
+                "cte4 as(\n" +
+                "select l_orderkey,l_partkey, l_suppkey, sum(n) over(partition by l_orderkey,l_suppkey) as sum1\n" +
+                "from cte2\n" +
+                "),\n" +
+                "cte5 as(\n" +
+                "select l_orderkey,l_partkey, l_suppkey, sum(n) over(partition by l_partkey) as sum2\n" +
+                "from cte1\n" +
+                "),\n" +
+                "cte6 as(\n" +
+                "select l_orderkey,l_partkey, l_suppkey, sum(n) over(partition by l_suppkey) as sum3\n" +
+                "from cte2\n" +
+                ")\n" +
+                "select /*+SET_VAR(cbo_cte_reuse_rate=0)*/ a.l_orderkey, a.l_partkey, a.l_suppkey, sum0, sum1,sum2,sum3\n" +
+                "from cte3 a \n" +
+                "inner join cte4 b on \n" +
+                "   a.l_orderkey = b.l_orderkey and a.l_partkey = a.l_partkey and a.l_suppkey = b.l_suppkey\n" +
+                "inner join cte5 c on \n" +
+                "   a.l_orderkey = c.l_orderkey and a.l_partkey = c.l_partkey and a.l_suppkey = c.l_suppkey\n" +
+                "inner join cte6 d on \n" +
+                "   a.l_orderkey = d.l_orderkey and a.l_partkey = d.l_partkey and a.l_suppkey = d.l_suppkey;";
+        checkHashJoinCountWithBothRBOAndCBO(sql, 3);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

In plan containing nested CTE,  when setting enable_rbo_table_prune=false, it will throws error
```
cannot obtain cte statistics for LogicalCTEConsumeOperator{cteId='1', limit=-1, predicate=null}
```
since 3.4: This issue is fixed by this PR: https://github.com/StarRocks/starrocks/pull/52150

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
