### PR TITLE
[Doc] Add zonemap and json configuration parameters

### DIFF
--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -2141,6 +2141,42 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: Whether to enable memory cache for zonemap index. Memory cache is recommended if you want to use zonemap indexes to accelerate scan.
 - Introduced in: -
 
+##### enable_string_prefix_zonemap
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to enable ZoneMap for string (CHAR/VARCHAR) columns using prefix-based min/max. For non-key string columns, the min/max values are truncated to a fixed prefix length configured by `string_prefix_zonemap_prefix_len`.
+- Introduced in: -
+
+##### string_prefix_zonemap_prefix_len
+
+- Default: 16
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Prefix length used for string ZoneMap min/max when `enable_string_prefix_zonemap` is enabled.
+- Introduced in: -
+
+##### string_zonemap_overlap_threshold
+
+- Default: 0.8
+- Type: Double
+- Unit: -
+- Is mutable: Yes
+- Description: Threshold for adaptive creation of page-level string ZoneMap. If the estimated overlap ratio across consecutive pages is greater than this threshold, StarRocks skips writing the page-level string ZoneMap. Range: [0.0, 1.0].
+- Introduced in: -
+
+##### string_zonemap_min_pages_for_adaptive_check
+
+- Default: 16
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Minimum number of non-empty pages required before applying the adaptive string ZoneMap quality check.
+- Introduced in: -
+
 ##### enable_ordinal_index_memory_page_cache
 
 - Default: true
@@ -3282,6 +3318,15 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Is mutable: Yes
 - Description: The maximum number of sub-fields that can be extracted by Flat JSON. This parameter takes effect only when `enable_json_flat` is set to `true`.
 - Introduced in: v3.3.0
+
+##### json_flat_create_zonemap
+
+- Default: true
+- Type: Boolean
+- Unit:
+- Is mutable: Yes
+- Description: Whether to create ZoneMaps for flattened JSON sub-columns during write. This parameter takes effect only when `enable_json_flat` is set to `true`.
+- Introduced in: -
 
 ##### enable_compaction_flat_json
 

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -1435,6 +1435,42 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: ゾーンマップインデックスのメモリーキャッシュを有効にするかどうか。ゾーンマップインデックスを使用してスキャンを高速化したい場合は、メモリキャッシュを使用することを推奨します。
 - 導入バージョン: -
 
+##### enable_string_prefix_zonemap
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 可変: はい
+- 説明: 文字列（CHAR/VARCHAR）列に対して、前置長に基づくゾーンマップを有効にするかどうか。非キー列では、最小値/最大値は `string_prefix_zonemap_prefix_len` で指定した長さに切り詰められます。
+- 導入バージョン: -
+
+##### string_prefix_zonemap_prefix_len
+
+- デフォルト: 16
+- タイプ: Int
+- 単位: -
+- 可変: はい
+- 説明: `enable_string_prefix_zonemap` が有効な場合に、文字列ゾーンマップの最小値/最大値に使用する前置長。
+- 導入バージョン: -
+
+##### string_zonemap_overlap_threshold
+
+- デフォルト: 0.8
+- タイプ: Double
+- 単位: -
+- 可変: はい
+- 説明: 文字列ページレベルのゾーンマップを自動作成するためのしきい値。連続するページ間の推定オーバーラップ率がこの値を超える場合、ページレベルのゾーンマップの書き込みをスキップします。範囲: [0.0, 1.0]。
+- 導入バージョン: -
+
+##### string_zonemap_min_pages_for_adaptive_check
+
+- デフォルト: 16
+- タイプ: Int
+- 単位: -
+- 可変: はい
+- 説明: 自適応チェックを適用する前に必要な非空ページの最小数。
+- 導入バージョン: -
+
 ##### enable_ordinal_index_memory_page_cache
 
 - デフォルト: true
@@ -1739,6 +1775,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 可変: はい
 - 説明: Flat JSON によって抽出できるサブフィールドの最大数。このパラメータは `enable_json_flat` が `true` に設定されている場合にのみ有効です。
 - 導入バージョン: v3.3.0
+
+##### json_flat_create_zonemap
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: 
+- 可変: はい
+- 説明: フラット化された JSON のサブカラムに対してゾーンマップを作成するかどうか。`enable_json_flat` が `true` の場合にのみ有効です。
+- 導入バージョン: -
 
 ##### enable_compaction_flat_json
 

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -2097,6 +2097,42 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：是否为 Zonemap index 开启 Memory Cache。使用 Zonemap index 加速 Scan 时，可以考虑开启。
 - 引入版本：-
 
+##### enable_string_prefix_zonemap
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：是否为字符串（CHAR/VARCHAR）列启用基于前缀的 Zonemap 索引。对于非键列，最小值/最大值会截断到由 `string_prefix_zonemap_prefix_len` 配置的前缀长度。
+- 引入版本：-
+
+##### string_prefix_zonemap_prefix_len
+
+- 默认值：16
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：启用 `enable_string_prefix_zonemap` 时用于字符串 Zonemap 最小值/最大值的前缀长度。
+- 引入版本：-
+
+##### string_zonemap_overlap_threshold
+
+- 默认值：0.8
+- 类型：Double
+- 单位：-
+- 是否动态：是
+- 描述：字符串页级 Zonemap 自适应创建的阈值。如果连续页之间的估算重叠比例大于该阈值，将跳过写入该页级 Zonemap。取值范围：[0.0, 1.0]。
+- 引入版本：-
+
+##### string_zonemap_min_pages_for_adaptive_check
+
+- 默认值：16
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：应用自适应检查前所需的非空页的最小数量。
+- 引入版本：-
+
 ##### enable_ordinal_index_memory_page_cache
 
 - 默认值：true
@@ -3241,6 +3277,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：是
 - 描述：控制 Flat JSON 时，最多提取的子列数量。该参数仅在 `enable_json_flat` 为 `true` 时生效。
 - 引入版本：v3.3.0
+
+##### json_flat_create_zonemap
+
+- 默认值：true
+- 类型：Boolean
+- 单位：
+- 是否动态：是
+- 描述：是否为打平后的 JSON 子列创建 Zonemap。仅当 `enable_json_flat` 为 `true` 时生效。
+- 引入版本：-
 
 ##### enable_compaction_flat_json
 


### PR DESCRIPTION
## Why I'm doing:

To document newly introduced BE configurations related to string zonemaps and flat JSON.

## What I'm doing:

Added documentation for the following BE configurations to the English, Chinese, and Japanese BE configuration files:
- `enable_string_prefix_zonemap`
- `string_prefix_zonemap_prefix_len`
- `string_zonemap_overlap_threshold`
- `string_zonemap_min_pages_for_adaptive_check`
- `json_flat_create_zonemap`
Defaults, types, and descriptions were extracted from `be/src/common/config.h`.

Fixes #61960

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-5f115d5e-b5f4-44a6-9ab4-14d51f21a00a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5f115d5e-b5f4-44a6-9ab4-14d51f21a00a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>