### PR TITLE
[Enhancement] turn on tablet balance between workers by default in shared-data mode

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -3493,7 +3493,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### lake_enable_balance_tablets_between_workers
 
-- Default: false
+- Default: true
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -2604,7 +2604,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### lake_enable_balance_tablets_between_workers
 
-- デフォルト: false
+- デフォルト: true
 - タイプ: Boolean
 - 単位: -
 - 変更可能: はい

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -3493,7 +3493,7 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 
 ##### lake_enable_balance_tablets_between_workers
 
-- 默认值：false
+- 默认值：true
 - 类型：Boolean
 - 单位：-
 - 是否动态：是

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2982,8 +2982,8 @@ public class Config extends ConfigBase {
     public static int lake_publish_delete_txnlog_max_threads = 16;
 
     @ConfField(mutable = true, comment =
-            "Consider balancing between workers during tablet migration in shared data mode. Default: false")
-    public static boolean lake_enable_balance_tablets_between_workers = false;
+            "Consider balancing between workers during tablet migration in shared data mode. Default: true")
+    public static boolean lake_enable_balance_tablets_between_workers = true;
 
     @ConfField(mutable = true, comment =
             "Threshold of considering the balancing between workers in shared-data mode, The imbalance factor is " +


### PR DESCRIPTION
## Why I'm doing:

This enhancement is proved to be helpful when new nodes are added into the shared-data cluster, it helps to reach to balanced tablets number distribution quickly and use all compute resources for the query more efficiently.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3