### PR TITLE
[BugFix] Clear mv's version map if restore job failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1682,6 +1682,8 @@ public class RestoreJob extends AbstractJob {
                                     MaterializedView mv = (MaterializedView) olapTable;
                                     mv.setInactiveAndReason(MaterializedViewExceptions
                                                     .inactiveReasonForMetadataTableRestoreCorrupted(mv.getName()));
+                                    // clear version map so can be refreshed later
+                                    mv.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMap();
                                     // drop all partitions
                                     Set<String> partitionNames = mv.getPartitionNames();
                                     for (String partitionName : partitionNames) {


### PR DESCRIPTION
## Why I'm doing:

This is a bug introduced by https://github.com/StarRocks/starrocks/pull/62514


- Clear mv's version map if restore job failed, otherwise following mv refresh may be skipped which will cause the mv result is empty.

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10191

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
