### PR TITLE
[BugFix] Fix mv refresh with potential to-refresh partitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ thirdparty/installed
 core.*
 extension/spark-doris-connector/.classpath
 extension/spark-doris-connector/target
-contrib/.*/target/
+contrib/*/target/
 fe/log
 **/ut_ports
 venv/

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -40,6 +40,7 @@ import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
@@ -306,9 +307,12 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
     /**
      * Get extra explain info for the mv refresh task run which is used for explain task run.
      */
-    public String getExtraExplainInfo() {
+    public String getExtraExplainInfo(StatementBase statement) {
         StringBuilder sb = new StringBuilder();
-        if (mvRefreshProcessor != null) {
+        if (mvRefreshProcessor != null && statement.isExplain()) {
+            if (statement.isExplainTrace() || statement.isExplainAnalyze()) {
+                return "";
+            }
             try {
                 TaskRunStatus status = mvTaskRunContext.getStatus();
                 if (status != null && status.getMvTaskRunExtraMessage() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -20,7 +20,6 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.StarRocksException;
@@ -37,6 +36,8 @@ import com.starrocks.scheduler.mv.BaseMVRefreshProcessor;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
 import com.starrocks.scheduler.mv.MVRefreshProcessorFactory;
 import com.starrocks.scheduler.mv.MVTraceUtils;
+import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
+import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.common.DmlException;
@@ -45,6 +46,7 @@ import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TUniqueId;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 
@@ -301,8 +303,57 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         return this.mvRefreshProcessor;
     }
 
-    public Set<String> getPCTMVToRefreshedPartitions(TaskRunContext context) throws AnalysisException, LockTimeoutException {
-        return this.mvRefreshProcessor.getPCTMVToRefreshedPartitions(context, true);
+    /**
+     * Get extra explain info for the mv refresh task run which is used for explain task run.
+     */
+    public String getExtraExplainInfo() {
+        StringBuilder sb = new StringBuilder();
+        if (mvRefreshProcessor != null) {
+            try {
+                TaskRunStatus status = mvTaskRunContext.getStatus();
+                if (status != null && status.getMvTaskRunExtraMessage() != null) {
+                    MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
+
+                    // mv partitions to refresh
+                    Set<String> mvPartitionsToRefresh = extraMessage.getMvPartitionsToRefresh();
+                    if (!CollectionUtils.isEmpty(mvPartitionsToRefresh)) {
+                        sb.append("\n");
+                        sb.append("MVToRefreshedPartitions: " + mvPartitionsToRefresh);
+                    }
+                    // base partitions to refresh
+                    Map<String, Set<String>> basePartitionsToRefreshMap = extraMessage.getBasePartitionsToRefreshMap();
+                    if (!basePartitionsToRefreshMap.isEmpty()) {
+                        sb.append("\n");
+                        sb.append("BasePartitionsToRefreshed: " + basePartitionsToRefreshMap);
+                    }
+                    // plan builder message
+                    Map<String, String> planBuilderMessage = extraMessage.getPlanBuilderMessage();
+                    if (!planBuilderMessage.isEmpty()) {
+                        sb.append("\n");
+                        sb.append("PlanBuilderMessage: " + extraMessage.getPlanBuilderMessage());
+                    }
+                    // next start partition
+                    String nextPartition = extraMessage.getNextPartitionStart();
+                    if (!StringUtils.isEmpty(nextPartition)) {
+                        sb.append("\n");
+                        sb.append("NextPartition: " + nextPartition);
+                    }
+                    // next end partition
+                    if (!StringUtils.isEmpty(extraMessage.getNextPartitionEnd())) {
+                        sb.append("\n");
+                        sb.append("NextPartitionEnd: " + extraMessage.getNextPartitionEnd());
+                    }
+                    // next partition values
+                    if (!StringUtils.isEmpty(extraMessage.getNextPartitionValues())) {
+                        sb.append("\n");
+                        sb.append("NextPartitionValues: " + extraMessage.getNextPartitionValues());
+                    }
+                }
+            } catch (Exception e) {
+                logger.warn("failed to get pct mv to refreshed partitions", e);
+            }
+        }
+        return sb.toString();
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -368,7 +368,7 @@ public class TaskManager implements MemoryTrackable {
         String explainString = StmtExecutor.buildExplainString(execPlan, statement,
                 ConnectContext.get(), ResourceGroupClassifier.QueryType.MV, statement.getExplainLevel());
         // add extra info
-        String extraInfo = getExtraExplainInfo(taskRun);
+        String extraInfo = getExtraExplainInfo(taskRun, statement);
         if (!Strings.isNullOrEmpty(extraInfo)) {
             explainString += "\n" + extraInfo;
         }
@@ -382,7 +382,8 @@ public class TaskManager implements MemoryTrackable {
                 .setConnectContext(ConnectContext.get()).build();
     }
 
-    private String getExtraExplainInfo(TaskRun taskRun) {
+    private String getExtraExplainInfo(TaskRun taskRun,
+                                       StatementBase statement) {
         TaskRunProcessor taskRunProcessor = taskRun.getProcessor();
         if (taskRunProcessor == null) {
             return "";
@@ -390,7 +391,7 @@ public class TaskManager implements MemoryTrackable {
         try {
             if (taskRunProcessor instanceof MVTaskRunProcessor) {
                 MVTaskRunProcessor mvRefreshProcessor = (MVTaskRunProcessor) taskRun.getProcessor();
-                return mvRefreshProcessor.getExtraExplainInfo();
+                return mvRefreshProcessor.getExtraExplainInfo(statement);
             } else {
                 return "";
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -66,7 +66,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -368,17 +367,13 @@ public class TaskManager implements MemoryTrackable {
         ExecPlan execPlan = getMVRefreshExecPlan(taskRun, task, option, statement);
         String explainString = StmtExecutor.buildExplainString(execPlan, statement,
                 ConnectContext.get(), ResourceGroupClassifier.QueryType.MV, statement.getExplainLevel());
-
-        // append pctmvToRefreshedPartitions
-        if (statement.getExplainLevel() == StatementBase.ExplainLevel.VERBOSE) {
-            Optional<Set<String>> pctmvToRefreshedPartitions = getPCTMVToRefreshedPartitions(taskRun);
-            if (pctmvToRefreshedPartitions.isPresent()) {
-                explainString += "\n" + "MVToRefreshedPartitions: " + pctmvToRefreshedPartitions.get();
-            }
+        // add extra info
+        String extraInfo = getExtraExplainInfo(taskRun);
+        if (!Strings.isNullOrEmpty(extraInfo)) {
+            explainString += "\n" + extraInfo;
         }
         return explainString;
     }
-
 
     public TaskRun buildTaskRun(Task task, ExecuteOption option) {
         return TaskRunBuilder.newBuilder(task)
@@ -387,13 +382,21 @@ public class TaskManager implements MemoryTrackable {
                 .setConnectContext(ConnectContext.get()).build();
     }
 
-    private Optional<Set<String>> getPCTMVToRefreshedPartitions(TaskRun taskRun) {
-        MVTaskRunProcessor mvRefreshProcessor = (MVTaskRunProcessor) taskRun.getProcessor();
+    private String getExtraExplainInfo(TaskRun taskRun) {
+        TaskRunProcessor taskRunProcessor = taskRun.getProcessor();
+        if (taskRunProcessor == null) {
+            return "";
+        }
         try {
-            return Optional.of(mvRefreshProcessor.getPCTMVToRefreshedPartitions(taskRun.buildTaskRunContext()));
+            if (taskRunProcessor instanceof MVTaskRunProcessor) {
+                MVTaskRunProcessor mvRefreshProcessor = (MVTaskRunProcessor) taskRun.getProcessor();
+                return mvRefreshProcessor.getExtraExplainInfo();
+            } else {
+                return "";
+            }
         } catch (Exception e) {
-            LOG.error("Failed to get PCTMVToRefreshedPartitions", e);
-            return Optional.empty();
+            LOG.error("Failed to get getExtraExplainInfo:", e);
+            return "";
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -372,6 +372,12 @@ public class TaskRun implements Comparable<TaskRun> {
 
         // post process task run
         try (Timer ignored = Tracers.watchScope("TaskRunPostProcess")) {
+            // record the final status of task run
+            if (taskRunContext != null && taskRunContext.getStatus() != null) {
+                Tracers.record("TaskRunStatus", taskRunContext.getStatus().toJSON());
+            }
+
+            // post process the task run
             processor.postTaskRun(taskRunContext);
         } catch (Exception e) {
             LOG.warn("Failed to post task run, task_id: {}, task_run_id: {}, error: {}",

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -96,6 +96,7 @@ public abstract class BaseMVRefreshProcessor {
     // Collect all bases tables of the mv to be updated meta after mv refresh success.
     // format :     table id -> <base table info, snapshot table>
     protected final MVPCTRefreshPartitioner mvRefreshPartitioner;
+    protected final MVRefreshParams mvRefreshParams;
 
     // Collect all base table snapshot infos for the mv which the snapshot infos are kept
     // and used in the final update meta.
@@ -128,8 +129,12 @@ public abstract class BaseMVRefreshProcessor {
         this.mvContext = mvContext;
         this.mvEntity = mvEntity;
         this.logger = MVTraceUtils.getLogger(mv, clazz);
+        // init mv refresh params
+        MaterializedView.PartitionRefreshStrategy partitionRefreshStrategy = mv.getPartitionRefreshStrategy();
+        boolean isForce = partitionRefreshStrategy == MaterializedView.PartitionRefreshStrategy.FORCE;
+        this.mvRefreshParams = new MVRefreshParams(mv.getPartitionInfo(), mvContext.getProperties(), isForce);
         // prepare mv refresh partitioner
-        this.mvRefreshPartitioner = buildMvRefreshPartitioner(mv, mvContext);
+        this.mvRefreshPartitioner = buildMvRefreshPartitioner(mv, mvContext, mvRefreshParams);
     }
 
     /**
@@ -177,14 +182,15 @@ public abstract class BaseMVRefreshProcessor {
      * Create a mv refresh partitioner by the mv's partition info.
      */
     private MVPCTRefreshPartitioner buildMvRefreshPartitioner(MaterializedView mv,
-                                                              TaskRunContext context) {
+                                                              TaskRunContext context,
+                                                              MVRefreshParams mvRefreshParams) {
         PartitionInfo partitionInfo = mv.getPartitionInfo();
         if (partitionInfo.isUnPartitioned()) {
-            return new MVPCTRefreshNonPartitioner(mvContext, context, db, mv);
+            return new MVPCTRefreshNonPartitioner(mvContext, context, db, mv, mvRefreshParams);
         } else if (partitionInfo.isRangePartition()) {
-            return new MVPCTRefreshRangePartitioner(mvContext, context, db, mv);
+            return new MVPCTRefreshRangePartitioner(mvContext, context, db, mv, mvRefreshParams);
         } else if (partitionInfo.isListPartition()) {
-            return new MVPCTRefreshListPartitioner(mvContext, context, db, mv);
+            return new MVPCTRefreshListPartitioner(mvContext, context, db, mv, mvRefreshParams);
         } else {
             throw new DmlException(String.format("materialized view:%s in database:%s refresh failed: partition info %s not " +
                     "supported", mv.getName(), db.getFullName(), partitionInfo));
@@ -297,7 +303,7 @@ public abstract class BaseMVRefreshProcessor {
                     throw new DmlException(String.format("materialized view %s refresh task failed: sync partition failed",
                             mv.getName()));
                 }
-                Set<String> mvCandidatePartition = getPCTMVToRefreshedPartitions(taskRunContext, true);
+                Set<String> mvCandidatePartition = getPCTMVToRefreshedPartitions(true);
                 baseTableCandidatePartitions = getPCTRefTableRefreshPartitions(mvCandidatePartition);
             } catch (Exception e) {
                 logger.warn("failed to compute candidate partitions in sync partitions",
@@ -333,7 +339,7 @@ public abstract class BaseMVRefreshProcessor {
     }
 
     protected void updatePCTToRefreshMetas(TaskRunContext taskRunContext) throws Exception {
-        this.pctMVToRefreshedPartitions = getPCTMVToRefreshedPartitions(taskRunContext, false);
+        this.pctMVToRefreshedPartitions = getPCTMVToRefreshedPartitions(false);
         // ref table of mv : refreshed partition names
         this.pctRefTableRefreshPartitions = getPCTRefTableRefreshPartitions(pctMVToRefreshedPartitions);
         // ref table of mv : refreshed partition names
@@ -562,18 +568,20 @@ public abstract class BaseMVRefreshProcessor {
         return tables;
     }
 
+    /**
+     * @param tentative: if true, it means this is called in the first phase to compute candidate partitions and not the
+     *                 standard phase to get final partitions to refresh.
+     */
     @VisibleForTesting
-    public Set<String> getPCTMVToRefreshedPartitions(TaskRunContext context,
-                                                     boolean tentative) throws AnalysisException, LockTimeoutException {
-        final MaterializedView.PartitionRefreshStrategy partitionRefreshStrategy = mv.getPartitionRefreshStrategy();
-        boolean isForce = partitionRefreshStrategy == MaterializedView.PartitionRefreshStrategy.FORCE || tentative;
-        final MVRefreshParams mvRefreshParams = new MVRefreshParams(mv.getPartitionInfo(), context.getProperties(), isForce);
+    public Set<String> getPCTMVToRefreshedPartitions(boolean tentative) throws AnalysisException, LockTimeoutException {
+        // change mv refresh params if needed
+        mvRefreshParams.setIsTentative(tentative);
 
         final Set<String> mvPotentialPartitionNames = Sets.newHashSet();
         final PCellSortedSet mvToRefreshedPartitions = mvRefreshPartitioner.getMVToRefreshedPartitions(
-                snapshotBaseTables, mvRefreshParams, mvPotentialPartitionNames, tentative);
+                snapshotBaseTables, mvPotentialPartitionNames);
         // update mv extra message
-        if (!tentative) {
+        if (!mvRefreshParams.isTentative()) {
             updateTaskRunStatus(status -> {
                 MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
                 extraMessage.setForceRefresh(mvRefreshParams.isForce());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -571,7 +571,7 @@ public abstract class BaseMVRefreshProcessor {
 
         final Set<String> mvPotentialPartitionNames = Sets.newHashSet();
         final PCellSortedSet mvToRefreshedPartitions = mvRefreshPartitioner.getMVToRefreshedPartitions(
-                snapshotBaseTables, mvRefreshParams, partitionRefreshStrategy, mvPotentialPartitionNames, tentative);
+                snapshotBaseTables, mvRefreshParams, mvPotentialPartitionNames, tentative);
         // update mv extra message
         if (!tentative) {
             updateTaskRunStatus(status -> {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
@@ -38,8 +38,9 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     public MVPCTRefreshNonPartitioner(MvTaskRunContext mvContext,
                                       TaskRunContext context,
                                       Database db,
-                                      MaterializedView mv) {
-        super(mvContext, context, db, mv);
+                                      MaterializedView mv,
+                                      MVRefreshParams mvRefreshParams) {
+        super(mvContext, context, db, mv, mvRefreshParams);
     }
 
     @Override
@@ -78,7 +79,6 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     @Override
     public PCellSortedSet getMVPartitionsToRefresh(PartitionInfo mvPartitionInfo,
                                                    Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
-                                                   MVRefreshParams mvRefreshParams,
                                                    Set<String> mvPotentialPartitionNames) {
         // non-partitioned materialized view
         if (mvRefreshParams.isForce() || isNonPartitionedMVNeedToRefresh(snapshotBaseTables, mv)) {
@@ -94,20 +94,19 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     }
 
     @Override
-    public PCellSortedSet getMVPartitionNamesWithTTL(MaterializedView materializedView,
-                                                     MVRefreshParams mvRefreshParams,
-                                                     boolean isAutoRefresh) {
+    public PCellSortedSet getMVPartitionNamesWithTTL(boolean isAutoRefresh) {
         return PCellSortedSet.of();
     }
 
+    @Override
     public void filterPartitionByRefreshNumber(PCellSortedSet mvPartitionsToRefresh,
-                                               Set<String> mvPotentialPartitionNames, boolean tentative) {
+                                               Set<String> mvPotentialPartitionNames) {
         // do nothing
     }
 
     @Override
     public void filterPartitionByAdaptiveRefreshNumber(PCellSortedSet mvPartitionsToRefresh,
-                                                       Set<String> mvPotentialPartitionNames, boolean tentative) {
+                                                       Set<String> mvPotentialPartitionNames) {
         // do nothing
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
@@ -88,6 +88,12 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     }
 
     @Override
+    public PCellSortedSet calcPotentialMVRefreshPartitions(Set<String> mvPotentialPartitionNames,
+                                                           PCellSortedSet result) {
+        return result;
+    }
+
+    @Override
     public PCellSortedSet getMVPartitionNamesWithTTL(MaterializedView materializedView,
                                                      MVRefreshParams mvRefreshParams,
                                                      boolean isAutoRefresh) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -153,8 +153,6 @@ public abstract class MVPCTRefreshPartitioner {
 
     /**
      * Get mv partition names with TTL based on the ref base table partitions.
-     *
-     * @param materializedView: materialized view to check.
      * @param isAutoRefresh:    is auto refresh or not.
      * @throws AnalysisException
      * @return: mv to refresh partition names with TTL based on the ref base table partitions.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
@@ -83,4 +83,13 @@ public class MVRefreshParams {
     public Set<PListCell> getListValues() {
         return listValues;
     }
+
+    @Override
+    public String toString() {
+        return "{rangeStart='" + rangeStart + '\'' +
+                ", rangeEnd='" + rangeEnd + '\'' +
+                ", isForce=" + isForce +
+                ", listValues=" + listValues +
+                '}';
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
@@ -34,6 +34,10 @@ public class MVRefreshParams {
     private final Set<PListCell> listValues;
     private final PartitionInfo mvPartitionInfo;
 
+    // whether the refresh is tentative, when it's true, it means the refresh is triggered temporarily and used for
+    // find candidate partitions to refresh.
+    private boolean isTentative = false;
+
     public MVRefreshParams(PartitionInfo partitionInfo,
                            Map<String, String> properties,
                            boolean tentative) {
@@ -47,11 +51,19 @@ public class MVRefreshParams {
     }
 
     public boolean isForceCompleteRefresh() {
-        return isForce && isCompleteRefresh();
+        return isForce() && isCompleteRefresh();
     }
 
     public boolean isForce() {
-        return isForce;
+        return isForce || isTentative;
+    }
+
+    public void setIsTentative(boolean tentative) {
+        this.isTentative = tentative;
+    }
+
+    public boolean isTentative() {
+        return isTentative;
     }
 
     public boolean isCompleteRefresh() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
@@ -101,6 +101,7 @@ public class MVRefreshParams {
         return "{rangeStart='" + rangeStart + '\'' +
                 ", rangeEnd='" + rangeEnd + '\'' +
                 ", isForce=" + isForce +
+                ", isTentative=" + isTentative +
                 ", listValues=" + listValues +
                 '}';
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
@@ -54,6 +54,10 @@ public class MVRefreshParams {
         return isForce() && isCompleteRefresh();
     }
 
+    public boolean isNonTentativeForce() {
+        return isForce && !isTentative;
+    }
+
     public boolean isForce() {
         return isForce || isTentative;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
@@ -179,6 +179,10 @@ public class MVTaskRunExtraMessage implements Writable {
                 Config.max_mv_task_run_meta_message_values_length);
     }
 
+    public Map<String, String> getPlanBuilderMessage() {
+        return planBuilderMessage;
+    }
+
     @Override
     public String toString() {
         return GsonUtils.GSON.toJson(this);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -989,7 +989,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
         PCellSortedSet mvToRefreshPartitionNames = getMVPCellWithNames(mv, mv.getPartitionNames());
         partitioner.filterPartitionByAdaptiveRefreshNumber(mvToRefreshPartitionNames,
-                Sets.newHashSet(), mv);
+                Sets.newHashSet());
         MvTaskRunContext mvContext = processor.getMvContext();
         Assertions.assertNull(mvContext.getNextPartitionStart());
         Assertions.assertNull(mvContext.getNextPartitionEnd());
@@ -1020,7 +1020,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
         partitioner.filterPartitionByAdaptiveRefreshNumber(getMVPCellWithNames(mv, mv.getPartitionNames()),
-                Sets.newHashSet(), mv);
+                Sets.newHashSet());
         MvTaskRunContext mvContext = processor.getMvContext();
         Assertions.assertNull(mvContext.getNextPartitionStart());
         Assertions.assertNull(mvContext.getNextPartitionEnd());
@@ -1064,7 +1064,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
         partitioner.filterPartitionByAdaptiveRefreshNumber(getMVPCellWithNames(mv, mv.getPartitionNames()),
-                Sets.newHashSet(), mv);
+                Sets.newHashSet());
         MvTaskRunContext mvContext = processor.getMvContext();
         Assertions.assertNull(mvContext.getNextPartitionStart());
         Assertions.assertNull(mvContext.getNextPartitionEnd());
@@ -1123,19 +1123,19 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
             // round 1
             PCellSortedSet toRefresh = getMVPCellWithNames(mv, allPartitions);
-            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet(), mv);
+            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet());
             assertPCellNameEquals("p0", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
 
             // round 2
             toRefresh = getMVPCellWithNames(mv, SetUtils.disjunction(allPartitions, refreshedPartitions));
-            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet(), mv);
+            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet());
             assertPCellNameEquals("p1", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
 
             // round 3
             toRefresh = getMVPCellWithNames(mv, SetUtils.disjunction(allPartitions, refreshedPartitions));
-            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet(), mv);
+            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet());
             assertPCellNameEquals("p2", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
         }
@@ -1147,31 +1147,31 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
             // round 1
             PCellSortedSet toRefresh = getMVPCellWithNames(mv, allPartitions);
-            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet(), mv);
+            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet());
             assertPCellNameEquals("p4", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
 
             // round 2
             toRefresh = getMVPCellWithNames(mv, SetUtils.disjunction(allPartitions, refreshedPartitions));
-            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet(), mv);
+            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet());
             assertPCellNameEquals("p3", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
 
             // round 3
             toRefresh = getMVPCellWithNames(mv, SetUtils.disjunction(allPartitions, refreshedPartitions));
-            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet(), mv);
+            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet());
             assertPCellNameEquals("p2", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
 
             // round 4
             toRefresh = getMVPCellWithNames(mv, SetUtils.disjunction(allPartitions, refreshedPartitions));
-            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet(), mv);
+            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet());
             assertPCellNameEquals("p1", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
 
             // round 5
             toRefresh = getMVPCellWithNames(mv, SetUtils.disjunction(allPartitions, refreshedPartitions));
-            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet(), mv);
+            partitioner.filterPartitionByRefreshNumber(toRefresh, Sets.newHashSet());
             assertPCellNameEquals("p0", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
             Config.materialized_view_refresh_ascending = true;
@@ -2816,7 +2816,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                     MVPCTBasedRefreshProcessor processor =
                             (MVPCTBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
 
-                    Set<String> result = processor.getPCTMVToRefreshedPartitions(mvTaskRunContext, false);
+                    Set<String> result = processor.getPCTMVToRefreshedPartitions(false);
                     Assertions.assertTrue(result.isEmpty());
                 });
     }
@@ -2859,7 +2859,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                     MVPCTBasedRefreshProcessor mvRefreshProcessor =
                             (MVPCTBasedRefreshProcessor) processor.getMVRefreshProcessor();
                     MvTaskRunContext mvTaskRunContext = new MvTaskRunContext(taskRunContext);
-                    Set<String> result = mvRefreshProcessor.getPCTMVToRefreshedPartitions(mvTaskRunContext, false);
+                    Set<String> result = mvRefreshProcessor.getPCTMVToRefreshedPartitions(false);
                     Assertions.assertFalse(result.isEmpty());
                     Set<String> expect = ImmutableSet.of("p0", "p1", "p2", "p3", "p4");
                     Assertions.assertEquals(expect, result);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitionerTest.java
@@ -34,8 +34,9 @@ public class MVPCTRefreshNonPartitionerTest {
         TaskRunContext taskRunContext = Mockito.mock(TaskRunContext.class);
         Database database = Mockito.mock(Database.class);
         MaterializedView mv = Mockito.mock(MaterializedView.class);
+        MVRefreshParams mvRefreshParams = Mockito.mock(MVRefreshParams.class);
         MVPCTRefreshNonPartitioner job = new MVPCTRefreshNonPartitioner(mvTaskRunContext, taskRunContext,
-                database, mv);
+                database, mv, mvRefreshParams);
         Iterator<PCellWithName> dummyIter = Collections.emptyIterator();
         int result = job.getAdaptivePartitionRefreshNumber(dummyIter);
         Assertions.assertEquals(0, result);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
@@ -68,7 +68,9 @@ public class MVPCTRefreshRangePartitionerTest {
         List<PCellWithName> partitions = Arrays.asList(PCellWithName.of("mv_p1", new PCellNone()),
                 PCellWithName.of("mv_p2", new PCellNone()));
         Iterator<PCellWithName> iter = partitions.iterator();
-        MVPCTRefreshRangePartitioner partitioner = new MVPCTRefreshRangePartitioner(mvContext, null, null, mv);
+        MVRefreshParams mvRefreshParams = new MVRefreshParams(mv.getPartitionInfo(), new HashMap<>(), false);
+        MVPCTRefreshRangePartitioner partitioner = new MVPCTRefreshRangePartitioner(mvContext, null,
+                null, mv, mvRefreshParams);
         MVAdaptiveRefreshException exception = Assertions.assertThrows(MVAdaptiveRefreshException.class,
                 () -> partitioner.getAdaptivePartitionRefreshNumber(iter));
         Assertions.assertTrue(exception.getMessage().contains("Missing too many partition stats"));
@@ -84,7 +86,9 @@ public class MVPCTRefreshRangePartitionerTest {
         when(mv.getPartitionInfo()).thenReturn(mock(PartitionInfo.class));
         when(mv.getTableProperty().getPartitionTTLNumber()).thenReturn(2);
 
-        MVPCTRefreshRangePartitioner partitioner = new MVPCTRefreshRangePartitioner(mvContext, null, null, mv);
+        MVRefreshParams mvRefreshParams = new MVRefreshParams(mv.getPartitionInfo(), new HashMap<>(), false);
+        MVPCTRefreshRangePartitioner partitioner = new MVPCTRefreshRangePartitioner(mvContext, null, null, mv,
+                mvRefreshParams);
 
         PCellSortedSet toRefreshPartitions = PCellSortedSet.of();
         toRefreshPartitions.add(PCellWithName.of("partition1", new PCellNone()));

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_potential_partitions
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_potential_partitions
@@ -1,0 +1,91 @@
+-- name: test_mv_refresh_with_potential_partitions
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+    `k1` date,
+    `k2` datetime,
+    `k3` char(20),
+    `k4` varchar(20),
+    `k5` boolean,
+    `k6` tinyint,
+    `k7` smallint,
+    `k8` int,
+    `k9` bigint,
+    `k10` largeint,
+    `k11` float,
+    `k12` double,
+    `k13` decimal(27,9)
+)
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
+COMMENT "OLAP"
+PARTITION BY RANGE (k1) (
+    START ("2020-06-01") END ("2020-09-01") EVERY (INTERVAL 3 day)
+    )
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1 
+SELECT 
+    date_add('2020-06-01', INTERVAL (series_id * 2) DAY) as k1,
+    date_add('2020-06-01 12:12:12', INTERVAL (series_id * 2) DAY) as k2,
+    'k3' as k3,
+    'k4' as k4,
+    (series_id % 2 = 0) as k5,
+    (series_id % 3 + 1) as k6,
+    2 as k7,
+    3 as k8,
+    4 as k9,
+    5 as k10,
+    1.1 as k11,
+    1.12 as k12,
+    2.889 as k13
+FROM TABLE(generate_series(0, 37)) t(series_id)
+WHERE date_add('2020-06-01', INTERVAL (series_id * 2) DAY) <= '2020-08-15';
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY date_trunc('month',k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH DEFERRED ASYNC
+AS SELECT k1,k6,k7,k8,k9,k10,k11,k12,k13 FROM t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT k1,k6,k7,k8,k9,k10,k11,k12,k13 FROM t1", "test_mv1")
+-- result:
+None
+-- !result
+SELECT COUNT(1) FROM test_mv1;
+-- result:
+38
+-- !result
+SELECT COUNT(1) FROM t1;
+-- result:
+38
+-- !result
+SELECT * FROM test_mv1 ORDER BY 1,2,3,4,5,6 LIMIT 5;
+-- result:
+2020-06-01	1	2	3	4	5	1.1	1.12	2.889000000
+2020-06-03	2	2	3	4	5	1.1	1.12	2.889000000
+2020-06-05	3	2	3	4	5	1.1	1.12	2.889000000
+2020-06-07	1	2	3	4	5	1.1	1.12	2.889000000
+2020-06-09	2	2	3	4	5	1.1	1.12	2.889000000
+-- !result
+SELECT * FROM t1 ORDER BY 1,2,3,4,5,6 LIMIT 5;
+-- result:
+2020-06-01	2020-06-01 12:12:12	k3	k4	1	1	2	3	4	5	1.1	1.12	2.889000000
+2020-06-03	2020-06-03 12:12:12	k3	k4	0	2	2	3	4	5	1.1	1.12	2.889000000
+2020-06-05	2020-06-05 12:12:12	k3	k4	1	3	2	3	4	5	1.1	1.12	2.889000000
+2020-06-07	2020-06-07 12:12:12	k3	k4	0	1	2	3	4	5	1.1	1.12	2.889000000
+2020-06-09	2020-06-09 12:12:12	k3	k4	1	2	2	3	4	5	1.1	1.12	2.889000000
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_potential_partitions
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_potential_partitions
@@ -1,0 +1,64 @@
+-- name: test_mv_refresh_with_potential_partitions
+
+create database db_${uuid0};
+use db_${uuid0};
+
+
+CREATE TABLE `t1` (
+    `k1` date,
+    `k2` datetime,
+    `k3` char(20),
+    `k4` varchar(20),
+    `k5` boolean,
+    `k6` tinyint,
+    `k7` smallint,
+    `k8` int,
+    `k9` bigint,
+    `k10` largeint,
+    `k11` float,
+    `k12` double,
+    `k13` decimal(27,9)
+)
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
+COMMENT "OLAP"
+PARTITION BY RANGE (k1) (
+    START ("2020-06-01") END ("2020-09-01") EVERY (INTERVAL 3 day)
+    )
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+);
+INSERT INTO t1 
+SELECT 
+    date_add('2020-06-01', INTERVAL (series_id * 2) DAY) as k1,
+    date_add('2020-06-01 12:12:12', INTERVAL (series_id * 2) DAY) as k2,
+    'k3' as k3,
+    'k4' as k4,
+    (series_id % 2 = 0) as k5,
+    (series_id % 3 + 1) as k6,
+    2 as k7,
+    3 as k8,
+    4 as k9,
+    5 as k10,
+    1.1 as k11,
+    1.12 as k12,
+    2.889 as k13
+FROM TABLE(generate_series(0, 37)) t(series_id)
+WHERE date_add('2020-06-01', INTERVAL (series_id * 2) DAY) <= '2020-08-15';
+
+
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY date_trunc('month',k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH DEFERRED ASYNC
+AS SELECT k1,k6,k7,k8,k9,k10,k11,k12,k13 FROM t1;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT k1,k6,k7,k8,k9,k10,k11,k12,k13 FROM t1", "test_mv1")
+SELECT COUNT(1) FROM test_mv1;
+SELECT COUNT(1) FROM t1;
+SELECT * FROM test_mv1 ORDER BY 1,2,3,4,5,6 LIMIT 5;
+SELECT * FROM t1 ORDER BY 1,2,3,4,5,6 LIMIT 5;
+
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

https://github.com/StarRocks/starrocks/pull/62301 introduces a bug which is caused by the wrong order:
- getPartitionsToRefreshForMaterializedView
  - calcPotentialMVRefreshPartitions
- filterMVToRefreshPartitions


`calcPotentialMVRefreshPartitions` must be put the end to find mv to-refresh associated partitions, the correct order is:
- getPartitionsToRefreshForMaterializedView
- filterMVToRefreshPartitions
- calcPotentialMVRefreshPartitions

## What I'm doing:
- Fix mv refresh with potential to-refresh partitions
- Remove some unnecessary codes.


Fixes https://github.com/StarRocks/StarRocksTest/issues/10148

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3