### PR TITLE
[Enhancement] Remove limitation on FORMAT_VERSION in IcebergApiConverter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -444,7 +444,10 @@ public class IcebergApiConverter {
         if (!PARQUET_COMPRESSION_TYPE_MAP.containsKey(compressionCodec.toLowerCase(Locale.ROOT))) {
             throw new IllegalArgumentException("Unsupported compression codec in USING: " + compressionCodec);
         }
-        tableProperties.put(TableProperties.FORMAT_VERSION, "1");
+
+        if (!createProperties.containsKey(TableProperties.FORMAT_VERSION)) {
+            tableProperties.put(TableProperties.FORMAT_VERSION, "1");
+        }
 
         return tableProperties.build();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -255,6 +256,10 @@ public class IcebergApiConverterTest {
         source = ImmutableMap.of("file_format", "avro", "compression_codec", "zstd");
         target = IcebergApiConverter.rebuildCreateTableProperties(source);
         assertEquals("zstd", target.get(AVRO_COMPRESSION));
+
+        source = ImmutableMap.of(TableProperties.FORMAT_VERSION, "2");
+        target = IcebergApiConverter.rebuildCreateTableProperties(source);
+        assertEquals("2", target.get(TableProperties.FORMAT_VERSION));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #62065

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3