### PR TITLE
[Enhancement] Add hll_deserialize in authorized function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1139,11 +1139,6 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         }
 
-        // hll must be used in agg_keys
-        if (newColumn.getType().isHllType() && KeysType.AGG_KEYS != olapTable.getKeysType()) {
-            throw new DdlException("HLL type column can only be in Aggregation data model table: " + newColName);
-        }
-
         if (newColumn.getAggregationType() == AggregateType.BITMAP_UNION && KeysType.AGG_KEYS != olapTable.getKeysType()) {
             throw new DdlException("BITMAP_UNION must be used in AGG_KEYS");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -344,10 +344,12 @@ public class StreamLoadScanNode extends LoadScanNode {
                 }
                 FunctionCallExpr fn = (FunctionCallExpr) expr;
                 if (!fn.getFnName().getFunction().equalsIgnoreCase(FunctionSet.HLL_HASH)
-                        && !fn.getFnName().getFunction().equalsIgnoreCase("hll_empty")) {
+                        && !fn.getFnName().getFunction().equalsIgnoreCase("hll_empty")
+                        && !fn.getFnName().getFunction().equalsIgnoreCase("hll_deserialize")) {
                     throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + " function, like "
                             + dstSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_HASH
-                            + "(xxx) or " + dstSlotDesc.getColumn().getName() + "=hll_empty()");
+                            + "(xxx) or " + dstSlotDesc.getColumn().getName() + "=hll_empty() or "
+                            + dstSlotDesc.getColumn().getName() + "=hll_deserialize(xxx)");
                 }
                 expr.setType(Type.HLL);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
@@ -147,7 +147,7 @@ public class ColumnDefAnalyzer {
                                     aggregateType, name, type, aggFunc.getReturnType()));
                 }
             }
-        } else if (type.isBitmapType() || type.isHllType() || type.isPercentile()) {
+        } else if (type.isBitmapType() || type.isPercentile()) {
             throw new AnalysisException(String.format("No aggregate function specified for '%s'", name));
         }
 


### PR DESCRIPTION
## Why I'm doing:
We want to use the hll_deserialize function in fe-core but it is so far not possible.
In a Kafka streaming ingestion process, if the incoming HLL hashes arrived in a serialized format, it is required to deserialize it before any other processing.

So far the usage of hll_deserialize is not allowed.

## What I'm doing:

Add the possibility to have HLL type column in Aggregation data model table (in creation and updates of the table)
Just adding hll_deserialize in the check, nothing more as the function is still available.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3