### PR TITLE
[Enhancement] Add config to disable statistics cache lazy refresh by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2113,7 +2113,7 @@ public class Config extends ConfigBase {
      * The size of the thread-pool which will be used to refresh statistic caches
      */
     @ConfField
-    public static int statistic_cache_thread_pool_size = 10;
+    public static int statistic_cache_thread_pool_size = 5;
 
     @ConfField
     public static int slot_manager_response_thread_pool_size = 16;
@@ -2135,6 +2135,9 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static long statistic_update_interval_sec = 24L * 60L * 60L;
+
+    @ConfField(mutable = true)
+    public static boolean enable_statistic_cache_refresh_after_write = false;
 
     @ConfField(mutable = true)
     public static long statistic_collect_too_many_version_sleep = 600000; // 10min

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -722,12 +722,17 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
     }
 
     private <K, V> AsyncLoadingCache<K, V> createAsyncLoadingCache(AsyncCacheLoader<K, V> cacheLoader) {
-        return Caffeine.newBuilder()
+        Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder()
                 .expireAfterWrite(Config.statistic_update_interval_sec * 2, TimeUnit.SECONDS)
-                .refreshAfterWrite(Config.statistic_update_interval_sec, TimeUnit.SECONDS)
                 .maximumSize(Config.statistic_cache_columns)
-                .executor(statsCacheRefresherExecutor)
-                .buildAsync(cacheLoader);
+                .executor(statsCacheRefresherExecutor);
+        
+        // Only enable refreshAfterWrite if the config is enabled
+        if (Config.enable_statistic_cache_refresh_after_write) {
+            cacheBuilder.refreshAfterWrite(Config.statistic_update_interval_sec, TimeUnit.SECONDS);
+        }
+        
+        return cacheBuilder.buildAsync(cacheLoader);
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:
The current lazy refresh mechanism (`refreshAfterWrite`) of statistics cache causes unnecessary cluster resource waste:

1. **Redundant cache loading**: When tables have many partitions, lazy refresh will reload all table content into FE cache, consuming significant cluster resources with the default thread pool size of 10

2. **Duplicate refresh logic**: We already have background ANALYZE jobs that refresh the statistics cache, making the lazy refresh completely redundant

3. **Resource inefficiency**: The combination of background ANALYZE + lazy refresh creates unnecessary concurrent pressure on the cluster

## What I'm doing:

- Add `enable_statistic_cache_refresh_after_write` config (default: false) to disable lazy refresh
- Reduce `statistic_cache_thread_pool_size` from 10 to 5
- Modify `CachedStatisticStorage.createAsyncLoadingCache()` to conditionally enable refreshAfterWrite

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
