### PR TITLE
[BugFix] avoid BE crash when LakePersistentIndex init fail

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -156,7 +156,9 @@ LakePersistentIndex::LakePersistentIndex(TabletManager* tablet_mgr, int64_t tabl
         : PersistentIndex(""), _tablet_mgr(tablet_mgr), _tablet_id(tablet_id) {}
 
 LakePersistentIndex::~LakePersistentIndex() {
-    _memtable->clear();
+    if (_memtable) {
+        _memtable->clear();
+    }
     _sstables.clear();
 }
 


### PR DESCRIPTION
## Why I'm doing:
If `LakePersistentIndex` call `init` and fail, then we may need to release current LakePersistentIndex and retry again, but `_memtable` is nullptr, and lead to crash.

## What I'm doing:
This pull request makes a minor improvement to the `LakePersistentIndex` destructor by ensuring that the `_memtable` is only cleared if it exists, which helps prevent potential null pointer issues.

* Added a null check before calling `clear()` on `_memtable` in the `LakePersistentIndex` destructor to improve safety.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
