### PR TITLE
[Enhancement] fix query profile when deploying more tasks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -80,6 +80,10 @@ public class Tracers {
         return THREAD_LOCAL.get();
     }
 
+    public static void set(Tracers tracers) {
+        THREAD_LOCAL.set(tracers);
+    }
+
     /**
      * Init tracer with context and mode.
      * @param context connect context


### PR DESCRIPTION
## Why I'm doing:

Deploy more tasks in done in another thread. 

But tracer is bound to a thread and a thread local object. 

So in deploy more tasks thread, tracer does not work any more. So in profile, we miss the metrics that should be collected in another thread.

## What I'm doing:

This PR is to:
- switch thread local object when deploying more tasks in thread.
- add another profile scope "DeployMore"

see also: https://github.com/StarRocks/starrocks/pull/62126

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
