### PR TITLE
[Enhancement] Change transform type prefer string for fixed length varchar

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -5547,7 +5547,6 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Whether to enable prefixes with materialized view names in logs for better debug.
 - Introduced in: v3.4.0
 
-
 ##### enable_mv_post_image_reload_cache
 
 - Default: true
@@ -5565,5 +5564,14 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: Yes
 - Description: Whether to allow the system to trace the historical nodes. By setting this item to `true`, you can enable the Cache Sharing feature and allow the system to choose the right cache nodes during elastic scaling.
 - Introduced in: v3.5.1
+
+##### transform_type_prefer_string_for_varchar
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to prefer string type for fixed length varchar columns in materialized view creation and CTAS operations.
+- Introduced in: v4.0.0
 
 <EditionSpecificFEItem />

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -3289,4 +3289,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: システムがヒストリカルノードをトレースすることを許可するかどうか。この項目を `true` に設定することで、キャッシュ共有機能を有効にし、エラスティックなスケーリング時にシステムが適切なキャッシュノードを選択できるようにすることができる。
 - 導入バージョン: v3.5.1
 
+##### transform_type_prefer_string_for_varchar
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: マテリアライズドビューの作成とCTAS操作において、固定長のVARCHAR列に対してSTRING型を優先するかどうか。
+- 導入バージョン: v4.0.0
+
 <EditionSpecificFEItem />

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -5530,4 +5530,13 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 - 描述：是否允许系统跟踪历史节点。将此项设置为 `true`，就可以启用 Cache Sharing 功能，并允许系统在弹性扩展过程中选择正确的缓存节点。
 - 引入版本：v3.5.1
 
+
+##### transform_type_prefer_string_for_varchar
+- 默认值：true
+- 类型：布尔值
+- 单位：-
+- 是否动态：是
+- 描述：在物化视图创建和 CTAS 操作中，是否优先对固定长度的 VARCHAR 列使用 STRING 类型。
+- 引入版本：v4.0.0
+
 <EditionSpecificFEItem />

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1481,7 +1481,7 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true, comment = "Whether to prefer string type for fixed length varchar column " +
             "in materialized view creation/ctas")
-    public static boolean transform_type_prefer_string_for_varchar = false;
+    public static boolean transform_type_prefer_string_for_varchar = true;
 
     /**
      * The number of query retries.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -177,9 +177,16 @@ public final class ColumnRefOperator extends ScalarOperator {
         }
 
         ColumnRefOperator rightColumn = (ColumnRefOperator) obj;
-        return SRStringUtils.areColumnNamesEqual(this.getName(), rightColumn.getName())
-                && this.getType().equals(rightColumn.getType())
-                && this.isNullable() == rightColumn.isNullable();
+        if (!SRStringUtils.areColumnNamesEqual(this.getName(), rightColumn.getName())
+                || this.isNullable() != rightColumn.isNullable()) {
+            return false;
+        }
+        if (type.isStringType()) {
+            // for string type, we only care about the type is string or not, since the length can be not strictly equal
+            return rightColumn.getType().isStringType();
+        } else {
+            return this.type.equals(rightColumn.type);
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
@@ -926,8 +926,8 @@ public class AggStateCombinatorTest extends MVTestBase {
                     + " from test_agg_state_table group by k1;";
             String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql1);
             PlanTestBase.assertContains(plan, "|  aggregate: array_agg_union[([2: v0, " +
-                    "struct<col1 array<varchar(100)>>, true]); args: INVALID_TYPE; result: " +
-                    "struct<col1 array<varchar(100)>>; args nullable: true; result nullable: true]");
+                    "struct<col1 array<varchar(1048576)>>, true]); args: INVALID_TYPE; " +
+                    "result: struct<col1 array<varchar(100)>>; args nullable: true; result nullable: true]");
             PlanTestBase.assertContains(plan, " 0:OlapScanNode\n" +
                     "     table: test_agg_state_table, rollup: test_agg_state_table");
         }
@@ -937,8 +937,8 @@ public class AggStateCombinatorTest extends MVTestBase {
             String sql1 = "select k1, " + Joiner.on(", ").join(mergeColumns)
                     + " from test_agg_state_table group by k1;";
             String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql1);
-            PlanTestBase.assertContains(plan, "|  aggregate: " +
-                    "array_agg_merge[([2: v0, struct<col1 array<varchar(100)>>, true]); args: INVALID_TYPE; " +
+            PlanTestBase.assertContains(plan, "|  aggregate: array_agg_merge[([2: v0, " +
+                    "struct<col1 array<varchar(1048576)>>, true]); args: INVALID_TYPE; " +
                     "result: ARRAY<VARCHAR(100)>; args nullable: true; result nullable: true]");
             PlanTestBase.assertContains(plan, " 0:OlapScanNode\n" +
                     "     table: test_agg_state_table, rollup: test_agg_state_table");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVRewriteWithSchemaChangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVRewriteWithSchemaChangeTest.java
@@ -158,6 +158,7 @@ public class MVRewriteWithSchemaChangeTest extends MVTestBase {
 
     @Test
     public void testMVWithSchemaChangeInStrictMode() throws Exception {
+        Config.transform_type_prefer_string_for_varchar = false;
         starRocksAssert.withTable("\n" +
                 "CREATE TABLE test_base_tbl(\n" +
                 "  `dt` datetime DEFAULT NULL,\n" +
@@ -204,6 +205,7 @@ public class MVRewriteWithSchemaChangeTest extends MVTestBase {
 
         starRocksAssert.dropTable("test_base_tbl");
         starRocksAssert.dropMaterializedView("test_mv1");
+        Config.transform_type_prefer_string_for_varchar = true;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
@@ -716,11 +716,11 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                         String[] expects = {
                                 "  4:Project\n" +
                                         "  |  <slot 19> : 19: k1\n" +
-                                        "  |  <slot 20> : 20: k2\n" +
                                         "  |  <slot 21> : 21: v1\n" +
                                         "  |  <slot 22> : 22: v2\n" +
-                                        "  |  <slot 24> : 24: v4\n" +
-                                        "  |  <slot 25> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 25> : CAST(20: k2 AS VARCHAR(65533))\n" +
+                                        "  |  <slot 26> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 27> : CAST(24: v4 AS VARCHAR(20))\n" +
                                         "  |  \n" +
                                         "  3:OlapScanNode\n" +
                                         "     TABLE: m3\n" +
@@ -728,11 +728,11 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                                         "     partitions=2/3",
                                 "  4:Project\n" +
                                         "  |  <slot 19> : 19: k1\n" +
-                                        "  |  <slot 20> : 20: k2\n" +
                                         "  |  <slot 21> : 21: v1\n" +
                                         "  |  <slot 22> : 22: v2\n" +
-                                        "  |  <slot 24> : 24: v4\n" +
-                                        "  |  <slot 25> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 25> : CAST(20: k2 AS VARCHAR(65533))\n" +
+                                        "  |  <slot 26> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 27> : CAST(24: v4 AS VARCHAR(20))\n" +
                                         "  |  \n" +
                                         "  3:OlapScanNode\n" +
                                         "     TABLE: m3\n" +
@@ -776,11 +776,11 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                         String[] expects = {
                                 "  4:Project\n" +
                                         "  |  <slot 19> : 19: k1\n" +
-                                        "  |  <slot 20> : 20: k2\n" +
                                         "  |  <slot 21> : 21: v1\n" +
                                         "  |  <slot 22> : 22: v2\n" +
-                                        "  |  <slot 24> : 24: v4\n" +
-                                        "  |  <slot 25> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 25> : CAST(20: k2 AS VARCHAR(65533))\n" +
+                                        "  |  <slot 26> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 27> : CAST(24: v4 AS VARCHAR(20))\n" +
                                         "  |  \n" +
                                         "  3:OlapScanNode\n" +
                                         "     TABLE: m3\n" +
@@ -789,11 +789,11 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                                         "     partitions=2/3",
                                 "  4:Project\n" +
                                         "  |  <slot 19> : 19: k1\n" +
-                                        "  |  <slot 20> : 20: k2\n" +
                                         "  |  <slot 21> : 21: v1\n" +
                                         "  |  <slot 22> : 22: v2\n" +
-                                        "  |  <slot 24> : 24: v4\n" +
-                                        "  |  <slot 25> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 25> : CAST(20: k2 AS VARCHAR(65533))\n" +
+                                        "  |  <slot 26> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 27> : CAST(24: v4 AS VARCHAR(20))\n" +
                                         "  |  \n" +
                                         "  3:OlapScanNode\n" +
                                         "     TABLE: m3\n" +
@@ -836,28 +836,28 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                                 "SELECT * from m3 where v1 > 1",
                         };
                         String[] expects = {
-                                "  4:Project\n" +
+                                "  7:Project\n" +
                                         "  |  <slot 19> : 19: k1\n" +
-                                        "  |  <slot 20> : 20: k2\n" +
                                         "  |  <slot 21> : 21: v1\n" +
                                         "  |  <slot 22> : 22: v2\n" +
-                                        "  |  <slot 24> : 24: v4\n" +
-                                        "  |  <slot 25> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 25> : CAST(20: k2 AS VARCHAR(65533))\n" +
+                                        "  |  <slot 26> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 27> : CAST(24: v4 AS VARCHAR(20))\n" +
                                         "  |  \n" +
-                                        "  3:OlapScanNode\n" +
+                                        "  6:OlapScanNode\n" +
                                         "     TABLE: m3\n" +
                                         "     PREAGGREGATION: ON\n" +
                                         "     PREDICATES: 21: v1 > 2\n" +
                                         "     partitions=2/3",
-                                "  4:Project\n" +
+                                "  7:Project\n" +
                                         "  |  <slot 19> : 19: k1\n" +
-                                        "  |  <slot 20> : 20: k2\n" +
                                         "  |  <slot 21> : 21: v1\n" +
                                         "  |  <slot 22> : 22: v2\n" +
-                                        "  |  <slot 24> : 24: v4\n" +
-                                        "  |  <slot 25> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 25> : CAST(20: k2 AS VARCHAR(65533))\n" +
+                                        "  |  <slot 26> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 27> : CAST(24: v4 AS VARCHAR(20))\n" +
                                         "  |  \n" +
-                                        "  3:OlapScanNode\n" +
+                                        "  6:OlapScanNode\n" +
                                         "     TABLE: m3\n" +
                                         "     PREAGGREGATION: ON\n" +
                                         "     PREDICATES: 21: v1 > 2\n" +
@@ -899,18 +899,17 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                         String[] expects = {
                                 "  4:Project\n" +
                                         "  |  <slot 19> : 19: k1\n" +
-                                        "  |  <slot 20> : 20: k2\n" +
                                         "  |  <slot 21> : 21: v1\n" +
                                         "  |  <slot 22> : 22: v2\n" +
-                                        "  |  <slot 24> : 24: v4\n" +
-                                        "  |  <slot 25> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 25> : CAST(20: k2 AS VARCHAR(65533))\n" +
+                                        "  |  <slot 26> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  <slot 27> : CAST(24: v4 AS VARCHAR(20))\n" +
                                         "  |  \n" +
                                         "  3:OlapScanNode\n" +
                                         "     TABLE: m3\n" +
                                         "     PREAGGREGATION: ON\n" +
                                         "     PREDICATES: 19: k1 = 1\n" +
-                                        "     partitions=0/3\n" + // pruned
-                                        "     rollup: m3"
+                                        "     partitions=0/3"
                         };
                         int len = sqls.length;
                         for (int i = 0; i < len; i++) {
@@ -1010,12 +1009,11 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                         {
                             String plan = getFragmentPlan("select dt from t3", TExplainLevel.COSTS, "");
                             PlanTestBase.assertContains(plan, "UNION", "mv0", "t3");
-                            PlanTestBase.assertContains(plan, "  0:UNION\n" +
-                                    "  |  output exprs:\n" +
-                                    "  |      [7, VARCHAR(10), false]\n" +
+                            PlanTestBase.assertContains(plan, "|  output exprs:\n" +
+                                    "  |      [7, VARCHAR(1048576), false]\n" +
                                     "  |  child exprs:\n" +
                                     "  |      [11: dt, VARCHAR, false]\n" +
-                                    "  |      [15: dt, VARCHAR, false]");
+                                    "  |      [17: cast, VARCHAR(10), false]");
                         }
                     });
         });
@@ -1041,11 +1039,12 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                         {
                             String plan = getFragmentPlan("select min(age) from t3 group by province;", TExplainLevel.COSTS, "");
                             PlanTestBase.assertContains(plan, "UNION", "mv0", "t3");
-                            PlanTestBase.assertContains(plan, "  |  output exprs:\n" +
-                                    "  |      [6, VARCHAR(64), false] | [8, SMALLINT, true]\n" +
+                            PlanTestBase.assertContains(plan, "  0:UNION\n" +
+                                    "  |  output exprs:\n" +
+                                    "  |      [6, VARCHAR(1048576), false] | [8, SMALLINT, true]\n" +
                                     "  |  child exprs:\n" +
                                     "  |      [9: province, VARCHAR, false] | [11: min(age), SMALLINT, true]\n" +
-                                    "  |      [14: province, VARCHAR, false] | [16: min, SMALLINT, true]");
+                                    "  |      [17: cast, VARCHAR(64), false] | [16: min, SMALLINT, true]");
                         }
                     });
         });

--- a/test/sql/test_automatic_partition/R/test_multi_expr
+++ b/test/sql/test_automatic_partition/R/test_multi_expr
@@ -403,7 +403,7 @@ show create table multi_level_expr_par_tbl_1;
 -- result:
 multi_level_expr_par_tbl_1	CREATE TABLE `multi_level_expr_par_tbl_1` (
   `c1` bigint(20) NOT NULL COMMENT "",
-  `c2` varchar(65533) NULL COMMENT "",
+  `c2` varchar(1048576) NULL COMMENT "",
   `c3` date NULL COMMENT "",
   `__generated_partition_column_0` varchar(1048576) NULL AS from_unixtime(c1) COMMENT ""
 ) ENGINE=OLAP 
@@ -449,8 +449,8 @@ show create table multi_level_expr_par_tbl_2;
 multi_level_expr_par_tbl_2	CREATE TABLE `multi_level_expr_par_tbl_2` (
   `k1` date NOT NULL COMMENT "",
   `k2` datetime NOT NULL COMMENT "",
-  `k3` varchar(20) NOT NULL COMMENT "",
-  `k4` varchar(20) NOT NULL COMMENT "",
+  `k3` varchar(1048576) NOT NULL COMMENT "",
+  `k4` varchar(1048576) NOT NULL COMMENT "",
   `k5` boolean NOT NULL COMMENT "",
   `k6` tinyint(4) NULL COMMENT "",
   `k7` smallint(6) NULL COMMENT "",

--- a/test/sql/test_files/R/test_orc_struct
+++ b/test/sql/test_files/R/test_orc_struct
@@ -24,7 +24,7 @@ create table t1 as select col_int, col_struct, col_struct.c_date from files("pat
 desc t1;
 -- result:
 col_int	int	YES	true	None	
-col_struct	struct<c_int int(11), c_float decimal(38, 9), c_double decimal(38, 9), c_char varchar(30), c_varchar varchar(200), c_date date, c_timestamp datetime, c_boolean boolean>	YES	false	None	
+col_struct	struct<c_int int(11), c_float decimal(38, 9), c_double decimal(38, 9), c_char varchar(1048576), c_varchar varchar(1048576), c_date date, c_timestamp datetime, c_boolean boolean>	YES	false	None	
 c_date	date	YES	false	None	
 -- !result
 


### PR DESCRIPTION
## Why I'm doing:

This is a followup of PR #61996.

We can always use `string` to replace fixed length chars in CTAS/Create MV to avoid column length deducing wrong which may cause mv refresh failed in new versions.

## What I'm doing:


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3