### PR TITLE
[BugFix] Fix async delta writer crash due to null pointer

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -450,8 +450,8 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
         }
         total_row_num += size;
         int64_t tablet_id = tablet_ids[row_indexes[from]];
-        auto& dw = _delta_writers[tablet_id];
-        if (dw == nullptr) {
+        auto delta_writer_iter = _delta_writers.find(tablet_id);
+        if (delta_writer_iter == _delta_writers.end()) {
             LOG(WARNING) << "LakeTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
                          << " not found tablet_id: " << tablet_id;
             response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
@@ -462,6 +462,7 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
         }
 
         // back pressure OlapTableSink since there are too many memtables need to flush
+        auto& dw = delta_writer_iter->second;
         while (dw->queueing_memtable_num() >= config::max_queueing_memtable_per_tablet) {
             if (watch.elapsed_time() / 1000000 > request.timeout_ms()) {
                 LOG(INFO) << "LakeTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
@@ -547,7 +548,18 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
 
     std::set<long> immutable_tablet_ids;
     for (auto tablet_id : request.tablet_ids()) {
-        auto& writer = _delta_writers[tablet_id];
+        auto writer_iter = _delta_writers.find(tablet_id);
+        if (writer_iter == _delta_writers.end()) {
+            LOG(WARNING) << "LakeTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
+                         << " not found tablet_id: " << tablet_id;
+            response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
+            response->mutable_status()->add_error_msgs(
+                    fmt::format("Failed to add_chunk since tablet_id {} not exists, txn_id: {}, load_id: {}", tablet_id,
+                                _txn_id, print_id(request.id())));
+            return;
+        }
+
+        auto& writer = writer_iter->second;
         if (writer->is_immutable() && immutable_tablet_ids.count(tablet_id) == 0) {
             response->add_immutable_tablet_ids(tablet_id);
             response->add_immutable_partition_ids(writer->partition_id());

--- a/be/test/exprs/agg/agg_compressed_key_test.cpp
+++ b/be/test/exprs/agg/agg_compressed_key_test.cpp
@@ -44,7 +44,7 @@ TEST(AggCompressedKey, could_bound) {
         used_bytes.resize(1);
 
         auto type1 = TypeDescriptor(TYPE_INT);
-        groupby.emplace_back(type1, false);
+        groupby.emplace_back(ColumnType{type1, false});
         std::vector<std::optional<std::pair<VectorizedLiteral*, VectorizedLiteral*>>> ranges;
         auto* min = pool.add(new VectorizedLiteral(ColumnHelper::create_const_column<TYPE_INT>(0, 1), type1));
         auto* max = pool.add(new VectorizedLiteral(ColumnHelper::create_const_column<TYPE_INT>(100, 1), type1));
@@ -70,8 +70,8 @@ TEST(AggCompressedKey, could_bound) {
         used_bytes.resize(2);
 
         auto type1 = TypeDescriptor(TYPE_INT);
-        groupby.emplace_back(type1, false);
-        groupby.emplace_back(type1, true);
+        groupby.emplace_back(ColumnType{type1, false});
+        groupby.emplace_back(ColumnType{type1, true});
         std::vector<std::optional<std::pair<VectorizedLiteral*, VectorizedLiteral*>>> ranges;
         auto* min = pool.add(new VectorizedLiteral(ColumnHelper::create_const_column<TYPE_INT>(0, 1), type1));
         auto* max = pool.add(new VectorizedLiteral(ColumnHelper::create_const_column<TYPE_INT>(100, 1), type1));
@@ -98,8 +98,8 @@ TEST(AggCompressedKey, could_bound) {
         used_bytes.resize(2);
 
         auto type1 = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 8, 4);
-        groupby.emplace_back(type1, false);
-        groupby.emplace_back(type1, true);
+        groupby.emplace_back(ColumnType{type1, false});
+        groupby.emplace_back(ColumnType{type1, true});
         std::vector<std::optional<std::pair<VectorizedLiteral*, VectorizedLiteral*>>> ranges;
         auto* min = pool.add(
                 new VectorizedLiteral(ColumnHelper::create_const_decimal_column<TYPE_DECIMAL128>(0, 8, 4, 1), type1));


### PR DESCRIPTION
## Why I'm doing:
```
3.3.7-13.2 RELEASE (build 7afd807)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000
tracker:process consumption: 77927381408
tracker:jemalloc_metadata consumption: 16657949088
tracker:jemalloc_fragmentation consumption: 4101717720
tracker:query_pool consumption: 2847840856
tracker:query_pool/connector_scan consumption: 0
tracker:load consumption: 0
tracker:metadata consumption: 1722083679
tracker:tablet_metadata consumption: 540785
tracker:rowset_metadata consumption: 0
tracker:segment_metadata consumption: 222142458
tracker:column_metadata consumption: 1499400436
tracker:tablet_schema consumption: 540785
tracker:segment_zonemap consumption: 152128800
tracker:short_key_index consumption: 59993257
tracker:column_zonemap_index consumption: 441565596
tracker:ordinal_index consumption: 410289224
tracker:bitmap_index consumption: 22144
tracker:bloom_filter_index consumption: 0
tracker:compaction consumption: 0
tracker:schema_change consumption: 0
tracker:column_pool consumption: 0
tracker:page_cache consumption: 40173793840
tracker:jit_cache consumption: 0
tracker:update consumption: 177860278
tracker:chunk_allocator consumption: 0
tracker:passthrough consumption: 0
tracker:clone consumption: 0
tracker:consistency consumption: 0
tracker:datacache consumption: 3439183569
tracker:replication consumption: 0
*** Aborted at 1756211321 (unix time) try "date -d @1756211321" if you are using GNU date ***
PC: @          0x625eb4f starrocks::lake::AsyncDeltaWriter::close()
*** SIGSEGV (@0x0) received by PID 982175 (TID 0x7fe3eae64700) from PID 0; stack trace: ***
    @     0x7fe6fec0620b __pthread_once_slow
    @          0x7bcd340 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fe6fec0f630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0x625eb4f starrocks::lake::AsyncDeltaWriter::close()
    @          0x37339f9 starrocks::LakeTabletsChannel::abort()
    @          0x36dbfdb starrocks::LoadChannel::abort()
    @          0x36d7430 starrocks::LoadChannelMgr::cancel(brpc::Controller*, starrocks::PTabletWriterCancelRequest const&, starrocks::PTabletWriterCancelResult*, google::protobuf::Closure*)
    @          0x7e5a114 brpc::policy::ProcessRpcRequest(brpc::InputMessageBase*)
    @          0x7d864b7 brpc::ProcessInputMessage(void*)
    @          0x7d87835 brpc::InputMessenger::OnNewMessages(brpc::Socket*)
    @          0x7d75b2e brpc::Socket::ProcessEvent(void*)
    @          0x7d46bb2 bthread::TaskGroup::task_runner(long)
    @          0x7e9c041 bthread_make_fcontext
```

## What I'm doing:

Fix async delta writer crash due to null pointer

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
