### PR TITLE
[BugFix] Fix division by zero for partition hash join

### DIFF
--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -612,6 +612,8 @@ void AdaptivePartitionHashJoinBuilder::_adjust_partition_rows(size_t hash_table_
     _hash_table_bytes_per_row = hash_table_bytes_per_row;
     _hash_table_probing_bytes_per_row = hash_table_probing_bytes_per_row;
 
+    hash_table_bytes_per_row = std::max<size_t>(hash_table_bytes_per_row, 1);
+
     _fit_L2_cache_max_rows = _L2_cache_size / hash_table_bytes_per_row;
     _fit_L3_cache_max_rows = _L3_cache_size / hash_table_bytes_per_row;
 


### PR DESCRIPTION
## Why I'm doing:
Introduced by ##61405.

`hash_table_bytes_per_row` may be zero, which cause BE crashed du to division by zero.

```cpp
    _fit_L2_cache_max_rows = _L2_cache_size / hash_table_bytes_per_row;
    _fit_L3_cache_max_rows = _L3_cache_size / hash_table_bytes_per_row;
```

In the 8th `do_append_chunk`, we’ve already counted the number of rows in the current chunk, but we compute
`const size_t build_row_size = (ht_mem_usage() + _mem_tracker.consumption()) / hash_table_row_count();`
before the append. As a result, there’s a small chance this evaluates to 0—specifically when the first seven chunks contain very few rows, the eighth chunk contains many rows, and the key size in bytes is small (e.g., `SMALLINT`).

```cpp
Status AdaptivePartitionHashJoinBuilder::do_append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
    if (_partition_num > 1 && !_need_partition_join_for_append(hash_table_row_count())) {
        RETURN_IF_ERROR(_convert_to_single_partition(state));
    }

    if (_partition_num > 1 && ++_pushed_chunks % 8 == 0) {
        const size_t build_row_size = (ht_mem_usage() + _mem_tracker.consumption()) / hash_table_row_count();
        _adjust_partition_rows(build_row_size, _hash_table_probing_bytes_per_row);
        if (_partition_num == 1) {
            RETURN_IF_ERROR(_convert_to_single_partition(state));
        }
    }

    if (_partition_num > 1) {
        RETURN_IF_ERROR(_do_append_chunk(state, chunk));
    } else {
        RETURN_IF_ERROR(_builders[0]->do_append_chunk(state, chunk));
    }

    return Status::OK();
}
```

## What I'm doing:


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
