### PR TITLE
[Enhancement] mask crendential info in submit task

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
@@ -23,6 +23,8 @@ import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.cluster.ClusterNamespace;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.SqlCredentialRedactor;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.Task;
@@ -96,12 +98,16 @@ public class TasksSystemTable {
                 scheduleStr = task.getType().name();
             }
             if (task.getType() == Constants.TaskType.PERIODICAL) {
-                scheduleStr += task.getSchedule();
+                scheduleStr += " " + task.getSchedule();
             }
             info.setSchedule(scheduleStr);
             info.setCatalog(task.getCatalogName());
             info.setDatabase(ClusterNamespace.getNameFromFullName(task.getDbName()));
-            info.setDefinition(task.getDefinition());
+            if (Config.enable_task_info_mask_credential) {
+                info.setDefinition(SqlCredentialRedactor.redact(task.getDefinition()));
+            } else {
+                info.setDefinition(task.getDefinition());
+            }
             info.setExpire_time(task.getExpireTime() / 1000);
             info.setProperties(task.getPropertiesString());
             if (task.getUserIdentity() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -418,6 +418,11 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_task_run_fe_evaluation = true;
 
+    // whether mask credential info in `information_schema.tasks` and `information_schema.task_runs`
+    // if task count is big, mask process can be time consuming
+    @ConfField(mutable = true)
+    public static boolean enable_task_info_mask_credential = true;
+
     /**
      * The max keep time of some kind of jobs.
      * like schema change job and rollup job.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskSchedule.java
@@ -67,7 +67,7 @@ public class TaskSchedule {
 
     public String toString() {
         if (startTime > 0) {
-            return " START(" + Utils.getDatetimeFromLong(startTime)
+            return "START(" + Utils.getDatetimeFromLong(startTime)
                     + ") EVERY(" + period + " " + timeUnit + ")";
         }
         return "EVERY(" + period + " " + timeUnit + ")";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.analyzer;
 
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.util.SqlCredentialRedactor;
 import com.starrocks.sql.ast.ParseNode;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.formatter.AST2SQLVisitor;
@@ -64,7 +65,7 @@ public class AstToSQLBuilder {
             return toSQL(statement);
         } catch (Exception e) {
             LOG.info("Ast to sql failed.", e);
-            return defaultSql;
+            return SqlCredentialRedactor.redact(defaultSql);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/AuditEncryptionChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/AuditEncryptionChecker.java
@@ -40,6 +40,7 @@ import com.starrocks.sql.ast.SetOperationRelation;
 import com.starrocks.sql.ast.SetPassVar;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.SubmitTaskStmt;
 import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.integration.ShowCreateSecurityIntegrationStatement;
 import com.starrocks.sql.ast.pipe.CreatePipeStmt;
@@ -82,6 +83,11 @@ public class AuditEncryptionChecker implements AstVisitor<Boolean, Void> {
     public Boolean visitQueryStatement(QueryStatement statement, Void context) {
         QueryRelation queryRelation = statement.getQueryRelation();
         return visit(queryRelation);
+    }
+
+    @Override
+    public Boolean visitSubmitTaskStatement(SubmitTaskStmt statement, Void context) {
+        return true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -57,6 +57,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.ParseUtil;
 import com.starrocks.common.util.PrintableMap;
+import com.starrocks.common.util.SqlCredentialRedactor;
 import com.starrocks.sql.ast.AlterStorageVolumeStmt;
 import com.starrocks.sql.ast.AlterUserStmt;
 import com.starrocks.sql.ast.ArrayExpr;
@@ -108,6 +109,7 @@ import com.starrocks.sql.ast.SetQualifier;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.SetType;
 import com.starrocks.sql.ast.SetUserPropertyStmt;
+import com.starrocks.sql.ast.SubmitTaskStmt;
 import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.TableFunctionRelation;
@@ -1570,4 +1572,22 @@ public class AST2StringVisitor implements AstVisitor<String, Void> {
         return hintBuilder.toString();
     }
 
+    @Override
+    public String visitSubmitTaskStatement(SubmitTaskStmt stmt, Void context) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("SUBMIT TASK ");
+        sb.append(stmt.getTaskName());
+        if (stmt.getSchedule() != null) {
+            sb.append(" ");
+            sb.append(stmt.getSchedule().toString());
+        }
+        if (!stmt.getProperties().isEmpty()) {
+            sb.append(" PROPERTIES (")
+                    .append(new PrintableMap<>(stmt.getProperties(), "=", true, false, false)).append(")");
+        }
+        sb.append(" AS ");
+        sb.append(SqlCredentialRedactor.redact(stmt.getSqlText()));
+
+        return sb.toString();
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
mask credential info in system table and audit log for SUBMIT TASK
```
mysql> select * from information_schema.tasks\G;
*************************** 1. row ***************************
  TASK_NAME: bbb
CREATE_TIME: 2025-08-26 11:24:59
   SCHEDULE: MANUAL
    CATALOG: default_catalog
   DATABASE: test
 DEFINITION: INSERT INTO
FILES(
    "path" = "s3://111.data",
    "format" = "csv",
    "compression" = "uncompressed",
    "aws.s3.endpoint" = "aliyuncs.com",
    "aws.s3.access_key" = "***",
    "aws.s3.secret_key" = "***"
)
SELECT * FROM test.t
EXPIRE_TIME: 2025-08-27 11:24:59
 PROPERTIES: ('session.insert_timeout'='10000','session.enable_profile'='true','warehouse'='default_warehouse')
    CREATOR: 'root'@'%'
```
```
2025-08-26 11:24:59.121+08:00 [query] |Timestamp=1756178699113|Client=127.0.0.1:39634|User=root|AuthorizedUser='root'@'%'|ResourceGroup=|Catalog=default_catalog|Db=test|State=EOF|ErrorCode=|Time=7|ScanBytes=0|ScanRows=0|ReturnRows=1|StmtId=35|QueryId=0198e468-5369-7279-8559-2e3ac9f50d32|IsQuery=false|feIp=172.26.92.212|Stmt=SUBMIT TASK bbb PROPERTIES ("session.insert_timeout" = "10000", "session.enable_profile" = "true") AS INSERT INTO
FILES(
    "path" = "s3://111.data",
    "format" = "csv",
    "compression" = "uncompressed",
    "aws.s3.endpoint" = "aliyuncs.com",
    "aws.s3.access_key" = "***",
    "aws.s3.secret_key" = "***"
)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
