### PR TITLE
[BugFix] Fix FE restart problem when enable query queue v2

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotManager.java
@@ -35,7 +35,7 @@ public class SlotManager extends BaseSlotManager {
 
     public SlotManager(ResourceUsageMonitor resourceUsageMonitor) {
         super(resourceUsageMonitor);
-        this.slotTracker = new SlotTracker(resourceUsageMonitor);
+        this.slotTracker = new SlotTracker(this, resourceUsageMonitor);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
@@ -19,7 +19,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.metric.LongCounterMetric;
 import com.starrocks.metric.MetricRepo;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.thrift.TUniqueId;
 import org.apache.commons.compress.utils.Lists;
@@ -62,9 +61,9 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
     private final long warehouseId;
     private final BaseSlotManager slotManager;
 
-    public SlotSelectionStrategyV2(long warehouseId) {
+    public SlotSelectionStrategyV2(BaseSlotManager slotManager, long warehouseId) {
         this.warehouseId = warehouseId;
-        this.slotManager = GlobalStateMgr.getCurrentState().getSlotManager();
+        this.slotManager = slotManager;
     }
 
     public QueryQueueOptions getOpts() {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/DefaultSlotSelectionStrategyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/DefaultSlotSelectionStrategyTest.java
@@ -33,7 +33,7 @@ public class DefaultSlotSelectionStrategyTest {
     public void testReleaseSlot() throws InterruptedException {
         DefaultSlotSelectionStrategy strategy =
                 new DefaultSlotSelectionStrategy(() -> false, (groupId) -> false);
-        SlotTracker slotTracker = new SlotTracker(ImmutableList.of(strategy));
+        SlotTracker slotTracker = new SlotTracker(null, ImmutableList.of(strategy));
 
         LogicalSlot slot1 = generateSlot(1, 0);
         LogicalSlot slot2 = generateSlot(1, 0);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotTrackerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotTrackerTest.java
@@ -30,14 +30,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SlotTrackerTest {
+    private static SlotManager slotManager;
+
     @BeforeAll
     public static void beforeClass() {
         MetricRepo.init();
+        ResourceUsageMonitor resourceUsageMonitor = new ResourceUsageMonitor();
+        slotManager = new SlotManager(resourceUsageMonitor);
     }
 
     @Test
     public void testRequireSlot() {
-        SlotTracker slotTracker = new SlotTracker(ImmutableList.of());
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of());
 
         LogicalSlot slot1 = generateSlot(1);
         assertThat(slotTracker.requireSlot(slot1)).isTrue();
@@ -49,7 +53,7 @@ public class SlotTrackerTest {
 
     @Test
     public void tesAllocateSlot() {
-        SlotTracker slotTracker = new SlotTracker(ImmutableList.of());
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of());
 
         LogicalSlot slot1 = generateSlot(1);
 
@@ -69,7 +73,7 @@ public class SlotTrackerTest {
 
     @Test
     public void tesReleaseSlot() {
-        SlotTracker slotTracker = new SlotTracker(ImmutableList.of());
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of());
 
         LogicalSlot slot1 = generateSlot(1);
 
@@ -109,7 +113,7 @@ public class SlotTrackerTest {
 
     @Test
     public void testSlotTrackerMetrics() {
-        SlotTracker slotTracker = new SlotTracker(ImmutableList.of());
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of());
         assertThat(slotTracker.getWarehouseId()).isEqualTo(WarehouseManager.DEFAULT_WAREHOUSE_ID);
         assertThat(slotTracker.getWarehouseName().equals(""));
         assertThat(slotTracker.getQueuePendingLength()).isEqualTo(0);
@@ -185,7 +189,7 @@ public class SlotTrackerTest {
 
     @Test
     public void testGetEarliestQueryWaitTimeSecond() {
-        SlotTracker slotTracker = new SlotTracker(ImmutableList.of());
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of());
         LogicalSlot slot1 = generateSlot(1);
         slotTracker.requireSlot(slot1);
         Uninterruptibles.sleepUninterruptibly(1000, java.util.concurrent.TimeUnit.MILLISECONDS);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetricEntityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetricEntityTest.java
@@ -20,7 +20,10 @@ package com.starrocks.qe.scheduler.warehouse;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.metric.Metric;
 import com.starrocks.metric.PrometheusMetricVisitor;
+import com.starrocks.qe.scheduler.slot.BaseSlotManager;
 import com.starrocks.qe.scheduler.slot.DefaultSlotSelectionStrategy;
+import com.starrocks.qe.scheduler.slot.ResourceUsageMonitor;
+import com.starrocks.qe.scheduler.slot.SlotManager;
 import com.starrocks.qe.scheduler.slot.SlotTracker;
 import com.starrocks.server.WarehouseManager;
 import org.junit.jupiter.api.Assertions;
@@ -31,9 +34,11 @@ import java.util.List;
 public class WarehouseMetricEntityTest {
     @Test
     public void testBasic() {
+        ResourceUsageMonitor resourceUsageMonitor = new ResourceUsageMonitor();
+        BaseSlotManager slotManager = new SlotManager(resourceUsageMonitor);
         DefaultSlotSelectionStrategy strategy =
                 new DefaultSlotSelectionStrategy(() -> false, (groupId) -> false);
-        SlotTracker slotTracker = new SlotTracker(ImmutableList.of(strategy));
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
         WarehouseMetricEntity entity = new WarehouseMetricEntity(slotTracker);
 
         List<Metric> metrics = entity.getMetrics();

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.system.information.ViewsSystemTable;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.scheduler.slot.BaseSlotManager;
 import com.starrocks.qe.scheduler.slot.BaseSlotTracker;
 import com.starrocks.qe.scheduler.slot.LogicalSlot;
 import com.starrocks.qe.scheduler.slot.SlotManager;
@@ -615,8 +616,9 @@ public class InformationSchemaDataSourceTest extends StarRocksTestBase {
     @Test
     public void testWarehouseMetricsEvaluation() throws Exception {
         starRocksAssert.withDatabase("d1").useDatabase("d1");
-        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(WarehouseManager.DEFAULT_WAREHOUSE_ID);
-        SlotTracker slotTracker = new SlotTracker(ImmutableList.of(strategy));
+        BaseSlotManager slotManager = GlobalStateMgr.getCurrentState().getSlotManager();
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
 
         new MockUp<SlotManager>() {
             @Mock


### PR DESCRIPTION
## Why I'm doing:

FE Restart failed when `enable_query_queue_v2` is on:
```
 2025-08-21 10:29:40.035+08:00 ERROR (main|1) [StarRocksFE.start():224] StarRocksFE start failed
 java.lang.ExceptionInInitializerError
        at com.starrocks.server.GlobalStateMgr.getCurrentState(GlobalStateMgr.java:889)
        at com.starrocks.StarRocksFE.start(StarRocksFE.java:152)
        at com.starrocks.StarRocksFE.main(StarRocksFE.java:102)
Caused by: java.lang.NullPointerException: Cannot invoke "com.starrocks.server.GlobalStateMgr.getSlotManager()" because the return value of "com.starrocks.server.GlobalStateMgr.getCurrentState()" is null
        at com.starrocks.qe.scheduler.slot.SlotSelectionStrategyV2.<init>(SlotSelectionStrategyV2.java:67)
        at com.starrocks.qe.scheduler.slot.SlotTracker.createSlotSelectionStrategy(SlotTracker.java:52)
        at com.starrocks.qe.scheduler.slot.SlotTracker.<init>(SlotTracker.java:32)
        at com.starrocks.qe.scheduler.slot.SlotManager.<init>(SlotManager.java:38)
        at com.starrocks.server.GlobalStateMgr.<init>(GlobalStateMgr.java:789)
        at com.starrocks.server.GlobalStateMgr.<init>(GlobalStateMgr.java:643)
        at com.starrocks.server.GlobalStateMgr.<init>(GlobalStateMgr.java:638)
        at com.starrocks.server.GlobalStateMgr$SingletonHolder.<clinit>(GlobalStateMgr.java:633)
        ... 3 more

```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
