### PR TITLE
[Refactor] Refactors how materialized view refresh types are represented and used throughout the codebase

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -43,6 +43,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaterializedViewRefreshType;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
@@ -416,7 +417,7 @@ public class AlterJobMgr {
             final MaterializedView.MvRefreshScheme oldRefreshScheme = oldMaterializedView.getRefreshScheme();
             newMvRefreshScheme.setAsyncRefreshContext(oldRefreshScheme.getAsyncRefreshContext());
             newMvRefreshScheme.setLastRefreshTime(oldRefreshScheme.getLastRefreshTime());
-            final MaterializedView.RefreshType refreshType = log.getRefreshType();
+            final MaterializedViewRefreshType refreshType = log.getRefreshType();
             final MaterializedView.AsyncRefreshContext asyncRefreshContext = log.getAsyncRefreshContext();
             final MaterializedView.RefreshMoment moment = oldRefreshScheme.getMoment();
             newMvRefreshScheme.setType(refreshType);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaterializedViewRefreshType;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.OlapTable;
@@ -443,8 +444,8 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             MaterializedView materializedView = (MaterializedView) table;
             String dbName = db.getFullName();
 
-            MaterializedView.RefreshType newRefreshType = refreshSchemeDesc.getType();
-            MaterializedView.RefreshType oldRefreshType = materializedView.getRefreshScheme().getType();
+            MaterializedViewRefreshType newRefreshType = MaterializedViewRefreshType.getType(refreshSchemeDesc);
+            MaterializedViewRefreshType oldRefreshType = materializedView.getRefreshScheme().getType();
 
             TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
             Task currentTask = taskManager.getTask(TaskBuilder.getMvTaskName(materializedView.getId()));
@@ -530,7 +531,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                 GlobalStateMgr.getCurrentState().getAlterJobMgr().
                         alterMaterializedViewStatus(materializedView, status, "", false);
                 // for manual refresh type, do not refresh
-                if (materializedView.getRefreshScheme().getType() != MaterializedView.RefreshType.MANUAL) {
+                if (materializedView.getRefreshScheme().getType() != MaterializedViewRefreshType.MANUAL) {
                     GlobalStateMgr.getCurrentState().getLocalMetastore()
                             .refreshMaterializedView(dbName, materializedView.getName(), false, null,
                                     Constants.TaskRunPriority.NORMAL.value(), true, false);
@@ -567,7 +568,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
 
     /**
      * Inactive the materialized view and its related materialized views.
-     *
+     * <p>
      * NOTE:
      * 1. This method will clear all visible version map of the MV since for all schema changes, the MV should be
      * refreshed.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedViewRefreshType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedViewRefreshType.java
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.common.DdlException;
+import com.starrocks.sql.ast.AsyncRefreshSchemeDesc;
+import com.starrocks.sql.ast.IncrementalRefreshSchemeDesc;
+import com.starrocks.sql.ast.ManualRefreshSchemeDesc;
+import com.starrocks.sql.ast.RefreshSchemeClause;
+import com.starrocks.sql.ast.SyncRefreshSchemeDesc;
+
+public enum MaterializedViewRefreshType {
+    SYNC,
+    ASYNC,
+    MANUAL,
+    INCREMENTAL;
+
+    public static MaterializedViewRefreshType getType(RefreshSchemeClause refreshSchemeDesc) throws DdlException {
+        MaterializedViewRefreshType newRefreshType;
+        if (refreshSchemeDesc instanceof AsyncRefreshSchemeDesc) {
+            newRefreshType = MaterializedViewRefreshType.ASYNC;
+        } else if (refreshSchemeDesc instanceof SyncRefreshSchemeDesc) {
+            newRefreshType = MaterializedViewRefreshType.SYNC;
+        } else if (refreshSchemeDesc instanceof ManualRefreshSchemeDesc) {
+            newRefreshType = MaterializedViewRefreshType.MANUAL;
+        } else if (refreshSchemeDesc instanceof IncrementalRefreshSchemeDesc) {
+            newRefreshType = MaterializedViewRefreshType.INCREMENTAL;
+        } else {
+            throw new DdlException("Unsupported refresh scheme type");
+        }
+
+        return newRefreshType;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -57,6 +57,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaterializedViewRefreshType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
@@ -623,7 +624,7 @@ public class PropertyAnalyzer {
     }
 
     public static int analyzeAutoRefreshPartitionsLimit(Map<String, String> properties, MaterializedView mv) {
-        if (mv.getRefreshScheme().getType() == MaterializedView.RefreshType.MANUAL) {
+        if (mv.getRefreshScheme().getType() == MaterializedViewRefreshType.MANUAL) {
             throw new SemanticException(
                     "The auto_refresh_partitions_limit property does not support manual refresh mode.");
         }
@@ -676,7 +677,7 @@ public class PropertyAnalyzer {
     public static List<TableName> analyzeExcludedTables(Map<String, String> properties,
                                                         String propertiesKey,
                                                         MaterializedView mv) {
-        if (mv.getRefreshScheme().getType() != MaterializedView.RefreshType.ASYNC) {
+        if (mv.getRefreshScheme().getType() != MaterializedViewRefreshType.ASYNC) {
             throw new SemanticException("The " + propertiesKey + " property only applies to asynchronous refreshes.");
         }
         List<TableName> tables = Lists.newArrayList();
@@ -1269,7 +1270,7 @@ public class PropertyAnalyzer {
     }
 
     public static double analyzerDoubleProp(Map<String, String> properties, String propKey, double defaultVal)
-        throws AnalysisException {
+            throws AnalysisException {
         double val = defaultVal;
         if (properties != null && properties.containsKey(propKey)) {
             String valStr = properties.get(propKey);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ChangeMaterializedViewRefreshSchemeLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ChangeMaterializedViewRefreshSchemeLog.java
@@ -16,6 +16,7 @@ package com.starrocks.persist;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaterializedViewRefreshType;
 import com.starrocks.common.Config;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -32,7 +33,7 @@ public class ChangeMaterializedViewRefreshSchemeLog implements Writable {
     private long dbId;
 
     @SerializedName(value = "refreshType")
-    private MaterializedView.RefreshType refreshType;
+    private MaterializedViewRefreshType refreshType;
 
     @SerializedName(value = "asyncRefreshContext")
     private MaterializedView.AsyncRefreshContext asyncRefreshContext;
@@ -55,7 +56,7 @@ public class ChangeMaterializedViewRefreshSchemeLog implements Writable {
         return dbId;
     }
 
-    public MaterializedView.RefreshType getRefreshType() {
+    public MaterializedViewRefreshType  getRefreshType() {
         return refreshType;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/IMTCreator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/IMTCreator.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.DistributionInfoBuilder;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaterializedViewRefreshType;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.common.DdlException;
 import com.starrocks.server.GlobalStateMgr;
@@ -106,7 +107,7 @@ class IMTCreator {
 
         // Refresh
         MaterializedView.MvRefreshScheme mvRefreshScheme = new MaterializedView.MvRefreshScheme();
-        mvRefreshScheme.setType(MaterializedView.RefreshType.INCREMENTAL);
+        mvRefreshScheme.setType(MaterializedViewRefreshType.INCREMENTAL);
 
         String mvName = stmt.getTableName().getTbl();
         return new MaterializedView(mvId, dbId, mvName, columns, stmt.getKeysType(), partitionInfo,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -45,7 +45,6 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.ListPartitionInfo;
-import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
@@ -116,6 +115,7 @@ import com.starrocks.sql.ast.SinglePartitionDesc;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.sql.ast.SplitTabletClause;
 import com.starrocks.sql.ast.StructFieldDesc;
+import com.starrocks.sql.ast.SyncRefreshSchemeDesc;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -1203,7 +1203,7 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
 
     @Override
     public Void visitRefreshSchemeClause(RefreshSchemeClause refreshSchemeDesc, ConnectContext context) {
-        if (refreshSchemeDesc.getType() == MaterializedView.RefreshType.SYNC) {
+        if (refreshSchemeDesc instanceof SyncRefreshSchemeDesc) {
             throw new SemanticException("Unsupported change to SYNC refresh type", refreshSchemeDesc.getPos());
         }
         if (refreshSchemeDesc instanceof AsyncRefreshSchemeDesc) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -87,6 +87,7 @@ import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.HashDistributionDesc;
+import com.starrocks.sql.ast.IncrementalRefreshSchemeDesc;
 import com.starrocks.sql.ast.IndexDef;
 import com.starrocks.sql.ast.PartitionRangeDesc;
 import com.starrocks.sql.ast.QueryRelation;
@@ -474,7 +475,8 @@ public class MaterializedViewAnalyzer {
             if (!ctx.getSessionVariable().isEnableIncrementalRefreshMV()) {
                 return;
             }
-            if (!createStmt.getRefreshSchemeDesc().getType().equals(MaterializedView.RefreshType.INCREMENTAL)) {
+
+            if (!(createStmt.getRefreshSchemeDesc() instanceof IncrementalRefreshSchemeDesc)) {
                 return;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AsyncRefreshSchemeDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AsyncRefreshSchemeDesc.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.MaterializedView;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.time.LocalDateTime;
@@ -29,8 +28,8 @@ public class AsyncRefreshSchemeDesc extends RefreshSchemeClause {
     private IntervalLiteral intervalLiteral;
 
     public AsyncRefreshSchemeDesc(boolean defineStartTime, LocalDateTime startTime, IntervalLiteral intervalLiteral,
-                                  MaterializedView.RefreshMoment moment, NodePosition pos) {
-        super(MaterializedView.RefreshType.ASYNC, pos, moment);
+                                  RefreshMoment moment, NodePosition pos) {
+        super(pos, moment);
         this.defineStartTime = defineStartTime;
         this.startTime = startTime;
         this.intervalLiteral = intervalLiteral;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/IncrementalRefreshSchemeDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/IncrementalRefreshSchemeDesc.java
@@ -14,12 +14,11 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.MaterializedView;
 import com.starrocks.sql.parser.NodePosition;
 
 public class IncrementalRefreshSchemeDesc extends RefreshSchemeClause {
 
-    public IncrementalRefreshSchemeDesc(MaterializedView.RefreshMoment moment, NodePosition pos) {
-        super(MaterializedView.RefreshType.INCREMENTAL, pos, moment);
+    public IncrementalRefreshSchemeDesc(RefreshMoment moment, NodePosition pos) {
+        super(pos, moment);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ManualRefreshSchemeDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ManualRefreshSchemeDesc.java
@@ -14,12 +14,11 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.MaterializedView;
 import com.starrocks.sql.parser.NodePosition;
 
 public class ManualRefreshSchemeDesc extends RefreshSchemeClause {
-    public ManualRefreshSchemeDesc(MaterializedView.RefreshMoment moment, NodePosition pos) {
-        super(MaterializedView.RefreshType.MANUAL, pos, moment);
+    public ManualRefreshSchemeDesc(RefreshMoment moment, NodePosition pos) {
+        super(pos, moment);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshSchemeClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshSchemeClause.java
@@ -12,27 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.MaterializedView;
 import com.starrocks.sql.parser.NodePosition;
 
 public class RefreshSchemeClause extends AlterTableClause {
-
-    protected MaterializedView.RefreshType type;
-    protected MaterializedView.RefreshMoment moment;
-    protected final NodePosition pos;
-
-    public RefreshSchemeClause(MaterializedView.RefreshType type, NodePosition pos, MaterializedView.RefreshMoment moment) {
-        super(pos);
-        this.type = type;
-        this.moment = moment;
-        this.pos = pos;
+    public enum RefreshMoment {
+        IMMEDIATE,
+        DEFERRED
     }
 
-    public MaterializedView.RefreshType getType() {
-        return type;
+    protected RefreshMoment moment;
+    protected final NodePosition pos;
+
+    public RefreshSchemeClause(NodePosition pos, RefreshMoment moment) {
+        super(pos);
+        this.moment = moment;
+        this.pos = pos;
     }
 
     @Override
@@ -40,7 +36,7 @@ public class RefreshSchemeClause extends AlterTableClause {
         return pos;
     }
 
-    public MaterializedView.RefreshMoment getMoment() {
+    public RefreshMoment getMoment() {
         return moment;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SyncRefreshSchemeDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SyncRefreshSchemeDesc.java
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.MaterializedView;
 import com.starrocks.sql.parser.NodePosition;
 
 public class SyncRefreshSchemeDesc extends RefreshSchemeClause {
@@ -25,6 +23,6 @@ public class SyncRefreshSchemeDesc extends RefreshSchemeClause {
     }
 
     public SyncRefreshSchemeDesc(NodePosition pos) {
-        super(MaterializedView.RefreshType.SYNC, pos, MaterializedView.RefreshMoment.IMMEDIATE);
+        super(pos, RefreshMoment.IMMEDIATE);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -33,6 +33,7 @@ import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaterializedViewRefreshType;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.OlapTable;
@@ -657,7 +658,7 @@ public class MvRewritePreprocessor {
                 }
                 // refresh schema
                 MaterializedView.MvRefreshScheme mvRefreshScheme =
-                        new MaterializedView.MvRefreshScheme(MaterializedView.RefreshType.SYNC);
+                        new MaterializedView.MvRefreshScheme(MaterializedViewRefreshType.SYNC);
                 MaterializedView mv;
                 if (olapTable.isCloudNativeTable()) {
                     mv = new LakeMaterializedView(db, mvName, indexMeta, olapTable,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -92,7 +92,6 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MapType;
-import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.StructField;
@@ -2131,8 +2130,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 refreshSchemeDesc = new SyncRefreshSchemeDesc();
             } else {
                 // use new manual refresh
-                refreshSchemeDesc =
-                        new ManualRefreshSchemeDesc(MaterializedView.RefreshMoment.IMMEDIATE, NodePosition.ZERO);
+                refreshSchemeDesc = new ManualRefreshSchemeDesc(RefreshSchemeClause.RefreshMoment.IMMEDIATE, NodePosition.ZERO);
             }
         }
         if (refreshSchemeDesc instanceof SyncRefreshSchemeDesc) {
@@ -8526,13 +8524,13 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         LocalDateTime startTime = LocalDateTime.now();
         IntervalLiteral intervalLiteral = null;
         NodePosition pos = createPos(context);
-        MaterializedView.RefreshMoment refreshMoment =
+        RefreshSchemeClause.RefreshMoment refreshMoment =
                 Config.default_mv_refresh_immediate ?
-                        MaterializedView.RefreshMoment.IMMEDIATE : MaterializedView.RefreshMoment.DEFERRED;
+                        RefreshSchemeClause.RefreshMoment.IMMEDIATE : RefreshSchemeClause.RefreshMoment.DEFERRED;
         if (context.DEFERRED() != null) {
-            refreshMoment = MaterializedView.RefreshMoment.DEFERRED;
+            refreshMoment = RefreshSchemeClause.RefreshMoment.DEFERRED;
         } else if (context.IMMEDIATE() != null) {
-            refreshMoment = MaterializedView.RefreshMoment.IMMEDIATE;
+            refreshMoment = RefreshSchemeClause.RefreshMoment.IMMEDIATE;
         }
         if (context.ASYNC() != null) {
             boolean defineStartTime = false;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -31,6 +31,7 @@ import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.RefreshSchemeClause;
+import com.starrocks.sql.ast.SyncRefreshSchemeDesc;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
@@ -103,7 +104,7 @@ public class AlterMaterializedViewTest extends MVTestBase  {
             AlterMaterializedViewStmt alterMvStmt =
                     (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
             RefreshSchemeClause refreshSchemeClause = (RefreshSchemeClause) alterMvStmt.getAlterTableClause();
-            Assertions.assertEquals(refreshSchemeClause.getType(), MaterializedView.RefreshType.SYNC);
+            Assertions.assertInstanceOf(SyncRefreshSchemeDesc.class, refreshSchemeClause);
         });
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -114,7 +114,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
         Assertions.assertEquals(null, mv.getTableProperty());
 
         MaterializedView mv2 = new MaterializedView(1000, 100, "mv2", columns, KeysType.AGG_KEYS,
-                    null, null, null);
+                null, null, null);
         Assertions.assertEquals(100, mv2.getDbId());
         Assertions.assertEquals(Table.TableType.MATERIALIZED_VIEW, mv2.getType());
         Assertions.assertEquals(null, mv2.getTableProperty());
@@ -154,16 +154,16 @@ public class MaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testSchema() {
         MaterializedView mv = new MaterializedView(1000, 100, "mv2", columns, KeysType.AGG_KEYS,
-                    null, null, null);
+                null, null, null);
         mv.setBaseIndexId(1L);
         mv.setIndexMeta(1L, "mv_name", columns, 0,
-                    111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
+                111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
         Assertions.assertEquals(1, mv.getBaseIndexId());
         mv.rebuildFullSchema();
         Assertions.assertEquals("mv_name", mv.getIndexNameById(1L));
         List<Column> indexColumns = Lists.newArrayList(columns.get(0), columns.get(2));
         mv.setIndexMeta(2L, "index_name", indexColumns, 0,
-                    222, (short) 1, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
+                222, (short) 1, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
         mv.rebuildFullSchema();
         Assertions.assertEquals("index_name", mv.getIndexNameById(2L));
     }
@@ -180,9 +180,9 @@ public class MaterializedViewTest extends StarRocksTestBase {
         MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
 
         MaterializedView mv = new MaterializedView(1000, 100, "mv_name", columns, KeysType.AGG_KEYS,
-                    partitionInfo, distributionInfo, refreshScheme);
+                partitionInfo, distributionInfo, refreshScheme);
         mv.setIndexMeta(1L, "mv_name", columns, 0,
-                    111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
+                111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
         Assertions.assertEquals("mv_name", mv.getName());
         mv.setName("new_name");
         Assertions.assertEquals("new_name", mv.getName());
@@ -207,9 +207,9 @@ public class MaterializedViewTest extends StarRocksTestBase {
         rangePartitionInfo.setTabletType(1, TTabletType.TABLET_TYPE_DISK);
 
         MaterializedView mv2 = new MaterializedView(1000, 100, "mv_name_2", columns, KeysType.AGG_KEYS,
-                    rangePartitionInfo, distributionInfo, refreshScheme);
+                rangePartitionInfo, distributionInfo, refreshScheme);
         mv2.setIndexMeta(1L, "mv_name_2", columns, 0,
-                    111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
+                111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
         Assertions.assertEquals("mv_name_2", mv2.getName());
         mv2.setName("new_name_2");
         Assertions.assertEquals("new_name_2", mv2.getName());
@@ -237,16 +237,16 @@ public class MaterializedViewTest extends StarRocksTestBase {
         MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
 
         MaterializedView mv = new MaterializedView(1000, 100, "mv_name", columns, KeysType.AGG_KEYS,
-                    partitionInfo, distributionInfo, refreshScheme);
+                partitionInfo, distributionInfo, refreshScheme);
         mv.setIndexMeta(1L, "mv_name", columns, 0,
-                    111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
+                111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
         DistributionInfo distributionInfo1 = mv.getDefaultDistributionInfo();
         Assertions.assertTrue(distributionInfo1 instanceof RandomDistributionInfo);
         Assertions.assertEquals(0, mv.getDistributionColumnNames().size());
 
         HashDistributionInfo hashDistributionInfo = new HashDistributionInfo(10, Lists.newArrayList(columns.get(0)));
         MaterializedView mv2 = new MaterializedView(1000, 100, "mv_name", columns, KeysType.AGG_KEYS,
-                    partitionInfo, hashDistributionInfo, refreshScheme);
+                partitionInfo, hashDistributionInfo, refreshScheme);
         DistributionInfo distributionInfo2 = mv2.getDefaultDistributionInfo();
         Assertions.assertTrue(distributionInfo2 instanceof HashDistributionInfo);
         Assertions.assertEquals(1, mv2.getDistributionColumnNames().size());
@@ -263,9 +263,9 @@ public class MaterializedViewTest extends StarRocksTestBase {
         MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
 
         MaterializedView mv = new MaterializedView(1000, 100, "mv_name", columns, KeysType.AGG_KEYS,
-                    partitionInfo, distributionInfo, refreshScheme);
+                partitionInfo, distributionInfo, refreshScheme);
         mv.setIndexMeta(1L, "mv_name", columns, 0,
-                    111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
+                111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
         TTableDescriptor tableDescriptor = mv.toThrift(null);
         Assertions.assertEquals(TTableType.MATERIALIZED_VIEW, tableDescriptor.getTableType());
         Assertions.assertEquals(1000, tableDescriptor.getId());
@@ -275,29 +275,29 @@ public class MaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testRenameMaterializedView() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE test.tbl1\n" +
-                                "(\n" +
-                                "    k1 date,\n" +
-                                "    k2 int,\n" +
-                                "    v1 int sum\n" +
-                                ")\n" +
-                                "PARTITION BY RANGE(k1)\n" +
-                                "(\n" +
-                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                                "PROPERTIES('replication_num' = '1');")
-                    .withMaterializedView("create materialized view mv_to_rename\n" +
-                                "PARTITION BY k1\n" +
-                                "distributed by hash(k2) buckets 3\n" +
-                                "refresh async\n" +
-                                "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;")
-                    .withMaterializedView("create materialized view mv_to_rename2\n" +
-                                "PARTITION BY date_trunc('month', k1)\n" +
-                                "distributed by hash(k2) buckets 3\n" +
-                                "refresh async\n" +
-                                "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;");
+                .withTable("CREATE TABLE test.tbl1\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withMaterializedView("create materialized view mv_to_rename\n" +
+                        "PARTITION BY k1\n" +
+                        "distributed by hash(k2) buckets 3\n" +
+                        "refresh async\n" +
+                        "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;")
+                .withMaterializedView("create materialized view mv_to_rename2\n" +
+                        "PARTITION BY date_trunc('month', k1)\n" +
+                        "distributed by hash(k2) buckets 3\n" +
+                        "refresh async\n" +
+                        "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;");
 
         Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
         Assertions.assertNotNull(db);
@@ -326,7 +326,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
         stmtExecutor.execute();
         Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(testDb.getFullName(), "mv_new_name"));
+                .getTable(testDb.getFullName(), "mv_new_name"));
         Assertions.assertNotNull(mv);
         Assertions.assertEquals("mv_new_name", mv.getName());
         ExpressionRangePartitionInfo partitionInfo = (ExpressionRangePartitionInfo) mv.getPartitionInfo();
@@ -342,7 +342,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
         StmtExecutor stmtExecutor2 = new StmtExecutor(connectContext, statement);
         stmtExecutor2.execute();
         MaterializedView mv2 = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(testDb.getFullName(), "mv_new_name2"));
+                .getTable(testDb.getFullName(), "mv_new_name2"));
         Assertions.assertNotNull(mv2);
         Assertions.assertEquals("mv_new_name2", mv2.getName());
         ExpressionRangePartitionInfo partitionInfo2 = (ExpressionRangePartitionInfo) mv2.getPartitionInfo();
@@ -359,24 +359,24 @@ public class MaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testReplay() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE test.tbl1\n" +
-                                "(\n" +
-                                "    k1 date,\n" +
-                                "    k2 int,\n" +
-                                "    v1 int sum\n" +
-                                ")\n" +
-                                "PARTITION BY RANGE(k1)\n" +
-                                "(\n" +
-                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                                "PROPERTIES('replication_num' = '1');")
-                    .withMaterializedView("create materialized view mv_replay\n" +
-                                "PARTITION BY k1\n" +
-                                "distributed by hash(k2) buckets 3\n" +
-                                "refresh async\n" +
-                                "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;");
+                .withTable("CREATE TABLE test.tbl1\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withMaterializedView("create materialized view mv_replay\n" +
+                        "PARTITION BY k1\n" +
+                        "distributed by hash(k2) buckets 3\n" +
+                        "refresh async\n" +
+                        "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;");
         connectContext.executeSql("insert into test.tbl1 values('2022-02-01', 2, 3)");
         connectContext.executeSql("insert into test.tbl1 values('2022-02-16', 3, 5)");
         connectContext.executeSql("refresh materialized view mv_replay with sync mode");
@@ -386,7 +386,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv_replay");
         MaterializedView mv = (MaterializedView) table;
         AlterMaterializedViewBaseTableInfosLog log = new AlterMaterializedViewBaseTableInfosLog(db.getId(), mv.getId(), null,
-                    mv.getBaseTableInfos(), mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap());
+                mv.getBaseTableInfos(), mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap());
         mv.replayAlterMaterializedViewBaseTableInfos(log);
 
         starRocksAssert.dropMaterializedView("mv_replay");
@@ -395,26 +395,26 @@ public class MaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testMvAfterDropBaseTable() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE test.tbl_drop\n" +
-                                "(\n" +
-                                "    k1 date,\n" +
-                                "    k2 int,\n" +
-                                "    v1 int sum\n" +
-                                ")\n" +
-                                "PARTITION BY RANGE(k1)\n" +
-                                "(\n" +
-                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                                "PROPERTIES('replication_num' = '1');")
-                    .withMaterializedView("create materialized view mv_to_check\n" +
-                                "distributed by hash(k2) buckets 3\n" +
-                                "refresh async\n" +
-                                "as select k2, sum(v1) as total from tbl_drop group by k2;");
+                .withTable("CREATE TABLE test.tbl_drop\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withMaterializedView("create materialized view mv_to_check\n" +
+                        "distributed by hash(k2) buckets 3\n" +
+                        "refresh async\n" +
+                        "as select k2, sum(v1) as total from tbl_drop group by k2;");
         Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(testDb.getFullName(), "mv_to_check"));
+                .getTable(testDb.getFullName(), "mv_to_check"));
         String dropSql = "drop table tbl_drop;";
         StatementBase statement = SqlParser.parseSingleStatement(dropSql, connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statement);
@@ -426,30 +426,30 @@ public class MaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testMvAfterBaseTableRename() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE test.tbl_to_rename\n" +
-                                "(\n" +
-                                "    k1 date,\n" +
-                                "    k2 int,\n" +
-                                "    v1 int sum\n" +
-                                ")\n" +
-                                "PARTITION BY RANGE(k1)\n" +
-                                "(\n" +
-                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                                "PROPERTIES('replication_num' = '1');")
-                    .withMaterializedView("create materialized view mv_to_check\n" +
-                                "distributed by hash(k2) buckets 3\n" +
-                                "refresh async\n" +
-                                "as select k2, sum(v1) as total from tbl_to_rename group by k2;");
+                .withTable("CREATE TABLE test.tbl_to_rename\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withMaterializedView("create materialized view mv_to_check\n" +
+                        "distributed by hash(k2) buckets 3\n" +
+                        "refresh async\n" +
+                        "as select k2, sum(v1) as total from tbl_to_rename group by k2;");
         Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         String alterSql = "alter table tbl_to_rename rename new_tbl_name;";
         StatementBase statement = SqlParser.parseSingleStatement(alterSql, connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statement);
         stmtExecutor.execute();
         MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(testDb.getFullName(), "mv_to_check"));
+                .getTable(testDb.getFullName(), "mv_to_check"));
         Assertions.assertNotNull(mv);
         Assertions.assertFalse(mv.isActive());
     }
@@ -457,28 +457,28 @@ public class MaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testMaterializedViewWithHint() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE test.tbl1\n" +
-                                "(\n" +
-                                "    k1 date,\n" +
-                                "    k2 int,\n" +
-                                "    v1 int sum\n" +
-                                ")\n" +
-                                "PARTITION BY RANGE(k1)\n" +
-                                "(\n" +
-                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                                "PROPERTIES('replication_num' = '1');")
-                    .withMaterializedView("create materialized view mv_with_hint\n" +
-                                "PARTITION BY k1\n" +
-                                "distributed by hash(k2) buckets 3\n" +
-                                "refresh async\n" +
-                                "as select /*+ SET_VAR(query_timeout = 500) */ k1, k2, sum(v1) " +
-                                "as total from tbl1 group by k1, k2;");
+                .withTable("CREATE TABLE test.tbl1\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withMaterializedView("create materialized view mv_with_hint\n" +
+                        "PARTITION BY k1\n" +
+                        "distributed by hash(k2) buckets 3\n" +
+                        "refresh async\n" +
+                        "as select /*+ SET_VAR(query_timeout = 500) */ k1, k2, sum(v1) " +
+                        "as total from tbl1 group by k1, k2;");
         Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(testDb.getFullName(), "mv_with_hint"));
+                .getTable(testDb.getFullName(), "mv_with_hint"));
         String mvTaskName = "mv-" + mv.getId();
         Task task = connectContext.getGlobalStateMgr().getTaskManager().getTask(mvTaskName);
         Assertions.assertNotNull(task);
@@ -492,24 +492,24 @@ public class MaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testRollupMaterializedViewWithScalarFunction() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE `part_with_mv` (\n" +
-                                "  `p_partkey` int(11) NOT NULL COMMENT \"\",\n" +
-                                "  `p_name` varchar(55) NOT NULL COMMENT \"\",\n" +
-                                "  `p_mfgr` varchar(25) NOT NULL COMMENT \"\",\n" +
-                                "  `p_brand` varchar(10) NOT NULL COMMENT \"\",\n" +
-                                "  `p_type` varchar(25) NOT NULL COMMENT \"\",\n" +
-                                "  `p_size` int(11) NOT NULL COMMENT \"\",\n" +
-                                "  `p_container` varchar(10) NOT NULL COMMENT \"\",\n" +
-                                "  `p_retailprice` decimal64(15, 2) NOT NULL COMMENT \"\",\n" +
-                                "  `p_comment` varchar(23) NOT NULL COMMENT \"\"\n" +
-                                ") ENGINE=OLAP\n" +
-                                "DUPLICATE KEY(`p_partkey`)\n" +
-                                "COMMENT \"OLAP\"\n" +
-                                "DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24\n" +
-                                "PROPERTIES (\n" +
-                                "\"replication_num\" = \"1\");");
+                .withTable("CREATE TABLE `part_with_mv` (\n" +
+                        "  `p_partkey` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `p_name` varchar(55) NOT NULL COMMENT \"\",\n" +
+                        "  `p_mfgr` varchar(25) NOT NULL COMMENT \"\",\n" +
+                        "  `p_brand` varchar(10) NOT NULL COMMENT \"\",\n" +
+                        "  `p_type` varchar(25) NOT NULL COMMENT \"\",\n" +
+                        "  `p_size` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `p_container` varchar(10) NOT NULL COMMENT \"\",\n" +
+                        "  `p_retailprice` decimal64(15, 2) NOT NULL COMMENT \"\",\n" +
+                        "  `p_comment` varchar(23) NOT NULL COMMENT \"\"\n" +
+                        ") ENGINE=OLAP\n" +
+                        "DUPLICATE KEY(`p_partkey`)\n" +
+                        "COMMENT \"OLAP\"\n" +
+                        "DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\");");
         String createMvSql = "create materialized view mv1 as select p_partkey, p_name, length(p_brand) as v1 " +
-                    "from part_with_mv;";
+                "from part_with_mv;";
         StatementBase statement = SqlParser.parseSingleStatement(createMvSql, connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statement);
         stmtExecutor.execute();
@@ -544,34 +544,34 @@ public class MaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testCreateMaterializedViewWithInactiveMaterializedView() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE base_table\n" +
-                                "(\n" +
-                                "    k1 date,\n" +
-                                "    k2 int,\n" +
-                                "    v1 int sum\n" +
-                                ")\n" +
-                                "PARTITION BY RANGE(k1)\n" +
-                                "(\n" +
-                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                                "PROPERTIES('replication_num' = '1');")
-                    .withMaterializedView("CREATE MATERIALIZED VIEW base_mv\n" +
-                                "PARTITION BY k1\n" +
-                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                                "REFRESH manual\n" +
-                                "as select k1,k2,v1 from base_table;");
+                .withTable("CREATE TABLE base_table\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withMaterializedView("CREATE MATERIALIZED VIEW base_mv\n" +
+                        "PARTITION BY k1\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "REFRESH manual\n" +
+                        "as select k1,k2,v1 from base_table;");
         Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         MaterializedView baseMv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(testDb.getFullName(), "base_mv"));
+                .getTable(testDb.getFullName(), "base_mv"));
         baseMv.setInactiveAndReason("");
 
         SinglePartitionInfo singlePartitionInfo = new SinglePartitionInfo();
         MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
         HashDistributionInfo hashDistributionInfo = new HashDistributionInfo(3, Lists.newArrayList(columns.get(0)));
         MaterializedView mv = new MaterializedView(1000, testDb.getId(), "mv", columns, KeysType.AGG_KEYS,
-                    singlePartitionInfo, hashDistributionInfo, refreshScheme);
+                singlePartitionInfo, hashDistributionInfo, refreshScheme);
         List<BaseTableInfo> baseTableInfos = Lists.newArrayList();
         BaseTableInfo baseTableInfo = new BaseTableInfo(testDb.getId(), testDb.getFullName(), baseMv.getName(), baseMv.getId());
         baseTableInfos.add(baseTableInfo);
@@ -592,7 +592,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
     public void testShouldRefreshBy() {
         MaterializedView mv = new MaterializedView();
         MaterializedView.MvRefreshScheme mvRefreshScheme = new MaterializedView.MvRefreshScheme();
-        mvRefreshScheme.setType(MaterializedView.RefreshType.ASYNC);
+        mvRefreshScheme.setType(MaterializedViewRefreshType.ASYNC);
         mv.setRefreshScheme(mvRefreshScheme);
         boolean shouldRefresh = mv.shouldTriggeredRefreshBy(null, null);
         Assertions.assertTrue(shouldRefresh);
@@ -604,22 +604,22 @@ public class MaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testShowSyncMV() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE test.tbl_sync_mv\n" +
-                                "(\n" +
-                                "    k1 date,\n" +
-                                "    k2 int,\n" +
-                                "    v1 int sum\n" +
-                                ")\n" +
-                                "PARTITION BY RANGE(k1)\n" +
-                                "(\n" +
-                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                                "PROPERTIES('replication_num' = '1');")
-                    .withMaterializedView("create materialized view sync_mv_to_check\n" +
-                                "distributed by hash(k2) buckets 3\n" +
-                                "as select k2, sum(v1) as total from tbl_sync_mv group by k2;");
+                .withTable("CREATE TABLE test.tbl_sync_mv\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withMaterializedView("create materialized view sync_mv_to_check\n" +
+                        "distributed by hash(k2) buckets 3\n" +
+                        "as select k2, sum(v1) as total from tbl_sync_mv group by k2;");
         String showSql = "show create materialized view sync_mv_to_check;";
         StatementBase statement = SqlParser.parseSingleStatement(showSql, connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statement);
@@ -669,7 +669,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
 
         String showCreateSql = "show create materialized view test.index_mv_to_check;";
         ShowCreateTableStmt showCreateTableStmt =
-                    (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateSql, connectContext);
+                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateSql, connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
         System.out.println(showResultSet.getMetaData().toString());
         System.out.println(showResultSet.getResultRows());
@@ -678,47 +678,47 @@ public class MaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testAlterViewWithIndex() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE test.table1\n" +
-                                "(\n" +
-                                "    k1 date,\n" +
-                                "    k2 int,\n" +
-                                "    v1 int sum\n" +
-                                ")\n" +
-                                "PARTITION BY RANGE(k1)\n" +
-                                "(\n" +
-                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                                "PROPERTIES('replication_num' = '1');")
-                    .withView("create view index_view_to_check\n" +
-                                "as select k2, sum(v1) as total from table1 group by k2;");
+                .withTable("CREATE TABLE test.table1\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withView("create view index_view_to_check\n" +
+                        "as select k2, sum(v1) as total from table1 group by k2;");
         String bitmapSql = "create index index1 ON test.index_view_to_check (k2) USING BITMAP COMMENT 'balabala'";
         AlterTableStmt alterViewStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(bitmapSql, connectContext);
         Assertions.assertThrows(SemanticException.class,
-                    () -> DDLStmtExecutor.execute(alterViewStmt, connectContext),
-                    "Do not support alter non-native table/materialized-view[index_view_to_check]");
+                () -> DDLStmtExecutor.execute(alterViewStmt, connectContext),
+                "Do not support alter non-native table/materialized-view[index_view_to_check]");
     }
 
     public void testCreateMV(String mvSql) throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE test.table1\n" +
-                                "(\n" +
-                                "    k1 date,\n" +
-                                "    k2 int,\n" +
-                                "    v1 int sum\n" +
-                                ")\n" +
-                                "PARTITION BY RANGE(k1)\n" +
-                                "(\n" +
-                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                                "PROPERTIES('replication_num' = '1');");
+                .withTable("CREATE TABLE test.table1\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');");
         starRocksAssert.withMaterializedView(mvSql);
         String showCreateSql = "show create materialized view test.index_mv_to_check;";
         ShowCreateTableStmt showCreateTableStmt =
-                    (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateSql, connectContext);
+                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateSql, connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
         System.out.println(showResultSet.getResultRows());
     }
@@ -766,48 +766,48 @@ public class MaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testCreateMVWithIndex() throws Exception {
         String mvSqlWithBitMapAndBloomfilter = "create materialized view index_mv_to_check " +
-                    "(k2 ," +
-                    " total ," +
-                    "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala' " +
-                    ")" +
-                    "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
-                    "REFRESH MANUAL\n" +
-                    "PROPERTIES " +
-                    "("
-                    + "\"replicated_storage\" = \"true\","
-                    + "\"replication_num\" = \"1\","
-                    + "\"storage_medium\" = \"HDD\","
-                    + "\"bloom_filter_columns\" = \"k2\""
-                    + ")" +
-                    "as select k2, sum(v1) as total from table1 group by k2;";
+                "(k2 ," +
+                " total ," +
+                "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala' " +
+                ")" +
+                "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
+                "REFRESH MANUAL\n" +
+                "PROPERTIES " +
+                "("
+                + "\"replicated_storage\" = \"true\","
+                + "\"replication_num\" = \"1\","
+                + "\"storage_medium\" = \"HDD\","
+                + "\"bloom_filter_columns\" = \"k2\""
+                + ")" +
+                "as select k2, sum(v1) as total from table1 group by k2;";
         String mvSqlWithBitMap = "create materialized view index_mv_to_check " +
-                    "(k2 ," +
-                    " total ," +
-                    "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala' " +
-                    ")" +
-                    "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
-                    "REFRESH MANUAL\n" +
-                    "PROPERTIES " +
-                    "("
-                    + "\"replicated_storage\" = \"true\","
-                    + "\"replication_num\" = \"1\","
-                    + "\"storage_medium\" = \"HDD\""
-                    + ")" +
-                    "as select k2, sum(v1) as total from table1 group by k2;";
+                "(k2 ," +
+                " total ," +
+                "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala' " +
+                ")" +
+                "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
+                "REFRESH MANUAL\n" +
+                "PROPERTIES " +
+                "("
+                + "\"replicated_storage\" = \"true\","
+                + "\"replication_num\" = \"1\","
+                + "\"storage_medium\" = \"HDD\""
+                + ")" +
+                "as select k2, sum(v1) as total from table1 group by k2;";
         String mvSqlWithBloomFilter = "create materialized view index_mv_to_check " +
-                    "(k2 ," +
-                    " total" +
-                    ")" +
-                    "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
-                    "REFRESH MANUAL\n" +
-                    "PROPERTIES " +
-                    "("
-                    + "\"replicated_storage\" = \"true\","
-                    + "\"replication_num\" = \"1\","
-                    + "\"storage_medium\" = \"HDD\","
-                    + "\"bloom_filter_columns\" = \"k2\""
-                    + ")" +
-                    "as select k2, sum(v1) as total from table1 group by k2;";
+                "(k2 ," +
+                " total" +
+                ")" +
+                "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
+                "REFRESH MANUAL\n" +
+                "PROPERTIES " +
+                "("
+                + "\"replicated_storage\" = \"true\","
+                + "\"replication_num\" = \"1\","
+                + "\"storage_medium\" = \"HDD\","
+                + "\"bloom_filter_columns\" = \"k2\""
+                + ")" +
+                "as select k2, sum(v1) as total from table1 group by k2;";
         testCreateMV(mvSqlWithBitMapAndBloomfilter);
         testCreateMV(mvSqlWithBitMap);
         testCreateMV(mvSqlWithBloomFilter);
@@ -816,58 +816,58 @@ public class MaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testCreateMVWithDuplicateIndexOrDuplicateColumn() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE test.table1\n" +
-                                "(\n" +
-                                "    k1 date,\n" +
-                                "    k2 int,\n" +
-                                "    v1 int sum\n" +
-                                ")\n" +
-                                "PARTITION BY RANGE(k1)\n" +
-                                "(\n" +
-                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                                "PROPERTIES('replication_num' = '1');");
+                .withTable("CREATE TABLE test.table1\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');");
         String mvSql = "create materialized view index_mv_to_check " +
-                    "(k2 ," +
-                    " total ," +
-                    "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala', " +
-                    "INDEX index1 (`total`) USING BITMAP COMMENT 'balabala' " +
-                    ")" +
-                    "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
-                    "REFRESH MANUAL\n" +
-                    "PROPERTIES " +
-                    "("
-                    + "\"replicated_storage\" = \"true\","
-                    + "\"replication_num\" = \"1\","
-                    + "\"storage_medium\" = \"HDD\","
-                    + "\"bloom_filter_columns\" = \"k2\""
-                    + ")" +
-                    "as select k2, sum(v1) as total from table1 group by k2;";
+                "(k2 ," +
+                " total ," +
+                "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala', " +
+                "INDEX index1 (`total`) USING BITMAP COMMENT 'balabala' " +
+                ")" +
+                "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
+                "REFRESH MANUAL\n" +
+                "PROPERTIES " +
+                "("
+                + "\"replicated_storage\" = \"true\","
+                + "\"replication_num\" = \"1\","
+                + "\"storage_medium\" = \"HDD\","
+                + "\"bloom_filter_columns\" = \"k2\""
+                + ")" +
+                "as select k2, sum(v1) as total from table1 group by k2;";
         Assertions.assertThrows(StarRocksException.class,
-                    () -> starRocksAssert.withMaterializedView(mvSql),
-                    "Duplicate index name 'index1'");
+                () -> starRocksAssert.withMaterializedView(mvSql),
+                "Duplicate index name 'index1'");
 
         String mvSql2 = "create materialized view index_mv_to_check " +
-                    "(k2 ," +
-                    " total ," +
-                    "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala', " +
-                    "INDEX index2 (`k2`) USING BITMAP COMMENT 'balabala' " +
-                    ")" +
-                    "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
-                    "REFRESH MANUAL\n" +
-                    "PROPERTIES " +
-                    "("
-                    + "\"replicated_storage\" = \"true\","
-                    + "\"replication_num\" = \"1\","
-                    + "\"storage_medium\" = \"HDD\","
-                    + "\"bloom_filter_columns\" = \"k2\""
-                    + ")" +
-                    "as select k2, sum(v1) as total from table1 group by k2;";
+                "(k2 ," +
+                " total ," +
+                "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala', " +
+                "INDEX index2 (`k2`) USING BITMAP COMMENT 'balabala' " +
+                ")" +
+                "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
+                "REFRESH MANUAL\n" +
+                "PROPERTIES " +
+                "("
+                + "\"replicated_storage\" = \"true\","
+                + "\"replication_num\" = \"1\","
+                + "\"storage_medium\" = \"HDD\","
+                + "\"bloom_filter_columns\" = \"k2\""
+                + ")" +
+                "as select k2, sum(v1) as total from table1 group by k2;";
         Assertions.assertThrows(StarRocksException.class,
-                    () -> starRocksAssert.withMaterializedView(mvSql2),
-                    "Duplicate column name 'k2' in index");
+                () -> starRocksAssert.withMaterializedView(mvSql2),
+                "Duplicate column name 'k2' in index");
     }
 
     @Test
@@ -880,7 +880,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
         Assertions.assertEquals(100, basePartitionInfo.getExtLastFileModifiedTime());
         Assertions.assertEquals(10, basePartitionInfo.getFileNumber());
         Assertions.assertTrue(basePartitionInfo.toString().contains(
-                    "BasePartitionInfo{id=-1, version=-1, lastRefreshTime=123456, lastFileModifiedTime=100, fileNumber=10}"));
+                "BasePartitionInfo{id=-1, version=-1, lastRefreshTime=123456, lastFileModifiedTime=100, fileNumber=10}"));
     }
 
     @Test
@@ -1091,7 +1091,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
         List<Table> baseTables = baseMv.getBaseTables();
         Assertions.assertEquals(1, baseTables.size());
         Assertions.assertEquals(baseTable.getId(), baseTables.get(0).getId());
-        List<Table.TableType>  baseTableTypes = baseMv.getBaseTableTypes();
+        List<Table.TableType> baseTableTypes = baseMv.getBaseTableTypes();
         Assertions.assertEquals(1, baseTableTypes.size());
         Assertions.assertEquals(Table.TableType.OLAP, baseTableTypes.get(0));
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
@@ -34,7 +34,7 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MaterializedView.MvRefreshScheme;
-import com.starrocks.catalog.MaterializedView.RefreshType;
+import com.starrocks.catalog.MaterializedViewRefreshType;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
@@ -97,17 +97,17 @@ public class LakeMaterializedViewTest {
         starRocksAssert.withDatabase(DB).useDatabase(DB);
 
         starRocksAssert.withTable("CREATE TABLE base_table\n" +
-                    "(\n" +
-                    "    k1 date,\n" +
-                    "    k2 int,\n" +
-                    "    k3 int\n" +
-                    ")\n" +
-                    "PARTITION BY RANGE(k1)\n" +
-                    "(\n" +
-                    "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                    "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                    ")\n" +
-                    "DISTRIBUTED BY HASH(k2) BUCKETS 3");
+                "(\n" +
+                "    k1 date,\n" +
+                "    k2 int,\n" +
+                "    k3 int\n" +
+                ")\n" +
+                "PARTITION BY RANGE(k1)\n" +
+                "(\n" +
+                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3");
     }
 
     @AfterAll
@@ -157,11 +157,11 @@ public class LakeMaterializedViewTest {
 
         // refresh scheme
         MvRefreshScheme mvRefreshScheme = new MvRefreshScheme();
-        mvRefreshScheme.setType(RefreshType.SYNC);
+        mvRefreshScheme.setType(MaterializedViewRefreshType.SYNC);
 
         // Lake mv
         LakeMaterializedView mv = new LakeMaterializedView(mvId, dbId, "mv1", columns, KeysType.AGG_KEYS,
-                    partitionInfo, distributionInfo, mvRefreshScheme);
+                partitionInfo, distributionInfo, mvRefreshScheme);
         Deencapsulation.setField(mv, "baseIndexId", indexId);
         mv.addPartition(partition);
         mv.setIndexMeta(indexId, "mv1", columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.AGG_KEYS);
@@ -206,24 +206,25 @@ public class LakeMaterializedViewTest {
     @Test
     public void testCreateMaterializedView() throws Exception {
         starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                    "distributed by hash(k2) buckets 3\n" +
-                    "PROPERTIES(\n" +
-                    "   'datacache.enable' = 'true',\n" +
-                    "   'enable_async_write_back' = 'false',\n" +
-                    "   'datacache.partition_duration' = '6 day'\n" +
-                    ")\n" +
-                    "refresh async\n" +
-                    "as select k2, sum(k3) as total from base_table group by k2;");
+                "distributed by hash(k2) buckets 3\n" +
+                "PROPERTIES(\n" +
+                "   'datacache.enable' = 'true',\n" +
+                "   'enable_async_write_back' = 'false',\n" +
+                "   'datacache.partition_duration' = '6 day'\n" +
+                ")\n" +
+                "refresh async\n" +
+                "as select k2, sum(k3) as total from base_table group by k2;");
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
         MaterializedView mv =
-                    (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv1");
+                (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv1");
         Assertions.assertTrue(mv.isCloudNativeMaterializedView());
         Assertions.assertTrue(mv.isActive());
 
         LakeMaterializedView lakeMv = (LakeMaterializedView) mv;
         // same as PseudoStarOSAgent.allocateFilePath
-        Assertions.assertTrue(lakeMv.getDefaultFilePathInfo().getFullPath().startsWith("s3://dummy_unittest_bucket/dummy_sub_path"));
+        Assertions.assertTrue(lakeMv.getDefaultFilePathInfo().getFullPath().startsWith("s3://dummy_unittest_bucket" +
+                "/dummy_sub_path"));
         // check table default cache info
         FileCacheInfo cacheInfo = lakeMv.getPartitionFileCacheInfo(0L);
         Assertions.assertTrue(cacheInfo.getEnableCache());
@@ -254,19 +255,19 @@ public class LakeMaterializedViewTest {
     @Test
     public void testInactiveMaterializedView() throws Exception {
         starRocksAssert.withTable("create table base_table2\n" +
-                    "(\n" +
-                    "    k4 date,\n" +
-                    "    k5 int\n" +
-                    ")\n" +
-                    "DISTRIBUTED BY HASH(k4) BUCKETS 3");
+                "(\n" +
+                "    k4 date,\n" +
+                "    k5 int\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(k4) BUCKETS 3");
         starRocksAssert.withMaterializedView("create materialized view mv2\n" +
-                    "distributed by hash(k2) buckets 3\n" +
-                    "refresh async\n" +
-                    "as select k1, k2, sum(k3) as total from base_table, base_table2 where k1 = k4 group by k1, k2;");
+                "distributed by hash(k2) buckets 3\n" +
+                "refresh async\n" +
+                "as select k1, k2, sum(k3) as total from base_table, base_table2 where k1 = k4 group by k1, k2;");
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
         MaterializedView mv =
-                    (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv2");
+                (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv2");
         Assertions.assertTrue(mv.isCloudNativeMaterializedView());
         Assertions.assertTrue(mv.isActive());
 
@@ -282,14 +283,14 @@ public class LakeMaterializedViewTest {
     @Test
     public void testAlterAsyncMaterializedViewInterval() throws Exception {
         starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv3\n" +
-                    "PARTITION BY k1\n" +
-                    "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                    "REFRESH async START('2122-12-31 20:45:11') EVERY(INTERVAL 1 DAY)\n" +
-                    "as select k1,k2 from base_table;");
+                "PARTITION BY k1\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                "REFRESH async START('2122-12-31 20:45:11') EVERY(INTERVAL 1 DAY)\n" +
+                "as select k1,k2 from base_table;");
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
         MaterializedView mv =
-                    (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv3");
+                (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv3");
         Assertions.assertTrue(mv.isCloudNativeMaterializedView());
 
         MaterializedView.AsyncRefreshContext asyncRefreshContext = mv.getRefreshScheme().getAsyncRefreshContext();
@@ -313,19 +314,19 @@ public class LakeMaterializedViewTest {
     public void testModifyRelatedColumnWithMaterializedView() {
         try {
             starRocksAssert.withTable("create table base_table4\n" +
-                        "(\n" +
-                        "    k4 date,\n" +
-                        "    k5 int\n" +
-                        ")\n" +
-                        "duplicate key(k4) distributed by hash(k4) buckets 3;");
+                    "(\n" +
+                    "    k4 date,\n" +
+                    "    k5 int\n" +
+                    ")\n" +
+                    "duplicate key(k4) distributed by hash(k4) buckets 3;");
             starRocksAssert.withMaterializedView("create materialized view mv4\n" +
-                        "distributed by hash(k1) buckets 3\n" +
-                        "refresh async\n" +
-                        "as select k1, k5, sum(k3) as total from base_table, base_table4 where k1 = k4 group by k1, k5;");
+                    "distributed by hash(k1) buckets 3\n" +
+                    "refresh async\n" +
+                    "as select k1, k5, sum(k3) as total from base_table, base_table4 where k1 = k4 group by k1, k5;");
 
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
             MaterializedView mv =
-                        (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv4");
+                    (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv4");
             Assertions.assertTrue(mv.isCloudNativeMaterializedView());
             Assertions.assertTrue(mv.isActive());
 
@@ -353,19 +354,19 @@ public class LakeMaterializedViewTest {
     public void testNonPartitionMvEnableFillDataCache() {
         try {
             starRocksAssert.withTable("create table base_table5\n" +
-                        "(\n" +
-                        "    k4 date,\n" +
-                        "    k5 int\n" +
-                        ")\n" +
-                        "duplicate key(k4) distributed by hash(k4) buckets 3;");
+                    "(\n" +
+                    "    k4 date,\n" +
+                    "    k5 int\n" +
+                    ")\n" +
+                    "duplicate key(k4) distributed by hash(k4) buckets 3;");
             starRocksAssert.withMaterializedView("create materialized view mv5\n" +
-                        "distributed by hash(k1) buckets 3\n" +
-                        "refresh async\n" +
-                        "as select k1, k5, sum(k3) as total from base_table, base_table5 where k1 = k4 group by k1, k5;");
+                    "distributed by hash(k1) buckets 3\n" +
+                    "refresh async\n" +
+                    "as select k1, k5, sum(k3) as total from base_table, base_table5 where k1 = k4 group by k1, k5;");
 
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
             MaterializedView mv =
-                        (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv5");
+                    (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv5");
             Assertions.assertTrue(mv.isCloudNativeMaterializedView());
 
             Partition p = mv.getPartition("mv5");
@@ -430,7 +431,7 @@ public class LakeMaterializedViewTest {
         LocalDate lower1 = upper1.minus(duration);
         Range<PartitionKey> range1 = Range.closedOpen(PartitionKey.ofDate(lower1), PartitionKey.ofDate(upper1));
         partitionInfo.addPartition(partition1Id, false, range1, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, false,
-                    new DataCacheInfo(true, false));
+                new DataCacheInfo(true, false));
 
         // partition2
         MaterializedIndex index2 = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
@@ -443,15 +444,15 @@ public class LakeMaterializedViewTest {
         LocalDate lower2 = upper2.minus(duration);
         Range<PartitionKey> range2 = Range.closedOpen(PartitionKey.ofDate(lower2), PartitionKey.ofDate(upper2));
         partitionInfo.addPartition(partition2Id, false, range2, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, false,
-                    new DataCacheInfo(true, false));
+                new DataCacheInfo(true, false));
 
         // refresh scheme
         MvRefreshScheme mvRefreshScheme = new MvRefreshScheme();
-        mvRefreshScheme.setType(RefreshType.SYNC);
+        mvRefreshScheme.setType(MaterializedViewRefreshType.SYNC);
 
         // Lake mv
         LakeMaterializedView mv = new LakeMaterializedView(mvId, dbId, "mv1", columns, KeysType.AGG_KEYS,
-                    partitionInfo, distributionInfo, mvRefreshScheme);
+                partitionInfo, distributionInfo, mvRefreshScheme);
         Deencapsulation.setField(mv, "baseIndexId", indexId);
         mv.addPartition(partition1);
         mv.addPartition(partition2);


### PR DESCRIPTION
## Why I'm doing:
These changes modernize the refresh type handling for materialized views, making the codebase more modular and easier to extend in the future.
## What I'm doing:
This pull request refactors how materialized view refresh types are represented and used throughout the codebase. The main change is the introduction of a new enum, `MaterializedViewRefreshType`, which replaces the previous `RefreshType` enum that was nested within the `MaterializedView` class. This update improves code clarity and maintainability by centralizing refresh type logic and updating all relevant usages.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
