### PR TITLE
[BugFix] Remove redundant status setting in CancelableAnalyzeTask to avoid overriding StatisticsExecutor status

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/CancelableAnalyzeTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/CancelableAnalyzeTask.java
@@ -55,9 +55,6 @@ public class CancelableAnalyzeTask implements RunnableFuture<Void> {
 
         try {
             originalTask.run();
-            if (!cancelled) {
-                analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FINISH);
-            }
         } catch (Throwable t) {
             exception = t;
             analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);


### PR DESCRIPTION
## Why I'm doing:
The original implementation in `CancelableAnalyzeTask` had a redundant status setting issue:

1. **Duplicate status management**: `StatisticsExecutor.collectStatistics()` already handles status setting:
   - Line 523-528: Sets `FAILED` status when catching exceptions
   - Line 534: Sets `FINISH` status when execution succeeds

2. **Status override problem**: Even when `StatisticsExecutor` internally caught exceptions and set the status to `FAILED`, `CancelableAnalyzeTask` would still override it to `FINISH` in the success path, causing incorrect status reporting

3. **Responsibility confusion**: Both `CancelableAnalyzeTask` and `StatisticsExecutor` were trying to manage the same status, leading to inconsistent behavior
## What I'm doing:
- Remove redundant `analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FINISH)` call in `CancelableAnalyzeTask.run()` method
- Keep only the exception handling that sets `FAILED` status when tasks throw exceptions

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

