### PR TITLE
[Enhancement] Improve the runtime of materialize_by_permutation

### DIFF
--- a/be/src/bench/chunks_sorter_bench.cpp
+++ b/be/src/bench/chunks_sorter_bench.cpp
@@ -491,7 +491,7 @@ static void do_bench_materialize(benchmark::State& state, LogicalType data_type,
 
     constexpr size_t output_chunk_size = 4096;
     const size_t num_output_chunks = (perm.size() + output_chunk_size - 1) / output_chunk_size;
-    
+
     for (auto _ : state) {
         for (size_t i = 0; i < num_output_chunks; ++i) {
             ChunkPtr dst = template_chunk->clone_empty();

--- a/be/src/bench/chunks_sorter_bench.cpp
+++ b/be/src/bench/chunks_sorter_bench.cpp
@@ -28,6 +28,7 @@
 #include "exec/chunks_sorter_heap_sort.h"
 #include "exec/chunks_sorter_topn.h"
 #include "exec/sorting/merge.h"
+#include "exec/sorting/sort_permute.h"
 #include "exec/sorting/sorting.h"
 #include "exprs/column_ref.h"
 #include "runtime/chunk_cursor.h"
@@ -445,6 +446,65 @@ static void do_merge_columnwise(benchmark::State& state, int num_runs, bool null
     suite.TearDown();
 }
 
+static void do_bench_materialize(benchmark::State& state, LogicalType data_type, int num_chunks, int num_columns,
+                                 bool nullable) {
+    ChunkSorterBase suite;
+    suite.SetUp();
+
+    TypeDescriptor type_desc;
+    if (data_type == TYPE_INT) {
+        type_desc = TypeDescriptor(TYPE_INT);
+    } else if (data_type == TYPE_VARCHAR) {
+        type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+    } else if (data_type == TYPE_DOUBLE) {
+        type_desc = TypeDescriptor(TYPE_DOUBLE);
+    } else {
+        ASSERT_TRUE(false) << "not support type: " << data_type;
+    }
+
+    Columns columns;
+    Chunk::SlotHashMap map;
+
+    for (int i = 0; i < num_columns; i++) {
+        auto [column, expr] = suite.build_column(type_desc, i, false, nullable);
+        columns.push_back(column);
+        map[i] = i;
+    }
+    auto template_chunk = std::make_shared<Chunk>(columns, map);
+
+    std::vector<ChunkPtr> chunks;
+    std::vector<PermutationItem> perm;
+
+    for (size_t i = 0; i < num_chunks; ++i) {
+        // Ensure a deep copy
+        ChunkPtr clone = template_chunk->clone_empty();
+        clone->append_safe(*template_chunk);
+        const size_t num_rows = clone->num_rows();
+        for (size_t inner_idx = 0; inner_idx < num_rows; ++inner_idx) {
+            perm.emplace_back(i, inner_idx);
+        }
+        chunks.push_back(std::move(clone));
+    }
+
+    std::mt19937 rng(42);
+    std::shuffle(std::begin(perm), std::end(perm), rng);
+
+    constexpr size_t output_chunk_size = 4096;
+    const size_t num_output_chunks = (perm.size() + output_chunk_size - 1) / output_chunk_size;
+    
+    for (auto _ : state) {
+        for (size_t i = 0; i < num_output_chunks; ++i) {
+            ChunkPtr dst = template_chunk->clone_empty();
+            PermutationView curr_view{perm.data() + i * output_chunk_size,
+                                      std::min(output_chunk_size, perm.size() - i * output_chunk_size)};
+            materialize_by_permutation(dst.get(), chunks, curr_view);
+            ASSERT_EQ(dst->num_rows(), std::min(output_chunk_size, perm.size() - i * output_chunk_size));
+        }
+    }
+
+    suite.TearDown();
+}
+
 // Sort full data: ORDER BY
 static void BM_fullsort_notnull(benchmark::State& state) {
     do_bench(state, FullSort, TYPE_INT, state.range(0), state.range(1));
@@ -505,6 +565,23 @@ static void BM_merge_columnwise_nullable(benchmark::State& state) {
     do_merge_columnwise(state, state.range(0), true);
 }
 
+// Test materialize_by_premutation
+static void BM_materialize_nullable(benchmark::State& state) {
+    do_bench_materialize(state, TYPE_INT, state.range(0), state.range(1), true);
+}
+
+static void BM_materialize_non_null(benchmark::State& state) {
+    do_bench_materialize(state, TYPE_INT, state.range(0), state.range(1), false);
+}
+
+static void BM_materialize_strings_nullable(benchmark::State& state) {
+    do_bench_materialize(state, TYPE_VARCHAR, state.range(0), state.range(1), true);
+}
+
+static void BM_materialize_strings_non_null(benchmark::State& state) {
+    do_bench_materialize(state, TYPE_VARCHAR, state.range(0), state.range(1), false);
+}
+
 static void CustomArgsFull(benchmark::internal::Benchmark* b) {
     // num_chunks
     for (int num_chunks = 64; num_chunks <= 32768; num_chunks *= 8) {
@@ -516,16 +593,25 @@ static void CustomArgsFull(benchmark::internal::Benchmark* b) {
 }
 static void CustomArgsLimit(benchmark::internal::Benchmark* b) {
     // num_chunks
-    for (int num_chunks = 1024; num_chunks <= 32768; num_chunks *= 4) {
+    for (int num_chunks = 1024; num_chunks <= 32768; num_chunks *= 8) {
         // num_columns
-        for (int num_columns = 1; num_columns <= 4; num_columns++) {
+        for (int num_columns = 1; num_columns <= 4; num_columns += 3) {
             // limit
-            for (int limit = 1; limit <= num_chunks * kTestChunkSize / 8; limit *= 8) {
+            for (int limit = 1; limit <= num_chunks * kTestChunkSize / 8; limit *= 16) {
                 b->Args({num_chunks, num_columns, limit});
             }
         }
     }
 }
+
+BENCHMARK(BM_materialize_nullable)->ArgsProduct({{1, 16, 256, 4096, 8192}, {1, 2, 4}})->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_materialize_non_null)->ArgsProduct({{1, 16, 256, 4096, 8192}, {1, 2, 4}})->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_materialize_strings_nullable)
+        ->ArgsProduct({{1, 16, 256, 4096, 8192}, {1, 2, 4}})
+        ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_materialize_strings_non_null)
+        ->ArgsProduct({{1, 16, 256, 4096, 8192}, {1, 2, 4}})
+        ->Unit(benchmark::kMillisecond);
 
 // Full sort
 BENCHMARK(BM_fullsort_notnull)->Apply(CustomArgsFull);

--- a/be/src/exec/sorting/sort_permute.cpp
+++ b/be/src/exec/sorting/sort_permute.cpp
@@ -107,13 +107,10 @@ public:
         auto& data = dst->get_data();
         size_t output = data.size();
         data.resize(output + _perm.size());
-        std::vector<const Container*> srcs;
-        for (auto& column : _columns) {
-            srcs.push_back(&(down_cast<const ColumnType*>(column)->get_data()));
-        }
 
         for (auto& p : _perm) {
-            data[output++] = (*srcs[p.chunk_index])[p.index_in_chunk];
+            const Container& container = down_cast<const ColumnType*>(_columns[p.chunk_index])->get_data();
+            data[output++] = container[p.index_in_chunk];
         }
 
         return Status::OK();
@@ -127,13 +124,10 @@ public:
         auto& data = dst->get_data();
         size_t output = data.size();
         data.resize(output + _perm.size());
-        std::vector<const Container*> srcs;
-        for (auto& column : _columns) {
-            srcs.push_back(&(down_cast<const ColumnType*>(column)->get_data()));
-        }
 
         for (auto& p : _perm) {
-            data[output++] = (*srcs[p.chunk_index])[p.index_in_chunk];
+            const Container& container = down_cast<const ColumnType*>(_columns[p.chunk_index])->get_data();
+            data[output++] = container[p.index_in_chunk];
         }
 
         return Status::OK();

--- a/be/src/exec/sorting/sort_permute.h
+++ b/be/src/exec/sorting/sort_permute.h
@@ -105,7 +105,7 @@ inline void permutate_to_selective(const Permutation& perm, std::vector<uint32_t
 
 // Materialize chunk by permutation
 void materialize_by_permutation(Chunk* dst, const std::vector<ChunkPtr>& chunks, const PermutationView& perm);
-void materialize_column_by_permutation(Column* dst, const Columns& columns, const PermutationView& perm);
+void materialize_column_by_permutation(Column* dst, const std::vector<const Column*>& columns, const PermutationView& perm);
 
 // Tie and TieIterator
 // Tie is a compact representation of equal ranges in a vector, in which `1` means equal and `0` means not equal.

--- a/be/src/exec/sorting/sort_permute.h
+++ b/be/src/exec/sorting/sort_permute.h
@@ -105,7 +105,8 @@ inline void permutate_to_selective(const Permutation& perm, std::vector<uint32_t
 
 // Materialize chunk by permutation
 void materialize_by_permutation(Chunk* dst, const std::vector<ChunkPtr>& chunks, const PermutationView& perm);
-void materialize_column_by_permutation(Column* dst, const std::vector<const Column*>& columns, const PermutationView& perm);
+void materialize_column_by_permutation(Column* dst, const std::vector<const Column*>& columns,
+                                       const PermutationView& perm);
 
 // Tie and TieIterator
 // Tie is a compact representation of equal ranges in a vector, in which `1` means equal and `0` means not equal.


### PR DESCRIPTION
## Why I'm doing:

When playing around with materialize_by_permutation, I saw that it can become a bottleneck for performance, so I tried to improve its runtime.

## What I'm doing:

There are two main issues I looked at for this PR:

1. materialize_by_permutation has a linear factor in the number of source chunks. This is esp. problematic, because materialize_by_permutation is called once for every output chunk. There are three locations where this behavior is triggered. The first is in materialize_by_permutation itself, where all columns of the source chunks corresponding to the current output column are copied into a vector. The second is the copy of the columns in the visit function for NullableColumns. The third are the copies of the Container pointers in multiple visit functions. The first commit of this PR converts the shared pointer copies triggered by first and second occurrences to raw pointer copies, heavily reducing the cost of each copy operation (esp. on larger nodes). The third PR removes the Container copies (for strings this is done in the second commit). To fully get rid of the linear factor of the input chunks per invocation, one would need to convert the chunks to a full column wise view before the first call to materialize_by_permutation. This view then needs to be used by each invocation. As this requires quite a few changes, I did not do it for this PR.
2. Taking a closer look at the visit function for BinaryColumns, I saw that the two accesses to the Slices (one in each loop) were quite expensive, with the second one being much more expensive than the first (probably due to the string writes interfering). I think I found quite a nice solution to get rid of the second Slice access, without needing to use prefetching intrinsics. This is probably the more important improvement of the two, because I think most/all of the callers call materialize_by_permutation with only one or very few (potentially large chunks). While the previous improvements are not very helpful for these cases, the string improvements improve the performance quite a bit, as long as you have a lot of data. I think that the performance for strings (and also for the other data types) could be improved further with prefetching intrinsics, but as as they are quite finicky, I did not try them for this PR.

As I have quite a lot of benchmarks results, I will add the results for each commit one by one as comments.

I will clean up the benchmark code a bit and then I would add it as well in a separate commit as well.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
