### PR TITLE
[BugFix] Fix mv refresh bug with case-insensitive partition names

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -90,10 +90,9 @@ public class CatalogUtils {
                 } else {
                     // add more information for user
                     Partition existedPartition = olapTable.getPartition(partitionName);
-                    String errorMsg = String.format("%s, existed partition:%s, current partition:%s", partitionName,
+                    LOG.warn("Duplicate partition name {}, existed partition:{}, current partition:{}", partitionName,
                             existedPartition, partitionDesc);
-                    LOG.warn("Duplicate partition name {}", errorMsg);
-                    ErrorReport.reportDdlException(ErrorCode.ERR_SAME_NAME_PARTITION, errorMsg);
+                    ErrorReport.reportDdlException(ErrorCode.ERR_SAME_NAME_PARTITION, partitionName);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -88,7 +88,12 @@ public class CatalogUtils {
                 if (partitionDesc.isSetIfNotExists()) {
                     existPartitionNameSet.add(partitionName);
                 } else {
-                    ErrorReport.reportDdlException(ErrorCode.ERR_SAME_NAME_PARTITION, partitionName);
+                    // add more information for user
+                    Partition existedPartition = olapTable.getPartition(partitionName);
+                    String errorMsg = String.format("%s, existed partition:%s, current partition:%s", partitionName,
+                            existedPartition, partitionDesc);
+                    LOG.warn("Duplicate partition name {}", errorMsg);
+                    ErrorReport.reportDdlException(ErrorCode.ERR_SAME_NAME_PARTITION, errorMsg);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -115,6 +115,7 @@ import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.ast.ViewRelation;
 import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.PCell;
 import com.starrocks.sql.common.PListCell;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -1427,7 +1428,7 @@ public class AnalyzerUtils {
                     ImmutableMap.of("replication_num", String.valueOf(replicationNum));
 
             // table partitions for check
-            TreeMap<String, PListCell> tablePartitions = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+            TreeMap<String, PCell> tablePartitions = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
             tablePartitions.putAll(olapTable.getListPartitionItems());
             List<String> partitionColNames = Lists.newArrayList();
             List<PartitionDesc> partitionDescs = Lists.newArrayList();
@@ -1475,8 +1476,8 @@ public class AnalyzerUtils {
     /**
      * Calculate the unique partition name for list partition.
      */
-    private static String calculateUniquePartitionName(String partitionName, PListCell cell,
-                                                       Map<String, PListCell> tablePartitions) throws AnalysisException {
+    public static String calculateUniquePartitionName(String partitionName, PCell cell,
+                                                      Map<String, PCell> tablePartitions) throws AnalysisException {
         String orignialPartitionName = partitionName;
         int i = 0;
         // If the partition name already exists and their partition values are different, change the partition name.

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -1547,4 +1547,61 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
                         "     PREDICATES: 5: dt2 = '2025-05-17'\n" +
                         "     partitions=1/1");
     }
+
+    private void testMVWithDuplicatedPartitionNames(String sql1,
+                                                    String sql2,
+                                                    String mvName) throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `s1` (\n" +
+                "  `col1` varchar(100),\n"  +
+                "  `col2` varchar(100),\n" +
+                "  `col3` bigint(20) \n" +
+                ") PARTITION BY (`col1`)");
+        starRocksAssert.withTable("CREATE TABLE `s2` (\n" +
+                "  `col1` varchar(100),\n"  +
+                "  `col2` varchar(100),\n" +
+                "  `col3` bigint(20) \n" +
+                ") PARTITION BY (`col1`)");
+        executeInsertSql(sql1);
+        executeInsertSql(sql2);
+
+        List<String> s1PartitionNames = extractColumnValues(sql1, 0);
+        System.out.println(s1PartitionNames);
+        addListPartition("s1", s1PartitionNames);
+
+        List<String> s2PartitionNames = extractColumnValues(sql2, 0);
+        System.out.println(s2PartitionNames);
+        addListPartition("s2", s2PartitionNames);
+        starRocksAssert.withRefreshedMaterializedView(String.format("CREATE MATERIALIZED VIEW %s\n" +
+                        "PARTITION BY col1\n" +
+                        "REFRESH DEFERRED MANUAL \n" +
+                        "PROPERTIES (\n" +
+                        "    \"partition_refresh_number\" = \"-1\"\n" +
+                        ")\n" +
+                        "AS\n" +
+                        "select t1.col1, t1.col2 from s1 as t1 left join s2 as t2 on t1.col1 = t2.col1;\n",
+                mvName));
+        starRocksAssert.dropTable("s1");
+        starRocksAssert.dropTable("s2");
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testCreateMVWithDuplicatedPartitionNames1() throws Exception {
+        String query1 = "insert into s1 values('demo-diu.com', 'b', 2), " +
+                "('demo-dIu.com', 'a', 1) , ('demo-Diu.com', 'b', 2), ('demo-DIU.com', 'a', 1), " +
+                "('demo-diu.com', 'b', 2);";
+        String query2 = "insert into s2 values('demo-DIU.com', 'a', 1) , ('demo-diu.com', 'b', 2), " +
+                "('demo-dIU.com', 'a', 1) , ('demo-Diu.com', 'b', 2);";
+        testMVWithDuplicatedPartitionNames(query1, query2, "test_mv1");
+    }
+
+    @Test
+    public void testCreateMVWithDuplicatedPartitionNames2() throws Exception {
+        String query1 = "insert into s1 values('demo-diu.com', 'b', 2), " +
+                "('demo-DIU.com', 'a', 1) , ('demo-diu.com', 'b', 2);";
+        String query2 = "insert into s2 values('demo-diu.com', 'b', 2), " +
+                "('demo-dIu.com', 'a', 1) , ('demo-Diu.com', 'b', 2), ('demo-DIU.com', 'a', 1), " +
+                "('demo-diu.com', 'b', 2);";
+        testMVWithDuplicatedPartitionNames(query1, query2, "test_mv2");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
@@ -188,7 +188,8 @@ public class SyncPartitionUtilsTest {
 
     private Map<String, PListCell> diffList(Map<String, PCell> baseListMap,
                                             Map<String, PCell> mvListMap) {
-        Map<String, PCell> result = ListPartitionDiffer.diffList(baseListMap, mvListMap);
+        Map<String, PCell> result = ListPartitionDiffer.diffList(baseListMap, mvListMap,
+                mvListMap.keySet().stream().collect(Collectors.toSet()));
         return result.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> (PListCell) entry.getValue()));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
@@ -50,11 +51,14 @@ import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.scheduler.mv.MVPCTBasedRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SystemVariable;
+import com.starrocks.sql.common.PCell;
+import com.starrocks.sql.common.PListCell;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.MaterializedViewOptimizer;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -88,10 +92,13 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -675,5 +682,74 @@ public abstract class MVTestBase extends StarRocksTestBase {
         ExecuteOption executeOption = new ExecuteOption(70, false, new HashMap<>());
         TaskRun taskRun = taskManager.buildTaskRun(task, executeOption);
         return taskManager.getMVRefreshExecPlan(taskRun, task, executeOption, stmt);
+    }
+
+    public static List<String> extractColumnValues(String sql, int columnIndex) {
+        List<String> result = new ArrayList<>();
+
+        // Regex pattern to match the VALUES clause and all parenthesized value groups
+        Pattern pattern = Pattern.compile("(?i)values\\s*([^)]+)(?:\\s*,\\s*([^)]+))*\\s*;?");
+        Matcher matcher = pattern.matcher(sql);
+
+        if (matcher.find()) {
+            // Process first set of values
+            processValueGroup(matcher.group(1), columnIndex, result);
+
+            // Process subsequent value groups
+            for (int i = 2; i <= matcher.groupCount(); i++) {
+                if (matcher.group(i) != null) {
+                    processValueGroup(matcher.group(i), columnIndex, result);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static void processValueGroup(String valueGroup, int columnIndex, List<String> result) {
+        // Split by commas but ignore commas inside quotes
+        String[] values = valueGroup.split(",(?=(?:[^']*'[^']*')*[^']*$)");
+
+        if (columnIndex < values.length) {
+            String value = values[columnIndex].trim();
+            // Remove surrounding quotes if present
+            value = cleanSqlValue(value);
+            result.add(value);
+        }
+    }
+
+    public static String cleanSqlValue(String input) {
+        if (input == null) {
+            return null;
+        }
+        String result = input.trim();
+        int len = result.length();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < len; i++) {
+            if (result.charAt(i) == '\'' || result.charAt(i) == '\"' || result.charAt(i) == '`' ||
+                    result.charAt(i) == '(' || result.charAt(i) == ')') {
+                continue;
+            } else {
+                sb.append(result.charAt(i));
+            }
+        }
+        return sb.toString();
+    }
+
+    protected void addListPartition(String tbl, List<String> values) {
+        Map<String, PCell> partitions = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+        for (String val : values) {
+            PListCell pListCell = new PListCell(val);
+            String pName = AnalyzerUtils.getFormatPartitionValue(val);
+            if (partitions.containsKey(pName)) {
+                try {
+                    pName = AnalyzerUtils.calculateUniquePartitionName(pName, pListCell, partitions);
+                } catch (Exception e) {
+                    Assertions.fail("add partition failed:" + e);
+                }
+            }
+            partitions.put(pName, pListCell);
+            addListPartition(tbl, pName, val);
+        }
     }
 }

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_duplicated_partition_names
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_duplicated_partition_names
@@ -1,0 +1,103 @@
+-- name: test_mv_refresh_list_partitions_with_duplicated_partition_names
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `col1` varchar(100) NOT NULL COMMENT "",
+  `col2` varchar(100) NULL COMMENT "",
+  `col3` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`col1`)
+PARTITION BY (`col1`)
+DISTRIBUTED BY HASH(`col1`) BUCKETS 5
+ORDER BY(`col2`)
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "true",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 values('demo-diu.com', 'b', 2), ('demo-DIU.com', 'a', 1) , ('demo-diu.com', 'b', 2);
+-- result:
+-- !result
+insert into t1 values('demo-dIU.com', 'a', 1) , ('demo-Diu.com', 'b', 2);
+-- result:
+-- !result
+CREATE TABLE `t2` (
+  `col1` varchar(100) NOT NULL COMMENT "",
+  `col2` varchar(100) NULL COMMENT "",
+  `col3` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`col1`)
+PARTITION BY (`col1`)
+DISTRIBUTED BY HASH(`col1`) BUCKETS 5
+ORDER BY(`col2`)
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "true",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t2 values('demo-DIU.com', 'a', 1) , ('demo-diu.com', 'b', 2), ('demo-dIU.com', 'a', 1) , ('demo-Diu.com', 'b', 2);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY col1
+DISTRIBUTED BY HASH(col1) BUCKETS 5
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "partition_refresh_number" = "-1"
+)
+AS
+select t1.col1, t1.col2 from t1 left join t2 on t1.col1 = t2.col1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT * FROM test_mv1 ORDER BY col1, col2;
+-- result:
+demo-DIU.com	a
+demo-Diu.com	b
+demo-dIU.com	a
+demo-diu.com	b
+-- !result
+insert into t1 values('demo-diu.com', 'b', 2), ('demo-DIU.com', 'a', 1) , ('demo-diu.com', 'b', 2);
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT * FROM test_mv1 ORDER BY col1, col2;
+-- result:
+demo-DIU.com	a
+demo-Diu.com	b
+demo-dIU.com	a
+demo-diu.com	b
+-- !result
+insert into t1 values('demo-DIU.com', 'a', 1) , ('demo-DiU.com', 'b', 2);
+-- result:
+-- !result
+insert into t2 values('demo-DIU.com', 'a', 1) , ('demo-dIu.com', 'b', 2), ('demo-dIU.com', 'a', 1) , ('demo-DIu.com', 'b', 2);
+-- result:
+-- !result
+insert into t1 values('demo-diu.com', 'b', 2), ('demo-DIU.com', 'a', 1) , ('demo-diu.com', 'b', 2);
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT * FROM test_mv1 ORDER BY col1, col2;
+-- result:
+demo-DIU.com	a
+demo-DiU.com	b
+demo-Diu.com	b
+demo-dIU.com	a
+demo-diu.com	b
+-- !result
+DROP database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_duplicated_partition_names
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_duplicated_partition_names
@@ -1,0 +1,67 @@
+-- name: test_mv_refresh_list_partitions_with_duplicated_partition_names
+
+create database db_${uuid0};
+use db_${uuid0};
+
+
+CREATE TABLE `t1` (
+  `col1` varchar(100) NOT NULL COMMENT "",
+  `col2` varchar(100) NULL COMMENT "",
+  `col3` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`col1`)
+PARTITION BY (`col1`)
+DISTRIBUTED BY HASH(`col1`) BUCKETS 5
+ORDER BY(`col2`)
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "true",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+insert into t1 values('demo-diu.com', 'b', 2), ('demo-DIU.com', 'a', 1) , ('demo-diu.com', 'b', 2);
+insert into t1 values('demo-dIU.com', 'a', 1) , ('demo-Diu.com', 'b', 2);
+
+CREATE TABLE `t2` (
+  `col1` varchar(100) NOT NULL COMMENT "",
+  `col2` varchar(100) NULL COMMENT "",
+  `col3` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`col1`)
+PARTITION BY (`col1`)
+DISTRIBUTED BY HASH(`col1`) BUCKETS 5
+ORDER BY(`col2`)
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "true",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+insert into t2 values('demo-DIU.com', 'a', 1) , ('demo-diu.com', 'b', 2), ('demo-dIU.com', 'a', 1) , ('demo-Diu.com', 'b', 2);
+
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY col1
+DISTRIBUTED BY HASH(col1) BUCKETS 5
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "partition_refresh_number" = "-1"
+)
+AS
+select t1.col1, t1.col2 from t1 left join t2 on t1.col1 = t2.col1;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT * FROM test_mv1 ORDER BY col1, col2;
+
+insert into t1 values('demo-diu.com', 'b', 2), ('demo-DIU.com', 'a', 1) , ('demo-diu.com', 'b', 2);
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT * FROM test_mv1 ORDER BY col1, col2;
+
+insert into t1 values('demo-DIU.com', 'a', 1) , ('demo-DiU.com', 'b', 2);
+insert into t2 values('demo-DIU.com', 'a', 1) , ('demo-dIu.com', 'b', 2), ('demo-dIU.com', 'a', 1) , ('demo-DIu.com', 'b', 2);
+insert into t1 values('demo-diu.com', 'b', 2), ('demo-DIU.com', 'a', 1) , ('demo-diu.com', 'b', 2);
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT * FROM test_mv1 ORDER BY col1, col2;
+
+DROP database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

```
2025-08-22 09:23:44.383Z WARN (starrocks-taskrun-pool-2644|1012347) [PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry():385] [application_app_stage_position_profile_mv] refresh mv failed at 1th time: com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: Duplicate partition name xxxx.
```

For list partition MV, we need to ensure mv's partition name should be unique in case-insensitive mode since StarRocks OlapTable's partitions are case-insensitive.


## What I'm doing:
- Follow #54278 's design, ensure mv's partition name unique in case-insensitive mode.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
