### PR TITLE
[BugFix] Fix publish incorrectly reported as successful during graceful shutdown in shared-nothing

### DIFF
--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -141,7 +141,7 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
                         tablet_span->SetAttribute("tablet_id", task.tablet_id);
                         tablet_span->SetAttribute("version", task.version);
                         if (!is_replication_txn && !task.rowset) {
-                            task.st = Status::NotFound(fmt::format("rowset not found  of tablet: {}, txn_id: {}",
+                            task.st = Status::NotFound(fmt::format("rowset not found of tablet: {}, txn_id: {}",
                                                                    task.tablet_id, task.txn_id));
                             LOG(WARNING) << task.st;
                             return;

--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -128,83 +128,94 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
         uint32_t retry_time = 0;
         Status st;
         while (retry_time++ < PUBLISH_VERSION_SUBMIT_MAX_RETRY) {
-            st = token->submit_func([&]() {
-                auto& task = tablet_task;
-                auto tablet_span = Tracer::Instance().add_span("tablet_publish_txn", span);
-                auto scoped_tablet_span = trace::Scope(tablet_span);
-                tablet_span->SetAttribute("txn_id", transaction_id);
-                tablet_span->SetAttribute("tablet_id", task.tablet_id);
-                tablet_span->SetAttribute("version", task.version);
-                if (!is_replication_txn && !task.rowset) {
-                    task.st = Status::NotFound(
-                            fmt::format("rowset not found  of tablet: {}, txn_id: {}", task.tablet_id, task.txn_id));
-                    LOG(WARNING) << task.st;
-                    return;
-                }
-                TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(task.tablet_id);
-                if (!tablet) {
-                    // tablet may get dropped, it's ok to ignore this situation
-                    LOG(WARNING) << fmt::format(
-                            "publish_version tablet not found tablet_id: {}, version: {} txn_id: {}", task.tablet_id,
-                            task.version, task.txn_id);
-                    return;
-                }
-                {
-                    std::lock_guard lg(affected_dirs_lock);
-                    affected_dirs.insert(tablet->data_dir());
-                }
-                if (is_replication_txn) {
-                    task.st = StorageEngine::instance()->replication_txn_manager()->publish_txn(
-                            task.txn_id, task.partition_id, tablet, task.version);
-                    if (!task.st.ok()) {
-                        LOG(WARNING) << "Publish txn failed tablet:" << tablet->tablet_id()
-                                     << " version:" << task.version << " partition:" << task.partition_id
-                                     << " txn_id: " << task.txn_id;
-                        std::string_view msg = task.st.message();
-                        tablet_span->SetStatus(trace::StatusCode::kError, {msg.data(), msg.size()});
-                    } else {
-                        VLOG(2) << "Publish txn success tablet:" << tablet->tablet_id() << " version:" << task.version
-                                << " tablet_max_version:" << tablet->max_continuous_version()
-                                << " partition:" << task.partition_id << " txn_id: " << task.txn_id;
-                    }
-                } else if (is_version_overwrite) {
-                    task.st = StorageEngine::instance()->txn_manager()->publish_overwrite_txn(
-                            task.partition_id, tablet, task.txn_id, task.version, task.rowset, wait_time);
-                    if (!task.st.ok()) {
-                        LOG(WARNING) << "Publish overwrite txn failed tablet:" << tablet->tablet_id()
-                                     << " version:" << task.version << " partition:" << task.partition_id
-                                     << " txn_id: " << task.txn_id << " rowset:" << task.rowset->rowset_id();
-                        std::string_view msg = task.st.message();
-                        tablet_span->SetStatus(trace::StatusCode::kError, {msg.data(), msg.size()});
-                    } else {
-                        LOG(INFO) << "Publish overwrite txn success tablet:" << tablet->tablet_id()
-                                  << " version:" << task.version
-                                  << " tablet_max_version:" << tablet->max_continuous_version()
-                                  << " partition:" << task.partition_id << " txn_id: " << task.txn_id
-                                  << " rowset:" << task.rowset->rowset_id();
-                    }
-                } else {
-                    task.st = StorageEngine::instance()->txn_manager()->publish_txn(
-                            task.partition_id, tablet, task.txn_id, task.version, task.rowset, wait_time,
-                            task.is_double_write);
-                    if (!task.st.ok()) {
-                        LOG(WARNING) << "Publish txn failed tablet:" << tablet->tablet_id()
-                                     << " version:" << task.version << " partition:" << task.partition_id
-                                     << " txn_id: " << task.txn_id << " rowset:" << task.rowset->rowset_id();
-                        std::string_view msg = task.st.message();
-                        tablet_span->SetStatus(trace::StatusCode::kError, {msg.data(), msg.size()});
-                    } else {
-                        if (task.is_double_write || VLOG_ROW_IS_ON) {
-                            LOG(INFO) << "Publish txn success tablet:" << tablet->tablet_id()
-                                      << " version:" << task.version
-                                      << " tablet_max_version:" << tablet->max_continuous_version()
-                                      << " is_double_write:" << task.is_double_write
-                                      << " partition:" << task.partition_id << " txn_id: " << task.txn_id
-                                      << " rowset:" << task.rowset->rowset_id();
+            auto task = std::make_shared<CancellableRunnable>(
+                    [&]() {
+                        auto& task = tablet_task;
+                        auto tablet_span = Tracer::Instance().add_span("tablet_publish_txn", span);
+                        auto scoped_tablet_span = trace::Scope(tablet_span);
+                        tablet_span->SetAttribute("txn_id", transaction_id);
+                        tablet_span->SetAttribute("tablet_id", task.tablet_id);
+                        tablet_span->SetAttribute("version", task.version);
+                        if (!is_replication_txn && !task.rowset) {
+                            task.st = Status::NotFound(fmt::format("rowset not found  of tablet: {}, txn_id: {}",
+                                                                   task.tablet_id, task.txn_id));
+                            LOG(WARNING) << task.st;
+                            return;
                         }
-                    }
-                }
-            });
+                        TabletSharedPtr tablet =
+                                StorageEngine::instance()->tablet_manager()->get_tablet(task.tablet_id);
+                        if (!tablet) {
+                            // tablet may get dropped, it's ok to ignore this situation
+                            LOG(WARNING) << fmt::format(
+                                    "publish_version tablet not found tablet_id: {}, version: {} txn_id: {}",
+                                    task.tablet_id, task.version, task.txn_id);
+                            return;
+                        }
+                        {
+                            std::lock_guard lg(affected_dirs_lock);
+                            affected_dirs.insert(tablet->data_dir());
+                        }
+                        if (is_replication_txn) {
+                            task.st = StorageEngine::instance()->replication_txn_manager()->publish_txn(
+                                    task.txn_id, task.partition_id, tablet, task.version);
+                            if (!task.st.ok()) {
+                                LOG(WARNING) << "Publish txn failed tablet:" << tablet->tablet_id()
+                                             << " version:" << task.version << " partition:" << task.partition_id
+                                             << " txn_id: " << task.txn_id;
+                                std::string_view msg = task.st.message();
+                                tablet_span->SetStatus(trace::StatusCode::kError, {msg.data(), msg.size()});
+                            } else {
+                                VLOG(2) << "Publish txn success tablet:" << tablet->tablet_id()
+                                        << " version:" << task.version
+                                        << " tablet_max_version:" << tablet->max_continuous_version()
+                                        << " partition:" << task.partition_id << " txn_id: " << task.txn_id;
+                            }
+                        } else if (is_version_overwrite) {
+                            task.st = StorageEngine::instance()->txn_manager()->publish_overwrite_txn(
+                                    task.partition_id, tablet, task.txn_id, task.version, task.rowset, wait_time);
+                            if (!task.st.ok()) {
+                                LOG(WARNING) << "Publish overwrite txn failed tablet:" << tablet->tablet_id()
+                                             << " version:" << task.version << " partition:" << task.partition_id
+                                             << " txn_id: " << task.txn_id << " rowset:" << task.rowset->rowset_id();
+                                std::string_view msg = task.st.message();
+                                tablet_span->SetStatus(trace::StatusCode::kError, {msg.data(), msg.size()});
+                            } else {
+                                LOG(INFO) << "Publish overwrite txn success tablet:" << tablet->tablet_id()
+                                          << " version:" << task.version
+                                          << " tablet_max_version:" << tablet->max_continuous_version()
+                                          << " partition:" << task.partition_id << " txn_id: " << task.txn_id
+                                          << " rowset:" << task.rowset->rowset_id();
+                            }
+                        } else {
+                            task.st = StorageEngine::instance()->txn_manager()->publish_txn(
+                                    task.partition_id, tablet, task.txn_id, task.version, task.rowset, wait_time,
+                                    task.is_double_write);
+                            if (!task.st.ok()) {
+                                LOG(WARNING) << "Publish txn failed tablet:" << tablet->tablet_id()
+                                             << " version:" << task.version << " partition:" << task.partition_id
+                                             << " txn_id: " << task.txn_id << " rowset:" << task.rowset->rowset_id();
+                                std::string_view msg = task.st.message();
+                                tablet_span->SetStatus(trace::StatusCode::kError, {msg.data(), msg.size()});
+                            } else {
+                                if (task.is_double_write || VLOG_ROW_IS_ON) {
+                                    LOG(INFO) << "Publish txn success tablet:" << tablet->tablet_id()
+                                              << " version:" << task.version
+                                              << " tablet_max_version:" << tablet->max_continuous_version()
+                                              << " is_double_write:" << task.is_double_write
+                                              << " partition:" << task.partition_id << " txn_id: " << task.txn_id
+                                              << " rowset:" << task.rowset->rowset_id();
+                                }
+                            }
+                        }
+                    },
+                    [&]() {
+                        tablet_task.st = st = Status::Cancelled(fmt::format(
+                                "publish version task has been cancelled, tablet_id={}, version={}",
+                                    tablet_task.tablet_id, tablet_task.version));
+                        VLOG(1) << tablet_task.st;
+                    });
+
+            st = token->submit(std::move(task));
             if (st.is_service_unavailable()) {
                 int64_t retry_sleep_ms = 50 * retry_time;
                 LOG(WARNING) << "publish version threadpool is busy, retry in  " << retry_sleep_ms

--- a/be/test/storage/publish_version_task_test.cpp
+++ b/be/test/storage/publish_version_task_test.cpp
@@ -454,7 +454,7 @@ TEST_F(PublishVersionTaskTest, test_publish_version_cancellation) {
                 cv.wait(lk, [&] { return release_blocker; });
             },
             [&]() {
-                // no-op for blocker cancel
+                // Cancel is a no-op since the blocker task is released via condition variable, not by cancellation.
             });
     ASSERT_TRUE(pool->submit(std::move(blocker)).ok());
 


### PR DESCRIPTION
## Why I'm doing:
* The publish-version path on BE could silently “lose” per-tablet results when the thread pool was shutting down.
* Tasks were submitted via a function wrapper whose `cancel()` was a no-op. During shutdown, queued tasks are removed and `cancel()` is invoked later; because `cancel()` did nothing, `task.status` was never set, so `error_tablet_ids` could be empty despite tasks being dropped.
* This can lead to inconsistencies:
   * BE fails to publish a tablet version, but FE considers the publish completed successfully because `error_tablet_ids` is empty
   * BE replica ends up with a version hole; subsequent queries on that replica fail with errors like: `capture_consistent_versions error: version not found`.

This issue is similar to #59814 on shared-data.

## What I'm doing:
* Replace function submission with `CancellableRunnable` for per-tablet publish tasks
  * Function-based submission (`submit_func`) uses a runnable whose `cancel()` is a no-op. When the pool shuts down and drops queued tasks, `cancel()` is invoked but has no effect, so task.st is never set.
  * `CancellableRunnable` gives us a real `cancel()` hook; on shutdown, we set task.st = Status::Cancelled(...), guaranteeing failures surface to the caller. So the error is included in `error_tablet_ids`.

* Coordinate completion with a per-task `CountDownLatch` instead of relying on `token->wait()`
  * Thread pool shutdown removes queued tasks first and defers calling `cancel()` (cleanup is deferred). `token->wait()` can return as soon as the token quiesces, which might happen before deferred cancel runs. That creates a race where aggregation sees “unset” tasks.
  * A `CountDownLatch` sized to the number of tablets ensures we only return after each task is accounted for by exactly one of:
    * `run()` has completed (DeferOp counts down on exit),
    * `cancel()` has executed (counts down and sets Cancelled),
    * submit failed (we set an error immediately and count down).

* Tests
  * Add a cancellation-focused test that:
    * Simulate a busy publish thread pool so publish tasks are enqueued, then trigger a controlled shutdown while a long-running task is active.
    * Expect the publish for the tablet to be reported as failed (cancelled) and no silent success; error_tablet_ids contains the target tablet.

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
