### PR TITLE
[Refactor] refactor count star optimization naming

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1262,7 +1262,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_JSON_V2_DICT_OPT)
     private boolean cboJSONV2DictOpt = true;
 
-
     /*
      * the parallel exec instance num for one Fragment in one BE
      * 1 means disable this feature
@@ -1792,7 +1791,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_REWRITE_PARTITION_COLUMN_MINMAX)
     private boolean enableRewritePartitionColumnMinMax = true;
 
-    @VarAttr(name = ENABLE_REWRITE_SIMPLE_AGG_TO_HDFS_SCAN)
+    @VarAttr(name = ENABLE_REWRITE_SIMPLE_AGG_TO_HDFS_SCAN, flag = VariableMgr.INVISIBLE)
     private boolean enableRewriteSimpleAggToHdfsScan = true;
 
     @VarAttr(name = ENABLE_EVALUATE_SCHEMA_SCAN_RULE)
@@ -2451,7 +2450,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_SIMPLIFY_CASE_WHEN, flag = VariableMgr.INVISIBLE)
     private boolean enableSimplifyCaseWhen = true;
 
-    @VarAttr(name = ENABLE_COUNT_STAR_OPTIMIZATION, flag = VariableMgr.INVISIBLE)
+    @VarAttr(name = ENABLE_COUNT_STAR_OPTIMIZATION)
     private boolean enableCountStarOptimization = true;
 
     @VarAttr(name = ENABLE_MIN_MAX_OPTIMIZATION)
@@ -5238,7 +5237,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public void setEnableJSONV2Rewrite(boolean enableJSONV2Rewrite) {
         this.cboJSONV2Rewrite = enableJSONV2Rewrite;
     }
-  
+
     public boolean isEnableDropTableCheckMvDependency() {
         return enableDropTableCheckMvDependency;
     }
@@ -5446,9 +5445,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         }
         return root.toString();
     }
-
-
-
 
     private void readFromJson(DataInput in) throws IOException {
         String json = Text.readString(in);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
@@ -62,7 +62,7 @@ public class FeNameFormat {
         FORBIDDEN_COLUMN_NAMES = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
         FORBIDDEN_COLUMN_NAMES.add("__op");
         FORBIDDEN_COLUMN_NAMES.add("__row");
-        // see RewriteSimpleAggToHDFSScanRule
+        // see CountStarOptOnScanRule
         FORBIDDEN_COLUMN_NAMES.add("___count___");
         String allowedSpecialCharacters = "";
         for (Character c : SPECIAL_CHARACTERS_IN_DB_NAME) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -61,6 +61,7 @@ import com.starrocks.sql.optimizer.rule.transformation.CastToEmptyRule;
 import com.starrocks.sql.optimizer.rule.transformation.CollectCTEConsumeRule;
 import com.starrocks.sql.optimizer.rule.transformation.CollectCTEProduceRule;
 import com.starrocks.sql.optimizer.rule.transformation.CombinationRule;
+import com.starrocks.sql.optimizer.rule.transformation.CountStarOptOnScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.DeferProjectAfterTopNRule;
 import com.starrocks.sql.optimizer.rule.transformation.DistributionPruneRule;
 import com.starrocks.sql.optimizer.rule.transformation.EliminateGroupByConstantRule;
@@ -152,7 +153,6 @@ import com.starrocks.sql.optimizer.rule.transformation.RewriteBitmapCountDistinc
 import com.starrocks.sql.optimizer.rule.transformation.RewriteCountIfFunction;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteDuplicateAggregateFnRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteHllCountDistinctRule;
-import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToHDFSScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToMetaScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteSumByAssociativeRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteToVectorPlanRule;
@@ -415,7 +415,7 @@ public class RuleSet {
                     new PushDownAggToMetaScanRule(),
                     new PushDownFlatJsonMetaToMetaScanRule(),
                     new RewriteSimpleAggToMetaScanRule(),
-                    RewriteSimpleAggToHDFSScanRule.SCAN_AND_PROJECT,
+                    CountStarOptOnScanRule.SCAN_AND_PROJECT,
                     new MinMaxOptOnScanRule()
             ));
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/CountStarOptOnScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/CountStarOptOnScanRule.java
@@ -51,29 +51,29 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
-    private static final Logger LOG = LogManager.getLogger(RewriteSimpleAggToHDFSScanRule.class);
+public class CountStarOptOnScanRule extends TransformationRule {
+    private static final Logger LOG = LogManager.getLogger(CountStarOptOnScanRule.class);
 
     private static final Set<OperatorType> SUPPORTED = Set.of(OperatorType.LOGICAL_HIVE_SCAN,
             OperatorType.LOGICAL_ICEBERG_SCAN,
             OperatorType.LOGICAL_FILE_SCAN
     );
 
-    public static final RewriteSimpleAggToHDFSScanRule SCAN_NO_PROJECT =
-            new RewriteSimpleAggToHDFSScanRule(false);
+    public static final CountStarOptOnScanRule SCAN_NO_PROJECT =
+            new CountStarOptOnScanRule(false);
 
-    public static final RewriteSimpleAggToHDFSScanRule SCAN_AND_PROJECT =
-            new RewriteSimpleAggToHDFSScanRule();
+    public static final CountStarOptOnScanRule SCAN_AND_PROJECT =
+            new CountStarOptOnScanRule();
 
     private final boolean hasProjectOperator;
 
-    private RewriteSimpleAggToHDFSScanRule(boolean /* unused */ noProject) {
+    private CountStarOptOnScanRule(boolean /* unused */ noProject) {
         super(RuleType.TF_REWRITE_SIMPLE_AGG, Pattern.create(OperatorType.LOGICAL_AGGR)
                 .addChildren(MultiOpPattern.of(SUPPORTED)));
         hasProjectOperator = false;
     }
 
-    private RewriteSimpleAggToHDFSScanRule() {
+    private CountStarOptOnScanRule() {
         super(RuleType.TF_REWRITE_SIMPLE_AGG, Pattern.create(OperatorType.LOGICAL_AGGR)
                 .addChildren(Pattern.create(OperatorType.LOGICAL_PROJECT).addChildren(MultiOpPattern.of(SUPPORTED))));
         hasProjectOperator = true;
@@ -200,7 +200,7 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
 
     @Override
     public boolean check(final OptExpression input, OptimizerContext context) {
-        if (!context.getSessionVariable().isEnableRewriteSimpleAggToHdfsScan()) {
+        if (!context.getSessionVariable().isEnableCountStarOptimization()) {
             return false;
         }
         LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) input.getOp();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -83,8 +83,8 @@ public class HiveScanTest extends ConnectorPlanTestBase {
     }
 
     @Test
-    public void testHiveRewriteSimpleAggToHdfsScan() throws Exception {
-        connectContext.getSessionVariable().setEnableRewriteSimpleAggToHdfsScan(true);
+    public void testHiveUseCountStartOptTest() throws Exception {
+        connectContext.getSessionVariable().setEnableCountStarOptimization(true);
         // positive cases.
         {
             String[] sqlString = {
@@ -131,12 +131,11 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                 assertNotContains(plan, "___count___");
             }
         }
-        connectContext.getSessionVariable().setEnableRewriteSimpleAggToHdfsScan(false);
     }
 
     @Test
-    public void testIcebergRewriteSimpleAggToHdfsScan() throws Exception {
-        connectContext.getSessionVariable().setEnableRewriteSimpleAggToHdfsScan(true);
+    public void testIcebergUseCountStarOptTest() throws Exception {
+        connectContext.getSessionVariable().setEnableCountStarOptimization(true);
         // positive cases.
         {
             String[] sqlString = {
@@ -174,7 +173,6 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                 assertNotContains(plan, "___count___");
             }
         }
-        connectContext.getSessionVariable().setEnableRewriteSimpleAggToHdfsScan(false);
     }
 
     private static File newFolder(File root, String... subDirs) throws IOException {


### PR DESCRIPTION
## Why I'm doing:

`enableRewriteSimpleAggToHdfsScan` is not intuitive for using count star optimization

and since we have a session variable `enableCountStarOptimization` for that, we should use that sv.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
