### PR TITLE
[Enhancement] Extend hour_from_unixtime optimization

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRuleTest.java
@@ -171,14 +171,6 @@ public class SimplifiedPredicateRuleTest {
         assertEquals(1, resultCall2.getChildren().size());
         assertEquals(tsColumn, resultCall2.getChild(0));
 
-        // hour(to_datetime(ts, 3)) should NOT be rewritten
-        CallOperator toDatetimeCallScale3 = new CallOperator(FunctionSet.TO_DATETIME, Type.DATETIME,
-                Lists.newArrayList(tsColumn, ConstantOperator.createInt(3)), null);
-        CallOperator hourCall3 = new CallOperator(FunctionSet.HOUR, Type.TINYINT,
-                Lists.newArrayList(toDatetimeCallScale3), null);
-        ScalarOperator result3 = rule.apply(hourCall3, null);
-        assertEquals(hourCall3, result3);
-
         // hour(to_datetime(ts, 3)) -> hour_from_unixtime(ts/1000)
         CallOperator toDatetimeCallScale3 = new CallOperator(FunctionSet.TO_DATETIME, Type.DATETIME,
                 Lists.newArrayList(tsColumn, ConstantOperator.createInt(3)), null);


### PR DESCRIPTION
## Why I'm doing:

To improve query performance, this PR extends the existing optimizer rule that transforms `hour(from_unixtime(ts))` to `hour_from_unixtime(ts)`. This optimization is now applied to `hour(to_datetime(ts))` and `hour(to_datetime(ts, 0))` expressions, leveraging the more efficient `hour_from_unixtime` function.

## What I'm doing:


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-cba5cb33-36fa-4fde-8f39-150c62ca0665">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cba5cb33-36fa-4fde-8f39-150c62ca0665">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

