### PR TITLE
[Enhancement] introduce a function to obtain the column size

### DIFF
--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -421,7 +421,7 @@ Status SegmentMetaCollecter::__collect_max_or_min(ColumnId cid, Column* column, 
     if (cid >= _segment->num_columns()) {
         return Status::NotFound("");
     }
-    const ColumnReader* col_reader = _segment->column(cid);
+    ColumnReader* col_reader = const_cast<ColumnReader*>(_segment->column(cid));
     if (col_reader == nullptr || col_reader->segment_zone_map() == nullptr) {
         return Status::NotFound("");
     }
@@ -473,7 +473,7 @@ Status SegmentMetaCollecter::_collect_count(ColumnId cid, Column* column, Logica
 Status SegmentMetaCollecter::_collect_column_size(ColumnId cid, Column* column, LogicalType type) {
     // Uncompressed size: not directly stored per page; we estimate using num_rows * avg_value_size when applicable
     // Prefer metadata footprint when available
-    const ColumnReader* col_reader = _segment->column(cid);
+    ColumnReader* col_reader = const_cast<ColumnReader*>(_segment->column(cid));
     if (col_reader == nullptr) {
         return Status::NotFound("");
     }
@@ -484,7 +484,7 @@ Status SegmentMetaCollecter::_collect_column_size(ColumnId cid, Column* column, 
 
 Status SegmentMetaCollecter::_collect_column_compressed_size(ColumnId cid, Column* column, LogicalType type) {
     // Compressed size estimation: sum of data page sizes via ordinal index ranges
-    const ColumnReader* col_reader = _segment->column(cid);
+    ColumnReader* col_reader = const_cast<ColumnReader*>(_segment->column(cid));
     if (col_reader == nullptr) {
         return Status::NotFound("");
     }

--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -35,8 +35,8 @@
 namespace starrocks {
 
 std::vector<std::string> SegmentMetaCollecter::support_collect_fields = {
-        META_FLAT_JSON_META,       META_DICT_MERGE,          META_MAX,           META_MIN,
-        META_COUNT_ROWS,           META_COUNT_COL,           META_COLUMN_SIZE,   META_COLUMN_COMPRESSED_SIZE};
+        META_FLAT_JSON_META, META_DICT_MERGE, META_MAX,         META_MIN,
+        META_COUNT_ROWS,     META_COUNT_COL,  META_COLUMN_SIZE, META_COLUMN_COMPRESSED_SIZE};
 
 Status SegmentMetaCollecter::parse_field_and_colname(const std::string& item, std::string* field,
                                                      std::string* col_name) {

--- a/be/src/storage/meta_reader.h
+++ b/be/src/storage/meta_reader.h
@@ -105,6 +105,8 @@ static const std::string META_MAX = "max";
 static const std::string META_DICT_MERGE = "dict_merge";
 static const std::string META_FLAT_JSON_META = "flat_json_meta";
 static const std::string META_COUNT_COL = "count";
+static const std::string META_COLUMN_SIZE = "column_size";
+static const std::string META_COLUMN_COMPRESSED_SIZE = "column_compressed_size";
 
 class SegmentMetaCollecter {
 public:
@@ -135,6 +137,8 @@ private:
     Status _collect_count(ColumnId cid, Column* column, LogicalType type);
     Status _collect_rows(Column* column, LogicalType type);
     Status _collect_flat_json(ColumnId cid, Column* column);
+    Status _collect_column_size(ColumnId cid, Column* column, LogicalType type);
+    Status _collect_column_compressed_size(ColumnId cid, Column* column, LogicalType type);
     template <bool is_max>
     Status __collect_max_or_min(ColumnId cid, Column* column, LogicalType type);
     SegmentSharedPtr _segment;

--- a/be/src/storage/meta_reader.h
+++ b/be/src/storage/meta_reader.h
@@ -141,6 +141,10 @@ private:
     Status _collect_column_compressed_size(ColumnId cid, Column* column, LogicalType type);
     template <bool is_max>
     Status __collect_max_or_min(ColumnId cid, Column* column, LogicalType type);
+
+    // Recursive helper methods for collecting column sizes
+    size_t _collect_column_size_recursive(ColumnReader* col_reader);
+    int64_t _collect_column_compressed_size_recursive(ColumnReader* col_reader);
     SegmentSharedPtr _segment;
     std::vector<std::unique_ptr<ColumnIterator>> _column_iterators;
     const SegmentMetaCollecterParams* _params = nullptr;

--- a/be/src/storage/olap_meta_reader.cpp
+++ b/be/src/storage/olap_meta_reader.cpp
@@ -87,7 +87,8 @@ Status OlapMetaReader::_build_collect_context(const OlapMetaReaderParams& read_p
 
         // only collect the field of dict need read data page
         // others just depend on footer
-        if (collect_field == META_DICT_MERGE || collect_field == META_COUNT_COL) {
+        if (collect_field == META_DICT_MERGE || collect_field == META_COUNT_COL ||
+            collect_field == META_COLUMN_COMPRESSED_SIZE) {
             _collect_context.seg_collecter_params.read_page.emplace_back(true);
         } else {
             _collect_context.seg_collecter_params.read_page.emplace_back(false);

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -565,7 +565,6 @@ std::pair<ordinal_t, ordinal_t> ColumnReader::get_page_range(size_t page_index) 
 
 // Iterate the oridinal index to get the total size of all data pages
 int64_t ColumnReader::data_page_footprint() const {
-    DCHECK(_ordinal_index);
     RETURN_IF(_ordinal_index == nullptr, 0);
     int64_t total_size = 0;
     auto iter = _ordinal_index->begin();

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -563,6 +563,19 @@ std::pair<ordinal_t, ordinal_t> ColumnReader::get_page_range(size_t page_index) 
     return std::make_pair(_ordinal_index->get_first_ordinal(page_index), _ordinal_index->get_last_ordinal(page_index));
 }
 
+// Iterate the oridinal index to get the total size of all data pages
+int64_t ColumnReader::data_page_footprint() const {
+    DCHECK(_ordinal_index);
+    RETURN_IF(_ordinal_index == nullptr, 0);
+    int64_t total_size = 0;
+    auto iter = _ordinal_index->begin();
+    while (iter.valid()) {
+        total_size += iter.page().size;
+        iter.next();
+    }
+    return total_size;
+}
+
 Status ColumnReader::zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
                                      const ColumnPredicate* del_predicate,
                                      std::unordered_set<uint32_t>* del_partial_filtered_pages,

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -148,7 +148,9 @@ public:
 
     uint64_t total_mem_footprint() const { return _total_mem_footprint; }
 
-    int32_t num_data_pages() { return _ordinal_index ? _ordinal_index->num_data_pages() : 0; }
+    int32_t num_data_pages() const { return _ordinal_index ? _ordinal_index->num_data_pages() : 0; }
+    // Return the total size of all data pages
+    int64_t data_page_footprint() const;
 
     // Return the ordinal range of a page
     std::pair<ordinal_t, ordinal_t> get_page_range(size_t page_index);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -308,6 +308,8 @@ public class FunctionSet {
     public static final String DISTINCT_PCSA = "distinct_pcsa";
     public static final String HISTOGRAM = "histogram";
     public static final String FLAT_JSON_META = "flat_json_meta";
+    public static final String COLUMN_SIZE = "column_size";
+    public static final String COLUMN_COMPRESSED_SIZE = "column_compressed_size";
     public static final String MANN_WHITNEY_U_TEST = "mann_whitney_u_test";
 
     // Bitmap functions:
@@ -1351,6 +1353,12 @@ public class FunctionSet {
                 Type.ARRAY_VARCHAR, Type.ARRAY_VARCHAR, false, false, false));
         addBuiltin(AggregateFunction.createBuiltin(FLAT_JSON_META, Lists.newArrayList(Type.ANY_ARRAY),
                 Type.ARRAY_VARCHAR, Type.ARRAY_VARCHAR, false, false, false));
+
+        // column meta size inspectors (used only in META_SCAN)
+        addBuiltin(AggregateFunction.createBuiltin(COLUMN_SIZE, Lists.newArrayList(Type.ANY_ELEMENT),
+                Type.BIGINT, Type.BIGINT, false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin(COLUMN_COMPRESSED_SIZE, Lists.newArrayList(Type.ANY_ELEMENT),
+                Type.BIGINT, Type.BIGINT, false, false, false));
 
         for (Type t : Type.getSupportedTypes()) {
             // null/char/time is handled through type promotion

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggToMetaScanRule.java
@@ -78,7 +78,9 @@ public class PushDownAggToMetaScanRule extends TransformationRule {
             if (!aggFuncName.equalsIgnoreCase(FunctionSet.DICT_MERGE)
                     && !aggFuncName.equalsIgnoreCase(FunctionSet.MAX)
                     && !aggFuncName.equalsIgnoreCase(FunctionSet.MIN)
-                    && !aggFuncName.equalsIgnoreCase(FunctionSet.COUNT)) {
+                    && !aggFuncName.equalsIgnoreCase(FunctionSet.COUNT)
+                    && !aggFuncName.equalsIgnoreCase(FunctionSet.COLUMN_SIZE)
+                    && !aggFuncName.equalsIgnoreCase(FunctionSet.COLUMN_COMPRESSED_SIZE)) {
                 return false;
             }
         }
@@ -135,7 +137,9 @@ public class PushDownAggToMetaScanRule extends TransformationRule {
 
             Column c = metaScan.getColRefToColumnMetaMap().get(usedColumn);
             Column copiedColumn = c.deepCopy();
-            if (aggCall.getFnName().equals(FunctionSet.COUNT)) {
+            if (aggCall.getFnName().equals(FunctionSet.COUNT)
+                    || aggCall.getFnName().equals(FunctionSet.COLUMN_SIZE)
+                    || aggCall.getFnName().equals(FunctionSet.COLUMN_COMPRESSED_SIZE)) {
                 // this variable is introduced to solve compatibility issues,
                 // see more details in the description of https://github.com/StarRocks/starrocks/pull/17619
                 copiedColumn.setType(Type.BIGINT);
@@ -152,7 +156,9 @@ public class PushDownAggToMetaScanRule extends TransformationRule {
                 newAggCalls.put(kv.getKey(),
                         new CallOperator(aggCall.getFnName(), aggCall.getType(),
                                 List.of(metaColumn, aggCall.getChild(1)), aggFunction));
-            } else if (aggCall.getFnName().equals(FunctionSet.COUNT)) {
+            } else if (aggCall.getFnName().equals(FunctionSet.COUNT)
+                    || aggCall.getFnName().equals(FunctionSet.COLUMN_SIZE)
+                    || aggCall.getFnName().equals(FunctionSet.COLUMN_COMPRESSED_SIZE)) {
                 // rewrite count to sum
                 Function aggFunction = Expr.getBuiltinFunction(FunctionSet.SUM, new Type[] {Type.BIGINT},
                         Function.CompareMode.IS_IDENTICAL);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
@@ -97,7 +97,9 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
             Type columnType = aggCall.getType();
 
             ColumnRefOperator metaColumn;
-            if (aggCall.getFnName().equals(FunctionSet.COUNT)) {
+            if (aggCall.getFnName().equals(FunctionSet.COUNT)
+                    || aggCall.getFnName().equals(FunctionSet.COLUMN_SIZE)
+                    || aggCall.getFnName().equals(FunctionSet.COLUMN_COMPRESSED_SIZE)) {
                 if (countPlaceHolderColumn != null) {
                     metaColumn = countPlaceHolderColumn;
                 } else {
@@ -121,7 +123,9 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
             Function aggFunction = aggCall.getFunction();
             String newAggFnName = aggCall.getFnName();
             Type newAggReturnType = aggCall.getType();
-            if (aggCall.getFnName().equals(FunctionSet.COUNT)) {
+            if (aggCall.getFnName().equals(FunctionSet.COUNT)
+                    || aggCall.getFnName().equals(FunctionSet.COLUMN_SIZE)
+                    || aggCall.getFnName().equals(FunctionSet.COLUMN_COMPRESSED_SIZE)) {
                 aggFunction = Expr.getBuiltinFunction(FunctionSet.SUM,
                         new Type[] {Type.BIGINT}, Function.CompareMode.IS_IDENTICAL);
                 newAggFnName = FunctionSet.SUM;
@@ -205,7 +209,9 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
                         // min/max column should have zonemap index
                         Type type = aggregator.getType();
                         return !(type.isStringType() || type.isComplexType());
-                    } else if (functionName.equals(FunctionSet.COUNT) && !aggregator.isDistinct()) {
+                    } else if ((functionName.equals(FunctionSet.COUNT) ||
+                            functionName.equals(FunctionSet.COLUMN_SIZE) ||
+                            functionName.equals(FunctionSet.COLUMN_COMPRESSED_SIZE)) && !aggregator.isDistinct()) {
                         if (usedColumns.size() == 1) {
                             ColumnRefOperator usedColumn =
                                     context.getColumnRefFactory().getColumnRef(usedColumns.getFirstId());

--- a/test/sql/test_meta_scan/R/test_meta_scan
+++ b/test/sql/test_meta_scan/R/test_meta_scan
@@ -202,18 +202,6 @@ SELECT count(*), max(k13), min(k13), count(k13) FROM duplicate_table_with_null_p
 0	None	None	0
 -- !result
 -- name: test_meta_column_size_functions
--- result:
--- !result
-SELECT sum(column_size(k4)), sum(column_compressed_size(k4)) FROM duplicate_table_with_null_partition [_META_];
--- result:
--- MATCH_ANY
--- !result
-SELECT sum(column_size(k8)), sum(column_compressed_size(k8)) FROM update_table_with_null_partition [_META_];
--- result:
--- MATCH_ANY
--- !result
-
--- name: test_meta_column_size_nested_types
 CREATE TABLE meta_nested_types (
     k1 int,
     j  json,
@@ -223,7 +211,7 @@ CREATE TABLE meta_nested_types (
 )
 DUPLICATE KEY(k1)
 DISTRIBUTED BY HASH(k1) BUCKETS 1
-PROPERTIES ("replication_num" = "1");
+PROPERTIES ("replication_num" = "1", "compression"="lz4");
 -- result:
 -- !result
 INSERT INTO meta_nested_types VALUES
@@ -232,21 +220,21 @@ INSERT INTO meta_nested_types VALUES
 (3, NULL,                  [4],          map{},         row(NULL,NULL));
 -- result:
 -- !result
-SELECT sum(column_size(j)), sum(column_compressed_size(j)) FROM meta_nested_types [_META_];
+SELECT column_size(j) > 0, column_compressed_size(j) > 0 FROM meta_nested_types [_META_];
 -- result:
--- MATCH_ANY
+1	1
 -- !result
-SELECT sum(column_size(a)), sum(column_compressed_size(a)) FROM meta_nested_types [_META_];
+SELECT column_size(a) > 0, column_compressed_size(a) > 0 FROM meta_nested_types [_META_];
 -- result:
--- MATCH_ANY
+1	1
 -- !result
-SELECT sum(column_size(m)), sum(column_compressed_size(m)) FROM meta_nested_types [_META_];
+SELECT column_size(m) > 0, column_compressed_size(m) > 0 FROM meta_nested_types [_META_];
 -- result:
--- MATCH_ANY
+1	1
 -- !result
-SELECT sum(column_size(s)), sum(column_compressed_size(s)) FROM meta_nested_types [_META_];
+SELECT column_size(s) > 0, column_compressed_size(s) > 0 FROM meta_nested_types [_META_];
 -- result:
--- MATCH_ANY
+1	1
 -- !result
 -- name: test_update_table_on_meta_scan
 CREATE TABLE `update_table_with_null_partition` (

--- a/test/sql/test_meta_scan/R/test_meta_scan
+++ b/test/sql/test_meta_scan/R/test_meta_scan
@@ -201,6 +201,17 @@ SELECT count(*), max(k13), min(k13), count(k13) FROM duplicate_table_with_null_p
 -- result:
 0	None	None	0
 -- !result
+-- name: test_meta_column_size_functions
+-- result:
+-- !result
+SELECT sum(column_size(k4)), sum(column_compressed_size(k4)) FROM duplicate_table_with_null_partition [_META_];
+-- result:
+-- MATCH_ANY
+-- !result
+SELECT sum(column_size(k8)), sum(column_compressed_size(k8)) FROM update_table_with_null_partition [_META_];
+-- result:
+-- MATCH_ANY
+-- !result
 -- name: test_update_table_on_meta_scan
 CREATE TABLE `update_table_with_null_partition` (
     `k1` date,

--- a/test/sql/test_meta_scan/R/test_meta_scan
+++ b/test/sql/test_meta_scan/R/test_meta_scan
@@ -212,6 +212,42 @@ SELECT sum(column_size(k8)), sum(column_compressed_size(k8)) FROM update_table_w
 -- result:
 -- MATCH_ANY
 -- !result
+
+-- name: test_meta_column_size_nested_types
+CREATE TABLE meta_nested_types (
+    k1 int,
+    j  json,
+    a  array<int>,
+    m  map<int, varchar(20)>,
+    s  struct<c0 int, c1 varchar(20)>
+)
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO meta_nested_types VALUES
+(1, json_object('k','v'), [1,2,3], map{1:'a',2:'b'}, row(1,'x')),
+(2, json_object('k','w'), [],           map{3:'c'},     row(2,'y')),
+(3, NULL,                  [4],          map{},         row(NULL,NULL));
+-- result:
+-- !result
+SELECT sum(column_size(j)), sum(column_compressed_size(j)) FROM meta_nested_types [_META_];
+-- result:
+-- MATCH_ANY
+-- !result
+SELECT sum(column_size(a)), sum(column_compressed_size(a)) FROM meta_nested_types [_META_];
+-- result:
+-- MATCH_ANY
+-- !result
+SELECT sum(column_size(m)), sum(column_compressed_size(m)) FROM meta_nested_types [_META_];
+-- result:
+-- MATCH_ANY
+-- !result
+SELECT sum(column_size(s)), sum(column_compressed_size(s)) FROM meta_nested_types [_META_];
+-- result:
+-- MATCH_ANY
+-- !result
 -- name: test_update_table_on_meta_scan
 CREATE TABLE `update_table_with_null_partition` (
     `k1` date,

--- a/test/sql/test_meta_scan/T/test_meta_scan
+++ b/test/sql/test_meta_scan/T/test_meta_scan
@@ -85,11 +85,6 @@ SELECT count(*), max(k12), min(k12), count(k12) FROM duplicate_table_with_null_p
 SELECT count(*), max(k13), min(k13), count(k13) FROM duplicate_table_with_null_partition PARTITION (p202008);
 
 -- name: test_meta_column_size_functions
--- basic smoke: ensure functions run on META_ and return BIGINTs
-SELECT sum(column_size(k4)), sum(column_compressed_size(k4)) FROM duplicate_table_with_null_partition [_META_];
-SELECT sum(column_size(k8)), sum(column_compressed_size(k8)) FROM update_table_with_null_partition [_META_];
-
--- name: test_meta_column_size_nested_types
 CREATE TABLE meta_nested_types (
     k1 int,
     j  json,
@@ -99,7 +94,7 @@ CREATE TABLE meta_nested_types (
 )
 DUPLICATE KEY(k1)
 DISTRIBUTED BY HASH(k1) BUCKETS 1
-PROPERTIES ("replication_num" = "1");
+PROPERTIES ("replication_num" = "1", "compression"="lz4");
 
 INSERT INTO meta_nested_types VALUES
 (1, json_object('k','v'), [1,2,3], map{1:'a',2:'b'}, row(1,'x')),
@@ -107,10 +102,10 @@ INSERT INTO meta_nested_types VALUES
 (3, NULL,                  [4],          map{},         row(NULL,NULL));
 
 -- aggregated sizes across segments
-SELECT sum(column_size(j)), sum(column_compressed_size(j)) FROM meta_nested_types [_META_];
-SELECT sum(column_size(a)), sum(column_compressed_size(a)) FROM meta_nested_types [_META_];
-SELECT sum(column_size(m)), sum(column_compressed_size(m)) FROM meta_nested_types [_META_];
-SELECT sum(column_size(s)), sum(column_compressed_size(s)) FROM meta_nested_types [_META_];
+SELECT column_size(j) > 0, column_compressed_size(j) > 0 FROM meta_nested_types [_META_];
+SELECT column_size(a) > 0, column_compressed_size(a) > 0 FROM meta_nested_types [_META_];
+SELECT column_size(m) > 0, column_compressed_size(m) > 0 FROM meta_nested_types [_META_];
+SELECT column_size(s) > 0, column_compressed_size(s) > 0 FROM meta_nested_types [_META_];
 
 -- name: test_update_table_on_meta_scan
 CREATE TABLE `update_table_with_null_partition` (

--- a/test/sql/test_meta_scan/T/test_meta_scan
+++ b/test/sql/test_meta_scan/T/test_meta_scan
@@ -89,6 +89,29 @@ SELECT count(*), max(k13), min(k13), count(k13) FROM duplicate_table_with_null_p
 SELECT sum(column_size(k4)), sum(column_compressed_size(k4)) FROM duplicate_table_with_null_partition [_META_];
 SELECT sum(column_size(k8)), sum(column_compressed_size(k8)) FROM update_table_with_null_partition [_META_];
 
+-- name: test_meta_column_size_nested_types
+CREATE TABLE meta_nested_types (
+    k1 int,
+    j  json,
+    a  array<int>,
+    m  map<int, varchar(20)>,
+    s  struct<c0 int, c1 varchar(20)>
+)
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO meta_nested_types VALUES
+(1, json_object('k','v'), [1,2,3], map{1:'a',2:'b'}, row(1,'x')),
+(2, json_object('k','w'), [],           map{3:'c'},     row(2,'y')),
+(3, NULL,                  [4],          map{},         row(NULL,NULL));
+
+-- aggregated sizes across segments
+SELECT sum(column_size(j)), sum(column_compressed_size(j)) FROM meta_nested_types [_META_];
+SELECT sum(column_size(a)), sum(column_compressed_size(a)) FROM meta_nested_types [_META_];
+SELECT sum(column_size(m)), sum(column_compressed_size(m)) FROM meta_nested_types [_META_];
+SELECT sum(column_size(s)), sum(column_compressed_size(s)) FROM meta_nested_types [_META_];
+
 -- name: test_update_table_on_meta_scan
 CREATE TABLE `update_table_with_null_partition` (
     `k1` date,

--- a/test/sql/test_meta_scan/T/test_meta_scan
+++ b/test/sql/test_meta_scan/T/test_meta_scan
@@ -84,6 +84,11 @@ SELECT count(*), max(k11), min(k11), count(k11) FROM duplicate_table_with_null_p
 SELECT count(*), max(k12), min(k12), count(k12) FROM duplicate_table_with_null_partition PARTITION (p202008);
 SELECT count(*), max(k13), min(k13), count(k13) FROM duplicate_table_with_null_partition PARTITION (p202008);
 
+-- name: test_meta_column_size_functions
+-- basic smoke: ensure functions run on META_ and return BIGINTs
+SELECT sum(column_size(k4)), sum(column_compressed_size(k4)) FROM duplicate_table_with_null_partition [_META_];
+SELECT sum(column_size(k8)), sum(column_compressed_size(k8)) FROM update_table_with_null_partition [_META_];
+
 -- name: test_update_table_on_meta_scan
 CREATE TABLE `update_table_with_null_partition` (
     `k1` date,


### PR DESCRIPTION
## Why I'm doing:
This PR resolves issue #60535 by adding the ability to query column size and compressed column size via `_META_` scans. This provides users with estimates of data storage for individual columns.

## What I'm doing:
- Introduced `column_size(col)` and `column_compressed_size(col)` built-in functions.
- Implemented BE-side meta collection for these new fields in `SegmentMetaCollecter` and `OlapMetaReader`.
  - `column_size` uses `ColumnMetaPB.total_mem_footprint()` as an uncompressed size proxy.
  - `column_compressed_size` calculates the sum of data page sizes by iterating through ordinal page indexes.
- Extended FE rules (`PushDownAggToMetaScanRule`, `RewriteSimpleAggToMetaScanRule`) to support pushing down `SUM(column_size(col))` and `SUM(column_compressed_size(col))` to meta scans.

**Usage:**
- Decompressed estimate: `SELECT column_size(col) FROM t [_META_];`
- Compressed estimate: `SELECT column_compressed_size(col) FROM t [_META_];`
- Both can be aggregated and pushed down, e.g., `SELECT sum(column_size(col)) FROM t [_META_];`

Fixes #60535

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-a88af9eb-a7d7-4779-816d-bcfd9f5f8035">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a88af9eb-a7d7-4779-816d-bcfd9f5f8035">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

