### PR TITLE
[Enhancement] Suspend the task after consecutive failures

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -251,8 +251,8 @@ public class AlterJobMgr {
             if (currentTask != null) {
                 TaskRunManager taskRunManager = taskManager.getTaskRunManager();
                 if (!taskRunManager.tryTaskRunLock()) {
-                    LOG.warn("skip clear pending and running task runs for inactive materialized view {}, " +
-                            "since get task run lock failed", materializedView.getName());
+                    throw new SemanticException("Failed to acquire task run lock when altering " +
+                            "mv status:" + materializedView.getName());
                 }
                 try {
                     taskRunManager.killTaskRun(currentTask.getId(), true);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -235,14 +235,25 @@ public class AlterJobMgr {
                     Lists.newArrayList(MaterializedViewAnalyzer.getBaseTableInfos(mvQueryStatement, !isReplay));
             materializedView.setBaseTableInfos(baseTableInfos);
             materializedView.fixRelationship();
+
+            // resume the mv scheduler
+            TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
+            Task task = taskManager.getTask(materializedView);
+            if (task == null) {
+                throw new SemanticException("Can not find running task for materialized view [%s]", materializedView.getName());
+            }
+            taskManager.resumeTask(task);
         } else if (AlterMaterializedViewStatusClause.INACTIVE.equalsIgnoreCase(status)) {
             materializedView.setInactiveAndReason(reason);
             // clear running & pending task runs since the mv has been inactive
             final TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
             Task currentTask = taskManager.getTask(TaskBuilder.getMvTaskName(materializedView.getId()));
+            // suspend the inactive mv's task
             if (currentTask != null) {
                 TaskRunManager taskRunManager = taskManager.getTaskRunManager();
                 taskRunManager.killTaskRun(currentTask.getId(), true);
+                // suspend the task to avoid scheduling new task runs
+                taskManager.suspendTask(currentTask);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -788,4 +788,19 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         }
     }
 
+    /**
+     * Inactive the materialized view because of its task is failed for consecutive times and write the edit log.
+     */
+    public static void inactiveForConsecutiveFailures(MaterializedView mv) {
+        if (mv == null) {
+            return;
+        }
+        final String inactiveReason = MaterializedViewExceptions.inactiveReasonForConsecutiveFailures(mv.getName());
+        // inactive related mv
+        mv.setInactiveAndReason(inactiveReason);
+        // write edit log
+        AlterMaterializedViewStatusLog log = new AlterMaterializedViewStatusLog(mv.getDbId(),
+                mv.getId(), AlterMaterializedViewStatusClause.INACTIVE, inactiveReason);
+        GlobalStateMgr.getCurrentState().getEditLog().logAlterMvStatus(log);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -411,6 +411,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "task ttl")
     public static int task_ttl_second = 24 * 3600;         // 1 day
 
+    @ConfField(mutable = true, comment = "Max consecutive fail count of a task after which the task will be paused")
+    public static int max_task_consecutive_fail_count = 10;
+
     @ConfField(mutable = true, comment = "task run ttl")
     public static int task_runs_ttl_second = 7 * 24 * 3600;     // 7 day
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
@@ -31,6 +31,8 @@ public class MaterializedViewExceptions {
 
     public static final String INACTIVE_REASON_FOR_METADATA_TABLE_RESTORE_CORRUPTED = "metadata backup/restore mv corrupted:";
 
+    public static final String INACTIVE_REASON_FOR_CONSECUTIVE_FAILURES = "mv consecutive failures: ";
+
     /**
      * Create the inactive reason when base table not exists
      */
@@ -95,5 +97,9 @@ public class MaterializedViewExceptions {
 
     public static SemanticException reportBaseTableNotExists(String tableName) {
         return new SemanticException(inactiveReasonForBaseTableNotExists(tableName));
+    }
+
+    public static String inactiveReasonForConsecutiveFailures(String mvName) {
+        return INACTIVE_REASON_FOR_CONSECUTIVE_FAILURES + mvName;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.ConnectContext;
@@ -41,8 +42,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
-import static com.starrocks.common.MaterializedViewExceptions.INACTIVE_REASON_FOR_BASE_TABLE_OPTIMIZED;
 
 /**
  * A daemon thread that check the MV active status, try to activate the MV it's inactive.
@@ -61,9 +60,10 @@ public class MVActiveChecker extends FrontendDaemon {
 
     // there are some reasons that we don't active mv automatically, eg: mv backup/restore which may cause to refresh all
     // mv's data behind which is not expected.
-    private static final Set<String> MV_NO_AUTOMATIC_ACTIVE_REASONS = ImmutableSet.of(
+    public static final Set<String> MV_NO_AUTOMATIC_ACTIVE_REASONS = ImmutableSet.of(
             MV_BACKUP_INACTIVE_REASON,
-            INACTIVE_REASON_FOR_BASE_TABLE_OPTIMIZED
+            MaterializedViewExceptions.INACTIVE_REASON_FOR_BASE_TABLE_OPTIMIZED,
+            MaterializedViewExceptions.INACTIVE_REASON_FOR_CONSECUTIVE_FAILURES
     );
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -60,7 +60,7 @@ public class MVActiveChecker extends FrontendDaemon {
 
     // there are some reasons that we don't active mv automatically, eg: mv backup/restore which may cause to refresh all
     // mv's data behind which is not expected.
-    public static final Set<String> MV_NO_AUTOMATIC_ACTIVE_REASONS = ImmutableSet.of(
+    private static final Set<String> MV_NO_AUTOMATIC_ACTIVE_REASONS = ImmutableSet.of(
             MV_BACKUP_INACTIVE_REASON,
             MaterializedViewExceptions.INACTIVE_REASON_FOR_BASE_TABLE_OPTIMIZED,
             MaterializedViewExceptions.INACTIVE_REASON_FOR_CONSECUTIVE_FAILURES

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -17,8 +17,10 @@ package com.starrocks.scheduler;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.alter.OptimizeTask;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MaterializedViewRefreshType;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
@@ -38,6 +40,8 @@ import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.IntervalLiteral;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.warehouse.Warehouse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -47,6 +51,7 @@ import static com.starrocks.scheduler.TaskRun.MV_ID;
 // TaskBuilder is responsible for converting Stmt to Task Class
 // and also responsible for generating taskId and taskName
 public class TaskBuilder {
+    private static final Logger LOG = LogManager.getLogger(TaskBuilder.class);
 
     public static Task buildPipeTask(PipeTaskDesc desc) {
         Task task = new Task(desc.getUniqueTaskName());
@@ -285,5 +290,37 @@ public class TaskBuilder {
 
     public static String getMvTaskName(long mvId) {
         return "mv-" + mvId;
+    }
+
+    /**
+     * Get MaterializedView object from task if the task is mv task, otherwise return null.
+     */
+    public static MaterializedView getMvFromTask(Task task) {
+        if (task == null || task.getSource() != Constants.TaskSource.MV) {
+            return null;
+        }
+
+        Map<String, String> properties = task.getProperties();
+        if (properties == null || !properties.containsKey(MV_ID)) {
+            LOG.warn("mv id is missing in task properties, task: {}", task.getName());
+            return null;
+        }
+        String dbName = task.getDbName();
+        if (dbName == null) {
+            LOG.warn("db name is missing in task, task: {}", task.getName());
+            return null;
+        }
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        if (db == null) {
+            LOG.warn("db not found: {}, task: {}", dbName, task.getName());
+            return null;
+        }
+        long mvId = Long.parseLong(properties.get(MV_ID));
+        Table table = db.getTable(mvId);
+        if (table == null || !(table instanceof MaterializedView)) {
+            LOG.warn("mv not found: {}, task: {}", mvId, task.getName());
+            return null;
+        }
+        return (MaterializedView) table;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -401,7 +401,9 @@ public class TaskRun implements Comparable<TaskRun> {
         try {
             Constants.TaskRunState result = doExecuteTaskRun();
             // clear the fail count
-            task.resetConsecutiveFailCount();
+            if (result != null && result.isSuccessState()) {
+                task.resetConsecutiveFailCount();
+            }
             return result;
         } catch (Exception e) {
             task.incConsecutiveFailCount();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.alter.AlterMVJobExecutor;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.authorization.PrivilegeBuiltinConstants;
 import com.starrocks.authorization.PrivilegeException;
@@ -31,6 +32,7 @@ import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.LogUtil;
@@ -396,6 +398,37 @@ public class TaskRun implements Comparable<TaskRun> {
     }
 
     public Constants.TaskRunState executeTaskRun() throws Exception {
+        try {
+            Constants.TaskRunState result = doExecuteTaskRun();
+            // clear the fail count
+            task.resetConsecutiveFailCount();
+            return result;
+        } catch (Exception e) {
+            task.incConsecutiveFailCount();
+            LOG.warn("Failed to execute task run, task_id: {}, task_run_id: {}, failCount:{}",
+                    taskId, taskRunId, task.getConsecutiveFailCount(), e);
+            if (Constants.TaskSource.MV.equals(task.getSource()) && Config.max_task_consecutive_fail_count > 0 &&
+                    task.getConsecutiveFailCount() >= Config.max_task_consecutive_fail_count) {
+                LOG.warn("Task {} has failed {} times continuously, so we disable it",
+                        task.getName(), task.getConsecutiveFailCount());
+                TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
+                taskManager.suspendTask(task);
+                String mvName = "";
+                MaterializedView mv = TaskBuilder.getMvFromTask(task);
+                if (mv != null) {
+                    // If the task is an mv task, inactive the mv
+                    AlterMVJobExecutor.inactiveForConsecutiveFailures(mv);
+                    mvName = mv.getName();
+                }
+                throw new StarRocksException(String.format("Task %s has continuously failed %d times " +
+                                "and has been suspended. If you want active it again, try `ALTER MATERIALIZED VIEW %s ACTIVE`.",
+                        task.getName(), task.getConsecutiveFailCount(), mvName), e);
+            }
+            throw e;
+        }
+    }
+
+    private Constants.TaskRunState doExecuteTaskRun() throws Exception {
         TaskRunContext taskRunContext = buildTaskRunContext();
 
         // prepare to execute task run, move it here so that we can catch the exception and set the status

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunFIFOQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunFIFOQueue.java
@@ -17,7 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
-import com.nimbusds.oauth2.sdk.util.CollectionUtils;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -141,6 +141,13 @@ public class TaskRunManager implements MemoryTrackable {
         }
     }
 
+    /**
+     * Kill all task runs of the input task id, including pending and running task runs.
+     * @param taskId task id
+     * @param force whether to force kill the running task run, if true, it will always clear the task run from task run no
+     *              matter the task is cancelled or not.
+     * NOTE: This method is not thread safe, caller should take lock if necessary.
+     */
     public boolean killTaskRun(Long taskId, boolean force) {
         // kill all pending task runs of the task id
         killPendingTaskRuns(taskId);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -24,16 +24,27 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.qe.ShowMaterializedViewStatus;
+import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.MVActiveChecker;
+import com.starrocks.scheduler.MVTaskRunProcessor;
+import com.starrocks.scheduler.Task;
+import com.starrocks.scheduler.TaskManager;
+import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
+import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.RefreshSchemeClause;
 import com.starrocks.sql.ast.SyncRefreshSchemeDesc;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -195,7 +206,6 @@ public class AlterMaterializedViewTest extends MVTestBase  {
 
     @Test
     public void testInactiveMV() throws Exception {
-
         starRocksAssert
                 .withTable("CREATE TABLE IF NOT EXISTS par_tbl1\n" +
                         "(\n" +
@@ -255,6 +265,11 @@ public class AlterMaterializedViewTest extends MVTestBase  {
         MaterializedView mv = (MaterializedView) starRocksAssert.getTable(connectContext.getDatabase(), "mv_test1");
         Assertions.assertTrue(starRocksAssert.waitRefreshFinished(mv.getId()));
 
+        TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
+        Task task = taskManager.getTask(mv);
+        Assertions.assertNotNull(task);
+        Assertions.assertEquals(0, task.getConsecutiveFailCount());
+
         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                 mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         Assertions.assertTrue(!baseTableVisibleVersionMap.isEmpty());
@@ -264,6 +279,8 @@ public class AlterMaterializedViewTest extends MVTestBase  {
                 (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
         currentState.getLocalMetastore().alterMaterializedView(stmt);
         Assertions.assertFalse(mv.isActive());
+        Assertions.assertEquals(Constants.TaskState.PAUSE, task.getState());
+        Assertions.assertEquals(0, task.getConsecutiveFailCount());
 
         alterMvSql = "alter materialized view mv_test1 ACTIVE";
         stmt = (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
@@ -273,6 +290,7 @@ public class AlterMaterializedViewTest extends MVTestBase  {
         baseTableVisibleVersionMap =
                 mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         Assertions.assertTrue(!baseTableVisibleVersionMap.isEmpty());
+        Assertions.assertNotEquals(Constants.TaskState.PAUSE, task.getState());
 
         alterMvSql = "alter materialized view mv_test1 INACTIVE";
         stmt = (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
@@ -664,5 +682,87 @@ public class AlterMaterializedViewTest extends MVTestBase  {
             currentState.getLocalMetastore().alterMaterializedView(stmt);
             starRocksAssert.query(query).explainContains("test_mv1");
         }
+    }
+
+    @Test
+    public void testMVPausedWithConsecutiveFailCount1() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_t1 (\n" +
+                "   k1 int,\n" +
+                "   k2 date,\n" +
+                "   k3 string\n" +
+                ")\n" +
+                "DUPLICATE KEY(k1);");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test_refresh_fail_mv1\n" +
+                "REFRESH MANUAL\n" +
+                "AS select sum(k1), k2, k3 from base_t1 group by k2, k3;");
+        executeInsertSql("insert into base_t1 values(1, '2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');");
+        MaterializedView mv = getMv("test_refresh_fail_mv1");
+        Config.max_task_consecutive_fail_count = 3;
+        for (int i = 0; i < Config.max_task_consecutive_fail_count; i++) {
+            new MockUp<MVTaskRunProcessor>() {
+                @Mock
+                public void executePlan(ExecPlan execPlan, InsertStmt insertStmt) throws Exception {
+                    throw new RuntimeException("Mocked exception");
+                }
+            };
+            try {
+                refreshMV("test", mv);
+            } catch (Exception e) {
+                // do nothing
+            }
+        }
+        TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
+        Task task = taskManager.getTask(mv);
+        Assertions.assertEquals(Config.max_task_consecutive_fail_count, task.getConsecutiveFailCount());
+        Assertions.assertEquals(Constants.TaskState.PAUSE, task.getState());
+
+        Map<String, List<TaskRunStatus>> taskNameJobStatusMap =
+                taskManager.listMVRefreshedTaskRunStatus(DB_NAME, Set.of("test_refresh_fail_mv1"));
+        List<TaskRunStatus> taskRunStatuses = taskNameJobStatusMap.getOrDefault(mv.getName(), Lists.newArrayList());
+        ShowMaterializedViewStatus mvStatus = ShowMaterializedViewStatus.of("test", mv, taskRunStatuses);
+        Assertions.assertFalse(mv.isActive());
+        Config.max_task_consecutive_fail_count = 10;
+    }
+
+    @Test
+    public void testMVPausedWithConsecutiveFailCount2() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_t1 (\n" +
+                "   k1 int,\n" +
+                "   k2 date,\n" +
+                "   k3 string\n" +
+                ")\n" +
+                "DUPLICATE KEY(k1);");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test_refresh_fail_mv2\n" +
+                "REFRESH MANUAL\n" +
+                "AS select sum(k1), k2, k3 from base_t1 group by k2, k3;");
+        executeInsertSql("insert into base_t1 values(1, '2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');");
+        MaterializedView mv = getMv("test_refresh_fail_mv2");
+        Config.max_task_consecutive_fail_count = 3;
+        for (int i = 0; i < Config.max_task_consecutive_fail_count - 1; i++) {
+            new MockUp<MVTaskRunProcessor>() {
+                @Mock
+                public void executePlan(ExecPlan execPlan, InsertStmt insertStmt) throws Exception {
+                    throw new RuntimeException("Mocked exception");
+                }
+            };
+            try {
+                refreshMV("test", mv);
+            } catch (Exception e) {
+                // do nothing
+            }
+        }
+        // refresh success
+        new MockUp<MVTaskRunProcessor>() {
+            @Mock
+            public void executePlan(ExecPlan execPlan, InsertStmt insertStmt) throws Exception {
+                // do nothing
+            }
+        };
+        refreshMV("test", mv);
+        Task task = GlobalStateMgr.getCurrentState().getTaskManager().getTask(mv);
+        Assertions.assertEquals(0, task.getConsecutiveFailCount());
+        Assertions.assertNotEquals(Constants.TaskState.PAUSE, task.getState());
+        Assertions.assertTrue(mv.isActive());
+        Config.max_task_consecutive_fail_count = 10;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -385,7 +385,15 @@ public abstract class MVTestBase extends StarRocksTestBase {
     }
 
     protected TaskRun withMVRefreshTaskRun(String dbName, MaterializedView mv) throws Exception {
-        Task task = TaskBuilder.buildMvTask(mv, dbName);
+        TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
+
+        // create a task if not exist
+        Task task = taskManager.getTask(mv);
+        if (task == null) {
+            task = TaskBuilder.buildMvTask(mv, dbName);
+            taskManager.createTask(task, false);
+        }
+
         Map<String, String> testProperties = task.getProperties();
         testProperties.put(TaskRun.IS_TEST, "true");
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Remove scheduler from task manager after `inactive` to avoid meaningless refreshes.
- Added logic to automatically pause MV tasks when their consecutive failure count exceeds the new configurable threshold (`max_task_consecutive_fail_count` in `Config.java`). The failure count is tracked per task, reset on success, and incremented on failure. When the threshold is reached, the task is suspended and its state set to `PAUSE`. [[1]](diffhunk://#diff-c4dd949472990c944bb229f17a8fda3b329551819852735b5a7d7ae75aab1e18R403-R405) [[2]](diffhunk://#diff-32bc53e46495c2019614db3089c92989235da203897e342018f2034d077201bfR78-R80) [[3]](diffhunk://#diff-32bc53e46495c2019614db3089c92989235da203897e342018f2034d077201bfR217-R228) [[4]](diffhunk://#diff-f1d76aae12ea6926db5615eab37682926e130f7c796fcbb8e8a22cf18d32901bR349-R368) [[5]](diffhunk://#diff-ed40d0f2bad300ed05a6b9e6fa7f6e8b982d908570d54cb91ff41a98822593feL445-R506)

## Behavior Changes


Before:
- Inactive mvs(Mannual Setting) still can be scheduled in TaskRunManager and will always fails.
- Invalid mvs will always be scheduled even after consecutive failures;

After:
- Inactive mvs will be suspend in TaskRunManager and will not be scheduled again.
- Invalid mvs will always be not be scheduled and be set `inactive` after the setting max consecutive failures(`Config.max_task_consecutive_fail_count`), and only can be scheduled after users active it again;


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
