### PR TITLE
[Enhancement] Fast schema evolution supports adding key columns for shared-data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
@@ -42,6 +42,7 @@ class SchemaChangeData {
     private final double bloomFilterFpp;
     private final boolean hasIndexChanged;
     private final Map<Long, Short> newIndexShortKeyCount;
+    private final boolean shortKeyChanged;
     private final List<Integer> sortKeyIdxes;
     private final List<Integer> sortKeyUniqueIds;
     private final long warehouseId;
@@ -99,6 +100,10 @@ class SchemaChangeData {
         return Collections.unmodifiableMap(newIndexShortKeyCount);
     }
 
+    boolean isShortKeyChanged() {
+        return shortKeyChanged;
+    }
+
     @Nullable
     List<Integer> getSortKeyIdxes() {
         return sortKeyIdxes;
@@ -129,6 +134,7 @@ class SchemaChangeData {
         this.bloomFilterFpp = builder.bloomFilterFpp;
         this.hasIndexChanged = builder.hasIndexChanged;
         this.newIndexShortKeyCount = Objects.requireNonNull(builder.newIndexShortKeyCount, "newIndexShortKeyCount is null");
+        this.shortKeyChanged = builder.shortKeyChanged;
         this.sortKeyIdxes = builder.sortKeyIdxes;
         this.sortKeyUniqueIds = builder.sortKeyUniqueIds;
         this.warehouseId = builder.warehouseId;
@@ -147,6 +153,7 @@ class SchemaChangeData {
         private double bloomFilterFpp;
         private boolean hasIndexChanged = false;
         private Map<Long, Short> newIndexShortKeyCount = new HashMap<>();
+        private boolean shortKeyChanged = false;
         private List<Integer> sortKeyIdxes;
         private List<Integer> sortKeyUniqueIds;
         private long warehouseId;
@@ -188,8 +195,9 @@ class SchemaChangeData {
             return this;
         }
 
-        Builder withNewIndexShortKeyCount(long indexId, short shortKeyCount) {
+        Builder withNewIndexShortKeyCount(long indexId, short shortKeyCount, boolean shortKeyChanged) {
             this.newIndexShortKeyCount.put(indexId, shortKeyCount);
+            this.shortKeyChanged |= shortKeyChanged;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1161,6 +1161,11 @@ public class SchemaChangeHandler extends AlterHandler {
                     "Can not add column which already exists in base table: " + newColName);
         }
 
+        // TODO shared-nothing needs to modify codes on BE side, and will support fast schema evolution later
+        if (newColumn.isKey() && RunMode.isSharedNothingMode()) {
+            fastSchemaEvolution = false;
+        }
+
         // check if the new column already exist in column id.
         // do not support adding new column which already exist in column id.
         foundColumn = olapTable.getBaseSchema().stream()

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1693,7 +1693,8 @@ public class SchemaChangeHandler extends AlterHandler {
         for (int i = 0; i < originShortKeyColumns.size(); i++) {
             Column originColumn = originShortKeyColumns.get(i);
             Column newColumn = newShortKeyColumns.get(i);
-            if (!originColumn.equals(newColumn)) {
+            if (!originColumn.getName().equalsIgnoreCase(newColumn.getName())
+                    || !originColumn.getType().equals(newColumn.getType())) {
                 return true;
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter;
 
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndexMeta;
@@ -24,6 +25,8 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -69,23 +72,14 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(connectContext, stmt);
     }
 
-    private LakeTableAsyncFastSchemaChangeJob getAlterJob(Table table) {
+    private AlterJobV2 getAlterJob(Table table) {
         AlterJobMgr alterJobMgr = GlobalStateMgr.getCurrentState().getAlterJobMgr();
         List<AlterJobV2> jobs = alterJobMgr.getSchemaChangeHandler().getUnfinishedAlterJobV2ByTableId(table.getId());
         Assertions.assertEquals(1, jobs.size());
-        AlterJobV2 alterJob = jobs.get(0);
-        Assertions.assertTrue(alterJob instanceof LakeTableAsyncFastSchemaChangeJob);
-        return (LakeTableAsyncFastSchemaChangeJob) alterJob;
+        return jobs.get(0);
     }
 
-    private LakeTableAsyncFastSchemaChangeJob removeAlterJob(Table table) {
-        LakeTableAsyncFastSchemaChangeJob job = getAlterJob(table);
-        AlterHandler handler = GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler();
-        handler.alterJobsV2.remove(job.getJobId());
-        return job;
-    }
-
-    private AlterJobV2 mustAlterTable(Table table, String sql) throws Exception {
+    private AlterJobV2 executeAlterAndWaitFinish(Table table, String sql, boolean expectFastSchemaEvolution) throws Exception {
         alterTable(connectContext, sql);
         AlterJobV2 alterJob = getAlterJob(table);
         alterJob.run();
@@ -94,6 +88,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
             Thread.sleep(100);
         }
         Assertions.assertEquals(AlterJobV2.JobState.FINISHED, alterJob.getJobState());
+        Assertions.assertEquals(expectFastSchemaEvolution, (alterJob instanceof LakeTableAsyncFastSchemaChangeJob));
         return alterJob;
     }
 
@@ -104,7 +99,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         long oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
 
         {
-            mustAlterTable(table, "ALTER TABLE t0 ADD COLUMN c1 BIGINT");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t0 ADD COLUMN c1 BIGINT", true);
             List<Column> columns = table.getBaseSchema();
             Assertions.assertEquals(2, columns.size());
             Assertions.assertEquals("c0", columns.get(0).getName());
@@ -116,7 +111,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         }
         oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
         {
-            mustAlterTable(table, "ALTER TABLE t0 DROP COLUMN c1");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t0 DROP COLUMN c1", true);
             List<Column> columns = table.getBaseSchema();
             Assertions.assertEquals(1, columns.size());
             Assertions.assertEquals("c0", columns.get(0).getName());
@@ -126,7 +121,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         }
         oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
         {
-            mustAlterTable(table, "ALTER TABLE t0 ADD COLUMN c1 BIGINT");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t0 ADD COLUMN c1 BIGINT", true);
             List<Column> columns = table.getBaseSchema();
             Assertions.assertEquals(2, columns.size());
             Assertions.assertEquals("c0", columns.get(0).getName());
@@ -142,7 +137,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
     public void testGetInfo() throws Exception {
         LakeTable table = createTable(connectContext, "CREATE TABLE t1(c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) " +
                     "BUCKETS 2 PROPERTIES('fast_schema_evolution'='true')");
-        AlterJobV2 job = mustAlterTable(table, "ALTER TABLE t1 ADD COLUMN c1 BIGINT");
+        AlterJobV2 job = executeAlterAndWaitFinish(table, "ALTER TABLE t1 ADD COLUMN c1 BIGINT", true);
         List<List<Comparable>> infoList = new ArrayList<>();
         job.getInfo(infoList);
         Assertions.assertEquals(1, infoList.size());
@@ -220,7 +215,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         long oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
 
         {
-            mustAlterTable(table, "ALTER TABLE t_test_sort_key ADD COLUMN c2 BIGINT");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t_test_sort_key ADD COLUMN c2 BIGINT", true);
             List<Column> columns = table.getBaseSchema();
             Assertions.assertEquals(3, columns.size());
             Assertions.assertEquals("c0", columns.get(0).getName());
@@ -234,7 +229,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         }
         oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
         {
-            mustAlterTable(table, "ALTER TABLE t_test_sort_key DROP COLUMN c2");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t_test_sort_key DROP COLUMN c2", true);
             List<Column> columns = table.getBaseSchema();
             Assertions.assertEquals(2, columns.size());
             Assertions.assertEquals("c0", columns.get(0).getName());
@@ -253,7 +248,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         long oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
 
         {
-            mustAlterTable(table, "ALTER TABLE t_test_sort_key_index_changed DROP COLUMN c1");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t_test_sort_key_index_changed DROP COLUMN c1", true);
             List<Column> columns = table.getBaseSchema();
             Assertions.assertEquals(2, columns.size());
             Assertions.assertEquals("c0", columns.get(0).getName());
@@ -275,8 +270,8 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
                     "BUCKETS 1 PROPERTIES('fast_schema_evolution'='true')");
         long oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
         {
-            mustAlterTable(table, "ALTER TABLE t_modify_type MODIFY COLUMN c1 BIGINT, MODIFY COLUMN c2 VARCHAR(10)," +
-                        "MODIFY COLUMN c3 DATETIME");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t_modify_type MODIFY COLUMN c1 BIGINT, MODIFY COLUMN c2 VARCHAR(10)," +
+                        "MODIFY COLUMN c3 DATETIME", true);
             List<Column> columns = table.getBaseSchema();
             Assertions.assertEquals(4, columns.size());
 
@@ -300,5 +295,208 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
             Assertions.assertTrue(table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId() > oldSchemaId);
             Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
         }
+    }
+
+    private List<Column> getShortKeyColumns(Database db, OlapTable table) {
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        try {
+            long baseIndexId = table.getBaseIndexId();
+            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(baseIndexId);
+            List<Column> schema = indexMeta.getSchema();
+            List<Column> shortKeyCols = new ArrayList<>();
+            List<Integer> sortKeyIdxes = indexMeta.getSortKeyIdxes();
+            int count = indexMeta.getShortKeyColumnCount();
+            if (sortKeyIdxes != null && !sortKeyIdxes.isEmpty()) {
+                for (int i = 0; i < count; i++) {
+                    shortKeyCols.add(schema.get(sortKeyIdxes.get(i)));
+                }
+            } else {
+                for (int i = 0; i < count; i++) {
+                    shortKeyCols.add(schema.get(i));
+                }
+            }
+            return shortKeyCols;
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        }
+    }
+
+    private boolean isShortKeyChanged(Database db, OlapTable table, List<Column> oldShortKeys) {
+        List<Column> newShortKeys = getShortKeyColumns(db, table);
+        if (oldShortKeys.size() != newShortKeys.size()) {
+            return true;
+        }
+        for (int i = 0; i < oldShortKeys.size(); i++) {
+            if (!oldShortKeys.get(i).equals(newShortKeys.get(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isSchemaMatch(Database db, OlapTable table, List<String> columNames) {
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        try {
+            long baseIndexId = table.getBaseIndexId();
+            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(baseIndexId);
+            List<Column> schema = indexMeta.getSchema();
+            if (schema.size() != columNames.size()) {
+                return false;
+
+            }
+            for (int i = 0; i < schema.size(); i++) {
+                if (!schema.get(i).getName().equals(columNames.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        }
+    }
+
+    private void createDupTableForAddKeyColumnTest(String tableName) throws Exception {
+        String createStmt = String.format("""
+                CREATE TABLE IF NOT EXISTS %s.%s (
+                k0 DATETIME,
+                k1 INT,
+                k2 BIGINT,\
+                v0 VARCHAR(1024)
+                ) DUPLICATE  KEY(k0, k1, k2)
+                DISTRIBUTED BY HASH(k0) BUCKETS 1
+                PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');""", DB_NAME, tableName);
+        createTable(connectContext, createStmt);
+    }
+
+    private void createUniqueTableForAddKeyColumnTest(String tableName) throws Exception {
+        String createStmt = String.format("""
+                CREATE TABLE IF NOT EXISTS  %s.%s (
+                k0 DATETIME,
+                k1 INT,
+                k2 BIGINT,\
+                v0 VARCHAR(1024)
+                ) UNIQUE KEY(k0, k1, k2)
+                DISTRIBUTED BY HASH(k0) BUCKETS 1
+                PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');""", DB_NAME, tableName);
+        createTable(connectContext, createStmt);
+    }
+
+    private void createAggTableForAddKeyColumnTest(String tableName) throws Exception {
+        String createStmt = String.format("""
+                CREATE TABLE IF NOT EXISTS %s.%s (
+                k0 DATETIME,
+                k1 INT,
+                k2 BIGINT,\
+                v0 INT SUM DEFAULT '0'
+                ) AGGREGATE KEY(k0, k1, k2)
+                DISTRIBUTED BY HASH(k0) BUCKETS 1
+                PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');""", DB_NAME, tableName);
+        createTable(connectContext, createStmt);
+    }
+
+    private void testAddKeyColumnWithFastSchemaEvolutionBase(String  tableName) throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeTable tbl = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), tableName);
+        Assertions.assertNotNull(tbl);
+        List<Column> oldShortKeys = getShortKeyColumns(db, tbl);
+
+        executeAlterAndWaitFinish(tbl,
+                String.format("ALTER TABLE %s.%s ADD COLUMN new_k1 INT KEY DEFAULT '0'", DB_NAME, tableName), true);
+        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("k0", "k1", "k2", "new_k1", "v0")));
+
+        executeAlterAndWaitFinish(tbl,
+                String.format("ALTER TABLE %s.%s ADD COLUMN new_k2 INT KEY DEFAULT NULL", DB_NAME, tableName), true);
+        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("k0", "k1", "k2", "new_k1", "new_k2", "v0")));
+
+        executeAlterAndWaitFinish(tbl,
+                String.format(
+                        "ALTER TABLE %s.%s ADD COLUMN new_k3 DATETIME KEY DEFAULT CURRENT_TIMESTAMP", DB_NAME, tableName), true);
+        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("k0", "k1", "k2", "new_k1", "new_k2", "new_k3", "v0")));
+
+        executeAlterAndWaitFinish(tbl,
+                String.format(
+                        "ALTER TABLE %s.%s ADD COLUMN new_k4 VARCHAR(100) KEY AFTER k2", DB_NAME, tableName), true);
+        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("k0", "k1", "k2", "new_k4", "new_k1", "new_k2", "new_k3", "v0")));
+    }
+
+    private void testAddKeyColumnWithoutFastSchemaEvolutionBase(String tableName) throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeTable tbl = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), tableName);
+        Assertions.assertNotNull(tbl);
+        List<Column> oldShortKeys = getShortKeyColumns(db, tbl);
+
+        executeAlterAndWaitFinish(tbl,
+                String.format("ALTER TABLE %s.%s ADD COLUMN new_k1 INT KEY FIRST", DB_NAME, tableName), false);
+        Assertions.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("new_k1", "k0", "k1", "k2", "v0")));
+
+        oldShortKeys = getShortKeyColumns(db, tbl);
+        executeAlterAndWaitFinish(tbl,
+                String.format("ALTER TABLE %s.%s ADD COLUMN new_k2 VARCHAR(100) KEY AFTER k0", DB_NAME, tableName), false);
+        Assertions.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("new_k1", "k0", "new_k2", "k1", "k2", "v0")));
+
+        oldShortKeys = getShortKeyColumns(db, tbl);
+        executeAlterAndWaitFinish(tbl,
+                String.format("ALTER TABLE %s.%s MODIFY COLUMN new_k1 BIGINT KEY", DB_NAME, tableName), false);
+        Assertions.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("new_k1", "k0", "new_k2", "k1", "k2", "v0")));
+    }
+
+    @Test
+    public void testDupTableAddKeyColumnWithFastSchemaEvolution() throws Exception {
+        String tableName = "dup_add_key_with_fse";
+        createDupTableForAddKeyColumnTest(tableName);
+        testAddKeyColumnWithFastSchemaEvolutionBase(tableName);
+    }
+
+    @Test
+    public void testDupTableAddKeyColumnWithoutFastSchemaEvolution() throws Exception {
+        String tableName = "dup_add_key_without_fse";
+        createDupTableForAddKeyColumnTest(tableName);
+        testAddKeyColumnWithoutFastSchemaEvolutionBase(tableName);
+    }
+
+    @Test
+    public void testUniqueTableAddKeyColumnWithFastSchemaEvolution() throws Exception {
+        String tableName = "unique_add_key_with_fse";
+        createUniqueTableForAddKeyColumnTest(tableName);
+        testAddKeyColumnWithFastSchemaEvolutionBase(tableName);
+    }
+
+    @Test
+    public void testUniqueTableAddKeyColumnWithoutFastSchemaEvolution() throws Exception {
+        String tableName = "unique_add_key_without_fse";
+        createUniqueTableForAddKeyColumnTest(tableName);
+        testAddKeyColumnWithoutFastSchemaEvolutionBase(tableName);
+    }
+
+    @Test
+    public void testAggTableAddKeyColumnWithFastSchemaEvolution() throws Exception {
+        String tableName = "agg_add_key_with_fse";
+        createAggTableForAddKeyColumnTest(tableName);
+        testAddKeyColumnWithFastSchemaEvolutionBase(tableName);
+    }
+
+    @Test
+    public void testAggTableAddKeyColumnWithoutFastSchemaEvolution() throws Exception {
+        String tableName = "agg_add_key_without_fse";
+        createAggTableForAddKeyColumnTest(tableName);
+        testAddKeyColumnWithoutFastSchemaEvolutionBase(tableName);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -62,7 +62,6 @@ import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -72,6 +71,7 @@ import java.util.Map;
 public class SchemaChangeHandlerTest extends TestWithFeService {
 
     private static final Logger LOG = LogManager.getLogger(SchemaChangeHandlerTest.class);
+    private int jobSize = 0;
 
     @Override
     protected void createStarrocksCluster() {
@@ -128,12 +128,8 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
 
     }
 
-    private void waitAlterJobDone(long dbId, long tableId) throws Exception {
-        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
+    private void waitAlterJobDone(Map<Long, AlterJobV2> alterJobs) throws Exception {
         for (AlterJobV2 alterJobV2 : alterJobs.values()) {
-            if (alterJobV2.getDbId() != dbId || alterJobV2.getTableId() != tableId) {
-                continue;
-            }
             while (!alterJobV2.getJobState().isFinalState()) {
                 LOG.info("alter job {} is running. state: {}", alterJobV2.getJobId(), alterJobV2.getJobState());
                 Thread.sleep(1000);
@@ -148,19 +144,6 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
                 Thread.sleep(1000);
             }
         }
-    }
-
-    private void executeAndWaitAlterJob(long dbId, long tableId, String alterSql) throws Exception {
-        AlterTableStmt stmt = (AlterTableStmt) parseAndAnalyzeStmt(alterSql);
-        DDLStmtExecutor.execute(stmt, connectContext);
-        waitAlterJobDone(dbId, tableId);
-    }
-
-    private void executeAlterAndVerifyJobNum(AlterTableStmt stmt) throws Exception {
-        int numAlterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2().size();
-        DDLStmtExecutor.execute(stmt, connectContext);
-        Assertions.assertEquals(numAlterJobs + 1,
-                GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2().size());
     }
 
     @Test
@@ -226,7 +209,11 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         //process agg add value column schema change
         String addValColStmtStr = "alter table test.sc_agg add column new_v1 int MAX default '0'";
         AlterTableStmt addValColStmt = (AlterTableStmt) parseAndAnalyzeStmt(addValColStmtStr);
-        executeAlterAndVerifyJobNum(addValColStmt);
+        DDLStmtExecutor.execute(addValColStmt, connectContext);
+        jobSize++;
+        // check alter job, do not create job
+        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
+        Assertions.assertEquals(jobSize, alterJobs.size());
 
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
         try {
@@ -242,8 +229,12 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         //process agg add  key column schema change
         String addKeyColStmtStr = "alter table test.sc_agg add column new_k1 int default '1'";
         AlterTableStmt addKeyColStmt = (AlterTableStmt) parseAndAnalyzeStmt(addKeyColStmtStr);
-        executeAlterAndVerifyJobNum(addKeyColStmt);
-        waitAlterJobDone(db.getId(), tbl.getId());
+        DDLStmtExecutor.execute(addKeyColStmt, connectContext);
+
+        //check alter job
+        jobSize++;
+        Assertions.assertEquals(jobSize, alterJobs.size());
+        waitAlterJobDone(alterJobs);
 
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
         try {
@@ -259,7 +250,11 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         //process agg drop value column schema change
         String dropValColStmtStr = "alter table test.sc_agg drop column new_v1";
         AlterTableStmt dropValColStmt = (AlterTableStmt) parseAndAnalyzeStmt(dropValColStmtStr);
-        executeAlterAndVerifyJobNum(dropValColStmt);
+        DDLStmtExecutor.execute(dropValColStmt, connectContext);
+        jobSize++;
+        //check alter job, do not create job
+        LOG.info("alterJobs:{}", alterJobs);
+        Assertions.assertEquals(jobSize, alterJobs.size());
 
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
         try {
@@ -282,7 +277,11 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         //process agg drop value column with rollup schema change
         String dropRollUpValColStmtStr = "alter table test.sc_agg drop column max_dwell_time";
         AlterTableStmt dropRollUpValColStmt = (AlterTableStmt) parseAndAnalyzeStmt(dropRollUpValColStmtStr);
-        executeAlterAndVerifyJobNum(dropRollUpValColStmt);
+        DDLStmtExecutor.execute(dropRollUpValColStmt, connectContext);
+        jobSize++;
+        //check alter job, need create job
+        LOG.info("alterJobs:{}", alterJobs);
+        Assertions.assertEquals(jobSize, alterJobs.size());
 
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
         try {
@@ -317,7 +316,12 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         //process uniq add value column schema change
         String addValColStmtStr = "alter table test.sc_uniq add column new_v1 int default '0'";
         AlterTableStmt addValColStmt = (AlterTableStmt) parseAndAnalyzeStmt(addValColStmtStr);
-        executeAlterAndVerifyJobNum(addValColStmt);
+        DDLStmtExecutor.execute(addValColStmt, connectContext);
+        jobSize++;
+        //check alter job, do not create job
+        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
+        LOG.info("alterJobs:{}", alterJobs);
+        Assertions.assertEquals(jobSize, alterJobs.size());
 
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
         try {
@@ -333,7 +337,10 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         //process uniq drop val column schema change
         String dropValColStmtStr = "alter table test.sc_uniq drop column new_v1";
         AlterTableStmt dropValColStm = (AlterTableStmt) parseAndAnalyzeStmt(dropValColStmtStr);
-        executeAlterAndVerifyJobNum(dropValColStm);
+        DDLStmtExecutor.execute(dropValColStm, connectContext);
+        jobSize++;
+        //check alter job
+        Assertions.assertEquals(jobSize, alterJobs.size());
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
         try {
             Assertions.assertEquals(8, tbl.getBaseSchema().size());
@@ -367,7 +374,12 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         //process uniq add value column schema change
         String addValColStmtStr = "alter table test.sc_dup add column new_v1 int default '0'";
         AlterTableStmt addValColStmt = (AlterTableStmt) parseAndAnalyzeStmt(addValColStmtStr);
-        executeAlterAndVerifyJobNum(addValColStmt);
+        DDLStmtExecutor.execute(addValColStmt, connectContext);
+        jobSize++;
+        //check alter job, do not create job
+        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
+        LOG.info("alterJobs:{}", alterJobs);
+        Assertions.assertEquals(jobSize, alterJobs.size());
 
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
         try {
@@ -383,7 +395,10 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         //process uniq drop val column schema change
         String dropValColStmtStr = "alter table test.sc_dup drop column new_v1";
         AlterTableStmt dropValColStm = (AlterTableStmt) parseAndAnalyzeStmt(dropValColStmtStr);
-        executeAlterAndVerifyJobNum(dropValColStm);
+        DDLStmtExecutor.execute(dropValColStm, connectContext);
+        jobSize++;
+        //check alter job
+        Assertions.assertEquals(jobSize, alterJobs.size());
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
         try {
             Assertions.assertEquals(6, tbl.getBaseSchema().size());
@@ -412,19 +427,19 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         }
         List<Index> newIndexes = tbl.getCopiedIndexes();
 
-        int numAlterJobs = alterJobs.size();
         Assertions.assertDoesNotThrow(
                     () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
                                 .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 100, 100,
                                             indexToNewSchemaId, false));
-        Assertions.assertEquals(numAlterJobs + 1, alterJobs.size());
+        jobSize++;
+        Assertions.assertEquals(jobSize, alterJobs.size());
 
-        numAlterJobs = alterJobs.size();
         Assertions.assertDoesNotThrow(
                     () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
                                 .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 101, 101,
                                             indexToNewSchemaId, true));
-        Assertions.assertEquals(numAlterJobs + 1, alterJobs.size());
+        jobSize++;
+        Assertions.assertEquals(jobSize, alterJobs.size());
 
         OlapTableState beforeState = tbl.getState();
         tbl.setState(OlapTableState.ROLLUP);
@@ -666,224 +681,5 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         boolean result = handler.updateFlatJsonConfigMeta(db, 99999L, properties,
                 TTabletMetaType.FLAT_JSON_CONFIG);
         Assertions.assertFalse(result);
-    }
-
-    private List<Column> getShortKeyColumns(Database db, OlapTable table) {
-        Locker locker = new Locker();
-        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
-        try {
-            long baseIndexId = table.getBaseIndexId();
-            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(baseIndexId);
-            List<Column> schema = indexMeta.getSchema();
-            List<Column> shortKeyCols = new ArrayList<>();
-            List<Integer> sortKeyIdxes = indexMeta.getSortKeyIdxes();
-            int count = indexMeta.getShortKeyColumnCount();
-            if (sortKeyIdxes != null && !sortKeyIdxes.isEmpty()) {
-                for (int i = 0; i < count; i++) {
-                    shortKeyCols.add(schema.get(sortKeyIdxes.get(i)));
-                }
-            } else {
-                for (int i = 0; i < count; i++) {
-                    shortKeyCols.add(schema.get(i));
-                }
-            }
-            return shortKeyCols;
-        } finally {
-            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
-        }
-    }
-
-    private boolean isShortKeyChanged(Database db, OlapTable table, List<Column> oldShortKeys) {
-        List<Column> newShortKeys = getShortKeyColumns(db, table);
-        if (oldShortKeys.size() != newShortKeys.size()) {
-            return true;
-        }
-        for (int i = 0; i < oldShortKeys.size(); i++) {
-            if (!oldShortKeys.get(i).equals(newShortKeys.get(i))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean isFastSchemaEvolution(Database db, OlapTable table, long oldIndexId) {
-        Locker locker = new Locker();
-        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
-        try {
-            return oldIndexId == table.getBaseIndexId();
-        } finally {
-            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
-        }
-    }
-
-    private boolean isSchemaMatch(Database db, OlapTable table, List<String> columNames) {
-        Locker locker = new Locker();
-        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
-        try {
-            long baseIndexId = table.getBaseIndexId();
-            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(baseIndexId);
-            List<Column> schema = indexMeta.getSchema();
-            if (schema.size() != columNames.size()) {
-                return false;
-
-            }
-            for (int i = 0; i < schema.size(); i++) {
-                if (!schema.get(i).getName().equals(columNames.get(i))) {
-                    return false;
-                }
-            }
-            return true;
-        } finally {
-            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
-        }
-    }
-
-    private void createDupTableForAddKeyColumnTest(String tableName) throws Exception {
-        String createStmt = "CREATE TABLE IF NOT EXISTS test." + tableName + " (\n"
-                + "k0 DATETIME,\n"
-                + "k1 INT,\n"
-                + "k2 BIGINT,"
-                + "v0 VARCHAR(1024)\n"
-                + ") DUPLICATE  KEY(k0, k1, k2)\n"
-                + "DISTRIBUTED BY HASH(k0) BUCKETS 1\n"
-                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
-        createTable(createStmt);
-    }
-
-    private void createUniqueTableForAddKeyColumnTest(String tableName) throws Exception {
-        String createStmt = "CREATE TABLE IF NOT EXISTS test." + tableName + " (\n"
-                + "k0 DATETIME,\n"
-                + "k1 INT,\n"
-                + "k2 BIGINT,"
-                + "v0 VARCHAR(1024)\n"
-                + ") UNIQUE KEY(k0, k1, k2)\n"
-                + "DISTRIBUTED BY HASH(k0) BUCKETS 1\n"
-                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
-        createTable(createStmt);
-    }
-
-    private void createAggTableForAddKeyColumnTest(String tableName) throws Exception {
-        String createStmt = "CREATE TABLE IF NOT EXISTS test." + tableName + " (\n"
-                + "k0 DATETIME,\n"
-                + "k1 INT,\n"
-                + "k2 BIGINT,"
-                + "v0 INT SUM DEFAULT '0'\n"
-                + ") AGGREGATE KEY(k0, k1, k2)\n"
-                + "DISTRIBUTED BY HASH(k0) BUCKETS 1\n"
-                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
-        createTable(createStmt);
-    }
-
-    private void testAddKeyColumnWithFastSchemaEvolutionBase(String tableName) throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
-        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .getTable(db.getFullName(), tableName);
-        Assertions.assertNotNull(tbl);
-        long oldIndexId = tbl.getBaseIndexId();
-        List<Column> oldShortKeys = getShortKeyColumns(db, tbl);
-
-        executeAndWaitAlterJob(db.getId(), tbl.getId(),
-                String.format("ALTER TABLE test.%s ADD COLUMN new_k1 INT KEY DEFAULT '0'", tableName));
-        Assertions.assertTrue(isFastSchemaEvolution(db, tbl, oldIndexId));
-        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
-                Lists.newArrayList("k0", "k1", "k2", "new_k1", "v0")));
-
-        executeAndWaitAlterJob(db.getId(), tbl.getId(),
-                String.format("ALTER TABLE test.%s ADD COLUMN new_k2 INT KEY DEFAULT NULL", tableName));
-        Assertions.assertTrue(isFastSchemaEvolution(db, tbl, oldIndexId));
-        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
-                Lists.newArrayList("k0", "k1", "k2", "new_k1", "new_k2", "v0")));
-
-        executeAndWaitAlterJob(db.getId(), tbl.getId(),
-                String.format(
-                        "ALTER TABLE test.%s ADD COLUMN new_k3 DATETIME KEY DEFAULT CURRENT_TIMESTAMP", tableName));
-        Assertions.assertTrue(isFastSchemaEvolution(db, tbl, oldIndexId));
-        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
-                Lists.newArrayList("k0", "k1", "k2", "new_k1", "new_k2", "new_k3", "v0")));
-
-        executeAndWaitAlterJob(db.getId(), tbl.getId(),
-                String.format(
-                        "ALTER TABLE test.%s ADD COLUMN new_k4 VARCHAR(100) KEY AFTER k2", tableName));
-        Assertions.assertTrue(isFastSchemaEvolution(db, tbl, oldIndexId));
-        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
-                Lists.newArrayList("k0", "k1", "k2", "new_k4", "new_k1", "new_k2", "new_k3", "v0")));
-    }
-
-    private void testAddKeyColumnWithoutFastSchemaEvolutionBase(String tableName) throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
-        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .getTable(db.getFullName(), tableName);
-        Assertions.assertNotNull(tbl);
-        long oldIndexId = tbl.getBaseIndexId();
-        List<Column> oldShortKeys = getShortKeyColumns(db, tbl);
-
-        executeAndWaitAlterJob(db.getId(), tbl.getId(),
-                String.format("ALTER TABLE test.%s ADD COLUMN new_k1 INT KEY FIRST", tableName));
-        Assertions.assertFalse(isFastSchemaEvolution(db, tbl, oldIndexId));
-        Assertions.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
-                Lists.newArrayList("new_k1", "k0", "k1", "k2", "v0")));
-
-        oldShortKeys = getShortKeyColumns(db, tbl);
-        executeAndWaitAlterJob(db.getId(), tbl.getId(),
-                String.format("ALTER TABLE test.%s ADD COLUMN new_k2 VARCHAR(100) KEY AFTER k0", tableName));
-        Assertions.assertFalse(isFastSchemaEvolution(db, tbl, oldIndexId));
-        Assertions.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
-                Lists.newArrayList("new_k1", "k0", "new_k2", "k1", "k2", "v0")));
-
-        oldShortKeys = getShortKeyColumns(db, tbl);
-        executeAndWaitAlterJob(db.getId(), tbl.getId(),
-                String.format("ALTER TABLE test.%s MODIFY COLUMN new_k1 BIGINT KEY", tableName));
-        Assertions.assertFalse(isFastSchemaEvolution(db, tbl, oldIndexId));
-        Assertions.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
-                Lists.newArrayList("new_k1", "k0", "new_k2", "k1", "k2", "v0")));
-    }
-
-    @Test
-    public void testDupTableAddKeyColumnWithFastSchemaEvolution() throws Exception {
-        String tableName = "dup_add_key_with_fse";
-        createDupTableForAddKeyColumnTest(tableName);
-        testAddKeyColumnWithFastSchemaEvolutionBase(tableName);
-    }
-
-    @Test
-    public void testDupTableAddKeyColumnWithoutFastSchemaEvolution() throws Exception {
-        String tableName = "dup_add_key_without_fse";
-        createDupTableForAddKeyColumnTest(tableName);
-        testAddKeyColumnWithoutFastSchemaEvolutionBase(tableName);
-    }
-
-    @Test
-    public void testUniqueTableAddKeyColumnWithFastSchemaEvolution() throws Exception {
-        String tableName = "unique_add_key_with_fse";
-        createUniqueTableForAddKeyColumnTest(tableName);
-        testAddKeyColumnWithFastSchemaEvolutionBase(tableName);
-    }
-
-    @Test
-    public void testUniqueTableAddKeyColumnWithoutFastSchemaEvolution() throws Exception {
-        String tableName = "unique_add_key_without_fse";
-        createUniqueTableForAddKeyColumnTest(tableName);
-        testAddKeyColumnWithoutFastSchemaEvolutionBase(tableName);
-    }
-
-    @Test
-    public void testAggTableAddKeyColumnWithFastSchemaEvolution() throws Exception {
-        String tableName = "agg_add_key_with_fse";
-        createAggTableForAddKeyColumnTest(tableName);
-        testAddKeyColumnWithFastSchemaEvolutionBase(tableName);
-    }
-
-    @Test
-    public void testAggTableAddKeyColumnWithoutFastSchemaEvolution() throws Exception {
-        String tableName = "agg_add_key_without_fse";
-        createAggTableForAddKeyColumnTest(tableName);
-        testAddKeyColumnWithoutFastSchemaEvolutionBase(tableName);
     }
 }


### PR DESCRIPTION
### Why I’m doing this
- Reduce schema change latency and avoid full data rewrite when adding key columns under the following conditions.
  - The new key column’s default is a constant or NULL (deterministic backfill).
  - The short key remains unchanged, so prefix index layout is not affected.
- Duplicate/Aggregate/Unique tables are supported. (Primary table does not support adding key column)
- Only shared-data is supported in this PR
   -  Will support shared-nothing in another PR which is based on this PR and also needs to modify BE codes, otherwise ingestions for aggregate/unique table will fail with error `sort key columns is different with key columns` 

### What I’m doing
- Remove the blanket ban on fast schema evolution when adding KEY columns; allow the fast path when conditions are met (removed the one-size-fits-all `newColumn.isKey()` disable).
- Extract and refine short-key computation: add `calculateShortKey(...)` to compute the new short-key columns and compare them with the original ones.
- Add a `shortKeyChanged` flag to `SchemaChangeData`, and propagate it via `withNewIndexShortKeyCount(..., shortKeyChanged)` to decide fast-path eligibility.
- In `analyzeAndCreateJob(...)`, if `isShortKeyChanged()` is true, automatically fall back to the normal schema change; otherwise, keep using fast schema evolution (shared-nothing: direct metadata update; shared-data: async fast job).

- Changes are focused in:
  - `com.starrocks.alter.SchemaChangeHandler`
  - `com.starrocks.alter.SchemaChangeData`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
