### PR TITLE
[Enhancement] Ensure mv force refresh will refresh target partitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1084,7 +1084,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         }
     }
 
-
     @Override
     public void dropPartition(long dbId, String partitionName, boolean isForceDrop) {
         super.dropPartition(dbId, partitionName, isForceDrop);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
@@ -433,7 +433,7 @@ public class DynamicPartitionUtil {
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
         PartitionType partitionType = partitionInfo.getType();
         if (!isDynamicPartitionTable(olapTable, partitionInfo, tableProperty)) {
-            LOG.info("unable to schedule olap table {}-{} because dynamic partition is not enabled, " +
+            LOG.debug("unable to schedule olap table {}-{} because dynamic partition is not enabled, " +
                             "partition type: {}, partition column size: {}",
                     table.getName(), table.getId(), partitionType, partitionInfo.getPartitionColumnsSize());
             return false;
@@ -479,7 +479,7 @@ public class DynamicPartitionUtil {
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
         PartitionType partitionType = partitionInfo.getType();
         if (!isTTLPartitionTable(olapTable, partitionInfo, tableProperty)) {
-            LOG.info("unable to schedule olap table {}-{} because partition ttl is not enabled, " +
+            LOG.debug("unable to schedule olap table {}-{} because partition ttl is not enabled, " +
                             "partition type: {}, partition column size: {}",
                     table.getName(), table.getId(), partitionType, partitionInfo.getPartitionColumnsSize());
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/BaseTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/BaseTaskRunProcessor.java
@@ -24,8 +24,9 @@ import org.apache.commons.lang3.StringUtils;
 
 public abstract class BaseTaskRunProcessor implements TaskRunProcessor {
     @Override
-    public void prepare(TaskRunContext context) throws Exception {
+    public TaskRunContext prepare(TaskRunContext context) throws Exception {
         // do nothing
+        return context;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -87,7 +87,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
 
     @VisibleForTesting
     @Override
-    public void prepare(TaskRunContext context) throws Exception {
+    public TaskRunContext prepare(TaskRunContext context) throws Exception {
         // NOTE: mvId is set in Task's properties when creating
         final Map<String, String> properties = context.getProperties();
         final long mvId = Long.parseLong(properties.get(MV_ID));
@@ -142,6 +142,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
 
         this.mvRefreshProcessor = MVRefreshProcessorFactory.INSTANCE.newProcessor(db, mv, mvTaskRunContext, mvMetricsEntity);
         logger.info("finish prepare refresh mv:{}, jobId: {}", mvId, jobId);
+        return mvTaskRunContext;
     }
 
     /**
@@ -154,6 +155,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         Preconditions.checkNotNull(mvRefreshProcessor);
 
         // get exec plan
+        mvTaskRunContext.setIsExplain(true);
         BaseMVRefreshProcessor.ProcessExecPlan processExecPlan =
                 mvRefreshProcessor.getProcessExecPlan(mvTaskRunContext);
         if (processExecPlan == null || processExecPlan.state() != Constants.TaskRunState.SUCCESS) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -423,7 +423,7 @@ public class TaskManager implements MemoryTrackable {
         TaskRunContext taskRunContext = taskRun.buildTaskRunContext();
         try {
             // prepare the task run context
-            mvRefreshProcessor.prepare(taskRunContext);
+            taskRunContext = mvRefreshProcessor.prepare(taskRunContext);
             // execute the task run
             return mvRefreshProcessor.getMVRefreshExecPlan();
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -349,7 +349,7 @@ public class TaskRun implements Comparable<TaskRun> {
         TaskRunContext taskRunContext = buildTaskRunContext();
 
         // prepare to execute task run, move it here so that we can catch the exception and set the status
-        processor.prepare(taskRunContext);
+        taskRunContext = processor.prepare(taskRunContext);
 
         // process task run
         Constants.TaskRunState taskRunState;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunContext.java
@@ -32,6 +32,9 @@ public class TaskRunContext {
     String taskRunId;
     TaskRun taskRun;
 
+    // whether the task run is used to explain the execution plan without actual execution.
+    private boolean isExplain = false;
+
     public TaskRunContext() {
     }
 
@@ -135,5 +138,13 @@ public class TaskRunContext {
 
     public void setTaskRun(TaskRun taskRun) {
         this.taskRun = taskRun;
+    }
+
+    public boolean isExplain() {
+        return isExplain;
+    }
+
+    public void setIsExplain(boolean explain) {
+        this.isExplain = explain;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunProcessor.java
@@ -20,7 +20,7 @@ public interface TaskRunProcessor {
      * Before task run, prepare the context.
      * @param context: task run context
      */
-    void prepare(TaskRunContext context) throws Exception;
+    TaskRunContext prepare(TaskRunContext context) throws Exception;
 
     /**
     * Process a task run with the given context.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -24,9 +24,11 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.Table;
@@ -54,11 +56,13 @@ import com.starrocks.scheduler.TaskRunContext;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.PCellSortedSet;
+import com.starrocks.sql.common.PCellWithName;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
@@ -329,6 +333,49 @@ public abstract class BaseMVRefreshProcessor {
         final Stopwatch stopwatch = Stopwatch.createStarted();
         // collect base table snapshot infos
         this.snapshotBaseTables = collectBaseTableSnapshotInfos();
+
+        if (!mvContext.isExplain() && mvRefreshParams.isNonTentativeForce()) {
+            // drop existing partitions for force refresh
+            PCellSortedSet toRefreshPartitions = mvRefreshPartitioner.getMVPartitionsToRefreshByParams();
+            if (toRefreshPartitions != null && !toRefreshPartitions.isEmpty()) {
+                logger.info("force refresh, drop partitions: [{}]",
+                        Joiner.on(",").join(toRefreshPartitions.getPartitionNames()));
+
+                // first lock and drop partitions from a visible map
+                Locker locker = new Locker();
+                if (!locker.lockDatabaseAndCheckExist(db, this.mv, LockType.WRITE)) {
+                    logger.warn("failed to lock database: {} in syncPartitions for force refresh", db.getFullName());
+                    throw new DmlException("Force refresh failed, database:" + db.getFullName() + " not exist");
+                }
+                try {
+                    PartitionInfo partitionInfo = mv.getPartitionInfo();
+                    DataProperty dataProperty = null;
+                    if (!mv.isPartitionedTable()) {
+                        String partitionName = toRefreshPartitions.partitions().iterator().next().name();
+                        Partition partition = mv.getPartition(partitionName);
+                        dataProperty = partitionInfo.getDataProperty(partition.getId());
+                    }
+                    for (PCellWithName partName : toRefreshPartitions.partitions()) {
+                        mv.dropPartition(db.getId(), partName.name(), false);
+                    }
+
+                    // for non-partitioned table, we need to build the partition here
+                    if (!mv.isPartitionedTable()) {
+                        LocalMetastore localMetastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+                        ConnectContext connectContext = mvContext.getCtx();
+                        localMetastore.buildNonPartitionOlapTable(db, mv, partitionInfo, dataProperty,
+                                connectContext.getCurrentComputeResource());
+                    }
+                } catch (Exception e) {
+                    logger.warn("failed to drop partitions {} for force refresh",
+                            Joiner.on(",").join(toRefreshPartitions.getPartitionNames()),
+                            DebugUtil.getRootStackTrace(e));
+                    throw new AnalysisException("failed to drop partitions for force refresh: " + e.getMessage());
+                } finally {
+                    locker.unLockTableWithIntensiveDbLock(db.getId(), this.mv.getId(), LockType.WRITE);
+                }
+            }
+        }
         // do sync partitions (add or drop partitions) for materialized view
         boolean result = mvRefreshPartitioner.syncAddOrDropPartitions();
         logger.info("finish sync partitions, cost(ms): {}", stopwatch.elapsed(TimeUnit.MILLISECONDS));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -69,6 +69,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.starrocks.connector.iceberg.IcebergPartitionUtils.getIcebergTablePartitionPredicateExpr;
 
@@ -84,6 +85,29 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         super(mvContext, context, db, mv, mvRefreshParams);
         this.differ = new ListPartitionDiffer(mv, false);
         this.logger = MVTraceUtils.getLogger(mv, MVPCTRefreshListPartitioner.class);
+    }
+
+    public PCellSortedSet getMVPartitionsToRefreshByParams() {
+        if (mvRefreshParams.isCompleteRefresh()) {
+            return PCellSortedSet.of(mv.getListPartitionItems());
+        } else {
+            Set<PListCell> pListCells = mvRefreshParams.getListValues();
+            Map<String, PListCell> mvPartitions = mv.getListPartitionItems();
+            Map<String, PListCell> mvFilteredPartitions = mvPartitions.entrySet().stream()
+                    .filter(e -> {
+                        PListCell mvListCell = e.getValue();
+                        if (mvListCell.getItemSize() == 1) {
+                            // if list value is a single value, check it directly
+                            return pListCells.contains(e.getValue());
+                        } else {
+                            // if list values is multi values, split it into single values and check it then.
+                            return mvListCell.toSingleValueCells().stream().anyMatch(i -> pListCells.contains(i));
+                        }
+                    })
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toMap(k -> k, mvPartitions::get));
+            return PCellSortedSet.of(mvFilteredPartitions);
+        }
     }
 
     @Override
@@ -336,14 +360,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
     }
 
     @Override
-    public PCellSortedSet getMVPartitionsToRefreshWithForce() {
-        Map<String, PCell> mvValidListPartitionMapMap = mv.getPartitionCells(Optional.empty());
-        filterPartitionsByTTL(mvValidListPartitionMapMap, false);
-        return PCellSortedSet.of(mvValidListPartitionMapMap);
-    }
-
-    @Override
-    public PCellSortedSet getMVPartitionsToRefresh(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables) {
+    public PCellSortedSet getMVPartitionsToRefreshWithCheck(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables) {
         // list partitioned materialized view
         boolean isAutoRefresh = mvContext.getTaskType().isAutoRefresh();
         PCellSortedSet mvListPartitionNames = getMVPartitionNamesWithTTL(isAutoRefresh);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
@@ -42,6 +42,10 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
         super(mvContext, context, db, mv, mvRefreshParams);
     }
 
+    public PCellSortedSet getMVPartitionsToRefreshByParams() {
+        return getNonPartitionedMVPartitionsToRefresh();
+    }
+
     @Override
     public boolean syncAddOrDropPartitions() {
         // do nothing
@@ -76,7 +80,7 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     }
 
     @Override
-    public PCellSortedSet getMVPartitionsToRefresh(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables) {
+    public PCellSortedSet getMVPartitionsToRefreshWithCheck(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables) {
         // non-partitioned materialized view
         if (mvRefreshParams.isForce() || isNonPartitionedMVNeedToRefresh(snapshotBaseTables, mv)) {
             return getNonPartitionedMVPartitionsToRefresh();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -141,15 +141,28 @@ public abstract class MVPCTRefreshPartitioner {
                                                       Set<String> mvPartitionNames) throws AnalysisException;
 
     /**
+     * Get mv partition names to refresh based on the mv refresh params.
+     */
+    public abstract PCellSortedSet getMVPartitionsToRefreshByParams() throws AnalysisException;
+
+    /**
      * Get mv partitions to refresh based on the ref base table partitions.
      * @param snapshotBaseTables:        snapshot base tables to check.
      * @throws AnalysisException
      * @return: Return mv partitions to refresh based on the ref base table partitions.
      */
-    public abstract PCellSortedSet getMVPartitionsToRefresh(
+    public abstract PCellSortedSet getMVPartitionsToRefreshWithCheck(
             Map<Long, BaseTableSnapshotInfo> snapshotBaseTables) throws AnalysisException;
 
-    public abstract PCellSortedSet getMVPartitionsToRefreshWithForce() throws AnalysisException;
+    /**
+     * Get mv partitions to refresh with force, filter partitions by ttl.
+     * @return : mv partitions to refresh with force.
+     */
+    public PCellSortedSet getMVPartitionsToRefreshWithForce() throws AnalysisException {
+        PCellSortedSet sortedSet = getMVPartitionsToRefreshByParams();
+        filterPartitionsByTTL(sortedSet, false);
+        return sortedSet;
+    }
 
     /**
      * Get mv partition names with TTL based on the ref base table partitions.
@@ -165,9 +178,17 @@ public abstract class MVPCTRefreshPartitioner {
      */
     public abstract void filterPartitionByAdaptiveRefreshNumber(PCellSortedSet mvPartitionsToRefresh);
 
+    /**
+     * Filter to refresh partitions by partition refresh number.
+     * @param partitionsToRefresh: partitions to refresh.
+     */
     @VisibleForTesting
     public abstract void filterPartitionByRefreshNumber(PCellSortedSet partitionsToRefresh);
 
+    /**
+     * Check whether to calculate the potential partitions to refresh or not. When the base table changed partitions
+     * contain many-to-many relation partitions with mv partitions, should calculate the potential partitions to refresh.
+     */
     public abstract boolean isCalcPotentialRefreshPartition(Map<Table, PCellSortedSet> baseChangedPartitionNames,
                                                             PCellSortedSet mvPartitions);
     /**
@@ -216,6 +237,10 @@ public abstract class MVPCTRefreshPartitioner {
         return result;
     }
 
+    /**
+     * Filter mv to refresh partitions by some properties, like auto_partition_refresh_number.
+     * @param mvToRefreshedPartitions: partitions to refresh for materialized view
+     */
     public void filterMVToRefreshPartitionsByProperty(PCellSortedSet mvToRefreshedPartitions) {
         // do nothing by default
     }
@@ -223,13 +248,13 @@ public abstract class MVPCTRefreshPartitioner {
     /**
      * @return the partitions to refresh for materialized view
      */
-    private PCellSortedSet getPartitionsToRefreshForMaterializedView(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables)
+    private PCellSortedSet getMVPartitionsToRefresh(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables)
             throws AnalysisException {
-        if (mvRefreshParams.isForceCompleteRefresh()) {
+        if (mvRefreshParams.isForce()) {
             // Force refresh
             return getMVPartitionsToRefreshWithForce();
         } else {
-            return getMVPartitionsToRefresh(snapshotBaseTables);
+            return getMVPartitionsToRefreshWithCheck(snapshotBaseTables);
         }
     }
 
@@ -249,7 +274,7 @@ public abstract class MVPCTRefreshPartitioner {
         }
 
         try {
-            mvToRefreshedPartitions = getPartitionsToRefreshForMaterializedView(snapshotBaseTables);
+            mvToRefreshedPartitions = getMVPartitionsToRefresh(snapshotBaseTables);
             if (mvToRefreshedPartitions == null || mvToRefreshedPartitions.isEmpty()) {
                 logger.info("no partitions to refresh for materialized view");
                 return mvToRefreshedPartitions;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
@@ -66,10 +66,6 @@ public class MVRefreshParams {
         return partitionRefreshStrategy == MaterializedView.PartitionRefreshStrategy.FORCE;
     }
 
-    public boolean isForceCompleteRefresh() {
-        return isForce() && isCompleteRefresh();
-    }
-
     public boolean isNonTentativeForce() {
         return isForce() && !isTentative;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3101,6 +3101,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
 
         boolean isNonPartitioned = partitionInfo.isUnPartitioned();
+        DataProperty dataProperty = PropertyAnalyzer.analyzeMVDataProperty(materializedView, properties);
         PropertyAnalyzer.analyzeMVProperties(db, materializedView, properties, isNonPartitioned,
                 stmt.getPartitionByExprToAdjustExprMap());
         final long warehouseId = materializedView.getWarehouseId();
@@ -3113,7 +3114,6 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 if (!warehouseManager.isResourceAvailable(computeResource)) {
                     throw new DdlException("No available resource for warehouse " + warehouseId);
                 }
-                DataProperty dataProperty = PropertyAnalyzer.analyzeMVDataProperty(materializedView, properties);
                 buildNonPartitionOlapTable(db, materializedView, partitionInfo, dataProperty, computeResource);
             } else {
                 List<Expr> mvPartitionExprs = stmt.getPartitionByExprs();

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3101,35 +3101,20 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
 
         boolean isNonPartitioned = partitionInfo.isUnPartitioned();
-        DataProperty dataProperty = PropertyAnalyzer.analyzeMVDataProperty(materializedView, properties);
         PropertyAnalyzer.analyzeMVProperties(db, materializedView, properties, isNonPartitioned,
                 stmt.getPartitionByExprToAdjustExprMap());
         final long warehouseId = materializedView.getWarehouseId();
         try {
-            Set<Long> tabletIdSet = new HashSet<>();
             // process single partition info
             if (isNonPartitioned) {
-                long partitionId = GlobalStateMgr.getCurrentState().getNextId();
-                Preconditions.checkNotNull(dataProperty);
-                partitionInfo.setDataProperty(partitionId, dataProperty);
-                partitionInfo.setReplicationNum(partitionId, materializedView.getDefaultReplicationNum());
-                partitionInfo.setIsInMemory(partitionId, false);
-                partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
-                StorageInfo storageInfo = materializedView.getTableProperty().getStorageInfo();
-                partitionInfo.setDataCacheInfo(partitionId,
-                        storageInfo == null ? null : storageInfo.getDataCacheInfo());
-                Long version = Partition.PARTITION_INIT_VERSION;
                 final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
                 final CRAcquireContext acquireContext = CRAcquireContext.of(warehouseId);
                 final ComputeResource computeResource = warehouseManager.acquireComputeResource(acquireContext);
                 if (!warehouseManager.isResourceAvailable(computeResource)) {
                     throw new DdlException("No available resource for warehouse " + warehouseId);
                 }
-                Partition partition = createPartition(db, materializedView, partitionId, mvName, version, tabletIdSet,
-                        computeResource);
-
-                buildPartitions(db, materializedView, new ArrayList<>(partition.getSubPartitions()), computeResource);
-                materializedView.addPartition(partition);
+                DataProperty dataProperty = PropertyAnalyzer.analyzeMVDataProperty(materializedView, properties);
+                buildNonPartitionOlapTable(db, materializedView, partitionInfo, dataProperty, computeResource);
             } else {
                 List<Expr> mvPartitionExprs = stmt.getPartitionByExprs();
                 LinkedHashMap<Expr, SlotRef> partitionExprMaps = MVPartitionExprResolver.getMVPartitionExprsChecked(
@@ -3157,6 +3142,35 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         // NOTE: The materialized view has been added to the database, and the following procedure cannot throw exception.
         createTaskForMaterializedView(dbName, materializedView, optHints);
         DynamicPartitionUtil.registerOrRemovePartitionTTLTable(db.getId(), materializedView);
+    }
+
+    /**
+     * Initialize a non-partitioned table with one partition.
+     */
+    public void buildNonPartitionOlapTable(Database db,
+                                           OlapTable olapTable,
+                                           PartitionInfo partitionInfo,
+                                           DataProperty dataProperty,
+                                           ComputeResource computeResource) throws DdlException {
+        if (olapTable.isPartitionedTable()) {
+            throw new DdlException("Table " + olapTable.getName() + " is a partitioned table, not a non-partitioned table");
+        }
+
+        long partitionId = GlobalStateMgr.getCurrentState().getNextId();
+        Preconditions.checkNotNull(dataProperty);
+        partitionInfo.setDataProperty(partitionId, dataProperty);
+        partitionInfo.setReplicationNum(partitionId, olapTable.getDefaultReplicationNum());
+        partitionInfo.setIsInMemory(partitionId, false);
+        partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
+        StorageInfo storageInfo = olapTable.getTableProperty().getStorageInfo();
+        partitionInfo.setDataCacheInfo(partitionId,
+                storageInfo == null ? null : storageInfo.getDataCacheInfo());
+        Set<Long> tabletIdSet = new HashSet<>();
+        Long version = Partition.PARTITION_INIT_VERSION;
+        Partition partition = createPartition(db, olapTable, partitionId, olapTable.getName(), version, tabletIdSet,
+                computeResource);
+        buildPartitions(db, olapTable, new ArrayList<>(partition.getSubPartitions()), computeResource);
+        olapTable.addPartition(partition);
     }
 
     private long getRandomStart(IntervalLiteral interval, long randomizeStart) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellSortedSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellSortedSet.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -39,7 +40,7 @@ public record PCellSortedSet(SortedSet<PCellWithName> partitions) {
         return new PCellSortedSet(partitions);
     }
 
-    public static PCellSortedSet of(Map<String, PCell> input) {
+    public static PCellSortedSet of(Map<String, ? extends PCell> input) {
         SortedSet<PCellWithName> partitions = input.entrySet()
                 .stream()
                 .map(entry -> PCellWithName.of(entry.getKey(), entry.getValue()))
@@ -153,6 +154,10 @@ public record PCellSortedSet(SortedSet<PCellWithName> partitions) {
             return;
         }
         partitions.addAll(other.partitions);
+    }
+
+    public Map<String, PCell> toCellMap() {
+        return partitions.stream().collect(Collectors.toMap(PCellWithName::name, PCellWithName::cell));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
@@ -199,7 +199,7 @@ public final class RangePartitionDiffer extends PartitionDiffer {
      * @param rangeToInclude range to check whether the to be checked range is in
      * @return true if included, else false
      */
-    private static boolean isRangeIncluded(Range<PartitionKey> rangeToCheck, Range<PartitionKey> rangeToInclude) {
+    public static boolean isRangeIncluded(Range<PartitionKey> rangeToCheck, Range<PartitionKey> rangeToInclude) {
         if (rangeToInclude == null) {
             return true;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MockTaskRunProcessor.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MockTaskRunProcessor.java
@@ -33,8 +33,8 @@ public class MockTaskRunProcessor implements TaskRunProcessor {
     }
 
     @Override
-    public void prepare(TaskRunContext context) throws Exception {
-        // do nothing
+    public TaskRunContext prepare(TaskRunContext context) throws Exception {
+        return context;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -1648,4 +1648,164 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
         }
         Assertions.assertEquals(0, mv.getPartitions().size());
     }
+
+    @Test
+    public void testMVForceRefresh() throws Exception {
+        String partitionTable = "CREATE TABLE list_t1 (dt1 date, int1 int)\n" +
+                "PARTITION BY list(dt1) (\n" +
+                "     PARTITION p1 VALUES IN (\"2025-05-16\") ,\n" +
+                "     PARTITION p2 VALUES IN (\"2025-05-17\") \n" +
+                ")\n";
+        starRocksAssert.withTable(partitionTable);
+        String[] sqls = {
+                "insert into list_t1 partition(p1) values('2025-05-16', 1);",
+                "insert into list_t1 partition(p2) values('2025-05-17', 1);"
+        };
+        for (String sql : sqls) {
+            executeInsertSql(sql);
+        }
+
+        String mvQuery = "CREATE MATERIALIZED VIEW test_mv1 " +
+                "PARTITION BY (dt1) " +
+                "REFRESH DEFERRED MANUAL PROPERTIES (\"partition_refresh_number\"=\"-1\")\n" +
+                "AS SELECT dt1,sum(int1) from list_t1 group by dt1 \n";
+        starRocksAssert.withMaterializedView(mvQuery);
+        MaterializedView mv = getMv("test_mv1");
+
+        TaskRun taskRun = buildMVTaskRun(mv, "test");
+        ExecPlan execPlan;
+        // explain without force
+        {
+            execPlan = getMVRefreshExecPlan(taskRun);
+            Assertions.assertNotNull(execPlan);
+
+            refreshMV("test", mv);
+            execPlan = getMVRefreshExecPlan(taskRun);
+            Assertions.assertNull(execPlan);
+
+            String plan = explainMVRefreshExecPlan(mv, "explain refresh materialized " +
+                    "view test_mv1;");
+            Assertions.assertTrue(plan.contains("PLAN NOT AVAILABLE"));
+        }
+
+        // refresh with force
+        Map<String, String> props = taskRun.getProperties();
+        props.put(TaskRun.FORCE, "true");
+        String result = "";
+        // explain with refresh
+        {
+            ExecuteOption executeOption = new ExecuteOption(taskRun.getTask());
+            Map<String, String> explainProps = executeOption.getTaskRunProperties();
+            explainProps.put(TaskRun.FORCE, "true");
+
+            execPlan =
+                    getMVRefreshExecPlan(mv, "explain refresh materialized view test_mv1 " +
+                            "force;");
+            Assertions.assertNotNull(execPlan);
+
+            String plan = explainMVRefreshExecPlan(mv, executeOption, "explain refresh materialized view test_mv1 " +
+                    "force;");
+            Assertions.assertTrue(plan.contains("MVToRefreshedPartitions: [p1, p2]"));
+
+            // after refresh, still can refresh with force
+            execPlan = getMVRefreshExecPlan(taskRun, true);
+            result = execPlan.getExplainString(TExplainLevel.NORMAL);
+            PlanTestBase.assertContains(plan, "     TABLE: list_t1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=2/2");
+            Assertions.assertNotNull(execPlan);
+
+            refreshMV("test", mv);
+
+            // after refresh, still can refresh with force
+            execPlan = getMVRefreshExecPlan(taskRun, true);
+            result = execPlan.getExplainString(TExplainLevel.NORMAL);
+            PlanTestBase.assertContains(plan, "     TABLE: list_t1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=2/2");
+            Assertions.assertNotNull(execPlan);
+        }
+    }
+
+    @Test
+    public void testMVForcePartialRefresh() throws Exception {
+        String partitionTable = "CREATE TABLE list_t1 (dt1 date, int1 int)\n" +
+                "PARTITION BY list(dt1) (\n" +
+                "     PARTITION p1 VALUES IN (\"2025-05-16\") ,\n" +
+                "     PARTITION p2 VALUES IN (\"2025-05-17\") \n" +
+                ")\n";
+        starRocksAssert.withTable(partitionTable);
+        String[] sqls = {
+                "insert into list_t1 partition(p1) values('2025-05-16', 1);",
+                "insert into list_t1 partition(p2) values('2025-05-17', 1);"
+        };
+        for (String sql : sqls) {
+            executeInsertSql(sql);
+        }
+
+        String mvQuery = "CREATE MATERIALIZED VIEW test_mv1 " +
+                "PARTITION BY (dt1) " +
+                "REFRESH DEFERRED MANUAL PROPERTIES (\"partition_refresh_number\"=\"-1\")\n" +
+                "AS SELECT dt1,sum(int1) from list_t1 group by dt1 \n";
+        starRocksAssert.withMaterializedView(mvQuery);
+        MaterializedView mv = getMv("test_mv1");
+
+        TaskRun taskRun = buildMVTaskRun(mv, "test");
+        // partial refresh with force
+        Map<String, String> props = taskRun.getProperties();
+        props.put(TaskRun.PARTITION_VALUES,
+                PListCell.batchSerialize(ImmutableSet.of(new PListCell("2025-05-16"))));
+
+        ExecPlan execPlan;
+        // explain without force
+        {
+            execPlan = getMVRefreshExecPlan(taskRun);
+            Assertions.assertNotNull(execPlan);
+
+            refreshMV("test", mv);
+            execPlan = getMVRefreshExecPlan(taskRun);
+            Assertions.assertNull(execPlan);
+
+            String plan = explainMVRefreshExecPlan(mv, "explain refresh materialized " +
+                    "view test_mv1 partition ('2025-05-16');");
+            Assertions.assertTrue(plan.contains("PLAN NOT AVAILABLE"));
+        }
+
+        String result = "";
+        // explain with partial refresh
+        {
+            ExecuteOption executeOption = new ExecuteOption(taskRun.getTask());
+            Map<String, String> explainProps = executeOption.getTaskRunProperties();
+            explainProps.put(TaskRun.PARTITION_VALUES,
+                    PListCell.batchSerialize(ImmutableSet.of(new PListCell("2025-05-16"))));
+            explainProps.put(TaskRun.FORCE, "true");
+
+            execPlan =
+                    getMVRefreshExecPlan(mv, "explain refresh materialized view test_mv1 " +
+                            "partition ('2025-05-16') force;");
+            Assertions.assertNotNull(execPlan);
+
+            String plan = explainMVRefreshExecPlan(mv, executeOption, "explain refresh materialized view test_mv1 " +
+                    "partition ('2025-05-16') force;");
+            Assertions.assertTrue(plan.contains("MVToRefreshedPartitions: [p1]"));
+
+            // after refresh, still can refresh with force
+            execPlan = getMVRefreshExecPlan(taskRun, true);
+            result = execPlan.getExplainString(TExplainLevel.NORMAL);
+            PlanTestBase.assertContains(plan, "     TABLE: list_t1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/2");
+            Assertions.assertNotNull(execPlan);
+
+            refreshMV("test", mv);
+
+            // after refresh, still can refresh with force
+            execPlan = getMVRefreshExecPlan(taskRun, true);
+            result = execPlan.getExplainString(TExplainLevel.NORMAL);
+            PlanTestBase.assertContains(plan, "     TABLE: list_t1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/2");
+            Assertions.assertNotNull(execPlan);
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshNonPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshNonPartitionOlapTest.java
@@ -1,0 +1,114 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.thrift.TExplainLevel;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+@TestMethodOrder(MethodName.class)
+public class PCTRefreshNonPartitionOlapTest extends MVTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        MVTestBase.beforeClass();
+    }
+
+    @Test
+    public void testMVForceRefresh() throws Exception {
+        String partitionTable = "CREATE TABLE range_t1 (dt1 date, int1 int)\n" +
+                "PARTITION BY date_trunc('day', dt1)";
+        starRocksAssert.withTable(partitionTable);
+        addRangePartition("range_t1", "p1", "2024-01-04", "2024-01-05");
+        addRangePartition("range_t1", "p2", "2024-01-05", "2024-01-06");
+        String[] sqls = {
+                "INSERT INTO range_t1 partition(p1) VALUES (\"2024-01-04\",1);",
+                "INSERT INTO range_t1 partition(p2) VALUES (\"2024-01-05\",1);"
+        };
+        for (String sql : sqls) {
+            executeInsertSql(sql);
+        }
+
+        String mvQuery = "CREATE MATERIALIZED VIEW test_mv1 " +
+                "REFRESH DEFERRED MANUAL\n" +
+                "AS SELECT dt1,sum(int1) from range_t1 group by dt1";
+        starRocksAssert.withMaterializedView(mvQuery);
+
+        MaterializedView mv = getMv("test_mv1");
+
+        TaskRun taskRun = buildMVTaskRun(mv, "test");
+        ExecPlan execPlan;
+        // explain without force
+        {
+            execPlan = getMVRefreshExecPlan(taskRun);
+            Assertions.assertNotNull(execPlan);
+
+            refreshMV("test", mv);
+            execPlan = getMVRefreshExecPlan(taskRun);
+            Assertions.assertNull(execPlan);
+
+            String plan = explainMVRefreshExecPlan(mv, "explain refresh materialized " +
+                    "view test_mv1;");
+            Assertions.assertTrue(plan.contains("PLAN NOT AVAILABLE"));
+        }
+
+        // refresh with force
+        Map<String, String> props = taskRun.getProperties();
+        props.put(TaskRun.FORCE, "true");
+        String result = "";
+        // explain with refresh
+        {
+            ExecuteOption executeOption = new ExecuteOption(taskRun.getTask());
+            Map<String, String> explainProps = executeOption.getTaskRunProperties();
+            explainProps.put(TaskRun.FORCE, "true");
+
+            execPlan =
+                    getMVRefreshExecPlan(mv, "explain refresh materialized view test_mv1 " +
+                            "force;");
+            Assertions.assertNotNull(execPlan);
+
+            String plan = explainMVRefreshExecPlan(mv, executeOption, "explain refresh materialized view test_mv1 " +
+                    "force;");
+            Assertions.assertTrue(plan.contains("MVToRefreshedPartitions: [test_mv1]"));
+
+            // after refresh, still can refresh with force
+            execPlan = getMVRefreshExecPlan(taskRun, true);
+            result = execPlan.getExplainString(TExplainLevel.NORMAL);
+            PlanTestBase.assertContains(plan, "     TABLE: range_t1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=2/2");
+            Assertions.assertNotNull(execPlan);
+
+            refreshMV("test", mv);
+
+            // after refresh, still can refresh with force
+            execPlan = getMVRefreshExecPlan(taskRun, true);
+            result = execPlan.getExplainString(TExplainLevel.NORMAL);
+            PlanTestBase.assertContains(plan, "     TABLE: range_t1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=2/2");
+            Assertions.assertNotNull(execPlan);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshRangePartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshRangePartitionOlapTest.java
@@ -1,0 +1,197 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.thrift.TExplainLevel;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+@TestMethodOrder(MethodName.class)
+public class PCTRefreshRangePartitionOlapTest extends MVTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        MVTestBase.beforeClass();
+    }
+
+    @Test
+    public void testMVForceRefresh() throws Exception {
+        String partitionTable = "CREATE TABLE range_t1 (dt1 date, int1 int)\n" +
+                "PARTITION BY date_trunc('day', dt1)";
+        starRocksAssert.withTable(partitionTable);
+        addRangePartition("range_t1", "p1", "2024-01-04", "2024-01-05");
+        addRangePartition("range_t1", "p2", "2024-01-05", "2024-01-06");
+        String[] sqls = {
+                "INSERT INTO range_t1 partition(p1) VALUES (\"2024-01-04\",1);",
+                "INSERT INTO range_t1 partition(p2) VALUES (\"2024-01-05\",1);"
+        };
+        for (String sql : sqls) {
+            executeInsertSql(sql);
+        }
+
+        String mvQuery = "CREATE MATERIALIZED VIEW test_mv1 " +
+                "PARTITION BY date_trunc('day', dt1) " +
+                "REFRESH DEFERRED MANUAL PROPERTIES (\"partition_refresh_number\"=\"-1\")\n" +
+                "AS SELECT dt1,sum(int1) from range_t1 group by dt1";
+        starRocksAssert.withMaterializedView(mvQuery);
+
+        MaterializedView mv = getMv("test_mv1");
+
+        TaskRun taskRun = buildMVTaskRun(mv, "test");
+        ExecPlan execPlan;
+        // explain without force
+        {
+            execPlan = getMVRefreshExecPlan(taskRun);
+            Assertions.assertNotNull(execPlan);
+
+            refreshMV("test", mv);
+            execPlan = getMVRefreshExecPlan(taskRun);
+            Assertions.assertNull(execPlan);
+
+            String plan = explainMVRefreshExecPlan(mv, "explain refresh materialized " +
+                    "view test_mv1;");
+            Assertions.assertTrue(plan.contains("PLAN NOT AVAILABLE"));
+        }
+
+        // refresh with force
+        Map<String, String> props = taskRun.getProperties();
+        props.put(TaskRun.FORCE, "true");
+        String result = "";
+        // explain with refresh
+        {
+            ExecuteOption executeOption = new ExecuteOption(taskRun.getTask());
+            Map<String, String> explainProps = executeOption.getTaskRunProperties();
+            explainProps.put(TaskRun.FORCE, "true");
+
+            execPlan =
+                    getMVRefreshExecPlan(mv, "explain refresh materialized view test_mv1 " +
+                            "force;");
+            Assertions.assertNotNull(execPlan);
+
+            String plan = explainMVRefreshExecPlan(mv, executeOption, "explain refresh materialized view test_mv1 " +
+                    "force;");
+            Assertions.assertTrue(plan.contains("MVToRefreshedPartitions: [p20240104_20240105, p20240105_20240106]"));
+
+            // after refresh, still can refresh with force
+            execPlan = getMVRefreshExecPlan(taskRun, true);
+            result = execPlan.getExplainString(TExplainLevel.NORMAL);
+            PlanTestBase.assertContains(plan, "     TABLE: range_t1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=2/2");
+            Assertions.assertNotNull(execPlan);
+
+            refreshMV("test", mv);
+
+            // after refresh, still can refresh with force
+            execPlan = getMVRefreshExecPlan(taskRun, true);
+            result = execPlan.getExplainString(TExplainLevel.NORMAL);
+            PlanTestBase.assertContains(plan, "     TABLE: range_t1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=2/2");
+            Assertions.assertNotNull(execPlan);
+        }
+    }
+
+    @Test
+    public void testMVForcePartialRefresh() throws Exception {
+        String partitionTable = "CREATE TABLE range_t1 (dt1 date, int1 int)\n" +
+                "PARTITION BY date_trunc('day', dt1)";
+        starRocksAssert.withTable(partitionTable);
+        addRangePartition("range_t1", "p1", "2024-01-04", "2024-01-05");
+        addRangePartition("range_t1", "p2", "2024-01-05", "2024-01-06");
+        String[] sqls = {
+                "INSERT INTO range_t1 partition(p1) VALUES (\"2024-01-04\",1);",
+                "INSERT INTO range_t1 partition(p2) VALUES (\"2024-01-05\",1);"
+        };
+        for (String sql : sqls) {
+            executeInsertSql(sql);
+        }
+
+        String mvQuery = "CREATE MATERIALIZED VIEW test_mv1 " +
+                "PARTITION BY date_trunc('day', dt1) " +
+                "REFRESH DEFERRED MANUAL PROPERTIES (\"partition_refresh_number\"=\"-1\")\n" +
+                "AS SELECT dt1,sum(int1) from range_t1 group by dt1";
+        starRocksAssert.withMaterializedView(mvQuery);
+
+        MaterializedView mv = getMv("test_mv1");
+
+        TaskRun taskRun = buildMVTaskRun(mv, "test");
+        Map<String, String> props = taskRun.getProperties();
+        props.put(TaskRun.PARTITION_START, "2024-01-04");
+        props.put(TaskRun.PARTITION_END, "2024-01-05");
+
+        ExecPlan execPlan;
+        // explain without force
+        {
+            execPlan = getMVRefreshExecPlan(taskRun);
+            Assertions.assertNotNull(execPlan);
+
+            refreshMV("test", mv);
+            execPlan = getMVRefreshExecPlan(taskRun);
+            Assertions.assertNull(execPlan);
+
+            String plan = explainMVRefreshExecPlan(mv, "explain refresh materialized " +
+                    "view test_mv1;");
+            Assertions.assertTrue(plan.contains("PLAN NOT AVAILABLE"));
+        }
+
+        // refresh with force
+        props.put(TaskRun.FORCE, "true");
+        String result = "";
+        // explain with refresh
+        {
+            ExecuteOption executeOption = new ExecuteOption(taskRun.getTask());
+            Map<String, String> explainProps = executeOption.getTaskRunProperties();
+            explainProps.put(TaskRun.FORCE, "true");
+            explainProps.put(TaskRun.PARTITION_START, "2024-01-04");
+            explainProps.put(TaskRun.PARTITION_END, "2024-01-05");
+            execPlan =
+                    getMVRefreshExecPlan(mv, "explain refresh materialized view test_mv1 " +
+                            "force;");
+            Assertions.assertNotNull(execPlan);
+
+            String plan = explainMVRefreshExecPlan(mv, executeOption, "explain refresh materialized view test_mv1 " +
+                    "force;");
+            Assertions.assertTrue(plan.contains("MVToRefreshedPartitions: [p20240104_20240105]"));
+
+            // after refresh, still can refresh with force
+            execPlan = getMVRefreshExecPlan(taskRun, true);
+            result = execPlan.getExplainString(TExplainLevel.NORMAL);
+            PlanTestBase.assertContains(plan, "     TABLE: range_t1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/2");
+            Assertions.assertNotNull(execPlan);
+
+            refreshMV("test", mv);
+
+            // after refresh, still can refresh with force
+            execPlan = getMVRefreshExecPlan(taskRun, true);
+            result = execPlan.getExplainString(TExplainLevel.NORMAL);
+            PlanTestBase.assertContains(plan, "     TABLE: range_t1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/2");
+            Assertions.assertNotNull(execPlan);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
@@ -239,7 +239,7 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVTestBase {
                             .collect(Collectors.toList());
             Assertions.assertEquals(Arrays.asList("p000101_202308", "p202308_202309"), partitions);
             // mv partition p202308_202309 is force refreshed and visible version is increased
-            Assertions.assertEquals(partitionVersionMap.get("p202308_202309") + 1,
+            Assertions.assertEquals(partitionVersionMap.get("p202308_202309"),
                     materializedView.getPartition("p202308_202309")
                             .getDefaultPhysicalPartition().getVisibleVersion());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -834,12 +834,20 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVTestBase {
         for (String query : explainQueries) {
             // skip run
             ExecPlan execPlan = getMVRefreshExecPlan(mv, query);
-            Assertions.assertTrue(execPlan == null);
+            if (query.contains("force")) {
+                Assertions.assertNotNull(execPlan, execPlan.getExplainString(StatementBase.ExplainLevel.NORMAL));
+            } else {
+                Assertions.assertNull(execPlan);
+            }
         }
         for (String query : traceQueries) {
             // skip run
             ExecPlan execPlan = getMVRefreshExecPlan(mv, query);
-            Assertions.assertTrue(execPlan == null);
+            if (query.contains("force")) {
+                Assertions.assertNotNull(execPlan, execPlan.getExplainString(StatementBase.ExplainLevel.NORMAL));
+            } else {
+                Assertions.assertNull(execPlan);
+            }
         }
 
         executeInsertSql("INSERT INTO t1 VALUES (\"2020-06-23\",1);\n");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -432,15 +432,15 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                 .getDefaultPhysicalPartition().getVisibleVersion());
 
         refreshMVRange(materializedView.getName(), "2021-12-03", "2022-05-06", true);
-        Assertions.assertEquals(3, materializedView.getPartition("p202112_202201")
+        Assertions.assertEquals(2, materializedView.getPartition("p202112_202201")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(3, materializedView.getPartition("p202201_202202")
+        Assertions.assertEquals(2, materializedView.getPartition("p202201_202202")
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(2, materializedView.getPartition("p202202_202203")
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(2, materializedView.getPartition("p202203_202204")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(3, materializedView.getPartition("p202204_202205")
+        Assertions.assertEquals(2, materializedView.getPartition("p202204_202205")
                 .getDefaultPhysicalPartition().getVisibleVersion());
     }
 

--- a/test/sql/test_materialized_view_refresh/R/test_mv_force_refresh
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_force_refresh
@@ -1,0 +1,178 @@
+-- name: test_mv_force_refresh
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+    `k1` date,
+    `k2` int,
+    `k3` int
+)
+DUPLICATE KEY(`k1`)
+PARTITION BY RANGE (k1) (
+START ("2020-10-01") END ("2022-03-04") EVERY (INTERVAL 15 day)
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+-- result:
+-- !result
+INSERT INTO t1 VALUES ("2020-11-10",1,1),("2020-11-11",2,2),("2020-11-12",3,3);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY k1
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="-1")
+AS SELECT * FROM t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	1	1
+2020-11-11	2	2
+2020-11-12	3	3
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	1	1
+2020-11-11	2	2
+2020-11-12	3	3
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION START("2020-11-10") END("2020-11-11") FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	1	1
+2020-11-11	2	2
+2020-11-12	3	3
+-- !result
+INSERT INTO t1 VALUES ("2020-11-10",4,4);
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	1	1
+2020-11-10	4	4
+2020-11-11	2	2
+2020-11-12	3	3
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE TABLE `t2` (
+    `k1` date,
+    `k2` int,
+    `k3` int
+)
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+-- result:
+-- !result
+INSERT INTO t2 VALUES ("2020-11-10",1,1),("2020-11-11",2,2),("2020-11-12",3,3);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH DEFERRED MANUAL
+AS SELECT * FROM t2;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	1	1
+2020-11-11	2	2
+2020-11-12	3	3
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	1	1
+2020-11-11	2	2
+2020-11-12	3	3
+-- !result
+INSERT INTO t2 VALUES ("2020-11-10",4,4);
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	1	1
+2020-11-10	4	4
+2020-11-11	2	2
+2020-11-12	3	3
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE TABLE t3 (
+    k1 date,
+    k2 int,
+    k3 int 
+)
+DUPLICATE KEY(k1)
+PARTITION BY date_trunc("day", k1), k2;
+-- result:
+-- !result
+INSERT INTO t3 VALUES ("2020-11-10",1,1),("2020-11-11",2,2),("2020-11-12",3,3);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+partition by (date_trunc("day", k1), k2)
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="-1")
+AS select k1, k2, sum(k3) from t3 group by k1, k2;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	1	1
+2020-11-11	2	2
+2020-11-12	3	3
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	1	1
+2020-11-11	2	2
+2020-11-12	3	3
+-- !result
+INSERT INTO t3 VALUES ("2020-11-10",4,4);
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION (("2020-11-10", "4")) FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	1	1
+2020-11-10	4	4
+2020-11-11	2	2
+2020-11-12	3	3
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	1	1
+2020-11-10	4	4
+2020-11-11	2	2
+2020-11-12	3	3
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop table t2;
+-- result:
+-- !result
+drop table t3;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_force_refresh
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_force_refresh
@@ -1,0 +1,104 @@
+-- name: test_mv_force_refresh
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- range partition table
+CREATE TABLE `t1` (
+    `k1` date,
+    `k2` int,
+    `k3` int
+)
+DUPLICATE KEY(`k1`)
+PARTITION BY RANGE (k1) (
+START ("2020-10-01") END ("2022-03-04") EVERY (INTERVAL 15 day)
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+
+INSERT INTO t1 VALUES ("2020-11-10",1,1),("2020-11-11",2,2),("2020-11-12",3,3);
+
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY k1
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="-1")
+AS SELECT * FROM t1;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+
+REFRESH MATERIALIZED VIEW test_mv1 FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION START("2020-11-10") END("2020-11-11") FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+
+INSERT INTO t1 VALUES ("2020-11-10",4,4);
+REFRESH MATERIALIZED VIEW test_mv1 FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+-- non partition table
+CREATE TABLE `t2` (
+    `k1` date,
+    `k2` int,
+    `k3` int
+)
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+INSERT INTO t2 VALUES ("2020-11-10",1,1),("2020-11-11",2,2),("2020-11-12",3,3);
+
+CREATE MATERIALIZED VIEW test_mv1
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH DEFERRED MANUAL
+AS SELECT * FROM t2;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+
+REFRESH MATERIALIZED VIEW test_mv1 FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+
+INSERT INTO t2 VALUES ("2020-11-10",4,4);
+REFRESH MATERIALIZED VIEW test_mv1 FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+-- list partition table
+CREATE TABLE t3 (
+    k1 date,
+    k2 int,
+    k3 int 
+)
+DUPLICATE KEY(k1)
+PARTITION BY date_trunc("day", k1), k2;
+
+INSERT INTO t3 VALUES ("2020-11-10",1,1),("2020-11-11",2,2),("2020-11-12",3,3);
+
+CREATE MATERIALIZED VIEW test_mv1
+partition by (date_trunc("day", k1), k2)
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="-1")
+AS select k1, k2, sum(k3) from t3 group by k1, k2;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+
+REFRESH MATERIALIZED VIEW test_mv1 FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+
+INSERT INTO t3 VALUES ("2020-11-10",4,4);
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION (("2020-11-10", "4")) FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+
+REFRESH MATERIALIZED VIEW test_mv1 FORCE WITH SYNC MODE;
+select * from test_mv1 order by k1, k2;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+drop table t1;
+drop table t2;
+drop table t3;
+drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

`refresh mv with force` is expected to refresh target partitions no matter what happens, but there are some situations that nothing is done in current implementation(eg: mv's partition data corruptions)

In those cases, what users can do is only to drop the mv and recreate it again.


## What I'm doing:
To ensure mv force refresh will refresh target partitions:
- drop target partitions first
- mark target partitions as to-refresh partitions.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
