### PR TITLE
[BugFix] fix missing compaction profile when file bundling is on

### DIFF
--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1074,6 +1074,7 @@ TEST_F(LakeServiceTest, test_aggregate_compact) {
                 txnlog2.set_tablet_id(101);
                 txnlog2.set_txn_id(100);
                 resp->add_txn_logs()->CopyFrom(txnlog2);
+                resp->add_compact_stats();
                 resp->mutable_status()->set_status_code(0);
                 done->Run();
             }));


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

when create table with `file_bundling` true, compaction profile will be 0 for all fields

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
