### PR TITLE
[BugFix] Fix version check failed while appling replication txn with compaction enabled

### DIFF
--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -786,10 +786,10 @@ private:
                              << ", base version: " << txn_meta.visible_version() << ", new version: " << _new_version;
                 return Status::Corruption("mismatched snapshot version and new version");
             }
-        } else if (txn_meta.snapshot_version() - txn_meta.data_version() +  _metadata->version() != _new_version) {
+        } else if (txn_meta.snapshot_version() - txn_meta.data_version() + _metadata->version() != _new_version) {
             LOG(WARNING) << "Fail to apply replication log, mismatched version, snapshot version: "
                          << txn_meta.snapshot_version() << ", data version: " << txn_meta.data_version()
-                         << ", base version: " <<  _metadata->version() << ", new version: " << _new_version;
+                         << ", base version: " << _metadata->version() << ", new version: " << _new_version;
             return Status::Corruption("mismatched version");
         }
 

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -391,10 +391,10 @@ private:
                              << ", base version: " << txn_meta.visible_version() << ", new version: " << _new_version;
                 return Status::Corruption("mismatched snapshot version and new version");
             }
-        } else if (txn_meta.snapshot_version() - txn_meta.data_version() + txn_meta.visible_version() != _new_version) {
+        } else if (txn_meta.snapshot_version() - txn_meta.data_version() + _base_version != _new_version) {
             LOG(WARNING) << "Fail to apply replication log, mismatched version, snapshot version: "
                          << txn_meta.snapshot_version() << ", data version: " << txn_meta.data_version()
-                         << ", old version: " << txn_meta.visible_version() << ", new version: " << _new_version;
+                         << ", base version: " << _base_version << ", new version: " << _new_version;
             return Status::Corruption("mismatched version");
         }
 
@@ -786,10 +786,10 @@ private:
                              << ", base version: " << txn_meta.visible_version() << ", new version: " << _new_version;
                 return Status::Corruption("mismatched snapshot version and new version");
             }
-        } else if (txn_meta.snapshot_version() - txn_meta.data_version() + txn_meta.visible_version() != _new_version) {
+        } else if (txn_meta.snapshot_version() - txn_meta.data_version() +  _metadata->version() != _new_version) {
             LOG(WARNING) << "Fail to apply replication log, mismatched version, snapshot version: "
                          << txn_meta.snapshot_version() << ", data version: " << txn_meta.data_version()
-                         << ", old version: " << txn_meta.visible_version() << ", new version: " << _new_version;
+                         << ", base version: " <<  _metadata->version() << ", new version: " << _new_version;
             return Status::Corruption("mismatched version");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -947,7 +947,7 @@ public class DatabaseTransactionMgr {
                         states = states.subList(0, Math.max(i, 1));
                         break;
                     }
-                    // Handle replication tansaction singly
+                    // Handle replication transaction singly
                     // e.g. assume there are 4 txns in `states`: <txn_normal_0, txn_rep_0, txn_normal_1, txn_normal_2>
                     // 3 txn batch will be generated as: <txn_normal_0>, <txn_rep>, <txn_normal_1, txn_normal_2>
                     if (state.getTransactionType() == TransactionType.TXN_REPLICATION) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -947,7 +947,7 @@ public class DatabaseTransactionMgr {
                         states = states.subList(0, Math.max(i, 1));
                         break;
                     }
-                    // Handle replication transaction singly
+                    // Handle replication transaction separately
                     // e.g. assume there are 4 txns in `states`: <txn_normal_0, txn_rep_0, txn_normal_1, txn_normal_2>
                     // 3 txn batch will be generated as: <txn_normal_0>, <txn_rep>, <txn_normal_1, txn_normal_2>
                     if (state.getTransactionType() == TransactionType.TXN_REPLICATION) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -947,6 +947,13 @@ public class DatabaseTransactionMgr {
                         states = states.subList(0, Math.max(i, 1));
                         break;
                     }
+                    // Handle replication tansaction singly
+                    // e.g. assume there are 4 txns in `states`: <txn_normal_0, txn_rep_0, txn_normal_1, txn_normal_2>
+                    // 3 txn batch will be generated as: <txn_normal_0>, <txn_rep>, <txn_normal_1, txn_normal_2>
+                    if (state.getTransactionType() == TransactionType.TXN_REPLICATION) {
+                        states = states.subList(0, Math.max(i, 1));
+                        break;
+                    }
                     Map<Long, PartitionCommitInfo> partitionInfoMap = tableInfo.getIdToPartitionCommitInfo();
                     for (Map.Entry<Long, PartitionCommitInfo> item : partitionInfoMap.entrySet()) {
                         PartitionCommitInfo currTxnInfo = item.getValue();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
@@ -92,6 +92,7 @@ public class GlobalStateMgrTestUtil {
     public static String testTxnLable10 = "testTxnLable10";
     public static String testTxnLableCompaction1 = "testTxnLableCompaction1";
     public static String testTxnLableCompaction2 = "testTxnLableCompaction2";
+    public static String testTxnLableReplication1 = "testTxnLableReplication1";
     public static String testEsTable1 = "partitionedEsTable1";
     public static long testEsTableId1 = 14;
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -630,8 +630,9 @@ public class DatabaseTransactionMgrTest {
         assertEquals(1, stateBatchesList.size());
         assertEquals(1, stateBatchesList.get(0).size());
 
-        // add one more transaction, the batch chosen should only have one transaction,
-        // and it should be the replication transaction
+        // Add one more normal transaction after the replication transaction.
+        // The batching logic should process the replication transaction in its own batch first,
+        // and then the new normal transaction will be in a separate batch.
         long transactionId9 = masterTransMgr
                 .beginTransaction(GlobalStateMgrTestUtil.testDbId1,
                         Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -36,7 +36,14 @@ package com.starrocks.transaction;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.starrocks.catalog.*;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.FakeEditLog;
+import com.starrocks.catalog.FakeGlobalStateMgr;
+import com.starrocks.catalog.GlobalStateMgrTestUtil;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ExceptionChecker;

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -36,13 +36,7 @@ package com.starrocks.transaction;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.starrocks.catalog.Database;
-import com.starrocks.catalog.FakeEditLog;
-import com.starrocks.catalog.FakeGlobalStateMgr;
-import com.starrocks.catalog.GlobalStateMgrTestUtil;
-import com.starrocks.catalog.OlapTable;
-import com.starrocks.catalog.PhysicalPartition;
-import com.starrocks.catalog.Table;
+import com.starrocks.catalog.*;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ExceptionChecker;
@@ -51,6 +45,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.load.routineload.RLTaskTxnCommitAttachment;
+import com.starrocks.replication.ReplicationTxnCommitAttachment;
 import com.starrocks.server.GlobalStateMgr;
 import mockit.Mock;
 import mockit.MockUp;
@@ -60,6 +55,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -553,6 +549,93 @@ public class DatabaseTransactionMgrTest {
         masterDbTransMgr.getLabelTransactionState(GlobalStateMgrTestUtil.testTxnLable6)
                 .removeTable(GlobalStateMgrTestUtil.testTableId1);
         stateBatchesList = masterDbTransMgr.getReadyToPublishTxnListBatch();
+        assertEquals(1, stateBatchesList.size());
+        assertEquals(1, stateBatchesList.get(0).size());
+    }
+
+    @Test
+    public void testGetReadyToPublishTxnListBatchWithReplicationTxn() throws StarRocksException {
+
+        // begin transaction
+        long replicationTransactionId1 = masterTransMgr
+                .beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                        Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                        GlobalStateMgrTestUtil.testTxnLableReplication1,
+                        transactionSource,
+                        TransactionState.LoadJobSourceType.REPLICATION, Config.replication_transaction_timeout_sec);
+
+        // commit a transaction
+        TabletCommitInfo tabletCommitInfo1 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
+                GlobalStateMgrTestUtil.testBackendId1);
+        TabletCommitInfo tabletCommitInfo2 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
+                GlobalStateMgrTestUtil.testBackendId2);
+        List<TabletCommitInfo> transTablets = Lists.newArrayList();
+        transTablets.add(tabletCommitInfo1);
+        transTablets.add(tabletCommitInfo2);
+
+        Map<Long, Long> partitionVersions = new HashMap<>();
+        Table table = masterGlobalStateMgr.getLocalMetastore().getTable(GlobalStateMgrTestUtil.testDbId1,
+                GlobalStateMgrTestUtil.testTableId1);
+        for (Partition partition : table.getPartitions()) {
+            partitionVersions.put(partition.getDefaultPhysicalPartition().getId(),
+                    partition.getDefaultPhysicalPartition().getVisibleVersion() + 2);
+        }
+
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, replicationTransactionId1, transTablets,
+                Lists.newArrayList(), new ReplicationTxnCommitAttachment(partitionVersions, partitionVersions));
+
+        // transactionGraph have 4 transactions total, and the last one is a replication transaction
+        transactionGraph.add(replicationTransactionId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1));
+
+        DatabaseTransactionMgr masterDbTransMgr = masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
+        List<TransactionStateBatch> stateBatchesList = masterDbTransMgr.getReadyToPublishTxnListBatch();
+        assertEquals(4, masterDbTransMgr.getCommittedTxnList().size());
+        assertEquals(1, stateBatchesList.size());
+        assertEquals(3, stateBatchesList.get(0).size());
+
+        // Let's finish the first batch transactions
+        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
+        long txnId6 = lableToTxnId.get(GlobalStateMgrTestUtil.testTxnLable6);
+        TransactionState transactionState6 = masterDbTransMgr.getTransactionState(txnId6);
+        long txnId7 = lableToTxnId.get(GlobalStateMgrTestUtil.testTxnLable7);
+        TransactionState transactionState7 = masterDbTransMgr.getTransactionState(txnId7);
+        long txnId8 = lableToTxnId.get(GlobalStateMgrTestUtil.testTxnLable8);
+        TransactionState transactionState8 = masterDbTransMgr.getTransactionState(txnId8);
+        List<TransactionState> states = new ArrayList<>();
+        states.add(transactionState6);
+        states.add(transactionState7);
+        states.add(transactionState8);
+
+        new MockUp<Table>() {
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+        };
+
+        TransactionStateBatch stateBatch = new TransactionStateBatch(states);
+        masterTransMgr.finishTransactionBatch(GlobalStateMgrTestUtil.testDbId1, stateBatch, null);
+
+        // after the first batch transactions are finished, the transactionGraph has only on transaction state
+        stateBatchesList = masterDbTransMgr.getReadyToPublishTxnListBatch();
+        assertEquals(1, masterDbTransMgr.getCommittedTxnList().size());
+        assertEquals(TransactionType.TXN_REPLICATION, masterDbTransMgr.getCommittedTxnList().get(0).getTransactionType());
+        assertEquals(1, stateBatchesList.size());
+        assertEquals(1, stateBatchesList.get(0).size());
+
+        // add one more transaction, the batch chosen should only have one transaction,
+        // and it should be the replication transaction
+        long transactionId9 = masterTransMgr
+                .beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                        Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                        GlobalStateMgrTestUtil.testTxnLable9,
+                        transactionSource,
+                        TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId9, transTablets,
+                Lists.newArrayList(), null);
+        stateBatchesList = masterDbTransMgr.getReadyToPublishTxnListBatch();
+        assertEquals(2, masterDbTransMgr.getCommittedTxnList().size());
         assertEquals(1, stateBatchesList.size());
         assertEquals(1, stateBatchesList.get(0).size());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -629,7 +629,7 @@ public class LakePublishBatchTest {
             batches = globalTransactionMgr.getReadyPublishTransactionsBatch();
             Assertions.assertEquals(1, batches.size());
             Assertions.assertEquals(1, batches.get(0).size());
-            // backend_streaming transaction
+            // normal transaction
             Assertions.assertEquals(TransactionType.TXN_NORMAL,
                     batches.get(0).getTransactionStates().get(0).getTransactionType());
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -605,13 +605,16 @@ public class LakePublishBatchTest {
                 Lists.newArrayList(), null);
 
         {
-            TransactionStateBatch readyStateBatch = globalTransactionMgr.getReadyPublishTransactionsBatch().get(0);
-            Assertions.assertEquals(2, readyStateBatch.size());
+            List<TransactionStateBatch> batches = globalTransactionMgr.getReadyPublishTransactionsBatch();
+            Assertions.assertEquals(1, batches.size());
+            Assertions.assertEquals(1, batches.get(0).size());
 
             PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
             publishVersionDaemon.runAfterCatalogReady();
 
             Assertions.assertTrue(waiter1.await(10, TimeUnit.SECONDS));
+
+            publishVersionDaemon.runAfterCatalogReady();
             Assertions.assertTrue(waiter2.await(10, TimeUnit.SECONDS));
 
             // Verify that the transactions have been published


### PR DESCRIPTION
## Why I'm doing:

In the current shared-nothing to shared-data cluster migration process, we've added support for enabling compaction on the target cluster.

However, a problem arises during this migration: when a compaction transaction happens concurrently with a replication transaction, the version check on the backend (BE) will fail when trying to publish the replication transaction. This failure causes the replication transaction to fail permanently.

## What I'm doing:

Fixes #62741

This fix addresses the issue by preventing replication transactions from being bundled with any other types of transactions. This ensures that replication transactions are processed separately, avoiding the version check conflicts that cause them to fail. By keeping them isolated, we guarantee that the replication process can complete successfully, even if other compaction transactions are occurring.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
