### PR TITLE
[BugFix] Fix integer overflow caused by integer left shift in compression key

### DIFF
--- a/be/src/exec/aggregate/compress_serializer.cpp
+++ b/be/src/exec/aggregate/compress_serializer.cpp
@@ -170,6 +170,7 @@ private:
 
 template <class T>
 T mask(T bits) {
+    if (bits == sizeof(T) * 8) return ~T(0);
     return (T(1) << bits) - 1;
 }
 

--- a/test/sql/test_agg/R/test_agg_compressed_key2
+++ b/test/sql/test_agg/R/test_agg_compressed_key2
@@ -1,0 +1,118 @@
+-- name: test_agg_compressed_key2
+CREATE TABLE t3 (
+    c_2_0 LARGEINT NOT NULL,
+    c_2_1 LARGEINT NOT NULL,
+    c_2_2 LARGEINT NOT NULL,
+    c_2_3 LARGEINT NOT NULL,
+    c_2_4 LARGEINT NOT NULL,
+    c_2_5 LARGEINT NOT NULL,
+    c_2_6 LARGEINT NOT NULL,
+    c_2_7 LARGEINT NOT NULL,
+    c_2_8 LARGEINT NOT NULL,
+    c_2_9 LARGEINT NOT NULL,
+    c_2_10 LARGEINT NOT NULL,
+    c_2_11 LARGEINT NOT NULL,
+    c_2_12 LARGEINT NOT NULL,
+    c_2_13 LARGEINT NOT NULL,
+    c_2_14 LARGEINT NOT NULL,
+    c_2_15 LARGEINT NOT NULL
+) DUPLICATE KEY (c_2_0) DISTRIBUTED BY HASH (c_2_0) properties("replication_num" = "1");
+-- result:
+-- !result
+insert into t3 values (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+-- result:
+-- !result
+insert into t3 values (128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128);
+-- result:
+-- !result
+insert into t3 values (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+-- result:
+-- !result
+function: wait_min_max_stat_ready('c_2_0', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_1', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_2', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_3', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_4', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_5', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_6', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_7', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_8', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_9', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_10', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_11', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_12', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_13', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_14', 't3') 
+-- result:
+
+-- !result
+function: wait_min_max_stat_ready('c_2_15', 't3') 
+-- result:
+
+-- !result
+select distinct c_2_0, c_2_1, c_2_2, c_2_3, c_2_4, c_2_5, c_2_6, c_2_7, c_2_8, c_2_9, c_2_10, c_2_11, c_2_12, c_2_13, c_2_14, c_2_15 from t3 order by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
+-- result:
+0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0
+1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1
+128	128	128	128	128	128	128	128	128	128	128	128	128	128	128	128
+-- !result
+CREATE TABLE t4 (
+    c_2_0 LARGEINT NOT NULL
+) DUPLICATE KEY (c_2_0) 
+DISTRIBUTED BY HASH (c_2_0) 
+properties("replication_num" = "1");
+-- result:
+-- !result
+insert into t4 values (1024), (-2139922094);
+-- result:
+-- !result
+function: wait_min_max_stat_ready('c_2_0', 't4') 
+-- result:
+
+-- !result
+select distinct c_2_0 from t4 order by t4;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 't4' cannot be resolved.")
+-- !result

--- a/test/sql/test_agg/T/test_agg_compressed_key2
+++ b/test/sql/test_agg/T/test_agg_compressed_key2
@@ -1,0 +1,52 @@
+-- name: test_agg_compressed_key2
+
+-- test compress to int128
+CREATE TABLE t3 (
+    c_2_0 LARGEINT NOT NULL,
+    c_2_1 LARGEINT NOT NULL,
+    c_2_2 LARGEINT NOT NULL,
+    c_2_3 LARGEINT NOT NULL,
+    c_2_4 LARGEINT NOT NULL,
+    c_2_5 LARGEINT NOT NULL,
+    c_2_6 LARGEINT NOT NULL,
+    c_2_7 LARGEINT NOT NULL,
+    c_2_8 LARGEINT NOT NULL,
+    c_2_9 LARGEINT NOT NULL,
+    c_2_10 LARGEINT NOT NULL,
+    c_2_11 LARGEINT NOT NULL,
+    c_2_12 LARGEINT NOT NULL,
+    c_2_13 LARGEINT NOT NULL,
+    c_2_14 LARGEINT NOT NULL,
+    c_2_15 LARGEINT NOT NULL
+) DUPLICATE KEY (c_2_0) DISTRIBUTED BY HASH (c_2_0) properties("replication_num" = "1");
+insert into t3 values (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+insert into t3 values (128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128);
+insert into t3 values (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+-- select distinct c_2_0, c_2_1, c_2_2, c_2_3, c_2_4, c_2_5, c_2_6, c_2_7 from t3 order by 1,2,3,4,5,6,7,8;
+function: wait_min_max_stat_ready('c_2_0', 't3') 
+function: wait_min_max_stat_ready('c_2_1', 't3') 
+function: wait_min_max_stat_ready('c_2_2', 't3') 
+function: wait_min_max_stat_ready('c_2_3', 't3') 
+function: wait_min_max_stat_ready('c_2_4', 't3') 
+function: wait_min_max_stat_ready('c_2_5', 't3') 
+function: wait_min_max_stat_ready('c_2_6', 't3') 
+function: wait_min_max_stat_ready('c_2_7', 't3') 
+-- select distinct c_2_8, c_2_9, c_2_10, c_2_11, c_2_12, c_2_13, c_2_14, c_2_15 from t3 order by 1,2,3,4,5,6,7,8;
+function: wait_min_max_stat_ready('c_2_8', 't3') 
+function: wait_min_max_stat_ready('c_2_9', 't3') 
+function: wait_min_max_stat_ready('c_2_10', 't3') 
+function: wait_min_max_stat_ready('c_2_11', 't3') 
+function: wait_min_max_stat_ready('c_2_12', 't3') 
+function: wait_min_max_stat_ready('c_2_13', 't3') 
+function: wait_min_max_stat_ready('c_2_14', 't3') 
+function: wait_min_max_stat_ready('c_2_15', 't3') 
+select distinct c_2_0, c_2_1, c_2_2, c_2_3, c_2_4, c_2_5, c_2_6, c_2_7, c_2_8, c_2_9, c_2_10, c_2_11, c_2_12, c_2_13, c_2_14, c_2_15 from t3 order by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
+--
+CREATE TABLE t4 (
+    c_2_0 LARGEINT NOT NULL
+) DUPLICATE KEY (c_2_0) 
+DISTRIBUTED BY HASH (c_2_0) 
+properties("replication_num" = "1");
+insert into t4 values (1024), (-2139922094);
+function: wait_min_max_stat_ready('c_2_0', 't4') 
+select distinct c_2_0 from t4 order by t4;


### PR DESCRIPTION
## Why I'm doing:

When the compressed data fits exactly into an int32, the used_bit is 32, and we expect the mask to be ~int(0). However, 1<<32 causes an overflow, resulting in a mask of 0.

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10144

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
