### PR TITLE
[BugFix] Fix possible NPE in mv backup restore

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1678,7 +1678,7 @@ public class RestoreJob extends AbstractJob {
                                 LOG.warn(" drop materialized view {} partitions because doAfterRestore failed",
                                         olapTable.getName());
                                 MaterializedView mv = (MaterializedView) olapTable;
-                                MaterializedViewExceptions.inactiveReasonForMetadataTableRestoreFailed(mv.getName());
+                                MaterializedViewExceptions.inactiveReasonForMetadataTableRestoreCorrupted(mv.getName());
                                 // drop all partitions
                                 Collection<Partition> partitions = mv.getPartitions();
                                 for (Partition partition : partitions) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
@@ -29,7 +29,7 @@ public class MaterializedViewExceptions {
 
     public static final String INACTIVE_REASON_FOR_BASE_TABLE_REORDER_COLUMNS = "base-table reordered columns:";
 
-    public static final String INACTIVE_REASON_FOR_METADATA_TABLE_RESTORE_FAILED = "metadata backup/restore mv failed:";
+    public static final String INACTIVE_REASON_FOR_METADATA_TABLE_RESTORE_CORRUPTED = "metadata backup/restore mv corrupted:";
 
     /**
      * Create the inactive reason when base table not exists
@@ -65,8 +65,8 @@ public class MaterializedViewExceptions {
         return INACTIVE_REASON_FOR_BASE_TABLE_REORDER_COLUMNS + tableName;
     }
 
-    public static String inactiveReasonForMetadataTableRestoreFailed(String tableName) {
-        return INACTIVE_REASON_FOR_METADATA_TABLE_RESTORE_FAILED + tableName;
+    public static String inactiveReasonForMetadataTableRestoreCorrupted(String tableName) {
+        return INACTIVE_REASON_FOR_METADATA_TABLE_RESTORE_CORRUPTED + tableName;
     }
 
     public static String inactiveReasonForBaseTableActive(String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
@@ -29,6 +29,8 @@ public class MaterializedViewExceptions {
 
     public static final String INACTIVE_REASON_FOR_BASE_TABLE_REORDER_COLUMNS = "base-table reordered columns:";
 
+    public static final String INACTIVE_REASON_FOR_METADATA_TABLE_RESTORE_FAILED = "metadata backup/restore mv failed:";
+
     /**
      * Create the inactive reason when base table not exists
      */
@@ -61,6 +63,10 @@ public class MaterializedViewExceptions {
 
     public static String inactiveReasonForBaseTableReorderColumns(String tableName) {
         return INACTIVE_REASON_FOR_BASE_TABLE_REORDER_COLUMNS + tableName;
+    }
+
+    public static String inactiveReasonForMetadataTableRestoreFailed(String tableName) {
+        return INACTIVE_REASON_FOR_METADATA_TABLE_RESTORE_FAILED + tableName;
     }
 
     public static String inactiveReasonForBaseTableActive(String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -355,7 +355,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         recreateOlapTableTabletInvertIndex(dbId, mv, invertedIndex);
                     } catch (Exception e) {
                         LOG.error("recreate inverted index for metadata table {} failed", mv.getName(), e);
-                        mv.setInactiveAndReason(MaterializedViewExceptions.inactiveReasonForMetadataTableRestoreFailed(
+                        mv.setInactiveAndReason(MaterializedViewExceptions.inactiveReasonForMetadataTableRestoreCorrupted(
                                 mv.getName()));
                     }
                 } else {
@@ -373,10 +373,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             long partitionId = partition.getParentId();
             TStorageMedium medium = olapTable.getPartitionInfo().getDataProperty(
                     partitionId).getStorageMedium();
+            long physicalPartitionId = partition.getId();
             for (MaterializedIndex index : partition
                     .getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
                 long indexId = index.getId();
-                long physicalPartitionId = partition.getId();
                 TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId,
                         indexId, medium, olapTable.isCloudNativeTableOrMaterializedView());
                 for (Tablet tablet : index.getTablets()) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -348,30 +348,48 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 }
 
                 OlapTable olapTable = (OlapTable) table;
-                long tableId = olapTable.getId();
-                for (PhysicalPartition partition : olapTable.getAllPhysicalPartitions()) {
-                    long physicalPartitionId = partition.getId();
-                    TStorageMedium medium = olapTable.getPartitionInfo().getDataProperty(
-                            partition.getParentId()).getStorageMedium();
-                    for (MaterializedIndex index : partition
-                            .getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
-                        long indexId = index.getId();
-                        int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
-                        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId,
-                                indexId, medium, table.isCloudNativeTableOrMaterializedView());
-                        for (Tablet tablet : index.getTablets()) {
-                            long tabletId = tablet.getId();
-                            invertedIndex.addTablet(tabletId, tabletMeta);
-                            if (table.isOlapTableOrMaterializedView()) {
-                                for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
-                                    invertedIndex.addReplica(tabletId, replica);
-                                }
-                            }
-                        }
-                    } // end for indices
-                } // end for partitions
+                if (olapTable.isMaterializedView()) {
+                    // For mv, this may throw exception in mv backup/restore case, we should catch it and set mv to inactive
+                    MaterializedView mv = (MaterializedView) olapTable;
+                    try {
+                        recreateOlapTableTabletInvertIndex(dbId, mv, invertedIndex);
+                    } catch (Exception e) {
+                        LOG.error("recreate inverted index for metadata table {} failed", mv.getName(), e);
+                        mv.setInactiveAndReason(MaterializedViewExceptions.inactiveReasonForMetadataTableRestoreFailed(
+                                mv.getName()));
+                    }
+                } else {
+                    recreateOlapTableTabletInvertIndex(dbId, olapTable, invertedIndex);
+                }
             } // end for tables
         } // end for dbs
+    }
+
+    private void recreateOlapTableTabletInvertIndex(long dbId,
+                                                    OlapTable olapTable,
+                                                    TabletInvertedIndex invertedIndex) {
+        long tableId = olapTable.getId();
+        for (PhysicalPartition partition : olapTable.getAllPhysicalPartitions()) {
+            long partitionId = partition.getParentId();
+            TStorageMedium medium = olapTable.getPartitionInfo().getDataProperty(
+                    partitionId).getStorageMedium();
+            for (MaterializedIndex index : partition
+                    .getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                long indexId = index.getId();
+                long physicalPartitionId = partition.getId();
+                TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId,
+                        indexId, medium, olapTable.isCloudNativeTableOrMaterializedView());
+                for (Tablet tablet : index.getTablets()) {
+                    long tabletId = tablet.getId();
+                    invertedIndex.addTablet(tabletId, tabletMeta);
+                    if (olapTable.isOlapTableOrMaterializedView()) {
+                        for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
+                            invertedIndex.addReplica(tabletId, replica);
+                        }
+                    }
+                }
+            } // end for indices
+        }
     }
 
     public void createDb(String dbName) throws DdlException, AlreadyExistsException {


### PR DESCRIPTION
## Why I'm doing:
Fix possible NPE in FE Restart for backup mv:
```
2025-08-28 10:44:29.981+08:00 WARN (UNKNOWN 172.26.81.45_9010_1756301174568(-1)|1) [GlobalStateMgr.loadImage():1705] load meta block 2 failed
java.lang.NullPointerException: null
        at com.starrocks.server.LocalMetastore.recreateTabletInvertIndex(LocalMetastore.java:347) ~[starrocks-fe.jar:?]
        at com.starrocks.server.LocalMetastore.load(LocalMetastore.java:5079) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.loadImage(GlobalStateMgr.java:1695) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.initialize(GlobalStateMgr.java:1253) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.start(StarRocksFE.java:132) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.main(StarRocksFE.java:85) ~[starrocks-fe.jar:?]
2025-08-28 10:44:30.005+08:00 WARN (UNKNOWN 172.26.81.45_9010_1756301174568(2)|76) [StateChangeExecutor.notifyNewFETypeTransfer():62] notify new FE type transfer: LEADER
2025-08-28 10:44:30.250+08:00 ERROR (UNKNOWN 172.26.81.45_9010_1756301174568(-1)|1) [StarRocksFE.start():192] StarRocksFE start failed
java.lang.NullPointerException: null
        at com.starrocks.server.LocalMetastore.recreateTabletInvertIndex(LocalMetastore.java:347) ~[starrocks-fe.jar:?]
        at com.starrocks.server.LocalMetastore.load(LocalMetastore.java:5079) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.loadImage(GlobalStateMgr.java:1695) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.initialize(GlobalStateMgr.java:1253) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.start(StarRocksFE.java:132) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.main(StarRocksFE.java:85) ~[starrocks-fe.jar:?]
```
## What I'm doing:
- After mv restore, check its data partitions, if exception is met, drop all partitions & mark it inactive;
- Add try-catch in FE restart for mv, if meets exception for mv, set it inactive and continue.

Fixes https://github.com/StarRocks/StarRocksTest/issues/10153

Add tests: https://github.com/StarRocks/StarRocksTest/pull/10166


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
