### PR TITLE
[Enhancement] support s3 path style in shared-data cluster

### DIFF
--- a/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
@@ -50,6 +50,7 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
 | aws.s3.secret_key                   | The Secret Access Key used to access your S3 bucket.         |
 | aws.s3.iam_role_arn                 | The ARN of the IAM role that has privileges on your S3 bucket in which your data files are stored. |
 | aws.s3.external_id                  | The external ID of the AWS account that is used for cross-account access to your S3 bucket. |
+| aws.s3.enable_path_style_access     | Whether to use the Path Style to access S3.<br />Valid values: `true` and `false`. Default: `false`. |
 | azure.blob.endpoint                 | The endpoint of your Azure Blob Storage Account, for example, `https://test.blob.core.windows.net`. |
 | azure.blob.shared_key               | The Shared Key used to authorize requests for your Azure Blob Storage. |
 | azure.blob.sas_token                | The shared access signatures (SAS) used to authorize requests for your Azure Blob Storage. |

--- a/docs/ja/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
+++ b/docs/ja/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
@@ -52,6 +52,7 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
 | aws.s3.secret_key                   | S3 バケットにアクセスするためのシークレットアクセスキーです。         |
 | aws.s3.iam_role_arn                 | データファイルが保存されている S3 バケットに対して権限を持つ IAM ロールの ARN です。 |
 | aws.s3.external_id                  | S3 バケットへのクロスアカウントアクセスに使用される AWS アカウントの外部 ID です。 |
+| aws.s3.enable_path_style_access     | Path Style を使用して S3 にアクセスするかどうか。<br />有効な値: `true` および `false`。デフォルト: `false`。 |
 | azure.blob.endpoint                 | Azure Blob Storage アカウントのエンドポイントです。例：`https://test.blob.core.windows.net`。 |
 | azure.blob.shared_key               | Azure Blob Storage へのリクエストを承認するために使用される共有キーです。 |
 | azure.blob.sas_token                | Azure Blob Storage へのリクエストを承認するために使用される共有アクセス署名 (SAS) です。 |

--- a/docs/zh/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
+++ b/docs/zh/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
@@ -53,7 +53,7 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
 | aws.s3.secret_key                   | 访问 S3 存储空间的 Secret Key。                              |
 | aws.s3.iam_role_arn                 | 有访问 S3 存储空间权限 IAM Role 的 ARN。                     |
 | aws.s3.external_id                  | 用于跨 AWS 账户访问 S3 存储空间的外部 ID。                   |
-| aws.s3.enable_path_style_access     | 指定是否使用 path style 方式访问 S3。<br />有效值：`true` 和 `false`。默认值：`false`。                   |
+| aws.s3.enable_path_style_access     | 指定是否使用 Path Style 方式访问 S3。<br />有效值：`true` 和 `false`。默认值：`false`。                   |
 | azure.blob.endpoint   | Azure Blob Storage 的链接地址，如 `https://test.blob.core.windows.net`。 |
 | azure.blob.shared_key | 访问 Azure Blob Storage 的共享密钥（Shared Key）。           |
 | azure.blob.sas_token  | 访问 Azure Blob Storage 的共享访问签名（SAS）。              |

--- a/docs/zh/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
+++ b/docs/zh/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
@@ -53,6 +53,7 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
 | aws.s3.secret_key                   | 访问 S3 存储空间的 Secret Key。                              |
 | aws.s3.iam_role_arn                 | 有访问 S3 存储空间权限 IAM Role 的 ARN。                     |
 | aws.s3.external_id                  | 用于跨 AWS 账户访问 S3 存储空间的外部 ID。                   |
+| aws.s3.enable_path_style_access     | 指定是否使用 path style 方式访问 S3。<br />有效值：`true` 和 `false`。默认值：`false`。                   |
 | azure.blob.endpoint   | Azure Blob Storage 的链接地址，如 `https://test.blob.core.windows.net`。 |
 | azure.blob.shared_key | 访问 Azure Blob Storage 的共享密钥（Shared Key）。           |
 | azure.blob.sas_token  | 访问 Azure Blob Storage 的共享访问签名（SAS）。              |

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudConfiguration.java
@@ -32,9 +32,9 @@ public class AwsCloudConfiguration extends CloudConfiguration {
 
     private final AwsCloudCredential awsCloudCredential;
 
-    // shared-data cluster uses 3 methods to determine whether enable path style access,
-    // if is null, BE/CN will auto-determine whether use path style access, otherwise it will
-    // be determined by corresponding value
+    // shared-data cluster uses 2 methods to determine whether to enable path style access:
+    // if it is null, BE/CN will auto-determine whether to use path style access; otherwise, it will
+    // be determined by the corresponding value.
     private Boolean enablePathStyleAccess = null;
 
     private boolean enableSSL = true;

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -292,6 +292,13 @@ public class StorageVolume implements Writable, GsonPostProcessable {
                     params.put(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX,
                             Integer.toString(s3FileStoreInfo.getNumPartitionedPrefix()));
                 }
+                if (s3FileStoreInfo.getPathStyleAccess() == 1) {
+                    params.put(CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS,
+                            Boolean.toString(true));
+                } else if (s3FileStoreInfo.getPathStyleAccess() == 2) {
+                    params.put(CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS,
+                            Boolean.toString(false));
+                }
                 AwsCredentialInfo credentialInfo = s3FileStoreInfo.getCredential();
                 if (credentialInfo.hasSimpleCredential()) {
                     params.put(CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE, "false");

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -55,6 +55,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_ACCESS_KEY;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_ENDPOINT;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_EXTERNAL_ID;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_IAM_ROLE_ARN;
@@ -120,6 +121,7 @@ public class StorageVolumeTest {
         storageParams.put(AWS_S3_ACCESS_KEY, "access_key");
         storageParams.put(AWS_S3_SECRET_KEY, "secret_key");
         storageParams.put(AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "false");
+        storageParams.put(AWS_S3_ENABLE_PATH_STYLE_ACCESS, "true");
 
         StorageVolume sv = new StorageVolume("1", "test", "s3", Arrays.asList("s3://abc"),
                 storageParams, true, "");
@@ -130,6 +132,7 @@ public class StorageVolumeTest {
         Assertions.assertTrue(fileStore.hasS3FsInfo());
         S3FileStoreInfo s3FileStoreInfo = fileStore.getS3FsInfo();
         Assertions.assertTrue(s3FileStoreInfo.getCredential().hasSimpleCredential());
+        Assertions.assertEquals(s3FileStoreInfo.getPathStyleAccess(), 1);
         AwsSimpleCredentialInfo simpleCredentialInfo = s3FileStoreInfo.getCredential().getSimpleCredential();
         Assertions.assertEquals("access_key", simpleCredentialInfo.getAccessKey());
         Assertions.assertEquals("secret_key", simpleCredentialInfo.getAccessKeySecret());
@@ -610,6 +613,24 @@ public class StorageVolumeTest {
             Assertions.assertTrue(params.containsKey(CloudConfigurationConstants.AWS_S3_ENABLE_PARTITIONED_PREFIX));
             Assertions.assertTrue(params.containsKey(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX));
             Assertions.assertEquals("32", params.get(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX));
+        }
+
+        fsInfoBuilder.getS3FsInfoBuilder()
+                .setPathStyleAccess(1);
+
+        {
+            FileStoreInfo fs = fsInfoBuilder.build();
+            Map<String, String> params = StorageVolume.getParamsFromFileStoreInfo(fs);
+            Assertions.assertEquals("true", params.get(CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS));
+        }
+
+        fsInfoBuilder.getS3FsInfoBuilder()
+                .setPathStyleAccess(2);
+
+        {
+            FileStoreInfo fs = fsInfoBuilder.build();
+            Map<String, String> params = StorageVolume.getParamsFromFileStoreInfo(fs);
+            Assertions.assertEquals("false", params.get(CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS));
         }
 
         // It's OK to have trailing '/' after bucket name


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #61590

support `"aws.s3.enable_path_style_access" = "true"` when create storage volume

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3