### PR TITLE
[Enhancement] Implement more from_unixtime functions

### DIFF
--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -722,12 +722,12 @@ public:
     DEFINE_VECTORIZED_FN(from_unix_to_datetime_ms_64);
 
     // TODO
-    // DEFINE_VECTORIZED_FN(year_from_unixtime);
-    // DEFINE_VECTORIZED_FN(month_from_unixtime);
-    // DEFINE_VECTORIZED_FN(day_from_unixtime);
+    DEFINE_VECTORIZED_FN(year_from_unixtime);
+    DEFINE_VECTORIZED_FN(month_from_unixtime);
+    DEFINE_VECTORIZED_FN(day_from_unixtime);
     DEFINE_VECTORIZED_FN(hour_from_unixtime);
-    // DEFINE_VECTORIZED_FN(minute_from_unixtime);
-    // DEFINE_VECTORIZED_FN(second_from_unixtime);
+    DEFINE_VECTORIZED_FN(minute_from_unixtime);
+    DEFINE_VECTORIZED_FN(second_from_unixtime);
 
     // from_unix_datetime with format's auxiliary method
     static Status from_unix_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -4734,12 +4734,12 @@ TEST_F(TimeFunctionsTest, minuteFromUnixTime) {
     DeferOp defer([&]() { state->set_timezone(prev_timezone); });
 
     Int64Column::Ptr tc = Int64Column::create();
-    tc->append(0);        // 00:00:00 -> 0
-    tc->append(59);       // 00:00:59 -> 0
-    tc->append(60);       // 00:01:00 -> 1
-    tc->append(3599);     // 00:59:59 -> 59
-    tc->append(3600);     // 01:00:00 -> 0
-    tc->append(3723);     // 01:02:03 -> 2
+    tc->append(0);    // 00:00:00 -> 0
+    tc->append(59);   // 00:00:59 -> 0
+    tc->append(60);   // 00:01:00 -> 1
+    tc->append(3599); // 00:59:59 -> 59
+    tc->append(3600); // 01:00:00 -> 0
+    tc->append(3723); // 01:02:03 -> 2
 
     int expected[] = {0, 0, 1, 59, 0, 2};
     Columns columns;
@@ -4758,11 +4758,11 @@ TEST_F(TimeFunctionsTest, secondFromUnixTime) {
     DeferOp defer([&]() { state->set_timezone(prev_timezone); });
 
     Int64Column::Ptr tc = Int64Column::create();
-    tc->append(0);        // -> 0
-    tc->append(59);       // -> 59
-    tc->append(60);       // -> 0
-    tc->append(61);       // -> 1
-    tc->append(3723);     // 01:02:03 -> 3
+    tc->append(0);    // -> 0
+    tc->append(59);   // -> 59
+    tc->append(60);   // -> 0
+    tc->append(61);   // -> 1
+    tc->append(3723); // 01:02:03 -> 3
 
     int expected[] = {0, 59, 0, 1, 3};
     Columns columns;
@@ -4781,11 +4781,11 @@ TEST_F(TimeFunctionsTest, ymdFromUnixTime) {
     DeferOp defer([&]() { state->set_timezone(prev_timezone); });
 
     Int64Column::Ptr tc = Int64Column::create();
-    tc->append(0);              // 1970-01-01
-    tc->append(86399);          // 1970-01-01
-    tc->append(86400);          // 1970-01-02
-    tc->append(946684800);      // 2000-01-01 00:00:00
-    tc->append(951868800);      // 2000-03-01 00:00:00 (leap year)
+    tc->append(0);         // 1970-01-01
+    tc->append(86399);     // 1970-01-01
+    tc->append(86400);     // 1970-01-02
+    tc->append(946684800); // 2000-01-01 00:00:00
+    tc->append(951868800); // 2000-03-01 00:00:00 (leap year)
 
     Columns columns;
     columns.emplace_back(tc);
@@ -4798,9 +4798,21 @@ TEST_F(TimeFunctionsTest, ymdFromUnixTime) {
     auto months = ColumnHelper::cast_to<TYPE_INT>(monthCol);
     auto days = ColumnHelper::cast_to<TYPE_INT>(dayCol);
 
-    EXPECT_EQ(1970, years->get_data()[0]); EXPECT_EQ(1, months->get_data()[0]); EXPECT_EQ(1, days->get_data()[0]);
-    EXPECT_EQ(1970, years->get_data()[1]); EXPECT_EQ(1, months->get_data()[1]); EXPECT_EQ(1, days->get_data()[1]);
-    EXPECT_EQ(1970, years->get_data()[2]); EXPECT_EQ(1, months->get_data()[2]); EXPECT_EQ(2, days->get_data()[2]);
-    EXPECT_EQ(2000, years->get_data()[3]); EXPECT_EQ(1, months->get_data()[3]); EXPECT_EQ(1, days->get_data()[3]);
-    EXPECT_EQ(2000, years->get_data()[4]); EXPECT_EQ(3, months->get_data()[4]); EXPECT_EQ(1, days->get_data()[4]);
+    EXPECT_EQ(1970, years->get_data()[0]);
+    EXPECT_EQ(1, months->get_data()[0]);
+    EXPECT_EQ(1, days->get_data()[0]);
+    EXPECT_EQ(1970, years->get_data()[1]);
+    EXPECT_EQ(1, months->get_data()[1]);
+    EXPECT_EQ(1, days->get_data()[1]);
+    EXPECT_EQ(1970, years->get_data()[2]);
+    EXPECT_EQ(1, months->get_data()[2]);
+    EXPECT_EQ(2, days->get_data()[2]);
+    EXPECT_EQ(2000, years->get_data()[3]);
+    EXPECT_EQ(1, months->get_data()[3]);
+    EXPECT_EQ(1, days->get_data()[3]);
+    EXPECT_EQ(2000, years->get_data()[4]);
+    EXPECT_EQ(3, months->get_data()[4]);
+    EXPECT_EQ(1, days->get_data()[4]);
 }
+
+} //namespace starrocks

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -4727,4 +4727,80 @@ TEST_F(TimeFunctionsTest, hourFromUnixTime) {
     }
 }
 
-} // namespace starrocks
+TEST_F(TimeFunctionsTest, minuteFromUnixTime) {
+    RuntimeState* state = _utils->get_fn_ctx()->state();
+    std::string prev_timezone = state->timezone();
+    ASSERT_TRUE(state->set_timezone("UTC"));
+    DeferOp defer([&]() { state->set_timezone(prev_timezone); });
+
+    Int64Column::Ptr tc = Int64Column::create();
+    tc->append(0);        // 00:00:00 -> 0
+    tc->append(59);       // 00:00:59 -> 0
+    tc->append(60);       // 00:01:00 -> 1
+    tc->append(3599);     // 00:59:59 -> 59
+    tc->append(3600);     // 01:00:00 -> 0
+    tc->append(3723);     // 01:02:03 -> 2
+
+    int expected[] = {0, 0, 1, 59, 0, 2};
+    Columns columns;
+    columns.emplace_back(tc);
+    ColumnPtr result = TimeFunctions::minute_from_unixtime(_utils->get_fn_ctx(), columns).value();
+    auto mins = ColumnHelper::cast_to<TYPE_INT>(result);
+    for (size_t i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i) {
+        EXPECT_EQ(expected[i], mins->get_data()[i]);
+    }
+}
+
+TEST_F(TimeFunctionsTest, secondFromUnixTime) {
+    RuntimeState* state = _utils->get_fn_ctx()->state();
+    std::string prev_timezone = state->timezone();
+    ASSERT_TRUE(state->set_timezone("UTC"));
+    DeferOp defer([&]() { state->set_timezone(prev_timezone); });
+
+    Int64Column::Ptr tc = Int64Column::create();
+    tc->append(0);        // -> 0
+    tc->append(59);       // -> 59
+    tc->append(60);       // -> 0
+    tc->append(61);       // -> 1
+    tc->append(3723);     // 01:02:03 -> 3
+
+    int expected[] = {0, 59, 0, 1, 3};
+    Columns columns;
+    columns.emplace_back(tc);
+    ColumnPtr result = TimeFunctions::second_from_unixtime(_utils->get_fn_ctx(), columns).value();
+    auto secs = ColumnHelper::cast_to<TYPE_INT>(result);
+    for (size_t i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i) {
+        EXPECT_EQ(expected[i], secs->get_data()[i]);
+    }
+}
+
+TEST_F(TimeFunctionsTest, ymdFromUnixTime) {
+    RuntimeState* state = _utils->get_fn_ctx()->state();
+    std::string prev_timezone = state->timezone();
+    ASSERT_TRUE(state->set_timezone("UTC"));
+    DeferOp defer([&]() { state->set_timezone(prev_timezone); });
+
+    Int64Column::Ptr tc = Int64Column::create();
+    tc->append(0);              // 1970-01-01
+    tc->append(86399);          // 1970-01-01
+    tc->append(86400);          // 1970-01-02
+    tc->append(946684800);      // 2000-01-01 00:00:00
+    tc->append(951868800);      // 2000-03-01 00:00:00 (leap year)
+
+    Columns columns;
+    columns.emplace_back(tc);
+
+    ColumnPtr yearCol = TimeFunctions::year_from_unixtime(_utils->get_fn_ctx(), columns).value();
+    ColumnPtr monthCol = TimeFunctions::month_from_unixtime(_utils->get_fn_ctx(), columns).value();
+    ColumnPtr dayCol = TimeFunctions::day_from_unixtime(_utils->get_fn_ctx(), columns).value();
+
+    auto years = ColumnHelper::cast_to<TYPE_INT>(yearCol);
+    auto months = ColumnHelper::cast_to<TYPE_INT>(monthCol);
+    auto days = ColumnHelper::cast_to<TYPE_INT>(dayCol);
+
+    EXPECT_EQ(1970, years->get_data()[0]); EXPECT_EQ(1, months->get_data()[0]); EXPECT_EQ(1, days->get_data()[0]);
+    EXPECT_EQ(1970, years->get_data()[1]); EXPECT_EQ(1, months->get_data()[1]); EXPECT_EQ(1, days->get_data()[1]);
+    EXPECT_EQ(1970, years->get_data()[2]); EXPECT_EQ(1, months->get_data()[2]); EXPECT_EQ(2, days->get_data()[2]);
+    EXPECT_EQ(2000, years->get_data()[3]); EXPECT_EQ(1, months->get_data()[3]); EXPECT_EQ(1, days->get_data()[3]);
+    EXPECT_EQ(2000, years->get_data()[4]); EXPECT_EQ(3, months->get_data()[4]); EXPECT_EQ(1, days->get_data()[4]);
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -90,6 +90,11 @@ public class FunctionSet {
     public static final String FROM_UNIXTIME_MS = "from_unixtime_ms";
     public static final String HOUR = "hour";
     public static final String HOUR_FROM_UNIXTIME = "hour_from_unixtime";
+    public static final String YEAR_FROM_UNIXTIME = "year_from_unixtime";
+    public static final String MONTH_FROM_UNIXTIME = "month_from_unixtime";
+    public static final String DAY_FROM_UNIXTIME = "day_from_unixtime";
+    public static final String MINUTE_FROM_UNIXTIME = "minute_from_unixtime";
+    public static final String SECOND_FROM_UNIXTIME = "second_from_unixtime";
     public static final String MINUTE = "minute";
     public static final String MONTH = "month";
     public static final String MONTHNAME = "monthname";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRuleTest.java
@@ -214,4 +214,57 @@ public class SimplifiedPredicateRuleTest {
         ScalarOperator result4 = rule.apply(hourCall4, null);
         assertEquals(hourCall4, result4);
     }
+
+    @Test
+    public void applyExtractFromUnixTime() {
+        ColumnRefOperator tsColumn = new ColumnRefOperator(1, Type.BIGINT, "ts", true);
+
+        CallOperator fromUnixTimeCall = new CallOperator(FunctionSet.FROM_UNIXTIME, Type.VARCHAR,
+                Lists.newArrayList(tsColumn), null);
+
+        // year(from_unixtime(ts)) -> year_from_unixtime(ts)
+        CallOperator yearCall = new CallOperator(FunctionSet.YEAR, Type.INT,
+                Lists.newArrayList(fromUnixTimeCall), null);
+        ScalarOperator yearResult = rule.apply(yearCall, null);
+        assertEquals(OperatorType.CALL, yearResult.getOpType());
+        CallOperator yearResultCall = (CallOperator) yearResult;
+        assertEquals(FunctionSet.YEAR_FROM_UNIXTIME, yearResultCall.getFnName());
+        assertEquals(tsColumn, yearResultCall.getChild(0));
+
+        // month(from_unixtime(ts)) -> month_from_unixtime(ts)
+        CallOperator monthCall = new CallOperator(FunctionSet.MONTH, Type.INT,
+                Lists.newArrayList(fromUnixTimeCall), null);
+        ScalarOperator monthResult = rule.apply(monthCall, null);
+        assertEquals(OperatorType.CALL, monthResult.getOpType());
+        CallOperator monthResultCall = (CallOperator) monthResult;
+        assertEquals(FunctionSet.MONTH_FROM_UNIXTIME, monthResultCall.getFnName());
+        assertEquals(tsColumn, monthResultCall.getChild(0));
+
+        // day(from_unixtime(ts)) -> day_from_unixtime(ts)
+        CallOperator dayCall = new CallOperator(FunctionSet.DAY, Type.INT,
+                Lists.newArrayList(fromUnixTimeCall), null);
+        ScalarOperator dayResult = rule.apply(dayCall, null);
+        assertEquals(OperatorType.CALL, dayResult.getOpType());
+        CallOperator dayResultCall = (CallOperator) dayResult;
+        assertEquals(FunctionSet.DAY_FROM_UNIXTIME, dayResultCall.getFnName());
+        assertEquals(tsColumn, dayResultCall.getChild(0));
+
+        // minute(from_unixtime(ts)) -> minute_from_unixtime(ts)
+        CallOperator minuteCall = new CallOperator(FunctionSet.MINUTE, Type.INT,
+                Lists.newArrayList(fromUnixTimeCall), null);
+        ScalarOperator minuteResult = rule.apply(minuteCall, null);
+        assertEquals(OperatorType.CALL, minuteResult.getOpType());
+        CallOperator minuteResultCall = (CallOperator) minuteResult;
+        assertEquals(FunctionSet.MINUTE_FROM_UNIXTIME, minuteResultCall.getFnName());
+        assertEquals(tsColumn, minuteResultCall.getChild(0));
+
+        // second(from_unixtime(ts)) -> second_from_unixtime(ts)
+        CallOperator secondCall = new CallOperator(FunctionSet.SECOND, Type.INT,
+                Lists.newArrayList(fromUnixTimeCall), null);
+        ScalarOperator secondResult = rule.apply(secondCall, null);
+        assertEquals(OperatorType.CALL, secondResult.getOpType());
+        CallOperator secondResultCall = (CallOperator) secondResult;
+        assertEquals(FunctionSet.SECOND_FROM_UNIXTIME, secondResultCall.getFnName());
+        assertEquals(tsColumn, secondResultCall.getChild(0));
+    }
 }

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -604,12 +604,12 @@ vectorized_functions = [
      
 
     # specialized version of from_unixtime to reduce the cost of datetime conversion
-    # TODO: 50380 year_from_unixtime
-    # TODO: 50381 month_from_unixtime
-    # TODO: 50382 day_from_unixtime
+    [50380, 'year_from_unixtime', True, False, 'INT', ['BIGINT'], 'TimeFunctions::year_from_unixtime'],
+    [50381, 'month_from_unixtime', True, False, 'INT', ['BIGINT'], 'TimeFunctions::month_from_unixtime'],
+    [50382, 'day_from_unixtime', True, False, 'INT', ['BIGINT'], 'TimeFunctions::day_from_unixtime'],
     [50383, 'hour_from_unixtime', True, False, 'INT', ['BIGINT'], 'TimeFunctions::hour_from_unixtime'],
-    # TODO: 50384 minute_from_unixtime
-    # TODO: 50385 second_from_unixtime
+    [50384, 'minute_from_unixtime', True, False, 'INT', ['BIGINT'], 'TimeFunctions::minute_from_unixtime'],
+    [50385, 'second_from_unixtime', True, False, 'INT', ['BIGINT'], 'TimeFunctions::second_from_unixtime'],
 
     [50310, 'dayname', True, False, 'VARCHAR', ['DATETIME'], 'TimeFunctions::day_name'],
     [50311, 'monthname', True, False, 'VARCHAR', ['DATETIME'], 'TimeFunctions::month_name'],


### PR DESCRIPTION
## Why I'm doing:
To enhance time-related functions by providing direct, optimized extraction of year, month, day, minute, and second from Unix timestamps, mirroring the existing `hour_from_unixtime`. This improves performance by avoiding intermediate `FROM_UNIXTIME` conversions.

## What I'm doing:
- Implemented `year_from_unixtime`, `month_from_unixtime`, `day_from_unixtime`, `minute_from_unixtime`, `second_from_unixtime` in the backend.
- Added corresponding frontend expression rewrite rules to optimize `EXTRACT(part FROM FROM_UNIXTIME(ts))` into the new direct functions.
- Included unit tests for both backend function logic and frontend rewrite rules.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-88dbc330-33cd-4749-8de8-36b3f3203b6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88dbc330-33cd-4749-8de8-36b3f3203b6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>