### PR TITLE
[BugFix] Fix trace times merge bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
@@ -90,7 +90,7 @@ public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
     @Override
     public String visitLogicalTableScan(LogicalScanOperator node, Void context) {
         return "LogicalScanOperator" + " {" +
-                "table='" + node.getTable().getId() + '\'' +
+                "table='" + node.getTable().getName() + '\'' +
                 ", outputColumns='" + new ArrayList<>(node.getColRefToColumnMetaMap().keySet()) + '\'' +
                 '}';
     }
@@ -110,7 +110,7 @@ public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
 
     @Override
     public String visitLogicalOlapScan(LogicalOlapScanOperator node, Void context) {
-        return "LogicalOlapScanOperator" + " {" + "table=" + node.getTable().getId() +
+        return "LogicalOlapScanOperator" + " {" + "table=" + node.getTable().getName() +
                 ", selectedPartitionId=" + node.getSelectedPartitionId() +
                 ", selectedIndexId=" + node.getSelectedIndexId() +
                 ", outputColumns=" + new ArrayList<>(node.getColRefToColumnMetaMap().keySet()) +


### PR DESCRIPTION
## Why I'm doing:
only merge scope timer in same level, avoid stack level print error

before this PR:
```
  0ms|-- Parser[2] 15ms
 15ms|-- Planner[2] 193ms
 20ms|    -- Analyzer[2] 16ms
 20ms|        -- Lock[2] 0
 20ms|        -- AnalyzeDatabase[6] 0
 20ms|        -- AnalyzeTemporaryTable[6] 0
 20ms|        -- AnalyzeTable[6] 0
 44ms|    -- Transformer[2] 26ms
 70ms|    -- Optimizer[2] 113ms
107ms|        -- MVPreprocess[2] 2ms
110ms|        -- MVTextRewrite[2] 0
111ms|        -- RuleBaseOptimize[2] 43ms
150ms|        -- CostBaseOptimize[2] 11ms
160ms|        -- PhysicalRewrite[2] 12ms
172ms|        -- DynamicRewrite[2] 0
173ms|        -- PlanValidate[2] 2ms
174ms|            -- InputDependenciesChecker[2] 0
174ms|            -- TypeChecker[2] 0
175ms|            -- CTEUniqueChecker[2] 0
175ms|            -- ColumnReuseChecker[2] 0
175ms|    -- ExecPlanBuild[2] 22ms
198ms|-- Test View[2] 23ms
221ms|-- thisIsPrivilegeCheckCall[1] 16ms
Tracer Cost: 181us
```

after this PR:
```
  0ms|-- Parser[1] 13ms
 14ms|-- Planner[1] 214ms
 19ms|    -- Analyzer[1] 18ms
 19ms|        -- Lock[1] 0
 19ms|        -- AnalyzeDatabase[3] 0
 19ms|        -- AnalyzeTemporaryTable[3] 0
 19ms|        -- AnalyzeTable[3] 0
 45ms|    -- Transformer[1] 26ms
 73ms|    -- Optimizer[1] 133ms
114ms|        -- MVPreprocess[1] 3ms
119ms|        -- MVTextRewrite[1] 1ms
120ms|        -- RuleBaseOptimize[1] 55ms
177ms|        -- CostBaseOptimize[1] 11ms
189ms|        -- PhysicalRewrite[1] 13ms
203ms|        -- DynamicRewrite[1] 0
204ms|        -- PlanValidate[1] 2ms
205ms|            -- InputDependenciesChecker[1] 0
205ms|            -- TypeChecker[1] 0
206ms|            -- CTEUniqueChecker[1] 0
206ms|            -- ColumnReuseChecker[1] 0
207ms|    -- ExecPlanBuild[1] 21ms
229ms|-- Test View[1] 13ms
230ms|    -- AnalyzeDatabase[2] 0
230ms|    -- AnalyzeTemporaryTable[2] 0
230ms|    -- AnalyzeTable[2] 0
245ms|    -- Parser[1] 0
245ms|-- thisIsPrivilegeCheckCall[1] 11ms
246ms|    -- Planner[1] 7ms
246ms|        -- Analyzer[1] 0
246ms|            -- Lock[1] 0
246ms|            -- AnalyzeDatabase[1] 0
246ms|            -- AnalyzeTemporaryTable[1] 0
246ms|            -- AnalyzeTable[1] 0
247ms|        -- Transformer[1] 0
248ms|        -- Optimizer[1] 5ms
248ms|            -- MVPreprocess[1] 0
248ms|            -- MVTextRewrite[1] 0
248ms|            -- RuleBaseOptimize[1] 3ms
251ms|            -- CostBaseOptimize[1] 1ms
252ms|            -- PhysicalRewrite[1] 0
253ms|            -- DynamicRewrite[1] 0
253ms|            -- PlanValidate[1] 0
253ms|                -- InputDependenciesChecker[1] 0
253ms|                -- TypeChecker[1] 0
253ms|                -- CTEUniqueChecker[1] 0
253ms|                -- ColumnReuseChecker[1] 0
253ms|        -- ExecPlanBuild[1] 0
253ms|    -- Test View[1] 2ms
Tracer Cost: 376us
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
