### PR TITLE
[Feature]support read iceberg v3's _row_id

### DIFF
--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -412,6 +412,8 @@ struct HdfsScannerContext {
     std::vector<SlotDescriptor*> not_existed_slots;
     std::vector<ExprContext*> conjunct_ctxs_of_non_existed_slots;
 
+    std::vector<SlotDescriptor*> reserved_field_slots;
+
     // other helper functions.
     bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
     Status evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Filter* filter);
@@ -499,6 +501,9 @@ protected:
     std::shared_ptr<io::CacheInputStream> _cache_input_stream = nullptr;
     std::shared_ptr<io::SharedBufferedInputStream> _shared_buffered_input_stream = nullptr;
     int64_t _total_running_time = 0;
+
+public:
+    static constexpr const std::string ICEBERG_ROW_ID = "_row_id";
 };
 
 } // namespace starrocks

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(Formats STATIC
         parquet/parquet_block_split_bloom_filter.cpp
         parquet/variant.h
         parquet/variant.cpp
+        parquet/iceberg_row_id_reader.cpp
         disk_range.hpp
         )
 

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -278,6 +278,7 @@ Status FileReader::_init_group_readers() {
     for (size_t i = 0; i < _file_metadata->t_metadata().row_groups.size(); i++) {
         if (i > 0) {
             row_group_first_row += _file_metadata->t_metadata().row_groups[i - 1].num_rows;
+            row_group_first_row_id += _file_metadata->t_metadata().row_groups[i - 1].num_rows;
         }
 
         if (!_select_row_group(_file_metadata->t_metadata().row_groups[i])) {

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -369,7 +369,7 @@ Status GroupReader::_create_column_readers() {
         }
     }
 
-    if (!_param.reserved_field_slots->empty()) {
+    if (_param.reserved_field_slots != nullptr && !_param.reserved_field_slots->empty()) {
         for (const auto* slot : *_param.reserved_field_slots) {
             if (slot->col_name() == HdfsScanner::ICEBERG_ROW_ID) {
                 _column_readers.emplace(slot->id(), std::make_unique<IcebergRowIdReader>(_row_group_first_row_id));

--- a/be/src/formats/parquet/iceberg_row_id_reader.cpp
+++ b/be/src/formats/parquet/iceberg_row_id_reader.cpp
@@ -14,6 +14,8 @@
 
 #include "formats/parquet/iceberg_row_id_reader.h"
 
+#include <limits>
+
 #include "column/datum.h"
 #include "formats/parquet/predicate_filter_evaluator.h"
 #include "storage/range.h"
@@ -21,24 +23,30 @@
 namespace starrocks::parquet {
 
 Status IcebergRowIdReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
-    // LOG(INFO) << "IcebergRowIdReader::read_range, range: " << range.to_string()
-    //           << ", dst: " << dst->get_name() << ", " << (void*)this;
-
-    for (uint64_t i = range.begin(); i < range.end(); ++i) {
-        // Generate row id based on the first row id and the current row index.
-        int64_t row_id = _first_row_id + i;
-        // Fill the dst column with the generated row id.
-        // @TODO handle filter
-        dst->append_datum(Datum(row_id));
+    if (filter == nullptr) {
+        // No filter, generate row ids for all rows in the range
+        for (uint64_t i = range.begin(); i < range.end(); ++i) {
+            // Generate row id based on the first row id and the current row index.
+            int64_t row_id = _first_row_id + i;
+            dst->append_datum(Datum(row_id));
+        }
+    } else {
+        // Apply filter, only generate row ids for selected rows
+        DCHECK_EQ(filter->size(), range.span_size()) << "Filter size must match range size";
+        for (uint64_t i = range.begin(); i < range.end(); ++i) {
+            size_t filter_index = i - range.begin();
+            if ((*filter)[filter_index]) {
+                // Generate row id based on the first row id and the current row index.
+                int64_t row_id = _first_row_id + i;
+                dst->append_datum(Datum(row_id));
+            }
+        }
     }
     return Status::OK();
 }
 
 Status IcebergRowIdReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
-    // LOG(INFO) << "IcebergRowIdReader::fill_dst_column, dst: " << dst->debug_string()
-    //           << ", src: " << src->debug_string();
     dst->swap_column(*src);
-
     return Status::OK();
 }
 
@@ -79,32 +87,65 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
                                                               SparseRange<uint64_t>* row_ranges,
                                                               CompoundNodeType pred_relation,
                                                               const uint64_t rg_first_row, const uint64_t rg_num_rows) {
-    [[maybe_unused]] std::ostringstream oss;
-    oss << "IcebergRowIdReader::page_index_zone_map_filter, rg_first_row: " << rg_first_row
-        << ", rg_num_rows: " << rg_num_rows << ", predicates size: " << predicates.size();
-    oss << " filters: [";
-    for (const auto& pred : predicates) {
-        oss << pred->debug_string() << ", ";
-    }
-    oss << "]";
-    // @TODO we need arange
-    DLOG(INFO) << oss.str();
-
     SparseRange<int64_t> row_id_range(_first_row_id + rg_first_row, _first_row_id + rg_first_row + rg_num_rows);
     DLOG(INFO) << "original range: " << row_id_range.to_string();
-    for (const auto& pred : predicates) {
-        if (pred->type() == PredicateType::kGE) {
-            row_id_range &= SparseRange<int64_t>(pred->value().get_int64(), std::numeric_limits<int64_t>::max());
-        } else if (pred->type() == PredicateType::kLT) {
-            row_id_range &= SparseRange<int64_t>(0, pred->value().get_int64());
+
+    if (pred_relation == CompoundNodeType::AND) {
+        // For AND relation, apply all predicates sequentially with intersection
+        for (const auto& pred : predicates) {
+            SparseRange<int64_t> pred_range;
+            StatusOr<bool> result = _apply_single_predicate(pred, pred_range);
+            if (!result.ok()) {
+                return result.status();
+            }
+            if (!result.value()) {
+                // Predicate not supported, can't apply filtering
+                return false;
+            }
+            row_id_range &= pred_range;
+            DLOG(INFO) << "after apply " << pred->debug_string() << ", ret: " << row_id_range.to_string();
+
+            // Early exit if range becomes empty
+            if (row_id_range.empty()) {
+                DLOG(INFO) << "range becomes empty after applying " << pred->debug_string();
+                break;
+            }
         }
-        DLOG(INFO) << "after apply " << pred->debug_string() << ", ret: " << row_id_range.to_string();
+    } else if (pred_relation == CompoundNodeType::OR) {
+        // For OR relation, apply all predicates and take union
+        SparseRange<int64_t> union_range;
+        bool has_valid_predicate = false;
+
+        for (const auto& pred : predicates) {
+            SparseRange<int64_t> pred_range;
+            StatusOr<bool> result = _apply_single_predicate(pred, pred_range);
+            if (!result.ok()) {
+                return result.status();
+            }
+            if (result.value()) {
+                has_valid_predicate = true;
+                union_range |= pred_range;
+            }
+        }
+
+        if (!has_valid_predicate) {
+            // No supported predicates, can't apply filtering
+            return false;
+        }
+
+        row_id_range &= union_range;
+        DLOG(INFO) << "after applying OR predicates, ret: " << row_id_range.to_string();
+    } else {
+        DLOG(WARNING) << "Unsupported predicate relation type: " << static_cast<int>(pred_relation);
+        return false;
     }
+
     if (row_id_range.span_size() == rg_num_rows) {
         DLOG(INFO) << "no filtering applied";
         return false;
     }
-    // we should convert row_idrange to row ranges
+
+    // Convert row_id range to row ranges
     for (size_t i = 0; i < row_id_range.size(); i++) {
         Range<int64_t> range = row_id_range[i];
         DLOG(INFO) << "add range: " << range.to_string();
@@ -112,6 +153,123 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
     }
 
     return true;
+}
+
+StatusOr<bool> IcebergRowIdReader::_apply_single_predicate(const ColumnPredicate* pred,
+                                                           SparseRange<int64_t>& result_range) {
+    switch (pred->type()) {
+    case PredicateType::kEQ: {
+        // Equal: [value, value]
+        int64_t value = pred->value().get_int64();
+        result_range = SparseRange<int64_t>(value, value + 1);
+        return true;
+    }
+    case PredicateType::kNE: {
+        // Not Equal: [0, value) | (value, max]
+        int64_t value = pred->value().get_int64();
+        if (value > 0) {
+            result_range.add(Range<int64_t>(0, value));
+        }
+        if (value < std::numeric_limits<int64_t>::max()) {
+            result_range.add(Range<int64_t>(value + 1, std::numeric_limits<int64_t>::max()));
+        }
+        return true;
+    }
+    case PredicateType::kGT: {
+        // Greater Than: (value, max]
+        int64_t value = pred->value().get_int64();
+        result_range = SparseRange<int64_t>(value + 1, std::numeric_limits<int64_t>::max());
+        return true;
+    }
+    case PredicateType::kGE: {
+        // Greater Equal: [value, max]
+        int64_t value = pred->value().get_int64();
+        result_range = SparseRange<int64_t>(value, std::numeric_limits<int64_t>::max());
+        return true;
+    }
+    case PredicateType::kLT: {
+        // Less Than: [0, value)
+        int64_t value = pred->value().get_int64();
+        result_range = SparseRange<int64_t>(0, value);
+        return true;
+    }
+    case PredicateType::kLE: {
+        // Less Equal: [0, value]
+        int64_t value = pred->value().get_int64();
+        result_range = SparseRange<int64_t>(0, value + 1);
+        return true;
+    }
+    case PredicateType::kInList: {
+        // In List: union of all values
+        const auto& values = pred->values();
+        if (values.empty()) {
+            // Empty IN list means no rows match
+            result_range = SparseRange<int64_t>();
+            return true;
+        }
+        for (const auto& value : values) {
+            int64_t int_value = value.get_int64();
+            result_range.add(Range<int64_t>(int_value, int_value + 1));
+        }
+        return true;
+    }
+    case PredicateType::kNotInList: {
+        // Not In List: complement of union of all values
+        const auto& values = pred->values();
+        if (values.empty()) {
+            // Empty NOT IN list means all rows match
+            result_range = SparseRange<int64_t>(0, std::numeric_limits<int64_t>::max());
+            return true;
+        }
+        // Start with full range
+        result_range.add(Range<int64_t>(0, std::numeric_limits<int64_t>::max()));
+
+        // Subtract each value from the range
+        for (const auto& value : values) {
+            int64_t int_value = value.get_int64();
+            SparseRange<int64_t> temp_range;
+
+            // For each range in result_range, subtract the excluded value
+            for (size_t i = 0; i < result_range.size(); i++) {
+                const auto& range = result_range[i];
+                if (range.begin() < int_value && range.end() > int_value + 1) {
+                    // Range spans the excluded value, split into two parts
+                    temp_range.add(Range<int64_t>(range.begin(), int_value));
+                    temp_range.add(Range<int64_t>(int_value + 1, range.end()));
+                } else if (range.begin() < int_value && range.end() > int_value) {
+                    // Range ends at or after excluded value
+                    temp_range.add(Range<int64_t>(range.begin(), int_value));
+                } else if (range.begin() < int_value + 1 && range.end() > int_value + 1) {
+                    // Range starts before excluded value ends
+                    temp_range.add(Range<int64_t>(int_value + 1, range.end()));
+                } else if (range.begin() >= int_value && range.end() <= int_value + 1) {
+                    // Range is completely within excluded value, skip it
+                    continue;
+                } else {
+                    // Range is outside excluded value, keep it
+                    temp_range.add(range);
+                }
+            }
+            result_range = temp_range;
+        }
+        return true;
+    }
+    case PredicateType::kIsNull: {
+        // IS NULL: no rows match for row_id column (it's always not null)
+        result_range = SparseRange<int64_t>();
+        return true;
+    }
+    case PredicateType::kNotNull: {
+        // IS NOT NULL: all rows match for row_id column (it's always not null)
+        result_range = SparseRange<int64_t>(0, std::numeric_limits<int64_t>::max());
+        return true;
+    }
+    default: {
+        DLOG(WARNING) << "Unsupported predicate type for row_id filtering: " << pred->type();
+        // For unsupported types, we can't apply filtering
+        return false;
+    }
+    }
 }
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/iceberg_row_id_reader.cpp
+++ b/be/src/formats/parquet/iceberg_row_id_reader.cpp
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/iceberg_row_id_reader.h"
+
+#include "column/datum.h"
+#include "formats/parquet/predicate_filter_evaluator.h"
+#include "storage/range.h"
+
+namespace starrocks::parquet {
+
+Status IcebergRowIdReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
+    // LOG(INFO) << "IcebergRowIdReader::read_range, range: " << range.to_string()
+    //           << ", dst: " << dst->get_name() << ", " << (void*)this;
+
+    for (uint64_t i = range.begin(); i < range.end(); ++i) {
+        // Generate row id based on the first row id and the current row index.
+        int64_t row_id = _first_row_id + i;
+        // Fill the dst column with the generated row id.
+        // @TODO handle filter
+        dst->append_datum(Datum(row_id));
+    }
+    return Status::OK();
+}
+
+Status IcebergRowIdReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
+    // LOG(INFO) << "IcebergRowIdReader::fill_dst_column, dst: " << dst->debug_string()
+    //           << ", src: " << src->debug_string();
+    dst->swap_column(*src);
+
+    return Status::OK();
+}
+
+void IcebergRowIdReader::collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges,
+                                                 int64_t* end_offset, ColumnIOTypeFlags types, bool active) {
+    // No IO ranges to collect for row id reader.
+}
+
+void IcebergRowIdReader::select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) {
+    // No offset index selection needed for row id reader.
+}
+
+StatusOr<bool> IcebergRowIdReader::row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                                             CompoundNodeType pred_relation,
+                                                             const uint64_t rg_first_row,
+                                                             const uint64_t rg_num_rows) const {
+    DLOG(INFO) << "IcebergRowIdReader::row_group_zone_map_filter, predicates size: " << predicates.size()
+               << ", rg_first_row: " << rg_first_row << ", rg_num_rows: " << rg_num_rows
+               << ", rg_first_row_id: " << _first_row_id;
+
+    ZoneMapDetail zone_map{Datum(_first_row_id + rg_first_row), Datum(_first_row_id + rg_first_row + rg_num_rows - 1),
+                           false};
+    bool ret = !PredicateFilterEvaluatorUtils::zonemap_satisfy(predicates, zone_map, pred_relation);
+    if (ret == false) {
+        DLOG(INFO) << "IcebergRowIdReader: row group zone map filter passed, no filtering applied."
+                   << " row_id range(" << (_first_row_id + rg_first_row) << ", "
+                   << (_first_row_id + rg_first_row + rg_num_rows - 1) << ")";
+    } else {
+        DLOG(INFO) << "IcebergRowIdReader: row group zone map filter applied, "
+                   << "filtering happened, row_id range(" << (_first_row_id + rg_first_row) << ", "
+                   << (_first_row_id + rg_first_row + rg_num_rows - 1) << ")";
+    }
+    return ret;
+    // return Status::NotSupported("IcebergRowIdReader does not support row group zone map filter");
+}
+
+StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                                              SparseRange<uint64_t>* row_ranges,
+                                                              CompoundNodeType pred_relation,
+                                                              const uint64_t rg_first_row, const uint64_t rg_num_rows) {
+    [[maybe_unused]] std::ostringstream oss;
+    oss << "IcebergRowIdReader::page_index_zone_map_filter, rg_first_row: " << rg_first_row
+        << ", rg_num_rows: " << rg_num_rows << ", predicates size: " << predicates.size();
+    oss << " filters: [";
+    for (const auto& pred : predicates) {
+        oss << pred->debug_string() << ", ";
+    }
+    oss << "]";
+    // @TODO we need arange
+    DLOG(INFO) << oss.str();
+
+    SparseRange<int64_t> row_id_range(_first_row_id + rg_first_row, _first_row_id + rg_first_row + rg_num_rows);
+    DLOG(INFO) << "original range: " << row_id_range.to_string();
+    for (const auto& pred : predicates) {
+        if (pred->type() == PredicateType::kGE) {
+            row_id_range &= SparseRange<int64_t>(pred->value().get_int64(), std::numeric_limits<int64_t>::max());
+        } else if (pred->type() == PredicateType::kLT) {
+            row_id_range &= SparseRange<int64_t>(0, pred->value().get_int64());
+        }
+        DLOG(INFO) << "after apply " << pred->debug_string() << ", ret: " << row_id_range.to_string();
+    }
+    if (row_id_range.span_size() == rg_num_rows) {
+        DLOG(INFO) << "no filtering applied";
+        return false;
+    }
+    // we should convert row_idrange to row ranges
+    for (size_t i = 0; i < row_id_range.size(); i++) {
+        Range<int64_t> range = row_id_range[i];
+        DLOG(INFO) << "add range: " << range.to_string();
+        row_ranges->add(Range<uint64_t>(range.begin() - _first_row_id, range.end() - _first_row_id));
+    }
+
+    return true;
+}
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/iceberg_row_id_reader.cpp
+++ b/be/src/formats/parquet/iceberg_row_id_reader.cpp
@@ -121,10 +121,11 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
             if (!result.ok()) {
                 return result.status();
             }
-            if (result.value()) {
-                has_valid_predicate = true;
-                union_range |= pred_range;
+            if (!result.value()) {
+                return false;
             }
+            has_valid_predicate = true;
+            union_range |= pred_range;
         }
 
         if (!has_valid_predicate) {
@@ -135,7 +136,6 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
         row_id_range &= union_range;
         DLOG(INFO) << "after applying OR predicates, ret: " << row_id_range.to_string();
     } else {
-        DLOG(WARNING) << "Unsupported predicate relation type: " << static_cast<int>(pred_relation);
         return false;
     }
 

--- a/be/src/formats/parquet/iceberg_row_id_reader.cpp
+++ b/be/src/formats/parquet/iceberg_row_id_reader.cpp
@@ -80,7 +80,6 @@ StatusOr<bool> IcebergRowIdReader::row_group_zone_map_filter(const std::vector<c
                    << (_first_row_id + rg_first_row + rg_num_rows - 1) << ")";
     }
     return ret;
-    // return Status::NotSupported("IcebergRowIdReader does not support row group zone map filter");
 }
 
 StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,

--- a/be/src/formats/parquet/iceberg_row_id_reader.h
+++ b/be/src/formats/parquet/iceberg_row_id_reader.h
@@ -22,7 +22,6 @@ class IcebergRowIdReader final : public ColumnReader {
 public:
     explicit IcebergRowIdReader(int64_t first_row_id) : ColumnReader(nullptr), _first_row_id(first_row_id) {
         _cur_row_id = _first_row_id;
-        // LOG(INFO) << "create IcebergRowIdReader with first_row_id: " << _first_row_id;
     }
     ~IcebergRowIdReader() override = default;
 
@@ -48,6 +47,9 @@ public:
                                               const uint64_t rg_first_row, const uint64_t rg_num_rows) override;
 
 private:
+    // Helper method to apply a single predicate and return the resulting range
+    StatusOr<bool> _apply_single_predicate(const ColumnPredicate* pred, SparseRange<int64_t>& result_range);
+
     int64_t _first_row_id = 0;
     int64_t _cur_row_id = 0;
 };

--- a/be/src/formats/parquet/iceberg_row_id_reader.h
+++ b/be/src/formats/parquet/iceberg_row_id_reader.h
@@ -1,0 +1,54 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "formats/parquet/column_reader.h"
+
+namespace starrocks::parquet {
+
+class IcebergRowIdReader final : public ColumnReader {
+public:
+    explicit IcebergRowIdReader(int64_t first_row_id) : ColumnReader(nullptr), _first_row_id(first_row_id) {
+        _cur_row_id = _first_row_id;
+        // LOG(INFO) << "create IcebergRowIdReader with first_row_id: " << _first_row_id;
+    }
+    ~IcebergRowIdReader() override = default;
+
+    Status prepare() override { return Status::OK(); }
+
+    Status read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) override;
+    void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {}
+    void set_need_parse_levels(bool need_parse_levels) override {}
+
+    Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
+
+    void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
+                                 ColumnIOTypeFlags types, bool active) override;
+
+    void select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) override;
+
+    StatusOr<bool> row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                             CompoundNodeType pred_relation, const uint64_t rg_first_row,
+                                             const uint64_t rg_num_rows) const override;
+
+    StatusOr<bool> page_index_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                              SparseRange<uint64_t>* row_ranges, CompoundNodeType pred_relation,
+                                              const uint64_t rg_first_row, const uint64_t rg_num_rows) override;
+
+private:
+    int64_t _first_row_id = 0;
+    int64_t _cur_row_id = 0;
+};
+} // namespace starrocks::parquet

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -146,10 +146,9 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     @SerializedName(value = "materializedColumnExpr")
     private ExpressionSerializedObject generatedColumnExprSerialized;
     private ColumnIdExpr generatedColumnExpr;
-
     // Whether this column is a hidden column, hidden columns are used to store some internal data(eg: _ROW_ID).
     @SerializedName(value = "isHidden")
-    private boolean isHidden;
+    private boolean isHidden = false;
 
     // Only for persist
     public Column() {
@@ -264,6 +263,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
                 this.type.getPrimitiveType() != PrimitiveType.INVALID_TYPE);
         this.uniqueId = column.getUniqueId();
         this.generatedColumnExpr = column.generatedColumnExpr;
+        this.isHidden = column.isHidden;
     }
 
     public Column deepCopy() {
@@ -874,6 +874,9 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         }
         if (this.isGeneratedColumn() &&
                 !this.generatedColumnExpr.equals(other.generatedColumnExpr)) {
+            return false;
+        }
+        if (this.isHidden != other.isHidden()) {
             return false;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -96,6 +96,7 @@ public class IcebergTable extends Table {
     public static final String DATA_SEQUENCE_NUMBER = "$data_sequence_number";
     public static final String SPEC_ID = "$spec_id";
     public static final String EQUALITY_DELETE_TABLE_COMMENT = "equality_delete_table_comment";
+    public static final String ROW_ID = "_row_id";
 
     private String catalogName;
     @SerializedName(value = "dn")
@@ -245,6 +246,9 @@ public class IcebergTable extends Table {
         return ((BaseTable) getNativeTable()).operations().current().formatVersion() > 1;
     }
 
+    public int getFormatVersion() {
+        return ((BaseTable) getNativeTable()).operations().current().formatVersion();
+    }
     /**
      * <p>
      * In the Iceberg Partition Evolution scenario, 'org.apache.iceberg.PartitionField#name' only represents the

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -65,6 +65,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 /**
  * Internal representation of table-related metadata. A table contains several partitions.
@@ -443,6 +444,10 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
 
     public List<Column> getFullSchema() {
         return fullSchema;
+    }
+
+    public List<Column> getFullVisibleSchema() {
+        return fullSchema.stream().filter(column -> !column.isHidden()).collect(Collectors.toList());
     }
 
     // should override in subclass if necessary

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalSchemaProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalSchemaProcNode.java
@@ -46,7 +46,7 @@ public class ExternalSchemaProcNode implements ProcNodeInterface {
         BaseProcResult result = new BaseProcResult();
         result.setNames(TITLE_NAMES);
 
-        List<Column> schema = table.getFullSchema();
+        List<Column> schema = table.getFullVisibleSchema();
         List<String> partitionColumns = table.getPartitionColumnNames();
 
         for (Column column : schema) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/DataFileWrapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/DataFileWrapper.java
@@ -160,4 +160,9 @@ public class DataFileWrapper implements DataFile {
     public DataFile copyWithStats(Set<Integer> requestedColumnIds) {
         return dataFile.copyWithStats(requestedColumnIds);
     }
+
+    @Override
+    public Long firstRowId() {
+        return dataFile.firstRowId();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -47,6 +47,7 @@ import com.starrocks.thrift.TIcebergDataFile;
 import com.starrocks.thrift.TIcebergSchema;
 import com.starrocks.thrift.TIcebergSchemaField;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.Metrics;
@@ -120,7 +121,7 @@ public class IcebergApiConverter {
                 .setCatalogTableName(remoteTableName)
                 .setComment(nativeTbl.properties().getOrDefault("common", ""))
                 .setNativeTable(nativeTbl)
-                .setFullSchema(toFullSchemas(nativeTbl.schema()))
+                .setFullSchema(toFullSchemas(nativeTbl.schema(), nativeTbl))
                 .setIcebergProperties(toIcebergProps(
                         nativeTbl.properties() != null ? Optional.of(copyOf(nativeTbl.properties())) : Optional.empty(),
                         nativeCatalogType));
@@ -296,6 +297,21 @@ public class IcebergApiConverter {
         }
 
         throw new StarRocksConnectorException("Unsupported complex column type %s", type);
+    }
+
+    public static List<Column> toFullSchemas(Schema schema, Table table) {
+        List<Column> fullSchema = toFullSchemas(schema);
+        if (table instanceof BaseTable) {
+            if (((BaseTable) table).operations().current().formatVersion() >= 3) {
+                boolean hasRowId = fullSchema.stream().anyMatch(column -> column.getName().equals(IcebergTable.ROW_ID));
+                if (!hasRowId) {
+                    Column column = new Column(IcebergTable.ROW_ID, Type.BIGINT, true);
+                    column.setIsHidden(true);
+                    fullSchema.add(column);
+                }
+            }
+        }
+        return fullSchema;
     }
 
     public static List<Column> toFullSchemas(Schema schema) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -362,6 +362,11 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
                     file.nullValueCounts(), file.valueCounts(), slots);
             hdfsScanRange.setMin_max_values(tExprMinMaxValueMap);
         }
+
+        if (task.file() != null && task.file().firstRowId() != null) {
+            hdfsScanRange.setFirst_row_id(task.file().firstRowId());
+        }
+
         return hdfsScanRange;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -18,6 +18,7 @@ package com.starrocks.connector.iceberg;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.common.util.TimeUtils;
@@ -145,6 +146,9 @@ public class ScalarOperatorToIcebergExpr {
                 for (String path : paths) {
                     type = type.asStructType().fieldType(path);
                 }
+            }
+            if (qualifiedName.equals(IcebergTable.ROW_ID)) {
+                type = new Types.LongType();
             }
             return type;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -405,7 +405,7 @@ public class AstToStringBuilder {
                 .append(" (\n");
 
         // Columns
-        List<String> columns = table.getFullSchema().stream().map(AstToStringBuilder::toMysqlDDL).
+        List<String> columns = table.getFullVisibleSchema().stream().map(AstToStringBuilder::toMysqlDDL).
                 collect(Collectors.toList());
         createTableSql.append(String.join(",\n", columns))
                 .append("\n)");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -319,6 +319,11 @@ public class IcebergMetadataTest extends TableTestBase {
             }
 
             @Mock
+            public List<Column> getFullVisibleSchema() {
+                return ImmutableList.of(new Column("c1", Type.INT), new Column("c2", STRING));
+            }
+
+            @Mock
             public Table.TableType getType() {
                 return ICEBERG;
             }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -439,6 +439,8 @@ struct THdfsScanRange {
 
     // mapping transformed bucket id, used to schedule scan range
     36: optional i32 bucket_id;
+
+    37: optional i64 first_row_id;
 }
 
 struct TBinlogScanRange {

--- a/test/sql/test_iceberg/R/test_iceberg_v3_row_id
+++ b/test/sql/test_iceberg/R/test_iceberg_v3_row_id
@@ -63,6 +63,70 @@ select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _ro
 11	12	22	112	12
 12	13	23	113	13
 -- !result
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id = 10 or _row_id < 5 order by _row_id limit 10;
+-- result:
+0	1	11	101	1
+1	2	12	102	2
+2	3	13	103	3
+3	4	14	104	4
+4	5	15	105	5
+10	11	21	111	11
+-- !result
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id != 2 order by _row_id limit 10;
+-- result:
+0	1	11	101	1
+1	2	12	102	2
+3	4	14	104	4
+4	5	15	105	5
+5	6	16	106	6
+6	7	17	107	7
+7	8	18	108	8
+8	9	19	109	9
+9	10	20	110	10
+10	11	21	111	11
+-- !result
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id != 11 and _row_id >= 10 and _row_id <= 30 order by _row_id limit 10;
+-- result:
+10	11	21	111	11
+12	13	23	113	13
+13	14	24	114	14
+14	15	25	115	15
+15	16	26	116	16
+16	17	27	117	17
+17	18	28	118	18
+18	19	29	119	19
+19	20	30	120	20
+20	21	31	121	21
+-- !result
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id not in (1, 11, 21) order by _row_id limit 10;
+-- result:
+0	1	11	101	1
+2	3	13	103	3
+3	4	14	104	4
+4	5	15	105	5
+5	6	16	106	6
+6	7	17	107	7
+7	8	18	108	8
+8	9	19	109	9
+9	10	20	110	10
+10	11	21	111	11
+-- !result
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id is null order by _row_id limit 10;
+-- result:
+-- !result
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id is not null order by _row_id limit 10;
+-- result:
+0	1	11	101	1
+1	2	12	102	2
+2	3	13	103	3
+3	4	14	104	4
+4	5	15	105	5
+5	6	16	106	6
+6	7	17	107	7
+7	8	18	108	8
+8	9	19	109	9
+9	10	20	110	10
+-- !result
 drop catalog iceberg_sql_test_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_iceberg/R/test_iceberg_v3_row_id
+++ b/test/sql/test_iceberg/R/test_iceberg_v3_row_id
@@ -1,0 +1,68 @@
+-- name: test_iceberg_v3_row_id
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+select min(_row_id),max(_row_id) from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3;
+-- result:
+0	9999
+-- !result
+select count(_row_id) from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3;
+-- result:
+10000
+-- !result
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 order by _row_id limit 10;
+-- result:
+0	1	11	101	1
+1	2	12	102	2
+2	3	13	103	3
+3	4	14	104	4
+4	5	15	105	5
+5	6	16	106	6
+6	7	17	107	7
+7	8	18	108	8
+8	9	19	109	9
+9	10	20	110	10
+-- !result
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where c0=20 order by _row_id limit 10;
+-- result:
+9	10	20	110	10
+-- !result
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where c0>100 order by _row_id limit 10;
+-- result:
+90	91	101	191	91
+91	92	102	192	92
+92	93	103	193	93
+93	94	104	194	94
+94	95	105	195	95
+95	96	106	196	96
+96	97	107	197	97
+97	98	108	198	98
+98	99	109	199	99
+99	100	110	None	100
+-- !result
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id=9 order by _row_id limit 10;
+-- result:
+9	10	20	110	10
+-- !result
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id >=10 and _row_id <= 20 order by _row_id limit 10;
+-- result:
+10	11	21	111	11
+11	12	22	112	12
+12	13	23	113	13
+13	14	24	114	14
+14	15	25	115	15
+15	16	26	116	16
+16	17	27	117	17
+17	18	28	118	18
+18	19	29	119	19
+19	20	30	120	20
+-- !result
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id in (10,11,12) order by _row_id limit 10;
+-- result:
+10	11	21	111	11
+11	12	22	112	12
+12	13	23	113	13
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_v3_row_id
+++ b/test/sql/test_iceberg/T/test_iceberg_v3_row_id
@@ -1,0 +1,17 @@
+-- name: test_iceberg_v3_row_id
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+select min(_row_id),max(_row_id) from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3;
+select count(_row_id) from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3;
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 order by _row_id limit 10;
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where c0=20 order by _row_id limit 10;
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where c0>100 order by _row_id limit 10;
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id=9 order by _row_id limit 10;
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id >=10 and _row_id <= 20 order by _row_id limit 10;
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id in (10,11,12) order by _row_id limit 10;
+
+
+
+
+drop catalog iceberg_sql_test_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_v3_row_id
+++ b/test/sql/test_iceberg/T/test_iceberg_v3_row_id
@@ -10,7 +10,12 @@ select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where c0>
 select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id=9 order by _row_id limit 10;
 select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id >=10 and _row_id <= 20 order by _row_id limit 10;
 select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id in (10,11,12) order by _row_id limit 10;
-
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id = 10 or _row_id < 5 order by _row_id limit 10;
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id != 2 order by _row_id limit 10;
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id != 11 and _row_id >= 10 and _row_id <= 30 order by _row_id limit 10;
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id not in (1, 11, 21) order by _row_id limit 10;
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id is null order by _row_id limit 10;
+select _row_id,* from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_v3 where _row_id is not null order by _row_id limit 10;
 
 
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #62580

As a reserved field introduced in Iceberg v3, we need to support reading this column in queries, but hide it in the show create table/desc table statements.

Main Changes

1. add a new interface `toFullSchemas ` to IcebergAPIConverter to add `_row_id` column for iceberg v3+ tables.This column must be set to hidden to prevent it from being displayed during the show/desc functions.

2. add a new field `first_row_id` to `THdfsScanRange` to record the row_id of the first row in the scan range. A dedicated IcebergRowIdReader has been implemented for the _row_id column to calculate the _row_id for each row.

3. add reserved_field_slots to `HdfsScannerContext` to facilitate handling of Iceberg reserved fields in the future. and the file reader and group reader now support predicates related to reserved field slots.


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds end-to-end support for Iceberg v3 reserved `_row_id` (hidden in DDL/SHOW), including BE/Parquet reader generation and filtering, FE schema/planner wiring, and a new scan-range `first_row_id`.
> 
> - **Iceberg v3 `_row_id` support (hidden)**
>   - **Frontend**:
>     - Add hidden `_row_id` to schemas for Iceberg tables with format version ≥3 via `IcebergApiConverter.toFullSchemas(...)`.
>     - Introduce `Column.isHidden` (persisted, default false); exclude hidden columns via `Table.getFullVisibleSchema()` in DDL/describe paths.
>     - Recognize `_row_id` as BIGINT in predicate pushdown (`ScalarOperatorToIcebergExpr`).
>     - Expose constants/methods in `IcebergTable` and wire `firstRowId()` through `DataFileWrapper` and `IcebergConnectorScanRangeSource`.
>   - **Planner/Thrift**:
>     - Extend `THdfsScanRange` with `first_row_id`.
>   - **Backend/Parquet**:
>     - Add `reserved_field_slots` to `HdfsScannerContext`; exclude them from min/max fast path.
>     - Parquet `FileReader`/`GroupReader` support reserved fields in read paths and filters; handle active/lazy read chunks accordingly.
>     - Implement `IcebergRowIdReader` to synthesize row ids and support zone-map/page-index filtering.
>     - Pass row-group first-row-id and scan-range `first_row_id` through readers; adjust no-materialized-column scan condition.
>     - Define `ICEBERG_ROW_ID` constant; include new source in build.
> - **Tests**:
>   - Add SQL tests validating `_row_id` min/max, count, ordering, and predicate behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56327e9dc5a68fd7f655f7df959452e0a8aacf60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->