### PR TITLE
[Refactor]  Refactors the partitionDesc analysis logic in the SQL analyzer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -602,7 +602,7 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
             }
 
             try {
-                expressionPartitionDesc.analyze(columnDefs, olapTable.getProperties());
+                PartitionDescAnalyzer.analyze(expressionPartitionDesc, columnDefs, olapTable.getProperties());
             } catch (AnalysisException e) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, e.getMessage());
             }
@@ -1362,7 +1362,8 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
             if (partitionDesc instanceof SingleRangePartitionDesc) {
                 RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
                 SingleRangePartitionDesc singleRangePartitionDesc = ((SingleRangePartitionDesc) partitionDesc);
-                singleRangePartitionDesc.analyze(rangePartitionInfo.getPartitionColumnsSize(), cloneProperties);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc,
+                        rangePartitionInfo.getPartitionColumnsSize(), cloneProperties);
                 if (!existPartitionNameSet.contains(singleRangePartitionDesc.getPartitionName())) {
                     rangePartitionInfo.checkAndCreateRange(table.getIdToColumn(), singleRangePartitionDesc,
                             addPartitionClause.isTempPartition());
@@ -1372,8 +1373,7 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                 List<ColumnDef> columnDefList = partitionInfo.getPartitionColumns(olapTable.getIdToColumn()).stream()
                         .map(item -> new ColumnDef(item.getName(), new TypeDef(item.getType())))
                         .collect(Collectors.toList());
-                PartitionDescAnalyzer.analyze(partitionDesc);
-                partitionDesc.analyze(columnDefList, cloneProperties);
+                PartitionDescAnalyzer.analyze(partitionDesc, columnDefList, cloneProperties);
                 if (!existPartitionNameSet.contains(partitionDesc.getPartitionName())) {
                     CatalogUtils.checkPartitionValuesExistForAddListPartition(olapTable, partitionDesc,
                             addPartitionClause.isTempPartition());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -574,8 +574,7 @@ public class CreateTableAnalyzer {
                         partitionDesc instanceof SingleItemListPartitionDesc ||
                         partitionDesc instanceof SingleRangePartitionDesc) {
                     try {
-                        PartitionDescAnalyzer.analyze(partitionDesc);
-                        partitionDesc.analyze(stmt.getColumnDefs(), stmt.getProperties());
+                        PartitionDescAnalyzer.analyze(partitionDesc, stmt.getColumnDefs(), stmt.getProperties());
                     } catch (AnalysisException e) {
                         throw new SemanticException(e.getMessage());
                     }
@@ -591,8 +590,7 @@ public class CreateTableAnalyzer {
                 } else if (partitionDesc instanceof ExpressionPartitionDesc) {
                     ExpressionPartitionDesc expressionPartitionDesc = (ExpressionPartitionDesc) partitionDesc;
                     try {
-                        PartitionDescAnalyzer.analyze(partitionDesc);
-                        expressionPartitionDesc.analyze(stmt.getColumnDefs(), stmt.getProperties());
+                        PartitionDescAnalyzer.analyze(expressionPartitionDesc, stmt.getColumnDefs(), stmt.getProperties());
                     } catch (AnalysisException e) {
                         throw new SemanticException(e.getMessage());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionDescAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionDescAnalyzer.java
@@ -14,13 +14,22 @@
 package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.CastExpr;
+import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TimestampArithmeticExpr;
+import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
+import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.OlapTable;
@@ -28,34 +37,70 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.ColumnDef;
+import com.starrocks.sql.ast.ExpressionPartitionDesc;
+import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.MultiItemListPartitionDesc;
 import com.starrocks.sql.ast.MultiRangePartitionDesc;
+import com.starrocks.sql.ast.PartitionConvertContext;
 import com.starrocks.sql.ast.PartitionDesc;
+import com.starrocks.sql.ast.PartitionKeyDesc;
+import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.SingleItemListPartitionDesc;
+import com.starrocks.sql.ast.SinglePartitionDesc;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TTabletType;
+import org.apache.logging.log4j.util.Strings;
+import org.threeten.extra.PeriodDuration;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class PartitionDescAnalyzer {
     public static void analyze(PartitionDesc partitionDesc) {
-        if (partitionDesc instanceof SingleRangePartitionDesc) {
-            analyzeSingleRangePartitionDesc((SingleRangePartitionDesc) partitionDesc);
-        } else if (partitionDesc instanceof MultiRangePartitionDesc) {
+        if (partitionDesc instanceof MultiRangePartitionDesc) {
             analyzeMultiRangePartitionDesc((MultiRangePartitionDesc) partitionDesc);
         }
     }
 
-    public static void analyzeSingleRangePartitionDesc(SingleRangePartitionDesc singleRangePartitionDesc) {
+    /**
+     * Main analyze method that handles both column definitions and properties
+     */
+    public static void analyze(PartitionDesc partitionDesc, List<ColumnDef> columnDefs, Map<String, String> otherProperties)
+            throws AnalysisException {
+        if (partitionDesc instanceof ListPartitionDesc) {
+            analyzeListPartitionDesc((ListPartitionDesc) partitionDesc, columnDefs, otherProperties);
+        } else if (partitionDesc instanceof RangePartitionDesc) {
+            analyzeRangePartitionDesc((RangePartitionDesc) partitionDesc, columnDefs, otherProperties);
+        } else if (partitionDesc instanceof ExpressionPartitionDesc) {
+            analyzeExpressionPartitionDesc((ExpressionPartitionDesc) partitionDesc, columnDefs, otherProperties);
+        } else if (partitionDesc instanceof SingleItemListPartitionDesc) {
+            analyzeSingleItemListPartitionDesc((SingleItemListPartitionDesc) partitionDesc, columnDefs, otherProperties);
+        } else if (partitionDesc instanceof MultiItemListPartitionDesc) {
+            analyzeMultiItemListPartitionDesc((MultiItemListPartitionDesc) partitionDesc, columnDefs, otherProperties);
+        } else {
+            throw new AnalysisException("Unsupported partition description type: " + partitionDesc.getClass().getSimpleName());
+        }
     }
 
     public static void analyzeMultiRangePartitionDesc(MultiRangePartitionDesc multiRangePartitionDesc) {
@@ -71,6 +116,21 @@ public class PartitionDescAnalyzer {
             } else if (!MultiRangePartitionDesc.SUPPORTED_TIME_UNIT_TYPE.contains(timeUnitType)) {
                 throw new SemanticException("Batch build partition does not support time interval type: " + timeUnit);
             }
+        }
+    }
+
+    /**
+     * Analyze SingleRangePartitionDesc with partition column number and table properties
+     */
+    public static void analyzeSingleRangePartitionDesc(SingleRangePartitionDesc desc, int partColNum,
+                                                       Map<String, String> tableProperties) throws AnalysisException {
+        FeNameFormat.checkPartitionName(desc.getPartitionName());
+        desc.getPartitionKeyDesc().analyze(partColNum);
+
+        if (partColNum == 1) {
+            analyzeSinglePartitionProperties(desc, tableProperties, desc.getPartitionKeyDesc());
+        } else {
+            analyzeSinglePartitionProperties(desc, tableProperties, null);
         }
     }
 
@@ -278,6 +338,436 @@ public class PartitionDescAnalyzer {
             msg += "If you want to create partial partitions in batch, you can turn off this check by " +
                     "setting the FE config enable_create_partial_partition_in_batch=true";
             throw new SemanticException(msg);
+        }
+    }
+
+    // Analyze methods for different partition types
+
+    public static void analyzeListPartitionDesc(ListPartitionDesc desc, List<ColumnDef> columnDefs,
+                                                Map<String, String> tableProperties) throws AnalysisException {
+        // analyze partition columns
+        List<ColumnDef> columnDefList = analyzeListPartitionColumns(desc, columnDefs);
+        // analyze partition expr
+        analyzeListPartitionExprs(desc, columnDefs);
+        // analyze single list property
+        analyzeSingleListPartitions(desc, tableProperties, columnDefList);
+        // analyze multi list partition
+        analyzeMultiListPartitions(desc, tableProperties, columnDefList);
+        // list partition values should not contain NULL partition value if this column is not nullable.
+        postAnalyzeListPartitionColumns(desc, columnDefList);
+    }
+
+    public static void analyzeRangePartitionDesc(RangePartitionDesc desc, List<ColumnDef> columnDefs,
+                                                 Map<String, String> otherProperties) throws AnalysisException {
+        if (desc.getPartitionColNames() == null || desc.getPartitionColNames().isEmpty()) {
+            throw new AnalysisException("No partition columns.");
+        }
+
+        Set<String> partColNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        ColumnDef firstPartitionColumn = null;
+        for (String partitionCol : desc.getPartitionColNames()) {
+            if (!partColNames.add(partitionCol)) {
+                throw new AnalysisException("Duplicated partition column " + partitionCol);
+            }
+
+            boolean found = false;
+            for (ColumnDef columnDef : columnDefs) {
+                if (columnDef.getName().equalsIgnoreCase(partitionCol)) {
+                    if (!columnDef.isKey() && columnDef.getAggregateType() != AggregateType.NONE) {
+                        throw new AnalysisException("The partition column could not be aggregated column"
+                                + " and unique table's partition column must be key column");
+                    }
+                    if (columnDef.getType().isFloatingPointType() || columnDef.getType().isComplexType()) {
+                        throw new AnalysisException(String.format("Invalid partition column '%s': %s",
+                                columnDef.getName(), "invalid data type " + columnDef.getType()));
+                    }
+                    found = true;
+                    firstPartitionColumn = columnDef;
+                    break;
+                }
+            }
+
+            if (!found) {
+                throw new AnalysisException("Partition column[" + partitionCol + "] does not exist in column list.");
+            }
+        }
+
+        // use buildSinglePartitionDesc to build singleRangePartitionDescs
+        if (desc.getMultiRangePartitionDescs().size() != 0) {
+
+            if (desc.getPartitionColNames().size() > 1) {
+                throw new AnalysisException("Batch build partition only support single range column.");
+            }
+
+            for (MultiRangePartitionDesc multiRangePartitionDesc : desc.getMultiRangePartitionDescs()) {
+                TimestampArithmeticExpr.TimeUnit timeUnit = TimestampArithmeticExpr.TimeUnit
+                        .fromName(multiRangePartitionDesc.getTimeUnit());
+                if (timeUnit == TimestampArithmeticExpr.TimeUnit.HOUR && firstPartitionColumn.getType() != Type.DATETIME) {
+                    throw new AnalysisException("Batch build partition for hour interval only supports " +
+                            "partition column as DATETIME type");
+                }
+                PartitionConvertContext context = new PartitionConvertContext();
+                context.setAutoPartitionTable(desc.isAutoPartitionTable());
+                if (desc.getPartitionType() != null) {
+                    context.setFirstPartitionColumnType(desc.getPartitionType());
+                } else {
+                    context.setFirstPartitionColumnType(firstPartitionColumn.getType());
+                }
+                context.setProperties(otherProperties);
+
+                desc.getSingleRangePartitionDescs().addAll(multiRangePartitionDesc.convertToSingle(context));
+            }
+        }
+
+        Set<String> nameSet = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        PartitionKeyDesc.PartitionRangeType partitionType = PartitionKeyDesc.PartitionRangeType.INVALID;
+        for (SingleRangePartitionDesc singleDesc : desc.getSingleRangePartitionDescs()) {
+            if (!nameSet.add(singleDesc.getPartitionName())) {
+                throw new AnalysisException("Duplicated partition name: " + singleDesc.getPartitionName());
+            }
+            // in create table stmt, we use given properties
+            // copy one. because ProperAnalyzer will remove entry after analyze
+            Map<String, String> givenProperties = null;
+            if (otherProperties != null) {
+                givenProperties = Maps.newHashMap(otherProperties);
+            }
+            // check partitionType
+            if (partitionType == PartitionKeyDesc.PartitionRangeType.INVALID) {
+                partitionType = singleDesc.getPartitionKeyDesc().getPartitionType();
+            } else if (partitionType != singleDesc.getPartitionKeyDesc().getPartitionType()) {
+                throw new AnalysisException("You can only use one of these methods to create partitions");
+            }
+            analyzeSingleRangePartitionDesc(singleDesc, desc.getPartitionColNames().size(), givenProperties);
+        }
+    }
+
+    public static void analyzeExpressionPartitionDesc(ExpressionPartitionDesc desc, List<ColumnDef> columnDefs, Map<String,
+            String> otherProperties) throws AnalysisException {
+        boolean hasExprAnalyze = false;
+        SlotRef slotRef;
+        RangePartitionDesc rangePartitionDesc = desc.getRangePartitionDesc();
+        Expr expr = desc.getExpr();
+
+        if (rangePartitionDesc != null) {
+            // for automatic partition table
+            if (rangePartitionDesc.isAutoPartitionTable()) {
+                rangePartitionDesc.setAutoPartitionTable(true);
+                slotRef = AnalyzerUtils.getSlotRefFromFunctionCall(expr);
+                if (expr instanceof FunctionCallExpr) {
+                    FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
+                    List<String> autoPartitionSupportFunctions = Lists.newArrayList(FunctionSet.TIME_SLICE,
+                            FunctionSet.DATE_TRUNC);
+                    if (!autoPartitionSupportFunctions.contains(functionCallExpr.getFnName().getFunction())) {
+                        throw new SemanticException("Only support date_trunc and time_slice as partition expression");
+                    }
+                }
+            } else {
+                // for partition by range expr table
+                // The type of the partition field may be different from the type after the expression
+                if (expr instanceof CastExpr) {
+                    slotRef = AnalyzerUtils.getSlotRefFromCast(expr);
+                    // Set partition type from cast target type
+                    if (expr instanceof CastExpr) {
+                        CastExpr castExpr = (CastExpr) expr;
+                        Type partitionType = castExpr.getTargetTypeDef().getType();
+                        desc.setPartitionType(partitionType);
+                    }
+                } else if (expr instanceof FunctionCallExpr) {
+                    slotRef = AnalyzerUtils.getSlotRefFromFunctionCall(expr);
+
+                    Optional<ColumnDef> columnDef = columnDefs.stream()
+                            .filter(c -> c.getName().equals(slotRef.getColumnName())).findFirst();
+                    Preconditions.checkState(columnDef.isPresent());
+                    slotRef.setType(columnDef.get().getType());
+
+                    String functionName = ((FunctionCallExpr) expr).getFnName().getFunction().toLowerCase();
+                    if (functionName.equals(FunctionSet.STR2DATE)) {
+                        desc.setPartitionType(Type.DATE);
+                        if (!PartitionFunctionChecker.checkStr2date(expr)) {
+                            throw new SemanticException("partition function check fail, only supports the result " +
+                                    "of the function str2date(VARCHAR str, VARCHAR format) as a strict DATE type");
+                        }
+                    }
+                } else {
+                    throw new AnalysisException("Unsupported expr:" + expr.toSql());
+                }
+            }
+            rangePartitionDesc.setPartitionType(desc.getPartitionType());
+            PartitionDescAnalyzer.analyze(rangePartitionDesc);
+            analyzeRangePartitionDesc(rangePartitionDesc, columnDefs, otherProperties);
+        } else {
+            // for materialized view
+            slotRef = AnalyzerUtils.getSlotRefFromFunctionCall(expr);
+        }
+
+        for (ColumnDef columnDef : columnDefs) {
+            if (columnDef.getName().equalsIgnoreCase(slotRef.getColumnName())) {
+                slotRef.setType(columnDef.getType());
+                PartitionExprAnalyzer.analyzePartitionExpr(expr, slotRef);
+                desc.setPartitionType(expr.getType());
+                hasExprAnalyze = true;
+            }
+        }
+        if (!hasExprAnalyze) {
+            throw new AnalysisException("Partition expr without analyzed.");
+        }
+    }
+
+    public static void analyzeSingleItemListPartitionDesc(SingleItemListPartitionDesc desc, List<ColumnDef> columnDefList,
+                                                          Map<String, String> tableProperties) throws AnalysisException {
+        FeNameFormat.checkPartitionName(desc.getPartitionName());
+        analyzeSinglePartitionProperties(desc, tableProperties, null);
+
+        if (columnDefList.size() != 1) {
+            throw new AnalysisException("Partition column size should be one when use single list partition ");
+        }
+
+        desc.setColumnDefList(columnDefList);
+    }
+
+    public static void analyzeMultiItemListPartitionDesc(MultiItemListPartitionDesc desc, List<ColumnDef> columnDefList,
+                                                         Map<String, String> tableProperties) throws AnalysisException {
+        FeNameFormat.checkPartitionName(desc.getPartitionName());
+        analyzeMultiItemValues(desc, columnDefList.size());
+        analyzeSinglePartitionProperties(desc, tableProperties, null);
+        desc.setColumnDefList(columnDefList);
+    }
+
+    private static void analyzeMultiItemValues(MultiItemListPartitionDesc desc, int partitionColSize) throws AnalysisException {
+        for (List<String> values : desc.getMultiValues()) {
+            if (values.size() != partitionColSize) {
+                throw new AnalysisException(
+                        "(" + String.join(",", values) + ") size should be equal to partition column size ");
+            }
+        }
+    }
+
+    // Helper methods for ListPartitionDesc analysis
+
+    private static List<ColumnDef> analyzeListPartitionColumns(ListPartitionDesc desc, List<ColumnDef> columnDefs)
+            throws AnalysisException {
+        if (desc.getPartitionColNames() == null || desc.getPartitionColNames().isEmpty()) {
+            throw new AnalysisException("No partition columns.");
+        }
+        List<ColumnDef> partitionColumns = new ArrayList<>(desc.getPartitionColNames().size());
+        Set<String> partColNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        for (String partitionCol : desc.getPartitionColNames()) {
+            if (!partColNames.add(partitionCol)) {
+                throw new AnalysisException("Duplicated partition column " + partitionCol);
+            }
+            boolean found = false;
+            for (ColumnDef columnDef : columnDefs) {
+                if (columnDef.getName().equals(partitionCol)) {
+                    if (columnDef.getType().isFloatingPointType() || columnDef.getType().isComplexType()
+                            || columnDef.getType().isDecimalOfAnyVersion()) {
+                        throw new AnalysisException(String.format("Invalid partition column '%s': %s",
+                                columnDef.getName(), "invalid data type " + columnDef.getType()));
+                    }
+                    if (!columnDef.isKey() && columnDef.getAggregateType() != AggregateType.NONE
+                            && !columnDef.isGeneratedColumn()) {
+                        throw new AnalysisException("The partition column could not be aggregated column"
+                                + " and unique table's partition column must be key column");
+                    }
+                    found = true;
+                    columnDef.setIsPartitionColumn(true);
+                    partitionColumns.add(columnDef);
+                    break;
+                }
+            }
+            if (!found) {
+                throw new AnalysisException("Partition column[" + partitionCol + "] does not exist in column list.");
+            }
+        }
+        return partitionColumns;
+    }
+
+    private static void analyzeListPartitionExprs(ListPartitionDesc desc, List<ColumnDef> columnDefs) throws AnalysisException {
+        if (desc.getPartitionExprs() == null) {
+            return;
+        }
+        List<String> slotRefs = desc.getPartitionExprs().stream()
+                .flatMap(e -> e.collectAllSlotRefs().stream())
+                .map(SlotRef::getColumnName)
+                .collect(Collectors.toList());
+        for (ColumnDef columnDef : columnDefs) {
+            if (slotRefs.contains(columnDef.getName()) && !columnDef.isKey()
+                    && columnDef.getAggregateType() != AggregateType.NONE) {
+                throw new AnalysisException("The partition expr should base on key column");
+            }
+        }
+    }
+
+    private static void analyzeSingleListPartitions(ListPartitionDesc desc, Map<String, String> tableProperties,
+                                                    List<ColumnDef> columnDefList) throws AnalysisException {
+        List<LiteralExpr> allLiteralExprValues = Lists.newArrayList();
+        Set<String> singListPartitionName = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        for (SingleItemListPartitionDesc singleDesc : desc.getSingleListPartitionDescs()) {
+            if (!singListPartitionName.add(singleDesc.getPartitionName())) {
+                throw new AnalysisException("Duplicated partition name: " + singleDesc.getPartitionName());
+            }
+            PartitionDescAnalyzer.analyze(singleDesc);
+            analyzeSingleItemListPartitionDesc(singleDesc, columnDefList, tableProperties);
+            allLiteralExprValues.addAll(singleDesc.getLiteralExprValues());
+        }
+        analyzeDuplicateValues(allLiteralExprValues);
+    }
+
+    private static void analyzeMultiListPartitions(ListPartitionDesc desc, Map<String, String> tableProperties,
+                                                   List<ColumnDef> columnDefList) throws AnalysisException {
+        Set<String> multiListPartitionName = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        List<List<LiteralExpr>> allMultiLiteralExprValues = Lists.newArrayList();
+        for (MultiItemListPartitionDesc multiDesc : desc.getMultiListPartitionDescs()) {
+            if (!multiListPartitionName.add(multiDesc.getPartitionName())) {
+                throw new AnalysisException("Duplicated partition name: " + multiDesc.getPartitionName());
+            }
+            PartitionDescAnalyzer.analyze(multiDesc);
+            analyzeMultiItemListPartitionDesc(multiDesc, columnDefList, tableProperties);
+            allMultiLiteralExprValues.addAll(multiDesc.getMultiLiteralExprValues());
+        }
+        analyzeDuplicateValues(desc.getPartitionColNames().size(), allMultiLiteralExprValues);
+    }
+
+    private static void postAnalyzeListPartitionColumns(ListPartitionDesc desc, List<ColumnDef> columnDefs)
+            throws AnalysisException {
+        // list partition values should not contain NULL partition value if this column is not nullable.
+        int partitionColSize = columnDefs.size();
+        for (int i = 0; i < columnDefs.size(); i++) {
+            ColumnDef columnDef = columnDefs.get(i);
+            if (columnDef.isAllowNull()) {
+                continue;
+            }
+            String partitionCol = columnDef.getName();
+            for (SingleItemListPartitionDesc singleDesc : desc.getSingleListPartitionDescs()) {
+                for (LiteralExpr literalExpr : singleDesc.getLiteralExprValues()) {
+                    if (literalExpr.isNullable()) {
+                        throw new AnalysisException("Partition column[" + partitionCol + "] could not be null but " +
+                                "contains null value in partition[" + singleDesc.getPartitionName() + "]");
+                    }
+                }
+            }
+            for (MultiItemListPartitionDesc multiDesc : desc.getMultiListPartitionDescs()) {
+                for (List<LiteralExpr> literalExprs : multiDesc.getMultiLiteralExprValues()) {
+                    if (literalExprs.size() != partitionColSize) {
+                        throw new AnalysisException("Partition column[" + partitionCol + "] size should be equal to " +
+                                "partition column size but contains " + literalExprs.size() + " values in partition[" +
+                                multiDesc.getPartitionName() + "]");
+                    }
+                    if (literalExprs.get(i).isNullable()) {
+                        throw new AnalysisException("Partition column[" + partitionCol + "] could not be null but " +
+                                "contains null value in partition[" + multiDesc.getPartitionName() + "]");
+                    }
+                }
+            }
+        }
+    }
+
+    private static void analyzeDuplicateValues(int partitionColSize, List<List<LiteralExpr>> allMultiLiteralExprValues)
+            throws AnalysisException {
+        for (int i = 0; i < allMultiLiteralExprValues.size(); i++) {
+            List<LiteralExpr> literalExprValues1 = allMultiLiteralExprValues.get(i);
+            for (int j = i + 1; j < allMultiLiteralExprValues.size(); j++) {
+                List<LiteralExpr> literalExprValues2 = allMultiLiteralExprValues.get(j);
+                int duplicatedSize = 0;
+                for (int k = 0; k < literalExprValues1.size(); k++) {
+                    String value = literalExprValues1.get(k).getStringValue();
+                    String tmpValue = literalExprValues2.get(k).getStringValue();
+                    if (value.equals(tmpValue)) {
+                        duplicatedSize++;
+                    }
+                }
+                if (duplicatedSize == partitionColSize) {
+                    List<String> msg = literalExprValues1.stream()
+                            .map(value -> ("\"" + value.getStringValue() + "\""))
+                            .collect(Collectors.toList());
+                    throw new AnalysisException("Duplicate values " +
+                            "(" + String.join(",", msg) + ") not allow");
+                }
+            }
+        }
+    }
+
+    private static void analyzeDuplicateValues(List<LiteralExpr> allLiteralExprValues) throws AnalysisException {
+        Set<String> hashSet = new HashSet<>();
+        for (LiteralExpr value : allLiteralExprValues) {
+            if (!hashSet.add(value.getStringValue())) {
+                throw new AnalysisException("Duplicated value " + value.getStringValue());
+            }
+        }
+    }
+
+    /**
+     * Analyze SinglePartitionDesc properties - moved from SinglePartitionDesc.analyzeProperties
+     */
+    public static void analyzeSinglePartitionProperties(SinglePartitionDesc desc, Map<String, String> tableProperties,
+                                                        PartitionKeyDesc partitionKeyDesc) throws AnalysisException {
+        Map<String, String> partitionAndTableProperties = Maps.newHashMap();
+        // The priority of the partition attribute is higher than that of the table
+        if (tableProperties != null) {
+            partitionAndTableProperties.putAll(tableProperties);
+        }
+        if (desc.getProperties() != null) {
+            partitionAndTableProperties.putAll(desc.getProperties());
+        }
+
+        // analyze data property
+        DataProperty partitionDataProperty = PropertyAnalyzer.analyzeDataProperty(partitionAndTableProperties,
+                DataProperty.getInferredDefaultDataProperty(), false);
+        Preconditions.checkNotNull(partitionDataProperty);
+
+        if (tableProperties != null && partitionKeyDesc != null
+                && tableProperties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL)) {
+            String storageCoolDownTTL = tableProperties.get(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL);
+            if (Strings.isNotBlank(storageCoolDownTTL)) {
+                PeriodDuration periodDuration = TimeUtils.parseHumanReadablePeriodOrDuration(storageCoolDownTTL);
+                if (partitionKeyDesc.isMax()) {
+                    partitionDataProperty = new DataProperty(TStorageMedium.SSD, DataProperty.MAX_COOLDOWN_TIME_MS);
+                } else {
+                    String stringUpperValue = partitionKeyDesc.getUpperValues().get(0).getStringValue();
+                    DateTimeFormatter dateTimeFormatter = DateUtils.probeFormat(stringUpperValue);
+                    LocalDateTime upperTime = DateUtils.parseStringWithDefaultHSM(stringUpperValue, dateTimeFormatter);
+                    LocalDateTime updatedUpperTime = upperTime.plus(periodDuration);
+                    DateLiteral dateLiteral = new DateLiteral(updatedUpperTime, Type.DATETIME);
+                    long coolDownTimeStamp = dateLiteral.unixTimestamp(TimeUtils.getTimeZone());
+                    partitionDataProperty = new DataProperty(TStorageMedium.SSD, coolDownTimeStamp);
+                }
+            }
+        }
+
+        // analyze replication num
+        Short replicationNum = PropertyAnalyzer
+                .analyzeReplicationNum(partitionAndTableProperties, RunMode.defaultReplicationNum());
+        if (replicationNum == null) {
+            throw new AnalysisException("Invalid replication number: " + replicationNum);
+        }
+
+        // analyze version info
+        Long versionInfo = PropertyAnalyzer.analyzeVersionInfo(partitionAndTableProperties);
+
+        // analyze in memory
+        boolean isInMemory = PropertyAnalyzer
+                .analyzeBooleanProp(partitionAndTableProperties, PropertyAnalyzer.PROPERTIES_INMEMORY, false);
+
+        TTabletType tabletType = PropertyAnalyzer.analyzeTabletType(partitionAndTableProperties);
+
+        DataCacheInfo dataCacheInfo = PropertyAnalyzer.analyzeDataCacheInfo(partitionAndTableProperties);
+
+        // Set the analyzed properties back to the desc
+        desc.setPartitionDataProperty(partitionDataProperty);
+        desc.setReplicationNum(replicationNum);
+        desc.setVersionInfo(versionInfo);
+        desc.setInMemory(isInMemory);
+        desc.setTabletType(tabletType);
+        desc.setDataCacheInfo(dataCacheInfo);
+
+        if (desc.getProperties() != null) {
+            // check unknown properties
+            Sets.SetView<String> intersection =
+                    Sets.intersection(partitionAndTableProperties.keySet(), desc.getProperties().keySet());
+            if (!intersection.isEmpty()) {
+                Map<String, String> unknownProperties = Maps.newHashMap();
+                intersection.stream().forEach(x -> unknownProperties.put(x, desc.getProperties().get(x)));
+                throw new AnalysisException("Unknown properties: " + unknownProperties);
+            }
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExpressionPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExpressionPartitionDesc.java
@@ -17,23 +17,14 @@ package com.starrocks.sql.ast;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.starrocks.analysis.CastExpr;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
-import com.starrocks.common.AnalysisException;
-import com.starrocks.sql.analyzer.AnalyzerUtils;
-import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
-import com.starrocks.sql.analyzer.PartitionExprAnalyzer;
-import com.starrocks.sql.analyzer.PartitionFunctionChecker;
-import com.starrocks.sql.analyzer.SemanticException;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 public class ExpressionPartitionDesc extends PartitionDesc {
 
@@ -95,65 +86,9 @@ public class ExpressionPartitionDesc extends PartitionDesc {
         return partitionType;
     }
 
-    @Override
-    public void analyze(List<ColumnDef> columnDefs, Map<String, String> otherProperties) throws AnalysisException {
-        boolean hasExprAnalyze = false;
-        SlotRef slotRef;
-        if (rangePartitionDesc != null) {
-            // for automatic partition table
-            if (rangePartitionDesc.isAutoPartitionTable) {
-                rangePartitionDesc.setAutoPartitionTable(true);
-                slotRef = AnalyzerUtils.getSlotRefFromFunctionCall(expr);
-                if (expr instanceof FunctionCallExpr) {
-                    FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
-                    if (!AUTO_PARTITION_SUPPORT_FUNCTIONS.contains(functionCallExpr.getFnName().getFunction())) {
-                        throw new SemanticException("Only support date_trunc and time_slice as partition expression");
-                    }
-                }
-            } else {
-                // for partition by range expr table
-                // The type of the partition field may be different from the type after the expression
-                if (expr instanceof CastExpr) {
-                    slotRef = AnalyzerUtils.getSlotRefFromCast(expr);
-                    partitionType = ((CastExpr) expr).getTargetTypeDef().getType();
-                } else if (expr instanceof FunctionCallExpr) {
-                    slotRef = AnalyzerUtils.getSlotRefFromFunctionCall(expr);
-
-                    Optional<ColumnDef> columnDef = columnDefs.stream()
-                            .filter(c -> c.getName().equals(slotRef.getColumnName())).findFirst();
-                    Preconditions.checkState(columnDef.isPresent());
-                    slotRef.setType(columnDef.get().getType());
-
-                    String functionName = ((FunctionCallExpr) expr).getFnName().getFunction().toLowerCase();
-                    if (functionName.equals(FunctionSet.STR2DATE)) {
-                        partitionType = Type.DATE;
-                        if (!PartitionFunctionChecker.checkStr2date(expr)) {
-                            throw new SemanticException("partition function check fail, only supports the result " +
-                                    "of the function str2date(VARCHAR str, VARCHAR format) as a strict DATE type");
-                        }
-                    }
-                } else {
-                    throw new AnalysisException("Unsupported expr:" + expr.toSql());
-                }
-            }
-            rangePartitionDesc.partitionType = partitionType;
-            PartitionDescAnalyzer.analyze(rangePartitionDesc);
-            rangePartitionDesc.analyze(columnDefs, otherProperties);
-        } else {
-            // for materialized view
-            slotRef = AnalyzerUtils.getSlotRefFromFunctionCall(expr);
-        }
-
-        for (ColumnDef columnDef : columnDefs) {
-            if (columnDef.getName().equalsIgnoreCase(slotRef.getColumnName())) {
-                slotRef.setType(columnDef.getType());
-                PartitionExprAnalyzer.analyzePartitionExpr(expr, slotRef);
-                partitionType = expr.getType();
-                hasExprAnalyze = true;
-            }
-        }
-        if (!hasExprAnalyze) {
-            throw new AnalysisException("Partition expr without analyzed.");
-        }
+    public void setPartitionType(Type partitionType) {
+        this.partitionType = partitionType;
     }
+
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ListPartitionDesc.java
@@ -17,20 +17,13 @@ package com.starrocks.sql.ast;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
-import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.ParseNode;
-import com.starrocks.analysis.SlotRef;
-import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Table;
-import com.starrocks.common.AnalysisException;
-import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -111,105 +104,6 @@ public class ListPartitionDesc extends PartitionDesc {
         return partitionNames;
     }
 
-    @Override
-    public void analyze(List<ColumnDef> columnDefs, Map<String, String> tableProperties) throws AnalysisException {
-        // analyze partition columns
-        List<ColumnDef> columnDefList = this.analyzePartitionColumns(columnDefs);
-        // analyze partition expr
-        this.analyzePartitionExprs(columnDefs);
-        // analyze single list property
-        this.analyzeSingleListPartition(tableProperties, columnDefList);
-        // analyze multi list partition
-        this.analyzeMultiListPartition(tableProperties, columnDefList);
-        // list partition values should not contain NULL partition value if this column is not nullable.
-        this.postAnalyzePartitionColumns(columnDefList);
-    }
-
-    public void analyzePartitionExprs(List<ColumnDef> columnDefs) throws AnalysisException {
-        if (partitionExprs == null) {
-            return;
-        }
-        List<String> slotRefs = partitionExprs.stream()
-                .flatMap(e -> e.collectAllSlotRefs().stream())
-                .map(SlotRef::getColumnName)
-                .collect(Collectors.toList());
-        for (ColumnDef columnDef : columnDefs) {
-            if (slotRefs.contains(columnDef.getName()) && !columnDef.isKey()
-                    && columnDef.getAggregateType() != AggregateType.NONE) {
-                throw new AnalysisException("The partition expr should base on key column");
-            }
-        }
-    }
-
-    public List<ColumnDef> analyzePartitionColumns(List<ColumnDef> columnDefs) throws AnalysisException {
-        if (this.partitionColNames == null || this.partitionColNames.isEmpty()) {
-            throw new AnalysisException("No partition columns.");
-        }
-        List<ColumnDef> partitionColumns = new ArrayList<>(this.partitionColNames.size());
-        Set<String> partColNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-        for (String partitionCol : this.partitionColNames) {
-            if (!partColNames.add(partitionCol)) {
-                throw new AnalysisException("Duplicated partition column " + partitionCol);
-            }
-            boolean found = false;
-            for (ColumnDef columnDef : columnDefs) {
-                if (columnDef.getName().equals(partitionCol)) {
-                    if (columnDef.getType().isFloatingPointType() || columnDef.getType().isComplexType()
-                            || columnDef.getType().isDecimalOfAnyVersion()) {
-                        throw new AnalysisException(String.format("Invalid partition column '%s': %s",
-                                columnDef.getName(), "invalid data type " + columnDef.getType()));
-                    }
-                    if (!columnDef.isKey() && columnDef.getAggregateType() != AggregateType.NONE
-                            && !columnDef.isGeneratedColumn()) {
-                        throw new AnalysisException("The partition column could not be aggregated column"
-                                + " and unique table's partition column must be key column");
-                    }
-                    found = true;
-                    columnDef.setIsPartitionColumn(true);
-                    partitionColumns.add(columnDef);
-                    break;
-                }
-            }
-            if (!found) {
-                throw new AnalysisException("Partition column[" + partitionCol + "] does not exist in column list.");
-            }
-        }
-        return partitionColumns;
-    }
-
-    private void postAnalyzePartitionColumns(List<ColumnDef> columnDefs) throws AnalysisException {
-        // list partition values should not contain NULL partition value if this column is not nullable.
-        int partitionColSize = columnDefs.size();
-        for (int i = 0; i < columnDefs.size(); i++) {
-            ColumnDef columnDef = columnDefs.get(i);
-            if (columnDef.isAllowNull()) {
-                continue;
-            }
-            String partitionCol = columnDef.getName();
-            for (SingleItemListPartitionDesc desc : singleListPartitionDescs) {
-                for (LiteralExpr literalExpr : desc.getLiteralExprValues()) {
-                    if (literalExpr.isNullable()) {
-                        throw new AnalysisException("Partition column[" + partitionCol + "] could not be null but " +
-                                "contains null value in partition[" + desc.getPartitionName() + "]");
-                    }
-                }
-            }
-            for (MultiItemListPartitionDesc desc : multiListPartitionDescs) {
-                for (List<LiteralExpr> literalExprs : desc.getMultiLiteralExprValues()) {
-                    if (literalExprs.size() != partitionColSize) {
-                        throw new AnalysisException("Partition column[" + partitionCol + "] size should be equal to " +
-                                "partition column size but contains " + literalExprs.size() + " values in partition[" +
-                                desc.getPartitionName() + "]");
-                    }
-                    if (literalExprs.get(i).isNullable()) {
-                        throw new AnalysisException("Partition column[" + partitionCol + "] could not be null but " +
-                                "contains null value in partition[" + desc.getPartitionName() + "]");
-                    }
-                }
-            }
-        }
-    }
-
     public void analyzeExternalPartitionColumns(List<ColumnDef> columnDefs, String engineName) {
         if (this.partitionColNames == null || this.partitionColNames.isEmpty()) {
             throw new SemanticException("No partition columns.");
@@ -274,87 +168,6 @@ public class ListPartitionDesc extends PartitionDesc {
                     "in the same order as partition by clause: %s", partitionColNames);
         }
     }
-
-    private void analyzeMultiListPartition(Map<String, String> tableProperties,
-                                           List<ColumnDef> columnDefList) throws AnalysisException {
-        Set<String> multiListPartitionName = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-        List<List<LiteralExpr>> allMultiLiteralExprValues = Lists.newArrayList();
-        for (MultiItemListPartitionDesc desc : this.multiListPartitionDescs) {
-            if (!multiListPartitionName.add(desc.getPartitionName())) {
-                throw new AnalysisException("Duplicated partition name: " + desc.getPartitionName());
-            }
-            PartitionDescAnalyzer.analyze(desc);
-            desc.analyze(columnDefList, tableProperties);
-            allMultiLiteralExprValues.addAll(desc.getMultiLiteralExprValues());
-        }
-        this.analyzeDuplicateValues(this.partitionColNames.size(), allMultiLiteralExprValues);
-    }
-
-    private void analyzeSingleListPartition(Map<String, String> tableProperties, List<ColumnDef> columnDefList)
-            throws AnalysisException {
-        List<LiteralExpr> allLiteralExprValues = Lists.newArrayList();
-        Set<String> singListPartitionName = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-        for (SingleItemListPartitionDesc desc : this.singleListPartitionDescs) {
-            if (!singListPartitionName.add(desc.getPartitionName())) {
-                throw new AnalysisException("Duplicated partition name: " + desc.getPartitionName());
-            }
-            PartitionDescAnalyzer.analyze(desc);
-            desc.analyze(columnDefList, tableProperties);
-            allLiteralExprValues.addAll(desc.getLiteralExprValues());
-        }
-        this.analyzeDuplicateValues(allLiteralExprValues);
-    }
-
-    /**
-     * Check if duplicate values are found
-     * If the value of the member in the same position is equals, it is considered a duplicate
-     *
-     * @param partitionColSize          the partition column size
-     * @param allMultiLiteralExprValues values from multi list partition
-     * @throws AnalysisException
-     */
-    private void analyzeDuplicateValues(int partitionColSize, List<List<LiteralExpr>> allMultiLiteralExprValues)
-            throws AnalysisException {
-        for (int i = 0; i < allMultiLiteralExprValues.size(); i++) {
-            List<LiteralExpr> literalExprValues1 = allMultiLiteralExprValues.get(i);
-            for (int j = i + 1; j < allMultiLiteralExprValues.size(); j++) {
-                List<LiteralExpr> literalExprValues2 = allMultiLiteralExprValues.get(j);
-                int duplicatedSize = 0;
-                for (int k = 0; k < literalExprValues1.size(); k++) {
-                    String value = literalExprValues1.get(k).getStringValue();
-                    String tmpValue = literalExprValues2.get(k).getStringValue();
-                    if (value.equals(tmpValue)) {
-                        duplicatedSize++;
-                    }
-                }
-                if (duplicatedSize == partitionColSize) {
-                    List<String> msg = literalExprValues1.stream()
-                            .map(value -> ("\"" + value.getStringValue() + "\""))
-                            .collect(Collectors.toList());
-                    throw new AnalysisException("Duplicate values " +
-                            "(" + String.join(",", msg) + ") not allow");
-                }
-            }
-        }
-    }
-
-    /**
-     * Check if duplicate values are found
-     * Use hashSet to check duplicate value
-     *
-     * @param allLiteralExprValues values from single list partition
-     * @throws AnalysisException
-     */
-    private void analyzeDuplicateValues(List<LiteralExpr> allLiteralExprValues) throws AnalysisException {
-        Set<String> hashSet = new HashSet<>();
-        for (LiteralExpr value : allLiteralExprValues) {
-            if (!hashSet.add(value.getStringValue())) {
-                throw new AnalysisException("Duplicated value " + value.getStringValue());
-            }
-        }
-    }
-
-
 
     public List<Expr> getPartitionExprs() {
         return partitionExprs;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiItemListPartitionDesc.java
@@ -18,7 +18,6 @@ import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.PrintableMap;
-import com.starrocks.sql.analyzer.FeNameFormat;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.ArrayList;
@@ -67,20 +66,8 @@ public class MultiItemListPartitionDesc extends SinglePartitionDesc {
         return multiPartitionValues;
     }
 
-    public void analyze(List<ColumnDef> columnDefList, Map<String, String> tableProperties) throws AnalysisException {
-        FeNameFormat.checkPartitionName(getPartitionName());
-        analyzeValues(columnDefList.size());
-        analyzeProperties(tableProperties, null);
+    public void setColumnDefList(List<ColumnDef> columnDefList) {
         this.columnDefList = columnDefList;
-    }
-
-    private void analyzeValues(int partitionColSize) throws AnalysisException {
-        for (List<String> values : this.multiValues) {
-            if (values.size() != partitionColSize) {
-                throw new AnalysisException(
-                        "(" + String.join(",", values) + ") size should be equal to partition column size ");
-            }
-        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionDesc.java
@@ -17,13 +17,11 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.catalog.DataProperty;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.thrift.TTabletType;
 import org.apache.commons.lang.NotImplementedException;
 
-import java.util.List;
 import java.util.Map;
 
 public class PartitionDesc implements ParseNode {
@@ -37,10 +35,6 @@ public class PartitionDesc implements ParseNode {
 
     protected PartitionDesc(NodePosition pos) {
         this.pos = pos;
-    }
-
-    public void analyze(List<ColumnDef> columnDefs, Map<String, String> otherProperties) throws AnalysisException {
-        throw new NotImplementedException();
     }
 
     public String toSql() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleItemListPartitionDesc.java
@@ -21,7 +21,6 @@ import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.PrintableMap;
-import com.starrocks.sql.analyzer.FeNameFormat;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.ArrayList;
@@ -69,13 +68,7 @@ public class SingleItemListPartitionDesc extends SinglePartitionDesc {
         return partitionValues;
     }
 
-    public void analyze(List<ColumnDef> columnDefList, Map<String, String> tableProperties) throws AnalysisException {
-        FeNameFormat.checkPartitionName(this.getPartitionName());
-        analyzeProperties(tableProperties, null);
-
-        if (columnDefList.size() != 1) {
-            throw new AnalysisException("Partition column size should be one when use single list partition ");
-        }
+    public void setColumnDefList(List<ColumnDef> columnDefList) {
         this.columnDefList = columnDefList;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
@@ -14,15 +14,13 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.PrintableMap;
-import com.starrocks.sql.analyzer.FeNameFormat;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Map;
 
 public class SingleRangePartitionDesc extends SinglePartitionDesc {
-    private PartitionKeyDesc partitionKeyDesc;
+    private final PartitionKeyDesc partitionKeyDesc;
 
     public SingleRangePartitionDesc(boolean ifNotExists, String partName, PartitionKeyDesc partitionKeyDesc,
                                     Map<String, String> properties) {
@@ -37,17 +35,6 @@ public class SingleRangePartitionDesc extends SinglePartitionDesc {
 
     public PartitionKeyDesc getPartitionKeyDesc() {
         return partitionKeyDesc;
-    }
-
-    public void analyze(int partColNum, Map<String, String> tableProperties) throws AnalysisException {
-        FeNameFormat.checkPartitionName(getPartitionName());
-        partitionKeyDesc.analyze(partColNum);
-
-        if (partColNum == 1) {
-            analyzeProperties(tableProperties, partitionKeyDesc);
-        } else {
-            analyzeProperties(tableProperties, null);
-        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
@@ -27,6 +27,7 @@ import com.starrocks.persist.ColumnIdExpr;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.ExpressionPartitionDesc;
 import com.starrocks.sql.ast.PartitionKeyDesc;
@@ -73,7 +74,7 @@ public class ExpressionRangePartitionInfoTest {
         fnChildren.add(slotRef2);
         functionCallExpr = new FunctionCallExpr("date_trunc", fnChildren);
         functionCallExpr.setFn(Expr.getBuiltinFunction(
-                    "date_trunc", new Type[] {Type.VARCHAR, Type.DATETIME}, Function.CompareMode.IS_IDENTICAL));
+                "date_trunc", new Type[] {Type.VARCHAR, Type.DATETIME}, Function.CompareMode.IS_IDENTICAL));
 
         FeConstants.runningUnitTest = true;
         UtFrameUtils.createMinStarRocksCluster();
@@ -92,9 +93,9 @@ public class ExpressionRangePartitionInfoTest {
         partitionExprs.add(ColumnIdExpr.create(slotRef));
         List<Column> schema = Collections.singletonList(k1);
         ExpressionRangePartitionInfo expressionRangePartitionInfo = new ExpressionRangePartitionInfo(partitionExprs,
-                    schema, PartitionType.RANGE);
+                schema, PartitionType.RANGE);
         List<Column> partitionColumns = expressionRangePartitionInfo.getPartitionColumns(
-                    MetaUtils.buildIdToColumn(schema));
+                MetaUtils.buildIdToColumn(schema));
         Assertions.assertEquals(partitionColumns.size(), 1);
         Assertions.assertEquals(partitionColumns.get(0), k1);
     }
@@ -104,9 +105,9 @@ public class ExpressionRangePartitionInfoTest {
         partitionExprs.add(ColumnIdExpr.create(functionCallExpr));
         List<Column> schema = Collections.singletonList(k2);
         ExpressionRangePartitionInfo expressionRangePartitionInfo =
-                    new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
+                new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
         List<Column> partitionColumns = expressionRangePartitionInfo.getPartitionColumns(
-                    MetaUtils.buildIdToColumn(schema));
+                MetaUtils.buildIdToColumn(schema));
         Assertions.assertEquals(partitionColumns.size(), 1);
         Assertions.assertEquals(partitionColumns.get(0), k2);
     }
@@ -119,9 +120,9 @@ public class ExpressionRangePartitionInfoTest {
         partitionExprs.add(ColumnIdExpr.create(functionCallExpr));
         List<Column> schema = Arrays.asList(k1, k2);
         ExpressionRangePartitionInfo expressionRangePartitionInfo =
-                    new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
+                new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
         List<Column> partitionColumns = expressionRangePartitionInfo.getPartitionColumns(
-                    MetaUtils.buildIdToColumn(schema));
+                MetaUtils.buildIdToColumn(schema));
         Assertions.assertEquals(partitionColumns.size(), 2);
         Assertions.assertEquals(partitionColumns.get(0), k1);
         Assertions.assertEquals(partitionColumns.get(1), k2);
@@ -144,7 +145,7 @@ public class ExpressionRangePartitionInfoTest {
             List<Column> schema = Collections.singletonList(k1);
             partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
             for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                singleRangePartitionDesc.analyze(1, null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, 1, null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema),
                         singleRangePartitionDesc, 20000L, false);
             }
@@ -165,7 +166,7 @@ public class ExpressionRangePartitionInfoTest {
             List<Column> schema = Collections.singletonList(k1);
             partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
             for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                singleRangePartitionDesc.analyze(1, null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, 1, null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema),
                         singleRangePartitionDesc, 20000L, false);
             }
@@ -186,7 +187,7 @@ public class ExpressionRangePartitionInfoTest {
             List<Column> schema = Collections.singletonList(k1);
             partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
             for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                singleRangePartitionDesc.analyze(1, null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, 1, null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
                         20000L, false);
             }
@@ -213,7 +214,7 @@ public class ExpressionRangePartitionInfoTest {
             partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
 
             for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                singleRangePartitionDesc.analyze(1, null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, 1, null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
                         20000L, false);
             }
@@ -227,21 +228,21 @@ public class ExpressionRangePartitionInfoTest {
         partitionExprs.add(ColumnIdExpr.create(slotRef));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1", new PartitionKeyDesc(Lists
-                    .newArrayList(new PartitionValue("-9223372036854775806"))), null));
+                .newArrayList(new PartitionValue("-9223372036854775806"))), null));
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p2", new PartitionKeyDesc(Lists
-                    .newArrayList(new PartitionValue("-9223372036854775805"))), null));
+                .newArrayList(new PartitionValue("-9223372036854775805"))), null));
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p3", new PartitionKeyDesc(Lists
-                    .newArrayList(new PartitionValue("0"))), null));
+                .newArrayList(new PartitionValue("0"))), null));
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p4", new PartitionKeyDesc(Lists
-                    .newArrayList(new PartitionValue("9223372036854775806"))), null));
+                .newArrayList(new PartitionValue("9223372036854775806"))), null));
 
         List<Column> schema = Collections.singletonList(k1);
         partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
 
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-            singleRangePartitionDesc.analyze(1, null);
+            PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, 1, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
-                        20000L, false);
+                    20000L, false);
         }
     }
 
@@ -266,17 +267,17 @@ public class ExpressionRangePartitionInfoTest {
 
         //add RangePartitionDescs
         PartitionKeyDesc p1 = new PartitionKeyDesc(
-                    Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")),
-                    Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("200")));
+                Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")),
+                Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("200")));
         PartitionKeyDesc p2 = new PartitionKeyDesc(
-                    Lists.newArrayList(new PartitionValue("20190105"), new PartitionValue("10")),
-                    Lists.newArrayList(new PartitionValue("20190107"), new PartitionValue("10")));
+                Lists.newArrayList(new PartitionValue("20190105"), new PartitionValue("10")),
+                Lists.newArrayList(new PartitionValue("20190107"), new PartitionValue("10")));
         PartitionKeyDesc p3 = new PartitionKeyDesc(
-                    Lists.newArrayList(new PartitionValue("20181231"), new PartitionValue("10")),
-                    Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")));
+                Lists.newArrayList(new PartitionValue("20181231"), new PartitionValue("10")),
+                Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")));
         PartitionKeyDesc p4 = new PartitionKeyDesc(
-                    Lists.newArrayList(new PartitionValue("20190105"), new PartitionValue("100")),
-                    Lists.newArrayList(new PartitionValue("20190120"), new PartitionValue("10000000000")));
+                Lists.newArrayList(new PartitionValue("20190105"), new PartitionValue("100")),
+                Lists.newArrayList(new PartitionValue("20190120"), new PartitionValue("10000000000")));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1", p1, null));
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p2", p2, null));
@@ -287,9 +288,9 @@ public class ExpressionRangePartitionInfoTest {
         partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
 
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-            singleRangePartitionDesc.analyze(columns, null);
+            PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, columns, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
-                        20000L, false);
+                    20000L, false);
         }
     }
 
@@ -340,7 +341,7 @@ public class ExpressionRangePartitionInfoTest {
                 } else if (partitionType != singleRangePartitionDesc.getPartitionKeyDesc().getPartitionType()) {
                     throw new AnalysisException("You can only use one of these methods to create partitions");
                 }
-                singleRangePartitionDesc.analyze(partitionExprs.size(), null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, partitionExprs.size(), null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
                         20000L, false);
             }
@@ -365,7 +366,7 @@ public class ExpressionRangePartitionInfoTest {
 
         //add RangePartitionDescs
         PartitionKeyDesc p1 = new PartitionKeyDesc(new ArrayList<>(),
-                    Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("200")));
+                Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("200")));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1", p1, null));
 
@@ -373,9 +374,9 @@ public class ExpressionRangePartitionInfoTest {
         partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, Arrays.asList(k1, k2), PartitionType.RANGE);
 
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-            singleRangePartitionDesc.analyze(columns, null);
+            PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, columns, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
-                        20000L, false);
+                    20000L, false);
         }
     }
 
@@ -408,7 +409,7 @@ public class ExpressionRangePartitionInfoTest {
             partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
 
             for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                singleRangePartitionDesc.analyze(columns, null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, columns, null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
                         20000L, false);
             }
@@ -433,8 +434,8 @@ public class ExpressionRangePartitionInfoTest {
 
         //add RangePartitionDescs
         PartitionKeyDesc p1 = new PartitionKeyDesc(
-                    Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")),
-                    Lists.newArrayList(new PartitionValue("20190201")));
+                Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")),
+                Lists.newArrayList(new PartitionValue("20190201")));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1", p1, null));
 
@@ -442,9 +443,9 @@ public class ExpressionRangePartitionInfoTest {
         partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
 
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-            singleRangePartitionDesc.analyze(columns, null);
+            PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, columns, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
-                        20000L, false);
+                    20000L, false);
         }
     }
 
@@ -477,7 +478,7 @@ public class ExpressionRangePartitionInfoTest {
             partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
 
             for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                singleRangePartitionDesc.analyze(columns, null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, columns, null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
                         20000L, false);
             }
@@ -488,31 +489,31 @@ public class ExpressionRangePartitionInfoTest {
     public void testExpressionRangePartitionInfoSerialized_FunctionExpr() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE table_hitcount (\n" +
-                    "databaseName varchar(200) NULL COMMENT \"\",\n" +
-                    "tableName varchar(200) NULL COMMENT \"\",\n" +
-                    "queryTime varchar(50) NULL COMMENT \"\",\n" +
-                    "queryId varchar(50) NULL COMMENT \"\",\n" +
-                    "partitionHitSum int(11) NULL COMMENT \"\",\n" +
-                    "partitionSum int(11) NULL COMMENT \"\",\n" +
-                    "tabletHitNum int(11) NULL COMMENT \"\",\n" +
-                    "tabletSum int(11) NULL COMMENT \"\",\n" +
-                    "startHitPartition varchar(20) NULL COMMENT \"\",\n" +
-                    "dt date NULL COMMENT \"\",\n" +
-                    "clusterAddress varchar(50) NULL COMMENT \"\",\n" +
-                    "costTime int(11) NULL COMMENT \"\",\n" +
-                    "tableQueryCount int(11) NULL COMMENT \"\"\n" +
-                    ") ENGINE=OLAP\n" +
-                    "DUPLICATE KEY(databaseName, tableName)\n" +
-                    "COMMENT \"OLAP\"\n" +
-                    "PARTITION BY date_trunc('day', dt)\n" +
-                    "DISTRIBUTED BY HASH(databaseName) BUCKETS 1\n" +
-                    "PROPERTIES (\n" +
-                    "\"replication_num\" = \"1\",\n" +
-                    "\"in_memory\" = \"false\",\n" +
-                    "\"enable_persistent_index\" = \"true\",\n" +
-                    "\"replicated_storage\" = \"true\",\n" +
-                    "\"compression\" = \"LZ4\"\n" +
-                    ");";
+                "databaseName varchar(200) NULL COMMENT \"\",\n" +
+                "tableName varchar(200) NULL COMMENT \"\",\n" +
+                "queryTime varchar(50) NULL COMMENT \"\",\n" +
+                "queryId varchar(50) NULL COMMENT \"\",\n" +
+                "partitionHitSum int(11) NULL COMMENT \"\",\n" +
+                "partitionSum int(11) NULL COMMENT \"\",\n" +
+                "tabletHitNum int(11) NULL COMMENT \"\",\n" +
+                "tabletSum int(11) NULL COMMENT \"\",\n" +
+                "startHitPartition varchar(20) NULL COMMENT \"\",\n" +
+                "dt date NULL COMMENT \"\",\n" +
+                "clusterAddress varchar(50) NULL COMMENT \"\",\n" +
+                "costTime int(11) NULL COMMENT \"\",\n" +
+                "tableQueryCount int(11) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(databaseName, tableName)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "PARTITION BY date_trunc('day', dt)\n" +
+                "DISTRIBUTED BY HASH(databaseName) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"enable_persistent_index\" = \"true\",\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"compression\" = \"LZ4\"\n" +
+                ");";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
@@ -532,31 +533,31 @@ public class ExpressionRangePartitionInfoTest {
     public void testExpressionRangePartitionInfoSerialized_SlotRef() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test_table (\n" +
-                    "databaseName varchar(200) NULL COMMENT \"\",\n" +
-                    "tableName varchar(200) NULL COMMENT \"\",\n" +
-                    "queryTime varchar(50) NULL COMMENT \"\",\n" +
-                    "queryId varchar(50) NULL COMMENT \"\",\n" +
-                    "dt date NULL COMMENT \"\"\n" +
-                    ") ENGINE=OLAP\n" +
-                    "DUPLICATE KEY(databaseName, tableName)\n" +
-                    "PARTITION BY RANGE (`dt`)\n" +
-                    "(\n" +
-                    "    PARTITION p1 values less than('2021-02-01'),\n" +
-                    "    PARTITION p2 values less than('2021-03-01')\n" +
-                    ")\n" +
-                    "DISTRIBUTED BY HASH(databaseName) BUCKETS 1\n" +
-                    "PROPERTIES (\n" +
-                    "\"replication_num\" = \"1\"\n" +
-                    ");";
+                "databaseName varchar(200) NULL COMMENT \"\",\n" +
+                "tableName varchar(200) NULL COMMENT \"\",\n" +
+                "queryTime varchar(50) NULL COMMENT \"\",\n" +
+                "queryId varchar(50) NULL COMMENT \"\",\n" +
+                "dt date NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(databaseName, tableName)\n" +
+                "PARTITION BY RANGE (`dt`)\n" +
+                "(\n" +
+                "    PARTITION p1 values less than('2021-02-01'),\n" +
+                "    PARTITION p2 values less than('2021-03-01')\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(databaseName) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
 
         starRocksAssert.withMaterializedView("create materialized view test_mv1 " +
-                    " DISTRIBUTED BY HASH(dt, queryId) BUCKETS 4\n" +
-                    " PARTITION BY dt\n" +
-                    "PROPERTIES (\n" +
-                    "\"replication_num\" = \"1\"\n" +
-                    ") as select dt, queryId, count(1) from test_table group by dt, queryId"
+                " DISTRIBUTED BY HASH(dt, queryId) BUCKETS 4\n" +
+                " PARTITION BY dt\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") as select dt, queryId, count(1) from test_table group by dt, queryId"
         );
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_mv1");
@@ -578,31 +579,31 @@ public class ExpressionRangePartitionInfoTest {
     public void testExpressionRangePartitionInfoV2SerializedWrongNotFailed() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE `game_log2` (\n" +
-                    "  `cloud_id` varchar(65533) NULL COMMENT \"\",\n" +
-                    "  `user_id` varchar(65533) NULL COMMENT \"\",\n" +
-                    "  `day` date NULL COMMENT \"\"\n" +
-                    ") ENGINE=OLAP \n" +
-                    "DUPLICATE KEY(`cloud_id`, `user_id`)\n" +
-                    "PARTITION BY RANGE(cast(substr(cloud_id, 3, 11) as bigint))()\n" +
-                    "DISTRIBUTED BY HASH(`cloud_id`, `user_id`) BUCKETS 1 \n" +
-                    "PROPERTIES (\n" +
-                    "\"replication_num\" = \"1\",\n" +
-                    "\"in_memory\" = \"false\",\n" +
-                    "\"enable_persistent_index\" = \"true\",\n" +
-                    "\"replicated_storage\" = \"true\",\n" +
-                    "\"compression\" = \"ZSTD\"\n" +
-                    ");";
+                "  `cloud_id` varchar(65533) NULL COMMENT \"\",\n" +
+                "  `user_id` varchar(65533) NULL COMMENT \"\",\n" +
+                "  `day` date NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`cloud_id`, `user_id`)\n" +
+                "PARTITION BY RANGE(cast(substr(cloud_id, 3, 11) as bigint))()\n" +
+                "DISTRIBUTED BY HASH(`cloud_id`, `user_id`) BUCKETS 1 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"enable_persistent_index\" = \"true\",\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"compression\" = \"ZSTD\"\n" +
+                ");";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable olapTable =
-                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "game_log2");
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "game_log2");
         ExpressionRangePartitionInfoV2 expressionRangePartitionInfo =
-                    (ExpressionRangePartitionInfoV2) olapTable.getPartitionInfo();
+                (ExpressionRangePartitionInfoV2) olapTable.getPartitionInfo();
         expressionRangePartitionInfo.setPartitionExprs(Lists.newArrayList(
-                    ColumnIdExpr.create(new FunctionCallExpr("abc", Lists.newArrayList(new SlotRef(
-                                new TableName("test", "game_log2"), "cloud_id"))))));
+                ColumnIdExpr.create(new FunctionCallExpr("abc", Lists.newArrayList(new SlotRef(
+                        new TableName("test", "game_log2"), "cloud_id"))))));
         // serialize
         String json = GsonUtils.GSON.toJson(olapTable);
         // deserialize

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionDescTest.java
@@ -20,6 +20,7 @@ import com.starrocks.analysis.TypeDef;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
+import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.ListPartitionDesc;
@@ -122,7 +123,7 @@ public class ListPartitionDescTest {
     public ListPartitionInfo findSingleListPartitionInfo() throws AnalysisException, DdlException {
         ListPartitionDesc listPartitionDesc = this.findListSinglePartitionDesc("province",
                 "p1", "p2", this.findSupportedProperties(null));
-        listPartitionDesc.analyze(this.findColumnDefList(), null);
+        PartitionDescAnalyzer.analyze(listPartitionDesc, this.findColumnDefList(), null);
 
         Map<String, Long> partitionNameToId = new HashMap<>();
         partitionNameToId.put("p1", 10001L);
@@ -134,7 +135,7 @@ public class ListPartitionDescTest {
     public ListPartitionInfo findMultiListPartitionInfo() throws AnalysisException, DdlException {
         ListPartitionDesc listPartitionDesc = this.findListMultiPartitionDesc("dt,province",
                 "p1", "p2", this.findSupportedProperties(null));
-        listPartitionDesc.analyze(this.findColumnDefList(), null);
+        PartitionDescAnalyzer.analyze(listPartitionDesc, this.findColumnDefList(), null);
 
         Map<String, Long> partitionNameToId = new HashMap<>();
         partitionNameToId.put("p1", 10001L);
@@ -154,7 +155,7 @@ public class ListPartitionDescTest {
 
             List<PartitionDesc> partitionDescs = Lists.newArrayList(p1);
             ListPartitionDesc listPartitionDesc = new ListPartitionDesc(partitionColNames, partitionDescs);
-            listPartitionDesc.analyze(this.findColumnDefList(), null);
+            PartitionDescAnalyzer.analyze(listPartitionDesc, this.findColumnDefList(), null);
         });
     }
 
@@ -168,7 +169,7 @@ public class ListPartitionDescTest {
 
             List<PartitionDesc> partitionDescs = Lists.newArrayList(p1);
             ListPartitionDesc listPartitionDesc = new ListPartitionDesc(partitionColNames, partitionDescs);
-            listPartitionDesc.analyze(this.findColumnDefList(), null);
+            PartitionDescAnalyzer.analyze(listPartitionDesc, this.findColumnDefList(), null);
         });
     }
 
@@ -176,7 +177,7 @@ public class ListPartitionDescTest {
     public void testSingleListPartitionDesc() throws AnalysisException {
         ListPartitionDesc listPartitionDesc = this.findListSinglePartitionDesc("province",
                 "p1", "p2", null);
-        listPartitionDesc.analyze(this.findColumnDefList(), null);
+        PartitionDescAnalyzer.analyze(listPartitionDesc, this.findColumnDefList(), null);
         String sql = listPartitionDesc.toString();
         String target = "PARTITION BY LIST(`province`)(\n" +
                 "  PARTITION p1 VALUES IN (\'guangdong\',\'tianjin\'),\n" +
@@ -189,7 +190,7 @@ public class ListPartitionDescTest {
     public void testMultiListPartitionDesc() throws AnalysisException {
         ListPartitionDesc listPartitionDesc = this.findListMultiPartitionDesc("dt,province",
                 "p1", "p2", null);
-        listPartitionDesc.analyze(this.findColumnDefList(), null);
+        PartitionDescAnalyzer.analyze(listPartitionDesc, this.findColumnDefList(), null);
         String sql = listPartitionDesc.toString();
         String target = "PARTITION BY LIST(`dt`,`province`)(\n" +
                 "  PARTITION p1 VALUES IN ((\'2022-04-15\',\'guangdong\'),(\'2022-04-15\',\'tianjin\')),\n" +
@@ -202,7 +203,7 @@ public class ListPartitionDescTest {
     public void testDuplicatePartitionColumn() {
         assertThrows(AnalysisException.class, () -> {
             ListPartitionDesc listPartitionDesc = this.findListSinglePartitionDesc("dt,dt", "p1", "p1", null);
-            listPartitionDesc.analyze(this.findColumnDefList(), null);
+            PartitionDescAnalyzer.analyze(listPartitionDesc, this.findColumnDefList(), null);
         });
     }
 
@@ -215,7 +216,7 @@ public class ListPartitionDescTest {
             dt.setAggregateType(AggregateType.NONE);
             List<ColumnDef> columnDefList = Lists.newArrayList(province, dt);
             ListPartitionDesc listSinglePartitionDesc = this.findListSinglePartitionDesc("province", "p1", "p2", null);
-            listSinglePartitionDesc.analyze(columnDefList, null);
+            PartitionDescAnalyzer.analyzeListPartitionDesc(listSinglePartitionDesc, columnDefList, null);
         });
     }
 
@@ -223,7 +224,7 @@ public class ListPartitionDescTest {
     public void testColumnNoExist() {
         assertThrows(AnalysisException.class, () -> {
             ListPartitionDesc listPartitionDesc = this.findListSinglePartitionDesc("name", "p1", "p1", null);
-            listPartitionDesc.analyze(this.findColumnDefList(), null);
+            PartitionDescAnalyzer.analyze(listPartitionDesc, this.findColumnDefList(), null);
         });
     }
 
@@ -231,7 +232,7 @@ public class ListPartitionDescTest {
     public void testDuplicateSingleListPartitionNames() {
         assertThrows(AnalysisException.class, () -> {
             ListPartitionDesc listSinglePartitionDesc = this.findListSinglePartitionDesc("province", "p1", "p1", null);
-            listSinglePartitionDesc.analyze(this.findColumnDefList(), null);
+            PartitionDescAnalyzer.analyze(listSinglePartitionDesc, this.findColumnDefList(), null);
         });
     }
 
@@ -239,7 +240,7 @@ public class ListPartitionDescTest {
     public void testDuplicateMultiListPartitionNames() {
         assertThrows(AnalysisException.class, () -> {
             ListPartitionDesc listMultiPartitionDesc = this.findListMultiPartitionDesc("dt,province", "p1", "p1", null);
-            listMultiPartitionDesc.analyze(this.findColumnDefList(), null);
+            PartitionDescAnalyzer.analyze(listMultiPartitionDesc, this.findColumnDefList(), null);
         });
     }
 
@@ -250,7 +251,7 @@ public class ListPartitionDescTest {
             supportedProperties.put("storage_medium", "xxx");
             ListPartitionDesc listMultiPartitionDesc = this.findListMultiPartitionDesc(
                     "dt,province", "p1", "p1", this.findSupportedProperties(supportedProperties));
-            listMultiPartitionDesc.analyze(this.findColumnDefList(), this.findSupportedProperties(null));
+            PartitionDescAnalyzer.analyze(listMultiPartitionDesc, this.findColumnDefList(), this.findSupportedProperties(null));
         });
     }
 
@@ -261,7 +262,7 @@ public class ListPartitionDescTest {
             supportedProperties.put("storage_cooldown_time", "2021-04-01 12:12:12");
             ListPartitionDesc listMultiPartitionDesc = this.findListMultiPartitionDesc(
                     "dt,province", "p1", "p1", this.findSupportedProperties(supportedProperties));
-            listMultiPartitionDesc.analyze(this.findColumnDefList(), this.findSupportedProperties(null));
+            PartitionDescAnalyzer.analyze(listMultiPartitionDesc, this.findColumnDefList(), this.findSupportedProperties(null));
         });
     }
 
@@ -272,7 +273,7 @@ public class ListPartitionDescTest {
             supportedProperties.put("replication_num", "0");
             ListPartitionDesc listMultiPartitionDesc = this.findListMultiPartitionDesc(
                     "dt,province", "p1", "p1", this.findSupportedProperties(supportedProperties));
-            listMultiPartitionDesc.analyze(this.findColumnDefList(), this.findSupportedProperties(null));
+            PartitionDescAnalyzer.analyze(listMultiPartitionDesc, this.findColumnDefList(), this.findSupportedProperties(null));
         });
     }
 
@@ -283,7 +284,7 @@ public class ListPartitionDescTest {
             supportedProperties.put("in_memory", "xxx");
             ListPartitionDesc listMultiPartitionDesc = this.findListMultiPartitionDesc(
                     "dt,province", "p1", "p1", this.findSupportedProperties(supportedProperties));
-            listMultiPartitionDesc.analyze(this.findColumnDefList(), this.findSupportedProperties(null));
+            PartitionDescAnalyzer.analyze(listMultiPartitionDesc, this.findColumnDefList(), this.findSupportedProperties(null));
         });
     }
 
@@ -294,7 +295,7 @@ public class ListPartitionDescTest {
             supportedProperties.put("no_support", "xxx");
             ListPartitionDesc listMultiPartitionDesc = this.findListMultiPartitionDesc(
                     "dt,province", "p1", "p1", this.findSupportedProperties(supportedProperties));
-            listMultiPartitionDesc.analyze(this.findColumnDefList(), null);
+            PartitionDescAnalyzer.analyze(listMultiPartitionDesc, this.findColumnDefList(), null);
         });
     }
 
@@ -349,7 +350,7 @@ public class ListPartitionDescTest {
                             Lists.newArrayList("2022-04-15", "beijing")), null);
             List<PartitionDesc> partitionDescs = Lists.newArrayList(p1, p2);
             ListPartitionDesc listPartitionDesc = new ListPartitionDesc(partitionColNames, partitionDescs);
-            listPartitionDesc.analyze(this.findColumnDefList(), null);
+            PartitionDescAnalyzer.analyze(listPartitionDesc, this.findColumnDefList(), null);
         });
     }
 
@@ -370,7 +371,7 @@ public class ListPartitionDescTest {
                             Lists.newArrayList("2022-04-15", "guangdong")), null);
             List<PartitionDesc> partitionDescs = Lists.newArrayList(p1, p2);
             ListPartitionDesc listPartitionDesc = new ListPartitionDesc(partitionColNames, partitionDescs);
-            listPartitionDesc.analyze(this.findColumnDefList(), null);
+            PartitionDescAnalyzer.analyze(listPartitionDesc, this.findColumnDefList(), null);
         });
     }
 
@@ -389,7 +390,7 @@ public class ListPartitionDescTest {
                     Lists.newArrayList("shanghai", "beijing"), null);
             List<PartitionDesc> partitionDescs = Lists.newArrayList(p1, p2);
             ListPartitionDesc listPartitionDesc = new ListPartitionDesc(partitionColNames, partitionDescs);
-            listPartitionDesc.analyze(this.findColumnDefList(), null);
+            PartitionDescAnalyzer.analyze(listPartitionDesc, this.findColumnDefList(), null);
         });
     }
 
@@ -408,7 +409,7 @@ public class ListPartitionDescTest {
                     Lists.newArrayList("shanghai", "beijing"), null);
             List<PartitionDesc> partitionDescs = Lists.newArrayList(p1, p2);
             ListPartitionDesc listPartitionDesc = new ListPartitionDesc(partitionColNames, partitionDescs);
-            listPartitionDesc.analyze(this.findColumnDefList(), null);
+            PartitionDescAnalyzer.analyze(listPartitionDesc, this.findColumnDefList(), null);
         });
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MultiListPartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MultiListPartitionDescTest.java
@@ -17,6 +17,7 @@ package com.starrocks.catalog;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.TypeDef;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.MultiItemListPartitionDesc;
 import com.starrocks.thrift.TStorageMedium;
@@ -84,7 +85,7 @@ public class MultiListPartitionDescTest {
 
         MultiItemListPartitionDesc partitionDesc = new MultiItemListPartitionDesc(ifNotExists, partitionName,
                 multiValues, partitionProperties);
-        partitionDesc.analyze(columnDefLists, null);
+        PartitionDescAnalyzer.analyze(partitionDesc, columnDefLists, null);
 
         Assertions.assertEquals(partitionName, partitionDesc.getPartitionName());
         Assertions.assertEquals(1, partitionDesc.getReplicationNum());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PartitionDescTest.java
@@ -54,11 +54,6 @@ public class PartitionDescTest {
     }
 
     @Test
-    public void testAnalyzeByColumnDefs() {
-        assertThrows(NotImplementedException.class, () -> this.partitionDesc.analyze(columnDefs, otherProperties));
-    }
-
-    @Test
     public void testToSql() {
         assertThrows(NotImplementedException.class, () -> this.partitionDesc.toSql());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/RangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/RangePartitionInfoTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
+import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
 import com.starrocks.sql.ast.PartitionKeyDesc;
 import com.starrocks.sql.ast.PartitionKeyDesc.PartitionRangeType;
 import com.starrocks.sql.ast.PartitionValue;
@@ -61,7 +62,7 @@ public class RangePartitionInfoTest {
 
             partitionInfo = new RangePartitionInfo(partitionColumns);
             for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                singleRangePartitionDesc.analyze(1, null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, 1, null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns),
                         singleRangePartitionDesc, 20000L, false);
             }
@@ -80,7 +81,7 @@ public class RangePartitionInfoTest {
 
             partitionInfo = new RangePartitionInfo(partitionColumns);
             for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                singleRangePartitionDesc.analyze(1, null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, 1, null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns),
                         singleRangePartitionDesc, 20000L, false);
             }
@@ -99,7 +100,7 @@ public class RangePartitionInfoTest {
 
             partitionInfo = new RangePartitionInfo(partitionColumns);
             for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                singleRangePartitionDesc.analyze(1, null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, 1, null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns),
                         singleRangePartitionDesc, 20000L, false);
             }
@@ -124,7 +125,7 @@ public class RangePartitionInfoTest {
             partitionInfo = new RangePartitionInfo(partitionColumns);
 
             for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                singleRangePartitionDesc.analyze(1, null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, 1, null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns),
                         singleRangePartitionDesc, 20000L, false);
             }
@@ -148,7 +149,7 @@ public class RangePartitionInfoTest {
         partitionInfo = new RangePartitionInfo(partitionColumns);
 
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-            singleRangePartitionDesc.analyze(1, null);
+            PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, 1, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns),
                     singleRangePartitionDesc, 20000L, false);
         }
@@ -193,7 +194,7 @@ public class RangePartitionInfoTest {
         partitionInfo = new RangePartitionInfo(partitionColumns);
 
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-            singleRangePartitionDesc.analyze(columns, null);
+            PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, columns, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns),
                     singleRangePartitionDesc, 20000L, false);
         }
@@ -241,7 +242,7 @@ public class RangePartitionInfoTest {
                 } else if (partitionType != singleRangePartitionDesc.getPartitionKeyDesc().getPartitionType()) {
                     throw new AnalysisException("You can only use one of these methods to create partitions");
                 }
-                singleRangePartitionDesc.analyze(partitionColumns.size(), null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, partitionColumns.size(), null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns),
                         singleRangePartitionDesc, 20000L, false);
             }
@@ -271,7 +272,7 @@ public class RangePartitionInfoTest {
         partitionInfo = new RangePartitionInfo(partitionColumns);
 
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-            singleRangePartitionDesc.analyze(columns, null);
+            PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, columns, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns),
                     singleRangePartitionDesc, 20000L, false);
         }
@@ -303,7 +304,7 @@ public class RangePartitionInfoTest {
             partitionInfo = new RangePartitionInfo(partitionColumns);
 
             for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                singleRangePartitionDesc.analyze(columns, null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, columns, null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns),
                         singleRangePartitionDesc, 20000L, false);
             }
@@ -334,7 +335,7 @@ public class RangePartitionInfoTest {
         partitionInfo = new RangePartitionInfo(partitionColumns);
 
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-            singleRangePartitionDesc.analyze(columns, null);
+            PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, columns, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns),
                     singleRangePartitionDesc, 20000L, false);
         }
@@ -366,7 +367,7 @@ public class RangePartitionInfoTest {
             partitionInfo = new RangePartitionInfo(partitionColumns);
 
             for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                singleRangePartitionDesc.analyze(columns, null);
+                PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc, columns, null);
                 partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns),
                         singleRangePartitionDesc, 20000L, false);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/SingleListPartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/SingleListPartitionDescTest.java
@@ -17,6 +17,7 @@ package com.starrocks.catalog;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.TypeDef;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.SingleItemListPartitionDesc;
 import com.starrocks.thrift.TStorageMedium;
@@ -82,7 +83,7 @@ public class SingleListPartitionDescTest {
 
         SingleItemListPartitionDesc partitionDesc = new SingleItemListPartitionDesc(ifNotExists, partitionName,
                 values, partitionProperties);
-        partitionDesc.analyze(columnDefLists, null);
+        PartitionDescAnalyzer.analyze(partitionDesc, columnDefLists, null);
 
         Assertions.assertEquals(partitionName, partitionDesc.getPartitionName());
         Assertions.assertEquals(1, partitionDesc.getReplicationNum());

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadPendingTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadPendingTaskTest.java
@@ -67,6 +67,7 @@ import com.starrocks.load.loadv2.etl.EtlJobConfig.EtlPartition;
 import com.starrocks.load.loadv2.etl.EtlJobConfig.EtlPartitionInfo;
 import com.starrocks.load.loadv2.etl.EtlJobConfig.EtlTable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
 import com.starrocks.sql.ast.DataDescription;
 import com.starrocks.sql.ast.PartitionKeyDesc;
 import com.starrocks.sql.ast.PartitionNames;
@@ -114,7 +115,7 @@ public class SparkLoadPendingTaskTest {
         long partitionId = 2L;
         DistributionInfo distributionInfo = new HashDistributionInfo(2, Lists.newArrayList(columns.get(0)));
         PartitionInfo partitionInfo = new SinglePartitionInfo();
-        Partition partition = new Partition(partitionId, 21,  "p1", null, distributionInfo);
+        Partition partition = new Partition(partitionId, 21, "p1", null, distributionInfo);
         List<Partition> partitions = Lists.newArrayList(partition);
 
         // file group
@@ -266,11 +267,11 @@ public class SparkLoadPendingTaskTest {
         int distributionColumnIndex = 1;
         DistributionInfo distributionInfo =
                 new HashDistributionInfo(3, Lists.newArrayList(columns.get(distributionColumnIndex)));
-        Partition partition1 = new Partition(partition1Id, 21,  "p1", null,
+        Partition partition1 = new Partition(partition1Id, 21, "p1", null,
                 distributionInfo);
-        Partition partition2 = new Partition(partition2Id, 51,  "p2", null,
+        Partition partition2 = new Partition(partition2Id, 51, "p2", null,
                 new HashDistributionInfo(4, Lists.newArrayList(columns.get(distributionColumnIndex))));
-        Partition partition3 = new Partition(partition3Id, 61,  "tp3", null,
+        Partition partition3 = new Partition(partition3Id, 61, "tp3", null,
                 distributionInfo);
         int partitionColumnIndex = 0;
         List<Partition> partitions = Lists.newArrayList(partition1, partition2);
@@ -278,17 +279,17 @@ public class SparkLoadPendingTaskTest {
                 new RangePartitionInfo(Lists.newArrayList(columns.get(partitionColumnIndex)));
         PartitionKeyDesc partitionKeyDesc1 = new PartitionKeyDesc(Lists.newArrayList(new PartitionValue("10")));
         SingleRangePartitionDesc partitionDesc1 = new SingleRangePartitionDesc(false, "p1", partitionKeyDesc1, null);
-        partitionDesc1.analyze(1, null);
+        PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(partitionDesc1, 1, null);
         partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(columns),
                 partitionDesc1, partition1Id, false);
         PartitionKeyDesc partitionKeyDesc2 = new PartitionKeyDesc(Lists.newArrayList(new PartitionValue("20")));
         SingleRangePartitionDesc partitionDesc2 = new SingleRangePartitionDesc(false, "p2", partitionKeyDesc2, null);
-        partitionDesc2.analyze(1, null);
+        PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(partitionDesc2, 1, null);
         partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(columns),
                 partitionDesc2, partition2Id, false);
         PartitionKeyDesc partitionKeyDesc3 = new PartitionKeyDesc(Lists.newArrayList(new PartitionValue("10")));
         SingleRangePartitionDesc partitionDesc3 = new SingleRangePartitionDesc(false, "tp3", partitionKeyDesc1, null);
-        partitionDesc3.analyze(1, null);
+        PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(partitionDesc3, 1, null);
         partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(columns),
                 partitionDesc3, partition3Id, true);
 


### PR DESCRIPTION
## Why I'm doing:
These changes collectively improve code maintainability and make the partition analysis process more robust and easier to extend in the future.
## What I'm doing:
This pull request refactors the partition analysis logic in the SQL analyzer by removing the `analyze` method implementations from partition descriptor classes and consolidating partition analysis responsibilities into the `PartitionDescAnalyzer` utility class. This change simplifies the partition descriptor classes and centralizes analysis logic, making the codebase easier to maintain and extend.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
