### PR TITLE
[Enhancement] add remote file cache limit for hive

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CachingRemoteFileConf.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CachingRemoteFileConf.java
@@ -22,17 +22,20 @@ import java.util.Map;
 public class CachingRemoteFileConf {
     private final long cacheTtlSec;
     private final long cacheRefreshIntervalSec;
-    private long cacheMaxSize = 1000000L;
+    private long cacheMaxSize = 1000000L; //deprecated, use memSizeRatio ratio instead
     private final int perQueryCacheMaxSize = 10000;
     private final int refreshMaxThreadNum;
+    private double memSizeRatio = 0.1; // 10% of the total memory
 
     public CachingRemoteFileConf(Map<String, String> conf) {
         this.cacheTtlSec = Long.parseLong(conf.getOrDefault("remote_file_cache_ttl_sec",
                 String.valueOf(Config.remote_file_cache_ttl_s)));
         this.cacheRefreshIntervalSec = Long.parseLong(conf.getOrDefault("remote_file_cache_refresh_interval_sec",
                 String.valueOf(Config.remote_file_cache_refresh_interval_s)));
+        //deprecated, use memSizeRatio ratio instead
         this.cacheMaxSize = Long.parseLong(conf.getOrDefault("remote_file_cache_max_num", String.valueOf(cacheMaxSize)));
         this.refreshMaxThreadNum = Integer.parseInt(conf.getOrDefault("async_refresh_max_thread_num", "32"));
+        this.memSizeRatio = Double.parseDouble(conf.getOrDefault("remote_file_cache_memory_ratio", String.valueOf(memSizeRatio)));
     }
 
     public long getCacheTtlSec() {
@@ -53,5 +56,9 @@ public class CachingRemoteFileConf {
 
     public int getRefreshMaxThreadNum() {
         return refreshMaxThreadNum;
+    }
+
+    public double getMemSizeRatio() {
+        return memSizeRatio;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
@@ -153,7 +153,7 @@ public class HiveConnectorInternalMgr {
                     new ReentrantExecutor(refreshRemoteFileExecutor, remoteFileConf.getRefreshMaxThreadNum()),
                     remoteFileConf.getCacheTtlSec(),
                     enableHmsEventsIncrementalSync ? NEVER_REFRESH : remoteFileConf.getCacheRefreshIntervalSec(),
-                    remoteFileConf.getCacheMaxSize());
+                    remoteFileConf.getMemSizeRatio());
         }
 
         return baseRemoteFileIO;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
@@ -35,7 +35,8 @@ public class HiveMetadataFactory {
     private final IHiveMetastore metastore;
     private final RemoteFileIO remoteFileIO;
     private final long perQueryMetastoreMaxNum;
-    private final long perQueryCacheRemotePathMaxNum;
+    private final long perQueryCacheRemotePathMaxNum; //deprecated
+    private final double perQueryCacheRemotePathMaxMemoryRatio;
     private final ExecutorService pullRemoteFileExecutor;
     private final Executor updateRemoteFilesExecutor;
     private final Executor updateStatisticsExecutor;
@@ -64,7 +65,8 @@ public class HiveMetadataFactory {
         this.metastore = metastore;
         this.remoteFileIO = remoteFileIO;
         this.perQueryMetastoreMaxNum = hmsConf.getPerQueryCacheMaxNum();
-        this.perQueryCacheRemotePathMaxNum = fileConf.getPerQueryCacheMaxSize();
+        this.perQueryCacheRemotePathMaxNum = fileConf.getPerQueryCacheMaxSize(); // deprecated
+        this.perQueryCacheRemotePathMaxMemoryRatio = 0.0; //It is duplicated with Catalog level CachingRemoteFileIO, set as 0.
         this.pullRemoteFileExecutor = pullRemoteFileExecutor;
         this.updateRemoteFilesExecutor = updateRemoteFilesExecutor;
         this.updateStatisticsExecutor = updateStatisticsExecutor;
@@ -82,7 +84,7 @@ public class HiveMetadataFactory {
                 metastore instanceof CachingHiveMetastore,
                 hdfsEnvironment.getConfiguration(), metastoreType, catalogName);
         RemoteFileOperations remoteFileOperations = new RemoteFileOperations(
-                CachingRemoteFileIO.createQueryLevelInstance(remoteFileIO, perQueryCacheRemotePathMaxNum),
+                CachingRemoteFileIO.createQueryLevelInstance(remoteFileIO, perQueryCacheRemotePathMaxMemoryRatio),
                 pullRemoteFileExecutor,
                 updateRemoteFilesExecutor,
                 isRecursive,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
@@ -146,7 +146,7 @@ public class HudiConnectorInternalMgr {
                     new ReentrantExecutor(refreshRemoteFileExecutor, remoteFileConf.getRefreshMaxThreadNum()),
                     remoteFileConf.getCacheTtlSec(),
                     remoteFileConf.getCacheRefreshIntervalSec(),
-                    remoteFileConf.getCacheMaxSize());
+                    remoteFileConf.getMemSizeRatio());
         }
 
         return baseRemoteFileIO;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadataFactory.java
@@ -40,7 +40,8 @@ public class HudiMetadataFactory {
     private final IHiveMetastore metastore;
     private final RemoteFileIO remoteFileIO;
     private final long perQueryMetastoreMaxNum;
-    private final long perQueryCacheRemotePathMaxNum;
+    private final long perQueryCacheRemotePathMaxNum; //deprecated
+    private final double perQueryCacheRemotePathMaxMemoryRatio;
     private final ExecutorService pullRemoteFileExecutor;
     private final boolean isRecursive;
     private final HdfsEnvironment hdfsEnvironment;
@@ -62,6 +63,7 @@ public class HudiMetadataFactory {
         this.remoteFileIO = remoteFileIO;
         this.perQueryMetastoreMaxNum = hmsConf.getPerQueryCacheMaxNum();
         this.perQueryCacheRemotePathMaxNum = fileConf.getPerQueryCacheMaxSize();
+        this.perQueryCacheRemotePathMaxMemoryRatio = 0.0; //It is duplicated with Catalog level CachingRemoteFileIO, set as 0.
         this.pullRemoteFileExecutor = pullRemoteFileExecutor;
         this.isRecursive = isRecursive;
         this.hdfsEnvironment = hdfsEnvironment;
@@ -75,7 +77,7 @@ public class HudiMetadataFactory {
                 metastore instanceof CachingHiveMetastore,
                 hdfsEnvironment.getConfiguration(), metastoreType, catalogName);
         RemoteFileOperations remoteFileOperations = new RemoteFileOperations(
-                CachingRemoteFileIO.createQueryLevelInstance(remoteFileIO, perQueryCacheRemotePathMaxNum),
+                CachingRemoteFileIO.createQueryLevelInstance(remoteFileIO, perQueryCacheRemotePathMaxMemoryRatio),
                 pullRemoteFileExecutor,
                 pullRemoteFileExecutor,
                 isRecursive,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CachingRemoteFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CachingRemoteFileIOTest.java
@@ -40,7 +40,7 @@ public class CachingRemoteFileIOTest {
         hiveRemoteFileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;
         ExecutorService executor = Executors.newFixedThreadPool(5);
-        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executor, 10, 10, 10);
+        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executor, 10, 10, 0.1);
 
         String tableLocation = "hdfs://127.0.0.1:10000/hive.db/hive_tbl";
         RemotePathKey pathKey = RemotePathKey.of(tableLocation, false);
@@ -63,7 +63,7 @@ public class CachingRemoteFileIOTest {
         Assertions.assertEquals(20, blockDesc.getLength());
         Assertions.assertEquals(2, blockDesc.getReplicaHostIds().length);
 
-        CachingRemoteFileIO queryLevelCache = CachingRemoteFileIO.createQueryLevelInstance(cachingFileIO, 5);
+        CachingRemoteFileIO queryLevelCache = CachingRemoteFileIO.createQueryLevelInstance(cachingFileIO, 0.1);
         Assertions.assertEquals(1, queryLevelCache.getRemoteFiles(pathKey).size());
 
         Map<RemotePathKey, List<RemoteFileDesc>> presentRemoteFileInfos =

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
@@ -64,7 +64,7 @@ public class RemoteFileOperationsTest {
         ExecutorService executorToRefresh = Executors.newFixedThreadPool(5);
         ExecutorService executorToLoad = Executors.newFixedThreadPool(5);
 
-        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 10);
+        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 0.1);
         RemoteFileOperations ops = new RemoteFileOperations(cachingFileIO, executorToLoad, executorToLoad,
                 false, true, new Configuration());
 
@@ -104,7 +104,7 @@ public class RemoteFileOperationsTest {
         Assertions.assertEquals(20, blockDesc.getLength());
         Assertions.assertEquals(2, blockDesc.getReplicaHostIds().length);
 
-        CachingRemoteFileIO queryLevelCache = CachingRemoteFileIO.createQueryLevelInstance(cachingFileIO, 5);
+        CachingRemoteFileIO queryLevelCache = CachingRemoteFileIO.createQueryLevelInstance(cachingFileIO, 0.1);
         Assertions.assertEquals(1, queryLevelCache.getRemoteFiles(pathKey).size());
 
         Map<RemotePathKey, List<RemoteFileDesc>> presentRemoteFileInfos =
@@ -125,7 +125,7 @@ public class RemoteFileOperationsTest {
         ExecutorService executorToRefresh = Executors.newFixedThreadPool(5);
         ExecutorService executorToLoad = Executors.newFixedThreadPool(5);
 
-        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 10);
+        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 0.1);
         RemoteFileOperations ops = new RemoteFileOperations(cachingFileIO, executorToLoad, executorToLoad,
                 false, true, new Configuration());
 
@@ -193,7 +193,7 @@ public class RemoteFileOperationsTest {
         FeConstants.runningUnitTest = true;
         ExecutorService executorToRefresh = Executors.newSingleThreadExecutor();
         ExecutorService executorToLoad = Executors.newSingleThreadExecutor();
-        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 10);
+        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 0.1);
         RemoteFileOperations ops = new RemoteFileOperations(cachingFileIO, executorToLoad, executorToLoad,
                 false, true, new Configuration());
         new MockUp<HiveWriteUtils>() {
@@ -222,7 +222,7 @@ public class RemoteFileOperationsTest {
         FeConstants.runningUnitTest = true;
         ExecutorService executorToRefresh = Executors.newSingleThreadExecutor();
         ExecutorService executorToLoad = Executors.newSingleThreadExecutor();
-        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 10);
+        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 0.1);
         RemoteFileOperations ops = new RemoteFileOperations(cachingFileIO, executorToLoad, executorToLoad,
                 false, true, new Configuration());
 
@@ -261,7 +261,7 @@ public class RemoteFileOperationsTest {
         FeConstants.runningUnitTest = true;
         ExecutorService executorToRefresh = Executors.newSingleThreadExecutor();
         ExecutorService executorToLoad = Executors.newSingleThreadExecutor();
-        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 10);
+        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 0.1);
         RemoteFileOperations ops = new RemoteFileOperations(cachingFileIO, executorToLoad, executorToLoad,
                 false, true, new Configuration());
         Path targetPath = new Path("hdfs://hadoop01:9000/user/hive/warehouse/test.db/t1");
@@ -359,7 +359,7 @@ public class RemoteFileOperationsTest {
         ExecutorService executorToRefresh = Executors.newFixedThreadPool(5);
         ExecutorService executorToLoad = Executors.newFixedThreadPool(5);
 
-        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 10);
+        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 0.1);
         RemoteFileOperations ops = new RemoteFileOperations(cachingFileIO, executorToLoad, executorToLoad,
                 false, true, new Configuration());
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
@@ -66,7 +66,7 @@ public class HiveConnectorTest {
         FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         cachingRemoteFileIO = CachingRemoteFileIO.createCatalogLevelInstance(
-                hiveRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 10);
+                hiveRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 0.1);
     }
 
     @AfterEach

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -125,7 +125,7 @@ public class HiveMetadataTest {
         FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         cachingRemoteFileIO = CachingRemoteFileIO.createCatalogLevelInstance(
-                hiveRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 10);
+                hiveRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 0.1);
         fileOps = new RemoteFileOperations(cachingRemoteFileIO, executorForPullFiles, executorForPullFiles,
                 false, true, new Configuration());
         statisticsProvider = new HiveStatisticsProvider(hmsOps, fileOps);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
@@ -89,7 +89,7 @@ public class HiveStatisticsProviderTest {
         FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         cachingRemoteFileIO = CachingRemoteFileIO.createCatalogLevelInstance(
-                hiveRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 10);
+                hiveRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 0.1);
         fileOps = new RemoteFileOperations(cachingRemoteFileIO, executorForPullFiles, executorForPullFiles,
                 false, true, new Configuration());
         statisticsProvider = new HiveStatisticsProvider(hmsOps, fileOps);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
@@ -79,7 +79,7 @@ public class HudiMetadataTest {
 
         hudiRemoteFileIO = new HudiRemoteFileIO(new Configuration());
         cachingRemoteFileIO = CachingRemoteFileIO.createCatalogLevelInstance(
-                hudiRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 10);
+                hudiRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 0.1);
         fileOps = new RemoteFileOperations(cachingRemoteFileIO, executorForPullFiles, executorForPullFiles,
                 false, true, new Configuration());
         statisticsProvider = new HiveStatisticsProvider(hmsOps, fileOps);


### PR DESCRIPTION
## Why I'm doing:
Since hive may have numerous files under a partition path, the RemoteFileDesc cache can cost huge amount of memory.

The partition max num can not effectively limit the cache size, so it is easy to cause OOM.

## What I'm doing:
Add a hive catalog configure `remote_file_cache_memory_ratio` to limit the cache size of `LoadingCache<RemotePathKey, List<RemoteFileDesc>> cache` and deprecated the `remote_file_cache_max_num`

## Expriment
## Environment
Test results on local cluster:
- 1 FE, 4 BE (each 8G memory)

---

## Experiments

### 1. Query a huge partioned hive table with millions of files.

The catalog is created by SQL:
```sql
CREATE EXTERNAL CATALOG hive_catalog_hms
PROPERTIES
(
    "type" = "hive",
    "hive.metastore.type" = "hive",
    "hive.metastore.uris" = "thrift://x",
    "remote_file_cache_memory_ratio" = "0.01"
);
```
The debug level log:
```
2025-08-25 19:02:53.948+08:00 DEBUG (pull-hive-remote-files-30|273) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9740', isRecursive=true}, Value.size=183, Cause=SIZE
2025-08-25 19:02:53.948+08:00 DEBUG (hive-remote-files-refresh-4|280) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9740', isRecursive=true}, Value.size=183, Cause=SIZE
2025-08-25 19:02:55.711+08:00 DEBUG (pull-hive-remote-files-0|236) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=974', isRecursive=true}, Value.size=204, Cause=SIZE
2025-08-25 19:02:55.711+08:00 DEBUG (hive-remote-files-refresh-3|279) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=974', isRecursive=true}, Value.size=204, Cause=SIZE
2025-08-25 19:02:57.700+08:00 DEBUG (pull-hive-remote-files-22|265) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9739', isRecursive=true}, Value.size=160, Cause=SIZE
2025-08-25 19:02:57.700+08:00 DEBUG (hive-remote-files-refresh-4|280) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9739', isRecursive=true}, Value.size=160, Cause=SIZE
2025-08-25 19:02:58.138+08:00 DEBUG (hive-remote-files-refresh-3|279) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9738', isRecursive=true}, Value.size=183, Cause=SIZE
2025-08-25 19:02:58.138+08:00 DEBUG (pull-hive-remote-files-2|244) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9738', isRecursive=true}, Value.size=183, Cause=SIZE
2025-08-25 19:02:58.593+08:00 DEBUG (pull-hive-remote-files-28|271) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9737', isRecursive=true}, Value.size=164, Cause=SIZE
2025-08-25 19:02:58.606+08:00 DEBUG (hive-remote-files-refresh-4|280) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9737', isRecursive=true}, Value.size=164, Cause=REPLACED
2025-08-25 19:02:58.960+08:00 DEBUG (pull-hive-remote-files-12|254) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9736', isRecursive=true}, Value.size=185, Cause=SIZE
2025-08-25 19:02:58.960+08:00 DEBUG (hive-remote-files-refresh-3|279) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9736', isRecursive=true}, Value.size=185, Cause=SIZE
2025-08-25 19:02:59.419+08:00 DEBUG (pull-hive-remote-files-31|274) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9735', isRecursive=true}, Value.size=181, Cause=SIZE
2025-08-25 19:02:59.419+08:00 DEBUG (hive-remote-files-refresh-5|318) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9735', isRecursive=true}, Value.size=181, Cause=SIZE
2025-08-25 19:02:59.884+08:00 DEBUG (pull-hive-remote-files-16|258) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9734', isRecursive=true}, Value.size=188, Cause=SIZE
2025-08-25 19:02:59.884+08:00 DEBUG (hive-remote-files-refresh-3|279) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9734', isRecursive=true}, Value.size=188, Cause=SIZE
2025-08-25 19:03:00.414+08:00 DEBUG (pull-hive-remote-files-19|262) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9733', isRecursive=true}, Value.size=168, Cause=SIZE
2025-08-25 19:03:00.414+08:00 DEBUG (hive-remote-files-refresh-5|318) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9733', isRecursive=true}, Value.size=168, Cause=SIZE
2025-08-25 19:03:00.872+08:00 DEBUG (pull-hive-remote-files-27|270) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9732', isRecursive=true}, Value.size=190, Cause=SIZE
2025-08-25 19:03:00.872+08:00 DEBUG (hive-remote-files-refresh-3|279) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9732', isRecursive=true}, Value.size=190, Cause=SIZE
2025-08-25 19:03:01.323+08:00 DEBUG (pull-hive-remote-files-25|268) [CachingRemoteFileIO.lambda$new$1():69] Key=RemotePathKey{path='hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/owen_hive.db/t4/c2=9731', isRecursive=true}, Value.size=163, Cause=SIZE
```
after test, the jmap result:

```
sr@iZ8vbebs0ifhb6rsdfn5fjZ:~$ jmap -histo:live 65826 | head -n 10 
 num     #instances         #bytes  class name (module)
-------------------------------------------------------
   1:        490703      128417952  [B (java.base@17.0.13)
   2:         14774       14710640  [I (java.base@17.0.13)
   3:        480314       11527536  java.lang.String (java.base@17.0.13)
   4:        116833        8152360  [Ljava.lang.Object; (java.base@17.0.13)
   5:        190017        6310080  [J (java.base@17.0.13)
   6:         94652        5300512  com.starrocks.connector.RemoteFileDesc
   7:        156842        5018944  java.util.HashMap$Node (java.base@17.0.13)
   8:         94652        3786080  com.starrocks.connector.RemoteFileBlockDesc
After GC:
sr@iZ8vbebs0ifhb6rsdfn5fjZ:~$ jcmd 65826 GC.heap_info
65826:
 garbage-first heap   total 860160K, used 448259K [0x0000000666400000, 0x0000000800000000)
  region size 4096K, 50 young (204800K), 4 survivors (16384K)
 Metaspace       used 129228K, committed 130112K, reserved 1179648K
  class space    used 13546K, committed 13952K, reserved 1048576K
```
Memory Watcher:
The test began around 18:50
<img width="697" height="310" alt="image" src="https://github.com/user-attachments/assets/e2f9c3fb-3eb0-485a-97a3-7806d4dec796" />

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
