### PR TITLE
[Tool] Ignore fe/plugin/*/target/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ thirdparty/installed
 core.*
 extension/spark-doris-connector/.classpath
 extension/spark-doris-connector/target
-contrib/trino-connector/target/
+contrib/.*/target/
 fe/log
 **/ut_ports
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ fe_plugins/output
 fe/mocked
 fe/ut_ports
 fe/*/target
+fe/plugin/*/target/
 fe/fe-core/gen
 fe/fe-common/.classpath
 fe/fe-core/src/main/java/com/starrocks/sql/parser/gen


### PR DESCRIPTION
## Why I'm doing:

After build, `fe/plugin/*/target/ ` will untracked in git:
```
❯ git status
On branch support_ixx
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        fe/plugin/hive-udf/target/
        fe/plugin/spark-dpp/target/

```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
