### PR TITLE
[Enhancement] Support OFFSET syntax

### DIFF
--- a/test/sql/test_limit_offset_syntax/R/test_limit_offset_edge_cases
+++ b/test/sql/test_limit_offset_syntax/R/test_limit_offset_edge_cases
@@ -1,0 +1,67 @@
+-- name: test_limit_offset_edge_cases
+CREATE DATABASE db_${uuid0};
+-- result:
+-- !result
+USE db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE test_table (
+    id INT,
+    value VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1;
+-- result:
+-- !result
+INSERT INTO test_table VALUES 
+(1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+-- result:
+-- !result
+SET @my_limit = 2;
+-- result:
+-- !result
+SET @my_offset = 1;
+-- result:
+-- !result
+SELECT id, value FROM test_table ORDER BY id LIMIT @my_limit OFFSET @my_offset;
+-- result:
+2	b
+3	c
+-- !result
+SELECT id, value FROM test_table ORDER BY id LIMIT @my_offset, @my_limit;
+-- result:
+2	b
+3	c
+-- !result
+SELECT id, value FROM test_table ORDER BY id LIMIT 3 OFFSET @my_offset;
+-- result:
+2	b
+3	c
+4	d
+-- !result
+SELECT id, value FROM test_table ORDER BY id LIMIT @my_limit OFFSET 3;
+-- result:
+4	d
+5	e
+-- !result
+SELECT id, value FROM test_table ORDER BY id LIMIT 2 OFFSET 0;
+-- result:
+1	a
+2	b
+-- !result
+SELECT id, value FROM test_table ORDER BY id LIMIT 0, 2;
+-- result:
+1	a
+2	b
+-- !result
+SELECT id, value FROM test_table ORDER BY id LIMIT 2 OFFSET 10;
+-- result:
+-- !result
+SELECT id, value FROM test_table ORDER BY id LIMIT 10, 2;
+-- result:
+-- !result
+DROP TABLE test_table;
+-- result:
+-- !result
+DROP DATABASE db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_limit_offset_syntax/R/test_limit_offset_syntax
+++ b/test/sql/test_limit_offset_syntax/R/test_limit_offset_syntax
@@ -1,0 +1,76 @@
+-- name: test_limit_offset_syntax
+CREATE DATABASE db_${uuid0};
+-- result:
+-- !result
+USE db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE test_table (
+    id INT,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1;
+-- result:
+-- !result
+INSERT INTO test_table VALUES 
+(1, 'row1'),
+(2, 'row2'), 
+(3, 'row3'),
+(4, 'row4'),
+(5, 'row5'),
+(6, 'row6'),
+(7, 'row7'),
+(8, 'row8'),
+(9, 'row9'),
+(10, 'row10');
+-- result:
+-- !result
+SELECT id, name FROM test_table ORDER BY id LIMIT 3 OFFSET 2;
+-- result:
+3	row3
+4	row4
+5	row5
+-- !result
+SELECT id, name FROM test_table ORDER BY id LIMIT 2, 3;
+-- result:
+3	row3
+4	row4
+5	row5
+-- !result
+SELECT id, name FROM test_table ORDER BY id LIMIT 2;
+-- result:
+1	row1
+2	row2
+-- !result
+SELECT id, name FROM test_table ORDER BY id LIMIT 3 OFFSET 0;
+-- result:
+1	row1
+2	row2
+3	row3
+-- !result
+SELECT id, name FROM test_table ORDER BY id LIMIT 3 OFFSET 7;
+-- result:
+8	row8
+9	row9
+10	row10
+-- !result
+SELECT id, name FROM test_table ORDER BY id LIMIT 7, 3;
+-- result:
+8	row8
+9	row9
+10	row10
+-- !result
+SELECT id, name FROM test_table ORDER BY id LIMIT 1 OFFSET 9;
+-- result:
+10	row10
+-- !result
+SELECT id, name FROM test_table ORDER BY id LIMIT 9, 1;
+-- result:
+10	row10
+-- !result
+DROP TABLE test_table;
+-- result:
+-- !result
+DROP DATABASE db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_limit_offset_syntax/T/test_limit_offset_edge_cases
+++ b/test/sql/test_limit_offset_syntax/T/test_limit_offset_edge_cases
@@ -1,0 +1,48 @@
+-- name: test_limit_offset_edge_cases
+-- Test edge cases for LIMIT OFFSET syntax
+
+CREATE DATABASE db_${uuid0};
+USE db_${uuid0};
+
+-- Create test table
+CREATE TABLE test_table (
+    id INT,
+    value VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1;
+
+-- Insert test data
+INSERT INTO test_table VALUES 
+(1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+
+-- Test with user variables
+SET @my_limit = 2;
+SET @my_offset = 1;
+
+-- Test 1: Standard syntax with user variables
+SELECT id, value FROM test_table ORDER BY id LIMIT @my_limit OFFSET @my_offset;
+
+-- Test 2: StarRocks syntax with user variables
+SELECT id, value FROM test_table ORDER BY id LIMIT @my_offset, @my_limit;
+
+-- Test 3: Mixed - literal limit, variable offset
+SELECT id, value FROM test_table ORDER BY id LIMIT 3 OFFSET @my_offset;
+
+-- Test 4: Mixed - variable limit, literal offset  
+SELECT id, value FROM test_table ORDER BY id LIMIT @my_limit OFFSET 3;
+
+-- Test 5: Zero offset (standard syntax)
+SELECT id, value FROM test_table ORDER BY id LIMIT 2 OFFSET 0;
+
+-- Test 6: Zero offset (StarRocks syntax)
+SELECT id, value FROM test_table ORDER BY id LIMIT 0, 2;
+
+-- Test 7: Large offset that exceeds table size
+SELECT id, value FROM test_table ORDER BY id LIMIT 2 OFFSET 10;
+
+-- Test 8: Large offset that exceeds table size (StarRocks syntax)
+SELECT id, value FROM test_table ORDER BY id LIMIT 10, 2;
+
+-- Clean up
+DROP TABLE test_table;
+DROP DATABASE db_${uuid0};

--- a/test/sql/test_limit_offset_syntax/T/test_limit_offset_syntax
+++ b/test/sql/test_limit_offset_syntax/T/test_limit_offset_syntax
@@ -1,0 +1,62 @@
+-- name: test_limit_offset_syntax
+-- Test both LIMIT syntaxes to ensure they work correctly after the fix
+
+-- Create test database
+CREATE DATABASE db_${uuid0};
+USE db_${uuid0};
+
+-- Create test table
+CREATE TABLE test_table (
+    id INT,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1;
+
+-- Insert test data
+INSERT INTO test_table VALUES 
+(1, 'row1'),
+(2, 'row2'), 
+(3, 'row3'),
+(4, 'row4'),
+(5, 'row5'),
+(6, 'row6'),
+(7, 'row7'),
+(8, 'row8'),
+(9, 'row9'),
+(10, 'row10');
+
+-- Test 1: Standard SQL syntax - LIMIT count OFFSET offset
+-- Should return rows with id 3, 4, 5 (3 rows starting from offset 2)
+SELECT id, name FROM test_table ORDER BY id LIMIT 3 OFFSET 2;
+
+-- Test 2: StarRocks syntax - LIMIT offset, count  
+-- Should return the same rows with id 3, 4, 5
+SELECT id, name FROM test_table ORDER BY id LIMIT 2, 3;
+
+-- Test 3: LIMIT without OFFSET (standard syntax)
+-- Should return first 2 rows
+SELECT id, name FROM test_table ORDER BY id LIMIT 2;
+
+-- Test 4: LIMIT with OFFSET 0 (standard syntax)  
+-- Should return first 3 rows
+SELECT id, name FROM test_table ORDER BY id LIMIT 3 OFFSET 0;
+
+-- Test 5: Large offset (standard syntax)
+-- Should return rows 8, 9, 10
+SELECT id, name FROM test_table ORDER BY id LIMIT 3 OFFSET 7;
+
+-- Test 6: Large offset (StarRocks syntax)
+-- Should return the same rows 8, 9, 10
+SELECT id, name FROM test_table ORDER BY id LIMIT 7, 3;
+
+-- Test 7: Edge case - LIMIT 1 OFFSET 9
+-- Should return only row 10
+SELECT id, name FROM test_table ORDER BY id LIMIT 1 OFFSET 9;
+
+-- Test 8: Edge case - LIMIT 9, 1 (equivalent to above)
+-- Should return only row 10
+SELECT id, name FROM test_table ORDER BY id LIMIT 9, 1;
+
+-- Clean up
+DROP TABLE test_table;
+DROP DATABASE db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

This PR resolves issue #62629, a feature request to support the standard SQL `LIMIT count OFFSET offset` syntax. Previously, StarRocks only supported the `LIMIT offset, count` syntax. The root cause was a parsing bug in `AstBuilder.visitLimitElement` which failed to correctly distinguish and parse the two grammar alternatives for the LIMIT clause.

## What I'm doing:

- Modified `AstBuilder.visitLimitElement` to correctly parse both `LIMIT count OFFSET offset` (standard SQL) and `LIMIT offset, count` (StarRocks style) syntaxes.
- Implemented logic to detect the specific LIMIT syntax used (comma-separated vs. `OFFSET` keyword).
- Added comprehensive test cases for both syntaxes, including scenarios with user variables and edge cases.

Fixes #62629

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-45302c76-477d-4669-88a4-8c19fd835dea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45302c76-477d-4669-88a4-8c19fd835dea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

