### PR TITLE
[BugFix] Fix UAF for BinaryColumn::append_selective

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -93,14 +93,13 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
     indexes += from;
 
     const auto& src_column = down_cast<const BinaryColumnBase<T>&>(src);
-    const auto* __restrict src_offsets = src_column.get_offset().data();
-    const auto* __restrict src_bytes = src_column.get_bytes().data();
 
     const size_t prev_num_offsets = _offsets.size();
     const size_t prev_num_rows = prev_num_offsets - 1;
 
     _offsets.resize(prev_num_offsets + size * 2);
     auto* __restrict new_offsets = _offsets.data() + prev_num_offsets;
+    const auto* __restrict src_offsets = src_column.get_offset().data();
 
     // Buffer i-th start offset and end offset in new_offsets[i * 2] and new_offsets[i * 2 + 1].
     for (size_t i = 0; i < size; i++) {
@@ -116,6 +115,7 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
             num_bytes += new_offsets[i * 2 + 1] - new_offsets[i * 2];
         }
         _bytes.resize(num_bytes);
+        const auto* __restrict src_bytes = src_column.get_bytes().data();
         auto* __restrict dest_bytes = _bytes.data();
         size_t cur_offset = _offsets[prev_num_rows];
 


### PR DESCRIPTION
## Why I'm doing:

Introduced by #62165. 
Inspired by #62375.

`BinaryColumn::append_selective` gets pointers of `src_offsets` and `src_bytes` from `src_column` first, and then resizes `dst_offsets` and `dst_bytess` of `dst_column`.
However, if `src_column` and `dst_column` are identical, then `src_offsets` and `src_bytes` would be a dangling pointer.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
