### PR TITLE
[Enhancement] [Refactor] Correct materialized view's auto_partition_refresh_number

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeTask.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class OptimizeTask extends Task {
 
-    @SerializedName("partitionName")
+    @SerializedName("name")
     private String partitionName;
 
     @SerializedName("tempPartitionName")
@@ -96,7 +96,7 @@ public class OptimizeTask extends Task {
     public String toString() {
         return super.toString() +
                 " OptimizeTask{" +
-                "partitionName='" + partitionName + '\'' +
+                "name='" + partitionName + '\'' +
                 ", tempPartitionName='" + tempPartitionName + '\'' +
                 ", optimizeTaskState=" + optimizeTaskState +
                 ", lastVersion=" + lastVersion;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2551,7 +2551,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
         for (String partitionName : partitionNames) {
             try {
-                //updatePartitionInMemoryMeta(db, olapTable.getName(), partitionName, isInMemory);
+                //updatePartitionInMemoryMeta(db, olapTable.getName(), name, isInMemory);
                 updatePartitionTabletMeta(db, olapTable.getName(), partitionName, isInMemory, TTabletMetaType.INMEMORY);
             } catch (Exception e) {
                 String errMsg = "Failed to update partition[" + partitionName + "]'s 'in_memory' property. " +

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1549,12 +1549,12 @@ public class OlapTable extends Table {
      * formal or temporary partition.
      * Therefore, we need to get the partition through this method:
      *
-     * `getPartition(String partitionName, boolean isTemp)`
+     * `getPartition(String name, boolean isTemp)`
      *
      * To avoid modifying too much code, we leave the `getPartition(String
-     * partitionName)`, which is same as:
+     * name)`, which is same as:
      *
-     * `getPartition(partitionName, false)`
+     * `getPartition(name, false)`
      *
      * 2. Get by id
      *

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -599,7 +599,7 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
     public String toString() {
         StringBuilder buffer = new StringBuilder();
         buffer.append("partitionId: ").append(id).append("; ");
-        buffer.append("partitionName: ").append(name).append("; ");
+        buffer.append("name: ").append(name).append("; ");
         buffer.append("parentPartitionId: ").append(parentId).append("; ");
         buffer.append("shardGroupId: ").append(shardGroupId).append("; ");
         buffer.append("isImmutable: ").append(isImmutable()).append("; ");

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -133,7 +133,7 @@ public class PartitionUtil {
     }
 
 
-    // If partitionName is `par_col=0/par_date=2020-01-01`, return ["0", "2020-01-01"]
+    // If name is `par_col=0/par_date=2020-01-01`, return ["0", "2020-01-01"]
     public static List<String> toPartitionValues(String partitionName) {
         // mimics Warehouse.makeValsFromName
         ImmutableList.Builder<String> resultBuilder = ImmutableList.builder();
@@ -564,7 +564,7 @@ public class PartitionUtil {
         Map<String, Range<PartitionKey>> mvPartitionRangeMap = new LinkedHashMap<>();
         PrimitiveType partitionColPrimType = isConvertToDate ? PrimitiveType.DATE : partitionColumn.getPrimitiveType();
         for (Map.Entry<String, PartitionKey> entry : sortedPartitionLinkMap.entrySet()) {
-            // Adapt to the range partitioning method of JDBC Table, the partitionName adopts the name of upperBound
+            // Adapt to the range partitioning method of JDBC Table, the name adopts the name of upperBound
             partitionName = entry.getKey();
             if (lastPartitionKey == null) {
                 lastPartitionKey = entry.getValue();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
@@ -601,7 +601,7 @@ public class HiveCommitter {
                                     HivePartitionStats statistics, boolean merge) {
             this.dbName = requireNonNull(dbName, "dbName is null");
             this.tableName = requireNonNull(tableName, "tableName is null");
-            this.partitionName = requireNonNull(partitionName, "partitionName is null");
+            this.partitionName = requireNonNull(partitionName, "name is null");
             this.updatePartitionStat = requireNonNull(statistics, "statistics is null");
             this.merge = merge;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/GlueMetastoreClientDelegate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/GlueMetastoreClientDelegate.java
@@ -775,7 +775,7 @@ public class GlueMetastoreClientDelegate {
             throws TException {
         checkArgument(StringUtils.isNotEmpty(dbName), "dbName cannot be null or empty");
         checkArgument(StringUtils.isNotEmpty(tblName), "tblName cannot be null or empty");
-        checkArgument(StringUtils.isNotEmpty(partitionName), "partitionName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(partitionName), "name cannot be null or empty");
         List<String> values = partitionNameToVals(partitionName);
         return getPartition(dbName, tblName, values);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
@@ -53,10 +53,10 @@ public class IcebergPartitionUtils {
     // Normalize partition name to yyyy-MM-dd (Type is Date) or yyyy-MM-dd HH:mm:ss (Type is Datetime)
     // Iceberg partition field transform support year, month, day, hour now,
     // eg.
-    // year(ts)  partitionName : 2023              return 2023-01-01 (Date) or 2023-01-01 00:00:00 (Datetime)
-    // month(ts) partitionName : 2023-01           return 2023-01-01 (Date) or 2023-01-01 00:00:00 (Datetime)
-    // day(ts)   partitionName : 2023-01-01        return 2023-01-01 (Date) or 2023-01-01 00:00:00 (Datetime)
-    // hour(ts)  partitionName : 2023-01-01-12     return 2023-01-01 12:00:00 (Datetime)
+    // year(ts)  name : 2023              return 2023-01-01 (Date) or 2023-01-01 00:00:00 (Datetime)
+    // month(ts) name : 2023-01           return 2023-01-01 (Date) or 2023-01-01 00:00:00 (Datetime)
+    // day(ts)   name : 2023-01-01        return 2023-01-01 (Date) or 2023-01-01 00:00:00 (Datetime)
+    // hour(ts)  name : 2023-01-01-12     return 2023-01-01 12:00:00 (Datetime)
     public static String normalizeTimePartitionName(String partitionName,
                                                     PartitionField partitionField,
                                                     Schema schema,
@@ -110,7 +110,7 @@ public class IcebergPartitionUtils {
             // format to string
             result = localDateTime.format(formatter);
         } catch (Exception e) {
-            LOG.warn("parse partition name failed, partitionName: {}, partitionField: {}, type: {}",
+            LOG.warn("parse partition name failed, name: {}, partitionField: {}, type: {}",
                     partitionName, partitionField, type);
             throw new StarRocksConnectorException("parse/format partition name failed", e);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/Partition.java
@@ -67,7 +67,7 @@ public class Partition implements PartitionInfo {
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("Partition{");
-        sb.append("partitionName=").append(partitionName);
+        sb.append("name=").append(partitionName);
         sb.append(", modifiedTime=").append(modifiedTime);
         sb.append('}');
         return sb.toString();
@@ -75,7 +75,7 @@ public class Partition implements PartitionInfo {
 
     public JsonObject toJson() {
         JsonObject obj = new JsonObject();
-        obj.add("partitionName", (GsonUtils.GSON.toJsonTree(partitionName)));
+        obj.add("name", (GsonUtils.GSON.toJsonTree(partitionName)));
         obj.add("modifiedTime", (GsonUtils.GSON.toJsonTree(modifiedTime)));
         return obj;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/Partition.java
@@ -67,7 +67,7 @@ public class Partition implements PartitionInfo {
     @Override
     public String toString() {
         return "PaimonPartitionInfo{" +
-                "partitionName='" + partitionName + '\'' +
+                "name='" + partitionName + '\'' +
                 ", lastUpdateTime=" + lastUpdateTime +
                 ", recordCount=" + recordCount +
                 ", fileSizeInBytes=" + fileSizeInBytes +

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteInfo.java
@@ -52,7 +52,7 @@ public class DeleteInfo implements Writable {
     private String tableName;
     @SerializedName(value = "partitionId")
     private long partitionId;
-    @SerializedName(value = "partitionName")
+    @SerializedName(value = "name")
     private String partitionName;
     @SerializedName(value = "partitionVersion")
     private long partitionVersion;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/DropPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/DropPartitionInfo.java
@@ -42,7 +42,7 @@ public class DropPartitionInfo implements Writable {
     private Long dbId;
     @SerializedName(value = "tableId")
     private Long tableId;
-    @SerializedName(value = "partitionName")
+    @SerializedName(value = "name")
     private String partitionName;
     @SerializedName(value = "isTempPartition")
     private boolean isTempPartition = false;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -239,7 +239,7 @@ public class EditLog {
                     PartitionPersistInfoV2 info = (PartitionPersistInfoV2) journal.data();
                     LOG.info("Begin to unprotect add partition. db = " + info.getDbId()
                             + " table = " + info.getTableId()
-                            + " partitionName = " + info.getPartition().getName());
+                            + " name = " + info.getPartition().getName());
                     globalStateMgr.getLocalMetastore().replayAddPartition(info);
                     break;
                 }
@@ -261,7 +261,7 @@ public class EditLog {
                     DropPartitionInfo info = (DropPartitionInfo) journal.data();
                     LOG.info("Begin to unprotect drop partition. db = " + info.getDbId()
                             + " table = " + info.getTableId()
-                            + " partitionName = " + info.getPartitionName());
+                            + " name = " + info.getPartitionName());
                     globalStateMgr.getLocalMetastore().replayDropPartition(info);
                     break;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -58,6 +58,7 @@ import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.common.DmlException;
+import com.starrocks.sql.common.PCellWithName;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
@@ -569,7 +570,7 @@ public abstract class BaseMVRefreshProcessor {
         final MVRefreshParams mvRefreshParams = new MVRefreshParams(mv.getPartitionInfo(), context.getProperties(), isForce);
 
         final Set<String> mvPotentialPartitionNames = Sets.newHashSet();
-        Set<String> mvToRefreshedPartitions = mvRefreshPartitioner.getMVToRefreshedPartitions(
+        List<PCellWithName> mvToRefreshedPartitions = mvRefreshPartitioner.getMVToRefreshedPartitions(
                 snapshotBaseTables, mvRefreshParams, partitionRefreshStrategy, mvPotentialPartitionNames, tentative);
         // update mv extra message
         if (!tentative) {
@@ -580,7 +581,9 @@ public abstract class BaseMVRefreshProcessor {
                 extraMessage.setPartitionEnd(mvRefreshParams.getRangeEnd());
             });
         }
-        return mvToRefreshedPartitions;
+        return mvToRefreshedPartitions.stream()
+                .map(PCellWithName::partitionName)
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -58,7 +58,7 @@ import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.common.DmlException;
-import com.starrocks.sql.common.PCellWithName;
+import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
@@ -570,7 +570,7 @@ public abstract class BaseMVRefreshProcessor {
         final MVRefreshParams mvRefreshParams = new MVRefreshParams(mv.getPartitionInfo(), context.getProperties(), isForce);
 
         final Set<String> mvPotentialPartitionNames = Sets.newHashSet();
-        List<PCellWithName> mvToRefreshedPartitions = mvRefreshPartitioner.getMVToRefreshedPartitions(
+        final PCellSortedSet mvToRefreshedPartitions = mvRefreshPartitioner.getMVToRefreshedPartitions(
                 snapshotBaseTables, mvRefreshParams, partitionRefreshStrategy, mvPotentialPartitionNames, tentative);
         // update mv extra message
         if (!tentative) {
@@ -581,9 +581,7 @@ public abstract class BaseMVRefreshProcessor {
                 extraMessage.setPartitionEnd(mvRefreshParams.getRangeEnd());
             });
         }
-        return mvToRefreshedPartitions.stream()
-                .map(PCellWithName::partitionName)
-                .collect(Collectors.toSet());
+        return mvToRefreshedPartitions.getPartitionNames();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
@@ -15,7 +15,7 @@
 
 package com.starrocks.scheduler.mv;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.Lists;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
@@ -25,11 +25,14 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRunContext;
+import com.starrocks.sql.common.PCellNone;
+import com.starrocks.sql.common.PCellWithName;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     public MVPCTRefreshNonPartitioner(MvTaskRunContext mvContext,
@@ -60,42 +63,48 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     }
 
     @Override
-    public Set<String> getMVPartitionsToRefreshWithForce() {
-        return mv.getVisiblePartitionNames();
+    public List<PCellWithName> getMVPartitionsToRefreshWithForce() {
+        return  mv.getVisiblePartitionNames()
+                .stream()
+                .map(partitionName -> PCellWithName.of(partitionName, new PCellNone()))
+                .collect(Collectors.toList());
     }
 
     @Override
-    public Set<String> getMVPartitionsToRefresh(PartitionInfo mvPartitionInfo,
-                                                Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
-                                                MVRefreshParams mvRefreshParams,
-                                                Set<String> mvPotentialPartitionNames) {
+    public List<PCellWithName> getMVPartitionsToRefresh(PartitionInfo mvPartitionInfo,
+                                                        Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
+                                                        MVRefreshParams mvRefreshParams,
+                                                        Set<String> mvPotentialPartitionNames) {
         // non-partitioned materialized view
         if (mvRefreshParams.isForce() || isNonPartitionedMVNeedToRefresh(snapshotBaseTables, mv)) {
-            return mv.getVisiblePartitionNames();
+            return mv.getVisiblePartitionNames()
+                    .stream()
+                    .map(partitionName -> PCellWithName.of(partitionName, new PCellNone()))
+                    .collect(Collectors.toList());
         }
-        return Sets.newHashSet();
+        return Lists.newArrayList();
     }
 
     @Override
-    public Set<String> getMVPartitionNamesWithTTL(MaterializedView materializedView,
-                                                  MVRefreshParams mvRefreshParams,
-                                                  boolean isAutoRefresh) {
-        return Sets.newHashSet();
+    public List<PCellWithName> getMVPartitionNamesWithTTL(MaterializedView materializedView,
+                                                          MVRefreshParams mvRefreshParams,
+                                                          boolean isAutoRefresh) {
+        return Lists.newArrayList();
     }
 
-    public void filterPartitionByRefreshNumber(Set<String> mvPartitionsToRefresh,
+    public void filterPartitionByRefreshNumber(List<PCellWithName> mvPartitionsToRefresh,
                                                Set<String> mvPotentialPartitionNames, boolean tentative) {
         // do nothing
     }
 
     @Override
-    public void filterPartitionByAdaptiveRefreshNumber(Set<String> mvPartitionsToRefresh,
+    public void filterPartitionByAdaptiveRefreshNumber(List<PCellWithName> mvPartitionsToRefresh,
                                                        Set<String> mvPotentialPartitionNames, boolean tentative) {
         // do nothing
     }
 
     @Override
-    protected int getAdaptivePartitionRefreshNumber(Iterator<String> partitionNameIter) throws MVAdaptiveRefreshException {
+    protected int getAdaptivePartitionRefreshNumber(Iterator<PCellWithName> partitionNameIter) throws MVAdaptiveRefreshException {
         return 0;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.scheduler.mv;
 
-import com.google.api.client.util.Lists;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
@@ -45,6 +44,7 @@ import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.ast.DropPartitionClause;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.PCell;
+import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellWithName;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.Logger;
@@ -142,12 +142,12 @@ public abstract class MVPCTRefreshPartitioner {
      * @throws AnalysisException
      * @return: Return mv partitions to refresh based on the ref base table partitions.
      */
-    public abstract List<PCellWithName> getMVPartitionsToRefresh(PartitionInfo mvPartitionInfo,
-                                                                 Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
-                                                                 MVRefreshParams mvRefreshParams,
-                                                                 Set<String> mvPotentialPartitionNames) throws AnalysisException;
+    public abstract PCellSortedSet getMVPartitionsToRefresh(PartitionInfo mvPartitionInfo,
+                                                            Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
+                                                            MVRefreshParams mvRefreshParams,
+                                                            Set<String> mvPotentialPartitionNames) throws AnalysisException;
 
-    public abstract List<PCellWithName> getMVPartitionsToRefreshWithForce() throws AnalysisException;
+    public abstract PCellSortedSet getMVPartitionsToRefreshWithForce() throws AnalysisException;
 
     /**
      * Get mv partition names with TTL based on the ref base table partitions.
@@ -157,9 +157,9 @@ public abstract class MVPCTRefreshPartitioner {
      * @throws AnalysisException
      * @return: mv to refresh partition names with TTL based on the ref base table partitions.
      */
-    public abstract List<PCellWithName> getMVPartitionNamesWithTTL(MaterializedView materializedView,
-                                                                   MVRefreshParams mvRefreshParams,
-                                                                   boolean isAutoRefresh) throws AnalysisException;
+    public abstract PCellSortedSet getMVPartitionNamesWithTTL(MaterializedView materializedView,
+                                                              MVRefreshParams mvRefreshParams,
+                                                              boolean isAutoRefresh) throws AnalysisException;
 
     /**
      * Filter to refresh partitions by refresh number.
@@ -168,11 +168,11 @@ public abstract class MVPCTRefreshPartitioner {
      * @param mvPotentialPartitionNames : mv potential partition names to check.
      * @param tentative                 see {@link MVPCTBasedRefreshProcessor}
      */
-    public abstract void filterPartitionByRefreshNumber(List<PCellWithName> mvPartitionsToRefresh,
+    public abstract void filterPartitionByRefreshNumber(PCellSortedSet mvPartitionsToRefresh,
                                                         Set<String> mvPotentialPartitionNames,
                                                         boolean tentative);
 
-    public abstract void filterPartitionByAdaptiveRefreshNumber(List<PCellWithName> mvPartitionsToRefresh,
+    public abstract void filterPartitionByAdaptiveRefreshNumber(PCellSortedSet mvPartitionsToRefresh,
                                                                 Set<String> mvPotentialPartitionNames,
                                                                 boolean tentative);
 
@@ -182,10 +182,10 @@ public abstract class MVPCTRefreshPartitioner {
      * @return the partitions to refresh for materialized view
      * @throws AnalysisException
      */
-    private List<PCellWithName> getPartitionsToRefreshForMaterializedView(PartitionInfo mvPartitionInfo,
-                                                                          MVRefreshParams mvRefreshParams,
-                                                                          Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
-                                                                          Set<String> mvPotentialPartitionNames)
+    private PCellSortedSet getPartitionsToRefreshForMaterializedView(PartitionInfo mvPartitionInfo,
+                                                                     MVRefreshParams mvRefreshParams,
+                                                                     Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
+                                                                     Set<String> mvPotentialPartitionNames)
             throws AnalysisException {
         if (mvRefreshParams.isForceCompleteRefresh()) {
             // Force refresh
@@ -201,13 +201,13 @@ public abstract class MVPCTRefreshPartitioner {
      * If it's tentative, only return the result rather than modify any state
      * IF it's not, it would modify the context state, like `NEXT_PARTITION_START`
      */
-    public List<PCellWithName> getMVToRefreshedPartitions(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
-                                                          MVRefreshParams mvRefreshParams,
-                                                          MaterializedView.PartitionRefreshStrategy partitionRefreshStrategy,
-                                                          Set<String> mvPotentialPartitionNames,
-                                                          boolean tentative)
+    public PCellSortedSet getMVToRefreshedPartitions(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
+                                                     MVRefreshParams mvRefreshParams,
+                                                     MaterializedView.PartitionRefreshStrategy partitionRefreshStrategy,
+                                                     Set<String> mvPotentialPartitionNames,
+                                                     boolean tentative)
             throws AnalysisException, LockTimeoutException {
-        List<PCellWithName> mvToRefreshedPartitions = null;
+        PCellSortedSet mvToRefreshedPartitions = null;
         Locker locker = new Locker();
         if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), mv.getId(),
                 LockType.READ, Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
@@ -219,7 +219,7 @@ public abstract class MVPCTRefreshPartitioner {
         try {
             mvToRefreshedPartitions = getPartitionsToRefreshForMaterializedView(partitionInfo,
                     mvRefreshParams, snapshotBaseTables, mvPotentialPartitionNames);
-            if (CollectionUtils.isEmpty(mvToRefreshedPartitions)) {
+            if (mvToRefreshedPartitions == null || mvToRefreshedPartitions.isEmpty()) {
                 logger.info("no partitions to refresh for materialized view");
                 return mvToRefreshedPartitions;
             }
@@ -257,13 +257,13 @@ public abstract class MVPCTRefreshPartitioner {
     }
 
     @VisibleForTesting
-    public void filterPartitionByRefreshNumber(List<PCellWithName> partitionsToRefresh,
+    public void filterPartitionByRefreshNumber(PCellSortedSet partitionsToRefresh,
                                                Set<String> mvPotentialPartitionNames,
                                                MaterializedView mv) {
         filterPartitionByRefreshNumber(partitionsToRefresh, mvPotentialPartitionNames, mv, false);
     }
 
-    public void filterPartitionByRefreshNumber(List<PCellWithName> partitionsToRefresh,
+    public void filterPartitionByRefreshNumber(PCellSortedSet partitionsToRefresh,
                                                Set<String> mvPotentialPartitionNames,
                                                MaterializedView mv,
                                                boolean tentative) {
@@ -287,13 +287,13 @@ public abstract class MVPCTRefreshPartitioner {
     }
 
     @VisibleForTesting
-    public void filterPartitionByAdaptiveRefreshNumber(List<PCellWithName> partitionsToRefresh,
+    public void filterPartitionByAdaptiveRefreshNumber(PCellSortedSet partitionsToRefresh,
                                                        Set<String> mvPotentialPartitionNames,
                                                        MaterializedView mv) {
         filterPartitionByAdaptiveRefreshNumber(partitionsToRefresh, mvPotentialPartitionNames, mv, false);
     }
 
-    public void filterPartitionByAdaptiveRefreshNumber(List<PCellWithName> partitionsToRefresh,
+    public void filterPartitionByAdaptiveRefreshNumber(PCellSortedSet partitionsToRefresh,
                                                        Set<String> mvPotentialPartitionNames,
                                                        MaterializedView mv,
                                                        boolean tentative) {
@@ -335,7 +335,7 @@ public abstract class MVPCTRefreshPartitioner {
      * @return The number of partitions to refresh.
      */
     public int getRefreshNumberByMode(Iterator<PCellWithName> sortedPartitionIterator,
-                                       MaterializedView.PartitionRefreshStrategy refreshStrategy) {
+                                      MaterializedView.PartitionRefreshStrategy refreshStrategy) {
         try {
             switch (refreshStrategy) {
                 case ADAPTIVE:
@@ -396,12 +396,12 @@ public abstract class MVPCTRefreshPartitioner {
      * @param toRefreshPartitions all mv partition names
      * @return mv partitions to refresh based on the ref base table partitions
      */
-    protected List<PCellWithName> getMvPartitionNamesToRefresh(List<PCellWithName> toRefreshPartitions) {
-        List<PCellWithName> result = Lists.newArrayList();
+    protected PCellSortedSet getMvPartitionNamesToRefresh(PCellSortedSet toRefreshPartitions) {
+        PCellSortedSet result = PCellSortedSet.of();
         Map<Table, List<Column>> refBaseTablePartitionColumns = mv.getRefBaseTablePartitionColumns();
-        Map<String, PCellWithName> pCellWithNameMap = toRefreshPartitions
+        Map<String, PCellWithName> pCellWithNameMap = toRefreshPartitions.partitions()
                 .stream()
-                .map(p -> Pair.create(p.partitionName(), p))
+                .map(p -> Pair.create(p.name(), p))
                 .collect(Collectors.toMap(p -> p.first, p -> p.second));
         for (Table baseTable : refBaseTablePartitionColumns.keySet()) {
             // refresh all mv partitions when the ref base table is not supported partition refresh
@@ -523,12 +523,12 @@ public abstract class MVPCTRefreshPartitioner {
      * @param toRefreshPartitions : the need to refresh materialized view partition names
      * @return : the corresponding ref base table partition names to the materialized view partition names
      */
-    protected Map<Table, Set<String>> getBasePartitionNamesByMVPartitionNames(List<PCellWithName> toRefreshPartitions) {
+    protected Map<Table, Set<String>> getBasePartitionNamesByMVPartitionNames(PCellSortedSet toRefreshPartitions) {
         Map<Table, Set<String>> result = new HashMap<>();
         Map<String, Map<Table, Set<String>>> mvRefBaseTablePartitionMaps =
                 mvContext.getMvRefBaseTableIntersectedPartitions();
-        for (PCellWithName toRefreshPartition : toRefreshPartitions) {
-            String mvPartitionName = toRefreshPartition.partitionName();
+        for (PCellWithName toRefreshPartition : toRefreshPartitions.partitions()) {
+            String mvPartitionName = toRefreshPartition.name();
             if (mvRefBaseTablePartitionMaps == null || !mvRefBaseTablePartitionMaps.containsKey(mvPartitionName)) {
                 logger.warn("Cannot find need refreshed mv table partition from synced partition info: {}",
                         mvPartitionName);
@@ -557,45 +557,52 @@ public abstract class MVPCTRefreshPartitioner {
             // filter partitions by partition_retention_condition
             String ttlCondition = mv.getTableProperty().getPartitionRetentionCondition();
             if (!Strings.isNullOrEmpty(ttlCondition)) {
-                doFilterPartitionsByTTL(ttlCondition, toRefreshPartitions, isMockPartitionIds);
+                List<String> toRemovePartitions =
+                        getExpiredPartitionsWithRetention(ttlCondition, toRefreshPartitions, isMockPartitionIds);
+                if (CollectionUtils.isNotEmpty(toRemovePartitions)) {
+                    toRemovePartitions.stream()
+                            .forEach(p -> toRefreshPartitions.remove(p));
+                }
             }
         }
     }
 
-    private void doFilterPartitionsByTTL(String ttlCondition,
-                                         Map<String, PCell> toRefreshPartitions,
-                                         boolean isMockPartitionIds) {
-        List<String> expiredPartitionNames = getExpiredPartitionsByRetentionCondition(db, mv, ttlCondition,
-                toRefreshPartitions, isMockPartitionIds);
-        // remove the expired partitions
-        if (CollectionUtils.isNotEmpty(expiredPartitionNames)) {
-            logger.info("Filter partitions by partition_retention_condition, ttl_condition:{}, expired:{}",
-                    ttlCondition, expiredPartitionNames);
-            expiredPartitionNames.stream()
-                    .forEach(toRefreshPartitions::remove);
-        }
+    /**
+     * Filter partitions with retention ttl condition, remove the expired partitions from the toRefreshPartitions.
+     */
+    private List<String> getExpiredPartitionsWithRetention(String ttlCondition,
+                                                           Map<String, PCell> toRefreshPartitions,
+                                                           boolean isMockPartitionIds) {
+        return getExpiredPartitionsByRetentionCondition(db, mv, ttlCondition, toRefreshPartitions, isMockPartitionIds);
     }
 
-    protected void filterPartitionsByTTL(List<PCellWithName> toRefreshPartitions,
+    protected void filterPartitionsByTTL(PCellSortedSet toRefreshPartitions,
                                          boolean isMockPartitionIds) {
-
-        if (!CollectionUtils.sizeIsEmpty(toRefreshPartitions)) {
+        if (toRefreshPartitions != null && !toRefreshPartitions.isEmpty()) {
             // filter partitions by partition_retention_condition
             String ttlCondition = mv.getTableProperty().getPartitionRetentionCondition();
             if (!Strings.isNullOrEmpty(ttlCondition)) {
                 // convert PCellWithName to PCell
-                Map<String, PCell> toRefreshPartitionMap = toRefreshPartitions
+                Map<String, PCell> toRefreshPartitionMap = toRefreshPartitions.partitions()
                         .stream()
-                        .map(p -> Pair.create(p.partitionName(), p.cell()))
+                        .map(p -> Pair.create(p.name(), p.cell()))
                         .collect(Collectors.toMap(
                                 p -> p.first,
                                 p -> p.second
                         ));
-                doFilterPartitionsByTTL(ttlCondition, toRefreshPartitionMap, isMockPartitionIds);
+                List<String> toRemovePartitions =
+                        getExpiredPartitionsWithRetention(ttlCondition, toRefreshPartitionMap, isMockPartitionIds);
+                if (CollectionUtils.isNotEmpty(toRemovePartitions)) {
+                    toRemovePartitions.stream()
+                            .forEach(p -> toRefreshPartitions.remove(PCellWithName.of(p, toRefreshPartitionMap.get(p))));
+                }
             }
         }
     }
 
+    /**
+     * Get the partition ttl limit for the refreshed mv.
+     */
     protected int getPartitionTTLLimit() {
         int partitionTTLNumber = mvContext.getPartitionTTLNumber();
         if (partitionTTLNumber > 0) {
@@ -605,9 +612,19 @@ public abstract class MVPCTRefreshPartitioner {
         }
     }
 
-    protected int getRefreshPartitionLimit(boolean isAutoRefresh) {
+    /**
+     * Return the limit of partitions to refresh which is configured in the mv's table property.
+     * NOTE:
+     * - This parameter is used to limit the number of partitions to refresh after partition_ttl which is used for
+     * the refreshed mv partitions to avoid refreshing too many partitions at once.
+     * - But this parameter will make the mv's result unequal to the defined query's result, since it may refresh fewer
+     * partitions than its needs.
+     * - This parameter has different meanings with the old versions which it will limit the number of partitions to refresh
+     * no matter it's auto refresh or manual refresh from v4.0.
+     */
+    protected int getRefreshPartitionLimit() {
         int autoRefreshPartitionsLimit = mv.getTableProperty().getAutoRefreshPartitionsLimit();
-        if (isAutoRefresh && autoRefreshPartitionsLimit > 0) {
+        if (autoRefreshPartitionsLimit > 0) {
             return autoRefreshPartitionsLimit;
         } else {
             return TableProperty.INVALID;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/PCTTableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/PCTTableSnapshotInfo.java
@@ -203,7 +203,7 @@ public class PCTTableSnapshotInfo extends BaseTableSnapshotInfo {
         for (int index = 0; index < refreshedPartitionNames.size(); ++index) {
             long modifiedTime = partitions.get(index).getModifiedTime();
             String partitionName = refreshedPartitionNames.get(index);
-            Preconditions.checkArgument(partitionName != null, "partitionName should not be null");
+            Preconditions.checkArgument(partitionName != null, "name should not be null");
 
             MaterializedView.BasePartitionInfo basePartitionInfo = new MaterializedView.BasePartitionInfo(
                     -1, modifiedTime, modifiedTime);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PCell.java
@@ -20,7 +20,9 @@ package com.starrocks.sql.common;
  * For range partition, it can be {@code Range<PartitionKey>} to represent the range of the partition.
  * For list partition, it can be {@code List<List<String>>} to represent the list values of the partition.
  */
-public abstract class PCell {
+public abstract class PCell implements Comparable<PCell> {
 
     public abstract  boolean isIntersected(PCell o);
+
+    public abstract int compareTo(PCell o);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellNone.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellNone.java
@@ -14,8 +14,34 @@
 
 package com.starrocks.sql.common;
 
+/**
+ * PCellNone is a special PCell that represents the absence of a partition cell which can be used for non-partitioned tables.
+ */
 public class PCellNone extends PCell {
     public boolean isIntersected(PCell o) {
         return false;
+    }
+
+    @Override
+    public int compareTo(PCell o) {
+        if (o instanceof PCellNone) {
+            return 0; // Both are PCellNone, considered equal.
+        }
+        return -1; // PCellNone is less than any other PCell type.
+    }
+
+    @Override
+    public String toString() {
+        return "PCellNone";
+    }
+
+    @Override
+    public int hashCode() {
+        return 0; // PCellNone has no meaningful state, so it can return a constant hash code.
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof PCellNone; // Only equal to another PCellNone instance.
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellNone.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellNone.java
@@ -1,0 +1,21 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+public class PCellNone extends PCell {
+    public boolean isIntersected(PCell o) {
+        return false;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellSortedSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellSortedSet.java
@@ -1,0 +1,167 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+import com.google.common.base.Joiner;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * A sorted set of PCellWithName.
+ */
+public record PCellSortedSet(SortedSet<PCellWithName> partitions) {
+
+    public static PCellSortedSet of() {
+        return new PCellSortedSet(new TreeSet<>());
+    }
+
+    public static PCellSortedSet of(SortedSet<PCellWithName> partitions) {
+        return new PCellSortedSet(partitions);
+    }
+
+    public static PCellSortedSet of(Map<String, PCell> input) {
+        SortedSet<PCellWithName> partitions = input.entrySet()
+                .stream()
+                .map(entry -> PCellWithName.of(entry.getKey(), entry.getValue()))
+                .collect(TreeSet::new, TreeSet::add, TreeSet::addAll);
+        return new PCellSortedSet(partitions);
+    }
+
+    public static PCellSortedSet of(List<PCellWithName> input) {
+        SortedSet<PCellWithName> partitions = new TreeSet<>(input);
+        return new PCellSortedSet(partitions);
+    }
+
+    public void add(PCellWithName partition) {
+        partitions.add(partition);
+    }
+
+    public boolean isEmpty() {
+        return partitions.isEmpty();
+    }
+
+    public int size() {
+        return partitions.size();
+    }
+
+    public boolean contains(PCellWithName partition) {
+        return partitions.contains(partition);
+    }
+
+    public boolean remove(PCellWithName partition) {
+        return partitions.remove(partition);
+    }
+
+    public SortedSet<PCellWithName> getPartitions() {
+        return partitions;
+    }
+
+    public Stream<PCellWithName> stream() {
+        return partitions.stream();
+    }
+
+    public void forEach(Consumer<? super PCellWithName> action) {
+        partitions.forEach(action);
+    }
+
+    public Iterator<PCellWithName> iterator() {
+        return partitions.iterator();
+    }
+
+    public PCellSortedSet skip(int skip) {
+        if (skip <= 0) {
+            return this;
+        }
+        if (skip >= partitions.size()) {
+            return new PCellSortedSet(new TreeSet<>());
+        }
+        SortedSet<PCellWithName> skippedPartitions = new TreeSet<>(partitions);
+        Iterator<PCellWithName> iterator = skippedPartitions.iterator();
+        for (int i = 0; i < skip && iterator.hasNext(); i++) {
+            iterator.next();
+            iterator.remove();
+        }
+        return new PCellSortedSet(skippedPartitions);
+    }
+
+    /**
+     * only reserve the last limit of partitions.
+     * @param limit
+     * @return
+     */
+    public PCellSortedSet limit(int limit) {
+        if (limit <= 0 || limit >= partitions.size()) {
+            return this;
+        }
+        SortedSet<PCellWithName> limitedPartitions = new TreeSet<>(partitions);
+        Iterator<PCellWithName> iterator = limitedPartitions.iterator();
+        int count = 0;
+        while (iterator.hasNext() && count < limitedPartitions.size() - limit) {
+            iterator.next();
+            iterator.remove();
+            count++;
+        }
+        return new PCellSortedSet(limitedPartitions);
+    }
+
+    public void removeWithSize(int size) {
+        if (size <= 0 || size >= partitions.size()) {
+            return;
+        }
+        Iterator<PCellWithName> iterator = partitions.iterator();
+        int count = 0;
+        while (iterator.hasNext() && count < size) {
+            iterator.next();
+            iterator.remove();
+            count++;
+        }
+    }
+
+    public Set<String> getPartitionNames() {
+        return partitions.stream().map(PCellWithName::name).collect(java.util.stream.Collectors.toSet());
+    }
+
+    @Override
+    public String toString() {
+        if (partitions == null || partitions.isEmpty()) {
+            return "";
+        }
+        return Joiner.on(",").join(getPartitionNames());
+    }
+
+    @Override
+    public int hashCode() {
+        return partitions.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PCellSortedSet)) {
+            return false;
+        }
+        PCellSortedSet that = (PCellSortedSet) o;
+        return partitions.equals(that.partitions);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellWithName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellWithName.java
@@ -14,9 +14,45 @@
 
 package com.starrocks.sql.common;
 
-public record PCellWithName(String partitionName, PCell cell) {
-
+/**
+ * PCellWithName is a record that associates a partition name with a PCell.
+ */
+public record PCellWithName(String name, PCell cell) implements Comparable<PCellWithName> {
     public static PCellWithName of(String partitionName, PCell cell) {
         return new PCellWithName(partitionName, cell);
+    }
+
+    @Override
+    public String toString() {
+        return "name='" + name + '\'' +
+                ", cell=" + cell;
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode() * 31 + cell.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PCellWithName)) {
+            return false;
+        }
+        PCellWithName that = (PCellWithName) o;
+        return name.equals(that.name) && cell.equals(that.cell);
+    }
+
+    @Override
+    public int compareTo(PCellWithName o) {
+        // compare by pcell
+        int cellComparison = this.cell.compareTo(o.cell);
+        if (cellComparison != 0) {
+            return cellComparison;
+        }
+        // if pcell is equal, compare by partition name
+        return this.name.compareTo(o.name);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellWithName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellWithName.java
@@ -1,0 +1,22 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+public record PCellWithName(String partitionName, PCell cell) {
+
+    public static PCellWithName of(String partitionName, PCell cell) {
+        return new PCellWithName(partitionName, cell);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
@@ -47,7 +47,7 @@ import static com.starrocks.sql.ast.PartitionValue.STARROCKS_DEFAULT_PARTITION_V
  * with multi partition columns
  *  partitionItems  : ((1, 'a'), (2, 'b'))
  */
-public final class PListCell extends PCell implements Comparable<PListCell> {
+public final class PListCell extends PCell {
     // default partition values which may contain null value, and should be compared in the end
     public static Set<String> DEFAULT_PARTITION_VALUES = new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)
             .add(PartitionValue.STARROCKS_DEFAULT_PARTITION_VALUE)
@@ -145,9 +145,12 @@ public final class PListCell extends PCell implements Comparable<PListCell> {
     }
 
     @Override
-    public int compareTo(PListCell o) {
+    public int compareTo(PCell other) {
+        Preconditions.checkArgument(other instanceof PListCell,
+                "Cannot compare PListCell with other type: %s", other.getClass().getSimpleName());
+        PListCell otherPCell = (PListCell) other;
         int len1 = partitionItems.size();
-        int len2 = o.partitionItems.size();
+        int len2 = otherPCell.partitionItems.size();
         int len = Math.min(len1, len2);
         int ans = 0;
         // compare each partition item by item's value
@@ -160,7 +163,7 @@ public final class PListCell extends PCell implements Comparable<PListCell> {
         for (int i = 0; i < len; i++) {
             // prefer the partition item with greater values
             List<String> atom1 = partitionItems.get(i);
-            List<String> atom2 = o.partitionItems.get(i);
+            List<String> atom2 = otherPCell.partitionItems.get(i);
             if (atom1.size() != atom2.size()) {
                 return Integer.compare(atom1.size(), atom2.size());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCellPlus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCellPlus.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 /**
  * {@link PListCell} means a list partition with multiple values.
  * eg: partition p1 values in ((1, 'a'), (2, 'b')) is a partition items which contains multi values with multi partition columns
- *  partitionName: p1
+ *  name: p1
  *  partitionItems: ((1, 'a'), (2, 'b'))
  */
 public final class PListCellPlus {
@@ -92,7 +92,7 @@ public final class PListCellPlus {
     public String toString() {
         return "PListCell{" +
                 "cell=" + cell +
-                ", partitionName='" + partitionName + '\'' +
+                ", name='" + partitionName + '\'' +
                 '}';
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PRangeCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PRangeCell.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.common;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Range;
 import com.starrocks.catalog.PartitionKey;
 
@@ -24,7 +25,7 @@ import java.util.stream.Collectors;
 /**
  * {@link PRangeCell} contains the range partition's value which contains a `PartitionKey` range.
  */
-public final class PRangeCell extends PCell implements Comparable<PRangeCell> {
+public final class PRangeCell extends PCell {
     private final Range<PartitionKey> range;
 
     public PRangeCell(Range<PartitionKey> partitionKeyRange) {
@@ -50,12 +51,15 @@ public final class PRangeCell extends PCell implements Comparable<PRangeCell> {
      *   2. Choose two interact partition ranges as `equal` to let callers handle it directly.
      */
     @Override
-    public int compareTo(PRangeCell o) {
-        int res = this.range.lowerEndpoint().compareTo(o.range.lowerEndpoint());
+    public int compareTo(PCell o) {
+        Preconditions.checkArgument(o instanceof PRangeCell,
+                "Cannot compare PRangeCell with other type of PCell: %s", o.getClass().getName());
+        PRangeCell other = (PRangeCell) o;
+        int res = this.range.lowerEndpoint().compareTo(other.range.lowerEndpoint());
         if (res != 0) {
             return res;
         }
-        return this.range.upperEndpoint().compareTo(o.range.upperEndpoint());
+        return this.range.upperEndpoint().compareTo(other.range.upperEndpoint());
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -68,8 +68,8 @@ public abstract class PartitionDiffer {
 
     /**
      * Generate the mapping from materialized view partition to base table partition.
-     * @param mvRangeMap : materialized view partition range map: <partitionName, partitionRange>
-     * @param baseRangeMap: base table partition range map, <baseTable, <partitionName, partitionRange>>
+     * @param mvRangeMap : materialized view partition range map: <name, partitionRange>
+     * @param baseRangeMap: base table partition range map, <baseTable, <name, partitionRange>>
      * @return mv partition name -> <base table, base partition names> mapping
      */
     public abstract Map<String, Map<Table, Set<String>>> generateMvRefMap(Map<String, PCell> mvRangeMap,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
@@ -467,8 +467,8 @@ public final class RangePartitionDiffer extends PartitionDiffer {
 
     /**
      * Generate the mapping from materialized view partition to base table partition.
-     * @param mvRangeMap : materialized view partition range map: <partitionName, partitionRange>
-     * @param baseRangeMap: base table partition range map, <baseTable, <partitionName, partitionRange>>
+     * @param mvRangeMap : materialized view partition range map: <name, partitionRange>
+     * @param baseRangeMap: base table partition range map, <baseTable, <name, partitionRange>>
      * @return mv partition name -> <base table, base partition names> mapping
      */
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -352,22 +352,22 @@ public class SyncPartitionUtils {
         return result;
     }
 
-    public static void calcPotentialRefreshPartition(Set<String> needRefreshMvPartitionNames,
+    public static void calcPotentialRefreshPartition(Set<String> mvToRefreshPartitionNames,
                                                      Map<Table, Set<String>> baseChangedPartitionNames,
                                                      Map<Table, Map<String, Set<String>>> baseToMvNameRef,
                                                      Map<String, Map<Table, Set<String>>> mvToBaseNameRef,
                                                      Set<String> mvPotentialRefreshPartitionNames) {
-        gatherPotentialRefreshPartitionNames(needRefreshMvPartitionNames, baseChangedPartitionNames,
+        gatherPotentialRefreshPartitionNames(mvToRefreshPartitionNames, baseChangedPartitionNames,
                 baseToMvNameRef, mvToBaseNameRef, mvPotentialRefreshPartitionNames);
     }
 
-    private static void gatherPotentialRefreshPartitionNames(Set<String> needRefreshMvPartitionNames,
+    private static void gatherPotentialRefreshPartitionNames(Set<String> mvToRefreshPartitionNames,
                                                              Map<Table, Set<String>> baseChangedPartitionNames,
                                                              Map<Table, Map<String, Set<String>>> baseToMvNameRef,
                                                              Map<String, Map<Table, Set<String>>> mvToBaseNameRef,
                                                              Set<String> mvPotentialRefreshPartitionNames) {
-        int curNameCount = needRefreshMvPartitionNames.size();
-        Set<String> copiedNeedRefreshMvPartitionNames = Sets.newHashSet(needRefreshMvPartitionNames);
+        int curNameCount = mvToRefreshPartitionNames.size();
+        Set<String> copiedNeedRefreshMvPartitionNames = Sets.newHashSet(mvToRefreshPartitionNames);
         for (String needRefreshMvPartitionName : copiedNeedRefreshMvPartitionNames) {
             // baseTable with its partitions by mv's partition
             Map<Table, Set<String>> baseNames = mvToBaseNameRef.get(needRefreshMvPartitionName);
@@ -390,7 +390,7 @@ public class SyncPartitionUtils {
                 }
 
                 if (mvNeedRefreshPartitions.size() > 1) {
-                    needRefreshMvPartitionNames.addAll(mvNeedRefreshPartitions);
+                    mvToRefreshPartitionNames.addAll(mvNeedRefreshPartitions);
                     mvPotentialRefreshPartitionNames.add(needRefreshMvPartitionName);
                     baseChangedPartitionNames.computeIfAbsent(baseTable, x -> Sets.newHashSet())
                             .addAll(baseTablePartitions);
@@ -398,8 +398,8 @@ public class SyncPartitionUtils {
             }
         }
 
-        if (curNameCount != needRefreshMvPartitionNames.size()) {
-            gatherPotentialRefreshPartitionNames(needRefreshMvPartitionNames, baseChangedPartitionNames,
+        if (curNameCount != mvToRefreshPartitionNames.size()) {
+            gatherPotentialRefreshPartitionNames(mvToRefreshPartitionNames, baseChangedPartitionNames,
                     baseToMvNameRef, mvToBaseNameRef, mvPotentialRefreshPartitionNames);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedInfoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedInfoCollector.java
@@ -83,7 +83,7 @@ public class DesensitizedInfoCollector {
         }
 
         for (Map<String, Long> partitions : dumpInfo.getPartitionRowCountMap().values()) {
-            // desensitized partitionName
+            // desensitized name
             partitions.keySet().forEach(this::addIntoDict);
         }
         collectStmtDictInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpInfo.java
@@ -48,7 +48,7 @@ public class QueryDumpInfo implements DumpInfo {
     private final Map<String, Map<String, Map<String, HiveMetaStoreTableDumpInfo>>> hmsTableMap = new HashMap<>();
     // viewId-><dbName, view>
     private final Map<Long, Pair<String, View>> viewMap = new LinkedHashMap<>();
-    // dbName.tableName->partitionName->partitionRowCount
+    // dbName.tableName->name->partitionRowCount
     private final Map<String, Map<String, Long>> partitionRowCountMap = new HashMap<>();
     // tableName->columnName->column statistics
     private final Map<String, Map<String, ColumnStatistic>> tableStatisticsMap = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpSerializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpSerializer.java
@@ -236,7 +236,7 @@ public class QueryDumpSerializer implements JsonSerializer<QueryDumpInfo> {
             for (Map.Entry<String, Long> partitionEntry : entry.getValue().entrySet()) {
                 String partitionName = partitionEntry.getKey();
                 if (entry.getValue().size() == 1 && dict.containsKey(partitionEntry.getKey())) {
-                    // the partitionName of table without setting partition is the table name
+                    // the name of table without setting partition is the table name
                     partitionName = DesensitizedSQLBuilder.desensitizeTblName(partitionName, dict);
                 }
                 partitionRowCount.addProperty(partitionName, partitionEntry.getValue());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -84,7 +84,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
             ", $maxFunction" + // VARCHAR
             ", $minFunction " + // VARCHAR
             ", cast($collectionSizeFunction as BIGINT)" + // BIGINT
-            " FROM (select $quoteColumnName as column_key from `$dbName`.`$tableName` partition `$partitionName`) tt";
+            " FROM (select $quoteColumnName as column_key from `$dbName`.`$tableName` partition `$name`) tt";
     private static final String OVERWRITE_PARTITION_TEMPLATE =
             "INSERT INTO " + TABLE_NAME + "(" + StatisticUtils.buildStatsColumnDef(TABLE_NAME).stream().map(ColumnDef::getName)
                     .collect(Collectors.joining(", ")) + ") " + "\n" +
@@ -181,7 +181,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
 
     // INSERT INTO column_statistics(table_id, partition_id, column_name, db_id, table_name,
     // partition_name, row_count, data_size, ndv, null_count, max, min, update_time, collection_size) values
-    // ($tableId, $partitionId, '$columnName', $dbId, '$dbName.$tableName', '$partitionName',
+    // ($tableId, $partitionId, '$columnName', $dbId, '$dbName.$tableName', '$name',
     //  $count, $dataSize, hll_deserialize('$hll'), $countNull, $maxFunction, $minFunction, NOW(), $collectionSizeFunction);
     @Override
     public void collectStatisticSync(String sql, ConnectContext context) throws Exception {
@@ -331,7 +331,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
         context.put("partitionId", partition.getId());
         context.put("columnNameStr", columnNameStr);
         context.put("dataSize", fullAnalyzeGetDataSize(quoteColumnKey, columnType));
-        context.put("partitionName", partition.getName());
+        context.put("name", partition.getName());
         context.put("dbName", db.getOriginName());
         context.put("tableName", table.getName());
         context.put("quoteColumnName", quoteColumnName);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -631,7 +631,7 @@ public class StatisticUtils {
         return baseColumnType;
     }
 
-    // Use murmur3_128 hash function to break up the partitionName as randomly and scattered as possible,
+    // Use murmur3_128 hash function to break up the name as randomly and scattered as possible,
     // and return an ordered list of partitionNames.
     // In order to ensure more accurate sampling, put min and max in the sampled result.
     public static List<String> getRandomPartitionsSample(List<String> partitions, int sampleSize) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperStatisticSQLs.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperStatisticSQLs.java
@@ -70,7 +70,7 @@ public class HyperStatisticSQLs {
             ", $maxFunction" + // VARCHAR
             ", $minFunction" + // VARCHAR
             ", cast($collectionSizeFunction as BIGINT)" + // BIGINT
-            " FROM `$dbName`.`$tableName` partition `$partitionName`";
+            " FROM `$dbName`.`$tableName` partition `$name`";
 
     public static final String BATCH_META_STATISTIC_TEMPLATE = "SELECT cast($version as INT)" +
             ", cast($partitionId as BIGINT)" + // BIGINT, partition_id
@@ -82,7 +82,7 @@ public class HyperStatisticSQLs {
             ", $maxFunction" + // VARCHAR, max
             ", $minFunction " + // VARCHAR, min
             ", cast(-1 as BIGINT) " + // BIGINT, collection_size
-            " FROM `$dbName`.`$tableName` partitions(`$partitionName`) [_META_]";
+            " FROM `$dbName`.`$tableName` partitions(`$name`) [_META_]";
 
     public static final String BATCH_DATA_STATISTIC_SELECT_TEMPLATE = "SELECT cast($version as INT)" +
             ", cast($partitionId as BIGINT)" + // BIGINT, partition_id
@@ -142,7 +142,7 @@ public class HyperStatisticSQLs {
         context.put("version", StatsConstants.STATISTIC_BATCH_VERSION_V5);
         context.put("partitionId", p.getId());
         context.put("columnNameStr", columnNameStr);
-        context.put("partitionName", p.getName());
+        context.put("name", p.getName());
         context.put("dbName", db.getOriginName());
         context.put("tableName", table.getName());
         context.put("quoteColumnName", quoteColumnName);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -544,7 +544,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
                         // sanity check. should not happen
                         if (!index.visibleForTransaction(txnState.getTransactionId())) {
                             LOG.warn("Ignore shadow index included in the transaction but not visible, " +
-                                    "partitionId: {}, partitionName: {}, txnId: {}, indexId: {}, indexName: {}",
+                                    "partitionId: {}, name: {}, txnId: {}, indexId: {}, indexName: {}",
                                     partition.getId(), partition.getName(), txnState.getTransactionId(),
                                     index.getId(), table.getIndexNameById(index.getId()));
                             continue;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -162,9 +162,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         initAndExecuteTaskRun(taskRun);
         Assertions.assertEquals(1, materializedView.getPartition("p19980101").getDefaultPhysicalPartition()
                 .getVisibleVersion());
-        Assertions.assertEquals(1, materializedView.getPartition("p19980102").getDefaultPhysicalPartition()
+        Assertions.assertEquals(2, materializedView.getPartition("p19980102").getDefaultPhysicalPartition()
                 .getVisibleVersion());
-        Assertions.assertEquals(1, materializedView.getPartition("p19980103").getDefaultPhysicalPartition()
+        Assertions.assertEquals(2, materializedView.getPartition("p19980103").getDefaultPhysicalPartition()
                 .getVisibleVersion());
         Assertions.assertEquals(2, materializedView.getPartition("p19980104").getDefaultPhysicalPartition()
                 .getVisibleVersion());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitionerTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRunContext;
+import com.starrocks.sql.common.PCellWithName;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -35,8 +36,7 @@ public class MVPCTRefreshNonPartitionerTest {
         MaterializedView mv = Mockito.mock(MaterializedView.class);
         MVPCTRefreshNonPartitioner job = new MVPCTRefreshNonPartitioner(mvTaskRunContext, taskRunContext,
                 database, mv);
-        Iterator<String> dummyIter = Collections.emptyIterator();
-
+        Iterator<PCellWithName> dummyIter = Collections.emptyIterator();
         int result = job.getAdaptivePartitionRefreshNumber(dummyIter);
         Assertions.assertEquals(0, result);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
@@ -22,8 +22,8 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.scheduler.MvTaskRunContext;
-import com.starrocks.sql.common.PCell;
 import com.starrocks.sql.common.PCellNone;
+import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellWithName;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -86,10 +86,10 @@ public class MVPCTRefreshRangePartitionerTest {
 
         MVPCTRefreshRangePartitioner partitioner = new MVPCTRefreshRangePartitioner(mvContext, null, null, mv);
 
-        Map<String, PCell> toRefreshPartitions = Maps.newHashMap();
-        toRefreshPartitions.put("partition1", mock(PCell.class));
-        toRefreshPartitions.put("partition2", mock(PCell.class));
-        toRefreshPartitions.put("partition3", mock(PCell.class));
+        PCellSortedSet toRefreshPartitions = PCellSortedSet.of();
+        toRefreshPartitions.add(PCellWithName.of("partition1", new PCellNone()));
+        toRefreshPartitions.add(PCellWithName.of("partition2", new PCellNone()));
+        toRefreshPartitions.add(PCellWithName.of("partition3", new PCellNone()));
 
         partitioner.filterPartitionsByTTL(toRefreshPartitions, true);
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
@@ -23,6 +23,8 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.sql.common.PCell;
+import com.starrocks.sql.common.PCellNone;
+import com.starrocks.sql.common.PCellWithName;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -62,10 +64,10 @@ public class MVPCTRefreshRangePartitionerTest {
 
         Mockito.when(mvContext.getMvRefBaseTableIntersectedPartitions()).thenReturn(mvToBaseNameRefs);
         Mockito.when(mvContext.getExternalRefBaseTableMVPartitionMap()).thenReturn(new HashMap<>());
-
-        List<String> partitions = Arrays.asList("mv_p1", "mv_p2");
-        Iterator<String> iter = partitions.iterator();
-
+        // TODO: make range cells
+        List<PCellWithName> partitions = Arrays.asList(PCellWithName.of("mv_p1", new PCellNone()),
+                PCellWithName.of("mv_p2", new PCellNone()));
+        Iterator<PCellWithName> iter = partitions.iterator();
         MVPCTRefreshRangePartitioner partitioner = new MVPCTRefreshRangePartitioner(mvContext, null, null, mv);
         MVAdaptiveRefreshException exception = Assertions.assertThrows(MVAdaptiveRefreshException.class,
                 () -> partitioner.getAdaptivePartitionRefreshNumber(iter));


### PR DESCRIPTION
## Why I'm doing:

`auto_partition_refresh_number` property is always confused for users. For V4.0, we can correct materialized view's `auto_partition_refresh_number`:
- This parameter is used to limit the number of partitions to refresh after partition_ttl which is used for the refreshed mv partitions to avoid refreshing too many partitions at once.
- But this parameter will make the mv's result unequal to the defined query's result, since it may refresh fewer partitions than its needs.
- This parameter has different meanings with the old versions which it will limit the number of partitions to refresh no matter it's auto refresh or manual refresh from v4.0.



Behavior Changes:

- Before v4.0, only limit refreshed partitions for `AutoRefresh` which means the first `immediate` run will always refresh all partitions no matter this parameter is set.
- After V4.0, it will limit the number of partitions to refresh no matter it's auto refresh or manual refresh.


## What I'm doing:

This pull request refactors the materialized view (MV) refresh partitioning logic, primarily to improve type safety and partition management by introducing the `PCellSortedSet` and `PCellWithName` abstractions. The changes focus on replacing raw `Set<String>` usage for partition names with these new types, resulting in clearer, more maintainable, and more expressive code for MV partition refresh operations.

Partition management and type safety improvements:
* Replaced most usages of `Set<String>` for MV partition names with the new `PCellSortedSet` and `PCellWithName` types in `MVPCTRefreshListPartitioner`, `BaseMVRefreshProcessor`, and related APIs, ensuring partitions are handled with associated metadata and sorted order. [[1]](diffhunk://#diff-67454435c6e6bc9eb09da43d9cbff7e13b5a2ccb16c668fcaa794346e936904eL339-R352) [[2]](diffhunk://#diff-67454435c6e6bc9eb09da43d9cbff7e13b5a2ccb16c668fcaa794346e936904eL366-R398) [[3]](diffhunk://#diff-67454435c6e6bc9eb09da43d9cbff7e13b5a2ccb16c668fcaa794346e936904eL400-R412) [[4]](diffhunk://#diff-eb3450d770525518e04448190dbd758f653b38f2b3458ade0cb4e9d0c0035583L572-R573) [[5]](diffhunk://#diff-eb3450d770525518e04448190dbd758f653b38f2b3458ade0cb4e9d0c0035583L583-R584)
* Refactored partition filtering logic to operate directly on `PCellSortedSet` and iterate using `PCellWithName`, simplifying the code and improving correctness when filtering by TTL and refresh number. [[1]](diffhunk://#diff-67454435c6e6bc9eb09da43d9cbff7e13b5a2ccb16c668fcaa794346e936904eL428-L496) [[2]](diffhunk://#diff-67454435c6e6bc9eb09da43d9cbff7e13b5a2ccb16c668fcaa794346e936904eL507-R504)

API and interface changes:
* Updated partitioner interface methods (such as `getMVPartitionsToRefreshWithForce`, `getMVPartitionsToRefresh`, `getMVPartitionNamesWithTTL`, and filter methods) to return and accept `PCellSortedSet` instead of raw sets, aligning the interface with the new abstractions. [[1]](diffhunk://#diff-67454435c6e6bc9eb09da43d9cbff7e13b5a2ccb16c668fcaa794346e936904eL339-R352) [[2]](diffhunk://#diff-67454435c6e6bc9eb09da43d9cbff7e13b5a2ccb16c668fcaa794346e936904eL366-R398) [[3]](diffhunk://#diff-67454435c6e6bc9eb09da43d9cbff7e13b5a2ccb16c668fcaa794346e936904eL400-R412) [[4]](diffhunk://#diff-67454435c6e6bc9eb09da43d9cbff7e13b5a2ccb16c668fcaa794346e936904eL428-L496)
* Changed adaptive refresh logic to use iterators of `PCellWithName` instead of string partition names, improving partition selection based on richer metadata.

Code cleanup:
* Removed unused imports and legacy methods related to partition management in `OlapTable`, further streamlining the codebase. [[1]](diffhunk://#diff-171dae9f0bb57d4016183d17e215ac2dba38e31e0902cd331ec11660212eba4bL40) [[2]](diffhunk://#diff-171dae9f0bb57d4016183d17e215ac2dba38e31e0902cd331ec11660212eba4bL110-L115) [[3]](diffhunk://#diff-171dae9f0bb57d4016183d17e215ac2dba38e31e0902cd331ec11660212eba4bL1747-L1830) [[4]](diffhunk://#diff-24e54326260fccb6af7224a54dcf37303e568085ddf62b1a5e0007d7f1db7468L18) [[5]](diffhunk://#diff-24e54326260fccb6af7224a54dcf37303e568085ddf62b1a5e0007d7f1db7468R27-R35)

These changes collectively improve the clarity, maintainability, and correctness of MV partition refresh logic, making future enhancements easier and reducing the risk of subtle bugs.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
