### PR TITLE
[Enhancement] Add support for simple partition_by, buckets clauses

### DIFF
--- a/contrib/starrocks-python-client/README.md
+++ b/contrib/starrocks-python-client/README.md
@@ -87,6 +87,10 @@ class table1(Base):
         "starrocks_PRIMARY_KEY": "id",
         "starrocks_engine": "OLAP",
         "starrocks_comment": "table comment",
+        "starrocks_distributed_by": "id",
+        "starrocks_distributed_by_buckets": 5,
+        "starrocks_partition_by": "name",
+        "starrocks_order_by": "created_at",
         "starrocks_properties": (
             ("storage_medium", "SSD"),
             ("storage_cooldown_time", "2025-06-04 00:00:00"),

--- a/contrib/starrocks-python-client/starrocks/dialect.py
+++ b/contrib/starrocks-python-client/starrocks/dialect.py
@@ -233,7 +233,7 @@ class StarRocksDDLCompiler(MySQLDDLCompiler):
             table_opts.append(f'PRIMARY KEY({opts["PRIMARY_KEY"]})')
 
         if "PARTITION_BY" in opts:
-            table_opts.append(f"PARTITION BY ({opts['PARTITION_BY']})")
+            table_opts.append(f"PARTITION BY {opts['PARTITION_BY']}")
 
         if 'DISTRIBUTED_BY' in opts:
             table_opts.append(f'DISTRIBUTED BY HASH({opts["DISTRIBUTED_BY"]})')

--- a/contrib/starrocks-python-client/starrocks/dialect.py
+++ b/contrib/starrocks-python-client/starrocks/dialect.py
@@ -232,8 +232,16 @@ class StarRocksDDLCompiler(MySQLDDLCompiler):
         if 'PRIMARY_KEY' in opts:
             table_opts.append(f'PRIMARY KEY({opts["PRIMARY_KEY"]})')
 
+        if "PARTITION_BY" in opts:
+            table_opts.append(f"PARTITION BY ({opts['PARTITION_BY']})")
+
         if 'DISTRIBUTED_BY' in opts:
             table_opts.append(f'DISTRIBUTED BY HASH({opts["DISTRIBUTED_BY"]})')
+            if 'DISTRIBUTED_BY_BUCKETS' in opts:
+                table_opts.append(f'BUCKETS {opts["DISTRIBUTED_BY_BUCKETS"]}')
+        elif 'DISTRIBUTED_BY_BUCKETS' in opts:
+            # TODO: issue a warning/error?
+            pass
 
         if "COMMENT" in opts:
             comment = self.sql_compiler.render_literal_value(


### PR DESCRIPTION
## Why I'm doing:

We want to create tables of following format using alembic:
```sql
CREATE TABLE IF NOT EXISTS account (
       /* .... */
      )
      PRIMARY KEY (column1, column2)
      PARTITION BY (column1)
      DISTRIBUTED BY HASH (column2) BUCKETS 3
      ORDER BY (column3)
      PROPERTIES (
       /* .... */
      );
```

Unfortunately, this is not possible even using latest version of the library on `main` branch. The missing parts are:
1. `BUCKETS <num>` clause
2. `PARTITION BY <column>` - full support for this clause is complicated, but for us just a simple column expression will be enough.

## What I'm doing:

I'm adding basic support for those statements using `__table_args__`, similar to how `DISTRIBUTED BY HASH` statement is supported at the moment.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
