### PR TITLE
[Enhancement] Prune unnecessary cte consume when prune empty join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
@@ -96,6 +96,12 @@ public class CTEContext {
         this.consumeNums.put(cteId, i + 1);
     }
 
+    public void decCTEConsume(int cteId) {
+        int i = this.consumeNums.getOrDefault(cteId, 0) - 1;
+        Preconditions.checkState(i >= 0);
+        this.consumeNums.put(cteId, i);
+    }
+
     public void addCTEStatistics(int cteId, Statistics statistics) {
         produceStatistics.put(cteId, statistics);
     }
@@ -156,7 +162,7 @@ public class CTEContext {
      */
     public boolean needInline(int cteId) {
         // 0. All CTEConsumer been pruned
-        if (!consumeNums.containsKey(cteId)) {
+        if (consumeNums.getOrDefault(cteId, 0) == 0) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -383,7 +383,9 @@ public class RuleSet {
                     new PruneEmptyUnionRule(),
                     new PruneEmptyIntersectRule(),
                     new PruneEmptyExceptRule(),
-                    new PruneEmptyWindowRule()
+                    new PruneEmptyWindowRule(),
+                    new PruneCTEProduceRule(),
+                    new InlineOneCTEConsumeRule()
             ));
 
     public static final Rule SHORT_CIRCUIT_SET_RULES =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneEmptyJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneEmptyJoinRule.java
@@ -130,6 +130,7 @@ public class PruneEmptyJoinRule extends TransformationRule {
     }
 
     public List<OptExpression> transToEmpty(OptExpression input, OptimizerContext context) {
+        decCTEConsume(input.inputAt(1 - emptyIndex), context.getCteContext());
         List<ColumnRefOperator> refs =
                 input.getOutputColumns().getColumnRefOperators(context.getColumnRefFactory());
         return Lists.newArrayList(OptExpression.create(new LogicalValuesOperator(refs)));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneEmptyJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneEmptyJoinRule.java
@@ -131,6 +131,7 @@ public class PruneEmptyJoinRule extends TransformationRule {
 
     public List<OptExpression> transToEmpty(OptExpression input, OptimizerContext context) {
         decCTEConsume(input.inputAt(1 - emptyIndex), context.getCteContext());
+        
         List<ColumnRefOperator> refs =
                 input.getOutputColumns().getColumnRefOperators(context.getColumnRefFactory());
         return Lists.newArrayList(OptExpression.create(new LogicalValuesOperator(refs)));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -1086,4 +1086,14 @@ public class CTEPlanTest extends PlanTestBase {
                 "  1:Project\n" +
                 "  |  <slot 2> : rand()");
     }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testPruneCTEWhenPruneEmptyJoin(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+        String sql = "with cte as (select v1 from t0 where v1 = 1 and v1 = 2)" +
+                " select v1 from cte where v1 in (select v1 from t0) or v1 in (select v1 from t0);";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "0:EMPTYSET");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
When prune a empty join, it just replace join to a logical value, but do not decrease cte consume.
So if a cte consume join with a empty set, join will be execute even the it is unnecessary, 
## What I'm doing:
When prune a empty join, decrease possible cte consume. So it's possible to prune cte produce(since there is no cte consume)
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3