### PR TITLE
[BugFix] Increase default max connection limit for external users

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationMgr.java
@@ -57,7 +57,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public class AuthenticationMgr {
     private static final Logger LOG = LogManager.getLogger(AuthenticationMgr.class);
     public static final String ROOT_USER = "root";
-    public static final long DEFAULT_MAX_CONNECTION_FOR_EXTERNAL_USER = 100;
+    public static final long DEFAULT_MAX_CONNECTION_FOR_EXTERNAL_USER = 1000;
 
     // core data structure
     // user identity -> all the authentication information


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request updates the default maximum number of allowed connections for external users in the authentication manager. The change increases the limit from 100 to 1000, which will allow external users to establish more simultaneous connections.

* Increased the value of `DEFAULT_MAX_CONNECTION_FOR_EXTERNAL_USER` from 100 to 1000 in `AuthenticationMgr.java` to support more concurrent connections for external users.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
