### PR TITLE
[BugFix] Fix case-sensitive partition column validation in materialized view analyzer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -1081,7 +1081,7 @@ public class MaterializedViewAnalyzer {
             } else {
                 List<Column> refPartitionCols = refBaseTable.getPartitionColumns();
                 Optional<Column> refPartitionColOpt = refPartitionCols.stream()
-                        .filter(col -> col.getName().equals(slotRef.getColumnName()))
+                        .filter(col -> col.getName().equalsIgnoreCase(slotRef.getColumnName()))
                         .findFirst();
                 if (refPartitionColOpt.isEmpty()) {
                     throw new SemanticException("Materialized view partition column in partition exp " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -536,4 +536,10 @@ public class MaterializedViewAnalyzerTest {
 
         Config.default_replication_num = defaultReplication;
     }
+
+    @Test
+    public void testCreateMVCheckPartitionNameIgnoreCaseSensitive() {
+        analyzeSuccess("create materialized view mv_hive_0 partition by str2date(L_SHIPDATE, '%Y%m%d') refresh manual as " +
+                "SELECT l_partkey, L_SHIPDATE  FROM hive0.partitioned_db.lineitem_mul_par3 as a");
+    }
 }


### PR DESCRIPTION

## Why I'm doing:

When creating materialized views based on Hive external tables, if the partition expression column name case doesn't match the base table partition column name (e.g., base table partition column is l_shipdate, but expression uses L_SHIPDATE), the validation would fail and throw "Materialized view partition column in partition exp must be base table partition column" error.


## What I'm doing:
Modified partition column validation logic in MaterializedViewAnalyzer.java

Fixes #issue
https://github.com/StarRocks/starrocks/issues/62597

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
