### PR TITLE
[BugFix] Fix redundant replica handling after clone

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1176,8 +1176,14 @@ public class TabletScheduler extends FrontendDaemon {
 
         Set<Pair<String, String>> matchedLocations = new HashSet<>();
         Replica dupReplica = null;
-        //1. delete the unmatched replica
-        for (Replica replica : tabletCtx.getReplicas()) {
+        // 1. delete the unmatched replica
+        // To ensure the correctness of the cleanup process after a rebalance, we iterate the replicas in reverse order.
+        // After cloning a replica from the source BE to a newly added destination BE, the replica on the new BE will
+        // always be at the end of the list. By traversing the list in reverse, we process newer replicas first
+        // and preserve the newly added replica, preventing it from being mistakenly deleted.
+        List<Replica> replicas = tabletCtx.getReplicas();
+        for (int i = replicas.size() - 1; i >= 0; i--) {
+            Replica replica = replicas.get(i);
             if (!TabletChecker.isLocationMatch(replica.getBackendId(), tabletCtx.getRequiredLocation())) {
                 deleteReplicaInternal(tabletCtx, replica, "location mismatch", force);
                 return true;


### PR DESCRIPTION
## Why I'm doing:
Under the current rebalance + deletion mechanism, when a new BE node is added, data cannot be successfully migrated to it.

Here’s why:
- During rebalance, a tablet replica is cloned from a source BE to the new BE.
- At this moment, the source BE still holds the replica, so the system immediately treats the situation as redundant.
- Since the source BE’s replica is already recorded in cachedReplicaId and scheduled for deletion, the cloned replica on the new BE is also incorrectly judged as redundant and then removed.

As a result, the new BE node never keeps the migrated data, making the rebalance ineffective.


## What I'm doing:
I added an extra check in the redundant replica detection logic:
1. Before deciding whether a replica is redundant, we now verify if its tabletId already exists in cachedReplicaId.
2. If it does, we skip the redundant replica judgment because the replica is already scheduled for cleanup.

Fixes [#62541](https://github.com/StarRocks/starrocks/issues/62541)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
