### PR TITLE
[Enhancement] update persistent index size statistic when do major compaction

### DIFF
--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -783,7 +783,8 @@ public:
     // just for unit test
     bool has_bf() { return _l1_vec.empty() ? false : _l1_vec[0]->has_bf(); }
 
-    Status major_compaction(DataDir* data_dir, int64_t tablet_id, std::shared_timed_mutex* mutex);
+    Status major_compaction(DataDir* data_dir, int64_t tablet_id, std::shared_timed_mutex* mutex,
+                            IOStat* stat = nullptr);
 
     Status TEST_major_compaction(PersistentIndexMetaPB& index_meta);
 

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1552,7 +1552,8 @@ std::unique_ptr<PrimaryIndex> TEST_create_primary_index(const Schema& pk_schema)
     return std::make_unique<PrimaryIndex>(pk_schema);
 }
 
-Status PrimaryIndex::major_compaction(DataDir* data_dir, int64_t tablet_id, std::shared_timed_mutex* mutex) {
+Status PrimaryIndex::major_compaction(DataDir* data_dir, int64_t tablet_id, std::shared_timed_mutex* mutex,
+                                      IOStat* stat) {
     // `_persistent_index` could be reset when call `unload()`, so we need to fetch reference first.
     std::shared_ptr<PersistentIndex> pindex;
     {
@@ -1560,7 +1561,7 @@ Status PrimaryIndex::major_compaction(DataDir* data_dir, int64_t tablet_id, std:
         pindex = _persistent_index;
     }
     if (pindex != nullptr) {
-        return pindex->major_compaction(data_dir, tablet_id, mutex);
+        return pindex->major_compaction(data_dir, tablet_id, mutex, stat);
     } else {
         return Status::OK();
     }

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -131,7 +131,8 @@ public:
 
     Status on_commited();
 
-    Status major_compaction(DataDir* data_dir, int64_t tablet_id, std::shared_timed_mutex* mutex);
+    Status major_compaction(DataDir* data_dir, int64_t tablet_id, std::shared_timed_mutex* mutex,
+                            IOStat* stat = nullptr);
 
     Status abort();
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -4773,10 +4773,12 @@ Status TabletUpdates::pk_index_major_compaction() {
         }
     });
     manager->index_cache().update_object_size(index_entry, index.memory_usage());
-    st = index.major_compaction(_tablet.data_dir(), _tablet.tablet_id(), _tablet.updates()->get_index_lock());
+    IOStat stat;
+    st = index.major_compaction(_tablet.data_dir(), _tablet.tablet_id(), _tablet.updates()->get_index_lock(), &stat);
     if (st.ok()) {
         // reset score after major compaction finish
         _pk_index_write_amp_score.store(0.0);
+        _extra_file_size_cache.pindex_size.store(stat.total_file_size);
     }
     return st;
 }


### PR DESCRIPTION
## Why I'm doing:
After a major compaction, the disk space usage of the persistent index also changes and needs to be updated in time.

## What I'm doing:
This pull request introduces changes to the major compaction process for primary and persistent indexes, allowing the collection and reporting of file size statistics during compaction. The main updates involve modifying method signatures to accept an optional `IOStat` parameter and updating the logic to populate file size information after compaction.

**Enhancements to major compaction with file size statistics:**

* `PersistentIndex::major_compaction` and `PrimaryIndex::major_compaction` now accept an optional `IOStat* stat` parameter, enabling the reporting of total file size after compaction. [[1]](diffhunk://#diff-d3ea825657ade9c2ab9cc49583948c6e7599a94fedfd38a94dfe10e89b5203d5L5071-R5072) [[2]](diffhunk://#diff-da797af69ced87554b37fff696a558293c3ecda50ecca66a2c7ff4f6140d2d3eL786-R787) [[3]](diffhunk://#diff-66cd1cc77f8b406567ee573f07eb48a895713078bf99c8764033b4c5239b16a3L1555-R1564) [[4]](diffhunk://#diff-f821a59ac1fdae0efa5ef58f909ecc40f8f99059b2fa152d6ac4218c0d924c32L134-R135)
* During compaction, if the `stat` parameter is provided, it is populated with the sum of relevant file sizes.

**Integration with tablet updates:**

* `TabletUpdates::pk_index_major_compaction` now uses the updated compaction API, retrieves the total file size via `IOStat`, and updates `_extra_file_size_cache.pindex_size` accordingly.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
