### PR TITLE
[BugFix] Fix missing clone copy size and duration

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -412,6 +412,8 @@ void run_clone_task(const std::shared_ptr<CloneAgentTaskRequest>& agent_task_req
                 LOG(INFO) << "clone success, set tablet infos. status:" << status
                           << ", signature:" << agent_task_req->signature;
                 finish_task_request.__set_finish_tablet_infos(tablet_infos);
+                finish_task_request.__set_copy_size(engine_task.get_copy_size());
+                finish_task_request.__set_copy_time_ms(engine_task.get_copy_time_ms());
             }
         }
     }

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -655,6 +655,8 @@ Status EngineCloneTask::_download_files(DataDir* data_dir, const std::string& re
     if (total_time_ms > 0) {
         copy_rate = total_file_size / ((double)total_time_ms) / 1000;
     }
+    _copy_size = (int64_t)total_file_size;
+    _copy_time_ms = (int64_t)total_time_ms;
     LOG(INFO) << "Copied tablet " << _signature << " files=" << file_name_list.size() << ". bytes=" << total_file_size
               << " cost=" << total_time_ms << " ms"
               << " rate=" << copy_rate << " MB/s";

--- a/be/src/storage/task/engine_clone_task.h
+++ b/be/src/storage/task/engine_clone_task.h
@@ -57,6 +57,9 @@ public:
 
     Status execute() override;
 
+    int64_t get_copy_size() const { return _copy_size; }
+    int64_t get_copy_time_ms() const { return _copy_time_ms; }
+
 private:
     Status _do_clone_primary_tablet(Tablet* tablet);
 
@@ -95,6 +98,8 @@ private:
     vector<TTabletInfo>* _tablet_infos;
     AgentStatus* _res_status;
     int64_t _signature;
+    int64_t _copy_size = 0;
+    int64_t _copy_time_ms = 0;
 }; // EngineTask
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

`clone copy size and duration` are used in the frontend, but they are not reported when the clone task is finished in the backend.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
