### PR TITLE
forward SIGTERM in be_entrypoint.sh

### DIFF
--- a/docker/dockerfiles/be/be_entrypoint.sh
+++ b/docker/dockerfiles/be/be_entrypoint.sh
@@ -127,7 +127,12 @@ if [[ "x$LOG_CONSOLE" == "x1" ]] ; then
 fi
 
 while true; do
-  $STARROCKS_HOME/bin/start_be.sh $addition_args
+  $STARROCKS_HOME/bin/start_be.sh $addition_args &
+  be_process_pid=$!
+  # forward SIGTERM to be process_pid explicitly 
+  trap "kill -TERM $be_process_pid 2>/dev/null" TERM
+  wait $be_process_pid
+  
   ret=$?
   if [[ $ret -ne 0 && "x$LOG_CONSOLE" != "x1" ]] ; then
       nol=50


### PR DESCRIPTION
^ 

Currently SIGTERM is swallowed by `be_entrypoint.sh`, as a result a BE pod is always terminated forcefully, see the strace as below:

```
root@xxx-be-0:~# strace -e trace=signal -p  7 
strace: Process 7 attached
--- SIGTERM {si_signo=SIGTERM, si_code=SI_USER, si_pid=62784, si_uid=1000} ---
+++ killed by SIGTERM +++
```

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
