### PR TITLE
[Feature] configurable cipher-suite filtering

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -541,6 +541,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: The port on which the HTTPS server in the FE node listens.
 - Introduced in: v4.0
 
+##### ssl_cipher_whitelist
+
+- Default: Empty string
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: Comma separated list, with regex support to whitelist ssl cipher suites by IANA names. If both whitelist and blacklist are set, blacklist takes precedence.
+- Introduced in: v4.0
+
+##### ssl_cipher_blacklist
+
+- Default: Empty string
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: Comma separated list, with regex support to blacklist ssl cipher suites by IANA names. If both whitelist and blacklist are set, blacklist takes precedence.
+- Introduced in: v4.0
+
 ##### http_async_threads_num
 
 - Default: 4096

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -733,14 +733,14 @@ public class Config extends ConfigBase {
      *  If both whitelist and blacklist are set, blacklist takes precedence.
      */
     @ConfField
-    public static String sslCipherWhitelist = "";
+    public static String ssl_cipher_whitelist = "";
 
     /**
      *  Property to blacklist ssl cipher suites, comma separated list, with regex support.
      *  If both whitelist and blacklist are set, blacklist takes precedence.
      */
     @ConfField
-    public static String sslCipherBlacklist = "";
+    public static String ssl_cipher_blacklist = "";
 
     /**
      * Configs for query queue v2.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -729,6 +729,20 @@ public class Config extends ConfigBase {
     public static boolean enable_https = false;
 
     /**
+     *  Property to whitelist ssl cipher suites, comma separated list, with regex support.
+     *  If both whitelist and blacklist are set, blacklist takes precedence.
+     */
+    @ConfField
+    public static String sslCipherWhitelist = "";
+
+    /**
+     *  Property to blacklist ssl cipher suites, comma separated list, with regex support.
+     *  If both whitelist and blacklist are set, blacklist takes precedence.
+     */
+    @ConfField
+    public static String sslCipherBlacklist = "";
+
+    /**
      * Configs for query queue v2.
      * The configs {@code query_queue_v2_xxx} are effective only when {@code enable_query_queue_v2} is true.
      * @see com.starrocks.qe.scheduler.slot.QueryQueueOptions

--- a/fe/fe-core/src/main/java/com/starrocks/http/SslUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/SslUtil.java
@@ -50,8 +50,8 @@ public class SslUtil {
     }
 
     public static String[] filterCipherSuites(String[] defaults) {
-        List<Pattern> whitelist = parsePatterns(Config.sslCipherWhitelist);
-        List<Pattern> blacklist = parsePatterns(Config.sslCipherBlacklist);
+        List<Pattern> whitelist = parsePatterns(Config.ssl_cipher_whitelist);
+        List<Pattern> blacklist = parsePatterns(Config.ssl_cipher_blacklist);
 
         if (whitelist.isEmpty() && blacklist.isEmpty()) {
             return defaults;

--- a/fe/fe-core/src/main/java/com/starrocks/http/SslUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/SslUtil.java
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.starrocks.common.Config;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+public class SslUtil {
+
+    private static final Logger LOG = LogManager.getLogger(SslUtil.class);
+    private static final Pattern COMMA = Pattern.compile("\\s*,\\s*");
+
+    private static List<Pattern> parsePatterns(String cfg) {
+        if (cfg == null || cfg.isBlank()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(COMMA.split(cfg))
+                .filter(s -> !s.isEmpty())
+                .map(Pattern::compile)
+                .toList();
+    }
+
+    private static boolean matchesAny(List<Pattern> ps, String s) {
+        for (Pattern p : ps) {
+            if (p.matcher(s).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static String[] filterCipherSuites(String[] defaults) {
+        List<Pattern> whitelist = parsePatterns(Config.sslCipherWhitelist);
+        List<Pattern> blacklist = parsePatterns(Config.sslCipherBlacklist);
+
+        if (whitelist.isEmpty() && blacklist.isEmpty()) {
+            return defaults;
+        }
+
+        Predicate<String> allow = whitelist.isEmpty() ? x -> true  : c -> matchesAny(whitelist, c);
+        Predicate<String> deny  = blacklist.isEmpty() ? x -> false : c -> matchesAny(blacklist, c);
+
+        String[] filtered = Arrays.stream(defaults == null ? new String[0] : defaults)
+                .filter(Objects::nonNull)
+                .filter(allow)
+                .filter(deny.negate())
+                .toArray(String[]::new);
+
+        if (filtered.length == 0) {
+            LOG.warn("No cipher suites left, please check your whitelist and blacklist settings.");
+        }
+        return filtered;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1317,7 +1317,7 @@ public class ConnectContext {
     }
 
     public boolean enableSSL() throws IOException {
-        SSLChannel sslChannel = new SSLChannelImp(SSLContextLoader.getSslContext().createSSLEngine(), mysqlChannel);
+        SSLChannel sslChannel = new SSLChannelImp(SSLContextLoader.newServerEngine(), mysqlChannel);
         if (!sslChannel.init()) {
             return false;
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/http/HttpSslContextBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/HttpSslContextBuilderTest.java
@@ -12,26 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/http/StarRocksHttpTestCase.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 package com.starrocks.http;
 
 import com.starrocks.common.Config;

--- a/fe/fe-core/src/test/java/com/starrocks/http/HttpSslContextBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/HttpSslContextBuilderTest.java
@@ -1,0 +1,139 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/http/StarRocksHttpTestCase.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.http;
+
+import com.starrocks.common.Config;
+import com.starrocks.http.rest.HttpSSLContextLoader;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.security.KeyStore;
+import java.util.List;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLServerSocketFactory;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HttpSslContextBuilderTest {
+
+    private static void resetHttpSslContext() throws Exception {
+        Field f = HttpSSLContextLoader.class.getDeclaredField("initialized");
+        f.setAccessible(true);
+        f.set(null, false);
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        resetHttpSslContext();
+        Config.enable_https = true;
+        Config.ssl_keystore_password = "pass";
+        Config.ssl_key_password = "pass";
+        File f = File.createTempFile("keystore", ".jks");
+        f.deleteOnExit();
+        Config.ssl_keystore_location = f.getAbsolutePath();
+    }
+
+    @Test
+    void jdkSslFactoryPathFiltersAndApplies() throws Exception {
+        String[] supported = {"TLS_AES_256_GCM_SHA384", "TLS_RSA_WITH_AES_128_CBC_SHA"};
+        String[] filtered  = {"TLS_AES_256_GCM_SHA384"};
+
+        KeyStore ks = mock(KeyStore.class);
+        KeyManagerFactory kmf = mock(KeyManagerFactory.class);
+        SSLServerSocketFactory ssf = mock(SSLServerSocketFactory.class);
+        when(ssf.getSupportedCipherSuites()).thenReturn(supported);
+
+        SslContextBuilder builder = mock(SslContextBuilder.class, RETURNS_SELF);
+        SslContext ctx = mock(SslContext.class);
+        when(builder.build()).thenReturn(ctx);
+
+        try (MockedStatic<KeyStore> ksStatic = mockStatic(KeyStore.class);
+                MockedStatic<KeyManagerFactory> kmfStatic = mockStatic(KeyManagerFactory.class);
+                MockedStatic<SSLServerSocketFactory> ssfStatic = mockStatic(SSLServerSocketFactory.class);
+                MockedStatic<SslUtil> sslUtilStatic = mockStatic(SslUtil.class);
+                MockedStatic<SslContextBuilder> scbStatic = mockStatic(SslContextBuilder.class)) {
+
+            ksStatic.when(() -> KeyStore.getInstance("JKS")).thenReturn(ks);
+            doNothing().when(ks).load(any(), any());
+
+            kmfStatic.when(KeyManagerFactory::getDefaultAlgorithm).thenReturn("SunX509");
+            kmfStatic.when(() -> KeyManagerFactory.getInstance("SunX509")).thenReturn(kmf);
+            doNothing().when(kmf).init(any(KeyStore.class), any());
+
+            ssfStatic.when(SSLServerSocketFactory::getDefault).thenReturn(ssf);
+
+            sslUtilStatic.when(() -> SslUtil.filterCipherSuites(supported)).thenReturn(filtered);
+
+            scbStatic.when(() -> SslContextBuilder.forServer(kmf)).thenReturn(builder);
+
+            SslContext out = HttpSSLContextLoader.getSslContext();
+
+            assertSame(ctx, out);
+            ArgumentCaptor<List<String>> cap = ArgumentCaptor.forClass(List.class);
+            verify(builder).ciphers(cap.capture());
+            assertArrayEquals(filtered, cap.getValue().toArray(new String[0]));
+            sslUtilStatic.verify(() -> SslUtil.filterCipherSuites(supported));
+            verify(builder).build();
+        }
+    }
+
+    @Test
+    void disabledHttpsNoCipherFiltering() throws Exception {
+        resetHttpSslContext();
+        Config.enable_https = false;
+        Config.ssl_keystore_location = "whatever";
+
+        try (MockedStatic<SslUtil> sslUtilStatic = mockStatic(SslUtil.class);
+                MockedStatic<SSLServerSocketFactory> ssfStatic = mockStatic(SSLServerSocketFactory.class)) {
+
+            sslUtilStatic.verifyNoInteractions();
+            ssfStatic.verifyNoInteractions();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/SslUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/SslUtilTest.java
@@ -37,13 +37,13 @@ class SslUtilTest {
 
     @AfterEach
     void resetConfig() {
-        Config.sslCipherWhitelist = "";
-        Config.sslCipherBlacklist = "";
+        Config.ssl_cipher_whitelist = "";
+        Config.ssl_cipher_blacklist = "";
     }
 
     @Test
     void whitelistRegexOnlyGcmEcdheRsa() {
-        Config.sslCipherWhitelist = "^ECDHE-RSA-.*-GCM-.*$";
+        Config.ssl_cipher_whitelist = "^ECDHE-RSA-.*-GCM-.*$";
         String[] out = SslUtil.filterCipherSuites(DEFAULTS);
         assertArrayEquals(
                 new String[] {"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384"},
@@ -53,7 +53,7 @@ class SslUtilTest {
 
     @Test
     void blacklistShaCbc() {
-        Config.sslCipherBlacklist = ".*-SHA$";
+        Config.ssl_cipher_blacklist = ".*-SHA$";
         String[] out = SslUtil.filterCipherSuites(DEFAULTS);
         assertFalse(Arrays.asList(out).contains("AES128-SHA"));
         assertFalse(Arrays.asList(out).contains("AES256-SHA"));
@@ -64,7 +64,7 @@ class SslUtilTest {
 
     @Test
     void excludeAllTls13() {
-        Config.sslCipherBlacklist = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256";
+        Config.ssl_cipher_blacklist = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256";
         String[] out = SslUtil.filterCipherSuites(DEFAULTS);
         for (String s : out) {
             assertFalse(s.startsWith("TLS_"));
@@ -73,7 +73,7 @@ class SslUtilTest {
 
     @Test
     void whitelistSingleTls13() {
-        Config.sslCipherWhitelist = "TLS_AES_128_GCM_SHA256";
+        Config.ssl_cipher_whitelist = "TLS_AES_128_GCM_SHA256";
         String[] out = SslUtil.filterCipherSuites(DEFAULTS);
         assertArrayEquals(new String[] {"TLS_AES_128_GCM_SHA256"}, out);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/http/SslUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/SslUtilTest.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.starrocks.common.Config;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SslUtilTest {
+
+    private static final String[] DEFAULTS = {
+            // TLS 1.3
+            "TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256",
+            // TLS 1.2
+            "ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384",
+            "ECDHE-RSA-CHACHA20-POLY1305", "AES128-GCM-SHA256", "AES256-GCM-SHA384",
+            "AES128-SHA", "AES256-SHA"
+    };
+
+    @AfterEach
+    void resetConfig() {
+        Config.sslCipherWhitelist = "";
+        Config.sslCipherBlacklist = "";
+    }
+
+    @Test
+    void whitelistRegexOnlyGcmEcdheRsa() {
+        Config.sslCipherWhitelist = "^ECDHE-RSA-.*-GCM-.*$";
+        String[] out = SslUtil.filterCipherSuites(DEFAULTS);
+        assertArrayEquals(
+                new String[] {"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384"},
+                out
+        );
+    }
+
+    @Test
+    void blacklistShaCbc() {
+        Config.sslCipherBlacklist = ".*-SHA$";
+        String[] out = SslUtil.filterCipherSuites(DEFAULTS);
+        assertFalse(Arrays.asList(out).contains("AES128-SHA"));
+        assertFalse(Arrays.asList(out).contains("AES256-SHA"));
+
+        assertTrue(Arrays.asList(out).contains("AES128-GCM-SHA256"));
+        assertTrue(Arrays.asList(out).contains("AES256-GCM-SHA384"));
+    }
+
+    @Test
+    void excludeAllTls13() {
+        Config.sslCipherBlacklist = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256";
+        String[] out = SslUtil.filterCipherSuites(DEFAULTS);
+        for (String s : out) {
+            assertFalse(s.startsWith("TLS_"));
+        }
+    }
+
+    @Test
+    void whitelistSingleTls13() {
+        Config.sslCipherWhitelist = "TLS_AES_128_GCM_SHA256";
+        String[] out = SslUtil.filterCipherSuites(DEFAULTS);
+        assertArrayEquals(new String[] {"TLS_AES_128_GCM_SHA256"}, out);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlJsseTlsCiphersTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlJsseTlsCiphersTest.java
@@ -1,0 +1,126 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/http/StarRocksHttpTestCase.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.mysql;
+
+import org.junit.jupiter.api.Test;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MysqlJsseTlsCiphersTest {
+
+    private static boolean containsTls12(String s) {
+        return s.contains("_WITH_");
+    }
+
+    private static List<String> enabled(SSLEngine eng, String... suites) {
+        SSLParameters p = new SSLParameters();
+        p.setCipherSuites(suites);
+        eng.setSSLParameters(p);
+        return Arrays.asList(eng.getEnabledCipherSuites());
+    }
+
+    private static SSLEngine newEngine() throws Exception {
+        SSLContext ctx = SSLContext.getInstance("TLS");
+        ctx.init(null, null, new SecureRandom());
+        return ctx.createSSLEngine();
+    }
+
+    @Test
+    void jsseOnlyTls13OneEnabledNoTls12() throws Exception {
+        SSLEngine eng = newEngine();
+        List<String> en = enabled(eng, "TLS_AES_128_GCM_SHA256");
+        assertTrue(en.contains("TLS_AES_128_GCM_SHA256"));
+        assertFalse(en.contains("TLS_AES_256_GCM_SHA384"));
+        assertFalse(en.contains("TLS_CHACHA20_POLY1305_SHA256"));
+        assertTrue(en.stream().noneMatch(MysqlJsseTlsCiphersTest::containsTls12));
+    }
+
+    @Test
+    void jsseOnlyTls13allThreeExactlyThoseThreeNoTls12() throws Exception {
+        SSLEngine eng = newEngine();
+        String[] req = {
+                "TLS_AES_128_GCM_SHA256",
+                "TLS_AES_256_GCM_SHA384",
+                "TLS_CHACHA20_POLY1305_SHA256"
+        };
+        List<String> en = enabled(eng, req);
+        assertEquals(new HashSet<>(Arrays.asList(req)), new HashSet<>(en));
+        assertTrue(en.stream().noneMatch(MysqlJsseTlsCiphersTest::containsTls12));
+    }
+
+    @Test
+    void jsseOnlyTls12MultipleExactlyRequestedNoTls13() throws Exception {
+        SSLEngine eng = newEngine();
+        String[] req = {
+                "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+        };
+        List<String> en = enabled(eng, req);
+        assertEquals(new HashSet<>(Arrays.asList(req)), en.stream().filter(MysqlJsseTlsCiphersTest::containsTls12)
+                .collect(Collectors.toSet()));
+        assertFalse(en.contains("TLS_AES_128_GCM_SHA256"));
+        assertFalse(en.contains("TLS_AES_256_GCM_SHA384"));
+        assertFalse(en.contains("TLS_CHACHA20_POLY1305_SHA256"));
+    }
+
+    @Test
+    void jsseMixedSubsetExactUnionNoExtras() throws Exception {
+        SSLEngine eng = newEngine();
+        String[] req = {
+                "TLS_AES_128_GCM_SHA256",
+                "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+        };
+        List<String> en = enabled(eng, req);
+        assertEquals(new HashSet<>(Arrays.asList(req)), new HashSet<>(en));
+    }
+
+    @Test
+    void jsseEmptyListResultsInNoEnabledSuites() throws Exception {
+        SSLEngine eng = newEngine();
+        List<String> en = enabled(eng);
+        assertEquals(0, en.size());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlJsseTlsCiphersTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlJsseTlsCiphersTest.java
@@ -12,26 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/http/StarRocksHttpTestCase.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 package com.starrocks.mysql;
 
 import org.junit.jupiter.api.Test;

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlSslEngineConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlSslEngineConfigTest.java
@@ -1,0 +1,260 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/http/StarRocksHttpTestCase.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.mysql;
+
+import com.starrocks.common.Config;
+import com.starrocks.http.SslUtil;
+import com.starrocks.mysql.ssl.SSLContextLoader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MysqlSslEngineConfigTest {
+    private static void resetMysqlStatics() throws Exception {
+        Field c = SSLContextLoader.class.getDeclaredField("sslContext");
+        c.setAccessible(true);
+        c.set(null, null);
+        Field fc = SSLContextLoader.class.getDeclaredField("filteredCiphers");
+        fc.setAccessible(true);
+        fc.set(null, null);
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        resetMysqlStatics();
+        Config.ssl_keystore_password = "pass";
+        Config.ssl_key_password = "pass";
+        Config.ssl_truststore_location = "";
+        Config.ssl_truststore_password = "";
+        File f = File.createTempFile("keystore", ".jks");
+        f.deleteOnExit();
+        Config.ssl_keystore_location = f.getAbsolutePath();
+    }
+
+    @Test
+    void jsseAllTls13RemovedSetsOnlyTls12OnEngine() throws Exception {
+        String[] supported = {
+                "TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256",
+                "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+        };
+        String[] filtered = {"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"};
+
+        KeyStore ks = mock(KeyStore.class);
+        KeyManagerFactory kmf = mock(KeyManagerFactory.class);
+        SSLContext ctx = mock(SSLContext.class);
+        SSLEngine engine = mock(SSLEngine.class);
+
+        SSLParameters paramsSupported = new SSLParameters();
+        paramsSupported.setCipherSuites(supported);
+
+        when(ctx.getSupportedSSLParameters()).thenReturn(paramsSupported);
+        when(ctx.createSSLEngine()).thenReturn(engine);
+
+        try (MockedStatic<KeyStore> ksStatic = mockStatic(KeyStore.class);
+                MockedStatic<KeyManagerFactory> kmfStatic = mockStatic(KeyManagerFactory.class);
+                MockedStatic<SSLContext> sslCtxStatic = mockStatic(SSLContext.class);
+                MockedStatic<SslUtil> sslUtilStatic = mockStatic(SslUtil.class)) {
+
+            ksStatic.when(() -> KeyStore.getInstance("JKS")).thenReturn(ks);
+            kmfStatic.when(KeyManagerFactory::getDefaultAlgorithm).thenReturn("SunX509");
+            kmfStatic.when(() -> KeyManagerFactory.getInstance("SunX509")).thenReturn(kmf);
+            sslCtxStatic.when(() -> SSLContext.getInstance("TLSv1.2")).thenReturn(ctx);
+
+            sslUtilStatic.when(() -> SslUtil.filterCipherSuites(supported)).thenReturn(filtered);
+
+            SSLContextLoader.load();
+
+            verify(ctx).init(eq(kmf.getKeyManagers()), isNull(), any(SecureRandom.class));
+            sslUtilStatic.verify(() -> SslUtil.filterCipherSuites(supported));
+
+            SSLContextLoader.newServerEngine();
+            ArgumentCaptor<SSLParameters> cap = ArgumentCaptor.forClass(SSLParameters.class);
+            verify(engine).setSSLParameters(cap.capture());
+            assertArrayEquals(filtered, cap.getValue().getCipherSuites());
+        }
+    }
+
+    @Test
+    void jsseFilteredContainsTls13AndTls12SetsBoth() throws Exception {
+        String[] supported = {
+                "TLS_AES_128_GCM_SHA256",
+                "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+        };
+        String[] filtered = {
+                "TLS_AES_128_GCM_SHA256",
+                "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+        };
+
+        KeyStore ks = mock(KeyStore.class);
+        KeyManagerFactory kmf = mock(KeyManagerFactory.class);
+        SSLContext ctx = mock(SSLContext.class);
+        SSLEngine engine = mock(SSLEngine.class);
+        SSLParameters paramsSupported = new SSLParameters();
+        paramsSupported.setCipherSuites(supported);
+        when(ctx.getSupportedSSLParameters()).thenReturn(paramsSupported);
+        when(ctx.createSSLEngine()).thenReturn(engine);
+
+        try (MockedStatic<KeyStore> ksStatic = mockStatic(KeyStore.class);
+                MockedStatic<KeyManagerFactory> kmfStatic = mockStatic(KeyManagerFactory.class);
+                MockedStatic<SSLContext> sslCtxStatic = mockStatic(SSLContext.class);
+                MockedStatic<SslUtil> sslUtilStatic = mockStatic(SslUtil.class)) {
+
+            ksStatic.when(() -> KeyStore.getInstance("JKS")).thenReturn(ks);
+            kmfStatic.when(KeyManagerFactory::getDefaultAlgorithm).thenReturn("SunX509");
+            kmfStatic.when(() -> KeyManagerFactory.getInstance("SunX509")).thenReturn(kmf);
+            sslCtxStatic.when(() -> SSLContext.getInstance("TLSv1.2")).thenReturn(ctx);
+
+            sslUtilStatic.when(() -> SslUtil.filterCipherSuites(supported)).thenReturn(filtered);
+
+            SSLContextLoader.load();
+            SSLContextLoader.newServerEngine();
+
+            ArgumentCaptor<SSLParameters> cap = ArgumentCaptor.forClass(SSLParameters.class);
+            verify(engine).setSSLParameters(cap.capture());
+            assertArrayEquals(filtered, cap.getValue().getCipherSuites());
+        }
+    }
+
+    @Test
+    void jsseEmptyFilteredListSetsEmptyCipherArray() throws Exception {
+        String[] supported = {"TLS_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"};
+        String[] filtered = {};
+
+        KeyStore ks = mock(KeyStore.class);
+        KeyManagerFactory kmf = mock(KeyManagerFactory.class);
+        SSLContext ctx = mock(SSLContext.class);
+        SSLEngine engine = mock(SSLEngine.class);
+        SSLParameters paramsSupported = new SSLParameters();
+        paramsSupported.setCipherSuites(supported);
+        when(ctx.getSupportedSSLParameters()).thenReturn(paramsSupported);
+        when(ctx.createSSLEngine()).thenReturn(engine);
+
+        try (MockedStatic<KeyStore> ksStatic = mockStatic(KeyStore.class);
+                MockedStatic<KeyManagerFactory> kmfStatic = mockStatic(KeyManagerFactory.class);
+                MockedStatic<SSLContext> sslCtxStatic = mockStatic(SSLContext.class);
+                MockedStatic<SslUtil> sslUtilStatic = mockStatic(SslUtil.class)) {
+
+            ksStatic.when(() -> KeyStore.getInstance("JKS")).thenReturn(ks);
+            kmfStatic.when(KeyManagerFactory::getDefaultAlgorithm).thenReturn("SunX509");
+            kmfStatic.when(() -> KeyManagerFactory.getInstance("SunX509")).thenReturn(kmf);
+            sslCtxStatic.when(() -> SSLContext.getInstance("TLSv1.2")).thenReturn(ctx);
+
+            sslUtilStatic.when(() -> SslUtil.filterCipherSuites(supported)).thenReturn(filtered);
+
+            SSLContextLoader.load();
+            SSLContextLoader.newServerEngine();
+
+            ArgumentCaptor<SSLParameters> cap = ArgumentCaptor.forClass(SSLParameters.class);
+            verify(engine).setSSLParameters(cap.capture());
+            assertEquals(0, cap.getValue().getCipherSuites().length);
+        }
+    }
+
+    @Test
+    void jsseWithTruststoreUsesTrustManagersAndSetsFiltered() throws Exception {
+        File ts = File.createTempFile("truststore", ".jks");
+        ts.deleteOnExit();
+        Config.ssl_truststore_location = ts.getAbsolutePath();
+        Config.ssl_truststore_password = "tpass";
+
+        String[] supported = {"TLS_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"};
+        String[] filtered = {"TLS_AES_256_GCM_SHA384"};
+
+        KeyStore ks = mock(KeyStore.class);
+        KeyManagerFactory kmf = mock(KeyManagerFactory.class);
+        SSLContext ctx = mock(SSLContext.class);
+        SSLEngine engine = mock(SSLEngine.class);
+        SSLParameters paramsSupported = new SSLParameters();
+        paramsSupported.setCipherSuites(supported);
+        when(ctx.getSupportedSSLParameters()).thenReturn(paramsSupported);
+        when(ctx.createSSLEngine()).thenReturn(engine);
+
+        KeyStore trustKs = mock(KeyStore.class);
+        TrustManagerFactory tmf = mock(TrustManagerFactory.class);
+        TrustManager[] tms = new TrustManager[] {mock(TrustManager.class)};
+        when(tmf.getTrustManagers()).thenReturn(tms);
+
+        try (MockedStatic<KeyStore> ksStatic = mockStatic(KeyStore.class);
+                MockedStatic<KeyManagerFactory> kmfStatic = mockStatic(KeyManagerFactory.class);
+                MockedStatic<TrustManagerFactory> tmfStatic = mockStatic(TrustManagerFactory.class);
+                MockedStatic<SSLContext> sslCtxStatic = mockStatic(SSLContext.class);
+                MockedStatic<SslUtil> sslUtilStatic = mockStatic(SslUtil.class)) {
+
+            ksStatic.when(() -> KeyStore.getInstance("JKS"))
+                    .thenReturn(ks)
+                    .thenReturn(trustKs)
+            ;
+            kmfStatic.when(KeyManagerFactory::getDefaultAlgorithm).thenReturn("SunX509");
+            kmfStatic.when(() -> KeyManagerFactory.getInstance("SunX509")).thenReturn(kmf);
+            tmfStatic.when(TrustManagerFactory::getDefaultAlgorithm).thenReturn("PKIX");
+            tmfStatic.when(() -> TrustManagerFactory.getInstance("PKIX")).thenReturn(tmf);
+            sslCtxStatic.when(() -> SSLContext.getInstance("TLSv1.2")).thenReturn(ctx);
+
+            sslUtilStatic.when(() -> SslUtil.filterCipherSuites(supported)).thenReturn(filtered);
+
+            SSLContextLoader.load();
+
+            verify(ctx).init(eq(kmf.getKeyManagers()), same(tms), any(SecureRandom.class));
+
+            SSLContextLoader.newServerEngine();
+            ArgumentCaptor<SSLParameters> cap = ArgumentCaptor.forClass(SSLParameters.class);
+            verify(engine).setSSLParameters(cap.capture());
+            assertArrayEquals(filtered, cap.getValue().getCipherSuites());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlSslEngineConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlSslEngineConfigTest.java
@@ -12,26 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/http/StarRocksHttpTestCase.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 package com.starrocks.mysql;
 
 import com.starrocks.common.Config;


### PR DESCRIPTION
## Why I'm doing:
Reduce exposure to weak/legacy cipher suites by letting control what the FE advertises/accepts during TLS handshake.
## What I'm doing:
Introduce two optional FE config properties to shape the final cipher list, with regex support, matched against the full standard IANA cipher suite names:
* `sslCipherWhitelist` - comma-separated allowlist of cipher suite names
* `sslCipherBlacklist` - comma-separated denylist of cipher suite names
If both whitelist and blacklist are set, blacklist takes precedence.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3