### PR TITLE
[BugFix] Fix possible NPE in alter table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -610,7 +610,7 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
             Set<String> modifiedColumns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
             modifiedColumns.add(clause.getColName());
             ErrorReport.wrapWithRuntimeException(() ->
-                    schemaChangeHandler.checkModifiedColumWithMaterializedViews((OlapTable) table, modifiedColumns));
+                    AlterMVJobExecutor.checkModifiedColumWithMaterializedViews((OlapTable) table, modifiedColumns));
             GlobalStateMgr.getCurrentState().getLocalMetastore().renameColumn(db, table, clause);
 
             // If modified columns are already done, inactive related mv

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -45,7 +45,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.BloomFilterIndexUtil;
 import com.starrocks.analysis.ColumnPosition;
-import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.binlog.BinlogConfig;
 import com.starrocks.catalog.AggregateType;
@@ -1932,7 +1931,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 DropColumnClause dropColumnClause = (DropColumnClause) alterClause;
                 // check relative mvs with the modified column
                 Set<String> modifiedColumns = Set.of(dropColumnClause.getColName());
-                checkModifiedColumWithMaterializedViews(olapTable, modifiedColumns);
+                AlterMVJobExecutor.checkModifiedColumWithMaterializedViews(olapTable, modifiedColumns);
 
                 // drop column and drop indexes on this column
                 fastSchemaEvolution &=
@@ -1943,7 +1942,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
                 // check relative mvs with the modified column
                 Set<String> modifiedColumns = Set.of(modifyColumnClause.getColumn().getName());
-                checkModifiedColumWithMaterializedViews(olapTable, modifiedColumns);
+                AlterMVJobExecutor.checkModifiedColumWithMaterializedViews(olapTable, modifiedColumns);
 
                 // modify column
                 fastSchemaEvolution &= processModifyColumn(modifyColumnClause, olapTable, indexSchemaMap);
@@ -1961,7 +1960,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
                 AddFieldClause addFieldClause = (AddFieldClause) alterClause;
                 modifyFieldColumns = Set.of(addFieldClause.getColName());
-                checkModifiedColumWithMaterializedViews(olapTable, modifyFieldColumns);
+                AlterMVJobExecutor.checkModifiedColumWithMaterializedViews(olapTable, modifyFieldColumns);
                 int id = colUniqueIdSupplier.getAsInt();
                 processAddField((AddFieldClause) alterClause, olapTable, indexSchemaMap, id, newIndexes);
             } else if (alterClause instanceof DropFieldClause) {
@@ -1975,7 +1974,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
                 DropFieldClause dropFieldClause = (DropFieldClause) alterClause;
                 modifyFieldColumns = Set.of(dropFieldClause.getColName());
-                checkModifiedColumWithMaterializedViews(olapTable, modifyFieldColumns);
+                AlterMVJobExecutor.checkModifiedColumWithMaterializedViews(olapTable, modifyFieldColumns);
                 processDropField((DropFieldClause) alterClause, olapTable, indexSchemaMap, newIndexes);
             } else if (alterClause instanceof ReorderColumnsClause) {
                 // reorder column
@@ -2030,72 +2029,6 @@ public class SchemaChangeHandler extends AlterHandler {
             return null;
         } else {
             return createFastSchemaEvolutionJobInSharedDataMode(schemaChangeData);
-        }
-    }
-
-    /**
-     * Check related synchronous materialized views before modified columns, throw exceptions
-     * if modified columns affect the related rollup/synchronous mvs.
-     */
-    public void checkModifiedColumWithMaterializedViews(OlapTable olapTable,
-                                                        Set<String> modifiedColumns) throws DdlException {
-        if (modifiedColumns == null || modifiedColumns.isEmpty()) {
-            return;
-        }
-
-        // If there is synchronized materialized view referring the column, throw exception.
-        if (olapTable.getIndexNameToId().size() > 1) {
-            Map<Long, MaterializedIndexMeta> metaMap = olapTable.getIndexIdToMeta();
-            for (Map.Entry<Long, MaterializedIndexMeta> entry : metaMap.entrySet()) {
-                Long id = entry.getKey();
-                if (id == olapTable.getBaseIndexId()) {
-                    continue;
-                }
-                MaterializedIndexMeta meta = entry.getValue();
-                List<Column> schema = meta.getSchema();
-                String indexName = olapTable.getIndexNameById(id);
-                // ignore agg_keys type because it's like duplicated without agg functions
-                boolean hasAggregateFunction = olapTable.getKeysType() != KeysType.AGG_KEYS &&
-                        schema.stream().anyMatch(x -> x.isAggregated());
-                if (hasAggregateFunction) {
-                    for (Column rollupCol : schema) {
-                        String colName = rollupCol.getName();
-                        if (modifiedColumns.contains(colName)) {
-                            throw new DdlException(String.format("Can not drop/modify the column %s, " +
-                                            "because the column is used in the related rollup %s, " +
-                                            "please drop the rollup index first.", colName, indexName));
-                        }
-                        if (rollupCol.getRefColumns() != null) {
-                            for (SlotRef refColumn : rollupCol.getRefColumns()) {
-                                String refColName = refColumn.getColumnName();
-                                if (modifiedColumns.contains(refColName)) {
-                                    String defineExprSql = rollupCol.getDefineExpr() == null ? "" :
-                                            rollupCol.getDefineExpr().toSql();
-                                    throw new DdlException(String.format("Can not drop/modify the column %s, " +
-                                                    "because the column is used in the related rollup %s " +
-                                                    "with the define expr:%s, please drop the rollup index first.",
-                                            refColName, indexName, defineExprSql));
-                                }
-                            }
-                        }
-                    }
-                }
-                if (meta.getWhereClause() != null) {
-                    Expr whereExpr = meta.getWhereClause();
-                    List<SlotRef> whereSlots = new ArrayList<>();
-                    whereExpr.collect(SlotRef.class, whereSlots);
-                    for (SlotRef refColumn : whereSlots) {
-                        String colName = refColumn.getColumnName();
-                        if (modifiedColumns.contains(colName)) {
-                            String whereExprSql = whereExpr.toSql();
-                            throw new DdlException(String.format("Can not drop/modify the column %s, " +
-                                            "because the column is used in the related rollup %s " +
-                                            "with the where expr:%s, please drop the rollup index first.",
-                                    colName, indexName, whereExprSql));
-                        }
-                    }
-                }
-            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
@@ -222,9 +222,8 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                     "alter table sc_dup3 drop column error_code");
         } catch (Exception e) {
             Assertions.assertTrue(
-                    e.getMessage().contains("Can not drop/modify the column mv_count_error_code, because the column " +
-                    "is used in the related rollup mv1 with the define expr:" +
-                    "CASE WHEN `test`.`sc_dup3`.`error_code` IS NULL THEN 0 ELSE 1 END, please drop the rollup index first."));
+                    e.getMessage().contains("Can not drop/modify the column error_code, " +
+                            "because the column is used in the related rollup mv1 with the define exp"), e.getMessage());
         }
     }
 
@@ -237,9 +236,8 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                             "group by timestamp",
                     "alter table sc_dup3 modify column error_code BIGINT");
         } catch (Exception e) {
-            Assertions.assertTrue(e.getMessage().contains("Can not drop/modify the column mv_count_error_code, because " +
-                    "the column is used in the related rollup mv1 with the define expr:" +
-                    "CASE WHEN `test`.`sc_dup3`.`error_code` IS NULL THEN 0 ELSE 1 END, please drop the rollup index first."));
+            Assertions.assertTrue(e.getMessage().contains("Can not drop/modify the column error_code, because " +
+                    "the column is used in the related rollup mv1 with the define expr"), e.getMessage());
         }
     }
 

--- a/test/sql/test_alter_table/R/test_alter_table_with_mv
+++ b/test/sql/test_alter_table/R/test_alter_table_with_mv
@@ -1,0 +1,51 @@
+-- name: test_alter_table_with_mv
+CREATE TABLE t0(k0 BIGINT, k1 DATETIME, v0 INT, v1 VARCHAR(100))
+ distributed by hash(k0)
+ order by (v0)
+ properties('replication_num'='1');
+-- result:
+-- !result
+INSERT INTO t0 VALUES(0, '2024-01-01 00:00:00', 10, '100');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 AS SELECT k0, v1 FROM t0 WHERE v0 > 10;
+-- result:
+-- !result
+function: wait_table_rollup_finish()
+-- result:
+None
+-- !result
+CREATE MATERIALIZED VIEW test_mv2 AS SELECT k0, v1, k1, v0 FROM t0 WHERE v0 > 10 and k1 = '2024-01-01 00:00:00';
+-- result:
+-- !result
+function: wait_table_rollup_finish()
+-- result:
+None
+-- !result
+ALTER TABLE t0 DROP COLUMN k1;
+-- result:
+[REGEX].*Can not drop/modify the column k1, because the column is used in the related rollup.*
+-- !result
+ALTER TABLE t0 DROP COLUMN v0;
+-- result:
+[REGEX].*Can not drop/modify the column v0, because the column is used in the related rollup.*
+-- !result
+ALTER TABLE t0 DROP COLUMN v1, DROP COLUMN v0;
+-- result:
+[REGEX].*Can not drop/modify the column v0, because the column is used in the related rollup.*
+-- !result
+ALTER TABLE t0 DROP COLUMN v1, DROP COLUMN v100;
+-- result:
+E: (1064, 'Column does not exists: v100')
+-- !result
+DESC t0;
+-- result:
+k0	bigint	YES	true	None	
+k1	datetime	YES	true	None	
+v0	int	YES	true	None	
+v1	varchar(100)	YES	false	None	
+-- !result
+SELECT * from t0 order by k0;
+-- result:
+0	2024-01-01 00:00:00	10	100
+-- !result

--- a/test/sql/test_alter_table/T/test_alter_table_with_mv
+++ b/test/sql/test_alter_table/T/test_alter_table_with_mv
@@ -1,0 +1,25 @@
+-- name: test_alter_table_with_mv
+
+CREATE TABLE t0(k0 BIGINT, k1 DATETIME, v0 INT, v1 VARCHAR(100))
+ distributed by hash(k0)
+ order by (v0)
+ properties('replication_num'='1');
+
+INSERT INTO t0 VALUES(0, '2024-01-01 00:00:00', 10, '100');
+
+CREATE MATERIALIZED VIEW test_mv1 AS SELECT k0, v1 FROM t0 WHERE v0 > 10;
+function: wait_table_rollup_finish()
+CREATE MATERIALIZED VIEW test_mv2 AS SELECT k0, v1, k1, v0 FROM t0 WHERE v0 > 10 and k1 = '2024-01-01 00:00:00';
+function: wait_table_rollup_finish()
+
+ALTER TABLE t0 DROP COLUMN k1;
+
+ALTER TABLE t0 DROP COLUMN v0;
+
+ALTER TABLE t0 DROP COLUMN v1, DROP COLUMN v0;
+
+ALTER TABLE t0 DROP COLUMN v1, DROP COLUMN v100;
+
+DESC t0;
+
+SELECT * from t0 order by k0;


### PR DESCRIPTION
## Why I'm doing:

`Alter table Drop column` may throw exception if the table contains related rollup mvs:
```
 2025-08-26 10:09:52.660+08:00 WARN (thrift-server-pool-42|515) [StmtExecutor.handleDdlStmt():1966] DDL statement (ALTER TABLE duplicate_complex_table_200_abnormal DROP COLUMN v67) process failed.
 java.lang.NullPointerException
	at com.starrocks.alter.SchemaChangeHandler.checkModifiedColumWithMaterializedViews(SchemaChangeHandler.java:2031)
	at com.starrocks.alter.SchemaChangeHandler.analyzeAndCreateJob(SchemaChangeHandler.java:1880)
	at com.starrocks.alter.SchemaChangeHandler.process(SchemaChangeHandler.java:2043)
	at com.starrocks.alter.AlterJobExecutor.visitAlterTableStatement(AlterJobExecutor.java:170)
	at com.starrocks.alter.AlterJobExecutor.visitAlterTableStatement(AlterJobExecutor.java:116)
	at com.starrocks.sql.ast.AlterTableStmt.accept(AlterTableStmt.java:59)
	at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:80)
	at com.starrocks.alter.AlterJobExecutor.process(AlterJobExecutor.java:129)
	at com.starrocks.server.LocalMetastore.alterTable(LocalMetastore.java:3089)
	at com.starrocks.server.MetadataMgr.alterTable(MetadataMgr.java:393)
	at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.lambda$visitAlterTableStatement$17(DDLStmtExecutor.java:401)
	at com.starrocks.common.ErrorReport.wrapWithRuntimeException(ErrorReport.java:134)
	at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitAlterTableStatement(DDLStmtExecutor.java:400)
	at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitAlterTableStatement(DDLStmtExecutor.java:188)
	at com.starrocks.sql.ast.AlterTableStmt.accept(AlterTableStmt.java:59)
	at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:80)
	at com.starrocks.qe.DDLStmtExecutor.execute(DDLStmtExecutor.java:173)
	at com.starrocks.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:1936)
	at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:744)
	at com.starrocks.qe.ConnectProcessor.proxyExecute(ConnectProcessor.java:864)
	at com.starrocks.service.FrontendServiceImpl.forward(FrontendServiceImpl.java:1148)
	at com.starrocks.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:5193)
	at com.starrocks.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:5170)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40)
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40)
	at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```
## What I'm doing:
- Ensure not throw npe in throwing StarRocksException.

Fixes https://github.com/StarRocks/StarRocksTest/issues/10140

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
