### PR TITLE
[Refactor] Remove FrontendNodeType from constructors in frontend clause classes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddFollowerClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddFollowerClause.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.sql.parser.NodePosition;
 
 public class AddFollowerClause extends FrontendClause {
@@ -25,7 +24,7 @@ public class AddFollowerClause extends FrontendClause {
     }
 
     public AddFollowerClause(String hostPort, NodePosition pos) {
-        super(hostPort, FrontendNodeType.FOLLOWER, pos);
+        super(hostPort, pos);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddObserverClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddObserverClause.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.sql.parser.NodePosition;
 
 public class AddObserverClause extends FrontendClause {
@@ -25,7 +24,7 @@ public class AddObserverClause extends FrontendClause {
     }
 
     public AddObserverClause(String hostPort, NodePosition pos) {
-        super(hostPort, FrontendNodeType.OBSERVER, pos);
+        super(hostPort, pos);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropFollowerClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropFollowerClause.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.sql.parser.NodePosition;
 
 public class DropFollowerClause extends FrontendClause {
@@ -25,7 +24,7 @@ public class DropFollowerClause extends FrontendClause {
     }
 
     public DropFollowerClause(String hostPort, NodePosition pos) {
-        super(hostPort, FrontendNodeType.FOLLOWER, pos);
+        super(hostPort, pos);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropObserverClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropObserverClause.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.sql.parser.NodePosition;
 
 public class DropObserverClause extends FrontendClause {
@@ -25,7 +24,7 @@ public class DropObserverClause extends FrontendClause {
     }
 
     public DropObserverClause(String hostPort, NodePosition pos) {
-        super(hostPort, FrontendNodeType.OBSERVER, pos);
+        super(hostPort, pos);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/FrontendClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/FrontendClause.java
@@ -15,19 +15,16 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.sql.parser.NodePosition;
 
 public class FrontendClause extends AlterClause {
     protected String hostPort;
     protected String host;
     protected int port;
-    protected FrontendNodeType role;
 
-    protected FrontendClause(String hostPort, FrontendNodeType role, NodePosition pos) {
+    protected FrontendClause(String hostPort, NodePosition pos) {
         super(pos);
         this.hostPort = hostPort;
-        this.role = role;
     }
 
     public String getHost() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ModifyFrontendAddressClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ModifyFrontendAddressClause.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.sql.parser.NodePosition;
 
 public class ModifyFrontendAddressClause extends FrontendClause {
@@ -23,16 +22,12 @@ public class ModifyFrontendAddressClause extends FrontendClause {
     protected String srcHost;
     protected String destHost;
 
-    public ModifyFrontendAddressClause(String hostPort, FrontendNodeType role) {
-        super(hostPort, role, NodePosition.ZERO);
-    }
-
     public ModifyFrontendAddressClause(String srcHost, String destHost) {
         this(srcHost, destHost, NodePosition.ZERO);
     }
 
     public ModifyFrontendAddressClause(String srcHost, String destHost, NodePosition pos) {
-        super("", FrontendNodeType.UNKNOWN, pos);
+        super("", pos);
         this.srcHost = srcHost;
         this.destHost = destHost;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ModifyFrontendAddressClauseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ModifyFrontendAddressClauseTest.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.analysis;
 
-import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.sql.ast.ModifyFrontendAddressClause;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -28,11 +27,5 @@ public class ModifyFrontendAddressClauseTest {
         ModifyFrontendAddressClause clause = new ModifyFrontendAddressClause("originalHost-test", "sandbox");
         Assertions.assertEquals("sandbox", clause.getDestHost());
         Assertions.assertEquals("originalHost-test", clause.getSrcHost());
-    }
-
-    @Test
-    public void testNormal() {
-        ModifyFrontendAddressClause clause = new ModifyFrontendAddressClause("test:1000", FrontendNodeType.FOLLOWER);
-        Assertions.assertTrue(clause.getHostPort().equals("test:1000"));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request refactors several clause classes related to frontend node management by removing the dependency on the `FrontendNodeType` enum. The constructors for these classes no longer require a node type, simplifying their interfaces and reducing coupling. Additionally, related imports and test cases that referenced `FrontendNodeType` have been cleaned up.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
