### PR TITLE
[Enhancement] make profile counter as compile option

### DIFF
--- a/be/src/connector/connector.cpp
+++ b/be/src/connector/connector.cpp
@@ -104,7 +104,7 @@ Status DataSource::parse_runtime_filters(RuntimeState* state) {
 
 void DataSource::update_profile(const Profile& profile) {
     RuntimeProfile::Counter* mem_alloc_failed_counter = ADD_COUNTER(_runtime_profile, "MemAllocFailed", TUnit::UNIT);
-    mem_alloc_failed_counter->update(profile.mem_alloc_failed_count);
+    COUNTER_UPDATE(mem_alloc_failed_counter, profile.mem_alloc_failed_count);
 }
 
 StatusOr<pipeline::MorselQueuePtr> DataSourceProvider::convert_scan_range_to_morsel_queue(

--- a/be/src/exec/hash_join_node.h
+++ b/be/src/exec/hash_join_node.h
@@ -63,7 +63,7 @@ private:
     Status _create_implicit_local_join_runtime_filters(RuntimeState* state);
     void _final_update_profile() {
         if (_probe_chunk_count > 0) {
-            COUNTER_SET(_avg_input_probe_chunk_size, int64_t(_probe_rows_counter->value() / _probe_chunk_count));
+            COUNTER_SET(_avg_input_probe_chunk_size, int64_t(COUNTER_VALUE(_probe_rows_counter) / _probe_chunk_count));
         } else {
             COUNTER_SET(_avg_input_probe_chunk_size, int64_t(0));
         }

--- a/be/src/exec/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner_parquet.cpp
@@ -207,7 +207,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     int64_t page_stats = _app_stats.has_page_statistics ? 1 : 0;
     COUNTER_UPDATE(has_page_statistics, page_stats);
     COUNTER_UPDATE(page_skip, _app_stats.page_skip);
-    group_min_round_cost->set(_app_stats.group_min_round_cost);
+    COUNTER_SET(group_min_round_cost, _app_stats.group_min_round_cost);
     do_update_iceberg_v2_counter(root, kParquetProfileSectionPrefix);
     do_update_deletion_vector_filter_counter(root);
     COUNTER_UPDATE(rows_before_page_index, _app_stats.rows_before_page_index);

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -514,8 +514,8 @@ StatusOr<bool> OlapScanNode::_could_split_tablet_physically(const std::vector<TS
 Status OlapScanNode::collect_query_statistics(QueryStatistics* statistics) {
     RETURN_IF_ERROR(ExecNode::collect_query_statistics(statistics));
     QueryStatisticsItemPB stats_item;
-    stats_item.set_scan_bytes(_read_compressed_counter->value());
-    stats_item.set_scan_rows(_raw_rows_counter->value());
+    stats_item.set_scan_bytes(COUNTER_VALUE(_read_compressed_counter));
+    stats_item.set_scan_rows(COUNTER_VALUE(_raw_rows_counter));
     stats_item.set_table_id(_tuple_desc->table_desc()->table_id());
     statistics->add_stats_item(stats_item);
     return Status::OK();

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -43,7 +43,7 @@ Status AggregateBlockingSinkOperator::prepare(RuntimeState* state) {
 
 void AggregateBlockingSinkOperator::close(RuntimeState* state) {
     auto* counter = ADD_COUNTER(_unique_metrics, "HashTableMemoryUsage", TUnit::BYTES);
-    counter->set(_aggregator->hash_map_memory_usage());
+    COUNTER_SET(counter, _aggregator->hash_map_memory_usage());
     _aggregator->unref(state);
     Operator::close(state);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -29,7 +29,7 @@ Status AggregateDistinctBlockingSinkOperator::prepare(RuntimeState* state) {
 
 void AggregateDistinctBlockingSinkOperator::close(RuntimeState* state) {
     auto* counter = ADD_COUNTER(_unique_metrics, "HashTableMemoryUsage", TUnit::BYTES);
-    counter->set(_aggregator->hash_set_memory_usage());
+    COUNTER_SET(counter, _aggregator->hash_set_memory_usage());
     _aggregator->unref(state);
     Operator::close(state);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -39,7 +39,7 @@ Status AggregateDistinctStreamingSinkOperator::prepare(RuntimeState* state) {
 
 void AggregateDistinctStreamingSinkOperator::close(RuntimeState* state) {
     auto* counter = ADD_COUNTER(_unique_metrics, "HashTableMemoryUsage", TUnit::BYTES);
-    counter->set(_aggregator->hash_set_memory_usage());
+    COUNTER_SET(counter, _aggregator->hash_set_memory_usage());
     _aggregator->unref(state);
     Operator::close(state);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -36,7 +36,7 @@ Status AggregateStreamingSinkOperator::prepare(RuntimeState* state) {
 
 void AggregateStreamingSinkOperator::close(RuntimeState* state) {
     auto* counter = ADD_COUNTER(_unique_metrics, "HashTableMemoryUsage", TUnit::BYTES);
-    counter->set(_aggregator->hash_map_memory_usage());
+    COUNTER_SET(counter, _aggregator->hash_map_memory_usage());
     _aggregator->unref(state);
     Operator::close(state);
 }

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -154,13 +154,13 @@ bool SinkBuffer::is_finished() const {
 }
 
 void SinkBuffer::update_profile(RuntimeProfile* profile) {
-    auto* rpc_count = ADD_COUNTER(profile, "RpcCount", TUnit::UNIT);
-    auto* rpc_avg_timer = ADD_TIMER(profile, "RpcAvgTime");
-    auto* network_timer = ADD_TIMER(profile, "NetworkTime");
-    auto* wait_timer = ADD_TIMER(profile, "WaitTime");
-    auto* overall_timer = ADD_TIMER(profile, "OverallTime");
+    RuntimeProfile::Counter* rpc_count = ADD_COUNTER(profile, "RpcCount", TUnit::UNIT);
+    RuntimeProfile::Counter* rpc_avg_timer = ADD_TIMER(profile, "RpcAvgTime");
+    RuntimeProfile::Counter* network_timer = ADD_TIMER(profile, "NetworkTime");
+    RuntimeProfile::Counter* wait_timer = ADD_TIMER(profile, "WaitTime");
+    RuntimeProfile::Counter* overall_timer = ADD_TIMER(profile, "OverallTime");
 
-    COUNTER_SET(rpc_count, _rpc_count);
+    COUNTER_SET(rpc_count, _rpc_count.load());
     COUNTER_SET(rpc_avg_timer, _rpc_cumulative_time / std::max(_rpc_count.load(), static_cast<int64_t>(1)));
 
     COUNTER_SET(network_timer, _network_time());
@@ -169,16 +169,16 @@ void SinkBuffer::update_profile(RuntimeProfile* profile) {
     // WaitTime consists two parts
     // 1. buffer full time
     // 2. pending finish time
-    COUNTER_SET(wait_timer, _full_time);
+    COUNTER_SET(wait_timer, _full_time.load());
     COUNTER_UPDATE(wait_timer, MonotonicNanos() - _pending_timestamp);
 
-    auto* bytes_sent_counter = ADD_COUNTER(profile, "BytesSent", TUnit::BYTES);
-    auto* request_sent_counter = ADD_COUNTER(profile, "RequestSent", TUnit::UNIT);
-    COUNTER_SET(bytes_sent_counter, _bytes_sent);
-    COUNTER_SET(request_sent_counter, _request_sent);
+    RuntimeProfile::Counter* bytes_sent_counter = ADD_COUNTER(profile, "BytesSent", TUnit::BYTES);
+    RuntimeProfile::Counter* request_sent_counter = ADD_COUNTER(profile, "RequestSent", TUnit::UNIT);
+    COUNTER_SET(bytes_sent_counter, _bytes_sent.load());
+    COUNTER_SET(request_sent_counter, _request_sent.load());
 
-    auto* bytes_unsent_counter = ADD_COUNTER(profile, "BytesUnsent", TUnit::BYTES);
-    auto* request_unsent_counter = ADD_COUNTER(profile, "RequestUnsent", TUnit::UNIT);
+    RuntimeProfile::Counter* bytes_unsent_counter = ADD_COUNTER(profile, "BytesUnsent", TUnit::BYTES);
+    RuntimeProfile::Counter* request_unsent_counter = ADD_COUNTER(profile, "RequestUnsent", TUnit::UNIT);
     COUNTER_SET(bytes_unsent_counter, _bytes_enqueued - _bytes_sent);
     COUNTER_SET(request_unsent_counter, _request_enqueued - _request_sent);
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -855,7 +855,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
             auto fragment_ctx = _query_ctx->fragment_mgr()->get(request.fragment_instance_id());
             auto* profile = fragment_ctx->runtime_state()->runtime_profile();
 
-            auto* prepare_timer = ADD_TIMER_WITH_THRESHOLD(profile, "FragmentInstancePrepareTime", 10_ms);
+            auto* prepare_timer = ADD_TIMER_WITH_THRESHOLD(profile, "FragmentInstancePrepareTime", 1_ms);
             COUNTER_SET(prepare_timer, profiler.prepare_time);
 
             auto* prepare_query_ctx_timer =

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -128,14 +128,14 @@ Status HashJoinProbeOperator::reset_state(RuntimeState* state, const vector<Chun
 void HashJoinProbeOperator::update_exec_stats(RuntimeState* state) {
     auto ctx = state->query_ctx();
     if (ctx != nullptr) {
-        ctx->update_pull_rows_stats(_plan_node_id, _pull_row_num_counter->value());
+        ctx->update_pull_rows_stats(_plan_node_id, COUNTER_VALUE(_pull_row_num_counter));
         if (_conjuncts_input_counter != nullptr && _conjuncts_output_counter != nullptr) {
-            ctx->update_pred_filter_stats(_plan_node_id,
-                                          _conjuncts_input_counter->value() - _conjuncts_output_counter->value());
+            ctx->update_pred_filter_stats(
+                    _plan_node_id, COUNTER_VALUE(_conjuncts_input_counter) - COUNTER_VALUE(_conjuncts_output_counter));
         }
         if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr) {
-            int64_t input_rows = _bloom_filter_eval_context.join_runtime_filter_input_counter->value();
-            int64_t output_rows = _bloom_filter_eval_context.join_runtime_filter_output_counter->value();
+            int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
+            int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
             ctx->update_rf_filter_stats(_plan_node_id, input_rows - output_rows);
         }
     }

--- a/be/src/exec/pipeline/limit_operator.cpp
+++ b/be/src/exec/pipeline/limit_operator.cpp
@@ -49,15 +49,15 @@ Status LimitOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
 void LimitOperator::update_exec_stats(RuntimeState* state) {
     auto ctx = state->query_ctx();
     if (!_is_subordinate && ctx != nullptr) {
-        ctx->force_set_pull_rows_stats(_plan_node_id, _pull_row_num_counter->value());
+        ctx->force_set_pull_rows_stats(_plan_node_id, COUNTER_VALUE(_pull_row_num_counter));
         if (_conjuncts_input_counter != nullptr && _conjuncts_output_counter != nullptr) {
-            ctx->update_pred_filter_stats(_plan_node_id,
-                                          _conjuncts_input_counter->value() - _conjuncts_output_counter->value());
+            ctx->update_pred_filter_stats(
+                    _plan_node_id, COUNTER_VALUE(_conjuncts_input_counter) - COUNTER_VALUE(_conjuncts_output_counter));
         }
 
         if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr) {
-            int64_t input_rows = _bloom_filter_eval_context.join_runtime_filter_input_counter->value();
-            int64_t output_rows = _bloom_filter_eval_context.join_runtime_filter_output_counter->value();
+            int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
+            int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
             ctx->update_rf_filter_stats(_plan_node_id, input_rows - output_rows);
         }
     }

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -97,7 +97,7 @@ Status Operator::prepare(RuntimeState* state) {
 }
 
 void Operator::set_prepare_time(int64_t cost_ns) {
-    _prepare_timer->set(cost_ns);
+    COUNTER_SET(_prepare_timer, cost_ns);
 }
 
 void Operator::set_precondition_ready(RuntimeState* state) {
@@ -123,8 +123,8 @@ void Operator::close(RuntimeState* state) {
     _mem_resource_manager.close();
     if (auto* rf_bloom_filters = runtime_bloom_filters()) {
         _init_rf_counters(false);
-        _runtime_in_filter_num_counter->set((int64_t)runtime_in_filters().size());
-        _runtime_bloom_filter_num_counter->set((int64_t)rf_bloom_filters->size());
+        COUNTER_SET(_runtime_in_filter_num_counter, (int64_t)runtime_in_filters().size());
+        COUNTER_SET(_runtime_bloom_filter_num_counter, (int64_t)rf_bloom_filters->size());
 
         if (!rf_bloom_filters->descriptors().empty()) {
             std::string rf_desc = "";
@@ -143,9 +143,9 @@ void Operator::close(RuntimeState* state) {
 
     // Pipeline do not need the built in total time counter
     // Reset here to discard assignments from Analytor, Aggregator, etc.
-    _runtime_profile->total_time_counter()->set(0L);
-    _common_metrics->total_time_counter()->set(0L);
-    _unique_metrics->total_time_counter()->set(0L);
+    COUNTER_SET(_runtime_profile->total_time_counter(), (int64_t)0L);
+    COUNTER_SET(_common_metrics->total_time_counter(), (int64_t)0L);
+    COUNTER_SET(_unique_metrics->total_time_counter(), (int64_t)0L);
 }
 
 std::vector<ExprContext*>& Operator::runtime_in_filters() {
@@ -192,11 +192,11 @@ Status Operator::eval_conjuncts_and_in_filters(const std::vector<ExprContext*>& 
     {
         SCOPED_TIMER(_conjuncts_timer);
         auto before = chunk->num_rows();
-        _conjuncts_input_counter->update(before);
+        COUNTER_UPDATE(_conjuncts_input_counter, before);
         RETURN_IF_ERROR(
                 starrocks::ExecNode::eval_conjuncts(_cached_conjuncts_and_in_filters, chunk, filter, apply_filter));
         auto after = chunk->num_rows();
-        _conjuncts_output_counter->update(after);
+        COUNTER_UPDATE(_conjuncts_output_counter, after);
     }
 
     return Status::OK();
@@ -217,10 +217,10 @@ Status Operator::eval_no_eq_join_runtime_in_filters(Chunk* chunk) {
             }
         }
         size_t before = chunk->num_rows();
-        _conjuncts_input_counter->update(before);
+        COUNTER_UPDATE(_conjuncts_input_counter, before);
         RETURN_IF_ERROR(starrocks::ExecNode::eval_conjuncts(selected_vector, chunk, nullptr));
         size_t after = chunk->num_rows();
-        _conjuncts_output_counter->update(after);
+        COUNTER_UPDATE(_conjuncts_output_counter, after);
     }
 
     return Status::OK();
@@ -237,10 +237,10 @@ Status Operator::eval_conjuncts(const std::vector<ExprContext*>& conjuncts, Chun
     {
         SCOPED_TIMER(_conjuncts_timer);
         size_t before = chunk->num_rows();
-        _conjuncts_input_counter->update(before);
+        COUNTER_UPDATE(_conjuncts_input_counter, before);
         RETURN_IF_ERROR(starrocks::ExecNode::eval_conjuncts(conjuncts, chunk, filter));
         size_t after = chunk->num_rows();
-        _conjuncts_output_counter->update(after);
+        COUNTER_UPDATE(_conjuncts_output_counter, after);
     }
 
     return Status::OK();
@@ -295,16 +295,16 @@ void Operator::_init_conjuct_counters() {
 void Operator::update_exec_stats(RuntimeState* state) {
     auto ctx = state->query_ctx();
     if (!_is_subordinate && ctx != nullptr && ctx->need_record_exec_stats(_plan_node_id)) {
-        ctx->update_push_rows_stats(_plan_node_id, _push_row_num_counter->value());
-        ctx->update_pull_rows_stats(_plan_node_id, _pull_row_num_counter->value());
+        ctx->update_push_rows_stats(_plan_node_id, COUNTER_VALUE(_push_row_num_counter));
+        ctx->update_pull_rows_stats(_plan_node_id, COUNTER_VALUE(_pull_row_num_counter));
         if (_conjuncts_input_counter != nullptr && _conjuncts_output_counter != nullptr) {
-            ctx->update_pred_filter_stats(_plan_node_id,
-                                          _conjuncts_input_counter->value() - _conjuncts_output_counter->value());
+            ctx->update_pred_filter_stats(
+                    _plan_node_id, COUNTER_VALUE(_conjuncts_input_counter) - COUNTER_VALUE(_conjuncts_output_counter));
         }
         if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr &&
             _bloom_filter_eval_context.join_runtime_filter_output_counter != nullptr) {
-            int64_t input_rows = _bloom_filter_eval_context.join_runtime_filter_input_counter->value();
-            int64_t output_rows = _bloom_filter_eval_context.join_runtime_filter_output_counter->value();
+            int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
+            int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
             ctx->update_rf_filter_stats(_plan_node_id, input_rows - output_rows);
         }
     }

--- a/be/src/exec/pipeline/pipeline.cpp
+++ b/be/src/exec/pipeline/pipeline.cpp
@@ -129,7 +129,7 @@ void Pipeline::setup_drivers_profile(const DriverPtr& driver) {
             ADD_COUNTER_SKIP_MERGE(runtime_profile(), "DegreeOfParallelism", TUnit::UNIT, TCounterMergeType::SKIP_ALL);
     COUNTER_SET(dop_counter, static_cast<int64_t>(source_operator_factory()->degree_of_parallelism()));
     auto* total_dop_counter = ADD_COUNTER(runtime_profile(), "TotalDegreeOfParallelism", TUnit::UNIT);
-    COUNTER_SET(total_dop_counter, dop_counter->value());
+    COUNTER_SET(total_dop_counter, COUNTER_VALUE(dop_counter));
     auto& operators = driver->operators();
     for (int32_t i = operators.size() - 1; i >= 0; --i) {
         auto& curr_op = operators[i];

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -269,22 +269,22 @@ public:
         switch (_state) {
         case DriverState::INPUT_EMPTY: {
             auto elapsed_time = _input_empty_timer_sw->elapsed_time();
-            if (_first_input_empty_timer->value() == 0) {
-                _first_input_empty_timer->update(elapsed_time);
+            if (COUNTER_VALUE(_first_input_empty_timer) == 0) {
+                COUNTER_UPDATE(_first_input_empty_timer, elapsed_time);
             } else {
-                _followup_input_empty_timer->update(elapsed_time);
+                COUNTER_UPDATE(_followup_input_empty_timer, elapsed_time);
             }
-            _input_empty_timer->update(elapsed_time);
+            COUNTER_UPDATE(_input_empty_timer, elapsed_time);
             break;
         }
         case DriverState::OUTPUT_FULL:
-            _output_full_timer->update(_output_full_timer_sw->elapsed_time());
+            COUNTER_UPDATE(_output_full_timer, _output_full_timer_sw->elapsed_time());
             break;
         case DriverState::PRECONDITION_BLOCK:
-            _precondition_block_timer->update(_precondition_block_timer_sw->elapsed_time());
+            COUNTER_UPDATE(_precondition_block_timer, _precondition_block_timer_sw->elapsed_time());
             break;
         case DriverState::PENDING_FINISH:
-            _pending_finish_timer->update(_pending_finish_timer_sw->elapsed_time());
+            COUNTER_UPDATE(_pending_finish_timer, _pending_finish_timer_sw->elapsed_time());
             break;
         default:
             break;
@@ -330,7 +330,7 @@ public:
     bool precondition_prepared() const { return _precondition_prepared; }
     void start_timers();
     void stop_timers();
-    int64_t get_active_time() const { return _active_timer->value(); }
+    int64_t get_active_time() const { return COUNTER_VALUE(_active_timer); }
     void submit_operators();
     // Notify all the unfinished operators to be finished.
     // It is usually used when the sink operator is finished, or the fragment is cancelled or expired.

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -318,20 +318,22 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
         auto* query_peak_memory = profile->add_counter(
                 "QueryPeakMemoryUsage", TUnit::BYTES,
                 RuntimeProfile::Counter::create_strategy(TUnit::BYTES, TCounterMergeType::SKIP_FIRST_MERGE));
-        query_peak_memory->set(query_ctx->mem_cost_bytes());
+        COUNTER_SET(query_peak_memory, query_ctx->mem_cost_bytes());
         auto* query_cumulative_cpu = profile->add_counter(
                 "QueryCumulativeCpuTime", TUnit::TIME_NS,
                 RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS, TCounterMergeType::SKIP_FIRST_MERGE));
-        query_cumulative_cpu->set(query_ctx->cpu_cost());
+        COUNTER_SET(query_cumulative_cpu, query_ctx->cpu_cost());
+
         auto* query_spill_bytes = profile->add_counter(
                 "QuerySpillBytes", TUnit::BYTES,
                 RuntimeProfile::Counter::create_strategy(TUnit::BYTES, TCounterMergeType::SKIP_FIRST_MERGE));
-        query_spill_bytes->set(query_ctx->get_spill_bytes());
+        COUNTER_SET(query_spill_bytes, query_ctx->get_spill_bytes());
+
         // Add execution wall time
         auto* query_exec_wall_time = profile->add_counter(
                 "QueryExecutionWallTime", TUnit::TIME_NS,
                 RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS, TCounterMergeType::SKIP_FIRST_MERGE));
-        query_exec_wall_time->set(query_ctx->lifetime());
+        COUNTER_SET(query_exec_wall_time, query_ctx->lifetime());
     }
 
     const auto& fe_addr = fragment_ctx->fe_addr();

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -246,7 +246,7 @@ size_t PipelineDriverPoller::calculate_parked_driver(const ConstDriverPredicator
 
 void PipelineDriverPoller::remove_blocked_driver(DriverList& local_blocked_drivers, DriverList::iterator& driver_it) {
     auto& driver = *driver_it;
-    driver->_pending_timer->update(driver->_pending_timer_sw->elapsed_time());
+    COUNTER_UPDATE(driver->_pending_timer, driver->_pending_timer_sw->elapsed_time());
     local_blocked_drivers.erase(driver_it++);
     _metrics->poller_block_queue_len.increment(-1);
 }

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -135,7 +135,7 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
         _profile = std::make_shared<RuntimeProfile>("Query" + print_id(_query_id));
         auto* mem_tracker_counter =
                 ADD_COUNTER_SKIP_MERGE(_profile.get(), "MemoryLimit", TUnit::BYTES, TCounterMergeType::SKIP_ALL);
-        mem_tracker_counter->set(query_mem_limit);
+        COUNTER_SET(mem_tracker_counter, query_mem_limit);
         size_t lowest_limit = parent->lowest_limit();
         size_t tracker_reserve_limit = -1;
 

--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
@@ -42,7 +42,7 @@ Status OlapScanPrepareOperator::prepare(RuntimeState* state) {
 
     RETURN_IF_ERROR(_ctx->prepare(state));
 
-    auto* capture_tablet_rowsets_timer = ADD_TIMER(_unique_metrics, "CaptureTabletRowsetsTime");
+    RuntimeProfile::Counter* capture_tablet_rowsets_timer = ADD_TIMER(_unique_metrics, "CaptureTabletRowsetsTime");
     {
         SCOPED_TIMER(capture_tablet_rowsets_timer);
         RETURN_IF_ERROR(_ctx->capture_tablet_rowsets(_morsel_queue->prepare_olap_scan_ranges()));

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -251,10 +251,10 @@ void ScanOperator::_detach_chunk_sources() {
 void ScanOperator::update_exec_stats(RuntimeState* state) {
     auto ctx = state->query_ctx();
     if (ctx != nullptr) {
-        ctx->update_pull_rows_stats(_plan_node_id, _pull_row_num_counter->value());
+        ctx->update_pull_rows_stats(_plan_node_id, COUNTER_VALUE(_pull_row_num_counter));
         if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr) {
-            int64_t input_rows = _bloom_filter_eval_context.join_runtime_filter_input_counter->value();
-            int64_t output_rows = _bloom_filter_eval_context.join_runtime_filter_output_counter->value();
+            int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
+            int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
             ctx->update_rf_filter_stats(_plan_node_id, input_rows - output_rows);
         }
     }
@@ -264,11 +264,11 @@ Status ScanOperator::set_finishing(RuntimeState* state) {
     auto notify = scan_defer_notify(this);
     // check when expired, are there running io tasks or submitted tasks
     if (UNLIKELY(state != nullptr && state->query_ctx()->is_query_expired() &&
-                 (_num_running_io_tasks > 0 || _submit_task_counter->value() == 0))) {
+                 (_num_running_io_tasks > 0 || COUNTER_VALUE(_submit_task_counter) == 0))) {
         LOG(WARNING) << "set_finishing scan fragment " << print_id(state->fragment_instance_id()) << " driver_id  "
                      << get_driver_sequence() << " _num_running_io_tasks= " << _num_running_io_tasks
-                     << " _submit_task_counter= " << _submit_task_counter->value()
-                     << " _morsels_counter= " << _morsels_counter->value()
+                     << " _submit_task_counter= " << COUNTER_VALUE(_submit_task_counter)
+                     << " _morsels_counter= " << COUNTER_VALUE(_morsels_counter)
                      << (is_buffer_full() && (num_buffered_chunks() == 0) ? ", buff is full but without local chunks"
                                                                           : "");
     }
@@ -433,7 +433,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
     workgroup::ScanTask task;
     task.workgroup = _workgroup;
     // TODO: consider more factors, such as scan bytes and i/o time.
-    task.priority = OlapScanNode::compute_priority(_submit_task_counter->value());
+    task.priority = OlapScanNode::compute_priority(COUNTER_VALUE(_submit_task_counter));
     task.task_group = down_cast<const ScanOperatorFactory*>(_factory)->scan_task_group();
     task.peak_scan_task_queue_size_counter = _peak_scan_task_queue_size_counter;
     const auto io_task_start_nano = MonotonicNanos();
@@ -455,8 +455,8 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             FAIL_POINT_SCOPE(mem_alloc_error);
 #endif
             DeferOp timer_defer([chunk_source]() {
-                COUNTER_SET(chunk_source->scan_timer(),
-                            chunk_source->io_task_wait_timer()->value() + chunk_source->io_task_exec_timer()->value());
+                COUNTER_SET(chunk_source->scan_timer(), COUNTER_VALUE(chunk_source->io_task_wait_timer()) +
+                                                                COUNTER_VALUE(chunk_source->io_task_exec_timer()));
             });
             auto notify = scan_defer_notify(this);
             COUNTER_UPDATE(chunk_source->io_task_wait_timer(), MonotonicNanos() - io_task_start_nano);

--- a/be/src/exec/query_cache/cache_operator.cpp
+++ b/be/src/exec/query_cache/cache_operator.cpp
@@ -199,9 +199,9 @@ void CacheOperator::close(RuntimeState* state) {
         }
     }
 
-    _cache_populate_tablets_counter->update(_populate_tablets.size());
-    _cache_probe_tablets_counter->update(_probe_tablets.size());
-    _cache_passthrough_tablets_counter->update(passthrough_tablets.size());
+    COUNTER_UPDATE(_cache_populate_tablets_counter, _populate_tablets.size());
+    COUNTER_UPDATE(_cache_probe_tablets_counter, _probe_tablets.size());
+    COUNTER_UPDATE(_cache_passthrough_tablets_counter, passthrough_tablets.size());
 
     Operator::close(state);
 }
@@ -385,9 +385,9 @@ void CacheOperator::_update_probe_metrics(int64_t tablet_id, const std::vector<C
         num_bytes += chunk->bytes_usage();
         num_rows += chunk->num_rows();
     }
-    _cache_probe_bytes_counter->update(num_bytes);
-    _cache_probe_chunks_counter->update(chunks.size());
-    _cache_probe_rows_counter->update(num_rows);
+    COUNTER_UPDATE(_cache_probe_bytes_counter, num_bytes);
+    COUNTER_UPDATE(_cache_probe_chunks_counter, chunks.size());
+    COUNTER_UPDATE(_cache_probe_rows_counter, num_rows);
     _probe_tablets.insert(tablet_id);
 }
 
@@ -466,9 +466,9 @@ void CacheOperator::populate_cache(int64_t tablet_id) {
     CacheValue cache_value(current, buffer->required_version, std::move(chunks));
     // If the cache implementation is global, populate method must be asynchronous and try its best to
     // update the cache.
-    _cache_populate_bytes_counter->update(buffer->num_bytes);
-    _cache_populate_chunks_counter->update(buffer->chunks.size());
-    _cache_populate_rows_counter->update(buffer->num_rows);
+    COUNTER_UPDATE(_cache_populate_bytes_counter, buffer->num_bytes);
+    COUNTER_UPDATE(_cache_populate_chunks_counter, buffer->chunks.size());
+    COUNTER_UPDATE(_cache_populate_rows_counter, buffer->num_rows);
     _populate_tablets.insert(tablet_id);
     _cache_mgr->populate(cache_key, cache_value);
     buffer->state = PLBS_POPULATE;
@@ -625,9 +625,9 @@ StatusOr<ChunkPtr> CacheOperator::pull_chunk(RuntimeState* state) {
         if (!passthrough_mode || chunk == nullptr) {
             return;
         }
-        _cache_passthrough_bytes_counter->update(chunk->bytes_usage());
-        _cache_passthrough_chunks_counter->update(1);
-        _cache_passthrough_rows_counter->update(chunk->num_rows());
+        COUNTER_UPDATE(_cache_passthrough_bytes_counter, chunk->bytes_usage());
+        COUNTER_UPDATE(_cache_passthrough_chunks_counter, 1);
+        COUNTER_UPDATE(_cache_passthrough_rows_counter, chunk->num_rows());
     };
     auto opt_lane = _lane_arbiter->preferred_lane();
     if (opt_lane.has_value()) {

--- a/be/src/exec/short_circuit.cpp
+++ b/be/src/exec/short_circuit.cpp
@@ -30,6 +30,7 @@
 #include "service/brpc.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
+#include "util/runtime_profile.h"
 #include "util/thrift_util.h"
 
 namespace starrocks {
@@ -140,8 +141,7 @@ ShortCircuitExecutor::ShortCircuitExecutor(ExecEnv* exec_env)
 
 Status ShortCircuitExecutor::prepare(TExecShortCircuitParams& common_request) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
-    auto* timer = ADD_TIMER(_runtime_profile, "PrepareTime");
-    SCOPED_TIMER(timer);
+    SCOPED_TIMER(ADD_TIMER(_runtime_profile, "PrepareTime"));
 
     _common_request = &common_request;
     const TDescriptorTable& t_desc_tbl = _common_request->desc_tbl;
@@ -181,8 +181,7 @@ Status ShortCircuitExecutor::prepare(TExecShortCircuitParams& common_request) {
 
 Status ShortCircuitExecutor::execute() {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
-    auto* timer = ADD_TIMER(_runtime_profile, "ExecuteTime");
-    SCOPED_TIMER(timer);
+    SCOPED_TIMER(ADD_TIMER(_runtime_profile, "ExecuteTime"));
 
     RETURN_IF_ERROR(_source->open(runtime_state()));
     RETURN_IF_ERROR(_sink->open(runtime_state()));
@@ -259,8 +258,7 @@ RuntimeState* ShortCircuitExecutor::runtime_state() {
 Status ShortCircuitExecutor::fetch_data(brpc::Controller* cntl, PExecShortCircuitResult& response) {
     {
         SCOPED_TIMER(_runtime_profile->total_time_counter());
-        auto* timer = ADD_TIMER(_runtime_profile, "CloseTime");
-        SCOPED_TIMER(timer);
+        SCOPED_TIMER(ADD_TIMER(_runtime_profile, "CloseTime"));
 
         //TODO need row count
         // response.set_affected_rows(runtime_state()->num_rows_load_sink_success());

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -206,7 +206,7 @@ Status RawSpillerWriter::flush(RuntimeState* state, MemGuard&& guard) {
     auto io_task = workgroup::ScanTask(_spiller->options().wg, std::move(task), std::move(yield_func));
     RETURN_IF_ERROR(TaskExecutor::submit(std::move(io_task)));
     COUNTER_UPDATE(_spiller->metrics().flush_io_task_count, 1);
-    COUNTER_SET(_spiller->metrics().peak_flush_io_task_count, _running_flush_tasks);
+    COUNTER_SET(_spiller->metrics().peak_flush_io_task_count, _running_flush_tasks.load());
     return Status::OK();
 }
 
@@ -276,7 +276,7 @@ Status SpillerReader::trigger_restore(RuntimeState* state, MemGuard&& guard) {
         auto io_task = workgroup::ScanTask(_spiller->options().wg, std::move(restore_task), std::move(yield_func));
         RETURN_IF_ERROR(TaskExecutor::submit(std::move(io_task)));
         COUNTER_UPDATE(_spiller->metrics().restore_io_task_count, 1);
-        COUNTER_SET(_spiller->metrics().peak_restore_io_task_count, _running_restore_tasks);
+        COUNTER_SET(_spiller->metrics().peak_restore_io_task_count, _running_restore_tasks.load());
     }
     return Status::OK();
 }
@@ -373,7 +373,7 @@ Status PartitionedSpillerWriter::flush(RuntimeState* state, bool is_final_flush,
     auto io_task = workgroup::ScanTask(_spiller->options().wg, std::move(task), std::move(yield_func));
     RETURN_IF_ERROR(TaskExecutor::submit(std::move(io_task)));
     COUNTER_UPDATE(_spiller->metrics().flush_io_task_count, 1);
-    COUNTER_SET(_spiller->metrics().peak_flush_io_task_count, _running_flush_tasks);
+    COUNTER_SET(_spiller->metrics().peak_flush_io_task_count, _running_flush_tasks.load());
 
     return Status::OK();
 }

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -397,21 +397,21 @@ void TabletScanner::update_counter() {
     if (_reader->stats().flat_json_hits.size() > 0) {
         auto path_profile = _parent->_scan_profile->create_child("FlatJsonHits");
 
-        for (auto& [k, v] : _reader->stats().flat_json_hits) {
+        for (const auto& [k, v] : _reader->stats().flat_json_hits) {
             RuntimeProfile::Counter* path_counter = ADD_COUNTER(path_profile, k, TUnit::UNIT);
             COUNTER_SET(path_counter, v);
         }
     }
     if (_reader->stats().dynamic_json_hits.size() > 0) {
         auto path_profile = _parent->_scan_profile->create_child("FlatJsonUnhits");
-        for (auto& [k, v] : _reader->stats().dynamic_json_hits) {
+        for (const auto& [k, v] : _reader->stats().dynamic_json_hits) {
             RuntimeProfile::Counter* path_counter = ADD_COUNTER(path_profile, k, TUnit::UNIT);
             COUNTER_SET(path_counter, v);
         }
     }
     if (_reader->stats().merge_json_hits.size() > 0) {
         auto path_profile = _parent->_scan_profile->create_child("MergeJsonUnhits");
-        for (auto& [k, v] : _reader->stats().merge_json_hits) {
+        for (const auto& [k, v] : _reader->stats().merge_json_hits) {
             RuntimeProfile::Counter* path_counter = ADD_COUNTER(path_profile, k, TUnit::UNIT);
             COUNTER_SET(path_counter, v);
         }

--- a/be/src/exec/tablet_sink_colocate_sender.cpp
+++ b/be/src/exec/tablet_sink_colocate_sender.cpp
@@ -316,8 +316,8 @@ Status TabletSinkColocateSender::close_wait(RuntimeState* state, Status close_st
         ss << "{" << pair.first << ":(" << (pair.second.add_batch_execution_time_us / 1000) << ")("
            << (pair.second.add_batch_wait_lock_time_us / 1000) << ")(" << pair.second.add_batch_num << ")} ";
     }
-    ts_profile->server_rpc_timer->update(total_server_rpc_time_us * 1000);
-    ts_profile->server_wait_flush_timer->update(total_server_wait_memtable_flush_time_us * 1000);
+    COUNTER_UPDATE(ts_profile->server_rpc_timer, total_server_rpc_time_us * 1000);
+    COUNTER_UPDATE(ts_profile->server_wait_flush_timer, total_server_wait_memtable_flush_time_us * 1000);
     LOG(INFO) << ss.str();
 
     Expr::close(_output_expr_ctxs, state);

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -798,7 +798,7 @@ Status NodeChannel::_wait_request(ReusableClosure<PTabletWriterAddBatchResult>* 
 #endif
     _mem_tracker->release(closure->request_size);
 
-    _ts_profile->client_rpc_timer->update(closure->latency());
+    COUNTER_UPDATE(_ts_profile->client_rpc_timer, closure->latency());
 
     if (closure->cntl.Failed()) {
         _cancelled = true;

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -352,8 +352,8 @@ Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, Ta
         ss << "{" << pair.first << ":(" << (pair.second.add_batch_execution_time_us / 1000) << ")("
            << (pair.second.add_batch_wait_lock_time_us / 1000) << ")(" << pair.second.add_batch_num << ")} ";
     }
-    ts_profile->server_rpc_timer->update(total_server_rpc_time_us * 1000);
-    ts_profile->server_wait_flush_timer->update(total_server_wait_memtable_flush_time_us * 1000);
+    COUNTER_UPDATE(ts_profile->server_rpc_timer, total_server_rpc_time_us * 1000);
+    COUNTER_UPDATE(ts_profile->server_wait_flush_timer, total_server_wait_memtable_flush_time_us * 1000);
     LOG(INFO) << ss.str();
 
     Expr::close(_output_expr_ctxs, state);

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -604,7 +604,7 @@ Status RuntimeFilterProbeDescriptor::prepare(RuntimeState* state, RuntimeProfile
     _open_timestamp = UnixMillis();
     _latency_timer = ADD_COUNTER(p, strings::Substitute("JoinRuntimeFilter/$0/latency", _filter_id), TUnit::TIME_NS);
     // not set yet.
-    _latency_timer->set((int64_t)(-1));
+    COUNTER_SET(_latency_timer, (int64_t)(-1));
     return Status::OK();
 }
 
@@ -843,12 +843,12 @@ void RuntimeFilterProbeCollector::evaluate(Chunk* chunk, RuntimeMembershipFilter
 
     {
         SCOPED_TIMER(eval_context.join_runtime_filter_timer);
-        eval_context.join_runtime_filter_input_counter->update(before);
+        COUNTER_UPDATE(eval_context.join_runtime_filter_input_counter, before);
         eval_context.run_filter_nums = 0;
         do_evaluate(chunk, eval_context);
         size_t after = chunk->num_rows();
-        eval_context.join_runtime_filter_output_counter->update(after);
-        eval_context.join_runtime_filter_eval_counter->update(eval_context.run_filter_nums);
+        COUNTER_UPDATE(eval_context.join_runtime_filter_output_counter, after);
+        COUNTER_UPDATE(eval_context.join_runtime_filter_eval_counter, eval_context.run_filter_nums);
     }
 }
 
@@ -860,12 +860,12 @@ void RuntimeFilterProbeCollector::evaluate_partial_chunk(Chunk* partial_chunk,
 
     {
         SCOPED_TIMER(eval_context.join_runtime_filter_timer);
-        eval_context.join_runtime_filter_input_counter->update(before);
+        COUNTER_UPDATE(eval_context.join_runtime_filter_input_counter, before);
         eval_context.run_filter_nums = 0;
         do_evaluate_partial_chunk(partial_chunk, eval_context);
         size_t after = partial_chunk->num_rows();
-        eval_context.join_runtime_filter_output_counter->update(after);
-        eval_context.join_runtime_filter_eval_counter->update(eval_context.run_filter_nums);
+        COUNTER_UPDATE(eval_context.join_runtime_filter_output_counter, after);
+        COUNTER_UPDATE(eval_context.join_runtime_filter_eval_counter, eval_context.run_filter_nums);
     }
 }
 
@@ -1100,7 +1100,7 @@ void RuntimeFilterProbeDescriptor::set_runtime_filter(const RuntimeFilter* rf) {
     _runtime_filter.compare_exchange_strong(expected, rf, std::memory_order_seq_cst, std::memory_order_seq_cst);
     if (_ready_timestamp == 0 && rf != nullptr && _latency_timer != nullptr) {
         _ready_timestamp = UnixMillis();
-        _latency_timer->set((_ready_timestamp - _open_timestamp) * 1000);
+        COUNTER_SET(_latency_timer, (_ready_timestamp - _open_timestamp) * 1000);
     }
 }
 

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -876,16 +876,16 @@ void LakeTabletsChannel::update_profile() {
     if (!tablets_profile.empty()) {
         auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(&obj_pool, tablets_profile);
         RuntimeProfile* final_profile = _profile->create_child("PeerReplicas");
-        auto* tablets_counter = ADD_COUNTER(final_profile, "TabletsNum", TUnit::UNIT);
-        COUNTER_SET(tablets_counter, static_cast<int64_t>(tablets_profile.size()));
+        COUNTER_SET(ADD_COUNTER(final_profile, "TabletsNum", TUnit::UNIT),
+                    static_cast<int64_t>(tablets_profile.size()));
         final_profile->copy_all_info_strings_from(merged_profile);
         final_profile->copy_all_counters_from(merged_profile);
     }
 }
 
-#define ADD_AND_SET_COUNTER(profile, name, type, val) (ADD_COUNTER(profile, name, type))->set(val)
-#define ADD_AND_UPDATE_COUNTER(profile, name, type, val) (ADD_COUNTER(profile, name, type))->update(val)
-#define ADD_AND_UPDATE_TIMER(profile, name, val) (ADD_TIMER(profile, name))->update(val)
+#define ADD_AND_SET_COUNTER(profile, name, type, val) COUNTER_SET(ADD_COUNTER(profile, name, type), val)
+#define ADD_AND_UPDATE_COUNTER(profile, name, type, val) COUNTER_UPDATE(ADD_COUNTER(profile, name, type), val)
+#define ADD_AND_UPDATE_TIMER(profile, name, val) COUNTER_UPDATE(ADD_TIMER(profile, name), val)
 #define DEFAULT_IF_NULL(ptr, value, default_value) ((ptr) ? (value) : (default_value))
 
 void LakeTabletsChannel::_update_tablet_profile(DeltaWriter* writer, RuntimeProfile* profile) {

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -84,7 +84,7 @@ LoadChannel::LoadChannel(LoadChannelMgr* mgr, LakeTabletManager* lake_tablet_mgr
     _root_profile->add_info_string("TxnId", std::to_string(txn_id));
     _profile = _root_profile->create_child(fmt::format("Channel (host={})", BackendOptions::get_localhost()), true);
     _index_num = ADD_COUNTER(_profile, "IndexNum", TUnit::UNIT);
-    ADD_COUNTER(_profile, "LoadMemoryLimit", TUnit::BYTES)->set(_mem_tracker->limit());
+    COUNTER_SET(ADD_COUNTER(_profile, "LoadMemoryLimit", TUnit::BYTES), _mem_tracker->limit());
     _peak_memory_usage = ADD_PEAK_COUNTER(_profile, "PeakMemoryUsage", TUnit::BYTES);
     _deserialize_chunk_count = ADD_COUNTER(_profile, "DeserializeChunkCount", TUnit::UNIT);
     _deserialize_chunk_timer = ADD_TIMER(_profile, "DeserializeChunkTime");

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -1083,8 +1083,8 @@ void LocalTabletsChannel::update_profile() {
     if (!peer_or_primary_replica_profiles.empty()) {
         auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(&obj_pool, peer_or_primary_replica_profiles);
         RuntimeProfile* final_profile = _profile->create_child(replicated_storage ? "PrimaryReplicas" : "PeerReplicas");
-        auto* tablets_counter = ADD_COUNTER(final_profile, "TabletsNum", TUnit::UNIT);
-        COUNTER_SET(tablets_counter, static_cast<int64_t>(peer_or_primary_replica_profiles.size()));
+        COUNTER_SET(ADD_COUNTER(final_profile, "TabletsNum", TUnit::UNIT),
+                    static_cast<int64_t>(peer_or_primary_replica_profiles.size()));
         final_profile->copy_all_info_strings_from(merged_profile);
         final_profile->copy_all_counters_from(merged_profile);
     }
@@ -1092,8 +1092,8 @@ void LocalTabletsChannel::update_profile() {
     if (!secondary_replica_profiles.empty()) {
         auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(&obj_pool, secondary_replica_profiles);
         RuntimeProfile* final_profile = _profile->create_child("SecondaryReplicas");
-        auto* tablets_counter = ADD_COUNTER(final_profile, "TabletsNum", TUnit::UNIT);
-        COUNTER_SET(tablets_counter, static_cast<int64_t>(secondary_replica_profiles.size()));
+        COUNTER_SET(ADD_COUNTER(final_profile, "TabletsNum", TUnit::UNIT),
+                    static_cast<int64_t>(secondary_replica_profiles.size()));
         final_profile->copy_all_info_strings_from(merged_profile);
         final_profile->copy_all_counters_from(merged_profile);
     }
@@ -1144,9 +1144,9 @@ void LocalTabletsChannel::get_load_replica_status(const std::string& remote_ip,
     }
 }
 
-#define ADD_AND_SET_COUNTER(profile, name, type, val) (ADD_COUNTER(profile, name, type))->set(val)
-#define ADD_AND_UPDATE_COUNTER(profile, name, type, val) (ADD_COUNTER(profile, name, type))->update(val)
-#define ADD_AND_UPDATE_TIMER(profile, name, val) (ADD_TIMER(profile, name))->update(val)
+#define ADD_AND_SET_COUNTER(profile, name, type, val) COUNTER_SET(ADD_COUNTER(profile, name, type), val)
+#define ADD_AND_UPDATE_COUNTER(profile, name, type, val) COUNTER_UPDATE(ADD_COUNTER(profile, name, type), val)
+#define ADD_AND_UPDATE_TIMER(profile, name, val) COUNTER_UPDATE(ADD_TIMER(profile, name), val)
 
 void LocalTabletsChannel::_update_peer_replica_profile(DeltaWriter* writer, RuntimeProfile* profile) {
     const DeltaWriterStat& writer_stat = writer->get_writer_stat();
@@ -1169,7 +1169,7 @@ void LocalTabletsChannel::_update_peer_replica_profile(DeltaWriter* writer, Runt
     const FlushStatistic& flush_stat = writer->get_flush_stats();
     ADD_AND_UPDATE_COUNTER(profile, "MemtableFlushedCount", TUnit::UNIT, flush_stat.flush_count);
     ADD_AND_SET_COUNTER(profile, "MemtableFlushingCount", TUnit::UNIT, flush_stat.cur_flush_count);
-    ADD_AND_SET_COUNTER(profile, "MemtableQueueCount", TUnit::UNIT, flush_stat.queueing_memtable_num);
+    ADD_AND_SET_COUNTER(profile, "MemtableQueueCount", TUnit::UNIT, flush_stat.queueing_memtable_num.load());
     ADD_AND_UPDATE_TIMER(profile, "FlushTaskPendingTime", flush_stat.pending_time_ns);
     auto& memtable_stat = flush_stat.memtable_stats;
     ADD_AND_UPDATE_COUNTER(profile, "MemtableInsertCount", TUnit::UNIT, memtable_stat.insert_count);

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -218,7 +218,7 @@ MemTracker::SimpleItem* MemTracker::_get_snapshot_internal(ObjectPool* pool, Sim
     item->level = _level;
     item->limit = _limit;
     item->cur_consumption = _consumption->current_value();
-    item->peak_consumption = _consumption->value();
+    item->peak_consumption = COUNTER_VALUE(_consumption);
 
     if (_level < upper_level) {
         std::lock_guard<std::mutex> l(_child_trackers_lock);

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -195,14 +195,14 @@ public:
     void update_allocation(int64_t bytes) {
         if (bytes <= 0) return;
         for (auto* tracker : _all_trackers) {
-            tracker->_allocation->update(bytes);
+            COUNTER_UPDATE(tracker->_allocation, bytes);
         }
     }
 
     void update_deallocation(int64_t bytes) {
         if (bytes <= 0) return;
         for (auto* tracker : _all_trackers) {
-            tracker->_deallocation->update(bytes);
+            COUNTER_UPDATE(tracker->_deallocation, bytes);
         }
     }
 
@@ -374,9 +374,9 @@ public:
 
     int64_t consumption() const { return _consumption->current_value(); }
 
-    int64_t peak_consumption() const { return _consumption->value(); }
-    int64_t allocation() const { return _allocation->value(); }
-    int64_t deallocation() const { return _deallocation->value(); }
+    int64_t peak_consumption() const { return COUNTER_VALUE(_consumption); }
+    int64_t allocation() const { return COUNTER_VALUE(_allocation); }
+    int64_t deallocation() const { return COUNTER_VALUE(_deallocation); }
 
     MemTracker* parent() const { return _parent; }
 
@@ -393,8 +393,8 @@ public:
         msg << "limit: " << _limit << "; "
             << "reserve_limit: " << _reserve_limit << "; "
             << "consumption: " << _consumption->current_value() << "; "
-            << "allocation: " << _allocation->value() << "; "
-            << "deallocation: " << _deallocation->value() << "; "
+            << "allocation: " << COUNTER_VALUE(_allocation) << "; "
+            << "deallocation: " << COUNTER_VALUE(_deallocation) << "; "
             << "label: " << _label << "; "
             << "all tracker size: " << _all_trackers.size() << "; "
             << "limit trackers size: " << _limit_trackers.size() << "; "

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -47,6 +47,7 @@
 #include "exec/exec_node.h"
 #include "exec/pipeline/query_context.h"
 #include "fs/fs_util.h"
+#include "util/runtime_profile.h"
 #ifdef USE_STAROS
 #include "fslib/star_cache_handler.h"
 #endif
@@ -213,9 +214,9 @@ bool RuntimeState::set_timezone(const std::string& tz) {
 void RuntimeState::init_mem_trackers(const TUniqueId& query_id, MemTracker* parent) {
     bool has_query_mem_tracker = _query_options.__isset.mem_limit && (_query_options.mem_limit > 0);
     int64_t bytes_limit = has_query_mem_tracker ? _query_options.mem_limit : -1;
-    auto* mem_tracker_counter =
+    RuntimeProfile::Counter* mem_tracker_counter =
             ADD_COUNTER_SKIP_MERGE(_profile.get(), "MemoryLimit", TUnit::BYTES, TCounterMergeType::SKIP_ALL);
-    mem_tracker_counter->set(bytes_limit);
+    COUNTER_SET(mem_tracker_counter, bytes_limit);
 
     if (parent == nullptr) {
         parent = GlobalEnv::GetInstance()->query_pool_mem_tracker();
@@ -231,9 +232,8 @@ void RuntimeState::init_mem_trackers(const TUniqueId& query_id, MemTracker* pare
 void RuntimeState::init_mem_trackers(const std::shared_ptr<MemTracker>& query_mem_tracker) {
     DCHECK(query_mem_tracker != nullptr);
 
-    auto* mem_tracker_counter =
-            ADD_COUNTER_SKIP_MERGE(_profile.get(), "QueryMemoryLimit", TUnit::BYTES, TCounterMergeType::SKIP_ALL);
-    mem_tracker_counter->set(query_mem_tracker->limit());
+    COUNTER_SET(ADD_COUNTER_SKIP_MERGE(_profile.get(), "QueryMemoryLimit", TUnit::BYTES, TCounterMergeType::SKIP_ALL),
+                query_mem_tracker->limit());
 
     // all fragment instances in a BE shared a common query_mem_tracker.
     _query_mem_tracker = query_mem_tracker;

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -24,6 +24,7 @@
 #include "storage/lake/tablet_writer.h"
 #include "storage/load_spill_block_manager.h"
 #include "storage/merge_iterator.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks::lake {
 

--- a/be/src/storage/load_chunk_spiller.cpp
+++ b/be/src/storage/load_chunk_spiller.cpp
@@ -267,10 +267,10 @@ Status LoadChunkSpiller::merge_write(size_t target_size, bool do_sort, bool do_a
             (std::ostringstream() << _block_manager->load_id()).str(),
             (std::ostringstream() << _block_manager->fragment_instance_id()).str(), groups.size(), total_blocks,
             total_block_bytes, total_merges, total_rows, total_chunk, duration_ms);
-    ADD_COUNTER(_profile, "SpillMergeInputGroups", TUnit::UNIT)->update(groups.size());
-    ADD_COUNTER(_profile, "SpillMergeInputBytes", TUnit::BYTES)->update(total_block_bytes);
-    ADD_COUNTER(_profile, "SpillMergeCount", TUnit::UNIT)->update(total_merges);
-    ADD_COUNTER(_profile, "SpillMergeDurationNs", TUnit::TIME_NS)->update(duration_ms * 1000000);
+    COUNTER_UPDATE(ADD_COUNTER(_profile, "SpillMergeInputGroups", TUnit::UNIT), groups.size());
+    COUNTER_UPDATE(ADD_COUNTER(_profile, "SpillMergeInputBytes", TUnit::BYTES), total_block_bytes);
+    COUNTER_UPDATE(ADD_COUNTER(_profile, "SpillMergeCount", TUnit::UNIT), total_merges);
+    COUNTER_UPDATE(ADD_COUNTER(_profile, "SpillMergeDurationNs", TUnit::TIME_NS), duration_ms * 1000000);
     return Status::OK();
 }
 

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -68,57 +68,6 @@ inline unsigned long long operator"" _ms(unsigned long long x) {
 #define CONCAT_IMPL(x, y) x##y
 #define MACRO_CONCAT(x, y) CONCAT_IMPL(x, y)
 
-#if ENABLE_COUNTERS
-#define ADD_COUNTER(profile, name, type) \
-    (profile)->add_counter(name, type, RuntimeProfile::Counter::create_strategy(type))
-#define ADD_COUNTER_SKIP_MERGE(profile, name, type, merge_type) \
-    (profile)->add_counter(name, type, RuntimeProfile::Counter::create_strategy(type, merge_type))
-#define ADD_TIMER(profile, name) \
-    (profile)->add_counter(name, TUnit::TIME_NS, RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS))
-#define ADD_TIMER_WITH_THRESHOLD(profile, name, threshold) \
-    (profile)->add_counter(                                \
-            name, TUnit::TIME_NS,                          \
-            RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS, TCounterMergeType::MERGE_ALL, threshold))
-#define ADD_PEAK_COUNTER(profile, name, type) \
-    (profile)->AddHighWaterMarkCounter(name, type, RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG))
-#define ADD_CHILD_COUNTER(profile, name, type, parent) \
-    (profile)->add_child_counter(name, type, RuntimeProfile::Counter::create_strategy(type), parent)
-#define ADD_CHILD_COUNTER_SKIP_MERGE(profile, name, type, merge_type, parent) \
-    (profile)->add_child_counter(name, type, RuntimeProfile::Counter::create_strategy(type, merge_type), parent)
-#define ADD_CHILD_COUNTER_SKIP_MIN_MAX(profile, name, type, min_max_type, parent)                                      \
-    (profile)->add_child_counter(                                                                                      \
-            name, type, RuntimeProfile::Counter::create_strategy(type, TCounterMergeType::MERGE_ALL, 0, min_max_type), \
-            parent)
-#define ADD_CHILD_TIMER_THESHOLD(profile, name, parent, threshold) \
-    (profile)->add_child_counter(                                  \
-            name, TUnit::TIME_NS,                                  \
-            RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS, TCounterMergeType::MERGE_ALL, threshold), parent)
-#define ADD_CHILD_TIMER(profile, name, parent) \
-    (profile)->add_child_counter(name, TUnit::TIME_NS, RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS), parent)
-#define SCOPED_TIMER(c) ScopedTimer<MonotonicStopWatch> MACRO_CONCAT(SCOPED_TIMER, __COUNTER__)(c)
-#define CANCEL_SAFE_SCOPED_TIMER(c, is_cancelled) \
-    ScopedTimer<MonotonicStopWatch> MACRO_CONCAT(SCOPED_TIMER, __COUNTER__)(c, is_cancelled)
-#define SCOPED_RAW_TIMER(c) ScopedRawTimer<MonotonicStopWatch> MACRO_CONCAT(SCOPED_RAW_TIMER, __COUNTER__)(c)
-#define COUNTER_UPDATE(c, v) (c)->update(v)
-#define COUNTER_SET(c, v) (c)->set(v)
-// this is only used for HighWaterMarkCounter
-#define COUNTER_ADD(c, v) (c)->add(v)
-#define ADD_THREAD_COUNTERS(profile, prefix) (profile)->add_thread_counters(prefix)
-#define SCOPED_THREAD_COUNTER_MEASUREMENT(c) \
-    /*ThreadCounterMeasurement                                        \
-      MACRO_CONCAT(SCOPED_THREAD_COUNTER_MEASUREMENT, __COUNTER__)(c)*/
-#else
-#define ADD_COUNTER(profile, name, type) NULL
-#define ADD_TIMER(profile, name) NULL
-#define SCOPED_TIMER(c)
-#define SCOPED_RAW_TIMER(c)
-#define COUNTER_UPDATE(c, v)
-#define COUNTER_SET(c, v)
-#define COUNTER_ADD(c, v)
-#define ADD_THREADCOUNTERS(profile, prefix) NULL
-#define SCOPED_THREAD_COUNTER_MEASUREMENT(c)
-#endif
-
 class ObjectPool;
 
 // Runtime profile is a group of profiling counters.  It supports adding named counters
@@ -129,6 +78,26 @@ class ObjectPool;
 // corresponding rate based counter.  This thread wakes up at fixed intervals and updates
 // all of the rate counters.
 // Thread-safe.
+template <class Counter>
+class CounterAccesser {
+public:
+    CounterAccesser(Counter* counter) : accessor(counter) {}
+
+    template <typename T>
+    void set(T value) {
+        accessor->set(value);
+    }
+
+    void update(int64_t value) { accessor->update(value); }
+
+    void add(int64_t delta) { accessor->add(delta); }
+
+    int64_t value() const { return accessor->value(); }
+
+private:
+    Counter* accessor;
+};
+
 class RuntimeProfile {
 public:
     inline static const std::string MERGED_INFO_PREFIX_MIN = "__MIN_OF_";
@@ -163,8 +132,6 @@ public:
 
         virtual ~Counter() = default;
 
-        virtual void update(int64_t delta) { _value.fetch_add(delta, std::memory_order_relaxed); }
-
         // Use this to update if the counter is a bitmap
         void bit_or(int64_t delta) {
             int64_t old;
@@ -173,12 +140,6 @@ public:
                 if (LIKELY((old | delta) == old)) return; // Bits already set, avoid atomic.
             } while (UNLIKELY(!_value.compare_exchange_strong(old, old | delta, std::memory_order_relaxed)));
         }
-
-        virtual void set(int64_t value) { _value.store(value, std::memory_order_relaxed); }
-
-        virtual void set(double value) { _value.store(bit_cast<int64_t>(value), std::memory_order_relaxed); }
-
-        virtual int64_t value() const { return _value.load(std::memory_order_relaxed); }
 
         virtual double double_value() const { return bit_cast<double>(_value.load(std::memory_order_relaxed)); }
 
@@ -213,8 +174,18 @@ public:
             return threshold == 0 || value() > threshold;
         }
 
+    protected:
+        virtual void set(int64_t value) { _value.store(value, std::memory_order_relaxed); }
+
+        virtual void set(double value) { _value.store(bit_cast<int64_t>(value), std::memory_order_relaxed); }
+
+        virtual void update(int64_t delta) { _value.fetch_add(delta, std::memory_order_relaxed); }
+
+        virtual int64_t value() const { return _value.load(std::memory_order_relaxed); }
+
     private:
         friend class RuntimeProfile;
+        friend class CounterAccesser<Counter>;
 
         std::atomic<int64_t> _value;
         const TUnit::type _type;
@@ -268,6 +239,8 @@ public:
         int64_t current_value() const { return current_value_.load(std::memory_order_relaxed); }
 
     private:
+        friend class CounterAccesser<WaterMarkCounter>;
+
         void _set_init_value() {
             if constexpr (is_high) {
                 _value.store(0, std::memory_order_relaxed);
@@ -702,13 +675,13 @@ public:
             return;
         }
 
-        _counter->update(-1L * _val);
+        CounterAccesser(_counter).update(-1L * _val);
     }
 
     // Increment the counter when object is destroyed
     ~ScopedCounter() {
         if (_counter != nullptr) {
-            _counter->update(_val);
+            CounterAccesser(_counter).update(_val);
         }
     }
 
@@ -750,7 +723,7 @@ public:
 
     void UpdateCounter() {
         if (_counter != nullptr && !is_cancelled()) {
-            _counter->update(_sw.elapsed_time());
+            CounterAccesser(_counter).update(_sw.elapsed_time());
         }
     }
 
@@ -786,3 +759,66 @@ private:
 };
 
 } // namespace starrocks
+
+#if ENABLE_COUNTERS
+#define ADD_COUNTER(profile, name, type) \
+    (profile)->add_counter(name, type, RuntimeProfile::Counter::create_strategy(type))
+#define ADD_COUNTER_SKIP_MERGE(profile, name, type, merge_type) \
+    (profile)->add_counter(name, type, RuntimeProfile::Counter::create_strategy(type, merge_type))
+#define ADD_TIMER(profile, name) \
+    (profile)->add_counter(name, TUnit::TIME_NS, RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS))
+#define ADD_TIMER_WITH_THRESHOLD(profile, name, threshold) \
+    (profile)->add_counter(                                \
+            name, TUnit::TIME_NS,                          \
+            RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS, TCounterMergeType::MERGE_ALL, threshold))
+#define ADD_PEAK_COUNTER(profile, name, type) \
+    (profile)->AddHighWaterMarkCounter(name, type, RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG))
+#define ADD_CHILD_COUNTER(profile, name, type, parent) \
+    (profile)->add_child_counter(name, type, RuntimeProfile::Counter::create_strategy(type), parent)
+#define ADD_CHILD_COUNTER_SKIP_MERGE(profile, name, type, merge_type, parent) \
+    (profile)->add_child_counter(name, type, RuntimeProfile::Counter::create_strategy(type, merge_type), parent)
+#define ADD_CHILD_COUNTER_SKIP_MIN_MAX(profile, name, type, min_max_type, parent)                                      \
+    (profile)->add_child_counter(                                                                                      \
+            name, type, RuntimeProfile::Counter::create_strategy(type, TCounterMergeType::MERGE_ALL, 0, min_max_type), \
+            parent)
+#define ADD_CHILD_TIMER_THESHOLD(profile, name, parent, threshold) \
+    (profile)->add_child_counter(                                  \
+            name, TUnit::TIME_NS,                                  \
+            RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS, TCounterMergeType::MERGE_ALL, threshold), parent)
+#define ADD_CHILD_TIMER(profile, name, parent) \
+    (profile)->add_child_counter(name, TUnit::TIME_NS, RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS), parent)
+#define SCOPED_TIMER(c) ScopedTimer<MonotonicStopWatch> MACRO_CONCAT(SCOPED_TIMER, __COUNTER__)(c)
+#define CANCEL_SAFE_SCOPED_TIMER(c, is_cancelled) \
+    ScopedTimer<MonotonicStopWatch> MACRO_CONCAT(SCOPED_TIMER, __COUNTER__)(c, is_cancelled)
+#define SCOPED_RAW_TIMER(c) ScopedRawTimer<MonotonicStopWatch> MACRO_CONCAT(SCOPED_RAW_TIMER, __COUNTER__)(c)
+#define COUNTER_UPDATE(c, v) CounterAccesser(c).update(v)
+#define COUNTER_SET(c, v) CounterAccesser(c).set(v)
+// this is only used for HighWaterMarkCounter
+#define COUNTER_ADD(c, v) CounterAccesser(c).add(v)
+#define COUNTER_VALUE(c) CounterAccesser(c).value()
+#define COUNTER_CURRENT_VALUE(c) (c)->current_value()
+#define ADD_THREAD_COUNTERS(profile, prefix) (profile)->add_thread_counters(prefix)
+#define SCOPED_THREAD_COUNTER_MEASUREMENT(c) \
+    /*ThreadCounterMeasurement                                        \
+      MACRO_CONCAT(SCOPED_THREAD_COUNTER_MEASUREMENT, __COUNTER__)(c)*/
+#else
+#define ADD_COUNTER(profile, name, type) (RuntimeProfile::Counter*)NULL
+#define ADD_TIMER(profile, name) (RuntimeProfile::Counter*)NULL
+#define ADD_TIMER_WITH_THRESHOLD(profile, name, threshold) (RuntimeProfile::Counter*)NULL
+#define SCOPED_TIMER(c)
+#define SCOPED_RAW_TIMER(c)
+#define COUNTER_UPDATE(c, v)
+#define COUNTER_SET(c, v)
+#define COUNTER_ADD(c, v)
+#define COUNTER_VALUE(c) 0
+#define COUNTER_CURRENT_VALUE(c) 0
+#define ADD_PEAK_COUNTER(profile, name, type) (RuntimeProfile::HighWaterMarkCounter*)NULL
+#define ADD_COUNTER_SKIP_MERGE(profile, name, type, merge_type) (RuntimeProfile::Counter*)NULL
+#define ADD_CHILD_COUNTER(profile, name, type, parent) (RuntimeProfile::Counter*)NULL
+#define ADD_CHILD_COUNTER_SKIP_MERGE(profile, name, type, merge_type, parent) (RuntimeProfile::Counter*)NULL
+#define ADD_CHILD_COUNTER_SKIP_MIN_MAX(profile, name, type, min_max_type, parent) (RuntimeProfile::Counter*)NULL
+#define ADD_CHILD_TIMER(profile, name, parent) (RuntimeProfile::Counter*)NULL
+#define ADD_THREAD_COUNTERS(profile, prefix) (RuntimeProfile::ThreadCounters*)NULL
+#define ADD_CHILD_TIMER_THESHOLD(profile, name, parent, threshold) (RuntimeProfile::Counter*)NULL
+#define SCOPED_THREAD_COUNTER_MEASUREMENT(c)
+#endif


### PR DESCRIPTION

## Why I'm doing:

Make profile counter be a compilation option to
measure the impact of profile counter on performance.


## What I'm doing:

Use macro definitions for all operations on profiler counters.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
