### PR TITLE
[Enhancement] add a session variable to deploy scan ranges back/foreground

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -900,6 +900,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES = "enable_connector_incremental_scan_ranges";
     public static final String CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE = "connector_incremental_scan_ranges_size";
     public static final String ENABLE_CONNECTOR_ASYNC_LIST_PARTITIONS = "enable_connector_async_list_partitions";
+    public static final String ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES_BACKGROUND =
+            "enable_connector_incremental_scan_ranges_background";
     public static final String ENABLE_PLAN_ANALYZER = "enable_plan_analyzer";
 
     public static final String ENABLE_PLAN_ADVISOR = "enable_plan_advisor";
@@ -1261,7 +1263,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CBO_JSON_V2_DICT_OPT)
     private boolean cboJSONV2DictOpt = true;
-
 
     /*
      * the parallel exec instance num for one Fragment in one BE
@@ -2651,6 +2652,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES)
     private boolean enableConnectorIncrementalScanRanges = true;
+
+    @VarAttr(name = ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES_BACKGROUND)
+    private boolean enableConnectorIncrementalScanRangesBackground = false;
 
     @VarAttr(name = CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE)
     private int connectorIncrementalScanRangeSize = 500;
@@ -5063,6 +5067,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableConnectorIncrementalScanRanges;
     }
 
+    public boolean isEnableConnectorIncrementalScanRangesBackground() {
+        return enableConnectorIncrementalScanRangesBackground;
+    }
+
     public boolean isEnableConnectorAsyncListPartitions() {
         return enableConnectorAsyncListPartitions;
     }
@@ -5238,7 +5246,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public void setEnableJSONV2Rewrite(boolean enableJSONV2Rewrite) {
         this.cboJSONV2Rewrite = enableJSONV2Rewrite;
     }
-  
+
     public boolean isEnableDropTableCheckMvDependency() {
         return enableDropTableCheckMvDependency;
     }
@@ -5446,9 +5454,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         }
         return root.toString();
     }
-
-
-
 
     private void readFromJson(DataInput in) throws IOException {
         String json = Text.readString(in);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -900,7 +900,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES = "enable_connector_incremental_scan_ranges";
     public static final String CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE = "connector_incremental_scan_ranges_size";
     public static final String ENABLE_CONNECTOR_ASYNC_LIST_PARTITIONS = "enable_connector_async_list_partitions";
-    public static final String ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES_BACKGROUND =
+    public static final String ENABLE_CONNECTOR_DEPLOYSCAN_RANGES_BACKGROUND =
             "enable_connector_incremental_scan_ranges_background";
     public static final String ENABLE_PLAN_ANALYZER = "enable_plan_analyzer";
 
@@ -2653,8 +2653,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES)
     private boolean enableConnectorIncrementalScanRanges = true;
 
-    @VarAttr(name = ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES_BACKGROUND)
-    private boolean enableConnectorIncrementalScanRangesBackground = true;
+    @VarAttr(name = ENABLE_CONNECTOR_DEPLOYSCAN_RANGES_BACKGROUND)
+    private boolean enableConnectorDeployScanRangesBackground = true;
 
     @VarAttr(name = CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE)
     private int connectorIncrementalScanRangeSize = 500;
@@ -5067,8 +5067,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableConnectorIncrementalScanRanges;
     }
 
-    public boolean isEnableConnectorIncrementalScanRangesBackground() {
-        return enableConnectorIncrementalScanRangesBackground;
+    public boolean isEnableConnectorDeployScanRangesBackground() {
+        return enableConnectorDeployScanRangesBackground;
     }
 
     public boolean isEnableConnectorAsyncListPartitions() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2654,7 +2654,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enableConnectorIncrementalScanRanges = true;
 
     @VarAttr(name = ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES_BACKGROUND)
-    private boolean enableConnectorIncrementalScanRangesBackground = false;
+    private boolean enableConnectorIncrementalScanRangesBackground = true;
 
     @VarAttr(name = CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE)
     private int connectorIncrementalScanRangeSize = 500;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -900,8 +900,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES = "enable_connector_incremental_scan_ranges";
     public static final String CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE = "connector_incremental_scan_ranges_size";
     public static final String ENABLE_CONNECTOR_ASYNC_LIST_PARTITIONS = "enable_connector_async_list_partitions";
-    public static final String ENABLE_CONNECTOR_DEPLOYSCAN_RANGES_BACKGROUND =
-            "enable_connector_incremental_scan_ranges_background";
+    public static final String ENABLE_CONNECTOR_DEPLOY_SCAN_RANGES_BACKGROUND =
+            "enable_connector_deploy_scan_ranges_background";
     public static final String ENABLE_PLAN_ANALYZER = "enable_plan_analyzer";
 
     public static final String ENABLE_PLAN_ADVISOR = "enable_plan_advisor";
@@ -2653,7 +2653,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES)
     private boolean enableConnectorIncrementalScanRanges = true;
 
-    @VarAttr(name = ENABLE_CONNECTOR_DEPLOYSCAN_RANGES_BACKGROUND)
+    @VarAttr(name = ENABLE_CONNECTOR_DEPLOY_SCAN_RANGES_BACKGROUND)
     private boolean enableConnectorDeployScanRangesBackground = true;
 
     @VarAttr(name = CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1400,7 +1400,7 @@ public class StmtExecutor {
             return;
         }
 
-        coord.execWithQueryDeployExecutor();
+        coord.execWithQueryDeployExecutor(context);
         coord.setTopProfileSupplier(this::buildTopLevelProfile);
         coord.setExecPlan(execPlan);
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -107,9 +107,9 @@ public abstract class Coordinator {
         startScheduling(option);
     }
 
-    public void execWithQueryDeployExecutor() throws Exception {
+    public void execWithQueryDeployExecutor(ConnectContext context) throws Exception {
         ScheduleOption option = new ScheduleOption();
-        option.useQueryDeployExecutor = true;
+        option.useQueryDeployExecutor = context.getSessionVariable().isEnableConnectorIncrementalScanRangesBackground();
         startScheduling(option);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -109,7 +109,7 @@ public abstract class Coordinator {
 
     public void execWithQueryDeployExecutor(ConnectContext context) throws Exception {
         ScheduleOption option = new ScheduleOption();
-        option.useQueryDeployExecutor = context.getSessionVariable().isEnableConnectorIncrementalScanRangesBackground();
+        option.useQueryDeployExecutor = context.getSessionVariable().isEnableConnectorDeployScanRangesBackground();
         startScheduling(option);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
@@ -119,7 +119,7 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
 
     @Override
     public void schedule(Coordinator.ScheduleOption option) throws RpcException, StarRocksException {
-        List<DeployState> states = new ArrayList<>();        
+        List<DeployState> states = new ArrayList<>();
         for (List<ExecutionFragment> executionFragments : dag.getFragmentsInTopologicalOrderFromRoot()) {
             final DeployState deployState = deployer.createFragmentExecStates(executionFragments);
             deployer.deployFragments(deployState);
@@ -130,16 +130,12 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
         if (option.useQueryDeployExecutor) {
             deployScanRangesTask.executorService = GlobalStateMgr.getCurrentState().getQueryDeployExecutor();
             deployScanRangesTask.currentTracers = Tracers.get();
-        } else {
-            deployScanRangesTask.start();
         }
     }
 
     @Override
     public void continueSchedule(Coordinator.ScheduleOption option) throws RpcException, StarRocksException {
-        if (option.useQueryDeployExecutor) {
-            deployScanRangesTask.start();
-        }
+        deployScanRangesTask.start();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
@@ -72,9 +72,7 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
                 return;
             }
             try (TracerContext tracerContext = new TracerContext(currentTracers)) {
-                try (Timer timer = Tracers.watchScope(Tracers.Module.SCHEDULER, "DeployScanRanges")) {
-                    runOnce();
-                }
+                runOnce();
             }
             // If run in the executor service, we need to start the next turn.
             // To submit this task again so all queries could get the same opportunity to run by queueing up
@@ -82,7 +80,7 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
         }
 
         public void runOnce() {
-            try {
+            try (Timer timer = Tracers.watchScope(Tracers.Module.SCHEDULER, "DeployScanRanges")) {
                 states = coordinator.assignIncrementalScanRangesToDeployStates(deployer, states);
                 if (states.isEmpty()) {
                     return;


### PR DESCRIPTION
## Why I'm doing:

Add a session variable `enable_connector_deploy_scan_ranges_background`. 

if it's set to false, then deploy scan ranges in query thread.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
