### PR TITLE
[BugFix] fix the execState of multiple fe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -46,6 +46,7 @@ import com.starrocks.common.Status;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.qe.scheduler.Coordinator;
+import com.starrocks.qe.scheduler.slot.LogicalSlot;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
 import com.starrocks.thrift.TBatchReportExecStatusResult;
 import com.starrocks.thrift.TNetworkAddress;
@@ -168,6 +169,10 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
                 continue;
             }
             final String queryIdStr = DebugUtil.printId(info.getConnectContext().getExecutionId());
+            String execState = (
+                    info.getConnectContext().isPending() ?
+                            LogicalSlot.State.REQUIRING :
+                            LogicalSlot.State.ALLOCATED).toQueryStateString();
             final QueryStatisticsItem item = new QueryStatisticsItem.Builder()
                     .customQueryId(context.getCustomQueryId())
                     .queryId(queryIdStr)
@@ -181,6 +186,7 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
                     .profile(info.getCoord().getQueryProfile())
                     .warehouseName(info.coord.getWarehouseName())
                     .resourceGroupName(info.coord.getResourceGroupName())
+                    .execState(execState)
                     .build();
 
             querySet.put(queryIdStr, item);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
@@ -401,7 +401,7 @@ public class QueryStatisticsInfo {
                     .withExecTime(item.getQueryExecTime())
                     .withExecProgress(getExecProgress(FrontendOptions.getLocalHostAddress(), 
                                                       item.getQueryId(), httpClient))
-                    .withExecState(slotManager.getExecStateByQueryId(item.getQueryId()))
+                    .withExecState(item.getExecState())
                     .withWareHouseName(item.getWarehouseName())
                     .withCustomQueryId(item.getCustomQueryId())
                     .withResourceGroupName(item.getResourceGroupName());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
@@ -39,6 +39,8 @@ public final class QueryStatisticsItem {
     private final TUniqueId executionId;
     private final String warehouseName;
     private final String resourceGroupName;
+    // PENDING/RUNNING/FINISHED
+    private final String execState;
 
     private QueryStatisticsItem(Builder builder) {
         this.customQueryId = builder.customQueryId;
@@ -53,6 +55,7 @@ public final class QueryStatisticsItem {
         this.executionId = builder.executionId;
         this.warehouseName = builder.warehouseName;
         this.resourceGroupName = builder.resourceGroupName;
+        this.execState = builder.execState;
     }
 
     public String getDb() {
@@ -108,6 +111,10 @@ public final class QueryStatisticsItem {
         return resourceGroupName;
     }
 
+    public String getExecState() {
+        return execState;
+    }
+
     public static final class Builder {
         private String customQueryId;
         private String queryId;
@@ -121,6 +128,7 @@ public final class QueryStatisticsItem {
         private TUniqueId executionId;
         private String warehouseName;
         private String resourceGroupName;
+        private String execState;
 
         public Builder() {
             fragmentInstanceInfos = Lists.newArrayList();
@@ -183,6 +191,11 @@ public final class QueryStatisticsItem {
 
         public Builder resourceGroupName(String resourceGroupName) {
             this.resourceGroupName = resourceGroupName;
+            return this;
+        }
+
+        public Builder execState(String state) {
+            this.execState = state;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotManager.java
@@ -14,9 +14,11 @@
 
 package com.starrocks.qe.scheduler.slot;
 
+import com.google.common.base.Preconditions;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.metric.MetricVisitor;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import org.apache.commons.compress.utils.Lists;
@@ -64,7 +66,9 @@ public class SlotManager extends BaseSlotManager {
         // do nothing
     }
 
+    // It works only if's the leader node
     public String getExecStateByQueryId(String queryId) {
+        Preconditions.checkState(GlobalStateMgr.getCurrentState().isLeader());
         return getSlots().stream()
                 .filter(slot -> queryId.equals(DebugUtil.printId(slot.getSlotId())))
                 .map(slot -> slot.getState().toQueryStateString())


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

follow #62261


The `SlotManager::getExecStateByQueryId` works only on the leader node, on follower nodes we should fetch execState from the `ConnectContext::isPending`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
