### PR TITLE
[Enhancement] Support trace optimizer logs even if throw exceptions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -525,6 +525,78 @@ public class StmtExecutor {
         return parsedStmt instanceof DmlStmt || parsedStmt instanceof CreateTableAsSelectStmt;
     }
 
+    private ExecPlan generateExecPlan() throws Exception {
+        ExecPlan execPlan = null;
+        try (Timer ignored = Tracers.watchScope("Total")) {
+            redirectStatus = RedirectStatus.getRedirectStatus(parsedStmt);
+            if (!isForwardToLeader()) {
+                if (context.shouldDumpQuery()) {
+                    if (context.getDumpInfo() == null) {
+                        context.setDumpInfo(new QueryDumpInfo(context));
+                    } else {
+                        context.getDumpInfo().reset();
+                    }
+                    context.getDumpInfo().setOriginStmt(parsedStmt.getOrigStmt().originStmt);
+                    context.getDumpInfo().setStatement(parsedStmt);
+                }
+                if (parsedStmt instanceof ShowStmt) {
+                    com.starrocks.sql.analyzer.Analyzer.analyze(parsedStmt, context);
+                    Authorizer.check(parsedStmt, context);
+
+                    QueryStatement selectStmt = ((ShowStmt) parsedStmt).toSelectStmt();
+                    if (selectStmt != null) {
+                        parsedStmt = selectStmt;
+                        execPlan = StatementPlanner.plan(parsedStmt, context);
+                    }
+                } else if (parsedStmt instanceof ExecuteStmt) {
+                    ExecuteStmt executeStmt = (ExecuteStmt) parsedStmt;
+                    com.starrocks.sql.analyzer.Analyzer.analyze(executeStmt, context);
+                    prepareStmtContext = context.getPreparedStmt(executeStmt.getStmtName());
+                    if (null == prepareStmtContext) {
+                        throw new StarRocksPlannerException(ErrorType.INTERNAL_ERROR,
+                                "prepare statement can't be found @ %s, maybe has expired",
+                                executeStmt.getStmtName());
+                    }
+                    PrepareStmt prepareStmt = prepareStmtContext.getStmt();
+                    parsedStmt = prepareStmt.assignValues(executeStmt.getParamsExpr());
+                    parsedStmt.setOrigStmt(originStmt);
+
+                    if (prepareStmt.getInnerStmt().isExistQueryScopeHint()) {
+                        processQueryScopeHint();
+                    }
+
+                    try {
+                        execPlan = PrepareStmtPlanner.plan(executeStmt, parsedStmt, context);
+                    } catch (SemanticException e) {
+                        if (e.getMessage().contains("Unknown partition")) {
+                            throw new SemanticException(e.getMessage() +
+                                    " maybe table partition changed after prepared statement creation");
+                        } else {
+                            throw e;
+                        }
+                    }
+                } else {
+                    execPlan = StatementPlanner.plan(parsedStmt, context);
+                    if (parsedStmt instanceof QueryStatement && context.shouldDumpQuery()) {
+                        context.getDumpInfo().setExplainInfo(execPlan.getExplainString(TExplainLevel.COSTS));
+                    }
+                }
+            }
+        } catch (SemanticException e) {
+            dumpException(e);
+            throw new AnalysisException(e.getMessage(), e);
+        } catch (StarRocksPlannerException e) {
+            dumpException(e);
+            if (e.getType().equals(ErrorType.USER_ERROR)) {
+                throw e;
+            } else {
+                LOG.warn("Planner error: " + originStmt.originStmt, e);
+                throw e;
+            }
+        }
+        return execPlan;
+    }
+
     // Execute one statement.
     // Exception:
     // IOException: talk with client failed.
@@ -553,6 +625,7 @@ public class StmtExecutor {
         if (shouldMarkIdleCheck) {
             WarehouseIdleChecker.increaseRunningSQL(originWarehouseId);
         }
+
         try {
             context.getState().setIsQuery(parsedStmt instanceof QueryStatement);
             if (parsedStmt.isExistQueryScopeHint()) {
@@ -564,83 +637,28 @@ public class StmtExecutor {
                     .setWarehouse(context.getCurrentWarehouseName())
                     .setCNGroup(context.getCurrentComputeResourceName());
             LOG.debug("set warehouse {} for stmt: {}", context.getCurrentWarehouseName(), parsedStmt);
-
             if (parsedStmt.isExplain()) {
+                // reset the explain level to avoid the previous explain level affect the current query.
                 context.setExplainLevel(parsedStmt.getExplainLevel());
             } else {
-                // reset the explain level to avoid the previous explain level affect the current query.
                 context.setExplainLevel(null);
             }
 
-            // execPlan is the output of planner
-            ExecPlan execPlan = null;
-            try (Timer ignored = Tracers.watchScope("Total")) {
-                redirectStatus = RedirectStatus.getRedirectStatus(parsedStmt);
-                if (!isForwardToLeader()) {
-                    if (context.shouldDumpQuery()) {
-                        if (context.getDumpInfo() == null) {
-                            context.setDumpInfo(new QueryDumpInfo(context));
-                        } else {
-                            context.getDumpInfo().reset();
-                        }
-                        context.getDumpInfo().setOriginStmt(parsedStmt.getOrigStmt().originStmt);
-                        context.getDumpInfo().setStatement(parsedStmt);
-                    }
-                    if (parsedStmt instanceof ShowStmt) {
-                        com.starrocks.sql.analyzer.Analyzer.analyze(parsedStmt, context);
-                        Authorizer.check(parsedStmt, context);
-
-                        QueryStatement selectStmt = ((ShowStmt) parsedStmt).toSelectStmt();
-                        if (selectStmt != null) {
-                            parsedStmt = selectStmt;
-                            execPlan = StatementPlanner.plan(parsedStmt, context);
-                        }
-                    } else if (parsedStmt instanceof ExecuteStmt) {
-                        ExecuteStmt executeStmt = (ExecuteStmt) parsedStmt;
-                        com.starrocks.sql.analyzer.Analyzer.analyze(executeStmt, context);
-                        prepareStmtContext = context.getPreparedStmt(executeStmt.getStmtName());
-                        if (null == prepareStmtContext) {
-                            throw new StarRocksPlannerException(ErrorType.INTERNAL_ERROR,
-                                    "prepare statement can't be found @ %s, maybe has expired",
-                                    executeStmt.getStmtName());
-                        }
-                        PrepareStmt prepareStmt = prepareStmtContext.getStmt();
-                        parsedStmt = prepareStmt.assignValues(executeStmt.getParamsExpr());
-                        parsedStmt.setOrigStmt(originStmt);
-
-                        if (prepareStmt.getInnerStmt().isExistQueryScopeHint()) {
-                            processQueryScopeHint();
-                        }
-
-                        try {
-                            execPlan = PrepareStmtPlanner.plan(executeStmt, parsedStmt, context);
-                        } catch (SemanticException e) {
-                            if (e.getMessage().contains("Unknown partition")) {
-                                throw new SemanticException(e.getMessage() +
-                                        " maybe table partition changed after prepared statement creation");
-                            } else {
-                                throw e;
-                            }
-                        }
-                    } else {
-                        execPlan = StatementPlanner.plan(parsedStmt, context);
-                        if (parsedStmt instanceof QueryStatement && context.shouldDumpQuery()) {
-                            context.getDumpInfo().setExplainInfo(execPlan.getExplainString(TExplainLevel.COSTS));
-                        }
-                    }
+            // for explain query(not explain analyze), we can trace even if optimizer fails and execPlan is null
+            if (parsedStmt.isExplainTrace()) {
+                ExecPlan execPlan = null;
+                try {
+                    execPlan = generateExecPlan();
+                } catch (Exception e) {
+                    LOG.warn("Generate exec plan failed for explain stmt: {}",
+                            parsedStmt.getOrigStmt().originStmt, e);
                 }
-            } catch (SemanticException e) {
-                dumpException(e);
-                throw new AnalysisException(e.getMessage());
-            } catch (StarRocksPlannerException e) {
-                dumpException(e);
-                if (e.getType().equals(ErrorType.USER_ERROR)) {
-                    throw e;
-                } else {
-                    LOG.warn("Planner error: " + originStmt.originStmt, e);
-                    throw e;
-                }
+                handleExplainExecPlan(execPlan);
+                return;
             }
+
+            // execPlan is the output of planner
+            ExecPlan execPlan = generateExecPlan();
 
             // no need to execute http query dump request in BE
             if (context.isHTTPQueryDump) {
@@ -731,8 +749,7 @@ public class StmtExecutor {
 
                                 if (context.isProfileEnabled()) {
                                     isAsync = tryProcessProfileAsync(execPlan, i);
-                                    if (parsedStmt.isExplain() &&
-                                            StatementBase.ExplainLevel.ANALYZE.equals(parsedStmt.getExplainLevel())) {
+                                    if (parsedStmt.isExplainAnalyze()) {
                                         if (coord != null && coord.isShortCircuit()) {
                                             throw new StarRocksException(
                                                     "short circuit point query doesn't suppot explain analyze stmt, " +
@@ -1299,14 +1316,26 @@ public class StmtExecutor {
         return CostPredictor.getServiceBasedCostPredictor();
     }
 
+    /**
+     * Handle Explain stmt. NOTE: we can record some traces even if execPlan is null.
+     */
+    private void handleExplainExecPlan(ExecPlan execPlan) throws Exception {
+        // Every time set no send flag and clean all data in buffer
+        context.getMysqlChannel().reset();
+        String explainString = buildExplainString(execPlan, parsedStmt, context, ResourceGroupClassifier.QueryType.SELECT,
+                parsedStmt.getExplainLevel());
+        handleExplainStmt(explainString);
+    }
+
     // Process a select statement.
     private void handleQueryStmt(ExecPlan execPlan) throws Exception {
         // Every time set no send flag and clean all data in buffer
         context.getMysqlChannel().reset();
 
-        boolean isExplainAnalyze = parsedStmt.isExplain()
+        boolean isExplainQuery = parsedStmt.isExplain();
+        boolean isExplainAnalyze = isExplainQuery
                 && StatementBase.ExplainLevel.ANALYZE.equals(parsedStmt.getExplainLevel());
-        boolean isSchedulerExplain = parsedStmt.isExplain()
+        boolean isSchedulerExplain = isExplainQuery
                 && StatementBase.ExplainLevel.SCHEDULER.equals(parsedStmt.getExplainLevel());
 
         boolean isPlanAdvisorAnalyze = StatementBase.ExplainLevel.PLAN_ADVISOR.equals(parsedStmt.getExplainLevel());
@@ -1330,7 +1359,7 @@ public class StmtExecutor {
             context.getSessionVariable().setPipelineProfileLevel(1);
         } else if (isSchedulerExplain) {
             // Do nothing.
-        } else if (parsedStmt.isExplain()) {
+        } else if (isExplainQuery) {
             String explainString = buildExplainString(execPlan, parsedStmt, context, ResourceGroupClassifier.QueryType.SELECT,
                     parsedStmt.getExplainLevel());
             if (executeInFe) {
@@ -2080,6 +2109,10 @@ public class StmtExecutor {
         context.getState().setEof();
     }
 
+    /**
+     * Build explain string for explain statement.
+     * NOTE: execPlan maybe null but we can still trace some broken optimizer messages for better debug.
+     */
     public static String buildExplainString(ExecPlan execPlan, StatementBase parsedStmt, ConnectContext context,
                                             ResourceGroupClassifier.QueryType queryType,
                                             StatementBase.ExplainLevel explainLevel) {
@@ -2092,24 +2125,26 @@ public class StmtExecutor {
         }
         // marked delete will get execPlan null
         if (execPlan == null) {
-            explainString += "NOT AVAILABLE";
+            explainString += "PLAN NOT AVAILABLE\n";
+        }
+
+        if (parsedStmt.getTraceMode() == Tracers.Mode.TIMER) {
+            explainString += Tracers.printScopeTimer();
+        } else if (parsedStmt.getTraceMode() == Tracers.Mode.VARS) {
+            explainString += Tracers.printVars();
+        } else if (parsedStmt.getTraceMode() == Tracers.Mode.TIMING) {
+            explainString += Tracers.printTiming();
+        } else if (parsedStmt.getTraceMode() == Tracers.Mode.LOGS) {
+            explainString += Tracers.printLogs();
+        } else if (parsedStmt.getTraceMode() == Tracers.Mode.REASON) {
+            explainString += Tracers.printReasons();
         } else {
-            if (parsedStmt.getTraceMode() == Tracers.Mode.TIMER) {
-                explainString += Tracers.printScopeTimer();
-            } else if (parsedStmt.getTraceMode() == Tracers.Mode.VARS) {
-                explainString += Tracers.printVars();
-            } else if (parsedStmt.getTraceMode() == Tracers.Mode.TIMING) {
-                explainString += Tracers.printTiming();
-            } else if (parsedStmt.getTraceMode() == Tracers.Mode.LOGS) {
-                explainString += Tracers.printLogs();
-            } else if (parsedStmt.getTraceMode() == Tracers.Mode.REASON) {
-                explainString += Tracers.printReasons();
-            } else {
-                OperatorTuningGuides.OptimizedRecord optimizedRecord = PlanTuningAdvisor.getInstance()
-                        .getOptimizedRecord(context.getQueryId());
-                if (optimizedRecord != null) {
-                    explainString += optimizedRecord.getExplainString();
-                }
+            OperatorTuningGuides.OptimizedRecord optimizedRecord = PlanTuningAdvisor.getInstance()
+                    .getOptimizedRecord(context.getQueryId());
+            if (optimizedRecord != null) {
+                explainString += optimizedRecord.getExplainString();
+            }
+            if (execPlan != null) {
                 explainString += execPlan.getExplainString(explainLevel);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/StatementBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/StatementBase.java
@@ -125,6 +125,14 @@ public abstract class StatementBase implements ParseNode {
         return traceModule;
     }
 
+    public boolean isExplainTrace() {
+        return isExplain && traceMode != null && traceMode != Tracers.Mode.NONE;
+    }
+
+    public boolean isExplainAnalyze() {
+        return isExplain && explainLevel == ExplainLevel.ANALYZE;
+    }
+
     public ExplainLevel getExplainLevel() {
         if (explainLevel == null) {
             return ExplainLevel.defaultValue();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
@@ -314,6 +314,7 @@ public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
                 ", groupBy=" + node.getGroupBys() +
                 ", partitionBy=" + node.getPartitionByColumns() +
                 " ,aggregations=" + node.getAggregations() +
+                ", projection=" + node.getProjection() +
                 "}";
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -58,6 +58,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.ast.DictionaryGetExpr;
 import com.starrocks.sql.ast.LambdaFunctionExpr;
@@ -167,6 +168,10 @@ public class ScalarOperatorToExpr {
                 hackTypeNull(expr);
                 context.colRefToExpr.put(node, expr);
                 return expr;
+            }
+            if (expr == null) {
+                throw new SemanticException("Cannot convert ColumnRefOperator to Expr, " +
+                        "please check the input expression: " + node);
             }
 
             hackTypeNull(expr);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorNewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorNewTest.java
@@ -1,0 +1,120 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.utframe.StarRocksTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StmtExecutorNewTest extends StarRocksTestBase  {
+    private ConnectContext ctx;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setQueryId(UUIDUtil.genUUID());
+        ConnectContext.threadLocalInfo.set(ctx);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ConnectContext.threadLocalInfo.remove();
+    }
+
+    private StatementBase parse(String sql) throws Exception {
+        return SqlParser.parseSingleStatement(sql, ctx.getSessionVariable().getSqlMode());
+    }
+
+    @Test
+    public void testIsExplainTrace() throws Exception {
+        // Test case 1: Normal explain statement without trace
+        StatementBase stmt = parse("explain select * from t1");
+        StmtExecutor executor = new StmtExecutor(ctx, stmt);
+        assertFalse(stmt.isExplainTrace());
+
+        // Test case 2: Explain statement with trace
+        stmt = parse("trace logs optimizer select * from t1");
+        executor = new StmtExecutor(ctx, stmt);
+        assertTrue(stmt.isExplainTrace());
+
+        // Test case 3: Normal statement (not explain)
+        stmt = parse("select * from t1");
+        executor = new StmtExecutor(ctx, stmt);
+        assertFalse(stmt.isExplainTrace());
+    }
+
+    @Test
+    public void testIsExplainAnalyze() throws Exception {
+        // Test case 1: Normal explain statement
+        StatementBase stmt = parse("explain select * from t1");
+        StmtExecutor executor = new StmtExecutor(ctx, stmt);
+        assertFalse(stmt.isExplainAnalyze());
+
+        // Test case 2: Explain analyze statement
+        stmt = parse("explain analyze select * from t1");
+        executor = new StmtExecutor(ctx, stmt);
+        assertTrue(stmt.isExplainAnalyze());
+
+        // Test case 3: Explain statement with different level
+        stmt = parse("explain verbose select * from t1");
+        executor = new StmtExecutor(ctx, stmt);
+        assertFalse(stmt.isExplainAnalyze());
+    }
+
+    @Test
+    public void testHandleExplainStmtWithNullExecPlan() throws Exception {
+        StatementBase stmt = parse("trace times optimizer select * from t1");
+        StmtExecutor executor = new StmtExecutor(ctx, stmt);
+        
+        // Using reflection to test the private method
+        java.lang.reflect.Method method = StmtExecutor.class.getDeclaredMethod(
+                "handleExplainStmt", ExecPlan.class);
+        method.setAccessible(true);
+        
+        // Test with null execPlan
+        method.invoke(executor, new Object[] { null });
+        
+        // Verify that no exception is thrown
+        assertTrue(true);
+    }
+
+    @Test
+    public void testGenerateExecPlanWithException() throws Exception {
+        StatementBase stmt = parse("trace logs mv select * from non_existent_table");
+        StmtExecutor executor = new StmtExecutor(ctx, stmt);
+        
+        // Using reflection to test the private method
+        java.lang.reflect.Method method = StmtExecutor.class.getDeclaredMethod(
+                "generateExecPlan");
+        method.setAccessible(true);
+        
+        // This should not throw exception even if planning fails
+        try {
+            method.invoke(executor);
+        } catch (Exception e) {
+            // Exception is expected but should be handled gracefully
+            assertTrue(true);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorNewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorNewTest.java
@@ -89,7 +89,7 @@ public class StmtExecutorNewTest extends StarRocksTestBase  {
         
         // Using reflection to test the private method
         java.lang.reflect.Method method = StmtExecutor.class.getDeclaredMethod(
-                "handleExplainStmt", ExecPlan.class);
+                "handleExplainExecPlan", ExecPlan.class);
         method.setAccessible(true);
         
         // Test with null execPlan

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/DebugOperatorTracerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/DebugOperatorTracerTest.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.starrocks.sql.optimizer.operator.AggType.GLOBAL;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DebugOperatorTracerTest {
+
+    @Test
+    public void testVisitPhysicalHashAggregateWithProjection() {
+        // Create a PhysicalHashAggregateOperator with projection for testing
+        List<ColumnRefOperator> groupByColumns = new ArrayList<>();
+        ColumnRefOperator groupByCol = new ColumnRefOperator(1, Type.INT, "col1", true);
+        groupByColumns.add(groupByCol);
+
+        Map<ColumnRefOperator, CallOperator> aggregations = Maps.newHashMap();
+        ColumnRefOperator aggCol = new ColumnRefOperator(2, Type.BIGINT, "sum_col1", true);
+        CallOperator aggFunc = new CallOperator(
+                "sum", Type.BIGINT, List.of(groupByCol), null, false);
+        aggregations.put(aggCol, aggFunc);
+
+        Map<ColumnRefOperator, ScalarOperator> projection = Maps.newHashMap();
+        ColumnRefOperator projCol = new ColumnRefOperator(3, Type.INT, "proj_col1", true);
+        projection.put(projCol, groupByCol);
+
+        PhysicalHashAggregateOperator aggregateOperator = new PhysicalHashAggregateOperator(
+                GLOBAL, groupByColumns, null, aggregations, true, 1, null,
+                new Projection(projection));
+
+        DebugOperatorTracer tracer = new DebugOperatorTracer();
+        String result = tracer.visitPhysicalHashAggregate(aggregateOperator, null);
+
+        // Verify that the result contains projection information
+        assertTrue(result.contains("projection="));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScalarOperatorToExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScalarOperatorToExprTest.java
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ScalarOperatorToExprTest {
+
+    @Test
+    public void testVisitVariableReferenceWithNullExpr() {
+        // Test the new exception handling when expr is null
+        ColumnRefOperator columnRefOperator = new ColumnRefOperator(1, Type.INT, "test_col", true);
+
+        ScalarOperatorToExpr.buildExprIgnoreSlot(columnRefOperator,
+                new ScalarOperatorToExpr.FormatterContext(Maps.newHashMap()));
+
+        // This should throw SemanticException
+        SemanticException exception = assertThrows(SemanticException.class, () -> {
+            ScalarOperatorToExpr.buildExecExpression(columnRefOperator,
+                    new ScalarOperatorToExpr.FormatterContext(Maps.newHashMap()));
+        });
+        
+        assertTrue(exception.getMessage().contains("Cannot convert ColumnRefOperator to Expr"));
+        assertTrue(exception.getMessage().contains("test_col"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
`trace` cannot be used if Optimizer has bugs and cannot generate an available plan.

## What I'm doing:
- Support trace optimizer logs even if throw exceptions.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
