### PR TITLE
[BugFix] Fix the NullPointerException that occurs when cleaning up ex…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1687,9 +1687,11 @@ public class DatabaseTransactionMgr {
     private void clearTransactionState(TransactionState transactionState) {
         idToFinalStatusTransactionState.remove(transactionState.getTransactionId());
         Set<Long> txnIds = unprotectedGetTxnIdsByLabel(transactionState.getLabel());
-        txnIds.remove(transactionState.getTransactionId());
-        if (txnIds.isEmpty()) {
-            labelToTxnIds.remove(transactionState.getLabel());
+        if (null != txnIds) {
+            txnIds.remove(transactionState.getTransactionId());
+            if (txnIds.isEmpty()) {
+                labelToTxnIds.remove(transactionState.getLabel());
+            }
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
Fix the NullPointerException that occurs when cleaning up expired transactions.

There are many Routine Load tasks in the cluster, and the NPE causes historical tasks to accumulate, resulting in continuous memory growth.

**StackTrace**
```
 2025-08-23 11:45:16.362+08:00 WARN (LoadLabelCleaner|89) [GlobalStateMgr.clearExpiredJobs():2563] transaction manager remove expired txns failed
 java.lang.NullPointerException
        at com.starrocks.transaction.DatabaseTransactionMgr.clearTransactionState(DatabaseTransactionMgr.java:1567)
        at com.starrocks.transaction.DatabaseTransactionMgr.removeExpiredTxns(DatabaseTransactionMgr.java:1541)
        at com.starrocks.transaction.GlobalTransactionMgr.removeExpiredTxns(GlobalTransactionMgr.java:614)
        at com.starrocks.server.GlobalStateMgr.clearExpiredJobs(GlobalStateMgr.java:2561)
        at com.starrocks.server.GlobalStateMgr$2.runAfterCatalogReady(GlobalStateMgr.java:1771)
        at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72)
        at com.starrocks.common.util.Daemon.run(Daemon.java:107)
```
**Code**
```
    private void clearTransactionState(TransactionState transactionState) {
        idToFinalStatusTransactionState.remove(transactionState.getTransactionId());
        Set<Long> txnIds = unprotectedGetTxnIdsByLabel(transactionState.getLabel());
        txnIds.remove(transactionState.getTransactionId());  // 1567 line npe
        if (txnIds.isEmpty()) {
            labelToTxnIds.remove(transactionState.getLabel());
        }
    }
```
## What I'm doing:
I haven’t found out why the NPE is triggered, but adding a null check can avoid this issue.
I don’t understand why some transactions exist in finalStatusTransactionStateDeque but not in labelToTxnIds.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
