### PR TITLE
[Enhancement] Improve the iceberg table sink memory and small file problems by implementing a partition based global shuffle

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -493,6 +493,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String HIVE_PARTITION_STATS_SAMPLE_SIZE = "hive_partition_stats_sample_size";
 
     public static final String ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE = "enable_connector_sink_global_shuffle";
+    // Ideally, we should use the variable `enable_connector_sink_global_shuffle` to control the global shuffle
+    // behavior of all connectors. However, this session variable is currently default true, and we do not want
+    // to default to enabling Iceberg's global shuffle for now, as it can cause significant performance degradation
+    // when writing to fewer partitions. Therefore, we introduce a new invisible session variable with a default
+    // false value temporarily. Once we can handle the shuffle behavior automatically to avoid some bad cases,
+    // We will make it be controlled by the common connector session.
+    public static final String ENABLE_ICEBERG_SINK_GLOBAL_SHUFFLE = "enable_iceberg_sink_global_shuffle";
 
     public static final String ENABLE_CONNECTOR_SINK_SPILL = "enable_connector_sink_spill";
     public static final String CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD = "connector_sink_spill_mem_limit_threshold";
@@ -1274,6 +1281,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkGlobalShuffle = true;
 
+    @VariableMgr.VarAttr(name = ENABLE_ICEBERG_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE)
+    private boolean enableIcebergSinkGlobalShuffle = false;
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_SPILL, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkSpill = true;
 
@@ -3825,6 +3834,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableConnectorSinkGlobalShuffle() {
         return enableConnectorSinkGlobalShuffle;
+    }
+
+    public boolean isEnableIcebergSinkGlobalShuffle() {
+        return enableIcebergSinkGlobalShuffle;
     }
 
     public boolean isEnableConnectorSinkSpill() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -900,6 +901,136 @@ public class InsertPlanTest extends PlanTestBase {
                 "  0:UNION\n" +
                 "     constant exprs: \n" +
                 "         NULL\n";
+        Assertions.assertEquals(expected, actualRes);
+    }
+
+    @Test
+    public void testInsertIcebergWithGlobalShuffle() throws Exception {
+        String createIcebergCatalogStmt = "create external catalog iceberg_catalog_shuffle properties (\"type\"=\"iceberg\", " +
+                "\"hive.metastore.uris\"=\"thrift://hms:9083\", \"iceberg.catalog.type\"=\"hive\")";
+        starRocksAssert.withCatalog(createIcebergCatalogStmt);
+        MetadataMgr metadata = starRocksAssert.getCtx().getGlobalStateMgr().getMetadataMgr();
+
+        Table nativeTable = new BaseTable(null, null);
+
+        Column k1 = new Column("k1", Type.INT);
+        Column k2 = new Column("k2", Type.INT);
+        IcebergTable.Builder builder = IcebergTable.builder();
+        builder.setCatalogName("iceberg_catalog_shuffle");
+        builder.setCatalogDBName("iceberg_db");
+        builder.setCatalogTableName("iceberg_table");
+        builder.setSrTableName("iceberg_table");
+        builder.setFullSchema(Lists.newArrayList(k1, k2));
+        builder.setNativeTable(nativeTable);
+        IcebergTable icebergTable = builder.build();
+
+        new Expectations(icebergTable) {
+            {
+                icebergTable.getUUID();
+                result = 12345566;
+                minTimes = 0;
+
+                icebergTable.isUnPartitioned();
+                result = false;
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = Arrays.asList(k1);
+
+                icebergTable.partitionColumnIndexes();
+                result = Arrays.asList(0);
+            }
+        };
+
+        new Expectations(nativeTable) {
+            {
+                nativeTable.sortOrder();
+                result = SortOrder.unsorted();
+                minTimes = 0;
+
+                nativeTable.location();
+                result = "hdfs://fake_location";
+                minTimes = 0;
+
+                nativeTable.properties();
+                result = new HashMap<String, String>();
+                minTimes = 0;
+
+                nativeTable.io();
+                result = new HadoopFileIO();
+                minTimes = 0;
+
+                nativeTable.spec();
+                result = PartitionSpec.unpartitioned();
+            }
+        };
+
+        new Expectations(metadata) {
+            {
+                metadata.getDb((ConnectContext) any, "iceberg_catalog_shuffle", "iceberg_db");
+                result = new Database(12345566, "iceberg_db");
+                minTimes = 0;
+
+                metadata.getTable((ConnectContext) any, "iceberg_catalog_shuffle", "iceberg_db", "iceberg_table");
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        new MockUp<SessionVariable>() {
+            @Mock
+            public boolean isEnableIcebergSinkGlobalShuffle() {
+                return true;
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public Database getDatabase(String catalogName, String tableName) {
+                return new Database(12345566, "iceberg_db");
+            }
+
+            @Mock
+            public com.starrocks.catalog.Table getSessionAwareTable(
+                    ConnectContext context, Database database, TableName tableName) {
+                return icebergTable;
+            }
+        };
+
+        String actualRes = getInsertExecPlan(
+                "explain insert into iceberg_catalog_shuffle.iceberg_db.iceberg_table select 1, 2 from t0");
+        String expected = "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:6: k1 | 7: k2\n" +
+                "  PARTITION: HASH_PARTITIONED: 6: k1\n" +
+                "\n" +
+                "  Iceberg TABLE SINK\n" +
+                "    TABLE: 12345566\n" +
+                "    TUPLE ID: 2\n" +
+                "    RANDOM\n" +
+                "\n" +
+                "  2:EXCHANGE\n" +
+                "\n" +
+                "PLAN FRAGMENT 1\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: RANDOM\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 02\n" +
+                "    HASH_PARTITIONED: 6: k1\n" +
+                "\n" +
+                "  1:Project\n" +
+                "  |  <slot 6> : 1\n" +
+                "  |  <slot 7> : 2\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: t0\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=0/1\n" +
+                "     rollup: t0\n" +
+                "     tabletRatio=0/0\n" +
+                "     tabletList=\n" +
+                "     cardinality=1\n" +
+                "     avgRowSize=9.0\n";
         Assertions.assertEquals(expected, actualRes);
     }
 


### PR DESCRIPTION
## Why I'm doing:
Currently, StarRocks has introduced global shuffle in connector sink to reduce the small files during sink process. If the target table is partitioned, use hash shuffle based on partitioned columns. 

However, the iceberg table has not been supported this function and only the table function table is handled. So we need to implement the global shuffle for the iceberg table.

## What I'm doing:
Improve the iceberg table sink memory and small file problems by implementing a partition based global shuffle. 
NOTICE: We remove the sort property in `createPhysicalPropertySet` because we have optimized the iceberg local sorting in file writers in another PR, so it should be removed.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
