### PR TITLE
[BugFix] Change the `tuple_id` field in `TIcebergTableSink` to optional to fix the compatibility issues with historical versions.

### DIFF
--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -248,7 +248,7 @@ struct TIcebergTableSink {
     5: optional bool is_static_partition_sink
     6: optional CloudConfiguration.TCloudConfiguration cloud_configuration
     7: optional i64 target_max_file_size
-    8: required i32 tuple_id
+    8: optional i32 tuple_id
 }
 
 struct THiveTableSink {


### PR DESCRIPTION
## Why I'm doing:
We add a `tuple_id` field in `TIcebergTableSink`, but mistakenly mark it as `required`, which cause the compatibility issues with historical versions.

## What I'm doing:
Change the field to `optional`  to keep the compatibility with old versions.

Fixes https://github.com/StarRocks/StarRocksTest/issues/10171

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
