### PR TITLE
[Enhancement]support config bucket assign mode for bucket-aware execution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/BucketAwareBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/BucketAwareBackendSelector.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,17 +47,19 @@ public class BucketAwareBackendSelector implements BackendSelector {
     private final WorkerProvider workerProvider;
     private final boolean isRightOrFullBucketShuffleFragment;
     private final boolean useIncrementalScanRanges;
+    private final String assignMode;
 
     public BucketAwareBackendSelector(ScanNode scanNode, List<TScanRangeLocations> locations,
                                       ColocatedBackendSelector.Assignment colocatedAssignment,
                                       WorkerProvider workerProvider, boolean isRightOrFullBucketShuffleFragment,
-                                      boolean useIncrementalScanRanges) {
+                                      boolean useIncrementalScanRanges, String assignMode) {
         this.scanNode = scanNode;
         this.locations = locations;
         this.colocatedAssignment = colocatedAssignment;
         this.workerProvider = workerProvider;
         this.isRightOrFullBucketShuffleFragment = isRightOrFullBucketShuffleFragment;
         this.useIncrementalScanRanges = useIncrementalScanRanges;
+        this.assignMode = assignMode;
     }
 
     static class BucketIdFunnel implements Funnel<Integer> {
@@ -66,23 +69,39 @@ public class BucketAwareBackendSelector implements BackendSelector {
         }
     }
 
+    private Map<Integer, Long> assignBucketToWorker() throws StarRocksException {
+        Map<Integer, Long> bucketSeqToWorkerId = new HashMap<>();
+
+        if (assignMode.equals(SessionVariableConstants.ELASTIC)) {
+            // use consistent hashing to schedule remote scan ranges
+            HashRing<Integer, ComputeNode> hashRing = new RendezvousHashRing<>(Hashing.murmur3_128(), new BucketIdFunnel(),
+                    new HDFSBackendSelector.ComputeNodeFunnel(), workerProvider.getAllWorkers());
+            // mapping bucket seq to worker id
+            for (int i = 0; i < colocatedAssignment.getBucketNum(); i++) {
+                List<ComputeNode> backends = hashRing.get(i, 1);
+                if (backends.isEmpty()) {
+                    throw new StarRocksException("Failed to find backend to execute");
+                }
+                bucketSeqToWorkerId.put(i, backends.get(0).getId());
+            }
+        } else {
+            List<ComputeNode> workers = workerProvider.getAllWorkers().stream()
+                    .sorted(Comparator.comparingLong(ComputeNode::getId)).toList();
+            if (workers.isEmpty()) {
+                throw new StarRocksException("Failed to find backend to execute");
+            }
+            for (int i = 0; i < colocatedAssignment.getBucketNum(); i++) {
+                bucketSeqToWorkerId.put(i, workers.get(i % workers.size()).getId());
+            }
+        }
+
+        return bucketSeqToWorkerId;
+    }
+
     @Override
     public void computeScanRangeAssignment() throws StarRocksException {
         colocatedAssignment.recordAssignedScanNode(scanNode);
-
-        // use consistent hashing to schedule remote scan ranges
-        HashRing<Integer, ComputeNode> hashRing = new RendezvousHashRing<>(Hashing.murmur3_128(), new BucketIdFunnel(),
-                        new HDFSBackendSelector.ComputeNodeFunnel(), workerProvider.getAllWorkers());
-
-        Map<Integer, Long> bucketSeqToWorkerId = new HashMap<>();
-        // mapping bucket seq to worker id
-        for (int i = 0; i < colocatedAssignment.getBucketNum(); i++) {
-            List<ComputeNode> backends = hashRing.get(i, 1);
-            if (backends.isEmpty()) {
-                throw new StarRocksException("Failed to find backend to execute");
-            }
-            bucketSeqToWorkerId.put(i, backends.get(0).getId());
-        }
+        Map<Integer, Long> bucketSeqToWorkerId = assignBucketToWorker();
 
         Map<Integer, List<TScanRangeParams>> bucketToScanRange = new HashMap<>();
         // split scan ranges.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -531,6 +531,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_PER_BUCKET_OPTIMIZE = "enable_per_bucket_optimize";
     public static final String ENABLE_PARTITION_BUCKET_OPTIMIZE = "enable_partition_bucket_optimize";
     public static final String ENABLE_BUCKET_AWARE_EXECUTION_ON_LAKE = "enable_bucket_aware_execution_on_lake";
+    public static final String LAKE_BUCKET_ASSIGN_MODE = "lake_bucket_assign_mode";
     public static final String ENABLE_GROUP_EXECUTION = "enable_group_execution";
     public static final String GROUP_EXECUTION_GROUP_SCALE = "group_execution_group_scale";
     public static final String GROUP_EXECUTION_MAX_GROUPS = "group_execution_max_groups";
@@ -1743,6 +1744,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_BUCKET_AWARE_EXECUTION_ON_LAKE)
     private boolean enableBucketAwareExecutionOnLake = true;
 
+    @VarAttr(name = LAKE_BUCKET_ASSIGN_MODE)
+    private String lakeBucketAssignMode = SessionVariableConstants.BALANCE;
+
     @VarAttr(name = ENABLE_GROUP_EXECUTION)
     private boolean enableGroupExecution = true;
 
@@ -2025,6 +2029,20 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableBucketAwareExecutionOnLake() {
         return enableBucketAwareExecutionOnLake;
+    }
+
+    public String getLakeBucketAssignMode() {
+        return lakeBucketAssignMode;
+    }
+
+    public void setLakeBucketAssignMode(String mode) {
+        if (mode.equalsIgnoreCase(SessionVariableConstants.ELASTIC) ||
+                mode.equalsIgnoreCase(SessionVariableConstants.BALANCE)) {
+            lakeBucketAssignMode = mode.toLowerCase();
+        } else {
+            throw new IllegalArgumentException(
+                    "Legal values of lake_bucket_assign_mode are elastic|balance");
+        }
     }
 
     public void setEnableGroupExecution(boolean enableGroupExecution) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -39,6 +39,8 @@ public class SessionVariableConstants {
     public static final String ALWAYS = "always";
 
     public static final String NEVER = "never";
+    public static final String ELASTIC = "elastic";
+    public static final String BALANCE = "balance";
 
     public enum ChooseInstancesMode {
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/BackendSelectorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/BackendSelectorFactory.java
@@ -69,8 +69,9 @@ public class BackendSelectorFactory {
                 ColocatedBackendSelector.Assignment colocatedAssignment =
                         execFragment.getOrCreateColocatedAssignment(scanNode);
                 boolean isRightOrFullBucketShuffleFragment = execFragment.isRightOrFullBucketShuffle();
+                String mode = connectContext.getSessionVariable().getLakeBucketAssignMode();
                 return new BucketAwareBackendSelector(scanNode, locations, colocatedAssignment,
-                        workerProvider, isRightOrFullBucketShuffleFragment, useIncrementalScanRanges);
+                        workerProvider, isRightOrFullBucketShuffleFragment, useIncrementalScanRanges, mode);
             }
             return new HDFSBackendSelector(scanNode, locations, assignment, workerProvider,
                     sessionVariable.getForceScheduleLocal(),

--- a/fe/fe-core/src/test/java/com/starrocks/qe/BucketAwareBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/BucketAwareBackendSelectorTest.java
@@ -104,7 +104,7 @@ public class BucketAwareBackendSelectorTest {
 
         // Create and test BucketAwareBackendSelector
         BucketAwareBackendSelector selector = new BucketAwareBackendSelector(
-                scanNode, locations, colocatedAssignment, workerProvider, false, false);
+                scanNode, locations, colocatedAssignment, workerProvider, false, false, SessionVariableConstants.BALANCE);
 
         // Execute the method under test
         selector.computeScanRangeAssignment();
@@ -152,7 +152,7 @@ public class BucketAwareBackendSelectorTest {
 
         // Create and test BucketAwareBackendSelector with incremental scan ranges
         BucketAwareBackendSelector selector = new BucketAwareBackendSelector(
-                scanNode, locations, colocatedAssignment, workerProvider, false, true);
+                scanNode, locations, colocatedAssignment, workerProvider, false, true, SessionVariableConstants.BALANCE);
 
         // Execute the method under test
         selector.computeScanRangeAssignment();
@@ -202,7 +202,7 @@ public class BucketAwareBackendSelectorTest {
 
         // Create and test BucketAwareBackendSelector
         BucketAwareBackendSelector selector = new BucketAwareBackendSelector(
-                scanNode, locations, colocatedAssignment, workerProvider, true, false);
+                scanNode, locations, colocatedAssignment, workerProvider, true, false, SessionVariableConstants.ELASTIC);
 
         // Execute the method under test
         selector.computeScanRangeAssignment();
@@ -232,7 +232,7 @@ public class BucketAwareBackendSelectorTest {
 
         // Create BucketAwareBackendSelector
         BucketAwareBackendSelector selector = new BucketAwareBackendSelector(
-                scanNode, locations, colocatedAssignment, workerProvider, false, false);
+                scanNode, locations, colocatedAssignment, workerProvider, false, false, SessionVariableConstants.BALANCE);
 
         // Execute and expect exception
         Assertions.assertThrows(StarRocksException.class, selector::computeScanRangeAssignment);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -64,4 +64,23 @@ public class SessionVariableTest {
                     e.getMessage());
         }
     }
+
+    @Test
+    public void testLakeBucketAssignMode() {
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setLakeBucketAssignMode("balance");
+        Assertions.assertEquals(SessionVariableConstants.BALANCE, sessionVariable.getLakeBucketAssignMode());
+
+        sessionVariable.setLakeBucketAssignMode("elastic");
+        Assertions.assertEquals(SessionVariableConstants.ELASTIC, sessionVariable.getLakeBucketAssignMode());
+
+        try {
+            sessionVariable.setLakeBucketAssignMode("auto");
+            Assertions.fail("cannot set a invalid value");
+        } catch (Exception e) {
+            Assertions.assertTrue(
+                    e.getMessage().contains("Legal values of lake_bucket_assign_mode are elastic|balance"),
+                    e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request introduces a configurable bucket assignment mode for lake table scan scheduling, allowing users to select between "elastic" (consistent hashing) and "balance" (round-robin) strategies. The change adds a new session variable to control this behavior, refactors the backend selector logic to support both modes, and updates related tests to ensure correct functionality.

**Bucket assignment logic enhancements:**

* Refactored `BucketAwareBackendSelector` to support two bucket assignment strategies: "elastic" uses consistent hashing, while "balance" assigns buckets to workers in round-robin order, controlled by the new `assignMode` parameter. [[1]](diffhunk://#diff-d28fe6adf2d3c1089773690f565253342796509122e510d95bdc281869393f3dR50-R62) [[2]](diffhunk://#diff-d28fe6adf2d3c1089773690f565253342796509122e510d95bdc281869393f3dL69-L77) [[3]](diffhunk://#diff-d28fe6adf2d3c1089773690f565253342796509122e510d95bdc281869393f3dR87-R104)
* Added constants for assignment modes (`ELASTIC`, `BALANCE`) in `SessionVariableConstants` for type safety and clarity.

**Session variable improvements:**

* Introduced the `lake_bucket_assign_mode` session variable in `SessionVariable`, with getter/setter methods and validation to restrict values to "elastic" or "balance". [[1]](diffhunk://#diff-727d043183218b8a4cbbc92d0fc2796a9e1637cd2f21219c7c26add24b13972dR534) [[2]](diffhunk://#diff-727d043183218b8a4cbbc92d0fc2796a9e1637cd2f21219c7c26add24b13972dR1747-R1749) [[3]](diffhunk://#diff-727d043183218b8a4cbbc92d0fc2796a9e1637cd2f21219c7c26add24b13972dR2034-R2047)
* Updated `BackendSelectorFactory` to pass the assignment mode from session variables to the backend selector.

**Testing and validation:**

* Enhanced unit tests for `BucketAwareBackendSelector` and `SessionVariable` to validate both assignment modes and error handling for invalid values. [[1]](diffhunk://#diff-3d757357c939c029749034f8357057703dd624038d4f9f73a6c6fbde762c06acL107-R107) [[2]](diffhunk://#diff-3d757357c939c029749034f8357057703dd624038d4f9f73a6c6fbde762c06acL155-R155) [[3]](diffhunk://#diff-3d757357c939c029749034f8357057703dd624038d4f9f73a6c6fbde762c06acL205-R205) [[4]](diffhunk://#diff-3d757357c939c029749034f8357057703dd624038d4f9f73a6c6fbde762c06acL235-R235) [[5]](diffhunk://#diff-e0222424920f768ef9a570d0527747c2b3566fb62d4a2481fcc86d9e8090b8d5R67-R85)
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
