### PR TITLE
[Enhancement] Optimize append_selective for binary column 

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -141,7 +141,7 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
     }
 
     // Write offsets.
-    for (size_t i = 0; i < size; i++) {
+    for (int64_t i = 0; i < size; i++) {
         new_offsets[i] = new_offsets[i - 1] + (new_offsets[i * 2 + 1] - new_offsets[i * 2]);
     }
     _offsets.resize(prev_num_offsets + size);

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -134,7 +134,7 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
                 const T str_size = new_offsets[i * 2 + 1] - new_offsets[i * 2];
                 // Only copy 16 bytes extra when src_column is small enough, because the overhead of copying 16 bytes
                 // will be large when src_column is large enough.
-                memcpy_inlined_overflow16(dest_bytes + cur_offset, src_bytes + new_offsets[i * 2], str_size);
+                strings::memcpy_inlined_overflow16(dest_bytes + cur_offset, src_bytes + new_offsets[i * 2], str_size);
                 cur_offset += str_size;
             }
         }

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -103,7 +103,7 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
     auto* __restrict new_offsets = _offsets.data() + prev_num_offsets;
 
     // Buffer i-th start offset and end offset in new_offsets[i * 2] and new_offsets[i * 2 + 1].
-    for (uint32_t i = 0; i < size; i++) {
+    for (size_t i = 0; i < size; i++) {
         const uint32_t src_idx = indexes[i];
         new_offsets[i * 2] = src_offsets[src_idx];
         new_offsets[i * 2 + 1] = src_offsets[src_idx + 1];
@@ -120,7 +120,7 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
         size_t cur_offset = _offsets[prev_num_rows];
 
         if (src_column.get_bytes().size() > 32 * 1024 * 1024ull) {
-            for (uint32_t i = 0; i < size; i++) {
+            for (size_t i = 0; i < size; i++) {
                 if (i + 16 < size) {
                     // If the source column is large enough, use prefetch to speed up copying.
                     __builtin_prefetch(src_bytes + new_offsets[i * 2 + 32]);
@@ -130,7 +130,7 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
                 cur_offset += str_size;
             }
         } else {
-            for (uint32_t i = 0; i < size; i++) {
+            for (size_t i = 0; i < size; i++) {
                 const T str_size = new_offsets[i * 2 + 1] - new_offsets[i * 2];
                 // Only copy 16 bytes extra when src_column is small enough, because the overhead of copying 16 bytes
                 // will be large when src_column is large enough.

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -83,34 +83,68 @@ void BinaryColumnBase<T>::append(const Column& src, size_t offset, size_t count)
 }
 
 template <typename T>
-void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) {
+void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* indexes, uint32_t from,
+                                           const uint32_t size) {
     if (src.is_binary_view()) {
         down_cast<const ColumnView*>(&src)->append_to(*this, indexes, from, size);
         return;
     }
+
+    indexes += from;
+
     const auto& src_column = down_cast<const BinaryColumnBase<T>&>(src);
-    const auto& src_offsets = src_column.get_offset();
-    const auto& src_bytes = src_column.get_bytes();
+    const auto* __restrict src_offsets = src_column.get_offset().data();
+    const auto* __restrict src_bytes = src_column.get_bytes().data();
 
-    size_t cur_row_count = _offsets.size() - 1;
-    size_t cur_byte_size = _bytes.size();
+    const size_t prev_num_offsets = _offsets.size();
+    const size_t prev_num_rows = prev_num_offsets - 1;
 
-    _offsets.resize(cur_row_count + size + 1);
-    for (size_t i = 0; i < size; i++) {
-        uint32_t row_idx = indexes[from + i];
-        T str_size = src_offsets[row_idx + 1] - src_offsets[row_idx];
-        _offsets[cur_row_count + i + 1] = _offsets[cur_row_count + i] + str_size;
-        cur_byte_size += str_size;
+    _offsets.resize(prev_num_offsets + size * 2);
+    auto* __restrict new_offsets = _offsets.data() + prev_num_offsets;
+
+    // Buffer i-th start offset and end offset in new_offsets[i * 2] and new_offsets[i * 2 + 1].
+    for (uint32_t i = 0; i < size; i++) {
+        const uint32_t src_idx = indexes[i];
+        new_offsets[i * 2] = src_offsets[src_idx];
+        new_offsets[i * 2 + 1] = src_offsets[src_idx + 1];
     }
-    _bytes.resize(cur_byte_size);
 
-    auto* dest_bytes = _bytes.data();
-    for (size_t i = 0; i < size; i++) {
-        uint32_t row_idx = indexes[from + i];
-        T str_size = src_offsets[row_idx + 1] - src_offsets[row_idx];
-        strings::memcpy_inlined(dest_bytes + _offsets[cur_row_count + i], src_bytes.data() + src_offsets[row_idx],
-                                str_size);
+    // Write bytes
+    {
+        size_t num_bytes = _bytes.size();
+        for (size_t i = 0; i < size; i++) {
+            num_bytes += new_offsets[i * 2 + 1] - new_offsets[i * 2];
+        }
+        _bytes.resize(num_bytes);
+        auto* __restrict dest_bytes = _bytes.data();
+        size_t cur_offset = _offsets[prev_num_rows];
+
+        if (src_column.get_bytes().size() > 32 * 1024 * 1024ull) {
+            for (uint32_t i = 0; i < size; i++) {
+                if (i + 16 < size) {
+                    // If the source column is large enough, use prefetch to speed up copying.
+                    __builtin_prefetch(src_bytes + new_offsets[i * 2 + 32]);
+                }
+                const T str_size = new_offsets[i * 2 + 1] - new_offsets[i * 2];
+                strings::memcpy_inlined(dest_bytes + cur_offset, src_bytes + new_offsets[i * 2], str_size);
+                cur_offset += str_size;
+            }
+        } else {
+            for (uint32_t i = 0; i < size; i++) {
+                const T str_size = new_offsets[i * 2 + 1] - new_offsets[i * 2];
+                // Only copy 16 bytes extra when src_column is small enough, because the overhead of copying 16 bytes
+                // will be large when src_column is large enough.
+                memcpy_inlined_overflow16(dest_bytes + cur_offset, src_bytes + new_offsets[i * 2], str_size);
+                cur_offset += str_size;
+            }
+        }
     }
+
+    // Write offsets.
+    for (size_t i = 0; i < size; i++) {
+        new_offsets[i] = new_offsets[i - 1] + (new_offsets[i * 2 + 1] - new_offsets[i * 2]);
+    }
+    _offsets.resize(prev_num_offsets + size);
 
     _slices_cache = false;
 }

--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -255,7 +255,7 @@ std::unique_ptr<Chunk> Chunk::clone_empty_with_slot(size_t size) const {
         columns[i] = _columns[i]->clone_empty();
         columns[i]->reserve(size);
     }
-    return std::make_unique<Chunk>(columns, _slot_id_to_index);
+    return std::make_unique<Chunk>(std::move(columns), _slot_id_to_index);
 }
 
 std::unique_ptr<Chunk> Chunk::clone_empty_with_schema() const {

--- a/be/src/gutil/strings/fastmem.h
+++ b/be/src/gutil/strings/fastmem.h
@@ -199,7 +199,7 @@ ALWAYS_INLINE inline void memcpy_inlined_overflow16(void* __restrict _dst, const
 #elif defined(__ARM_NEON) && defined(__aarch64__)
         vst1q_u8(dst, vld1q_u8(src));
 #else
-        __builtin_memcpy(dst, src, 16);
+        std::memcpy(dst, src, 16);
 #endif
         dst += 16;
         src += 16;

--- a/be/src/gutil/strings/fastmem.h
+++ b/be/src/gutil/strings/fastmem.h
@@ -188,4 +188,25 @@ ALWAYS_INLINE inline void memcpy_inlined(void* __restrict _dst, const void* __re
 #endif
     }
 }
+
+ALWAYS_INLINE inline void memcpy_inlined_overflow16(void* __restrict _dst, const void* __restrict _src, ssize_t size) {
+    auto* __restrict dst = static_cast<uint8_t*>(_dst);
+    const auto* __restrict src = static_cast<const uint8_t*>(_src);
+
+    while (size > 0) {
+#ifdef __SSE2__
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(dst), _mm_loadu_si128(reinterpret_cast<const __m128i*>(src)));
+#elif defined(__ARM_NEON) && defined(__aarch64__)
+        vst1q_u8(dst, vld1q_u8(src));
+#else
+        __builtin_memcpy(dst, src, 16);
+#endif
+        dst += 16;
+        src += 16;
+        size -= 16;
+        // Inhibit loop-idiom optimization of compilers, which would collapse the per-16B copies into a single memcpy.
+        __asm__ __volatile__("" : : : "memory");
+    }
+}
+
 } // namespace strings

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -233,13 +233,14 @@ public:
     /// A counter that keeps track of the highest/lowest value seen (reporting that
     /// as value()) and the current value.
     template <bool is_high>
-    class WaterMarkCounter : public Counter {
+    class WaterMarkCounter final : public Counter {
     public:
         explicit WaterMarkCounter(TUnit::type type, int64_t value = 0) : Counter(type, value) { _set_init_value(); }
         explicit WaterMarkCounter(TUnit::type type, const TCounterStrategy& strategy, int64_t value = 0)
                 : Counter(type, strategy, value) {
             _set_init_value();
         }
+        ~WaterMarkCounter() override = default;
 
         virtual void add(int64_t delta) {
             int64_t new_val = current_value_.fetch_add(delta, std::memory_order_relaxed) + delta;

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -669,4 +669,44 @@ PARALLEL_TEST(BinaryColumnTest, test_reference_memory_usage) {
     ASSERT_EQ(0, column->Column::reference_memory_usage());
 }
 
+class BinaryColumnAppendSelectiveTestFixture : public ::testing::TestWithParam<std::tuple<uint32_t>> {};
+
+TEST_P(BinaryColumnAppendSelectiveTestFixture, test_append_selective) {
+    const uint32_t num_rows = std::get<0>(GetParam());
+
+    BinaryColumn::Ptr src_col = BinaryColumn::create();
+    for (uint32_t i = 0; i < num_rows; i++) {
+        const size_t str_len = i % 16 + 8; // Length between 8 and 23
+        std::string str(str_len, 'a' + (i % 26));
+        src_col->append(str);
+    }
+
+    std::vector<uint32_t> indexes;
+    indexes.reserve(num_rows / 16);
+    for (uint32_t i = 0; i < num_rows; i++) {
+        if (i % 16 == 0) {
+            indexes.push_back(i);
+        }
+    }
+
+    BinaryColumn::Ptr dst_col = BinaryColumn::create();
+
+    dst_col->append_selective(*src_col, indexes.data(), 0, static_cast<uint32_t>(indexes.size()));
+    const size_t num_dst_rows = dst_col->size();
+    ASSERT_EQ(indexes.size(), num_dst_rows);
+    for (uint32_t i = 0; i < num_dst_rows; i++) {
+        ASSERT_EQ(src_col->get_slice(indexes[i]), dst_col->get_slice(i));
+    }
+
+    dst_col->append_selective(*src_col, indexes.data(), 10, static_cast<uint32_t>(indexes.size()));
+    ASSERT_EQ(num_dst_rows + indexes.size(), dst_col->size());
+    for (uint32_t i = 10; i < indexes.size(); i++) {
+        ASSERT_EQ(src_col->get_slice(indexes[i]), dst_col->get_slice(num_dst_rows + i - 10));
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(BinaryColumnAppendSelectiveTest, BinaryColumnAppendSelectiveTestFixture,
+                         ::testing::Values(std::make_tuple(2048), std::make_tuple(4096), std::make_tuple(40960), ,
+                                           std::make_tuple(32 * 1024 * 1024 + 100))));
+
 } // namespace starrocks

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -706,7 +706,7 @@ TEST_P(BinaryColumnAppendSelectiveTestFixture, test_append_selective) {
 }
 
 INSTANTIATE_TEST_SUITE_P(BinaryColumnAppendSelectiveTest, BinaryColumnAppendSelectiveTestFixture,
-                         ::testing::Values(std::make_tuple(2048), std::make_tuple(4096), std::make_tuple(40960), ,
-                                           std::make_tuple(32 * 1024 * 1024 + 100))));
+                         ::testing::Values(std::make_tuple(2048), std::make_tuple(4096), std::make_tuple(40960),
+                                           std::make_tuple(32 * 1024 * 1024 + 100)));
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Optimize `BinaryColumnBase<T>::append_selective`

1. **cache src offsets**: buffer the i-th start offset and end offset in `new_offsets[i * 2]` and `new_offsets[i * 2 + 1]`. This way, only one random access to `src_offset[indexes[i]]` is needed.  
2. **memcpy_inlined_overflow16**： For `src_column` bytes ≤ 32MB, use `memcpy_inlined_overflow16` instead of `memcpy_inlined`.  
3. **prefetch**: For `src_column` > 32MB, apply prefetching.  

str_len | num_src_rows | baseline (ns) | cache src offset (ns) | cache src offset + memcpy_inlined_overflow16 (ns) | cache src offset + prefetch (ns)
-- | -- | -- | -- | -- | --
16~32 | 4096 | 7730 | 5058 | 3744 | -
16~32 | 40960 | 54998 | 50926 | 36238 | -
16~32 | 409600 | 696769 | 610758 | 510106 | -
16~32 | 32MB | 165557080 | 126796247 | - | 85988980
4~8 | 4096 | 6600 | 6093 | 4627 | -
4~8 | 40960 | 65818 | 54135 | 41275 | -
4~8 | 409600 | 1168200 | 891207 | 687830 | -
4~8 | 32MB | 116201189 | 99602161 | - | 76007723


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
