### PR TITLE
[BugFix] Fix int256_t negation undefined behavior causing memory allocation failure

### DIFF
--- a/be/src/types/int256.cpp
+++ b/be/src/types/int256.cpp
@@ -729,6 +729,11 @@ std::string int256_t::to_string() const {
         return "0";
     }
 
+    // Handle INT256_MIN special case directly
+    if (*this == INT256_MIN) {
+        return "-57896044618658097711785492504343953926634992332820282019728792003956564819968";
+    }
+
     int256_t temp = *this;
     bool negative = false;
     if (temp.high < 0) {

--- a/be/src/types/int256.h
+++ b/be/src/types/int256.h
@@ -189,6 +189,11 @@ public:
     /// @return Negated value using two's complement
     constexpr int256_t operator-() const {
         if (low == 0) {
+            // Handle INT256_MIN special case to avoid undefined behavior
+            if (high == static_cast<int128_t>(static_cast<uint128_t>(1) << 127)) {
+                // For INT256_MIN, return itself since -INT256_MIN cannot be represented
+                return *this;
+            }
             return int256_t(-high, 0);
         } else {
             uint128_t new_low = ~low + 1;


### PR DESCRIPTION
## Why I'm doing:
When this == INT256_MIN, we have:
     high = 0x80000000000000000000000000000000 (INT128_MIN)
     low  = 0x00000000000000000000000000000000
     
The original code would execute: return int256_t(-high, 0). But -high means -(INT128_MIN), which is +2^127. However, +2^127 exceeds INT128_MAX (which is 2^127-1). This signed integer overflow is UNDEFINED BEHAVIOR in C++

Different compilers/optimization levels handle this differently:
    - Sometimes it "works" by chance (returns wrong but usable value)
    - Sometimes it produces garbage values causing massive memory allocation
     - ASAN vs Release builds behave differently due to different optimizations

```
W20250828 23:18:43.349151 140394211620416 mem_hook.cpp:117] large memory alloc, query_id:0198f142-19c1-7fc0-bc99-3b2ff098be62 instance: 0198f142-19c1-7fc0-bc99-3b2ff098be63 acquire:2013265921 bytes, is_bad_alloc_caught: 1, stack:
    @          0xce8b804  starrocks::get_stack_trace[abi:cxx11]()
    @          0xcd0c20f  my_malloc
    @         0x143d7a4c  operator new(unsigned long)
    @          0xcd616c1  starrocks::int256_t::to_string[abi:cxx11]() const
    @          0x82cbbcf  void fmt::v8::detail::value<fmt::v8::basic_format_context<fmt::v8::appender, char> >::format_custom_arg<starrocks::int256_t, fmt::v8::formatter<starrocks::int256_t, char, void> >(void*, fmt::v8::basic_format_parse_context<char, fmt::v8::detail::error_handl.
    @          0x8185d4f  void fmt::v8::detail::vformat_to<char>(fmt::v8::detail::buffer<char>&, fmt::v8::basic_string_view<char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<std::conditional<std::is_same<fmt::v8::type_identity<char>::type, char>::value, fmt::v8::appen.
    @          0xb44bde6  starrocks::DecimalNonDecimalCast<(starrocks::OverflowMode)1, (starrocks::LogicalType)26, (starrocks::LogicalType)17, int, int>::decimal_to(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> const&)
    @          0xb44c593  starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::UnpackConstColumnUnaryFunction<starrocks::DecimalTo<(starrocks::OverflowMode)1> >::evaluate<(starrocks::LogicalType)26, (starrocks::LogicalType)17>(starrocks::Cow<starrocks::Column>:.
    @          0xb44c72b  starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::DealNullableColumnUnaryFunction<starrocks::UnpackConstColumnUnaryFunction<starrocks::DecimalTo<(starrocks::OverflowMode)1> > >::evaluate<(starrocks::LogicalType)26, (starrocks::Logic.
    @          0xb44ca12  starrocks::VectorizedCastToStringExpr<(starrocks::LogicalType)26, false>::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0xa63d1c7  starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @          0xa63d55f  starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @          0x96fe5b6  starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0x97e94a0  starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x97d2739  starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xcee42a8  starrocks::ThreadPool::dispatch_thread()
    @          0xcedb2f5  starrocks::Thread::supervise_thread(void*)
    @     0x7fb1a4795ac3  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
```
## What I'm doing:    
Detect INT256_MIN and return it unchanged, since mathematically
INT256_MIN cannot be represented in int256_t (similar to how -INT_MIN == INT_MIN)

Theoretically, this problem should not occur because we have imported decimal digit limits and overflow detection. However, it can indeed occur through [special construction](https://github.com/StarRocks/starrocks/blob/main/test/sql/test_decimal/T/test_decimal256_arithmetic_overflow#L21).  

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/10159

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
