### PR TITLE
[BugFix] Add lock when get max version from tablet in replication txn manager

### DIFF
--- a/be/src/storage/replication_txn_manager.cpp
+++ b/be/src/storage/replication_txn_manager.cpp
@@ -673,8 +673,11 @@ Status ReplicationTxnManager::convert_snapshot_for_primary(const std::string& ta
 
 Status ReplicationTxnManager::publish_snapshot(Tablet* tablet, const string& snapshot_dir, int64_t snapshot_version,
                                                bool incremental_snapshot) {
-    if (tablet->max_version().second >= snapshot_version) {
-        return Status::OK();
+    {
+        std::shared_lock lock(tablet->get_header_lock());
+        if (tablet->max_version().second >= snapshot_version) {
+            return Status::OK();
+        }
     }
 
     if (tablet->updates() != nullptr) {


### PR DESCRIPTION
## Why I'm doing:
No lock when get max version from tablet may cause concurrent issues.

## What I'm doing:
Add lock when get max version from tablet in replication txn manager.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
