### PR TITLE
[BugFix] Fix table with gin index use replicated_storage

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -92,6 +92,7 @@ import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SelectAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.IndexDef.IndexType;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TColumn;
 import com.starrocks.thrift.TDataSink;
@@ -206,7 +207,10 @@ public class OlapTableSink extends DataSink {
                 dstTable.isOlapExternalTable() && ((ExternalOlapTable) dstTable).isSourceTableCloudNativeTableOrMaterializedView());
         tSink.setKeys_type(dstTable.getKeysType().toThrift());
         tSink.setWrite_quorum_type(writeQuorum);
-        tSink.setEnable_replicated_storage(enableReplicatedStorage);
+        // If table has Gin index, do not allow replicated storage
+        boolean hasGin = dstTable.getIndexes().stream()
+                .anyMatch(index -> index.getIndexType() == IndexType.GIN);
+        tSink.setEnable_replicated_storage(enableReplicatedStorage && !hasGin);
         tSink.setAutomatic_bucket_size(automaticBucketSize);
         tSink.setEncryption_meta(GlobalStateMgr.getCurrentState().getKeyMgr().getCurrentKEKAsEncryptionMeta());
         tSink.setEnable_data_file_bundling(dstTable.isFileBundling());


### PR DESCRIPTION
## Why I'm doing:
Table with GIN index do not support replicated_storage right now. However, even though the replicated_storage of the table has been disabled, it may still be forcibly enabled when generating the ingestion plan. Therefore, an additional check should be added at the point where replicated_storage is enabled to ensure that the table does not have a GIN index.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
