### PR TITLE
[Enhancement] enable flat json by default

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1516,8 +1516,10 @@ CONF_mBool(lake_enable_vertical_compaction_fill_data_cache, "true");
 
 CONF_mInt32(dictionary_cache_refresh_timeout_ms, "60000"); // 1 min
 CONF_mInt32(dictionary_cache_refresh_threadpool_size, "8");
+
+// ======================= FLAT JSON start ==============================================
 // json flat flag
-CONF_mBool(enable_json_flat, "false");
+CONF_mBool(enable_json_flat, "true");
 
 // enable compaction is base on flat json, not whole json
 CONF_mBool(enable_compaction_flat_json, "true");
@@ -1551,6 +1553,7 @@ CONF_mInt32(json_flat_column_max, "100");
 
 // for whitelist on flat json remain data, max set 1kb
 CONF_mInt32(json_flat_remain_filter_max_bytes, "1024");
+// ======================= FLAT JSON end ==============================================
 
 // Allowable intervals for continuous generation of pk dumps
 // Disable when pk_dump_interval_seconds <= 0

--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -72,7 +72,8 @@ Status OlapMetaScanner::_init_meta_reader_params() {
             column.set_type(path->value_type().type);
             column.set_length(path->value_type().len);
             column.set_is_nullable(true);
-            column.set_extended_info(std::make_unique<ExtendedColumnInfo>(path.get(), root_column_index));
+            int32_t root_uid = tmp_schema->column(static_cast<size_t>(root_column_index)).unique_id();
+            column.set_extended_info(std::make_unique<ExtendedColumnInfo>(path.get(), root_uid));
 
             tmp_schema->append_column(column);
             VLOG(2) << "extend the tablet-schema: " << column.debug_string();

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -509,7 +509,17 @@ Status OlapChunkSource::_extend_schema_by_access_paths() {
         column.set_type(value_type);
         column.set_length(path->value_type().len);
         column.set_is_nullable(true);
-        column.set_extended_info(std::make_unique<ExtendedColumnInfo>(path.get(), root_column_index));
+        // Record root column unique id to make it robust across schema changes
+        int32_t root_uid = _tablet_schema->column(static_cast<size_t>(root_column_index)).unique_id();
+        column.set_extended_info(std::make_unique<ExtendedColumnInfo>(path.get(), root_uid));
+
+        // For UNIQUE/AGG tables, extended flat JSON subcolumns act as value columns and
+        // must have a valid aggregation method for pre-aggregation. Use REPLACE, which is
+        // consistent with value-column semantics in these models.
+        auto keys_type = _tablet_schema->keys_type();
+        if (keys_type == KeysType::UNIQUE_KEYS || keys_type == KeysType::AGG_KEYS) {
+            column.set_aggregation(StorageAggregateType::STORAGE_AGGREGATE_REPLACE);
+        }
 
         tmp_schema->append_column(column);
         VLOG(2) << "extend the access path column: " << path->linear_path();

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -49,7 +49,6 @@
 #include "segment_iterator.h"
 #include "segment_options.h"
 #include "storage/lake/tablet_manager.h"
-#include "storage/predicate_tree/predicate_tree.hpp"
 #include "storage/rowset/cast_column_iterator.h"
 #include "storage/rowset/column_reader.h"
 #include "storage/rowset/default_value_column_iterator.h"
@@ -58,7 +57,6 @@
 #include "storage/rowset/scalar_column_iterator.h"
 #include "storage/rowset/segment_writer.h" // k_segment_magic_length
 #include "storage/tablet_schema.h"
-#include "storage/type_utils.h"
 #include "storage/utils.h"
 #include "util/crc32c.h"
 #include "util/failpoint/fail_point.h"
@@ -485,15 +483,30 @@ StatusOr<ColumnIteratorUPtr> Segment::_new_extended_column_iterator(const Tablet
                                                                     ColumnAccessPath* path) {
     auto extended_info = column.extended_info();
     RETURN_IF(extended_info == nullptr, Status::InvalidArgument("extended info is null"));
-    auto source_index = extended_info->source_column_index;
-    RETURN_IF(source_index < 0 || static_cast<size_t>(source_index) >= _tablet_schema->num_columns(),
-              Status::InvalidArgument(fmt::format("invalid source column index: {}", source_index)));
     auto access_path = extended_info->access_path;
     RETURN_IF(access_path == nullptr, Status::InvalidArgument("access path is null for extended column"));
 
-    auto source_id = _tablet_schema->column(source_index).unique_id();
-    std::string full_path = access_path->linear_path();
+    // Resolve the root column by unique id to be robust across schema changes
+    auto full_path = access_path->linear_path();
     auto [col_name, field_name] = JsonFlatPath::split_path(full_path);
+
+    int32_t source_uid = extended_info->source_column_uid;
+    int32_t source_index = _tablet_schema->field_index(source_uid);
+    if (source_index < 0 || static_cast<size_t>(source_index) >= _tablet_schema->num_columns()) {
+        // The root column does not exist in this segment (e.g., added by schema change later).
+        // Fall back to column default/nullability.
+        const TypeInfoPtr& type_info = get_type_info(column);
+        auto default_iter = std::make_unique<DefaultValueColumnIterator>(column.has_default_value(),
+                                                                         column.default_value(), column.is_nullable(),
+                                                                         type_info, column.length(), num_rows());
+        ColumnIteratorOptions iter_opts;
+        RETURN_IF_ERROR(default_iter->init(iter_opts));
+        VLOG(2) << "root column '" << col_name << "' not found in segment, return default for path: " << full_path;
+        return default_iter;
+    }
+    RETURN_IF(access_path == nullptr, Status::InvalidArgument("access path is null for extended column"));
+
+    auto source_id = _tablet_schema->column(static_cast<size_t>(source_index)).unique_id();
     auto& leaf_type = access_path->leaf_value_type();
     RETURN_IF(!_column_readers.contains(source_id),
               Status::RuntimeError(fmt::format("unknown root column: {}", source_id)));

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -836,8 +836,8 @@ ColumnAccessPath* SegmentIterator::_lookup_access_path(ColumnId cid, const Table
     ColumnAccessPath* access_path = nullptr;
     if (col.is_extended()) {
         auto extended_info = col.extended_info();
-        if (extended_info != nullptr && extended_info->source_column_index >= 0) {
-            ColumnId source_id = _opts.tablet_schema->column(extended_info->source_column_index).unique_id();
+        if (extended_info != nullptr && extended_info->source_column_uid >= 0) {
+            ColumnId source_id = extended_info->source_column_uid;
             auto it = _column_access_paths.find(source_id);
             if (it != _column_access_paths.end() && it->second->is_extended()) {
                 access_path = it->second;

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -61,14 +61,13 @@ class POlapTableIndexSchema;
 class TColumn;
 
 struct ExtendedColumnInfo {
-    ExtendedColumnInfo(ColumnAccessPath* access_path, int source_column_index)
-            : access_path(access_path), source_column_index(source_column_index) {
+    ExtendedColumnInfo(ColumnAccessPath* access_path, int32_t source_column_uid)
+            : access_path(access_path), source_column_uid(source_column_uid) {
         DCHECK(access_path != nullptr);
-        DCHECK(source_column_index >= 0);
     }
 
     ColumnAccessPath* access_path = nullptr;
-    int source_column_index = -1;
+    int32_t source_column_uid = -1;
 };
 
 class TabletColumn {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1245,8 +1245,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean cboPruneSubfield = true;
 
     // it's need BE to enable flat json, else will take a poor performance
-    @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD)
-    private boolean cboPruneJsonSubfield = false;
+    @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD + "_v2", alias = CBO_PRUNE_JSON_SUBFIELD, show = CBO_PRUNE_JSON_SUBFIELD)
+    private boolean cboPruneJsonSubfield = true;
 
     @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD_DEPTH, flag = VariableMgr.INVISIBLE)
     private int cboPruneJsonSubfieldDepth = 20;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
@@ -64,6 +64,7 @@ public class MaterializedViewOptimizer {
         optimizerOptions.disableRule(RuleType.TF_ELIMINATE_AGG);
         optimizerOptions.disableRule(RuleType.TF_ELIMINATE_AGG_FUNCTION);
         optimizerOptions.disableRule(RuleType.TF_PULL_UP_PREDICATE_SCAN);
+        optimizerOptions.disableRule(RuleType.TF_JSON_PATH_REWRITE);
         // For sync mv, no rewrite query by original sync mv rule to avoid useless rewrite.
         if (mv.getRefreshScheme().isSync()) {
             optimizerOptions.disableRule(RuleType.TF_MATERIALIZED_VIEW);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -685,9 +685,6 @@ public class QueryOptimizer extends Optimizer {
         // After this rule, we shouldn't generate logical project operator
         scheduler.rewriteIterative(tree, rootTaskContext, new MergeProjectWithChildRule());
 
-        scheduler.rewriteOnce(tree, rootTaskContext, JsonPathRewriteRule.createForOlapScan());
-        scheduler.rewriteIterative(tree, rootTaskContext, new RewriteMinMaxByMonotonicFunctionRule());
-
         scheduler.rewriteOnce(tree, rootTaskContext, new EliminateSortColumnWithEqualityPredicateRule());
         scheduler.rewriteOnce(tree, rootTaskContext, new PushDownTopNBelowOuterJoinRule());
         // intersect rewrite depend on statistics
@@ -701,7 +698,9 @@ public class QueryOptimizer extends Optimizer {
         // rule based materialized view rewrite
         ruleBasedMaterializedViewRewriteStage2(tree, rootTaskContext, requiredColumns);
 
-        // this rewrite rule should be after mv.
+        // =============================== Rules after the MV rewrite ===============================
+        scheduler.rewriteOnce(tree, rootTaskContext, JsonPathRewriteRule.createForOlapScan());
+        scheduler.rewriteIterative(tree, rootTaskContext, new RewriteMinMaxByMonotonicFunctionRule());
         scheduler.rewriteOnce(tree, rootTaskContext, RewriteSimpleAggToHDFSScanRule.SCAN_NO_PROJECT);
 
         // NOTE: This rule should be after MV Rewrite because MV Rewrite cannot handle

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -78,6 +78,7 @@ public class MvRewriteTest extends MVTestBase {
         starRocksAssert.withTable(cluster, "test10");
         starRocksAssert.withTable(cluster, "test11");
 
+        starRocksAssert.getCtx().getSessionVariable().setEnableJSONV2Rewrite(false);
         prepareDatas();
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Behavior change:
- enable the FlatJSON feature by default since 4.0
- it can be disabled globally via BE Configuration `enable_json_flat=false` and `set global cboPruneJsonSubfield=false`
- It can be disabled in table level via set the property `flat_json.enable = false`


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
