### PR TITLE
[BugFix]Disable tablet creation optimization when partitions has multiple indexes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -215,6 +215,11 @@ public class TabletTaskExecutor {
                                                                    CreateTabletOption option)
             throws DdlException {
         ArrayList<CreateReplicaTask> tasks = new ArrayList<>((int) physicalPartition.storageReplicaCount());
+        // TabletCreationOptimization must ensure that the schemas of all tablets under a partition are consistent. 
+        // If multiple indexes exist in the partition, disable TabletCreationOptimization.
+        if (physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE).size() > 1) {
+            option.setEnableTabletCreationOptimization(false);
+        }
         for (MaterializedIndex index : physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
             tasks.addAll(buildCreateReplicaTasks(dbId, table, physicalPartition, index, computeResource, option));
         }


### PR DESCRIPTION
## Why I'm doing:
`TabletCreationOptimization` must ensure that the schemas of all tablets under a partition are consistent.  If multiple indexes exist in one partition and enable `TabletCreationOptimization`, some tablet schema maybe lost because different indexes will create one same initial tablet metadata. (0000000000000000_0000000000000001.meta) 
## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10172
If multiple indexes exist in the partition, disable TabletCreationOptimization.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
