### PR TITLE
[BugFix] Fix UAF when FixedLengthColumn append self

### DIFF
--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -37,32 +37,36 @@ StatusOr<ColumnPtr> FixedLengthColumnBase<T>::upgrade_if_overflow() {
 
 template <typename T>
 void FixedLengthColumnBase<T>::append(const Column& src, size_t offset, size_t count) {
-    const T* src_data = reinterpret_cast<const T*>(src.raw_data());
+    DCHECK(this != &src);
 
     const size_t orig_size = _data.size();
     raw::stl_vector_resize_uninitialized(&_data, orig_size + count);
 
+    const T* src_data = reinterpret_cast<const T*>(src.raw_data());
     strings::memcpy_inlined(_data.data() + orig_size, src_data + offset, count * sizeof(T));
 }
 
 template <typename T>
 void FixedLengthColumnBase<T>::append_selective(const Column& src, const uint32_t* indexes, uint32_t from,
                                                 uint32_t size) {
+    DCHECK(this != &src);
     indexes += from;
-    const T* src_data = reinterpret_cast<const T*>(src.raw_data());
 
     const size_t orig_size = _data.size();
     raw::stl_vector_resize_uninitialized(&_data, orig_size + size);
     auto* dest_data = _data.data() + orig_size;
 
+    const T* src_data = reinterpret_cast<const T*>(src.raw_data());
     SIMDGather::gather(dest_data, src_data, indexes, size);
 }
 
 template <typename T>
 void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
-    const T* src_data = reinterpret_cast<const T*>(src.raw_data());
+    DCHECK(this != &src);
     size_t orig_size = _data.size();
     _data.resize(orig_size + size);
+
+    const T* src_data = reinterpret_cast<const T*>(src.raw_data());
     for (size_t i = 0; i < size; ++i) {
         _data[orig_size + i] = src_data[index];
     }


### PR DESCRIPTION
## Why I'm doing:

in #62165 fixed_lengh_column self append may cause a dangling pointer

```
void FixedLengthColumnBase<T>::append(const Column& src, size_t offset, size_t count) {
    // Potential dangling pointer
    const T* src_data = reinterpret_cast<const T*>(src.raw_data());
    const size_t orig_size = _data.size();
    // Resizing causes src_data to point to an undefined address.
    raw::stl_vector_resize_uninitialized(&_data, orig_size + count);
    strings::memcpy_inlined(_data.data() + orig_size, src_data + offset, count * sizeof(T));
}
```

## What I'm doing:

1. add DCHECK to avoid self append
2. fix dangling pointer problems

Fixes https://github.com/StarRocks/StarRocksTest/issues/10145

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
