### PR TITLE
[BugFix] Fixed the issue where the query results were not output in the specified field order

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
@@ -77,7 +77,6 @@ public class TaskRunsSystemTable extends SystemTable {
                         .column("CREATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("FINISH_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("STATE", ScalarType.createVarchar(16))
-                        .column("CATALOG", ScalarType.createVarchar(64))
                         .column("DATABASE", ScalarType.createVarchar(64))
                         .column("DEFINITION", ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
                         .column("EXPIRE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
@@ -88,6 +87,7 @@ public class TaskRunsSystemTable extends SystemTable {
                         .column("PROPERTIES", ScalarType.createVarcharType(512))
                         .column("JOB_ID", ScalarType.createVarcharType(64))
                         .column("PROCESS_TIME", ScalarType.createType(PrimitiveType.DATETIME))
+                        .column("CATALOG", ScalarType.createVarchar(64))
                         .build(), TSchemaTableType.SCH_TASK_RUNS);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
@@ -97,6 +97,10 @@ public class OptExpression {
         return op;
     }
 
+    public void setOp(Operator op) {
+        this.op = op;
+    }
+
     public List<OptExpression> getInputs() {
         return inputs;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/PhysicalPlanColumnOrderUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/PhysicalPlanColumnOrderUtil.java
@@ -1,0 +1,200 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalValuesOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.plan.ExecPlan;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class to fix the output column order of PhysicalValuesOperator.
+ * The order must strictly follow the expected output column list.
+ *
+ * We match columns by ColumnRefOperator.id (unique identifier),
+ * ignoring alias names, since aliases are only for SQL syntax and
+ * may not exist in the optimized plan.
+ */
+public class PhysicalPlanColumnOrderUtil {
+    private static final Logger LOG = LogManager.getLogger(PhysicalPlanColumnOrderUtil.class);
+
+    // column reference operator
+    private final List<ColumnRefOperator> expectedOutputColumns;
+
+    public PhysicalPlanColumnOrderUtil(List<ColumnRefOperator> expectedOutputColumns) {
+        this.expectedOutputColumns = expectedOutputColumns;
+    }
+
+    /**
+     * Fix the column order issue in the physics plan
+     * @param optExpr
+     * @param context
+     */
+    public void fixPhysicalPlan(OptExpression optExpr, ExecPlan context) {
+        // There are no fields to output
+        if (expectedOutputColumns.isEmpty()) {
+            return;
+        }
+        visit(optExpr, context);
+    }
+
+    /**
+     * Visit OptExpression and fix the column order
+     * @param optExpr
+     * @param context
+     */
+    private void visit(OptExpression optExpr, ExecPlan context) {
+        // Visit the child nodes first
+        for (OptExpression input : optExpr.getInputs()) {
+            visit(input, context);
+        }
+
+        // Fix the current node
+        Operator op = optExpr.getOp();
+        if (op instanceof PhysicalValuesOperator) {
+            PhysicalValuesOperator operator = (PhysicalValuesOperator) op;
+            // There is no result to be output
+            if (operator.getRows().isEmpty()) {
+                return;
+            }
+            boolean isAllConstants = true;
+            if (operator.getProjection() != null) {
+                isAllConstants = operator.getProjection().getColumnRefMap().values().stream()
+                        .allMatch(ScalarOperator::isConstantRef);
+            } else if (CollectionUtils.isNotEmpty(operator.getRows())) {
+                isAllConstants = operator.getRows().stream().allMatch(row ->
+                        row.stream().allMatch(ScalarOperator::isConstantRef));
+            }
+            if (!isAllConstants) {
+                return;
+            }
+            fixPhysicalValuesOperator(optExpr, operator, context);
+        }
+    }
+
+    /**
+     * Fix the column order of PhysicalValuesOperator
+     * @param optExpr
+     * @param physicalValuesOperator
+     * @param context
+     */
+    public void fixPhysicalValuesOperator(OptExpression optExpr, PhysicalValuesOperator physicalValuesOperator, ExecPlan context) {
+        List<ColumnRefOperator> columnRefOperatorList = physicalValuesOperator.getColumnRefSet();
+        // Check if repair is needed
+        if (!needsOrderFix(columnRefOperatorList)) {
+            return;
+        }
+
+        // Create a sort mapping
+        List<Integer> sortList = new ArrayList<>();
+        List<ColumnRefOperator> newSortColumnRefList = new ArrayList<>();
+
+        for (ColumnRefOperator expectedColumn : expectedOutputColumns) {
+            boolean matched = false;
+            for (int i = 0; i < columnRefOperatorList.size(); i++) {
+                ColumnRefOperator columnRefOperator = columnRefOperatorList.get(i);
+                if (columnRefOperator.getId() == expectedColumn.getId()) {
+                    sortList.add(i);
+                    newSortColumnRefList.add(columnRefOperator);
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) {
+                LOG.warn("fixPhysicalValuesOperator: cannot match expected column {} in {}",
+                        expectedColumn, columnRefOperatorList);
+            }
+        }
+        // output column name complete different with ColumnRefOperator
+        if (newSortColumnRefList.isEmpty() || newSortColumnRefList.size() != columnRefOperatorList.size()) {
+            return;
+        }
+
+        // If the order remains unchanged, return directly
+        if (sortList.size() == columnRefOperatorList.size() && isAlreadyInOrder(sortList)) {
+            return;
+        }
+
+        // Reorder the row data
+        List<List<ScalarOperator>> newSortRowsList = new ArrayList<>();
+        for (List<ScalarOperator> row : physicalValuesOperator.getRows()) {
+            List<ScalarOperator> curRows = new ArrayList<>();
+            for (int index : sortList) {
+                curRows.add(row.get(index));
+            }
+            newSortRowsList.add(curRows);
+        }
+
+        // Create a new PhysicalValuesOperator
+        PhysicalValuesOperator newSortPhysicalValueOperator = new PhysicalValuesOperator(
+                newSortColumnRefList,
+                newSortRowsList,
+                physicalValuesOperator.getLimit(),
+                physicalValuesOperator.getPredicate(),
+                physicalValuesOperator.getProjection()
+        );
+
+        // Replacement operator
+        optExpr.setOp(newSortPhysicalValueOperator);
+        if (context.getPhysicalPlan() != null && context.getPhysicalPlan().getOp() == physicalValuesOperator) {
+            context.getPhysicalPlan().setOp(newSortPhysicalValueOperator);
+        }
+    }
+
+
+    /**
+     * Check if it is already in order
+     * @param sortList
+     * @return
+     */
+    public boolean isAlreadyInOrder(List<Integer> sortList) {
+        for (int i = 0; i < sortList.size(); i++) {
+            if (sortList.get(i) != i) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Check if the sequence needs to be repaired
+     * @param currentOrder
+     * @return
+     */
+    public boolean needsOrderFix(List<ColumnRefOperator> currentOrder) {
+        if (currentOrder.size() != expectedOutputColumns.size()) {
+            return false;
+        }
+        for (int i = 0; i < currentOrder.size(); i++) {
+            // The field has no name and cannot be sorted
+            if (currentOrder.get(i).getName().isEmpty()) {
+                return false;
+            }
+            String realOutputName = currentOrder.get(i).getName();
+            String realColumnName = expectedOutputColumns.get(i).getName();
+            if (!realOutputName.equalsIgnoreCase(realColumnName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -138,6 +138,7 @@ import com.starrocks.sql.common.UnsupportedException;
 import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.PhysicalPlanColumnOrderUtil;
 import com.starrocks.sql.optimizer.UKFKConstraintsCollector;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -1955,6 +1956,9 @@ public class PlanFragmentBuilder {
 
         @Override
         public PlanFragment visitPhysicalValues(OptExpression optExpr, ExecPlan context) {
+            PhysicalPlanColumnOrderUtil fixer = new PhysicalPlanColumnOrderUtil(context.getOutputColumns());
+            fixer.fixPhysicalPlan(optExpr, context);
+
             PhysicalValuesOperator valuesOperator = (PhysicalValuesOperator) optExpr.getOp();
 
             TupleDescriptor tupleDescriptor = context.getDescTbl().createTupleDescriptor();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/PhysicalPlanColumnOrderUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/PhysicalPlanColumnOrderUtilTest.java
@@ -1,0 +1,202 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalValuesOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.plan.ExecPlan;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.wildfly.common.Assert;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class PhysicalPlanColumnOrderUtilTest {
+    private List<String> expectedColumnNames;
+    private List<ColumnRefOperator> expectedColumnRefOperators;
+    private PhysicalPlanColumnOrderUtil fixer;
+
+    @BeforeEach
+    public void setUp() {
+        expectedColumnNames = Arrays.asList("col1", "col2", "col3");
+        ColumnRefOperator columnRefOperator1 = new ColumnRefOperator(0, Type.INT, expectedColumnNames.get(0), false);
+        ColumnRefOperator columnRefOperator2 = new ColumnRefOperator(1, Type.INT, expectedColumnNames.get(1), false);
+        ColumnRefOperator columnRefOperator3 = new ColumnRefOperator(2, Type.INT, expectedColumnNames.get(2), false);
+        expectedColumnRefOperators = Arrays.asList(columnRefOperator1, columnRefOperator2, columnRefOperator3);
+        fixer = new PhysicalPlanColumnOrderUtil(expectedColumnRefOperators);
+    }
+
+    @Test
+    public void testNeedsOrderFix_WhenOrderMatches_ReturnsFalse() {
+        // Prepare
+        List<ColumnRefOperator> currentOrder = Arrays.asList(
+                createColumnRefOperator("col1"),
+                createColumnRefOperator("col2"),
+                createColumnRefOperator("col3")
+        );
+
+        // Execution
+        boolean result = fixer.needsOrderFix(currentOrder);
+
+        // Verification
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testNeedsOrderFix_WhenOrderDifferent_ReturnsTrue() {
+        // Prepare
+        List<ColumnRefOperator> currentOrder = Arrays.asList(
+                createColumnRefOperator("col2"),
+                createColumnRefOperator("col1"),
+                createColumnRefOperator("col3")
+        );
+
+        // Execution
+        boolean result = fixer.needsOrderFix(currentOrder);
+
+        // Verification
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void testNeedsOrderFix_WhenDifferentSize_ReturnsFalse() {
+        // Prepare
+        List<ColumnRefOperator> currentOrder = Arrays.asList(
+                createColumnRefOperator("col1"),
+                createColumnRefOperator("col2")
+        );
+
+        // Execution
+        boolean result = fixer.needsOrderFix(currentOrder);
+
+        // Verification
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testIsAlreadyInOrder_WhenInOrder_ReturnsTrue() {
+        // Prepare
+        List<Integer> sortList = Arrays.asList(0, 1, 2);
+
+        // Execution
+        boolean result = fixer.isAlreadyInOrder(sortList);
+
+        // Verification
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void testIsAlreadyInOrder_WhenNotInOrder_ReturnsFalse() {
+        // Prepare
+        List<Integer> sortList = Arrays.asList(1, 0, 2);
+
+        // Execution
+        boolean result = fixer.isAlreadyInOrder(sortList);
+
+        // Verification
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testFixPhysicalValuesOperator_WhenOrderNeedsFix() {
+        // Prepare
+        List<ColumnRefOperator> columnRefs = Arrays.asList(
+                createColumnRefOperator("col2"),
+                createColumnRefOperator("col1"),
+                createColumnRefOperator("col3")
+        );
+
+        List<List<ScalarOperator>> rows = Arrays.asList(
+                Arrays.asList(createScalarOperator("value2"), createScalarOperator("value1"), createScalarOperator("value3")),
+                Arrays.asList(createScalarOperator("value2_2"), createScalarOperator("value1_2"), createScalarOperator("value3_2"))
+        );
+
+        PhysicalValuesOperator valuesOperator = Mockito.mock(PhysicalValuesOperator.class);
+        Mockito.when(valuesOperator.getColumnRefSet()).thenReturn(columnRefs);
+        Mockito.when(valuesOperator.getRows()).thenReturn(rows);
+        Mockito.when(valuesOperator.getLimit()).thenReturn(-1L);
+        Mockito.when(valuesOperator.getPredicate()).thenReturn(null);
+        Mockito.when(valuesOperator.getProjection()).thenReturn(null);
+
+        OptExpression optExpr = Mockito.mock(OptExpression.class);
+        Mockito.when(optExpr.getOp()).thenReturn(valuesOperator);
+
+        ExecPlan context = Mockito.mock(ExecPlan.class);
+        Mockito.when(context.getPhysicalPlan()).thenReturn(null);
+
+        // Execution
+        fixer.fixPhysicalValuesOperator(optExpr, valuesOperator, context);
+
+        // Verification - Check whether the operator has been replaced
+        Mockito.verify(optExpr).setOp(Mockito.any(PhysicalValuesOperator.class));
+    }
+
+    @Test
+    public void testVisit_WithPhysicalValuesOperator() {
+        // Prepare
+        PhysicalValuesOperator valuesOperator = Mockito.mock(PhysicalValuesOperator.class);
+        Mockito.when(valuesOperator.getColumnRefSet()).thenReturn(Arrays.asList(
+                createColumnRefOperator("col1"), createColumnRefOperator("col2"), createColumnRefOperator("col3")
+        ));
+        Mockito.when(valuesOperator.getRows()).thenReturn(Collections.emptyList());
+
+        OptExpression optExpr = Mockito.mock(OptExpression.class);
+        Mockito.when(optExpr.getOp()).thenReturn(valuesOperator);
+        Mockito.when(optExpr.getInputs()).thenReturn(Collections.emptyList());
+
+        ExecPlan context = Mockito.mock(ExecPlan.class);
+        Mockito.when(context.getPhysicalPlan()).thenReturn(null);
+
+        // Execution
+        fixer.fixPhysicalPlan(optExpr, context);
+
+        // Verification - Ensure that the method is executed normally without any abnormalities
+        Mockito.verify(optExpr).getInputs();
+    }
+
+    @Test
+    public void testFixPhysicalPlan() {
+        // Prepare
+        OptExpression optExpr = Mockito.mock(OptExpression.class);
+        Mockito.when(optExpr.getInputs()).thenReturn(Collections.emptyList());
+        Mockito.when(optExpr.getOp()).thenReturn(Mockito.mock(Operator.class));
+
+        ExecPlan context = Mockito.mock(ExecPlan.class);
+
+        // Execution
+        fixer.fixPhysicalPlan(optExpr, context);
+
+        // Verification - Make sure the visit method is called
+        Mockito.verify(optExpr).getInputs();
+    }
+
+    // Auxiliary methods
+    private ColumnRefOperator createColumnRefOperator(String name) {
+        ColumnRefOperator colRef = Mockito.mock(ColumnRefOperator.class);
+        Mockito.when(colRef.getName()).thenReturn(name);
+        return colRef;
+    }
+
+    private ScalarOperator createScalarOperator(String value) {
+        ScalarOperator scalar = Mockito.mock(ScalarOperator.class);
+        return scalar;
+    }
+}


### PR DESCRIPTION
Fixed the issue where the query results were not output in the specified field order #62647 
#62647

## Why I'm doing:

## What I'm doing:

Fixes #62647 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures VALUES outputs follow expected column order via a new planner utility and integration, exposes `OptExpression#setOp`, reorders `CATALOG` in `information_schema.task_runs`, and adds unit tests.
> 
> - **Planner/Optimizer**:
>   - **Column Order Fix**: Add `PhysicalPlanColumnOrderUtil` to reorder `PhysicalValuesOperator` outputs to match expected columns; invoked in `PlanFragmentBuilder.visitPhysicalValues`.
>   - **API**: Expose `OptExpression#setOp` to allow operator replacement during fixing.
> - **Information Schema**:
>   - Reorder `CATALOG` column position in `information/task_runs` table schema.
> - **Tests**:
>   - Add `PhysicalPlanColumnOrderUtilTest` covering order detection and reordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00324adaed44dca1f197b66866698b26fe9d3540. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->