### PR TITLE
[BugFix] Fix colocate group execution not found exec group

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExecGroupSets.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExecGroupSets.java
@@ -45,7 +45,14 @@ public class ExecGroupSets {
                 return execGroup;
             }
         }
-        Preconditions.checkState(false, "not found exec group node: %d", nodeId);
         return null;
+    }
+
+    public ExecGroupId getExecGroupId(int nodeId) {
+        ExecGroup group = getExecGroup(nodeId);
+        if (group != null) {
+            return group.getGroupId();
+        }
+        return new ExecGroupId(-1);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -266,7 +266,7 @@ public class RuntimeFilterDescription {
         }
         // colocate runtime filter couldn't apply to other exec groups
         if (isBuildFromColocateGroup && joinMode.equals(COLOCATE)) {
-            int probeExecGroupId = rfPushCtx.getExecGroup(node.getId().asInt()).getGroupId().asInt();
+            int probeExecGroupId = rfPushCtx.getExecGroupId(node.getId().asInt()).asInt();
             if (execGroupId != probeExecGroupId) {
                 return false;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterPushDownContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterPushDownContext.java
@@ -41,7 +41,7 @@ public class RuntimeFilterPushDownContext {
         return description;
     }
 
-    public ExecGroup getExecGroup(int planNodeId) {
-        return this.execGroups.getExecGroup(planNodeId);
+    public ExecGroupId getExecGroupId(int planNodeId) {
+        return this.execGroups.getExecGroupId(planNodeId);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupExecutionPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupExecutionPlanTest.java
@@ -225,6 +225,14 @@ public class GroupExecutionPlanTest extends PlanTestBase {
             querys.add("select distinct tb.k1,tb.k2,tb.k3,tb.k4 from (select l.k1 k1, l.k2 k2,r.k1 k3,r.k2 k4 " +
                     "from (select k1, k2 from colocate1 l) l join [bucket] colocate2 r on l.k1 = r.k1 and l.k2 = r.k2) tb " +
                     "join colocate1 z;");
+            //                                      Colocate Join
+            //                                      /          \
+            //                        Bucket Shuffle Join      Scan
+            //                          /          \
+            //                       Scan           Exchange
+            //                                      Scan
+            querys.add("select * from colocate1 l left join [bucket] colocate2 r on l.k1=r.k1 and l.k2=r.k2 " +
+                    "join [colocate] colocate2 z on l.k1=z.k1 and l.k2=z.k2;");
             // CTE as probe runtime filter probe side
             querys.add("with a as (select distinct k1, k2 from colocate1) " +
                     "select distinct l.k1,r.k2 from colocate1 l join [broadcast] a r on l.k1=r.k1 and l.k2=r.k2 " +


### PR DESCRIPTION

## Why I'm doing:

Bucket shuffle/set operations may delete the exec group. This can cause the runtime filter to fail to locate the corresponding exec group during construction. In this PR, when the probe side cannot find the exec group, a dummy ID will be generated.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
