### PR TITLE
[Feature] (IVM Part4) Support more agg combinator functions 

### DIFF
--- a/be/src/exprs/CMakeLists.txt
+++ b/be/src/exprs/CMakeLists.txt
@@ -31,6 +31,7 @@ set(EXPR_FILES
   agg/factory/aggregate_resolver_utility.cpp
   agg/factory/aggregate_resolver_variance.cpp
   agg/factory/aggregate_resolver_window.cpp
+  agg/combinator/agg_state_utils.cpp
   base64.cpp
   binary_functions.cpp
   expr_context.cpp

--- a/be/src/exprs/agg/combinator/agg_state_combine.h
+++ b/be/src/exprs/agg/combinator/agg_state_combine.h
@@ -1,0 +1,91 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "exprs/agg/aggregate.h"
+#include "exprs/agg/combinator/agg_state_combinator.h"
+#include "runtime/agg_state_desc.h"
+
+namespace starrocks {
+struct AggStateCombineState {};
+
+// An aggregate combine combinator that combines aggregate inputs to compute immediate results.
+// This combinator is equivalent to calling `{agg_func}_union({agg_func}_state(arg_types))` in SQL,
+// but with reduced function call overhead and memory allocation for better performance.
+// eg:
+// - SQL: sum_union(sum_state(col))
+// - This combinator: sum_combine(col)
+//
+// DESC: immediate_type {agg_func}_combine(arg types)
+//  input type          : aggregate function's arg types
+//  intermediate type   : aggregate function's immediate_type
+//  return type         : aggregate function's immediate_type
+class AggStateCombine final : public AggStateCombinator<AggStateCombineState, AggStateCombine> {
+public:
+    AggStateCombine(AggStateDesc agg_state_desc, const AggregateFunction* function)
+            : AggStateCombinator(agg_state_desc, function) {
+        DCHECK(_function != nullptr);
+        VLOG_ROW << "AggStateCombine constructor:" << _agg_state_desc.debug_string();
+    }
+
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
+        _function->update(ctx, columns, state, row_num);
+    }
+
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
+        _function->merge(ctx, column, state, row_num);
+    }
+
+    void serialize_to_column([[maybe_unused]] FunctionContext* ctx, ConstAggDataPtr __restrict state,
+                             Column* to) const override {
+        _serialize_to_column_nullable(ctx, state, to);
+    }
+
+    void convert_to_serialize_format([[maybe_unused]] FunctionContext* ctx, const Columns& srcs, size_t chunk_size,
+                                     ColumnPtr* dst) const override {
+        DCHECK_EQ(1, srcs.size());
+        *dst = srcs[0];
+    }
+
+    void finalize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr __restrict state,
+                            Column* to) const override {
+        _serialize_to_column_nullable(ctx, state, to);
+    }
+
+    std::string get_name() const override { return "agg_state_combine"; }
+
+private:
+    inline void _serialize_to_column_nullable(FunctionContext* ctx, ConstAggDataPtr __restrict state,
+                                              Column* to) const {
+        // `count` is a special case because `CountNullableAggregateFunction` is used to handle nullable column
+        // and its serialize/finalize is meant to not nullable.
+        if (_function->get_name() == "count" || _function->get_name() == "count_nullable") {
+            if (LIKELY(to->is_nullable())) {
+                auto* nullable_column = down_cast<NullableColumn*>(to);
+                _function->serialize_to_column(ctx, state, nullable_column->mutable_data_column());
+                nullable_column->null_column_data().push_back(0);
+            } else {
+                _function->serialize_to_column(ctx, state, to);
+            }
+        } else {
+            _function->serialize_to_column(ctx, state, to);
+        }
+    }
+};
+
+} // namespace starrocks

--- a/be/src/exprs/agg/combinator/agg_state_merge.h
+++ b/be/src/exprs/agg/combinator/agg_state_merge.h
@@ -23,9 +23,9 @@ struct AggStateMergeState {};
 
 // An aggregate merge combinator that merges aggregate intermediate states to compute the final result of aggregate function.
 //
-// DESC: return_type {agg_func}_merge(immediate_type)
-//  input type          : aggregate function's immediate_type
-//  intermediate type   : aggregate function's immediate_type
+// DESC: return_type {agg_func}_merge(intermediate_type)
+//  input type          : aggregate function's intermediate_type
+//  intermediate type   : aggregate function's intermediate_type
 //  return type         : aggregate function's return type
 class AggStateMerge final : public AggStateCombinator<AggStateMergeState, AggStateMerge> {
 public:

--- a/be/src/exprs/agg/combinator/agg_state_union.h
+++ b/be/src/exprs/agg/combinator/agg_state_union.h
@@ -21,12 +21,12 @@
 namespace starrocks {
 struct AggStateUnionState {};
 
-// An aggregate union combinator that combines intermediate states to compute the immediate result of aggregate function.
+// An aggregate union combinator that combines intermediate states to compute the intermediate result of aggregate function.
 //
-// DESC: immediate_type {agg_func}_union(immediate_type)
-//  input type          : aggregate function's immediate_type
-//  intermediate type   : aggregate function's immediate_type
-//  return type         : aggregate function's immediate_type
+// DESC: intermediate_type {agg_func}_union(intermediate_type)
+//  input type          : aggregate function's intermediate_type
+//  intermediate type   : aggregate function's intermediate_type
+//  return type         : aggregate function's intermediate_type
 class AggStateUnion final : public AggStateCombinator<AggStateUnionState, AggStateUnion> {
 public:
     AggStateUnion(AggStateDesc agg_state_desc, const AggregateFunction* function)

--- a/be/src/exprs/agg/combinator/agg_state_utils.cpp
+++ b/be/src/exprs/agg/combinator/agg_state_utils.cpp
@@ -1,0 +1,126 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs/agg/combinator/agg_state_utils.h"
+
+#include "exprs/agg/combinator/agg_state_combinator.h"
+#include "exprs/agg/combinator/agg_state_combine.h"
+#include "exprs/agg/combinator/agg_state_if.h"
+#include "exprs/agg/combinator/agg_state_merge.h"
+#include "exprs/agg/combinator/agg_state_union.h"
+#include "exprs/agg/combinator/state_function.h"
+#include "exprs/agg/combinator/state_merge_function.h"
+#include "exprs/agg/combinator/state_union_function.h"
+
+namespace starrocks {
+
+bool AggStateUtils::is_count_function(const std::string& func_name) noexcept {
+    return func_name == FUNCTION_COUNT || func_name == (FUNCTION_COUNT + AGG_STATE_IF_SUFFIX) ||
+           func_name == (FUNCTION_COUNT + AGG_STATE_UNION_SUFFIX) ||
+           func_name == (FUNCTION_COUNT + AGG_STATE_MERGE_SUFFIX) ||
+           func_name == (FUNCTION_COUNT + AGG_STATE_COMBINE_SUFFIX);
+}
+
+// Get the aggregate state descriptor from the aggregate function.
+const AggStateDesc* AggStateUtils::get_agg_state_desc(const AggregateFunction* agg_func) {
+    if (dynamic_cast<const AggStateUnion*>(agg_func)) {
+        auto* agg_state_union = down_cast<const AggStateUnion*>(agg_func);
+        return agg_state_union->get_agg_state_desc();
+    } else if (dynamic_cast<const AggStateMerge*>(agg_func)) {
+        auto* agg_state_merge = down_cast<const AggStateMerge*>(agg_func);
+        return agg_state_merge->get_agg_state_desc();
+    } else if (dynamic_cast<const AggStateCombine*>(agg_func)) {
+        auto* agg_state_merge = down_cast<const AggStateCombine*>(agg_func);
+        return agg_state_merge->get_agg_state_desc();
+    } else if (dynamic_cast<const AggStateIf*>(agg_func)) {
+        auto* agg_state_if = down_cast<const AggStateIf*>(agg_func);
+        return agg_state_if->get_agg_state_desc();
+    }
+    return nullptr;
+}
+
+// Get the aggregate state function according to the agg_state_desc and function name.
+// If the function is not an aggregate state function, return nullptr.
+StatusOr<AggregateFunctionPtr> AggStateUtils::get_agg_state_function(const AggStateDesc& agg_state_desc,
+                                                                     const std::string& func_name,
+                                                                     const std::vector<TypeDescriptor>& arg_types) {
+    auto nested_func_name = agg_state_desc.get_func_name();
+    bool is_merge_or_union = AggStateUtils::is_agg_state_merge(nested_func_name, func_name) ||
+                             AggStateUtils::is_agg_state_union(nested_func_name, func_name);
+    if (is_merge_or_union && arg_types.size() != 1) {
+        return Status::InternalError(
+                strings::Substitute("Invalid agg function plan: $0 with (arg type $1)", func_name, arg_types.size()));
+    }
+
+    if (AggStateUtils::is_agg_state_merge(nested_func_name, func_name)) {
+        // aggregate _merge combinator
+        auto* nested_func = AggStateDesc::get_agg_state_func(&agg_state_desc);
+        if (nested_func == nullptr) {
+            return Status::InternalError(strings::Substitute(
+                    "Merge combinator function $0 fails to get the nested agg func: $1 ", func_name, nested_func_name));
+        }
+        return std::make_shared<AggStateMerge>(std::move(agg_state_desc), nested_func);
+    } else if (AggStateUtils::is_agg_state_union(nested_func_name, func_name)) {
+        // aggregate _union combinator
+        auto* nested_func = AggStateDesc::get_agg_state_func(&agg_state_desc);
+        if (nested_func == nullptr) {
+            return Status::InternalError(strings::Substitute(
+                    "Union combinator function $0 fails to get the nested agg func: $1 ", func_name, nested_func_name));
+        }
+        return std::make_shared<AggStateUnion>(std::move(agg_state_desc), nested_func);
+    } else if (AggStateUtils::is_agg_state_combine(nested_func_name, func_name)) {
+        // aggregate _combine combinator
+        auto* nested_func = AggStateDesc::get_agg_state_func(&agg_state_desc);
+        if (nested_func == nullptr) {
+            return Status::InternalError(
+                    strings::Substitute("Combine combinator function $0 fails to get the nested agg func: $1 ",
+                                        func_name, nested_func_name));
+        }
+        return std::make_shared<AggStateCombine>(std::move(agg_state_desc), nested_func);
+    } else if (AggStateUtils::is_agg_state_if(nested_func_name, func_name)) {
+        // aggregate _if combinator
+        auto* nested_func = AggStateDesc::get_agg_state_func(&agg_state_desc);
+        if (nested_func == nullptr) {
+            return Status::InternalError(strings::Substitute(
+                    "if combinator function $0 fails to get the nested agg func: $1 ", func_name, nested_func_name));
+        }
+        return std::make_shared<AggStateIf>(std::move(agg_state_desc), nested_func);
+    } else {
+        return Status::InternalError(strings::Substitute("Agg function combinator is not implemented: $0 ", func_name));
+    }
+}
+
+// Get the aggregate state function according to the TAggStateDesc and function name.
+// If the function is not an aggregate state function, return nullptr.
+StateCombinatorPtr AggStateUtils::get_agg_state_function(const TAggStateDesc& desc, const std::string& func_name,
+                                                         const TypeDescriptor& return_type,
+                                                         std::vector<bool> arg_nullables) {
+    if (is_agg_state_function(func_name)) {
+        auto agg_state_desc = AggStateDesc::from_thrift(desc);
+        // For _state combinator function, it's created according to the agg_state_desc rather than fid.
+        return std::make_shared<StateFunction>(agg_state_desc, return_type, std::move(arg_nullables));
+    } else if (is_agg_state_union_function(func_name)) {
+        auto agg_state_desc = AggStateDesc::from_thrift(desc);
+        // For _state combinator function, it's created according to the agg_state_desc rather than fid.
+        return std::make_shared<StateUnionFunction>(agg_state_desc, return_type, std::move(arg_nullables));
+    } else if (is_agg_state_merge_function(func_name)) {
+        auto agg_state_desc = AggStateDesc::from_thrift(desc);
+        // For _state combinator function, it's created according to the agg_state_desc rather than fid.
+        return std::make_shared<StateMergeFunction>(agg_state_desc, return_type, std::move(arg_nullables));
+    } else {
+        return nullptr;
+    }
+}
+
+} // namespace starrocks

--- a/be/src/exprs/agg/combinator/agg_state_utils.cpp
+++ b/be/src/exprs/agg/combinator/agg_state_utils.cpp
@@ -14,6 +14,8 @@
 
 #include "exprs/agg/combinator/agg_state_utils.h"
 
+#include <fmt/format.h>
+
 #include "exprs/agg/combinator/agg_state_combinator.h"
 #include "exprs/agg/combinator/agg_state_combine.h"
 #include "exprs/agg/combinator/agg_state_if.h"
@@ -60,23 +62,23 @@ StatusOr<AggregateFunctionPtr> AggStateUtils::get_agg_state_function(const AggSt
                              AggStateUtils::is_agg_state_union(nested_func_name, func_name);
     if (is_merge_or_union && arg_types.size() != 1) {
         return Status::InternalError(
-                strings::Substitute("Invalid agg function plan: $0 with (arg type $1)", func_name, arg_types.size()));
+                fmt::format("Invalid agg function plan: {} with (arg type {})", func_name, arg_types.size()));
     }
 
     if (AggStateUtils::is_agg_state_merge(nested_func_name, func_name)) {
         // aggregate _merge combinator
         auto* nested_func = AggStateDesc::get_agg_state_func(&agg_state_desc);
         if (nested_func == nullptr) {
-            return Status::InternalError(strings::Substitute(
-                    "Merge combinator function $0 fails to get the nested agg func: $1 ", func_name, nested_func_name));
+            return Status::InternalError(fmt::format(
+                    "Merge combinator function {} fails to get the nested agg func: {}", func_name, nested_func_name));
         }
         return std::make_shared<AggStateMerge>(std::move(agg_state_desc), nested_func);
     } else if (AggStateUtils::is_agg_state_union(nested_func_name, func_name)) {
         // aggregate _union combinator
         auto* nested_func = AggStateDesc::get_agg_state_func(&agg_state_desc);
         if (nested_func == nullptr) {
-            return Status::InternalError(strings::Substitute(
-                    "Union combinator function $0 fails to get the nested agg func: $1 ", func_name, nested_func_name));
+            return Status::InternalError(fmt::format(
+                    "Union combinator function {} fails to get the nested agg func: {}", func_name, nested_func_name));
         }
         return std::make_shared<AggStateUnion>(std::move(agg_state_desc), nested_func);
     } else if (AggStateUtils::is_agg_state_combine(nested_func_name, func_name)) {
@@ -84,20 +86,20 @@ StatusOr<AggregateFunctionPtr> AggStateUtils::get_agg_state_function(const AggSt
         auto* nested_func = AggStateDesc::get_agg_state_func(&agg_state_desc);
         if (nested_func == nullptr) {
             return Status::InternalError(
-                    strings::Substitute("Combine combinator function $0 fails to get the nested agg func: $1 ",
-                                        func_name, nested_func_name));
+                    fmt::format("Combine combinator function {} fails to get the nested agg func: {}", func_name,
+                                nested_func_name));
         }
         return std::make_shared<AggStateCombine>(std::move(agg_state_desc), nested_func);
     } else if (AggStateUtils::is_agg_state_if(nested_func_name, func_name)) {
         // aggregate _if combinator
         auto* nested_func = AggStateDesc::get_agg_state_func(&agg_state_desc);
         if (nested_func == nullptr) {
-            return Status::InternalError(strings::Substitute(
-                    "if combinator function $0 fails to get the nested agg func: $1 ", func_name, nested_func_name));
+            return Status::InternalError(fmt::format("if combinator function {} fails to get the nested agg func: {}",
+                                                     func_name, nested_func_name));
         }
         return std::make_shared<AggStateIf>(std::move(agg_state_desc), nested_func);
     } else {
-        return Status::InternalError(strings::Substitute("Agg function combinator is not implemented: $0 ", func_name));
+        return Status::InternalError(fmt::format("Agg function combinator is not implemented: {}", func_name));
     }
 }
 

--- a/be/src/exprs/agg/combinator/agg_state_utils.h
+++ b/be/src/exprs/agg/combinator/agg_state_utils.h
@@ -34,6 +34,7 @@ public:
     static constexpr const char* AGG_STATE_COMBINE_SUFFIX = "_combine";
     static constexpr const char* AGG_STATE_IF_SUFFIX = "_if";
     static constexpr std::string FUNCTION_COUNT = "count";
+    static constexpr std::string FUNCTION_COUNT_NULLABLE = "count_nullable";
 
     static bool is_agg_state_function(const std::string& func_name) noexcept {
         return !func_name.empty() && func_name.ends_with(STATE_FUNCTION_SUFFIX);

--- a/be/src/exprs/agg/combinator/agg_state_utils.h
+++ b/be/src/exprs/agg/combinator/agg_state_utils.h
@@ -14,10 +14,7 @@
 
 #pragma once
 
-#include "exprs/agg/combinator/agg_state_if.h"
-#include "exprs/agg/combinator/agg_state_merge.h"
-#include "exprs/agg/combinator/agg_state_union.h"
-#include "exprs/agg/combinator/state_function.h"
+#include "exprs/agg/combinator/state_combinator.h"
 #include "runtime/agg_state_desc.h"
 
 namespace starrocks {
@@ -28,15 +25,26 @@ class AggStateUtils {
 public:
     // scalar function: suffix for aggregate state combinator functions
     static constexpr const char* STATE_FUNCTION_SUFFIX = "_state";
+    static constexpr const char* STATE_UNION_FUNCTION_SUFFIX = "_state_union";
+    static constexpr const char* STATE_MERGE_FUNCTION_SUFFIX = "_state_merge";
 
     // aggregate function: suffixes for aggregate state combinator functions
     static constexpr const char* AGG_STATE_UNION_SUFFIX = "_union";
     static constexpr const char* AGG_STATE_MERGE_SUFFIX = "_merge";
+    static constexpr const char* AGG_STATE_COMBINE_SUFFIX = "_combine";
     static constexpr const char* AGG_STATE_IF_SUFFIX = "_if";
     static constexpr std::string FUNCTION_COUNT = "count";
 
     static bool is_agg_state_function(const std::string& func_name) noexcept {
         return !func_name.empty() && func_name.ends_with(STATE_FUNCTION_SUFFIX);
+    }
+
+    static bool is_agg_state_union_function(const std::string& func_name) noexcept {
+        return !func_name.empty() && func_name.ends_with(STATE_UNION_FUNCTION_SUFFIX);
+    }
+
+    static bool is_agg_state_merge_function(const std::string& func_name) noexcept {
+        return !func_name.empty() && func_name.ends_with(STATE_MERGE_FUNCTION_SUFFIX);
     }
 
     static bool is_agg_state_if(const std::string& func_name) noexcept {
@@ -51,90 +59,30 @@ public:
         return nested_func_name + AGG_STATE_MERGE_SUFFIX == func_name;
     }
 
+    static bool is_agg_state_combine(const std::string& nested_func_name, const std::string& func_name) noexcept {
+        return nested_func_name + AGG_STATE_COMBINE_SUFFIX == func_name;
+    }
+
     static bool is_agg_state_if(const std::string& nested_func_name, const std::string& func_name) noexcept {
         return nested_func_name + AGG_STATE_IF_SUFFIX == func_name;
     }
 
-    static bool is_count_function(const std::string& func_name) noexcept {
-        return func_name == FUNCTION_COUNT || func_name == (FUNCTION_COUNT + AGG_STATE_IF_SUFFIX) ||
-               func_name == (FUNCTION_COUNT + AGG_STATE_UNION_SUFFIX) ||
-               func_name == (FUNCTION_COUNT + AGG_STATE_MERGE_SUFFIX);
-    }
+    static bool is_count_function(const std::string& func_name) noexcept;
 
     // Get the aggregate state descriptor from the aggregate function.
-    static const AggStateDesc* get_agg_state_desc(const AggregateFunction* agg_func) {
-        if (dynamic_cast<const AggStateUnion*>(agg_func)) {
-            auto* agg_state_union = down_cast<const AggStateUnion*>(agg_func);
-            return agg_state_union->get_agg_state_desc();
-        } else if (dynamic_cast<const AggStateMerge*>(agg_func)) {
-            auto* agg_state_merge = down_cast<const AggStateMerge*>(agg_func);
-            return agg_state_merge->get_agg_state_desc();
-        } else if (dynamic_cast<const AggStateIf*>(agg_func)) {
-            auto* agg_state_if = down_cast<const AggStateIf*>(agg_func);
-            return agg_state_if->get_agg_state_desc();
-        }
-        return nullptr;
-    }
+    static const AggStateDesc* get_agg_state_desc(const AggregateFunction* agg_func);
 
     // Get the aggregate state function according to the agg_state_desc and function name.
     // If the function is not an aggregate state function, return nullptr.
     static StatusOr<AggregateFunctionPtr> get_agg_state_function(const AggStateDesc& agg_state_desc,
                                                                  const std::string& func_name,
-                                                                 const std::vector<TypeDescriptor>& arg_types) {
-        auto nested_func_name = agg_state_desc.get_func_name();
-        bool is_merge_or_union = AggStateUtils::is_agg_state_merge(nested_func_name, func_name) ||
-                                 AggStateUtils::is_agg_state_union(nested_func_name, func_name);
-        if (is_merge_or_union && arg_types.size() != 1) {
-            return Status::InternalError(strings::Substitute("Invalid agg function plan: $0 with (arg type $1)",
-                                                             func_name, arg_types.size()));
-        }
-
-        if (AggStateUtils::is_agg_state_merge(nested_func_name, func_name)) {
-            // aggregate _merge combinator
-            auto* nested_func = AggStateDesc::get_agg_state_func(&agg_state_desc);
-            if (nested_func == nullptr) {
-                return Status::InternalError(
-                        strings::Substitute("Merge combinator function $0 fails to get the nested agg func: $1 ",
-                                            func_name, nested_func_name));
-            }
-            return std::make_shared<AggStateMerge>(std::move(agg_state_desc), nested_func);
-        } else if (AggStateUtils::is_agg_state_union(nested_func_name, func_name)) {
-            // aggregate _union combinator
-            auto* nested_func = AggStateDesc::get_agg_state_func(&agg_state_desc);
-            if (nested_func == nullptr) {
-                return Status::InternalError(
-                        strings::Substitute("Union combinator function $0 fails to get the nested agg func: $1 ",
-                                            func_name, nested_func_name));
-            }
-            return std::make_shared<AggStateUnion>(std::move(agg_state_desc), nested_func);
-        } else if (AggStateUtils::is_agg_state_if(nested_func_name, func_name)) {
-            // aggregate _if combinator
-            auto* nested_func = AggStateDesc::get_agg_state_func(&agg_state_desc);
-            if (nested_func == nullptr) {
-                return Status::InternalError(
-                        strings::Substitute("if combinator function $0 fails to get the nested agg func: $1 ",
-                                            func_name, nested_func_name));
-            }
-            return std::make_shared<AggStateIf>(std::move(agg_state_desc), nested_func);
-        } else {
-            return Status::InternalError(
-                    strings::Substitute("Agg function combinator is not implemented: $0 ", func_name));
-        }
-    }
+                                                                 const std::vector<TypeDescriptor>& arg_types);
 
     // Get the aggregate state function according to the TAggStateDesc and function name.
     // If the function is not an aggregate state function, return nullptr.
     static StateCombinatorPtr get_agg_state_function(const TAggStateDesc& desc, const std::string& func_name,
                                                      const TypeDescriptor& return_type,
-                                                     std::vector<bool> arg_nullables) {
-        if (is_agg_state_function(func_name)) {
-            auto agg_state_desc = AggStateDesc::from_thrift(desc);
-            // For _state combinator function, it's created according to the agg_state_desc rather than fid.
-            return std::make_shared<StateFunction>(agg_state_desc, return_type, std::move(arg_nullables));
-        } else {
-            return nullptr;
-        }
-    }
+                                                     std::vector<bool> arg_nullables);
 };
 
 } // namespace starrocks

--- a/be/src/exprs/agg/combinator/state_function.h
+++ b/be/src/exprs/agg/combinator/state_function.h
@@ -28,17 +28,15 @@
 
 namespace starrocks {
 
-// A state function that computes the immediate result of aggregate function.
+// A state function that computes the intermediate result of aggregate function.
 //
-// DESC: immediate_type {agg_func}_state(arg_types)
+// DESC: intermediate_type {agg_func}_state(arg_types)
 //  input type  : aggregate function's argument types
-//  return type : aggregate function's immediate type (e.g. sum_state(col) -> int)
+//  return type : aggregate function's intermediate type (e.g. sum_state(col) -> int)
 class StateFunction final : public StateCombinator {
 public:
-    StateFunction(AggStateDesc agg_state_desc, TypeDescriptor immediate_type, std::vector<bool> arg_nullables)
-            : StateCombinator(std::move(agg_state_desc), std::move(immediate_type), std::move(arg_nullables)) {
-        VLOG_ROW << "StateFunction constructor:" << _agg_state_desc.debug_string();
-    }
+    StateFunction(AggStateDesc agg_state_desc, TypeDescriptor intermediate_type, std::vector<bool> arg_nullables)
+            : StateCombinator(std::move(agg_state_desc), std::move(intermediate_type), std::move(arg_nullables)) {}
 
     StatusOr<ColumnPtr> execute(FunctionContext* context, const Columns& columns) override {
         DCHECK_GT(columns.size(), 0);
@@ -54,7 +52,7 @@ public:
         }
 
         // TODO: use mutable ptr as result
-        ColumnPtr result = ColumnHelper::create_column(_immediate_type, _agg_state_desc.is_result_nullable());
+        ColumnPtr result = ColumnHelper::create_column(_intermediate_type, _agg_state_desc.is_result_nullable());
         auto chunk_size = columns[0]->size();
         _function->convert_to_serialize_format(context, new_columns, chunk_size, &result);
 

--- a/be/src/exprs/agg/combinator/state_merge_function.h
+++ b/be/src/exprs/agg/combinator/state_merge_function.h
@@ -1,0 +1,124 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "column/column.h"
+#include "column/column_helper.h"
+#include "common/status.h"
+#include "exprs/agg/aggregate.h"
+#include "exprs/agg/aggregate_state_allocator.h"
+#include "exprs/agg/combinator/state_combinator.h"
+#include "exprs/function_context.h"
+#include "runtime/agg_state_desc.h"
+#include "runtime/mem_pool.h"
+
+namespace starrocks {
+
+// A state merge function that computes the final result from intermediate states.
+//
+// DESC: return_type {agg_func}_state_merge(intermediate_type)
+//  input type  : intermediate type
+//  return type : return type
+class StateMergeFunction final : public StateCombinator {
+public:
+    StateMergeFunction(AggStateDesc agg_state_desc, TypeDescriptor immediate_type, std::vector<bool> arg_nullables)
+            : StateCombinator(std::move(agg_state_desc), std::move(immediate_type), std::move(arg_nullables)) {
+        VLOG_ROW << "StateMergeFunction constructor:" << _agg_state_desc.debug_string();
+    }
+
+    ~StateMergeFunction() {
+        if (_nested_ctx != nullptr) {
+            delete _nested_ctx;
+        }
+    }
+
+    virtual Status prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+        if (_function == nullptr) {
+            return Status::InternalError("AggStateBaseFunction is nullptr  for " + _agg_state_desc.get_func_name());
+        }
+        _nested_ctx =
+                FunctionContext::create_context(context->state(), context->mem_pool(),
+                                                _agg_state_desc.get_return_type(), _agg_state_desc.get_arg_types());
+        return Status::OK();
+    }
+
+    StatusOr<ColumnPtr> execute(FunctionContext* context, const Columns& columns) override {
+        if (columns.size() != 1) {
+            return Status::InternalError("StateMergeFunction execute columns is not 1");
+        }
+        if (columns.size() != _arg_nullables.size()) {
+            return Status::InternalError("StateMergeFunction execute columns size " + std::to_string(columns.size()) +
+                                         " not match with arg_nullables size " + std::to_string(_arg_nullables.size()));
+        }
+
+        SCOPED_THREAD_LOCAL_AGG_STATE_ALLOCATOR_SETTER(&kDefaultAggStateMergeFunctionAllocator);
+
+        bool is_result_nullable = _agg_state_desc.is_result_nullable() || _arg_nullables[0];
+        ASSIGN_OR_RETURN(ColumnPtr new_column, _convert_to_nullable_column(columns[0], is_result_nullable, true));
+
+        // TODO: use mutable ptr as result
+        auto& ret_type = _agg_state_desc.get_return_type();
+        ColumnPtr result = ColumnHelper::create_column(ret_type, _agg_state_desc.is_result_nullable());
+        auto chunk_size = columns[0]->size();
+
+        // finalize agg states into result
+        auto align_size = _function->alignof_size();
+        auto state_size = align_to(_function->size(), align_size);
+        AggDataPtr agg_state = reinterpret_cast<AggDataPtr>(std::aligned_alloc(align_size, state_size));
+        if (UNLIKELY(agg_state == nullptr)) {
+            return Status::InternalError("Failed to allocate memory for aggregate state");
+        }
+
+        // `count` is a special case because `CountNullableAggregateFunction` is used to handle nullable column
+        // and its serialize/finalize is meant to not nullable.
+        DCHECK_EQ(is_result_nullable, new_column->is_nullable());
+        std::string function_name = _function->get_name();
+        if (function_name == "count" || function_name == "count_nullable") {
+            auto* data_column = ColumnHelper::get_data_column(new_column.get());
+            for (size_t i = 0; i < chunk_size; i++) {
+                if (new_column->is_null(i)) {
+                    result->append_nulls(1);
+                    continue;
+                }
+                _function->create(_nested_ctx, agg_state);
+                _function->merge(_nested_ctx, data_column, agg_state, i);
+                _function->finalize_to_column(_nested_ctx, agg_state, result.get());
+                _function->destroy(_nested_ctx, agg_state);
+            }
+        } else {
+            for (size_t i = 0; i < chunk_size; i++) {
+                if (new_column->is_null(i)) {
+                    result->append_nulls(1);
+                    continue;
+                }
+                _function->create(_nested_ctx, agg_state);
+                _function->merge(_nested_ctx, new_column.get(), agg_state, i);
+                _function->finalize_to_column(_nested_ctx, agg_state, result.get());
+                _function->destroy(_nested_ctx, agg_state);
+            }
+        }
+        std::free(agg_state);
+        return result;
+    }
+
+private:
+    // for nested function, the nested function's context is injected to the parent function's context.
+    FunctionContext* _nested_ctx;
+};
+
+} // namespace starrocks

--- a/be/src/exprs/agg/combinator/state_union_function.h
+++ b/be/src/exprs/agg/combinator/state_union_function.h
@@ -57,7 +57,7 @@ public:
     StatusOr<ColumnPtr> execute(FunctionContext* context, const Columns& columns) override {
         RETURN_IF_UNLIKELY(
                 columns.size() != _arg_nullables.size(),
-                Status::InternalError("StateMergeFunction execute columns size " + std::to_string(columns.size()) +
+                Status::InternalError("StateUnionFunction execute columns size " + std::to_string(columns.size()) +
                                       " not match with arg_nullables size " + std::to_string(_arg_nullables.size())));
 
         SCOPED_THREAD_LOCAL_AGG_STATE_ALLOCATOR_SETTER(&kDefaultAggStateMergeFunctionAllocator);

--- a/be/src/exprs/agg/combinator/state_union_function.h
+++ b/be/src/exprs/agg/combinator/state_union_function.h
@@ -1,0 +1,135 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <utility>
+
+#include "column/column.h"
+#include "column/column_helper.h"
+#include "common/status.h"
+#include "exprs/agg/aggregate.h"
+#include "exprs/agg/aggregate_state_allocator.h"
+#include "exprs/agg/combinator/state_combinator.h"
+#include "exprs/function_context.h"
+#include "runtime/agg_state_desc.h"
+#include "runtime/mem_pool.h"
+
+namespace starrocks {
+
+// A state union function that combines intermediate states into a single intermediate state.
+//
+// DESC: immediate_type {agg_func}_state_union(immediate_type, immediate_type)
+//  input type  : (immediate type, immediate type)
+//  return type : immediate type
+class StateUnionFunction final : public StateCombinator {
+public:
+    StateUnionFunction(AggStateDesc agg_state_desc, TypeDescriptor immediate_type, std::vector<bool> arg_nullables)
+            : StateCombinator(std::move(agg_state_desc), std::move(immediate_type), std::move(arg_nullables)) {
+        VLOG_ROW << "StateUnionFunction constructor:" << _agg_state_desc.debug_string();
+    }
+
+    ~StateUnionFunction() {
+        if (_nested_ctx != nullptr) {
+            delete _nested_ctx;
+        }
+    }
+
+    virtual Status prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+        if (_function == nullptr) {
+            return Status::InternalError("AggStateBaseFunction is nullptr  for " + _agg_state_desc.get_func_name());
+        }
+        _nested_ctx =
+                FunctionContext::create_context(context->state(), context->mem_pool(),
+                                                _agg_state_desc.get_return_type(), _agg_state_desc.get_arg_types());
+        return Status::OK();
+    }
+
+    StatusOr<ColumnPtr> execute(FunctionContext* context, const Columns& columns) override {
+        if (columns.size() != 2) {
+            return Status::InternalError("StateUnionFunction execute columns is not 2");
+        }
+        if (columns.size() != _arg_nullables.size()) {
+            return Status::InternalError("StateUnionFunction execute columns size " + std::to_string(columns.size()) +
+                                         " not match with arg_nullables size " + std::to_string(_arg_nullables.size()));
+        }
+
+        SCOPED_THREAD_LOCAL_AGG_STATE_ALLOCATOR_SETTER(&kDefaultAggStateMergeFunctionAllocator);
+
+        Columns new_columns;
+        new_columns.reserve(columns.size());
+        for (auto i = 0; i < columns.size(); i++) {
+            bool is_result_nullable = _agg_state_desc.is_result_nullable() || _arg_nullables[i];
+            ASSIGN_OR_RETURN(ColumnPtr new_column, _convert_to_nullable_column(columns[i], is_result_nullable, true));
+            new_columns.emplace_back(new_column);
+        }
+
+        auto chunk_size = columns[0]->size();
+        auto align_size = _function->alignof_size();
+        auto state_size = align_to(_function->size(), align_size);
+        ColumnPtr result = ColumnHelper::create_column(_immediate_type, _agg_state_desc.is_result_nullable());
+        // allocate the agg_state
+        AggDataPtr agg_state = reinterpret_cast<AggDataPtr>(std::aligned_alloc(align_size, state_size));
+        if (UNLIKELY(agg_state == nullptr)) {
+            return Status::InternalError("Failed to allocate memory for aggregate state");
+        }
+
+        // `count` is a special case because `CountNullableAggregateFunction` is used to handle nullable column
+        // and its serialize/finalize is meant to not nullable.
+        if (_function->get_name() == "count" || _function->get_name() == "count_nullable") {
+            std::vector<Column*> data_columns;
+            data_columns.reserve(new_columns.size());
+            for (size_t i = 0; i < new_columns.size(); i++) {
+                data_columns.emplace_back(ColumnHelper::get_data_column(new_columns[i].get()));
+            }
+            for (size_t i = 0; i < chunk_size; i++) {
+                _function->create(_nested_ctx, agg_state);
+                // merge input agg states into result
+                for (size_t j = 0; j < new_columns.size(); j++) {
+                    if (UNLIKELY(new_columns[j]->is_null(i))) {
+                        continue;
+                    }
+                    _function->merge(_nested_ctx, data_columns[j], agg_state, i);
+                }
+                // serialize the agg_state into result
+                _function->serialize_to_column(_nested_ctx, agg_state, result.get());
+                // destroy the agg_state
+                _function->destroy(_nested_ctx, agg_state);
+            }
+        } else {
+            for (size_t i = 0; i < chunk_size; i++) {
+                _function->create(_nested_ctx, agg_state);
+
+                // merge input agg states into result
+                for (size_t j = 0; j < new_columns.size(); j++) {
+                    _function->merge(_nested_ctx, new_columns[j].get(), agg_state, i);
+                }
+                // serialize the agg_state into result
+                _function->serialize_to_column(_nested_ctx, agg_state, result.get());
+
+                // destroy the agg_state
+                _function->destroy(_nested_ctx, agg_state);
+            }
+        }
+        std::free(agg_state);
+
+        return result;
+    }
+
+private:
+    // for nested function, the nested function's context is injected to the parent function's context.
+    FunctionContext* _nested_ctx;
+};
+
+} // namespace starrocks

--- a/be/test/exprs/agg/agg_state_functions_test.cpp
+++ b/be/test/exprs/agg/agg_state_functions_test.cpp
@@ -51,9 +51,9 @@ private:
 // Test helper functions for StateUnionFunction
 template <typename T>
 ColumnPtr create_agg_state_column(const AggregateFunction* func, FunctionContext* ctx, const ColumnPtr& input_column,
-                                  bool is_nullable, const TypeDescriptor& immediate_type) {
+                                  bool is_nullable, const TypeDescriptor& intermediate_type) {
     VLOG_ROW << "create_agg_state_column: " << func->get_name() << " is_nullable: " << is_nullable;
-    auto result_column = ColumnHelper::create_column(immediate_type, is_nullable);
+    auto result_column = ColumnHelper::create_column(intermediate_type, is_nullable);
     auto state = ManagedAggrState::create(ctx, func);
 
     const Column* row_column = input_column.get();
@@ -73,7 +73,7 @@ std::string get_func_name(const std::string& func_name) {
 template <typename T>
 void test_agg_state_union_basic(FunctionContext* ctx, const AggregateFunction* func, const std::string& func_name,
                                 const std::vector<TypeDescriptor>& arg_types, const TypeDescriptor& ret_type,
-                                const TypeDescriptor& immediate_type, bool is_result_nullable = false) {
+                                const TypeDescriptor& intermediate_type, bool is_result_nullable = false) {
     VLOG_ROW << "test_agg_state_union_basic: " << func_name << " is_result_nullable: " << is_result_nullable;
 
     // Create AggStateDesc
@@ -88,9 +88,9 @@ void test_agg_state_union_basic(FunctionContext* ctx, const AggregateFunction* f
 
     // Convert input data to aggregate state columns (intermediate format)
     ColumnPtr agg_state_column1 =
-            create_agg_state_column<T>(func, ctx, input_column1, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, input_column1, is_result_nullable, intermediate_type);
     ColumnPtr agg_state_column2 =
-            create_agg_state_column<T>(func, ctx, input_column2, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, input_column2, is_result_nullable, intermediate_type);
 
     // Test union operation by creating a state and merging the aggregate state columns
     auto state = ManagedAggrState::create(ctx, &union_func);
@@ -106,7 +106,7 @@ void test_agg_state_union_basic(FunctionContext* ctx, const AggregateFunction* f
     }
 
     // Serialize result
-    ColumnPtr result_column = ColumnHelper::create_column(immediate_type, is_result_nullable);
+    ColumnPtr result_column = ColumnHelper::create_column(intermediate_type, is_result_nullable);
     union_func.finalize_to_column(ctx, state->state(), result_column.get());
 
     // Verify result
@@ -117,7 +117,7 @@ void test_agg_state_union_basic(FunctionContext* ctx, const AggregateFunction* f
 template <typename T>
 void test_agg_state_union_nullable(FunctionContext* ctx, const AggregateFunction* func, const std::string& func_name,
                                    const std::vector<TypeDescriptor>& arg_types, const TypeDescriptor& ret_type,
-                                   const TypeDescriptor& immediate_type, bool is_result_nullable = true) {
+                                   const TypeDescriptor& intermediate_type, bool is_result_nullable = true) {
     VLOG_ROW << "test_agg_state_union_nullable: " << func_name << " is_result_nullable: " << is_result_nullable;
 
     // Create AggStateDesc
@@ -136,9 +136,9 @@ void test_agg_state_union_nullable(FunctionContext* ctx, const AggregateFunction
 
     // Convert input data to aggregate state columns (intermediate format)
     ColumnPtr agg_state_column1 =
-            create_agg_state_column<T>(func, ctx, nullable_column1, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, nullable_column1, is_result_nullable, intermediate_type);
     ColumnPtr agg_state_column2 =
-            create_agg_state_column<T>(func, ctx, nullable_column2, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, nullable_column2, is_result_nullable, intermediate_type);
 
     // Test union operation by creating a state and merging the aggregate state columns
     auto state = ManagedAggrState::create(ctx, &union_func);
@@ -154,7 +154,7 @@ void test_agg_state_union_nullable(FunctionContext* ctx, const AggregateFunction
     }
 
     // Serialize result
-    ColumnPtr result_column = ColumnHelper::create_column(immediate_type, is_result_nullable);
+    ColumnPtr result_column = ColumnHelper::create_column(intermediate_type, is_result_nullable);
     union_func.finalize_to_column(ctx, state->state(), result_column.get());
 
     // Verify result
@@ -165,7 +165,7 @@ void test_agg_state_union_nullable(FunctionContext* ctx, const AggregateFunction
 template <typename T>
 void test_agg_state_union_empty_column(FunctionContext* ctx, const AggregateFunction* func,
                                        const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
-                                       const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                       const TypeDescriptor& ret_type, const TypeDescriptor& intermediate_type,
                                        bool is_result_nullable = false) {
     VLOG_ROW << "test_agg_state_union_empty_column: " << func_name << " is_result_nullable: " << is_result_nullable;
 
@@ -195,7 +195,7 @@ void test_agg_state_union_empty_column(FunctionContext* ctx, const AggregateFunc
     }
 
     // Serialize result
-    ColumnPtr result_column = ColumnHelper::create_column(immediate_type, is_result_nullable);
+    ColumnPtr result_column = ColumnHelper::create_column(intermediate_type, is_result_nullable);
     union_func.finalize_to_column(ctx, state->state(), result_column.get());
 
     ASSERT_NE(result_column, nullptr);
@@ -354,7 +354,7 @@ TEST_F(AggStateFunctionsTest, test_agg_state_union_avg) {
 template <typename T>
 void test_agg_state_merge_basic(FunctionContext* ctx, const AggregateFunction* func, const std::string& func_name,
                                 const std::vector<TypeDescriptor>& arg_types, const TypeDescriptor& ret_type,
-                                const TypeDescriptor& immediate_type, bool is_result_nullable = false) {
+                                const TypeDescriptor& intermediate_type, bool is_result_nullable = false) {
     VLOG_ROW << "test_agg_state_merge_basic: " << func_name << " is_result_nullable: " << is_result_nullable;
 
     // Create AggStateDesc
@@ -369,9 +369,9 @@ void test_agg_state_merge_basic(FunctionContext* ctx, const AggregateFunction* f
 
     // Convert input data to aggregate state columns (intermediate format)
     ColumnPtr agg_state_column1 =
-            create_agg_state_column<T>(func, ctx, input_column1, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, input_column1, is_result_nullable, intermediate_type);
     ColumnPtr agg_state_column2 =
-            create_agg_state_column<T>(func, ctx, input_column2, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, input_column2, is_result_nullable, intermediate_type);
 
     // Test merge operation by creating a state and merging the aggregate state columns
     auto state = ManagedAggrState::create(ctx, &merge_func);
@@ -400,7 +400,7 @@ void test_agg_state_merge_basic(FunctionContext* ctx, const AggregateFunction* f
 template <typename T>
 void test_agg_state_merge_nullable(FunctionContext* ctx, const AggregateFunction* func, const std::string& func_name,
                                    const std::vector<TypeDescriptor>& arg_types, const TypeDescriptor& ret_type,
-                                   const TypeDescriptor& immediate_type, bool is_result_nullable = true) {
+                                   const TypeDescriptor& intermediate_type, bool is_result_nullable = true) {
     VLOG_ROW << "test_agg_state_merge_nullable: " << func_name << " is_result_nullable: " << is_result_nullable;
 
     // Create AggStateDesc
@@ -419,9 +419,9 @@ void test_agg_state_merge_nullable(FunctionContext* ctx, const AggregateFunction
 
     // Convert input data to aggregate state columns (intermediate format)
     ColumnPtr agg_state_column1 =
-            create_agg_state_column<T>(func, ctx, nullable_column1, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, nullable_column1, is_result_nullable, intermediate_type);
     ColumnPtr agg_state_column2 =
-            create_agg_state_column<T>(func, ctx, nullable_column2, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, nullable_column2, is_result_nullable, intermediate_type);
 
     // Test merge operation by creating a state and merging the aggregate state columns
     auto state = ManagedAggrState::create(ctx, &merge_func);
@@ -448,7 +448,7 @@ void test_agg_state_merge_nullable(FunctionContext* ctx, const AggregateFunction
 template <typename T>
 void test_agg_state_merge_empty_column(FunctionContext* ctx, const AggregateFunction* func,
                                        const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
-                                       const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                       const TypeDescriptor& ret_type, const TypeDescriptor& intermediate_type,
                                        bool is_result_nullable = false) {
     VLOG_ROW << "test_agg_state_merge_empty_column: " << func_name << " is_result_nullable: " << is_result_nullable;
 
@@ -466,9 +466,9 @@ void test_agg_state_merge_empty_column(FunctionContext* ctx, const AggregateFunc
 
     // Convert input data to aggregate state columns (intermediate format)
     ColumnPtr agg_state_column1 =
-            create_agg_state_column<T>(func, ctx, empty_column1, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, empty_column1, is_result_nullable, intermediate_type);
     ColumnPtr agg_state_column2 =
-            create_agg_state_column<T>(func, ctx, empty_column2, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, empty_column2, is_result_nullable, intermediate_type);
 
     // Test merge operation by creating a state and merging the aggregate state columns
     auto state = ManagedAggrState::create(ctx, &merge_func);
@@ -644,7 +644,7 @@ TEST_F(AggStateFunctionsTest, test_agg_state_merge_count) {
 template <typename T>
 void test_state_function_basic(FunctionContext* ctx, const AggregateFunction* func, const std::string& func_name,
                                const std::vector<TypeDescriptor>& arg_types, const TypeDescriptor& ret_type,
-                               const TypeDescriptor& immediate_type, bool is_result_nullable = false) {
+                               const TypeDescriptor& intermediate_type, bool is_result_nullable = false) {
     VLOG_ROW << "test_state_function_basic: " << func_name << " is_result_nullable: " << is_result_nullable;
 
     // Create AggStateDesc
@@ -654,7 +654,7 @@ void test_state_function_basic(FunctionContext* ctx, const AggregateFunction* fu
     std::vector<bool> arg_nullables(arg_types.size(), is_result_nullable);
 
     // Create StateFunction
-    StateFunction state_func(agg_state_desc, immediate_type, arg_nullables);
+    StateFunction state_func(agg_state_desc, intermediate_type, arg_nullables);
 
     // Create test data
     ColumnPtr input_column = gen_input_column1<T>();
@@ -673,7 +673,7 @@ void test_state_function_basic(FunctionContext* ctx, const AggregateFunction* fu
 template <typename T>
 void test_state_function_nullable(FunctionContext* ctx, const AggregateFunction* func, const std::string& func_name,
                                   const std::vector<TypeDescriptor>& arg_types, const TypeDescriptor& ret_type,
-                                  const TypeDescriptor& immediate_type, bool is_result_nullable = true) {
+                                  const TypeDescriptor& intermediate_type, bool is_result_nullable = true) {
     VLOG_ROW << "test_state_function_nullable: " << func_name << " is_result_nullable: " << is_result_nullable;
 
     // Create AggStateDesc
@@ -683,7 +683,7 @@ void test_state_function_nullable(FunctionContext* ctx, const AggregateFunction*
     std::vector<bool> arg_nullables(arg_types.size(), is_result_nullable);
 
     // Create StateFunction
-    StateFunction state_func(agg_state_desc, immediate_type, arg_nullables);
+    StateFunction state_func(agg_state_desc, intermediate_type, arg_nullables);
 
     // Create test data with nullable columns
     ColumnPtr input_column = gen_input_column1<T>();
@@ -705,7 +705,7 @@ void test_state_function_nullable(FunctionContext* ctx, const AggregateFunction*
 template <typename T>
 void test_state_function_empty_column(FunctionContext* ctx, const AggregateFunction* func, const std::string& func_name,
                                       const std::vector<TypeDescriptor>& arg_types, const TypeDescriptor& ret_type,
-                                      const TypeDescriptor& immediate_type, bool is_result_nullable = false) {
+                                      const TypeDescriptor& intermediate_type, bool is_result_nullable = false) {
     VLOG_ROW << "test_state_function_empty_column: " << func_name << " is_result_nullable: " << is_result_nullable;
 
     // Create AggStateDesc
@@ -715,7 +715,7 @@ void test_state_function_empty_column(FunctionContext* ctx, const AggregateFunct
     std::vector<bool> arg_nullables(arg_types.size(), is_result_nullable);
 
     // Create StateFunction
-    StateFunction state_func(agg_state_desc, immediate_type, arg_nullables);
+    StateFunction state_func(agg_state_desc, intermediate_type, arg_nullables);
 
     // Create empty column
     auto empty_column =
@@ -831,7 +831,7 @@ TEST_F(AggStateFunctionsTest, test_state_function_avg) {
 template <typename T>
 void test_agg_state_union_function_basic(FunctionContext* ctx, const AggregateFunction* func,
                                          const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
-                                         const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                         const TypeDescriptor& ret_type, const TypeDescriptor& intermediate_type,
                                          bool is_result_nullable = false) {
     VLOG_ROW << "test_agg_state_union_function_basic: " << func_name << " is_result_nullable: " << is_result_nullable;
 
@@ -841,16 +841,16 @@ void test_agg_state_union_function_basic(FunctionContext* ctx, const AggregateFu
 
     // Create agg state columns
     ColumnPtr agg_state_column1 =
-            create_agg_state_column<T>(func, ctx, input_column1, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, input_column1, is_result_nullable, intermediate_type);
     ColumnPtr agg_state_column2 =
-            create_agg_state_column<T>(func, ctx, input_column2, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, input_column2, is_result_nullable, intermediate_type);
 
     // Create AggStateDesc
     AggStateDesc agg_state_desc(func_name, ret_type, arg_types, is_result_nullable, 1);
 
     // Create StateUnionFunction
     std::vector<bool> arg_nullables = {false, false};
-    StateUnionFunction union_func(agg_state_desc, immediate_type, arg_nullables);
+    StateUnionFunction union_func(agg_state_desc, intermediate_type, arg_nullables);
 
     // Test prepare
     Status status = union_func.prepare(ctx, FunctionContext::FRAGMENT_LOCAL);
@@ -872,7 +872,7 @@ void test_agg_state_union_function_basic(FunctionContext* ctx, const AggregateFu
 template <typename T>
 void test_agg_state_union_function_nullable(FunctionContext* ctx, const AggregateFunction* func,
                                             const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
-                                            const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                            const TypeDescriptor& ret_type, const TypeDescriptor& intermediate_type,
                                             bool is_result_nullable = true) {
     VLOG_ROW << "test_agg_state_union_function_nullable: " << func_name
              << " is_result_nullable: " << is_result_nullable;
@@ -887,16 +887,16 @@ void test_agg_state_union_function_nullable(FunctionContext* ctx, const Aggregat
 
     // Create agg state columns
     ColumnPtr agg_state_column1 =
-            create_agg_state_column<T>(func, ctx, nullable_column1, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, nullable_column1, is_result_nullable, intermediate_type);
     ColumnPtr agg_state_column2 =
-            create_agg_state_column<T>(func, ctx, nullable_column2, is_result_nullable, immediate_type);
+            create_agg_state_column<T>(func, ctx, nullable_column2, is_result_nullable, intermediate_type);
 
     // Create AggStateDesc
     AggStateDesc agg_state_desc(func_name, ret_type, arg_types, is_result_nullable, 1);
 
     // Create StateUnionFunction with nullable arguments
     std::vector<bool> arg_nullables = {true, true};
-    StateUnionFunction union_func(agg_state_desc, immediate_type, arg_nullables);
+    StateUnionFunction union_func(agg_state_desc, intermediate_type, arg_nullables);
 
     // Test prepare
     Status status = union_func.prepare(ctx, FunctionContext::FRAGMENT_LOCAL);
@@ -1000,20 +1000,20 @@ TEST_F(AggStateFunctionsTest, test_agg_state_union_function_avg) {
     auto arg_type = TYPE_INT;
     TypeDescriptor return_type_desc = TypeDescriptor(return_type);
     std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
-    TypeDescriptor immediate_type_desc = TypeDescriptor(TYPE_VARBINARY);
+    TypeDescriptor intermediate_type_desc = TypeDescriptor(TYPE_VARBINARY);
     auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
     auto ctx = utils->get_fn_ctx();
     {
         auto func = get_aggregate_function("avg", {arg_type}, return_type, false);
         ASSERT_NE(func, nullptr);
         test_agg_state_union_function_basic<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
-                                                     immediate_type_desc, false);
+                                                     intermediate_type_desc, false);
     }
     {
         auto func = get_aggregate_function("avg", {arg_type}, return_type, true);
         ASSERT_NE(func, nullptr);
         test_agg_state_union_function_nullable<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
-                                                        immediate_type_desc, true);
+                                                        intermediate_type_desc, true);
     }
 }
 
@@ -1108,7 +1108,7 @@ TEST_F(AggStateFunctionsTest, test_agg_state_union_function_date) {
 template <typename T>
 void test_agg_state_merge_function_basic(FunctionContext* ctx, const AggregateFunction* func,
                                          const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
-                                         const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                         const TypeDescriptor& ret_type, const TypeDescriptor& intermediate_type,
                                          bool is_nullable = false) {
     VLOG_ROW << "test_agg_state_merge_function_basic: " << func_name << " is_nullable: " << is_nullable;
 
@@ -1116,14 +1116,14 @@ void test_agg_state_merge_function_basic(FunctionContext* ctx, const AggregateFu
     ColumnPtr input_column = gen_input_column1<T>();
 
     // Create agg state column
-    ColumnPtr agg_state_column = create_agg_state_column<T>(func, ctx, input_column, is_nullable, immediate_type);
+    ColumnPtr agg_state_column = create_agg_state_column<T>(func, ctx, input_column, is_nullable, intermediate_type);
 
     // Create AggStateDesc
     AggStateDesc agg_state_desc(func_name, ret_type, arg_types, is_nullable, 1);
 
     // Create StateMergeFunction
     std::vector<bool> arg_nullables = {is_nullable};
-    StateMergeFunction merge_func(agg_state_desc, immediate_type, arg_nullables);
+    StateMergeFunction merge_func(agg_state_desc, intermediate_type, arg_nullables);
 
     // Test prepare
     Status status = merge_func.prepare(ctx, FunctionContext::FRAGMENT_LOCAL);
@@ -1145,7 +1145,7 @@ void test_agg_state_merge_function_basic(FunctionContext* ctx, const AggregateFu
 template <typename T>
 void test_agg_state_merge_function_nullable(FunctionContext* ctx, const AggregateFunction* func,
                                             const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
-                                            const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                            const TypeDescriptor& ret_type, const TypeDescriptor& intermediate_type,
                                             bool is_nullable = true) {
     VLOG_ROW << "test_agg_state_merge_function_nullable: " << func_name << " is_nullable: " << is_nullable;
 
@@ -1156,14 +1156,14 @@ void test_agg_state_merge_function_nullable(FunctionContext* ctx, const Aggregat
     auto nullable_column = ColumnHelper::cast_to_nullable_column(input_column);
 
     // Create agg state column
-    ColumnPtr agg_state_column = create_agg_state_column<T>(func, ctx, nullable_column, is_nullable, immediate_type);
+    ColumnPtr agg_state_column = create_agg_state_column<T>(func, ctx, nullable_column, is_nullable, intermediate_type);
 
     // Create AggStateDesc
     AggStateDesc agg_state_desc(func_name, ret_type, arg_types, is_nullable, 1);
 
     // Create StateMergeFunction with nullable arguments
     std::vector<bool> arg_nullables = {is_nullable};
-    StateMergeFunction merge_func(agg_state_desc, immediate_type, arg_nullables);
+    StateMergeFunction merge_func(agg_state_desc, intermediate_type, arg_nullables);
 
     // Test prepare
     Status status = merge_func.prepare(ctx, FunctionContext::FRAGMENT_LOCAL);
@@ -1270,7 +1270,7 @@ TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_avg) {
     auto arg_type = TYPE_INT;
     TypeDescriptor return_type_desc = TypeDescriptor(return_type);
     std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
-    TypeDescriptor immediate_type_desc = TypeDescriptor(TYPE_VARBINARY);
+    TypeDescriptor intermediate_type_desc = TypeDescriptor(TYPE_VARBINARY);
     auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
     auto ctx = utils->get_fn_ctx();
     {
@@ -1278,13 +1278,13 @@ TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_avg) {
         ASSERT_NE(func, nullptr);
 
         test_agg_state_merge_function_basic<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
-                                                     immediate_type_desc);
+                                                     intermediate_type_desc);
     }
     {
         auto func = get_aggregate_function("avg", {arg_type}, return_type, true);
         ASSERT_NE(func, nullptr);
         test_agg_state_merge_function_nullable<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
-                                                        immediate_type_desc);
+                                                        intermediate_type_desc);
     }
 }
 
@@ -1389,13 +1389,14 @@ TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_memory_allocation) {
     AggStateDesc agg_state_desc(func->get_name(), return_type_desc, arg_type_descs, true, 1);
 
     // Create StateMergeFunction
-    TypeDescriptor immediate_type = return_type_desc;
+    TypeDescriptor intermediate_type = return_type_desc;
     std::vector<bool> arg_nullables = {false};
-    StateMergeFunction merge_func(agg_state_desc, immediate_type, arg_nullables);
+    StateMergeFunction merge_func(agg_state_desc, intermediate_type, arg_nullables);
 
     // Test with large dataset
     auto large_input_column = gen_input_column1<int32_t>();
-    ColumnPtr agg_state_column = create_agg_state_column<int32_t>(func, ctx, large_input_column, false, immediate_type);
+    ColumnPtr agg_state_column =
+            create_agg_state_column<int32_t>(func, ctx, large_input_column, false, intermediate_type);
 
     // Test prepare
     Status status = merge_func.prepare(ctx, FunctionContext::FRAGMENT_LOCAL);
@@ -1411,7 +1412,7 @@ TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_memory_allocation) {
 template <typename T>
 void test_agg_state_combine_basic(FunctionContext* ctx, const AggregateFunction* base_func,
                                   const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
-                                  const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                  const TypeDescriptor& ret_type, const TypeDescriptor& intermediate_type,
                                   bool is_nullable = false) {
     VLOG_ROW << "test_agg_state_combine_basic: " << func_name << " is_nullable: " << is_nullable;
 
@@ -1440,7 +1441,7 @@ void test_agg_state_combine_basic(FunctionContext* ctx, const AggregateFunction*
     combine_func.update_batch_single_state(ctx, row_column->size(), &row_column, combine_state->state());
 
     // Get result from combine function (should be serialized state)
-    auto combine_result_column = ColumnHelper::create_column(immediate_type, is_nullable);
+    auto combine_result_column = ColumnHelper::create_column(intermediate_type, is_nullable);
     combine_func.finalize_to_column(ctx, combine_state->state(), combine_result_column.get());
 
     // Test with base function for comparison
@@ -1448,7 +1449,7 @@ void test_agg_state_combine_basic(FunctionContext* ctx, const AggregateFunction*
     base_func->update_batch_single_state(ctx, row_column->size(), &row_column, base_state->state());
 
     // Get serialized state from base function
-    auto base_serialized_column = ColumnHelper::create_column(immediate_type, is_nullable);
+    auto base_serialized_column = ColumnHelper::create_column(intermediate_type, is_nullable);
     base_func->serialize_to_column(ctx, base_state->state(), base_serialized_column.get());
 
     // Get final result from base function
@@ -1467,7 +1468,7 @@ void test_agg_state_combine_basic(FunctionContext* ctx, const AggregateFunction*
 template <typename T>
 void test_agg_state_combine_merge(FunctionContext* ctx, const AggregateFunction* base_func,
                                   const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
-                                  const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                  const TypeDescriptor& ret_type, const TypeDescriptor& intermediate_type,
                                   bool is_nullable = false) {
     VLOG_ROW << "test_agg_state_combine_merge: " << func_name << " is_nullable: " << is_nullable;
 
@@ -1498,14 +1499,14 @@ void test_agg_state_combine_merge(FunctionContext* ctx, const AggregateFunction*
     combine_func.update_batch_single_state(ctx, row_column2->size(), &row_column2, state2->state());
 
     // Serialize first state for merging
-    auto serialize_column = ColumnHelper::create_column(immediate_type, is_nullable);
+    auto serialize_column = ColumnHelper::create_column(intermediate_type, is_nullable);
     combine_func.serialize_to_column(ctx, state1->state(), serialize_column.get());
 
     // Merge first state into second state
     combine_func.merge(ctx, serialize_column.get(), state2->state(), 0);
 
     // Get final result
-    auto result_column = ColumnHelper::create_column(immediate_type, is_nullable);
+    auto result_column = ColumnHelper::create_column(intermediate_type, is_nullable);
     combine_func.finalize_to_column(ctx, state2->state(), result_column.get());
 
     // Verify merge worked (result should contain combined data)
@@ -1515,7 +1516,7 @@ void test_agg_state_combine_merge(FunctionContext* ctx, const AggregateFunction*
 template <typename T>
 void test_agg_state_combine_convert_format(FunctionContext* ctx, const AggregateFunction* base_func,
                                            const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
-                                           const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                           const TypeDescriptor& ret_type, const TypeDescriptor& intermediate_type,
                                            bool is_nullable = false) {
     VLOG_ROW << "test_agg_state_combine_convert_format: " << func_name << " is_nullable: " << is_nullable;
 
@@ -1636,10 +1637,10 @@ TEST_F(AggStateFunctionsTest, test_agg_state_combine_count) {
 TEST_F(AggStateFunctionsTest, test_agg_state_combine_avg) {
     auto return_type = TYPE_DOUBLE;
     auto arg_type = TYPE_INT;
-    auto immediate_type = TYPE_VARBINARY;
+    auto intermediate_type = TYPE_VARBINARY;
     TypeDescriptor return_type_desc = TypeDescriptor(return_type);
     TypeDescriptor arg_type_desc = TypeDescriptor(arg_type);
-    TypeDescriptor immediate_type_desc = TypeDescriptor(immediate_type);
+    TypeDescriptor intermediate_type_desc = TypeDescriptor(intermediate_type);
     std::vector<TypeDescriptor> arg_type_descs = {arg_type_desc};
     auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
     auto ctx = utils->get_fn_ctx();
@@ -1649,22 +1650,22 @@ TEST_F(AggStateFunctionsTest, test_agg_state_combine_avg) {
         ASSERT_NE(func, nullptr);
         // For avg, the immediate type might be different from return type (contains count and sum)
         // Use the function's return type as immediate type for simplicity
-        test_agg_state_combine_basic<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc, immediate_type_desc,
-                                              false);
-        test_agg_state_combine_merge<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc, immediate_type_desc,
-                                              false);
+        test_agg_state_combine_basic<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
+                                              intermediate_type_desc, false);
+        test_agg_state_combine_merge<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
+                                              intermediate_type_desc, false);
         test_agg_state_combine_convert_format<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
-                                                       immediate_type_desc, false);
+                                                       intermediate_type_desc, false);
     }
     {
         auto func = get_aggregate_function("avg", {arg_type}, return_type, true);
         ASSERT_NE(func, nullptr);
-        test_agg_state_combine_basic<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc, immediate_type_desc,
-                                              true);
-        test_agg_state_combine_merge<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc, immediate_type_desc,
-                                              true);
+        test_agg_state_combine_basic<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
+                                              intermediate_type_desc, true);
+        test_agg_state_combine_merge<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
+                                              intermediate_type_desc, true);
         test_agg_state_combine_convert_format<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
-                                                       immediate_type_desc, true);
+                                                       intermediate_type_desc, true);
     }
 }
 

--- a/be/test/exprs/agg/agg_state_functions_test.cpp
+++ b/be/test/exprs/agg/agg_state_functions_test.cpp
@@ -19,10 +19,13 @@
 #include <memory>
 
 #include "exprs/agg/base_aggregate_test.h"
+#include "exprs/agg/combinator/agg_state_combine.h"
 #include "exprs/agg/combinator/agg_state_merge.h"
 #include "exprs/agg/combinator/agg_state_union.h"
 #include "exprs/agg/combinator/agg_state_utils.h"
 #include "exprs/agg/combinator/state_function.h"
+#include "exprs/agg/combinator/state_merge_function.h"
+#include "exprs/agg/combinator/state_union_function.h"
 #include "runtime/types.h"
 #include "types/logical_type.h"
 
@@ -45,7 +48,7 @@ private:
     std::unique_ptr<CountingAllocatorWithHook> _allocator;
 };
 
-// Test helper functions for AggStateUnionFunction
+// Test helper functions for StateUnionFunction
 template <typename T>
 ColumnPtr create_agg_state_column(const AggregateFunction* func, FunctionContext* ctx, const ColumnPtr& input_column,
                                   bool is_nullable, const TypeDescriptor& immediate_type) {
@@ -823,6 +826,920 @@ TEST_F(AggStateFunctionsTest, test_state_function_avg) {
         test_state_function_empty_column<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
                                                   intermediate_type_desc, true);
     }
+}
+
+template <typename T>
+void test_agg_state_union_function_basic(FunctionContext* ctx, const AggregateFunction* func,
+                                         const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
+                                         const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                         bool is_result_nullable = false) {
+    VLOG_ROW << "test_agg_state_union_function_basic: " << func_name << " is_result_nullable: " << is_result_nullable;
+
+    // Create test data
+    ColumnPtr input_column1 = gen_input_column1<T>();
+    ColumnPtr input_column2 = gen_input_column2<T>();
+
+    // Create agg state columns
+    ColumnPtr agg_state_column1 =
+            create_agg_state_column<T>(func, ctx, input_column1, is_result_nullable, immediate_type);
+    ColumnPtr agg_state_column2 =
+            create_agg_state_column<T>(func, ctx, input_column2, is_result_nullable, immediate_type);
+
+    // Create AggStateDesc
+    AggStateDesc agg_state_desc(func_name, ret_type, arg_types, is_result_nullable, 1);
+
+    // Create StateUnionFunction
+    std::vector<bool> arg_nullables = {false, false};
+    StateUnionFunction union_func(agg_state_desc, immediate_type, arg_nullables);
+
+    // Test prepare
+    Status status = union_func.prepare(ctx, FunctionContext::FRAGMENT_LOCAL);
+    ASSERT_TRUE(status.ok()) << "Prepare failed: " << status.message();
+
+    // Test execute
+    Columns columns = {agg_state_column1, agg_state_column2};
+    auto result = union_func.execute(ctx, columns);
+    ASSERT_TRUE(result.ok()) << "Execute failed: " << result.status().message();
+
+    // Verify result
+    ASSERT_EQ(result.value()->size(), agg_state_column1->size());
+
+    // Test close
+    status = union_func.close(ctx, FunctionContext::FRAGMENT_LOCAL);
+    ASSERT_TRUE(status.ok()) << "Close failed: " << status.message();
+}
+
+template <typename T>
+void test_agg_state_union_function_nullable(FunctionContext* ctx, const AggregateFunction* func,
+                                            const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
+                                            const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                            bool is_result_nullable = true) {
+    VLOG_ROW << "test_agg_state_union_function_nullable: " << func_name
+             << " is_result_nullable: " << is_result_nullable;
+
+    // Create test data with nullable columns
+    ColumnPtr input_column1 = gen_input_column1<T>();
+    ColumnPtr input_column2 = gen_input_column2<T>();
+
+    // Make columns nullable
+    auto nullable_column1 = ColumnHelper::cast_to_nullable_column(input_column1);
+    auto nullable_column2 = ColumnHelper::cast_to_nullable_column(input_column2);
+
+    // Create agg state columns
+    ColumnPtr agg_state_column1 =
+            create_agg_state_column<T>(func, ctx, nullable_column1, is_result_nullable, immediate_type);
+    ColumnPtr agg_state_column2 =
+            create_agg_state_column<T>(func, ctx, nullable_column2, is_result_nullable, immediate_type);
+
+    // Create AggStateDesc
+    AggStateDesc agg_state_desc(func_name, ret_type, arg_types, is_result_nullable, 1);
+
+    // Create StateUnionFunction with nullable arguments
+    std::vector<bool> arg_nullables = {true, true};
+    StateUnionFunction union_func(agg_state_desc, immediate_type, arg_nullables);
+
+    // Test prepare
+    Status status = union_func.prepare(ctx, FunctionContext::FRAGMENT_LOCAL);
+    ASSERT_TRUE(status.ok()) << "Prepare failed: " << status.message();
+
+    // Test execute
+    Columns columns = {agg_state_column1, agg_state_column2};
+    auto result = union_func.execute(ctx, columns);
+    ASSERT_TRUE(result.ok()) << "Execute failed: " << result.status().message();
+
+    // Verify result
+    ASSERT_EQ(result.value()->size(), agg_state_column1->size());
+
+    // Test close
+    status = union_func.close(ctx, FunctionContext::FRAGMENT_LOCAL);
+    ASSERT_TRUE(status.ok()) << "Close failed: " << status.message();
+}
+
+// Test cases for StateUnionFunction
+TEST_F(AggStateFunctionsTest, test_agg_state_union_function_sum) {
+    auto return_type = TYPE_BIGINT;
+    auto arg_type = TYPE_INT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+
+    {
+        auto func = get_aggregate_function("sum", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_basic<int32_t>(ctx, func, "sum", arg_type_descs, return_type_desc,
+                                                     return_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("sum", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_nullable<int32_t>(ctx, func, "sum", arg_type_descs, return_type_desc,
+                                                        return_type_desc, true);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_union_function_count) {
+    auto return_type = TYPE_BIGINT;
+    auto arg_type = TYPE_BIGINT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("count", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_basic<int32_t>(ctx, func, "count", arg_type_descs, return_type_desc,
+                                                     return_type_desc, false);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_union_function_max) {
+    auto return_type = TYPE_INT;
+    auto arg_type = TYPE_INT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("max", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_basic<int32_t>(ctx, func, "max", arg_type_descs, return_type_desc,
+                                                     return_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("max", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_nullable<int32_t>(ctx, func, "max", arg_type_descs, return_type_desc,
+                                                        return_type_desc, true);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_union_function_min) {
+    auto return_type = TYPE_INT;
+    auto arg_type = TYPE_INT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("min", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_basic<int32_t>(ctx, func, "min", arg_type_descs, return_type_desc,
+                                                     return_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("min", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_nullable<int32_t>(ctx, func, "min", arg_type_descs, return_type_desc,
+                                                        return_type_desc, true);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_union_function_avg) {
+    auto return_type = TYPE_DOUBLE;
+    auto arg_type = TYPE_INT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    TypeDescriptor immediate_type_desc = TypeDescriptor(TYPE_VARBINARY);
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("avg", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_basic<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
+                                                     immediate_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("avg", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_nullable<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
+                                                        immediate_type_desc, true);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_union_function_string) {
+    auto return_type = TYPE_VARCHAR;
+    auto arg_type = TYPE_VARCHAR;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("any_value", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_basic<Slice>(ctx, func, "any_value", arg_type_descs, return_type_desc,
+                                                   return_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("any_value", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_nullable<Slice>(ctx, func, "any_value", arg_type_descs, return_type_desc,
+                                                      return_type_desc, true);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_union_function_decimal) {
+    auto return_type = TYPE_DECIMALV2;
+    auto arg_type = TYPE_DECIMALV2;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("sum", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+
+        test_agg_state_union_function_basic<DecimalV2Value>(ctx, func, "sum", arg_type_descs, return_type_desc,
+                                                            return_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("sum", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_nullable<DecimalV2Value>(ctx, func, "sum", arg_type_descs, return_type_desc,
+                                                               return_type_desc, true);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_union_function_timestamp) {
+    auto return_type = TYPE_DATETIME;
+    auto arg_type = TYPE_DATETIME;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("max", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+
+        test_agg_state_union_function_basic<TimestampValue>(ctx, func, "max", arg_type_descs, return_type_desc,
+                                                            return_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("max", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_nullable<TimestampValue>(ctx, func, "max", arg_type_descs, return_type_desc,
+                                                               return_type_desc, true);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_union_function_date) {
+    auto return_type = TYPE_DATE;
+    auto arg_type = TYPE_DATE;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("min", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+
+        test_agg_state_union_function_basic<DateValue>(ctx, func, "min", arg_type_descs, return_type_desc,
+                                                       return_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("min", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_union_function_nullable<DateValue>(ctx, func, "min", arg_type_descs, return_type_desc,
+                                                          return_type_desc, true);
+    }
+}
+
+// Test helper functions for StateMergeFunction
+template <typename T>
+void test_agg_state_merge_function_basic(FunctionContext* ctx, const AggregateFunction* func,
+                                         const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
+                                         const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                         bool is_nullable = false) {
+    VLOG_ROW << "test_agg_state_merge_function_basic: " << func_name << " is_nullable: " << is_nullable;
+
+    // Create test data
+    ColumnPtr input_column = gen_input_column1<T>();
+
+    // Create agg state column
+    ColumnPtr agg_state_column = create_agg_state_column<T>(func, ctx, input_column, is_nullable, immediate_type);
+
+    // Create AggStateDesc
+    AggStateDesc agg_state_desc(func_name, ret_type, arg_types, is_nullable, 1);
+
+    // Create StateMergeFunction
+    std::vector<bool> arg_nullables = {is_nullable};
+    StateMergeFunction merge_func(agg_state_desc, immediate_type, arg_nullables);
+
+    // Test prepare
+    Status status = merge_func.prepare(ctx, FunctionContext::FRAGMENT_LOCAL);
+    ASSERT_TRUE(status.ok()) << "Prepare failed: " << status.message();
+
+    // Test execute
+    Columns columns = {agg_state_column};
+    auto result = merge_func.execute(ctx, columns);
+    ASSERT_TRUE(result.ok()) << "Execute failed: " << result.status().message();
+
+    // Verify result
+    ASSERT_EQ(result.value()->size(), agg_state_column->size());
+
+    // Test close
+    status = merge_func.close(ctx, FunctionContext::FRAGMENT_LOCAL);
+    ASSERT_TRUE(status.ok()) << "Close failed: " << status.message();
+}
+
+template <typename T>
+void test_agg_state_merge_function_nullable(FunctionContext* ctx, const AggregateFunction* func,
+                                            const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
+                                            const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                            bool is_nullable = true) {
+    VLOG_ROW << "test_agg_state_merge_function_nullable: " << func_name << " is_nullable: " << is_nullable;
+
+    // Create test data with nullable columns
+    ColumnPtr input_column = gen_input_column1<T>();
+
+    // Make column nullable
+    auto nullable_column = ColumnHelper::cast_to_nullable_column(input_column);
+
+    // Create agg state column
+    ColumnPtr agg_state_column = create_agg_state_column<T>(func, ctx, nullable_column, is_nullable, immediate_type);
+
+    // Create AggStateDesc
+    AggStateDesc agg_state_desc(func_name, ret_type, arg_types, is_nullable, 1);
+
+    // Create StateMergeFunction with nullable arguments
+    std::vector<bool> arg_nullables = {is_nullable};
+    StateMergeFunction merge_func(agg_state_desc, immediate_type, arg_nullables);
+
+    // Test prepare
+    Status status = merge_func.prepare(ctx, FunctionContext::FRAGMENT_LOCAL);
+    ASSERT_TRUE(status.ok()) << "Prepare failed: " << status.message();
+
+    // Test execute
+    Columns columns = {agg_state_column};
+    auto result = merge_func.execute(ctx, columns);
+    ASSERT_TRUE(result.ok()) << "Execute failed: " << result.status().message();
+
+    // Verify result
+    ASSERT_EQ(result.value()->size(), agg_state_column->size());
+
+    // Test close
+    status = merge_func.close(ctx, FunctionContext::FRAGMENT_LOCAL);
+    ASSERT_TRUE(status.ok()) << "Close failed: " << status.message();
+}
+
+// Test cases for StateMergeFunction
+TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_sum) {
+    auto return_type = TYPE_BIGINT;
+    auto arg_type = TYPE_INT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("sum", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+
+        test_agg_state_merge_function_basic<int32_t>(ctx, func, "sum", arg_type_descs, return_type_desc,
+                                                     return_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("sum", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_merge_function_nullable<int32_t>(ctx, func, "sum", arg_type_descs, return_type_desc,
+                                                        return_type_desc, true);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_count) {
+    auto return_type = TYPE_BIGINT;
+    auto arg_type = TYPE_BIGINT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("count", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+
+        test_agg_state_merge_function_basic<int32_t>(ctx, func, "count", arg_type_descs, return_type_desc,
+                                                     return_type_desc, false);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_max) {
+    auto return_type = TYPE_INT;
+    auto arg_type = TYPE_INT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("max", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+
+        test_agg_state_merge_function_basic<int32_t>(ctx, func, "max", arg_type_descs, return_type_desc,
+                                                     return_type_desc);
+    }
+    {
+        auto func = get_aggregate_function("max", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_merge_function_nullable<int32_t>(ctx, func, "max", arg_type_descs, return_type_desc,
+                                                        return_type_desc);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_min) {
+    auto return_type = TYPE_INT;
+    auto arg_type = TYPE_INT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("min", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+
+        test_agg_state_merge_function_basic<int32_t>(ctx, func, "min", arg_type_descs, return_type_desc,
+                                                     return_type_desc);
+    }
+    {
+        auto func = get_aggregate_function("min", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_merge_function_nullable<int32_t>(ctx, func, "min", arg_type_descs, return_type_desc,
+                                                        return_type_desc);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_avg) {
+    auto return_type = TYPE_DOUBLE;
+    auto arg_type = TYPE_INT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    TypeDescriptor immediate_type_desc = TypeDescriptor(TYPE_VARBINARY);
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("avg", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+
+        test_agg_state_merge_function_basic<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
+                                                     immediate_type_desc);
+    }
+    {
+        auto func = get_aggregate_function("avg", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_merge_function_nullable<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
+                                                        immediate_type_desc);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_string) {
+    auto return_type = TYPE_VARCHAR;
+    auto arg_type = TYPE_VARCHAR;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("any_value", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+
+        test_agg_state_merge_function_basic<Slice>(ctx, func, "any_value", arg_type_descs, return_type_desc,
+                                                   return_type_desc);
+    }
+    {
+        auto func = get_aggregate_function("any_value", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_merge_function_nullable<Slice>(ctx, func, "any_value", arg_type_descs, return_type_desc,
+                                                      return_type_desc);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_decimal) {
+    auto return_type = TYPE_DECIMALV2;
+    auto arg_type = TYPE_DECIMALV2;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("sum", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+
+        test_agg_state_merge_function_basic<DecimalV2Value>(ctx, func, "sum", arg_type_descs, return_type_desc,
+                                                            return_type_desc);
+    }
+    {
+        auto func = get_aggregate_function("sum", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_merge_function_nullable<DecimalV2Value>(ctx, func, "sum", arg_type_descs, return_type_desc,
+                                                               return_type_desc);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_timestamp) {
+    auto return_type = TYPE_DATETIME;
+    auto arg_type = TYPE_DATETIME;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("max", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_merge_function_basic<TimestampValue>(ctx, func, "max", arg_type_descs, return_type_desc,
+                                                            return_type_desc);
+    }
+    {
+        auto func = get_aggregate_function("max", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_merge_function_nullable<TimestampValue>(ctx, func, "max", arg_type_descs, return_type_desc,
+                                                               return_type_desc);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_date) {
+    auto return_type = TYPE_DATE;
+    auto arg_type = TYPE_DATE;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    {
+        auto func = get_aggregate_function("min", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+
+        test_agg_state_merge_function_basic<DateValue>(ctx, func, "min", arg_type_descs, return_type_desc,
+                                                       return_type_desc);
+    }
+    {
+        auto func = get_aggregate_function("min", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_merge_function_nullable<DateValue>(ctx, func, "min", arg_type_descs, return_type_desc,
+                                                          return_type_desc);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_merge_function_memory_allocation) {
+    auto return_type = TYPE_BIGINT;
+    auto arg_type = TYPE_INT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    std::vector<TypeDescriptor> arg_type_descs = {TypeDescriptor(arg_type)};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+    auto func = get_aggregate_function("sum", {arg_type}, return_type, false);
+    ASSERT_NE(func, nullptr);
+
+    // Create AggStateDesc
+    AggStateDesc agg_state_desc(func->get_name(), return_type_desc, arg_type_descs, true, 1);
+
+    // Create StateMergeFunction
+    TypeDescriptor immediate_type = return_type_desc;
+    std::vector<bool> arg_nullables = {false};
+    StateMergeFunction merge_func(agg_state_desc, immediate_type, arg_nullables);
+
+    // Test with large dataset
+    auto large_input_column = gen_input_column1<int32_t>();
+    ColumnPtr agg_state_column = create_agg_state_column<int32_t>(func, ctx, large_input_column, false, immediate_type);
+
+    // Test prepare
+    Status status = merge_func.prepare(ctx, FunctionContext::FRAGMENT_LOCAL);
+    ASSERT_TRUE(status.ok());
+
+    // Test execute with large dataset
+    Columns columns = {agg_state_column};
+    auto result = merge_func.execute(ctx, columns);
+    ASSERT_TRUE(result.ok());
+}
+
+// Test helper functions for AggStateCombine
+template <typename T>
+void test_agg_state_combine_basic(FunctionContext* ctx, const AggregateFunction* base_func,
+                                  const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
+                                  const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                  bool is_nullable = false) {
+    VLOG_ROW << "test_agg_state_combine_basic: " << func_name << " is_nullable: " << is_nullable;
+
+    // Create AggStateDesc
+    AggStateDesc agg_state_desc(func_name, ret_type, arg_types, is_nullable, 1);
+
+    // Create AggStateCombine
+    AggStateCombine combine_func(agg_state_desc, base_func);
+
+    // Test basic properties
+    ASSERT_EQ(combine_func.get_name(), "agg_state_combine");
+    ASSERT_EQ(combine_func.size(), base_func->size());
+    ASSERT_EQ(combine_func.alignof_size(), base_func->alignof_size());
+    ASSERT_EQ(combine_func.is_pod_state(), base_func->is_pod_state());
+    ASSERT_EQ(combine_func.get_agg_state_desc()->get_func_name(), func_name);
+
+    // Create test data
+    ColumnPtr input_column = gen_input_column1<T>();
+    if (is_nullable) {
+        input_column = ColumnHelper::cast_to_nullable_column(input_column);
+    }
+
+    // Test with AggStateCombine
+    auto combine_state = ManagedAggrState::create(ctx, &combine_func);
+    const Column* row_column = input_column.get();
+    combine_func.update_batch_single_state(ctx, row_column->size(), &row_column, combine_state->state());
+
+    // Get result from combine function (should be serialized state)
+    auto combine_result_column = ColumnHelper::create_column(immediate_type, is_nullable);
+    combine_func.finalize_to_column(ctx, combine_state->state(), combine_result_column.get());
+
+    // Test with base function for comparison
+    auto base_state = ManagedAggrState::create(ctx, base_func);
+    base_func->update_batch_single_state(ctx, row_column->size(), &row_column, base_state->state());
+
+    // Get serialized state from base function
+    auto base_serialized_column = ColumnHelper::create_column(immediate_type, is_nullable);
+    base_func->serialize_to_column(ctx, base_state->state(), base_serialized_column.get());
+
+    // Get final result from base function
+    auto base_final_column = ColumnHelper::create_column(ret_type, is_nullable);
+    base_func->finalize_to_column(ctx, base_state->state(), base_final_column.get());
+
+    // Verify that AggStateCombine's finalize_to_column returns the same as base function's serialize_to_column
+    ASSERT_EQ(combine_result_column->size(), base_serialized_column->size());
+
+    // The key difference: AggStateCombine should return serialized state, not final result
+    if (!is_nullable && combine_result_column->size() > 0 && base_serialized_column->size() > 0) {
+        ASSERT_TRUE(combine_result_column->equals(0, *base_serialized_column, 0));
+    }
+}
+
+template <typename T>
+void test_agg_state_combine_merge(FunctionContext* ctx, const AggregateFunction* base_func,
+                                  const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
+                                  const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                  bool is_nullable = false) {
+    VLOG_ROW << "test_agg_state_combine_merge: " << func_name << " is_nullable: " << is_nullable;
+
+    // Create AggStateDesc
+    AggStateDesc agg_state_desc(func_name, ret_type, arg_types, is_nullable, 1);
+
+    // Create AggStateCombine
+    AggStateCombine combine_func(agg_state_desc, base_func);
+
+    // Create test data
+    ColumnPtr input_column1 = gen_input_column1<T>();
+    ColumnPtr input_column2 = gen_input_column2<T>();
+    if (is_nullable) {
+        input_column1 = ColumnHelper::cast_to_nullable_column(input_column1);
+        input_column2 = ColumnHelper::cast_to_nullable_column(input_column2);
+    }
+
+    // Create two separate states
+    auto state1 = ManagedAggrState::create(ctx, &combine_func);
+    auto state2 = ManagedAggrState::create(ctx, &combine_func);
+
+    // Update first state
+    const Column* row_column1 = input_column1.get();
+    combine_func.update_batch_single_state(ctx, row_column1->size(), &row_column1, state1->state());
+
+    // Update second state
+    const Column* row_column2 = input_column2.get();
+    combine_func.update_batch_single_state(ctx, row_column2->size(), &row_column2, state2->state());
+
+    // Serialize first state for merging
+    auto serialize_column = ColumnHelper::create_column(immediate_type, is_nullable);
+    combine_func.serialize_to_column(ctx, state1->state(), serialize_column.get());
+
+    // Merge first state into second state
+    combine_func.merge(ctx, serialize_column.get(), state2->state(), 0);
+
+    // Get final result
+    auto result_column = ColumnHelper::create_column(immediate_type, is_nullable);
+    combine_func.finalize_to_column(ctx, state2->state(), result_column.get());
+
+    // Verify merge worked (result should contain combined data)
+    ASSERT_EQ(result_column->size(), 1);
+}
+
+template <typename T>
+void test_agg_state_combine_convert_format(FunctionContext* ctx, const AggregateFunction* base_func,
+                                           const std::string& func_name, const std::vector<TypeDescriptor>& arg_types,
+                                           const TypeDescriptor& ret_type, const TypeDescriptor& immediate_type,
+                                           bool is_nullable = false) {
+    VLOG_ROW << "test_agg_state_combine_convert_format: " << func_name << " is_nullable: " << is_nullable;
+
+    // Create AggStateDesc
+    AggStateDesc agg_state_desc(func_name, ret_type, arg_types, is_nullable, 1);
+
+    // Create AggStateCombine
+    AggStateCombine combine_func(agg_state_desc, base_func);
+
+    // Create test input column
+    ColumnPtr input_column = gen_input_column1<T>();
+    if (is_nullable) {
+        input_column = ColumnHelper::cast_to_nullable_column(input_column);
+    }
+
+    // Test convert_to_serialize_format
+    Columns input_columns = {input_column};
+    ColumnPtr output_column;
+    combine_func.convert_to_serialize_format(ctx, input_columns, input_column->size(), &output_column);
+
+    // Should return the same column (pass-through behavior)
+    ASSERT_EQ(output_column.get(), input_column.get());
+}
+
+template <typename T>
+void test_agg_state_combine_error_cases(FunctionContext* ctx, const std::string& func_name,
+                                        const std::vector<TypeDescriptor>& arg_types, const TypeDescriptor& ret_type) {
+    VLOG_ROW << "test_agg_state_combine_error_cases: " << func_name;
+
+    // Create AggStateDesc
+    AggStateDesc agg_state_desc(func_name, ret_type, arg_types, false, 1);
+
+    // Test with null function (should trigger DCHECK in debug builds)
+    // In release builds, this will likely crash, so we don't test it
+    // AggStateCombine null_combine_func(agg_state_desc, nullptr);
+
+    // Test convert_to_serialize_format with wrong number of columns
+    auto base_func = get_aggregate_function(func_name, {TYPE_INT}, TYPE_BIGINT, false);
+    ASSERT_NE(base_func, nullptr);
+
+    AggStateCombine combine_func(agg_state_desc, base_func);
+
+    ColumnPtr input_column1 = gen_input_column1<T>();
+    ColumnPtr input_column2 = gen_input_column2<T>();
+
+    // Test with wrong number of columns (should DCHECK fail)
+    Columns wrong_columns = {input_column1, input_column2}; // Should be 1 column
+    ColumnPtr output_column;
+
+    // This should trigger DCHECK_EQ(1, srcs.size()) in debug builds
+    // In release builds it might process incorrectly
+    // combine_func.convert_to_serialize_format(ctx, wrong_columns, input_column1->size(), &output_column);
+}
+
+// Test cases for AggStateCombine
+TEST_F(AggStateFunctionsTest, test_agg_state_combine_sum) {
+    auto return_type = TYPE_BIGINT;
+    auto arg_type = TYPE_INT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    TypeDescriptor arg_type_desc = TypeDescriptor(arg_type);
+    std::vector<TypeDescriptor> arg_type_descs = {arg_type_desc};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+
+    {
+        auto func = get_aggregate_function("sum", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_combine_basic<int32_t>(ctx, func, "sum", arg_type_descs, return_type_desc, return_type_desc,
+                                              false);
+        test_agg_state_combine_merge<int32_t>(ctx, func, "sum", arg_type_descs, return_type_desc, return_type_desc,
+                                              false);
+        test_agg_state_combine_convert_format<int32_t>(ctx, func, "sum", arg_type_descs, return_type_desc,
+                                                       return_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("sum", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_combine_basic<int32_t>(ctx, func, "sum", arg_type_descs, return_type_desc, return_type_desc,
+                                              true);
+        test_agg_state_combine_merge<int32_t>(ctx, func, "sum", arg_type_descs, return_type_desc, return_type_desc,
+                                              true);
+        test_agg_state_combine_convert_format<int32_t>(ctx, func, "sum", arg_type_descs, return_type_desc,
+                                                       return_type_desc, true);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_combine_count) {
+    auto return_type = TYPE_BIGINT;
+    auto arg_type = TYPE_BIGINT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    TypeDescriptor arg_type_desc = TypeDescriptor(arg_type);
+    std::vector<TypeDescriptor> arg_type_descs = {arg_type_desc};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+
+    {
+        auto func = get_aggregate_function("count", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_combine_basic<int32_t>(ctx, func, "count", arg_type_descs, return_type_desc, return_type_desc,
+                                              false);
+        test_agg_state_combine_merge<int32_t>(ctx, func, "count", arg_type_descs, return_type_desc, return_type_desc,
+                                              false);
+        test_agg_state_combine_convert_format<int32_t>(ctx, func, "count", arg_type_descs, return_type_desc,
+                                                       return_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("count", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_combine_basic<int32_t>(ctx, func, "count", arg_type_descs, return_type_desc, return_type_desc,
+                                              false);
+        test_agg_state_combine_merge<int32_t>(ctx, func, "count", arg_type_descs, return_type_desc, return_type_desc,
+                                              false);
+        test_agg_state_combine_convert_format<int32_t>(ctx, func, "count", arg_type_descs, return_type_desc,
+                                                       return_type_desc, false);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_combine_avg) {
+    auto return_type = TYPE_DOUBLE;
+    auto arg_type = TYPE_INT;
+    auto immediate_type = TYPE_VARBINARY;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    TypeDescriptor arg_type_desc = TypeDescriptor(arg_type);
+    TypeDescriptor immediate_type_desc = TypeDescriptor(immediate_type);
+    std::vector<TypeDescriptor> arg_type_descs = {arg_type_desc};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+
+    {
+        auto func = get_aggregate_function("avg", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+        // For avg, the immediate type might be different from return type (contains count and sum)
+        // Use the function's return type as immediate type for simplicity
+        test_agg_state_combine_basic<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc, immediate_type_desc,
+                                              false);
+        test_agg_state_combine_merge<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc, immediate_type_desc,
+                                              false);
+        test_agg_state_combine_convert_format<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
+                                                       immediate_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("avg", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_combine_basic<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc, immediate_type_desc,
+                                              true);
+        test_agg_state_combine_merge<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc, immediate_type_desc,
+                                              true);
+        test_agg_state_combine_convert_format<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
+                                                       immediate_type_desc, true);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_combine_max) {
+    auto return_type = TYPE_INT;
+    auto arg_type = TYPE_INT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    TypeDescriptor arg_type_desc = TypeDescriptor(arg_type);
+    std::vector<TypeDescriptor> arg_type_descs = {arg_type_desc};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+
+    {
+        auto func = get_aggregate_function("max", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_combine_basic<int32_t>(ctx, func, "max", arg_type_descs, return_type_desc, return_type_desc,
+                                              false);
+        test_agg_state_combine_merge<int32_t>(ctx, func, "max", arg_type_descs, return_type_desc, return_type_desc,
+                                              false);
+        test_agg_state_combine_convert_format<int32_t>(ctx, func, "max", arg_type_descs, return_type_desc,
+                                                       return_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("max", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_combine_basic<int32_t>(ctx, func, "max", arg_type_descs, return_type_desc, return_type_desc,
+                                              true);
+        test_agg_state_combine_merge<int32_t>(ctx, func, "max", arg_type_descs, return_type_desc, return_type_desc,
+                                              true);
+        test_agg_state_combine_convert_format<int32_t>(ctx, func, "max", arg_type_descs, return_type_desc,
+                                                       return_type_desc, true);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_combine_min) {
+    auto return_type = TYPE_INT;
+    auto arg_type = TYPE_INT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    TypeDescriptor arg_type_desc = TypeDescriptor(arg_type);
+    std::vector<TypeDescriptor> arg_type_descs = {arg_type_desc};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+
+    {
+        auto func = get_aggregate_function("min", {arg_type}, return_type, false);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_combine_basic<int32_t>(ctx, func, "min", arg_type_descs, return_type_desc, return_type_desc,
+                                              false);
+        test_agg_state_combine_merge<int32_t>(ctx, func, "min", arg_type_descs, return_type_desc, return_type_desc,
+                                              false);
+        test_agg_state_combine_convert_format<int32_t>(ctx, func, "min", arg_type_descs, return_type_desc,
+                                                       return_type_desc, false);
+    }
+    {
+        auto func = get_aggregate_function("min", {arg_type}, return_type, true);
+        ASSERT_NE(func, nullptr);
+        test_agg_state_combine_basic<int32_t>(ctx, func, "min", arg_type_descs, return_type_desc, return_type_desc,
+                                              true);
+        test_agg_state_combine_merge<int32_t>(ctx, func, "min", arg_type_descs, return_type_desc, return_type_desc,
+                                              true);
+        test_agg_state_combine_convert_format<int32_t>(ctx, func, "min", arg_type_descs, return_type_desc,
+                                                       return_type_desc, true);
+    }
+}
+
+TEST_F(AggStateFunctionsTest, test_agg_state_combine_error_cases) {
+    auto return_type = TYPE_BIGINT;
+    auto arg_type = TYPE_INT;
+    TypeDescriptor return_type_desc = TypeDescriptor(return_type);
+    TypeDescriptor arg_type_desc = TypeDescriptor(arg_type);
+    std::vector<TypeDescriptor> arg_type_descs = {arg_type_desc};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+
+    test_agg_state_combine_error_cases<int32_t>(ctx, "sum", arg_type_descs, return_type_desc);
 }
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -717,6 +717,12 @@ public class Function implements Writable {
                 optSuffix = Optional.of(FunctionSet.AGG_STATE_UNION_SUFFIX);
             } else if (s.endsWith(FunctionSet.AGG_STATE_IF_SUFFIX)) {
                 optSuffix = Optional.of(FunctionSet.AGG_STATE_IF_SUFFIX);
+            } else if (s.endsWith(FunctionSet.AGG_STATE_COMBINE_SUFFIX)) {
+                optSuffix = Optional.of(FunctionSet.AGG_STATE_COMBINE_SUFFIX);
+            } else if (s.endsWith(FunctionSet.STATE_UNION_SUFFIX)) {
+                optSuffix = Optional.of(FunctionSet.STATE_UNION_SUFFIX);
+            } else if (s.endsWith(FunctionSet.STATE_MERGE_SUFFIX)) {
+                optSuffix = Optional.of(FunctionSet.STATE_MERGE_SUFFIX);
             }
             if (optSuffix.isEmpty()) {
                 return s;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -43,11 +43,14 @@ import com.google.common.collect.Maps;
 import com.starrocks.analysis.ArithmeticExpr;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.builtins.VectorizedBuiltinFunctions;
+import com.starrocks.catalog.combinator.AggStateCombineCombinator;
 import com.starrocks.catalog.combinator.AggStateIf;
 import com.starrocks.catalog.combinator.AggStateMergeCombinator;
 import com.starrocks.catalog.combinator.AggStateUnionCombinator;
 import com.starrocks.catalog.combinator.AggStateUtils;
 import com.starrocks.catalog.combinator.StateFunctionCombinator;
+import com.starrocks.catalog.combinator.StateMergeCombinator;
+import com.starrocks.catalog.combinator.StateUnionCombinator;
 import com.starrocks.sql.analyzer.PolymorphicFunctionAnalyzer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -157,6 +160,7 @@ public class FunctionSet {
     public static final String MD5_SUM_NUMERIC = "md5sum_numeric";
     public static final String SHA2 = "sha2";
     public static final String SM3 = "sm3";
+    public static final String ROW_FINGERPRINT= "row_fingerprint";
 
     // Vector Index functions:
     public static final String APPROX_COSINE_SIMILARITY = "approx_cosine_similarity";
@@ -555,7 +559,11 @@ public class FunctionSet {
 
     // scalar function
     public static final String STATE_SUFFIX = "_state";
+    public static final String STATE_UNION_SUFFIX = "_state_union";
+    public static final String STATE_MERGE_SUFFIX = "_state_merge";
+
     // agg function
+    public static final String AGG_STATE_COMBINE_SUFFIX = "_combine";
     public static final String AGG_STATE_UNION_SUFFIX = "_union";
     public static final String AGG_STATE_MERGE_SUFFIX = "_merge";
     public static final String AGG_STATE_IF_SUFFIX = "_if";
@@ -1054,9 +1062,12 @@ public class FunctionSet {
         if (AggStateUtils.isSupportedAggStateFunction(aggFunc, false)) {
             // register `_state` combinator
             StateFunctionCombinator.of(aggFunc).ifPresent(this::addBuiltInFunction);
+            StateMergeCombinator.of(aggFunc).ifPresent(this::addBuiltInFunction);
+            StateUnionCombinator.of(aggFunc).ifPresent(this::addBuiltInFunction);
             // register `_merge`/`_union` combinator for aggregate functions
             AggStateUnionCombinator.of(aggFunc).ifPresent(this::addBuiltInFunction);
             AggStateMergeCombinator.of(aggFunc).ifPresent(this::addBuiltInFunction);
+            AggStateCombineCombinator.of(aggFunc).ifPresent(this::addBuiltInFunction);
         }
 
         if (AggStateUtils.isSupportedAggStateFunction(aggFunc, true)) {
@@ -1075,6 +1086,18 @@ public class FunctionSet {
 
     public static String getAggStateMergeName(String name) {
         return String.format("%s%s", name, AGG_STATE_MERGE_SUFFIX);
+    }
+
+    public static String getAggStateCombineName(String name) {
+        return String.format("%s%s", name, AGG_STATE_COMBINE_SUFFIX);
+    }
+
+    public static String getStateMergeName(String name) {
+        return String.format("%s%s", name, STATE_MERGE_SUFFIX);
+    }
+
+    public static String getStateUnionName(String name) {
+        return String.format("%s%s", name, STATE_UNION_SUFFIX);
     }
 
     public static String getAggStateIfName(String name) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateCombineCombinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateCombineCombinator.java
@@ -1,0 +1,112 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.combinator;
+
+import com.starrocks.analysis.FunctionName;
+import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.Type;
+import com.starrocks.thrift.TFunctionBinaryType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Combine combinator for aggregate function to union the agg state to return the immediate result of aggregate function.
+ * DESC: immediate_type {agg_func}_combine(arg_types)
+ *  input type          : aggregate function's arg_types
+ *  intermediate type   : aggregate function's immediate_type
+ *  return type         : aggregate function's immediate_type
+ */
+public final class AggStateCombineCombinator extends AggregateFunction {
+    private static final Logger LOG = LogManager.getLogger(AggStateCombineCombinator.class);
+
+    public AggStateCombineCombinator(FunctionName functionName, List<Type> argTypes, Type intermediateType) {
+        super(functionName, argTypes, intermediateType, intermediateType, false);
+    }
+
+    public AggStateCombineCombinator(AggStateCombineCombinator other) {
+        super(other);
+        this.setBinaryType(TFunctionBinaryType.BUILTIN);
+        this.setPolymorphic(other.isPolymorphic());
+        this.setAggStateDesc(other.aggStateDesc.clone());
+    }
+
+    public static Optional<AggStateCombineCombinator> of(AggregateFunction aggFunc) {
+        try {
+            Type intermediateType = aggFunc.getIntermediateTypeOrReturnType().clone();
+            FunctionName functionName = new FunctionName(AggStateUtils.aggStateCombineFunctionName(aggFunc.functionName()));
+            List<Type> argTypes = Arrays.asList(aggFunc.getArgs());
+            AggStateCombineCombinator aggStateCombineFunc = new AggStateCombineCombinator(functionName, argTypes,
+                    intermediateType);
+            aggStateCombineFunc.setBinaryType(TFunctionBinaryType.BUILTIN);
+            aggStateCombineFunc.setPolymorphic(aggFunc.isPolymorphic());
+            AggStateDesc aggStateDesc;
+            if (aggFunc.getAggStateDesc() != null) {
+                aggStateDesc = aggFunc.getAggStateDesc().clone();
+            } else {
+                aggStateDesc = new AggStateDesc(aggFunc);
+            }
+            aggStateCombineFunc.setAggStateDesc(aggStateDesc);
+            // set agg state desc for the function's result type so can be used as the later agg state functions.
+            intermediateType.setAggStateDesc(aggStateDesc);
+            // use agg state desc's nullable as `agg_state` function's nullable
+            aggStateCombineFunc.setIsNullable(aggStateDesc.getResultNullable());
+            return Optional.of(aggStateCombineFunc);
+        } catch (Exception e) {
+            LOG.warn("Failed to create AggStateCombineCombinator for function: {}", aggFunc.functionName(), e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Function copy() {
+        return new AggStateCombineCombinator(this);
+    }
+
+    @Override
+    public AggregateFunction withNewTypes(List<Type> newArgTypes, Type newRetType) {
+        // NOTE: It's fine that only changes agg state function's arg types and return type but inner agg state desc's,
+        // since FunctionAnalyzer will adjust it later.
+        AggStateCombineCombinator newFn = new AggStateCombineCombinator(this.getFunctionName(), newArgTypes, newRetType);
+        newFn.setFunctionId(this.getFunctionId());
+        newFn.setChecksum(this.getChecksum());
+        newFn.setBinaryType(this.getBinaryType());
+        newFn.setHasVarArgs(this.hasVarArgs());
+        newFn.setId(this.getId());
+        newFn.setUserVisible(this.isUserVisible());
+        newFn.setAggStateDesc(this.getAggStateDesc());
+        newFn.setPolymorphic(this.isPolymorphic());
+        return newFn;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(functionName());
+        sb.append("(");
+        for (int i = 0; i < getNumArgs(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(getArgs()[i].toSql());
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateCombineCombinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateCombineCombinator.java
@@ -27,11 +27,11 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Combine combinator for aggregate function to union the agg state to return the immediate result of aggregate function.
- * DESC: immediate_type {agg_func}_combine(arg_types)
+ * Combine combinator for aggregate function to combine the agg state to return the intermediate result of aggregate function.
+ * DESC: intermediate_type {agg_func}_combine(arg_types)
  *  input type          : aggregate function's arg_types
- *  intermediate type   : aggregate function's immediate_type
- *  return type         : aggregate function's immediate_type
+ *  intermediate type   : aggregate function's intermediate_type
+ *  return type         : aggregate function's intermediate_type
  */
 public final class AggStateCombineCombinator extends AggregateFunction {
     private static final Logger LOG = LogManager.getLogger(AggStateCombineCombinator.class);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateMergeCombinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateMergeCombinator.java
@@ -29,8 +29,8 @@ import java.util.Optional;
 /**
  * Merge combinator for aggregate function to merge the agg state to return the final result of aggregate function.
  * DESC: return_type {agg_func}_merge(immediate_type)
- *  input type          : aggregate function's immediate_type
- *  intermediate type   : aggregate function's immediate_type
+ *  input type          : aggregate function's intermediate_type
+ *  intermediate type   : aggregate function's intermediate_type
  *  return type         : aggregate function's return type
  */
 public final class AggStateMergeCombinator extends AggregateFunction {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUnionCombinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUnionCombinator.java
@@ -27,11 +27,11 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Union combinator for aggregate function to union the agg state to return the immediate result of aggregate function.
- * DESC: immediate_type {agg_func}_union(immediate_type)
- *  input type          : aggregate function's immediate_type
- *  intermediate type   : aggregate function's immediate_type
- *  return type         : aggregate function's immediate_type
+ * Union combinator for aggregate function to union the agg state to return the intermediate result of aggregate function.
+ * DESC: immediate_type {agg_func}_union(intermediate_type)
+ *  input type          : aggregate function's intermediate_type
+ *  intermediate type   : aggregate function's intermediate_type
+ *  return type         : aggregate function's intermediate_type
  */
 public final class AggStateUnionCombinator extends AggregateFunction {
     private static final Logger LOG = LogManager.getLogger(AggStateUnionCombinator.class);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
@@ -132,10 +132,16 @@ public class AggStateUtils {
     public static String getAggFuncNameOfCombinator(String fnName) {
         if (fnName.endsWith(FunctionSet.STATE_SUFFIX)) {
             return fnName.substring(0, fnName.length() - FunctionSet.STATE_SUFFIX.length());
+        } else if (fnName.endsWith(FunctionSet.STATE_MERGE_SUFFIX)) {
+            return fnName.substring(0, fnName.length() - FunctionSet.STATE_MERGE_SUFFIX.length());
+        } else if (fnName.endsWith(FunctionSet.STATE_UNION_SUFFIX)) {
+            return fnName.substring(0, fnName.length() - FunctionSet.STATE_UNION_SUFFIX.length());
         } else if (fnName.endsWith(FunctionSet.AGG_STATE_UNION_SUFFIX)) {
             return fnName.substring(0, fnName.length() - FunctionSet.AGG_STATE_UNION_SUFFIX.length());
         } else if (fnName.endsWith(FunctionSet.AGG_STATE_MERGE_SUFFIX)) {
             return fnName.substring(0, fnName.length() - FunctionSet.AGG_STATE_MERGE_SUFFIX.length());
+        } else if (fnName.endsWith(FunctionSet.AGG_STATE_COMBINE_SUFFIX)) {
+            return fnName.substring(0, fnName.length() - FunctionSet.AGG_STATE_COMBINE_SUFFIX.length());
         } else if (fnName.endsWith(FunctionSet.AGG_STATE_IF_SUFFIX)) {
             return fnName.substring(0, fnName.length() - FunctionSet.AGG_STATE_IF_SUFFIX.length());
         } else {
@@ -181,6 +187,39 @@ public class AggStateUtils {
             } else {
                 result = StateFunctionCombinator.of(aggFunc);
             }
+        } else if (func instanceof AggStateCombineCombinator) {
+            // correct aggregate function for type correction
+            // `_state`'s input types are the same with inputs' types.
+            String aggFuncName = AggStateUtils.getAggFuncNameOfCombinator(func.functionName());
+            Function argFn = FunctionAnalyzer.getAnalyzedAggregateFunction(session, aggFuncName,
+                    params, argumentTypes, argumentIsConstants, pos);
+            if (argFn == null) {
+                return null;
+            }
+            if (!(argFn instanceof AggregateFunction aggFunc)) {
+                return null;
+            }
+            if (aggFunc.getNumArgs() == 1) {
+                // only copy argument if it's a decimal type
+                AggregateFunction argFnCopy = (AggregateFunction) aggFunc.copy();
+                argFnCopy.setArgsType(argumentTypes);
+                result = AggStateCombineCombinator.of(argFnCopy);
+            } else {
+                result = AggStateCombineCombinator.of(aggFunc);
+            }
+        } else if (func instanceof StateMergeCombinator) {
+            AggregateFunction argFn = getAggStateFunction(session, func, argumentTypes, pos);
+            if (argFn == null) {
+                return null;
+            }
+            result = StateMergeCombinator.of(argFn);
+        } else if (func instanceof StateUnionCombinator) {
+            // TODO: how to deduce the argument types of state_union combinator?
+            AggregateFunction argFn = getAggStateFunction(session, func, argumentTypes, pos);
+            if (argFn == null) {
+                return null;
+            }
+            result = StateUnionCombinator.of(argFn);
         } else if (func instanceof AggStateUnionCombinator) {
             AggregateFunction argFn = getAggStateFunction(session, func, argumentTypes, pos);
             if (argFn == null) {
@@ -233,7 +272,8 @@ public class AggStateUtils {
                                                          Function inputFunc,
                                                          Type[] argumentTypes,
                                                          NodePosition pos) {
-        Preconditions.checkArgument(argumentTypes.length == 1,
+        // TODO: add more restrictions
+        Preconditions.checkArgument(argumentTypes.length >= 1,
                 "AggState's AggFunc should have only one argument");
         Type arg0Type = argumentTypes[0];
         if (arg0Type.getAggStateDesc() == null) {
@@ -298,18 +338,36 @@ public class AggStateUtils {
         return aggFuncName + FunctionSet.AGG_STATE_MERGE_SUFFIX;
     }
 
+    public static String stateUnionFunctionName(String aggFuncName) {
+        return aggFuncName + FunctionSet.STATE_UNION_SUFFIX;
+    }
+
+    public static String stateMergeFunctionName(String aggFuncName) {
+        return aggFuncName + FunctionSet.STATE_MERGE_SUFFIX;
+    }
+
+    public static String aggStateCombineFunctionName(String aggFuncName) {
+        return aggFuncName  + FunctionSet.AGG_STATE_COMBINE_SUFFIX;
+    }
+
     public static boolean isAggStateCombinator(Function function) {
         return function instanceof AggStateIf ||
                 function instanceof AggStateUnionCombinator ||
                 function instanceof AggStateMergeCombinator ||
+                function instanceof AggStateCombineCombinator ||
                 // scalar functions
-                function instanceof StateFunctionCombinator;
+                function instanceof StateFunctionCombinator ||
+                function instanceof StateMergeCombinator ||
+                function instanceof StateUnionCombinator;
     }
 
     public static boolean isAggStateCombinator(String functionName) {
         return functionName.endsWith(FunctionSet.STATE_SUFFIX) ||
                 functionName.endsWith(FunctionSet.AGG_STATE_UNION_SUFFIX) ||
                 functionName.endsWith(FunctionSet.AGG_STATE_MERGE_SUFFIX) ||
-                functionName.endsWith(FunctionSet.AGG_STATE_IF_SUFFIX);
+                functionName.endsWith(FunctionSet.AGG_STATE_COMBINE_SUFFIX) ||
+                functionName.endsWith(FunctionSet.AGG_STATE_IF_SUFFIX) ||
+                functionName.endsWith(FunctionSet.STATE_UNION_SUFFIX) ||
+                functionName.endsWith(FunctionSet.STATE_MERGE_SUFFIX);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
@@ -272,9 +272,8 @@ public class AggStateUtils {
                                                          Function inputFunc,
                                                          Type[] argumentTypes,
                                                          NodePosition pos) {
-        // TODO: add more restrictions
         Preconditions.checkArgument(argumentTypes.length >= 1,
-                "AggState's AggFunc should have only one argument");
+                "AggState's AggFunc should have at least one argument");
         Type arg0Type = argumentTypes[0];
         if (arg0Type.getAggStateDesc() == null) {
             String functionName = inputFunc.functionName();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/StateMergeCombinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/StateMergeCombinator.java
@@ -1,0 +1,112 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.combinator;
+
+import com.starrocks.analysis.FunctionName;
+import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.catalog.Type;
+import com.starrocks.thrift.TFunctionBinaryType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+
+/**
+ * DESC: result_type {agg_func}_state_merge(intermediate state types)
+ *  input type  : aggregate function's intermediate state types
+ *  return type : aggregate function's result type
+ */
+public final class StateMergeCombinator extends ScalarFunction  {
+    private static final Logger LOG = LogManager.getLogger(StateMergeCombinator.class);
+
+    public StateMergeCombinator(FunctionName functionName, List<Type> argTypes, Type retType) {
+        super(functionName, argTypes, retType, false);
+    }
+
+    public StateMergeCombinator(StateMergeCombinator other) {
+        super(other);
+        this.setBinaryType(TFunctionBinaryType.BUILTIN);
+        this.setPolymorphic(other.isPolymorphic());
+        this.setAggStateDesc(other.aggStateDesc.clone());
+    }
+
+    public static Optional<StateMergeCombinator> of(AggregateFunction aggFunc) {
+        try {
+            Type intermediateType = aggFunc.getIntermediateTypeOrReturnType().clone();
+            Type retType = aggFunc.getReturnType();
+            FunctionName funcName = new FunctionName(AggStateUtils.stateMergeFunctionName(aggFunc.functionName()));
+            StateMergeCombinator aggStateFunc = new StateMergeCombinator(funcName, Arrays.asList(intermediateType),
+                    retType);
+            aggStateFunc.setBinaryType(TFunctionBinaryType.BUILTIN);
+            aggStateFunc.setPolymorphic(aggFunc.isPolymorphic());
+
+            AggStateDesc aggStateDesc = new AggStateDesc(aggFunc);
+            aggStateFunc.setAggStateDesc(aggStateDesc);
+            // `agg_state` function's type will contain agg state desc.
+            intermediateType.setAggStateDesc(aggStateDesc);
+            // use agg state desc's nullable as `agg_state` function's nullable
+            aggStateFunc.setIsNullable(aggStateDesc.getResultNullable());
+            return Optional.of(aggStateFunc);
+        } catch (Exception e) {
+            LOG.warn("Failed to create AggStateMergeCombinator for function: {}", aggFunc.functionName(), e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Function copy() {
+        return new StateMergeCombinator(this);
+    }
+
+    @Override
+    public ScalarFunction withNewTypes(List<Type> newArgTypes, Type newRetType) {
+        // NOTE: It's fine that only changes agg state function's arg types and return type but inner agg state desc's,
+        // since FunctionAnalyzer will adjust it later.
+        StateMergeCombinator newFn = new StateMergeCombinator(this.getFunctionName(), newArgTypes, newRetType);
+        newFn.setLocation(this.getLocation());
+        newFn.setSymbolName(this.getSymbolName());
+        newFn.setPrepareFnSymbol(this.getPrepareFnSymbol());
+        newFn.setCloseFnSymbol(this.getCloseFnSymbol());
+        newFn.setFunctionId(this.getFunctionId());
+        newFn.setChecksum(this.getChecksum());
+        newFn.setBinaryType(this.getBinaryType());
+        newFn.setHasVarArgs(this.hasVarArgs());
+        newFn.setId(this.getId());
+        newFn.setUserVisible(this.isUserVisible());
+        newFn.setAggStateDesc(this.getAggStateDesc());
+        newFn.setPolymorphic(this.isPolymorphic());
+        return newFn;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(functionName());
+        sb.append("(");
+        for (int i = 0; i < getNumArgs(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(getArgs()[i].toSql());
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/StateUnionCombinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/StateUnionCombinator.java
@@ -1,0 +1,112 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.combinator;
+
+import com.starrocks.analysis.FunctionName;
+import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.catalog.Type;
+import com.starrocks.thrift.TFunctionBinaryType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * DESC: intermediate type {agg_func}_state_union(intermediate state type, intermediate state type)
+ *  input type  : aggregate function's intermediate state types
+ *  return type : aggregate function's intermediate type
+ */
+public final class StateUnionCombinator extends ScalarFunction  {
+    private static final Logger LOG = LogManager.getLogger(StateUnionCombinator.class);
+
+    public StateUnionCombinator(FunctionName functionName, List<Type> argTypes, Type retType) {
+        super(functionName, argTypes, retType, false);
+    }
+
+    public StateUnionCombinator(StateUnionCombinator other) {
+        super(other);
+        this.setBinaryType(TFunctionBinaryType.BUILTIN);
+        this.setPolymorphic(other.isPolymorphic());
+        this.setAggStateDesc(other.aggStateDesc.clone());
+    }
+
+    public static Optional<StateUnionCombinator> of(AggregateFunction aggFunc) {
+        try {
+            Type intermediateType = aggFunc.getIntermediateTypeOrReturnType().clone();
+            String origAggFuncName = aggFunc.functionName();
+            FunctionName funcName = new FunctionName(AggStateUtils.stateUnionFunctionName(origAggFuncName));
+            // merge two intermediate state types into one intermediate type
+            StateUnionCombinator aggStateFunc = new StateUnionCombinator(funcName,
+                    Arrays.asList(intermediateType, intermediateType), intermediateType);
+            aggStateFunc.setBinaryType(TFunctionBinaryType.BUILTIN);
+            aggStateFunc.setPolymorphic(aggFunc.isPolymorphic());
+
+            AggStateDesc aggStateDesc = new AggStateDesc(aggFunc);
+            aggStateFunc.setAggStateDesc(aggStateDesc);
+            // `agg_state` function's type will contain agg state desc.
+            intermediateType.setAggStateDesc(aggStateDesc);
+            // use agg state desc's nullable as `agg_state` function's nullable
+            aggStateFunc.setIsNullable(aggStateDesc.getResultNullable());
+            return Optional.of(aggStateFunc);
+        } catch (Exception e) {
+            LOG.warn("Failed to create AggStateUnionCombinator for function: {}", aggFunc.functionName(), e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Function copy() {
+        return new StateUnionCombinator(this);
+    }
+
+    @Override
+    public ScalarFunction withNewTypes(List<Type> newArgTypes, Type newRetType) {
+        // NOTE: It's fine that only changes agg state function's arg types and return type but inner agg state desc's,
+        // since FunctionAnalyzer will adjust it later.
+        StateUnionCombinator newFn = new StateUnionCombinator(this.getFunctionName(), newArgTypes, newRetType);
+        newFn.setLocation(this.getLocation());
+        newFn.setSymbolName(this.getSymbolName());
+        newFn.setPrepareFnSymbol(this.getPrepareFnSymbol());
+        newFn.setCloseFnSymbol(this.getCloseFnSymbol());
+        newFn.setFunctionId(this.getFunctionId());
+        newFn.setChecksum(this.getChecksum());
+        newFn.setBinaryType(this.getBinaryType());
+        newFn.setHasVarArgs(this.hasVarArgs());
+        newFn.setId(this.getId());
+        newFn.setUserVisible(this.isUserVisible());
+        newFn.setAggStateDesc(this.getAggStateDesc());
+        newFn.setPolymorphic(this.isPolymorphic());
+        return newFn;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(functionName());
+        sb.append("(");
+        for (int i = 0; i < getNumArgs(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(getArgs()[i].toSql());
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
@@ -217,14 +217,22 @@ public class PolymorphicFunctionAnalyzer {
             // it's mock, need handle it in expressionAnalyzer
             .put(FunctionSet.NAMED_STRUCT, new RowDeduce())
             .put(FunctionSet.ANY_VALUE, types -> types[0])
+            // any_value functions
             .put(FunctionSet.getAggStateName(FunctionSet.ANY_VALUE), types -> types[0])
             .put(FunctionSet.getAggStateUnionName(FunctionSet.ANY_VALUE), types -> types[0])
             .put(FunctionSet.getAggStateMergeName(FunctionSet.ANY_VALUE), types -> types[0])
             .put(FunctionSet.getAggStateIfName(FunctionSet.ANY_VALUE), types -> types[0])
+            .put(FunctionSet.getStateUnionName(FunctionSet.ANY_VALUE), types -> types[0])
+            .put(FunctionSet.getStateMergeName(FunctionSet.ANY_VALUE), types -> types[0])
+            .put(FunctionSet.getAggStateCombineName(FunctionSet.ANY_VALUE), types -> types[0])
+            // array functions
             .put(FunctionSet.getAggStateName(FunctionSet.ARRAY_AGG), new ArrayAggStateDeduce())
             .put(FunctionSet.getAggStateUnionName(FunctionSet.ARRAY_AGG), types -> types[0])
             .put(FunctionSet.getAggStateMergeName(FunctionSet.ARRAY_AGG), new ArrayAggMergeDeduce())
             .put(FunctionSet.getAggStateIfName(FunctionSet.ARRAY_AGG), types -> types[0])
+            .put(FunctionSet.getStateMergeName(FunctionSet.ARRAY_AGG), new ArrayAggMergeDeduce())
+            .put(FunctionSet.getStateUnionName(FunctionSet.ARRAY_AGG), types -> types[0])
+            .put(FunctionSet.getAggStateCombineName(FunctionSet.ARRAY_AGG), types -> types[0])
             .put(FunctionSet.MAP_AGG, new MapAggDeduce())
             .build();
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
@@ -127,7 +127,7 @@ public class AggStateCombinatorTest extends MVTestBase {
         } else if (type instanceof AnyMapType) {
             return new MapType(Type.STRING, Type.STRING);
         } else if (type instanceof AnyStructType) {
-            Type[] argsTypes = {Type.STRING};
+            Type[] argsTypes = { Type.STRING };
             ArrayList<Type> structTypes = new ArrayList<>();
             for (Type t : argsTypes) {
                 structTypes.add(new ArrayType(t));
@@ -344,12 +344,24 @@ public class AggStateCombinatorTest extends MVTestBase {
             if (FunctionSet.UNSUPPORTED_AGG_STATE_FUNCTIONS.contains(aggFunc.functionName())) {
                 continue;
             }
+            // merge combinator
             var mergeCombinator = AggStateMergeCombinator.of(aggFunc);
             Assertions.assertTrue(mergeCombinator.isPresent());
+            // union combinator
             var unionCombinator = AggStateUnionCombinator.of(aggFunc);
             Assertions.assertTrue(unionCombinator.isPresent());
+            // if combinator
             var ifCombinator = AggStateIf.of(aggFunc);
             Assertions.assertTrue(ifCombinator.isPresent());
+            // combine combinator
+            var combineCombinator = AggStateCombineCombinator.of(aggFunc);
+            Assertions.assertTrue(combineCombinator.isPresent());
+            // agg union state combinator
+            var stateUnionCombinator = StateUnionCombinator.of(aggFunc);
+            Assertions.assertTrue(stateUnionCombinator.isPresent());
+            // agg merge state combinator
+            var stateMergeCombinator = StateMergeCombinator.of(aggFunc);
+            Assertions.assertTrue(stateMergeCombinator.isPresent());
         }
     }
 
@@ -392,8 +404,8 @@ public class AggStateCombinatorTest extends MVTestBase {
             List<Type> argTypes = Stream.of(aggFunc.getArgs()).map(this::mockType).collect(Collectors.toList());
             intermediateType.setAggStateDesc(new AggStateDesc(aggFunc.functionName(),
                     aggFunc.getReturnType(), argTypes));
-            Type[] argumentTypes = {intermediateType};
-            Boolean[] argArgumentConstants = {false};
+            Type[] argumentTypes = { intermediateType };
+            Boolean[] argArgumentConstants = { false };
 
             Function result = FunctionAnalyzer.getAnalyzedAggregateFunction(ConnectContext.get(),
                     aggStateFuncName, params, argumentTypes, argArgumentConstants, NodePosition.ZERO);
@@ -423,8 +435,8 @@ public class AggStateCombinatorTest extends MVTestBase {
             List<Type> argTypes = Stream.of(aggFunc.getArgs()).map(this::mockType).collect(Collectors.toList());
             intermediateType.setAggStateDesc(new AggStateDesc(aggFunc.functionName(),
                     aggFunc.getReturnType(), argTypes));
-            Type[] argumentTypes = {intermediateType};
-            Boolean[] argArgumentConstants = {false};
+            Type[] argumentTypes = { intermediateType };
+            Boolean[] argArgumentConstants = { false };
 
             String aggStateFuncName = FunctionSet.getAggStateMergeName(aggFunc.functionName());
             FunctionParams params = new FunctionParams(false, Lists.newArrayList());
@@ -1229,5 +1241,102 @@ public class AggStateCombinatorTest extends MVTestBase {
         starRocksAssert.dropTable("t1");
         starRocksAssert.dropMaterializedView("test_mv1");
     }
-}
 
+    private Function getAggStateCombineFunc(AggregateFunction aggFunc) {
+        List<Type> argTypes = Stream.of(aggFunc.getArgs()).map(this::mockType).collect(Collectors.toList());
+        String aggStateFuncName = AggStateUtils.aggStateCombineFunctionName(aggFunc.functionName());
+        Type[] argumentTypes = argTypes.toArray(Type[]::new);
+        FunctionParams params = new FunctionParams(false, Lists.newArrayList());
+        Boolean[] argArgumentConstants = IntStream.range(0, aggFunc.getNumArgs()).mapToObj(x -> Boolean.FALSE)
+                .toArray(Boolean[]::new);
+        Function result = FunctionAnalyzer.getAnalyzedAggregateFunction(ConnectContext.get(),
+                aggStateFuncName, params, argumentTypes, argArgumentConstants, NodePosition.ZERO);
+        return result;
+    }
+
+    @Test
+    public void testFunctionAnalyzeCombineCombinator() {
+        var builtInAggregateFunctions = getBuiltInAggFunctions();
+        Set<String> supportedAggFunctions = Sets.newHashSet();
+        Set<String> unSupportedAggFunctions = Sets.newHashSet();
+        for (AggregateFunction aggFunc : builtInAggregateFunctions) {
+            if (!AggStateUtils.isSupportedAggStateFunction(aggFunc, false)) {
+                unSupportedAggFunctions.add(aggFunc.functionName());
+                continue;
+            }
+            supportedAggFunctions.add(aggFunc.functionName());
+            Function result = getAggStateCombineFunc(aggFunc);
+            Assertions.assertNotNull(result);
+            Assertions.assertTrue(result instanceof AggStateCombineCombinator);
+            Assertions.assertFalse(result.getReturnType().isWildcardDecimal(),
+                    "Wildcard decimal is not supported for agg state combine function: " + result.getFunctionName());
+            Assertions.assertFalse(result.getReturnType().isPseudoType());
+        }
+        Assertions.assertTrue(supportedAggFunctions.size() >= SUPPORTED_AGG_STATE_FUNCTIONS.size());
+    }
+
+    @Test
+    public void testFunctionAnalyzeStateUnionCombinator() {
+        var builtInAggregateFunctions = getBuiltInAggFunctions();
+        Set<String> supportedAggFunctions = Sets.newHashSet();
+        for (AggregateFunction aggFunc : builtInAggregateFunctions) {
+            if (!AggStateUtils.isSupportedAggStateFunction(aggFunc, false)) {
+                continue;
+            }
+            supportedAggFunctions.add(aggFunc.functionName());
+            Function aggStateFunc = getAggStateFunc(aggFunc);
+            Assertions.assertNotNull(aggStateFunc);
+            String aggStateFuncName = FunctionSet.getStateUnionName(aggFunc.functionName());
+            FunctionParams params = new FunctionParams(false, Lists.newArrayList());
+
+            Type intermediateType = aggStateFunc.getReturnType();
+            // set agg_state_desc
+            List<Type> argTypes = Stream.of(aggFunc.getArgs()).map(this::mockType).collect(Collectors.toList());
+            intermediateType.setAggStateDesc(new AggStateDesc(aggFunc.functionName(),
+                    aggFunc.getReturnType(), argTypes));
+            Type[] argumentTypes = { intermediateType, intermediateType };
+            Boolean[] argArgumentConstants = { false, false };
+
+            Function result = FunctionAnalyzer.getAnalyzedAggregateFunction(ConnectContext.get(),
+                    aggStateFuncName, params, argumentTypes, argArgumentConstants, NodePosition.ZERO);
+            Assertions.assertNotNull(result);
+            Assertions.assertTrue(result instanceof StateUnionCombinator);
+            Assertions.assertFalse(result.getReturnType().isWildcardDecimal());
+            Assertions.assertFalse(result.getReturnType().isPseudoType());
+        }
+        Assertions.assertTrue(supportedAggFunctions.size() >= SUPPORTED_AGG_STATE_FUNCTIONS.size());
+    }
+
+
+    @Test
+    public void testFunctionAnalyzeStateMergeCombinator() {
+        var builtInAggregateFunctions = getBuiltInAggFunctions();
+        Set<String> supportedAggFunctions = Sets.newHashSet();
+        for (AggregateFunction aggFunc : builtInAggregateFunctions) {
+            if (!AggStateUtils.isSupportedAggStateFunction(aggFunc, false)) {
+                continue;
+            }
+            supportedAggFunctions.add(aggFunc.functionName());
+            Function aggStateFunc = getAggStateFunc(aggFunc);
+            Assertions.assertNotNull(aggStateFunc);
+            String aggStateFuncName = FunctionSet.getStateMergeName(aggFunc.functionName());
+            FunctionParams params = new FunctionParams(false, Lists.newArrayList());
+
+            Type intermediateType = aggStateFunc.getReturnType();
+            // set agg_state_desc
+            List<Type> argTypes = Stream.of(aggFunc.getArgs()).map(this::mockType).collect(Collectors.toList());
+            intermediateType.setAggStateDesc(new AggStateDesc(aggFunc.functionName(),
+                    aggFunc.getReturnType(), argTypes));
+            Type[] argumentTypes = { intermediateType };
+            Boolean[] argArgumentConstants = { false };
+
+            Function result = FunctionAnalyzer.getAnalyzedAggregateFunction(ConnectContext.get(),
+                    aggStateFuncName, params, argumentTypes, argArgumentConstants, NodePosition.ZERO);
+            Assertions.assertNotNull(result);
+            Assertions.assertTrue(result instanceof StateMergeCombinator);
+            Assertions.assertFalse(result.getReturnType().isWildcardDecimal());
+            Assertions.assertFalse(result.getReturnType().isPseudoType());
+        }
+        Assertions.assertTrue(supportedAggFunctions.size() >= SUPPORTED_AGG_STATE_FUNCTIONS.size());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
In `IVM` refresh, to support incremental aggregate, we need more combinator functions to compute the incremental states. Those functions can be used for IVM refresh to combine existed agg state and new input state to compute the final result and the final state.


Scalar Function:
- `{agg_func}_state_merge(state1, state2)`: merge two intermediate states into final result
- `{agg_func}_state_union(state1, state2)`: merge two intermediate states into an intermediate result


Aggregate Function:
- `{agg_func}_combine(args)`: translate args into intermediate state and union the intermedate state into the final which is equal to `{agg_func}_union(`{agg_func}_state(args)`)` but will be more efficient.



eg:
```
avg(c1)

 -- scalar function: translate c1 into `avg`'s intermediate state
avg_state(c1)
-- scalar function: merge two intermediate states into an intermediate result
avg_state_union(s1, s2)
 -- scalar function: merge two intermediate states into final result
avg_state_merge(s1, s2)


 -- aggregate function: translate args into intermediate state and union the intermedate state into the final  intermediate state
avg_combine(c1)
```

## What I'm doing:
This pull request introduces a new aggregate function combinator, _combine, to the aggregation framework and refactors aggregate state function handling for improved code reuse and maintainability. The main changes include the addition of the AggStateCombine class, integration of the _combine suffix into aggregator logic, and the extraction of shared logic into a new base class for aggregate state functions.

### Aggregate state combinator support

* Added the new `AggStateCombine` combinator in `agg_state_combine.h`, which efficiently combines aggregate inputs to compute immediate results, reducing function call overhead and memory allocations.
* Implemented the corresponding utility logic in `agg_state_utils.cpp` to support the new combinator, including function identification and construction.
* Registered the new source file `agg_state_utils.cpp` in the build system (`CMakeLists.txt`).

### Utility and header refactoring

* Refactored `agg_state_utils.h` to move implementation details to the `.cpp` file, added new suffix constants, and extended function identification logic for new combinators. [[1]](diffhunk://#diff-4cb67e177c4ea1b4640b78b0b32078276d6bb426d0576faf23efa533c913f20cL17-R17) [[2]](diffhunk://#diff-4cb67e177c4ea1b4640b78b0b32078276d6bb426d0576faf23efa533c913f20cR28-R49) [[3]](diffhunk://#diff-4cb67e177c4ea1b4640b78b0b32078276d6bb426d0576faf23efa533c913f20cR62-R85)

### Additional combinator support

* Added `state_merge_function.h`, implementing the `StateMergeFunction` to compute final results from intermediate aggregate states, further extending support for aggregate state combinators.

Fixes  https://github.com/StarRocks/starrocks/issues/61789

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
