### PR TITLE
[BugFix] fix combine txnlog vacuum issue when delete tablets

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -792,7 +792,9 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
             }
             // delete files under txnlog
             for (const auto& log : combine_log_ptr->txn_logs()) {
-                RETURN_IF_ERROR(delete_files_under_txnlog(data_dir, log, contains_alive_tablets, true, deleter));
+                if (std::binary_search(tablet_ids.begin(), tablet_ids.end(), log.tablet_id())) {
+                    RETURN_IF_ERROR(delete_files_under_txnlog(data_dir, log, contains_alive_tablets, true, deleter));
+                }
             }
             // delete txnlog
             if (!contains_alive_tablets) {


### PR DESCRIPTION
## Why I'm doing:
When do schema change or drop sync MV, we need to call `deleteTablets` to delete useless tablets. And in this `deleteTablets` call, there will be some combine txnlogs which not only contains these useless tablets, so we need to skip these tablets when handle these combine txnlogs.

## What I'm doing:
This pull request addresses an issue with tablet deletion in the Lake storage engine, ensuring that transaction log (txnlog) files and associated data files are not incorrectly deleted for tablets that are in the process of being deleted. It also adds a new unit test to verify the fix.

**Bug fix in tablet deletion logic:**

* Updated `delete_tablets_impl` in `vacuum.cpp` to skip deleting txnlog files for tablets that are currently being deleted, preventing accidental removal of files needed by still-alive tablets.

**Testing improvements:**

* Added a new test case `test_delete_tablets_skip_txnlog_files_for_deleted_tablets` in `vacuum_test.cpp` to verify that txnlog and data files are correctly preserved or deleted based on the deletion status of each tablet.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
