### PR TITLE
[BugFix] Align enable_merge_commit setting for FE/BE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
@@ -531,5 +531,18 @@ public class Util {
         return objectsUnResolved;
     }
 
-
+    /**
+     * To align with BE's string_to_bool function, the following string values are considered as true.
+     */
+    public static boolean stringToBool(String str) {
+        if (str == null) {
+            return false;
+        }
+        str = str.trim().toLowerCase();
+        if ("true".equals(str) || "1".equals(str) || "true".equals(str.stripTrailing())) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -161,8 +161,7 @@ public class LoadAction extends RestBaseAction {
         // affect subsequent requests processing.
         response.setForceCloseConnection(true);
 
-        boolean enableBatchWrite = "true".equalsIgnoreCase(
-                request.getRequest().headers().get(StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE));
+        boolean enableBatchWrite = StreamLoadHttpHeader.isEnabledBatchWrite(request);
         if (enableBatchWrite && redirectToLeader(request, response)) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/StreamLoadMetaAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/StreamLoadMetaAction.java
@@ -79,8 +79,7 @@ public class StreamLoadMetaAction extends RestBaseAction {
     @Override
     public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException,
             AccessDeniedException {
-        boolean enableBatchWrite = "true".equalsIgnoreCase(
-                request.getRequest().headers().get(StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE));
+        boolean enableBatchWrite = StreamLoadHttpHeader.isEnabledBatchWrite(request);
         if (enableBatchWrite && redirectToLeader(request, response)) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadHttpHeader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadHttpHeader.java
@@ -13,6 +13,9 @@
 
 package com.starrocks.load.streamload;
 
+import com.starrocks.common.util.Util;
+import com.starrocks.http.BaseRequest;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -74,4 +77,12 @@ public class StreamLoadHttpHeader {
             HTTP_LOG_REJECTED_RECORD_NUM, HTTP_COMPRESSION, HTTP_WAREHOUSE, HTTP_ENABLE_BATCH_WRITE,
             HTTP_BATCH_WRITE_ASYNC, HTTP_BATCH_WRITE_INTERVAL_MS, HTTP_BATCH_WRITE_PARALLEL
     );
+
+    public static boolean isEnabledBatchWrite(BaseRequest request) {
+        if (request == null) {
+            return false;
+        }
+        String val = request.getRequest().headers().get(StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE);
+        return Util.stringToBool(val);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadKvParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadKvParams.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.load.streamload;
 
+import com.starrocks.common.util.Util;
 import com.starrocks.thrift.TFileFormatType;
 import com.starrocks.thrift.TFileType;
 import com.starrocks.thrift.TPartialUpdateMode;
@@ -317,7 +318,7 @@ public class StreamLoadKvParams implements StreamLoadParams {
         if (value == null) {
             return Optional.empty();
         }
-        return Optional.of(Boolean.parseBoolean(value));
+        return Optional.of(Util.stringToBool(value));
     }
 
     private Optional<Integer> getIntParam(String paramName) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/UtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/UtilTest.java
@@ -17,11 +17,67 @@ package com.starrocks.common.util;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class UtilTest {
 
     @Test
     public void testGetResultForUrl() {
         Assertions.assertThrows(Exception.class,
                 () -> Util.getResultForUrl("http://127.0.0.1:23/invalid", null, 1000, 1000));
+    }
+
+
+    @Test
+    public void returnsFalseWhenInputIsNull() {
+        assertFalse(Util.stringToBool(null));
+    }
+
+    @Test
+    public void returnsFalseWhenInputIsEmpty() {
+        assertFalse(Util.stringToBool(""));
+    }
+
+    @Test
+    public void returnsFalseWhenInputIsWhitespace() {
+        assertFalse(Util.stringToBool("   "));
+    }
+
+    @Test
+    public void returnsTrueWhenInputIsTrueIgnoringCase() {
+        assertTrue(Util.stringToBool("TRUE"));
+        assertTrue(Util.stringToBool("true"));
+        assertTrue(Util.stringToBool("TrUe"));
+    }
+
+    @Test
+    public void returnsTrueWhenInputIsOne() {
+        assertTrue(Util.stringToBool("1"));
+    }
+
+    @Test
+    public void returnsFalseWhenInputIsZero() {
+        assertFalse(Util.stringToBool("0"));
+    }
+
+    @Test
+    public void returnsFalseWhenInputIsFalseIgnoringCase() {
+        assertFalse(Util.stringToBool("FALSE"));
+        assertFalse(Util.stringToBool("false"));
+        assertFalse(Util.stringToBool("FaLsE"));
+    }
+
+    @Test
+    public void returnsTrueWhenInputHasTrailingWhitespace() {
+        assertTrue(Util.stringToBool("true   "));
+        assertTrue(Util.stringToBool("1   "));
+    }
+
+    @Test
+    public void returnsFalseWhenInputIsInvalid() {
+        assertFalse(Util.stringToBool("invalid"));
+        assertFalse(Util.stringToBool("yes"));
+        assertFalse(Util.stringToBool("no"));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Test will be failed when `enable_merge_commit=1 `  because of fe/be's checking are not aligned for string to bool.


BE IMPLEMENTION:

<img width="1206" height="424" alt="image" src="https://github.com/user-attachments/assets/d87fed56-710e-4596-b949-2014ca78da79" />


<img width="1057" height="582" alt="image" src="https://github.com/user-attachments/assets/8697252a-9f65-4347-b67b-fcff8b970c4a" />



## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10129

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
