### PR TITLE
[Feature] Support Null Field in Primary keys.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1412,6 +1412,9 @@ CONF_mBool(enable_pindex_compression, "true");
 // filter bytes is less or equal than 10% of pindex bytes, we will use bloom filter to filter some records
 CONF_mInt32(max_bf_read_bytes_percent, "10");
 
+// set true to use different encoding to support null primary keys.
+CONF_mBool(enable_null_primary_key, "false");
+
 // If primary compaction pick all rowsets, we could rebuild pindex directly and skip read from index.
 CONF_mBool(enable_pindex_rebuild_in_compaction, "true");
 

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -106,6 +106,7 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
     _enable_data_file_bundling = table_sink.enable_data_file_bundling;
     _is_multi_statements_txn = table_sink.is_multi_statements_txn;
     _keys_type = table_sink.keys_type;
+    _enable_null_primary_key = table_sink.enable_null_primary_key;
     if (table_sink.__isset.null_expr_in_auto_increment) {
         _null_expr_in_auto_increment = table_sink.null_expr_in_auto_increment;
         _miss_auto_increment_column = table_sink.miss_auto_increment_column;

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -191,6 +191,7 @@ private:
     bool _is_multi_statements_txn = false;
 
     TKeysType::type _keys_type;
+    bool _enable_null_primary_key = false;
 
     // TODO(zc): think about cache this data
     std::shared_ptr<OlapTableSchemaParam> _schema;

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -217,6 +217,7 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
     request.set_is_vectorized(true);
     request.set_timeout_ms(std::min(_rpc_timeout_ms, config::tablet_writer_open_rpc_timeout_sec * 1000));
     request.mutable_load_channel_profile_config()->CopyFrom(_parent->_load_channel_profile_config);
+    request.set_enable_null_primary_key(_parent->_enable_null_primary_key);
 
     // set global dict
     const auto& global_dict = _runtime_state->get_load_global_dict_map();

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -820,6 +820,7 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
                                               .set_bundle_writable_file_context(bundle_writable_file_context)
                                               .set_global_dicts(&_global_dicts)
                                               .set_is_multi_statements_txn(multi_stmt)
+                                              .set_enable_null_primary_key(params.enable_null_primary_key())
                                               .build());
         mutable_delta_writers()->emplace(tablet.tablet_id(), std::move(writer));
         tablet_ids.emplace_back(tablet.tablet_id());

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -698,6 +698,7 @@ Status DeltaWriter::_reset_mem_table() {
                                                 _mem_table_sink.get(), "", _mem_tracker);
     }
     RETURN_IF_ERROR(_mem_table->prepare());
+    _mem_table->set_enable_null_primary_key(_tablet->get_enable_null_primary_key());
     _mem_table->set_write_buffer_row(_memtable_buffer_row);
     _write_buffer_size = _mem_table->write_buffer_size();
     return Status::OK();
@@ -885,13 +886,14 @@ Status DeltaWriter::_fill_auto_increment_id(const Chunk& chunk) {
         pk_columns.push_back((uint32_t)i);
     }
     Schema pkey_schema = ChunkHelper::convert_schema(_tablet_schema, pk_columns);
+    bool enable_null_primary_key = _tablet->get_enable_null_primary_key();
     MutableColumnPtr pk_column;
-    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
+    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, enable_null_primary_key).ok()) {
         CHECK(false) << "create column for primary key encoder failed";
     }
     auto col = pk_column->clone();
 
-    PrimaryKeyEncoder::encode(pkey_schema, chunk, 0, chunk.num_rows(), col.get());
+    PrimaryKeyEncoder::encode(pkey_schema, chunk, 0, chunk.num_rows(), col.get(), enable_null_primary_key);
     MutableColumnPtr upserts = std::move(col);
 
     std::vector<uint64_t> rss_rowids;

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -424,6 +424,7 @@ StatusOr<AsyncDeltaWriterBuilder::AsyncDeltaWriterPtr> AsyncDeltaWriterBuilder::
                                           .set_bundle_writable_file_context(_bundle_writable_file_context)
                                           .set_global_dicts(_global_dicts)
                                           .set_is_multi_statements_txn(_is_multi_statements_txn)
+                                          .set_enable_null_primary_key(_enable_null_primary_key)
                                           .build());
     auto impl = new AsyncDeltaWriterImpl(std::move(writer));
     return std::make_unique<AsyncDeltaWriter>(impl);

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -223,6 +223,11 @@ public:
         return *this;
     }
 
+    AsyncDeltaWriterBuilder& set_enable_null_primary_key(bool enable_null_primary_key) {
+        _enable_null_primary_key = enable_null_primary_key;
+        return *this;
+    }
+
     StatusOr<AsyncDeltaWriterPtr> build();
 
 private:
@@ -244,6 +249,7 @@ private:
     BundleWritableFileContext* _bundle_writable_file_context{nullptr};
     GlobalDictByNameMaps* _global_dicts = nullptr;
     bool _is_multi_statements_txn = false;
+    bool _enable_null_primary_key = false;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -271,6 +271,11 @@ public:
         return *this;
     }
 
+    DeltaWriterBuilder& set_enable_null_primary_key(bool enable_null_primary_key) {
+        _enable_null_primary_key = enable_null_primary_key;
+        return *this;
+    }
+
     StatusOr<DeltaWriterPtr> build();
 
 private:
@@ -293,6 +298,7 @@ private:
     BundleWritableFileContext* _bundle_writable_file_context{nullptr};
     GlobalDictByNameMaps* _global_dicts = nullptr;
     bool _is_multi_statements_txn = false;
+    bool _enable_null_primary_key = false;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -55,10 +55,12 @@ void collect_writer_stats(OlapWriterStatistics& writer_stats, SegmentWriter* seg
 
 HorizontalGeneralTabletWriter::HorizontalGeneralTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                                              std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
-                                                             bool is_compaction, ThreadPool* flush_pool,
+                                                             bool is_compaction, bool enable_null_primary_key,
+                                                             ThreadPool* flush_pool,
                                                              BundleWritableFileContext* bundle_file_context,
                                                              GlobalDictByNameMaps* global_dicts)
-        : TabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id, is_compaction, flush_pool),
+        : TabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id, is_compaction, enable_null_primary_key,
+                       flush_pool),
           _bundle_file_context(bundle_file_context),
           _global_dicts(global_dicts) {}
 
@@ -195,8 +197,9 @@ Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
 VerticalGeneralTabletWriter::VerticalGeneralTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                                          std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
                                                          uint32_t max_rows_per_segment, bool is_compaction,
-                                                         ThreadPool* flush_pool)
-        : TabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id, is_compaction, flush_pool),
+                                                         bool enable_null_primary_key, ThreadPool* flush_pool)
+        : TabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id, is_compaction, enable_null_primary_key,
+                       flush_pool),
           _max_rows_per_segment(max_rows_per_segment) {}
 
 VerticalGeneralTabletWriter::~VerticalGeneralTabletWriter() {

--- a/be/src/storage/lake/general_tablet_writer.h
+++ b/be/src/storage/lake/general_tablet_writer.h
@@ -36,7 +36,8 @@ class HorizontalGeneralTabletWriter : public TabletWriter {
 public:
     explicit HorizontalGeneralTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                            std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
-                                           bool is_compaction, ThreadPool* flush_pool = nullptr,
+                                           bool is_compaction, bool enable_null_primary_key,
+                                           ThreadPool* flush_pool = nullptr,
                                            BundleWritableFileContext* bundle_file_context = nullptr,
                                            GlobalDictByNameMaps* global_dicts = nullptr);
 
@@ -91,7 +92,7 @@ public:
     explicit VerticalGeneralTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                          std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
                                          uint32_t max_rows_per_segment, bool is_compaction,
-                                         ThreadPool* flush_pool = nullptr);
+                                         bool enable_null_primary_key, ThreadPool* flush_pool = nullptr);
 
     ~VerticalGeneralTabletWriter() override;
 

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -138,7 +138,8 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         // preload primary key table's compaction state
         Tablet t(_tablet.tablet_manager(), _tablet.id());
-        _tablet.tablet_manager()->update_mgr()->preload_compaction_state(*txn_log, t, _tablet_schema);
+        _tablet.tablet_manager()->update_mgr()->preload_compaction_state(*txn_log, t, _tablet_schema,
+                                                                         _tablet.metadata()->enable_null_primary_key());
     }
 
     LOG(INFO) << "Horizontal compaction finished. tablet: " << _tablet.id() << ", txn_id: " << _txn_id

--- a/be/src/storage/lake/lake_local_persistent_index_tablet_loader.h
+++ b/be/src/storage/lake/lake_local_persistent_index_tablet_loader.h
@@ -57,6 +57,13 @@ public:
 
     void set_write_amp_score(double score) override;
 
+    bool enable_null_primary_key() override {
+        if (_metadata->has_enable_null_primary_key()) {
+            return _metadata->enable_null_primary_key();
+        }
+        return config::enable_null_primary_key;
+    }
+
 private:
     TabletManager* _tablet_mgr;
     const TabletMetadataPtr _metadata;

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -178,7 +178,8 @@ private:
                              int64_t version) const;
 
     // rebuild delete operation from rowset.
-    Status load_dels(const RowsetPtr& rowset, const Schema& pkey_schema, int64_t rowset_version);
+    Status load_dels(const RowsetPtr& rowset, const Schema& pkey_schema, int64_t rowset_version,
+                     bool enable_null_primary_key);
 
     static void set_difference(KeyIndexSet* key_indexes, const KeyIndexSet& found_key_indexes);
 

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -32,7 +32,8 @@ class TabletManager;
 class LakePrimaryIndex : public PrimaryIndex {
 public:
     LakePrimaryIndex() : PrimaryIndex() {}
-    LakePrimaryIndex(const Schema& pk_schema) : PrimaryIndex(pk_schema) {}
+    LakePrimaryIndex(const Schema& pk_schema, bool enable_null_primary_key)
+            : PrimaryIndex(pk_schema, enable_null_primary_key) {}
     ~LakePrimaryIndex() override;
 
     // Fetch all primary keys from the tablet associated with this index into memory

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.h
@@ -56,6 +56,13 @@ public:
                                        const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>& handler)
             override;
 
+    bool enable_null_primary_key() override {
+        if (_metadata->has_enable_null_primary_key()) {
+            return _metadata->enable_null_primary_key();
+        }
+        return config::enable_null_primary_key;
+    }
+
 private:
     // input
     const TabletMetadata* _metadata = nullptr;

--- a/be/src/storage/lake/lake_primary_key_recover.cpp
+++ b/be/src/storage/lake/lake_primary_key_recover.cpp
@@ -131,4 +131,11 @@ int64_t LakePrimaryKeyRecover::tablet_id() {
     return _tablet->id();
 }
 
+bool LakePrimaryKeyRecover::enable_null_primary_key() {
+    if (_metadata->has_enable_null_primary_key()) {
+        return _metadata->enable_null_primary_key();
+    }
+    return config::enable_null_primary_key;
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/lake_primary_key_recover.h
+++ b/be/src/storage/lake/lake_primary_key_recover.h
@@ -55,6 +55,8 @@ public:
 
     int64_t tablet_id() override;
 
+    bool enable_null_primary_key() override;
+
     // Sorrt rowset by rowsetid
     // also consider sorting in data loading and compact concurrency scenarios
     static Status sort_rowsets(std::vector<RowsetPtr>* rowsets);

--- a/be/src/storage/lake/pk_tablet_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_sst_writer.cpp
@@ -43,11 +43,12 @@ Status PkTabletSSTWriter::append_sst_record(const Chunk& data) {
             pk_columns.push_back((uint32_t)i);
         }
         _pkey_schema = ChunkHelper::convert_schema(_tablet_schema_ptr, pk_columns);
-        RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(_pkey_schema, &_pk_column));
-        _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pkey_schema);
+        RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(_pkey_schema, &_pk_column, enable_null_primary_key()));
+        _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pkey_schema, enable_null_primary_key());
     }
     auto clone_pk_column = _pk_column->clone_empty();
-    TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(_pkey_schema, data, 0, data.num_rows(), clone_pk_column.get()));
+    TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(_pkey_schema, data, 0, data.num_rows(), clone_pk_column.get(),
+                                                  enable_null_primary_key()));
     std::vector<Slice> keys;
     const Slice* vkeys =
             PrimaryIndex::build_persistent_keys(*clone_pk_column, _key_size, 0, clone_pk_column->size(), &keys);

--- a/be/src/storage/lake/pk_tablet_sst_writer.h
+++ b/be/src/storage/lake/pk_tablet_sst_writer.h
@@ -31,6 +31,7 @@ class PersistentIndexSstableStreamBuilder;
 
 class DefaultSSTWriter {
 public:
+    DefaultSSTWriter(bool enable_null_primary_key) : _enable_null_primary_key(enable_null_primary_key) {}
     virtual ~DefaultSSTWriter() = default;
     virtual Status append_sst_record(const Chunk& data) { return Status::OK(); }
     virtual Status reset_sst_writer(const std::shared_ptr<LocationProvider>& location_provider,
@@ -39,12 +40,20 @@ public:
     }
     virtual StatusOr<FileInfo> flush_sst_writer() { return Status::OK(); }
     virtual bool has_file_info() const { return false; }
+    virtual bool enable_null_primary_key() { return _enable_null_primary_key; }
+
+private:
+    bool _enable_null_primary_key;
 };
 
 class PkTabletSSTWriter : public DefaultSSTWriter {
 public:
-    PkTabletSSTWriter(const TabletSchemaCSPtr& tablet_schema_ptr, TabletManager* tablet_mgr, int64_t tablet_id)
-            : _tablet_schema_ptr(tablet_schema_ptr), _tablet_mgr(tablet_mgr), _tablet_id(tablet_id) {}
+    PkTabletSSTWriter(bool enable_null_primary_key, const TabletSchemaCSPtr& tablet_schema_ptr,
+                      TabletManager* tablet_mgr, int64_t tablet_id)
+            : DefaultSSTWriter(enable_null_primary_key),
+              _tablet_schema_ptr(tablet_schema_ptr),
+              _tablet_mgr(tablet_mgr),
+              _tablet_id(tablet_id) {}
     ~PkTabletSSTWriter() override = default;
     Status append_sst_record(const Chunk& data) override;
     Status reset_sst_writer(const std::shared_ptr<LocationProvider>& location_provider,

--- a/be/src/storage/lake/pk_tablet_writer.h
+++ b/be/src/storage/lake/pk_tablet_writer.h
@@ -35,7 +35,7 @@ class HorizontalPkTabletWriter : public HorizontalGeneralTabletWriter {
 public:
     explicit HorizontalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                       std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
-                                      ThreadPool* flush_pool, bool is_compaction,
+                                      ThreadPool* flush_pool, bool is_compaction, bool enable_null_primary_key,
                                       BundleWritableFileContext* bundle_file_context = nullptr,
                                       GlobalDictByNameMaps* _global_dicts = nullptr);
 
@@ -71,7 +71,8 @@ class VerticalPkTabletWriter : public VerticalGeneralTabletWriter {
 public:
     explicit VerticalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                     std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
-                                    uint32_t max_rows_per_segment, ThreadPool* flush_pool, bool is_compaction);
+                                    uint32_t max_rows_per_segment, ThreadPool* flush_pool, bool is_compaction,
+                                    bool enable_null_primary_key);
 
     ~VerticalPkTabletWriter() override;
 

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -84,7 +84,7 @@ struct RowsetUpdateStateParams {
 
 class SegmentPKEncodeResult {
 public:
-    SegmentPKEncodeResult() = default;
+    SegmentPKEncodeResult(bool enable_null_primary_key) : _enable_null_primary_key(enable_null_primary_key) {}
     ~SegmentPKEncodeResult() { close(); }
     Status init(const ChunkIteratorPtr& iter, const Schema& pkey_schema, bool load_whole);
     void next();
@@ -104,6 +104,7 @@ public:
 private:
     Status _load();
 
+    bool _enable_null_primary_key;
     // Iterator of this segment file.
     ChunkIteratorPtr _iter;
     // The PK schema of this segment file.
@@ -217,6 +218,8 @@ private:
     // Because we can load partial segments when preload, so need vector to track their version.
     std::vector<int64_t> _base_versions;
     int64_t _schema_version = 0;
+
+    bool _enable_null_primary_key = false;
 
     // TODO: dump to disk if memory usage is too large
     std::vector<PartialUpdateState> _partial_update_states;

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -72,26 +72,26 @@ StatusOr<TxnLogPtr> Tablet::get_txn_vlog(int64_t version) {
 }
 
 StatusOr<std::unique_ptr<TabletWriter>> Tablet::new_writer(WriterType type, int64_t txn_id,
-                                                           uint32_t max_rows_per_segment, ThreadPool* flush_pool,
-                                                           bool is_compaction) {
+                                                           bool enable_null_primary_key, uint32_t max_rows_per_segment,
+                                                           ThreadPool* flush_pool, bool is_compaction) {
     ASSIGN_OR_RETURN(auto tablet_schema, get_schema());
     if (tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         if (type == kHorizontal) {
             return std::make_unique<HorizontalPkTabletWriter>(_mgr, _id, tablet_schema, txn_id, flush_pool,
-                                                              is_compaction);
+                                                              is_compaction, enable_null_primary_key);
         } else {
             DCHECK(type == kVertical);
             return std::make_unique<VerticalPkTabletWriter>(_mgr, _id, tablet_schema, txn_id, max_rows_per_segment,
-                                                            flush_pool, is_compaction);
+                                                            flush_pool, is_compaction, enable_null_primary_key);
         }
     } else {
         if (type == kHorizontal) {
             return std::make_unique<HorizontalGeneralTabletWriter>(_mgr, _id, tablet_schema, txn_id, is_compaction,
-                                                                   flush_pool);
+                                                                   enable_null_primary_key, flush_pool);
         } else {
             DCHECK(type == kVertical);
             return std::make_unique<VerticalGeneralTabletWriter>(_mgr, _id, tablet_schema, txn_id, max_rows_per_segment,
-                                                                 is_compaction, flush_pool);
+                                                                 is_compaction, enable_null_primary_key, flush_pool);
         }
     }
 }

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -103,7 +103,7 @@ public:
 
     // `segment_max_rows` is used in vertical writer
     // NOTE: This method may update the version hint
-    StatusOr<std::unique_ptr<TabletWriter>> new_writer(WriterType type, int64_t txn_id,
+    StatusOr<std::unique_ptr<TabletWriter>> new_writer(WriterType type, int64_t txn_id, bool enable_null_primary_key,
                                                        uint32_t max_rows_per_segment = 0,
                                                        ThreadPool* flush_pool = nullptr, bool is_compaction = false);
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -204,6 +204,7 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
             }
         }
     }
+    tablet_metadata_pb->set_enable_null_primary_key(req.__isset.enable_null_primary_key && req.enable_null_primary_key);
 
     if (req.__isset.flat_json_config) {
         FlatJsonConfig flat_json_config;

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -43,13 +43,15 @@ enum WriterType : int { kHorizontal = 0, kVertical = 1 };
 class TabletWriter {
 public:
     explicit TabletWriter(TabletManager* tablet_mgr, int64_t tablet_id, std::shared_ptr<const TabletSchema> schema,
-                          int64_t txn_id, bool is_compaction, ThreadPool* flush_pool = nullptr)
+                          int64_t txn_id, bool is_compaction, bool enable_null_primary_key,
+                          ThreadPool* flush_pool = nullptr)
             : _tablet_mgr(tablet_mgr),
               _tablet_id(tablet_id),
               _schema(std::move(schema)),
               _txn_id(txn_id),
               _flush_pool(flush_pool),
-              _is_compaction(is_compaction) {}
+              _is_compaction(is_compaction),
+              _enable_null_primary_key(enable_null_primary_key) {}
 
     virtual ~TabletWriter() = default;
 
@@ -170,6 +172,7 @@ protected:
     OlapWriterStatistics _stats;
 
     bool _is_compaction = false;
+    bool _enable_null_primary_key = false;
     DictColumnsValidMap _global_dict_columns_valid_info;
     bool _enable_pk_parallel_execution = false;
 };

--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -64,7 +64,7 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
     Schema pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
 
     MutableColumnPtr pk_column;
-    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true));
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, _enable_null_primary_key, true));
 
     if (_segment_iters.empty()) {
         ASSIGN_OR_RETURN(_segment_iters, rowset->get_each_segment_iterator(pkey_schema, false, &_stats));
@@ -90,7 +90,8 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
             } else if (!st.ok()) {
                 return st;
             } else {
-                TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get()));
+                TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get(),
+                                                              _enable_null_primary_key));
             }
         }
         itr->close();

--- a/be/src/storage/lake/update_compaction_state.h
+++ b/be/src/storage/lake/update_compaction_state.h
@@ -46,6 +46,10 @@ public:
 
     std::vector<MutableColumnPtr> pk_cols;
 
+    void set_enable_null_primary_key(bool enable_null_primary_key) {
+        _enable_null_primary_key = enable_null_primary_key;
+    }
+
 private:
     Status _load_segments(Rowset* rowset, const TabletSchemaCSPtr& tablet_schema, uint32_t segment_id);
 
@@ -56,6 +60,7 @@ private:
     std::vector<ChunkIteratorPtr> _segment_iters;
     int64_t _tablet_id = 0;
     std::mutex _state_lock;
+    bool _enable_null_primary_key = false;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const CompactionState& o) {

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -165,7 +165,8 @@ public:
 
     void evict_cache(int64_t memory_urgent_level, int64_t memory_high_level);
     void preload_update_state(const TxnLog& op_write, Tablet* tablet);
-    void preload_compaction_state(const TxnLog& txnlog, const Tablet& tablet, const TabletSchemaCSPtr& tablet_schema);
+    void preload_compaction_state(const TxnLog& txnlog, const Tablet& tablet, const TabletSchemaCSPtr& tablet_schema,
+                                  bool enable_null_primary_key);
 
     // check if pk index's cache ref == ref_cnt
     bool TEST_check_primary_index_cache_ref(uint32_t tablet_id, uint32_t ref_cnt);

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -110,7 +110,8 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         // preload primary key table's compaction state
         Tablet t(_tablet.tablet_manager(), _tablet.id());
-        _tablet.tablet_manager()->update_mgr()->preload_compaction_state(*txn_log, t, _tablet_schema);
+        _tablet.tablet_manager()->update_mgr()->preload_compaction_state(*txn_log, t, _tablet_schema,
+                                                                         _tablet.metadata()->enable_null_primary_key());
     }
 
     LOG(INFO) << "Vertical compaction finished. tablet: " << _tablet.id() << ", txn_id: " << _txn_id

--- a/be/src/storage/local_primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/local_primary_key_compaction_conflict_resolver.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "storage/primary_key_compaction_conflict_resolver.h"
+#include "tablet.h"
 
 namespace starrocks {
 
@@ -48,6 +49,8 @@ public:
                     Status(const CompactConflictResolveParams&, const std::vector<std::shared_ptr<Segment>>&,
                            const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>& handler) override;
     Status breakpoint_check() override;
+
+    bool enable_null_primary_key() override { return _tablet->get_enable_null_primary_key(); }
 
 private:
     // input

--- a/be/src/storage/local_primary_key_recover.cpp
+++ b/be/src/storage/local_primary_key_recover.cpp
@@ -143,4 +143,8 @@ int64_t LocalPrimaryKeyRecover::tablet_id() {
     return _tablet->tablet_id();
 }
 
+bool LocalPrimaryKeyRecover::enable_null_primary_key() {
+    return _tablet->get_enable_null_primary_key();
+}
+
 } // namespace starrocks

--- a/be/src/storage/local_primary_key_recover.h
+++ b/be/src/storage/local_primary_key_recover.h
@@ -38,6 +38,8 @@ public:
 
     int64_t tablet_id() override;
 
+    bool enable_null_primary_key() override;
+
     // Sorrt rowset by rowsetid
     // also consider sorting in data loading and compact concurrency scenarios
     static Status sort_rowsets(std::vector<RowsetSharedPtr>* rowsets);

--- a/be/src/storage/local_tablet_reader.cpp
+++ b/be/src/storage/local_tablet_reader.cpp
@@ -115,9 +115,11 @@ Status LocalTabletReader::multi_get(const Chunk& keys, const std::vector<uint32_
     for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }
+    bool enable_null_primary_key = _tablet->get_enable_null_primary_key();
     MutableColumnPtr pk_column;
-    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column));
-    PrimaryKeyEncoder::encode(*tablet_schema->schema(), keys, 0, keys.num_rows(), pk_column.get());
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column, enable_null_primary_key));
+    PrimaryKeyEncoder::encode(*tablet_schema->schema(), keys, 0, keys.num_rows(), pk_column.get(),
+                              enable_null_primary_key);
 
     // search pks in pk index to get rowids
     EditVersion edit_version;

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -481,7 +481,7 @@ Status MemTable::_split_upserts_deletes(ChunkPtr& src, ChunkPtr* upserts, Mutabl
     *upserts = src->clone_empty_with_schema(nupsert);
     (*upserts)->append_selective(*src, indexes[TOpType::UPSERT].data(), 0, nupsert);
     if (!(*deletes)) {
-        auto st = PrimaryKeyEncoder::create_column(*_vectorized_schema, deletes);
+        auto st = PrimaryKeyEncoder::create_column(*_vectorized_schema, deletes, _enable_null_primary_key);
         if (!st.ok()) {
             LOG(ERROR) << "create column for primary key encoder failed, schema:" << *_vectorized_schema
                        << ", status:" << st.to_string();
@@ -494,7 +494,8 @@ Status MemTable::_split_upserts_deletes(ChunkPtr& src, ChunkPtr* upserts, Mutabl
         (*deletes)->reset_column();
     }
     auto& delidx = indexes[TOpType::DELETE];
-    PrimaryKeyEncoder::encode_selective(*_vectorized_schema, *src, delidx.data(), delidx.size(), deletes->get());
+    PrimaryKeyEncoder::encode_selective(*_vectorized_schema, *src, delidx.data(), delidx.size(), deletes->get(),
+                                        _enable_null_primary_key);
     return Status::OK();
 }
 

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -108,6 +108,10 @@ public:
 
     void set_write_buffer_row(size_t max_buffer_row) { _max_buffer_row = max_buffer_row; }
 
+    void set_enable_null_primary_key(size_t enable_null_primary_key) {
+        _enable_null_primary_key = enable_null_primary_key;
+    }
+
     static Schema convert_schema(const TabletSchemaCSPtr& tablet_schema,
                                  const std::vector<SlotDescriptor*>* slot_descs);
 
@@ -154,6 +158,7 @@ private:
 
     std::string _merge_condition;
 
+    bool _enable_null_primary_key = false;
     int64_t _max_buffer_size = config::write_buffer_size;
     // initial value is max size
     size_t _max_buffer_row = std::numeric_limits<size_t>::max();

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -51,6 +51,8 @@ public:
 
     virtual void set_write_amp_score(double score) = 0;
 
+    virtual bool enable_null_primary_key() = 0;
+
     size_t total_data_size() const { return _total_data_size; }
     size_t total_segments() const { return _total_segments; }
     size_t rowset_num() const { return _rowset_num; };
@@ -903,7 +905,7 @@ private:
     // Calculate total memory usage after index been modified.
     void _calc_memory_usage();
 
-    size_t _get_encoded_fixed_size(const Schema& schema);
+    size_t _get_encoded_fixed_size(const Schema& schema, bool enable_null_primary_key);
 
 protected:
     // index storage directory

--- a/be/src/storage/persistent_index_tablet_loader.h
+++ b/be/src/storage/persistent_index_tablet_loader.h
@@ -45,6 +45,8 @@ public:
 
     void set_write_amp_score(double score) override;
 
+    bool enable_null_primary_key() override { return _tablet->get_enable_null_primary_key(); }
+
 private:
     Tablet* _tablet;
 };

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -40,7 +40,7 @@ public:
     using tablet_rowid_t = uint64_t;
 
     PrimaryIndex();
-    PrimaryIndex(const Schema& pk_schema);
+    PrimaryIndex(const Schema& pk_schema, bool enable_null_primary_key);
     virtual ~PrimaryIndex();
 
     // Fetch all primary keys from the tablet associated with this index into memory
@@ -170,7 +170,7 @@ public:
                                               std::vector<Slice>* key_slices);
 
 protected:
-    void _set_schema(const Schema& pk_schema);
+    void _set_schema(const Schema& pk_schema, bool enable_null_primary_key);
 
 private:
     Status _do_load(Tablet* tablet);

--- a/be/src/storage/primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.h
@@ -51,6 +51,7 @@ public:
             const std::function<
                     Status(const CompactConflictResolveParams&, const std::vector<std::shared_ptr<Segment>>&,
                            const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>& handler) = 0;
+    virtual bool enable_null_primary_key() = 0;
 
     Status execute();
 

--- a/be/src/storage/primary_key_encoder.h
+++ b/be/src/storage/primary_key_encoder.h
@@ -114,13 +114,14 @@ public:
     static LogicalType encoded_primary_key_type(const Schema& schema, const std::vector<ColumnId>& key_idxes);
 
     // Return -1 if encoded key is not fixed size
-    static size_t get_encoded_fixed_size(const Schema& schema);
+    static size_t get_encoded_fixed_size(const Schema& schema, bool enable_null_primary_key);
 
     // create suitable column to hold encoded key
     //   schema: schema of the table
     //   pcolumn: output column
     //   large_column: some usage may fill the column with more than uint32_max elements, set true to support this
-    static Status create_column(const Schema& schema, MutableColumnPtr* pcolumn, bool large_column = false);
+    static Status create_column(const Schema& schema, MutableColumnPtr* pcolumn, bool enable_null_primary_key,
+                                bool large_column = false);
 
     // create suitable column to hold encoded key
     //   schema: schema of the table
@@ -128,20 +129,22 @@ public:
     //   key_idxes: indexes of columns for encoding
     //   large_column: some usage may fill the column with more than uint32_max elements, set true to support this
     static Status create_column(const Schema& schema, MutableColumnPtr* pcolumn, const std::vector<ColumnId>& key_idxes,
-                                bool large_column = false);
+                                bool enable_null_primary_key, bool large_column = false);
 
-    static void encode(const Schema& schema, const Chunk& chunk, size_t offset, size_t len, Column* dest);
+    static void encode(const Schema& schema, const Chunk& chunk, size_t offset, size_t len, Column* dest,
+                       bool enable_null_primary_key);
 
-    static Status encode_sort_key(const Schema& schema, const Chunk& chunk, size_t offset, size_t len, Column* dest);
+    static Status encode_sort_key(const Schema& schema, const Chunk& chunk, size_t offset, size_t len, Column* dest,
+                                  bool enable_null_primary_key);
 
     static void encode_selective(const Schema& schema, const Chunk& chunk, const uint32_t* indexes, size_t len,
-                                 Column* dest);
+                                 Column* dest, bool enable_null_primary_key);
 
     static bool encode_exceed_limit(const Schema& schema, const Chunk& chunk, size_t offset, size_t len,
                                     size_t limit_size);
 
     static Status decode(const Schema& schema, const Column& keys, size_t offset, size_t len, Chunk* dest,
-                         std::vector<uint8_t>* value_encode_flags = nullptr);
+                         bool enable_null_primary_key, std::vector<uint8_t>* value_encode_flags = nullptr);
 };
 
 } // namespace starrocks

--- a/be/src/storage/primary_key_recover.h
+++ b/be/src/storage/primary_key_recover.h
@@ -60,6 +60,8 @@ public:
 
     virtual int64_t tablet_id() = 0;
 
+    virtual bool enable_null_primary_key() = 0;
+
     // delete pk index and delvec, then rebuild them
     Status recover();
 };

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -236,6 +236,7 @@ private:
 
 private:
     int64_t _tablet_id = 0;
+    bool _enable_null_primary_key = false;
     std::once_flag _load_once_flag;
     Status _status;
     // it contains primary key seriable column for each update segment file

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -174,6 +174,7 @@ private:
     std::vector<MutableColumnPtr> _deletes;
     size_t _memory_usage = 0;
     int64_t _tablet_id = 0;
+    bool _enable_null_primary_key = false;
     TabletSchemaCSPtr _tablet_schema = nullptr;
 
     // column_with_row partial update states

--- a/be/src/storage/sstable/sstable_predicate.cpp
+++ b/be/src/storage/sstable/sstable_predicate.cpp
@@ -18,9 +18,10 @@
 
 namespace starrocks::sstable {
 
-StatusOr<SstablePredicateUPtr> SstablePredicate::create(const TabletSchemaPB& tablet_schema_pb,
+StatusOr<SstablePredicateUPtr> SstablePredicate::create(bool enable_null_primary_key,
+                                                        const TabletSchemaPB& tablet_schema_pb,
                                                         const PersistentIndexSstablePredicatePB& sstable_predicate_pb) {
-    ASSIGN_OR_RETURN(auto converter, KeyToChunkConverter::create(tablet_schema_pb));
+    ASSIGN_OR_RETURN(auto converter, KeyToChunkConverter::create(enable_null_primary_key, tablet_schema_pb));
     auto predicate = std::make_unique<SstablePredicate>();
     RETURN_IF_ERROR(predicate->_init(sstable_predicate_pb, converter));
     return predicate;

--- a/be/src/storage/sstable/sstable_predicate.h
+++ b/be/src/storage/sstable/sstable_predicate.h
@@ -27,7 +27,7 @@ public:
     SstablePredicate() : _record_predicate(nullptr), _converter(nullptr) {}
     ~SstablePredicate() = default;
 
-    static StatusOr<SstablePredicateUPtr> create(const TabletSchemaPB& tablet_schema_pb,
+    static StatusOr<SstablePredicateUPtr> create(bool enable_null_primary_key, const TabletSchemaPB& tablet_schema_pb,
                                                  const PersistentIndexSstablePredicatePB& predicate_pb);
 
     Status evaluate(const std::string& row, uint8_t* selection);

--- a/be/src/storage/sstable/sstable_predicate_utils.h
+++ b/be/src/storage/sstable/sstable_predicate_utils.h
@@ -25,15 +25,21 @@ namespace sstable {
 
 class KeyToChunkConverter {
 public:
-    KeyToChunkConverter(Schema pkey_schema, ChunkUniquePtr& pk_chunk, MutableColumnPtr& pk_column)
-            : _pkey_schema(pkey_schema), _pk_chunk(std::move(pk_chunk)), _pk_column(std::move(pk_column)) {}
+    KeyToChunkConverter(bool enable_null_primary_key, Schema pkey_schema, ChunkUniquePtr& pk_chunk,
+                        MutableColumnPtr& pk_column)
+            : _enable_null_primary_key(enable_null_primary_key),
+              _pkey_schema(pkey_schema),
+              _pk_chunk(std::move(pk_chunk)),
+              _pk_column(std::move(pk_column)) {}
     ~KeyToChunkConverter() = default;
 
-    static StatusOr<KeyToChunkConverterUPtr> create(const TabletSchemaPB& tablet_schema_pb);
+    static StatusOr<KeyToChunkConverterUPtr> create(bool enable_null_primary_key,
+                                                    const TabletSchemaPB& tablet_schema_pb);
     // Convert key from sstable to a chunk
     StatusOr<ChunkUniquePtr> convert_to_chunk(const std::string& key);
 
 private:
+    bool _enable_null_primary_key;
     // convert context for key
     Schema _pkey_schema;
     ChunkUniquePtr _pk_chunk;

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -302,6 +302,12 @@ public:
         return _tablet_meta->set_enable_persistent_index(enable_persistent_index);
     }
 
+    bool get_enable_null_primary_key() { return _tablet_meta->get_enable_null_primary_key(); }
+
+    void set_enable_null_primary_key(bool enable_null_primary_key) {
+        return _tablet_meta->set_enable_null_primary_key(enable_null_primary_key);
+    }
+
     Status support_binlog();
 
     // This will modify the TabletMeta, and save_meta() will be called outside

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -108,8 +108,8 @@ public:
     explicit TabletMeta();
     TabletMeta(int64_t table_id, int64_t partition_id, int64_t tablet_id, int32_t schema_hash, uint64_t shard_id,
                const TTabletSchema& tablet_schema, uint32_t next_unique_id, bool enable_persistent_index,
-               const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id, const TabletUid& tablet_uid,
-               TTabletType::type tabletType, TCompressionType::type compression_type,
+               bool enable_null_primary_key, const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id,
+               const TabletUid& tablet_uid, TTabletType::type tabletType, TCompressionType::type compression_type,
                int32_t primary_index_cache_expire_sec, TStorageType::type storage_type, int compression_level);
 
     virtual ~TabletMeta();
@@ -212,6 +212,14 @@ public:
         _enable_persistent_index = enable_persistent_index;
     }
 
+    bool get_enable_null_primary_key() const {
+        return _enable_null_primary_key.value_or(config::enable_null_primary_key);
+    }
+
+    void set_enable_null_primary_key(bool enable_null_primary_key) {
+        _enable_null_primary_key = enable_null_primary_key;
+    }
+
     int32_t get_primary_index_cache_expire_sec() const { return _primary_index_cache_expire_sec; }
     void set_primary_index_cache_expire_sec(int32_t primary_index_cache_expire_sec) {
         _primary_index_cache_expire_sec = primary_index_cache_expire_sec;
@@ -264,6 +272,7 @@ private:
     int64_t _creation_time = 0;
     int64_t _cumulative_layer_point = 0;
     bool _enable_persistent_index = false;
+    std::optional<bool> _enable_null_primary_key = std::nullopt;
     int32_t _primary_index_cache_expire_sec = 0;
     TabletUid _tablet_uid;
     TabletTypePB _tablet_type = TabletTypePB::TABLET_TYPE_DISK;

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -245,8 +245,10 @@ Status TabletReader::_init_collector_for_pk_index_read() {
                                                         num_pk_eq_predicates, tablet_schema->num_key_columns()));
     }
     MutableColumnPtr pk_column;
-    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column));
-    PrimaryKeyEncoder::encode(*tablet_schema->schema(), *keys, 0, keys->num_rows(), pk_column.get());
+    bool enable_null_primary_key = _tablet->get_enable_null_primary_key();
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column, enable_null_primary_key));
+    PrimaryKeyEncoder::encode(*tablet_schema->schema(), *keys, 0, keys->num_rows(), pk_column.get(),
+                              enable_null_primary_key);
 
     // get rowid using pk index
     std::vector<uint64_t> rowids(1);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2178,7 +2178,7 @@ Status TabletUpdates::_commit_compaction(std::unique_ptr<CompactionInfo>* pinfo,
                                          EditVersion* commit_version) {
     auto span = Tracer::Instance().start_trace_tablet("commit_compaction", _tablet.tablet_id());
     auto scoped_span = trace::Scope(span);
-    _compaction_state = std::make_unique<CompactionState>();
+    _compaction_state = std::make_unique<CompactionState>(_tablet.get_enable_null_primary_key());
     if (!config::enable_light_pk_compaction_publish) {
         // Skip load compaction state when enable light pk compaction
         auto status = _compaction_state->load(rowset.get());
@@ -2341,7 +2341,7 @@ Status TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_in
     // if compaction_state == null, it must be the case that BE restarted
     // need to rebuild/load state from disk
     if (!_compaction_state) {
-        _compaction_state = std::make_unique<CompactionState>();
+        _compaction_state = std::make_unique<CompactionState>(_tablet.get_enable_null_primary_key());
     }
     auto failure_handler = [&](const std::string& msg, TStatusCode::type code) {
         _compaction_state.reset();

--- a/be/src/storage/update_compaction_state.h
+++ b/be/src/storage/update_compaction_state.h
@@ -28,7 +28,7 @@ class Rowset;
 
 class CompactionState {
 public:
-    CompactionState();
+    CompactionState(bool enable_null_primary_key);
     ~CompactionState();
 
     CompactionState(const CompactionState&) = delete;
@@ -50,6 +50,7 @@ private:
     std::once_flag _load_once_flag;
     Status _status;
     size_t _memory_usage = 0;
+    bool _enable_null_primary_key = false;
 };
 
 } // namespace starrocks

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -102,7 +102,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
     auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     std::shared_ptr<const TabletSchema> const_schema = _tablet_schema;
-    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id, false));
     ASSERT_OK(writer->open());
     // write segment #1
     ASSERT_OK(writer->write(chunk0));
@@ -522,7 +522,7 @@ TEST_F(AlterTabletMetaTest, test_alter_persistent_index_type) {
         auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
         ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
         std::shared_ptr<const TabletSchema> const_schema = _tablet_schema;
-        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id, false));
         ASSERT_OK(writer->open());
         // write segment #1
         ASSERT_OK(writer->write(chunk0));

--- a/be/test/storage/lake/lake_data_source_test.cpp
+++ b/be/test/storage/lake/lake_data_source_test.cpp
@@ -102,7 +102,7 @@ public:
         {
             int64_t txn_id = next_id();
             // write rowset 1 with 2 segments
-            ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+            ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id, false));
             ASSERT_OK(writer->open());
 
             // write rowset data

--- a/be/test/storage/lake/lake_scan_node_test.cpp
+++ b/be/test/storage/lake/lake_scan_node_test.cpp
@@ -102,7 +102,7 @@ public:
         {
             int64_t txn_id = next_id();
             // write rowset 1 with 2 segments
-            ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+            ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id, false));
             ASSERT_OK(writer->open());
 
             // write rowset data

--- a/be/test/storage/lake/metacache_test.cpp
+++ b/be/test/storage/lake/metacache_test.cpp
@@ -156,7 +156,7 @@ TEST_F(LakeMetacacheTest, test_segment_cache) {
     {
         int64_t txn_id = next_id();
         // write rowset 1 with 2 segments
-        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id, false));
         ASSERT_OK(writer->open());
 
         // write rowset data

--- a/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
+++ b/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
@@ -155,7 +155,7 @@ TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_basic_operations) {
     const int64_t tablet_id = 12345;
 
     // Create PkTabletSSTWriter
-    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(false, _tablet_schema, _tablet_mgr.get(), tablet_id);
 
     // Test reset_sst_writer
     auto location_provider = std::make_shared<FixedLocationProvider>(kTestDirectory);
@@ -184,7 +184,7 @@ TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_basic_operations) {
 TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_multiple_chunks) {
     const int64_t tablet_id = 67890;
 
-    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(false, _tablet_schema, _tablet_mgr.get(), tablet_id);
 
     // Reset writer
     auto location_provider = std::make_shared<FixedLocationProvider>(kTestDirectory);
@@ -210,7 +210,7 @@ TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_multiple_chunks) {
 TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_error_handling) {
     const int64_t tablet_id = 11111;
 
-    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(false, _tablet_schema, _tablet_mgr.get(), tablet_id);
 
     // Test append_sst_record before reset - should fail
     auto chunk = generate_data(10);
@@ -232,7 +232,7 @@ TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_error_handling) {
 TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_empty_chunk) {
     const int64_t tablet_id = 22222;
 
-    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(false, _tablet_schema, _tablet_mgr.get(), tablet_id);
 
     // Reset writer
     auto location_provider = std::make_shared<FixedLocationProvider>(kTestDirectory);
@@ -255,7 +255,7 @@ TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_empty_chunk) {
 TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_reuse) {
     const int64_t tablet_id = 33333;
 
-    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(false, _tablet_schema, _tablet_mgr.get(), tablet_id);
 
     // First use
     auto location_provider = std::make_shared<FixedLocationProvider>(kTestDirectory);

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -190,7 +190,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_read_success) {
     int64_t txn_id = next_id();
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     std::shared_ptr<const TabletSchema> const_schema = _tablet_schema;
-    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id, false));
     ASSERT_OK(writer->open());
 
     // write segment #1

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -75,7 +75,7 @@ public:
         {
             int64_t txn_id = next_id();
             // write rowset 1 with 2 segments
-            ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+            ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id, false));
             ASSERT_OK(writer->open());
 
             // write rowset data
@@ -215,7 +215,7 @@ TEST_F(LakeRowsetTest, test_partial_compaction) {
 
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     int64_t txn_id = next_id();
-    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id, false));
 
     // prepare writer
     {

--- a/be/test/storage/lake/spill_mem_table_sink_test.cpp
+++ b/be/test/storage/lake/spill_mem_table_sink_test.cpp
@@ -91,7 +91,7 @@ TEST_F(SpillMemTableSinkTest, test_flush_chunk) {
             TUniqueId(), UniqueId(tablet_id, txn_id).to_thrift(), kTestDir, nullptr);
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
-            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
+            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false, false);
     SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
     for (int i = 0; i < 3; i++) {
         // 3 times
@@ -131,7 +131,7 @@ TEST_F(SpillMemTableSinkTest, test_flush_chunk_with_deletes) {
             TUniqueId(), UniqueId(tablet_id, txn_id).to_thrift(), kTestDir, nullptr);
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalPkTabletWriter>(
-            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, nullptr, false);
+            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, nullptr, false, false);
     SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
     for (int i = 0; i < 3; i++) {
         // 3 times
@@ -169,7 +169,7 @@ TEST_F(SpillMemTableSinkTest, test_flush_chunk2) {
             TUniqueId(), UniqueId(tablet_id, txn_id).to_thrift(), kTestDir, nullptr);
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
-            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
+            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false, false);
     SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
     auto chunk = gen_data(kChunkSize, 0);
     starrocks::SegmentPB segment;
@@ -184,7 +184,7 @@ TEST_F(SpillMemTableSinkTest, test_flush_chunk_with_delete2) {
             TUniqueId(), UniqueId(tablet_id, txn_id).to_thrift(), kTestDir, nullptr);
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalPkTabletWriter>(
-            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, nullptr, false);
+            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, nullptr, false, false);
     SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
     auto chunk = gen_data(kChunkSize, 0);
     starrocks::SegmentPB segment;
@@ -199,7 +199,7 @@ TEST_F(SpillMemTableSinkTest, test_flush_chunk_with_limit) {
             TUniqueId(), UniqueId(tablet_id, txn_id).to_thrift(), kTestDir, nullptr);
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
-            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
+            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false, false);
     SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
     for (int i = 0; i < 3; i++) {
         int64_t old_val = config::load_spill_max_chunk_bytes;
@@ -242,7 +242,7 @@ TEST_F(SpillMemTableSinkTest, test_merge) {
             TUniqueId(), UniqueId(tablet_id, txn_id).to_thrift(), kTestDir, nullptr);
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
-            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
+            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false, false);
     SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
     auto chunk = gen_data(kChunkSize, 0);
     starrocks::SegmentPB segment0;
@@ -267,7 +267,7 @@ TEST_F(SpillMemTableSinkTest, test_out_of_disk_space) {
             TUniqueId(), UniqueId(tablet_id, txn_id).to_thrift(), kTestDir, nullptr);
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
-            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
+            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false, false);
     SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
     auto chunk = gen_data(kChunkSize, 0);
     starrocks::SegmentPB segment0;

--- a/be/test/storage/lake/tablet_test.cpp
+++ b/be/test/storage/lake/tablet_test.cpp
@@ -100,7 +100,7 @@ public:
         {
             int64_t txn_id = next_id();
             // write rowset 1 with 2 segments
-            ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+            ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id, false));
             ASSERT_OK(writer->open());
 
             // write rowset data

--- a/be/test/storage/primary_index_test.cpp
+++ b/be/test/storage/primary_index_test.cpp
@@ -376,8 +376,8 @@ PARALLEL_TEST(PrimaryIndexTest, test_composite_key) {
     }
 
     MutableColumnPtr pk_column;
-    PrimaryKeyEncoder::create_column(*schema, &pk_column);
-    PrimaryKeyEncoder::encode(*schema, *chunk, 0, chunk->num_rows(), pk_column.get());
+    PrimaryKeyEncoder::create_column(*schema, &pk_column, false);
+    PrimaryKeyEncoder::encode(*schema, *chunk, 0, chunk->num_rows(), pk_column.get(), false);
 
     ASSERT_TRUE(pk_index->insert(0, 0, *pk_column).ok());
     LOG(INFO) << "pk_index memory:" << pk_index->memory_usage();

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -75,7 +75,7 @@ TEST(PrimaryKeyEncoderTest, testEncodeNull) {
 
     for (int i = 0; i < n; i++) {
         if (i % 3 == 0) {
-            nullable_column->set_null(i);
+            nullable_column->append_nulls(1);
         } else {
             Datum tmp;
             tmp.set_int32(i * 2343);

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -265,7 +265,7 @@ TEST_F(RowsetMergerTest, horizontal_merge) {
     EXPECT_EQ(pks.size(), read_tablet(_tablet, version));
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
-    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks).ok());
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks, false).ok());
     ASSERT_TRUE(compaction_merge_rowsets(*_tablet, version, rowsets, &writer, cfg).ok());
     ASSERT_EQ(pks.size(), writer.all_pks->size());
     const auto* raw_pk_array = reinterpret_cast<const int64_t*>(writer.all_pks->raw_data());
@@ -313,7 +313,7 @@ TEST_F(RowsetMergerTest, vertical_merge) {
     EXPECT_EQ(pks.size(), read_tablet(_tablet, version));
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
-    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks).ok());
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks, false).ok());
     writer.non_key_columns.emplace_back(Int16Column::create());
     writer.non_key_columns.emplace_back(Int32Column::create());
     ASSERT_TRUE(compaction_merge_rowsets(*_tablet, version, rowsets, &writer, cfg).ok());
@@ -374,7 +374,7 @@ TEST_F(RowsetMergerTest, horizontal_merge_seq) {
     EXPECT_EQ(pks.size(), read_tablet(_tablet, version));
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
-    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks).ok());
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks, false).ok());
     ASSERT_TRUE(compaction_merge_rowsets(*_tablet, version, rowsets, &writer, cfg).ok());
     ASSERT_EQ(pks.size(), writer.all_pks->size());
     const auto* raw_pk_array = reinterpret_cast<const int64_t*>(writer.all_pks->raw_data());
@@ -421,7 +421,7 @@ TEST_F(RowsetMergerTest, vertical_merge_seq) {
     EXPECT_EQ(pks.size(), read_tablet(_tablet, version));
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
-    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks).ok());
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks, false).ok());
     writer.non_key_columns.emplace_back(Int16Column::create());
     writer.non_key_columns.emplace_back(Int32Column::create());
     ASSERT_TRUE(compaction_merge_rowsets(*_tablet, version, rowsets, &writer, cfg).ok());

--- a/be/test/storage/sstable/sstable_predicate_test.cpp
+++ b/be/test/storage/sstable/sstable_predicate_test.cpp
@@ -86,7 +86,7 @@ TEST_F(SstablePredicateTest, basicSstablePredicateTest) {
         column_hash_is_congruent_pb->set_modulus(2);
         column_hash_is_congruent_pb->set_remainder(0);
         column_hash_is_congruent_pb->add_column_names("col1");
-        ASSIGN_OR_ABORT(auto sstable_predicate, SstablePredicate::create(_schema_pb_1, sstable_predicate_pb));
+        ASSIGN_OR_ABORT(auto sstable_predicate, SstablePredicate::create(false, _schema_pb_1, sstable_predicate_pb));
 
         std::shared_ptr<TabletSchema> tablet_schema_1 = std::make_shared<TabletSchema>(_schema_pb_1);
         ASSERT_EQ(tablet_schema_1->num_key_columns(), 1);
@@ -104,9 +104,9 @@ TEST_F(SstablePredicateTest, basicSstablePredicateTest) {
         bool expected = (hashes % 2 == 0);
 
         MutableColumnPtr encoded_columns;
-        ASSERT_OK(PrimaryKeyEncoder::create_column(pkey_schema, &encoded_columns));
-        PrimaryKeyEncoder::encode(pkey_schema, *pk_chunk, 0, 1, encoded_columns.get());
-        auto key_size = PrimaryKeyEncoder::get_encoded_fixed_size(pkey_schema);
+        ASSERT_OK(PrimaryKeyEncoder::create_column(pkey_schema, &encoded_columns, false));
+        PrimaryKeyEncoder::encode(pkey_schema, *pk_chunk, 0, 1, encoded_columns.get(), false);
+        auto key_size = PrimaryKeyEncoder::get_encoded_fixed_size(pkey_schema, false);
         Slice key(encoded_columns->continuous_data(), key_size);
         std::string row = key.to_string();
 
@@ -124,7 +124,7 @@ TEST_F(SstablePredicateTest, basicSstablePredicateTest) {
         column_hash_is_congruent_pb->set_remainder(0);
         column_hash_is_congruent_pb->add_column_names("col1");
         column_hash_is_congruent_pb->add_column_names("col2");
-        ASSIGN_OR_ABORT(auto sstable_predicate, SstablePredicate::create(_schema_pb_2, sstable_predicate_pb));
+        ASSIGN_OR_ABORT(auto sstable_predicate, SstablePredicate::create(false, _schema_pb_2, sstable_predicate_pb));
 
         std::shared_ptr<TabletSchema> tablet_schema_2 = std::make_shared<TabletSchema>(_schema_pb_2);
         ASSERT_EQ(tablet_schema_2->num_key_columns(), 2);
@@ -144,8 +144,8 @@ TEST_F(SstablePredicateTest, basicSstablePredicateTest) {
         bool expected = (hashes % 2 == 0);
 
         MutableColumnPtr encoded_columns;
-        ASSERT_OK(PrimaryKeyEncoder::create_column(pkey_schema, &encoded_columns));
-        PrimaryKeyEncoder::encode(pkey_schema, *pk_chunk, 0, 1, encoded_columns.get());
+        ASSERT_OK(PrimaryKeyEncoder::create_column(pkey_schema, &encoded_columns, false));
+        PrimaryKeyEncoder::encode(pkey_schema, *pk_chunk, 0, 1, encoded_columns.get(), false);
         ASSERT_TRUE(encoded_columns->is_binary() || encoded_columns->is_large_binary());
         std::string row = reinterpret_cast<const Slice*>(encoded_columns->raw_data())->to_string();
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -464,6 +464,9 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC)) {
                 schemaChangeHandler.updateTableMeta(db, tableName.getTbl(), properties,
                         TTabletMetaType.PRIMARY_INDEX_CACHE_EXPIRE_SEC);
+            } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY)) {
+                throw new DdlException("Property " + PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY
+                        + " cannot be modified.");
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_FILE_BUNDLING)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -225,6 +225,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                             .setVersion(Partition.PARTITION_INIT_VERSION)
                             .setStorageMedium(storageMedium)
                             .setLatch(countDownLatch)
+                            .setEnableNullPrimaryKey(table.enableNullPrimaryKey())
                             .setEnablePersistentIndex(table.enablePersistentIndex())
                             .setPrimaryIndexCacheExpireSec(table.primaryIndexCacheExpireSec())
                             .setTabletType(TTabletType.TABLET_TYPE_LAKE)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -431,6 +431,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                                 .setVersion(Partition.PARTITION_INIT_VERSION)
                                 .setStorageMedium(storageMedium)
                                 .setLatch(countDownLatch)
+                                .setEnableNullPrimaryKey(table.enableNullPrimaryKey())
                                 .setEnablePersistentIndex(table.enablePersistentIndex())
                                 .setPersistentIndexType(table.getPersistentIndexType())
                                 .setPrimaryIndexCacheExpireSec(table.primaryIndexCacheExpireSec())

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -332,6 +332,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                                 .setVersion(Partition.PARTITION_INIT_VERSION)
                                 .setStorageMedium(storageMedium)
                                 .setLatch(countDownLatch)
+                                .setEnableNullPrimaryKey(tbl.enableNullPrimaryKey())
                                 .setEnablePersistentIndex(tbl.enablePersistentIndex())
                                 .setPrimaryIndexCacheExpireSec(tbl.primaryIndexCacheExpireSec())
                                 .setTabletType(tabletType)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -382,6 +382,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                                     .setVersion(Partition.PARTITION_INIT_VERSION)
                                     .setStorageMedium(storageMedium)
                                     .setLatch(countDownLatch)
+                                    .setEnableNullPrimaryKey(tbl.enableNullPrimaryKey())
                                     .setEnablePersistentIndex(tbl.enablePersistentIndex())
                                     .setPrimaryIndexCacheExpireSec(tbl.primaryIndexCacheExpireSec())
                                     .setTabletType(tbl.getPartitionInfo().getTabletType(partition.getParentId()))

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1302,6 +1302,7 @@ public class RestoreJob extends AbstractJob {
                                 .setTabletId(restoreTablet.getId())
                                 .setVersion(restoreReplica.getVersion())
                                 .setStorageMedium(TStorageMedium.HDD) /* all restored replicas will be saved to HDD */
+                                .setEnableNullPrimaryKey(localTbl.enableNullPrimaryKey())
                                 .setEnablePersistentIndex(localTbl.enablePersistentIndex())
                                 .setPrimaryIndexCacheExpireSec(localTbl.primaryIndexCacheExpireSec())
                                 .setTabletType(localTbl.getPartitionInfo().getTabletType(restorePart.getId()))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Dictionary.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Dictionary.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.starrocks.common.util.PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY;
+
 public class Dictionary implements Writable {
     // Dictionary properties
     public static final String PROPERTIES_DICTIONARY_WARM_UP = "dictionary_warm_up";
@@ -52,6 +54,8 @@ public class Dictionary implements Writable {
     private String dbName;
     @SerializedName(value = "queryableObject")
     private String queryableObject;
+    @SerializedName(value = "enable_null_primary_key")
+    private boolean enableNullPrimaryKey;
 
     @SerializedName(value = "dictionaryKeys")
     private List<String> dictionaryKeys = Lists.newArrayList();
@@ -136,6 +140,10 @@ public class Dictionary implements Writable {
         return dictionaryValues;
     }
 
+    public boolean isEnableNullPrimaryKey() {
+        return enableNullPrimaryKey;
+    }
+
     public boolean needWarmUp() {
         return warmUp;
     }
@@ -164,6 +172,17 @@ public class Dictionary implements Writable {
 
     public boolean getIgnoreFailedRefresh() {
         return ignoreFailedRefresh;
+    }
+
+    private void buildEnableNullPrimaryKey(String value) throws DdlException {
+        if (value.equalsIgnoreCase("TRUE")) {
+            enableNullPrimaryKey = true;
+        } else if (value.equalsIgnoreCase("FALSE")) {
+            enableNullPrimaryKey = false;
+        } else {
+            throw new DdlException("parse " + PROPERTIES_ENABLE_NULL_PRIMARY_KEY + " failed" +
+                    ", given parameter: " + value);
+        }
     }
 
     private void buildWarmUp(String value) throws DdlException {
@@ -267,6 +286,9 @@ public class Dictionary implements Writable {
             String value = entry.getValue();
 
             switch (key) {
+                case PROPERTIES_ENABLE_NULL_PRIMARY_KEY:
+                    buildEnableNullPrimaryKey(value);
+                    break;
                 case PROPERTIES_DICTIONARY_WARM_UP:
                     buildWarmUp(value);
                     break;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
@@ -700,6 +700,7 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
             request.dictId = dictionary.getDictionaryId();
             request.txnId = txnId;
             request.type = PProcessDictionaryCacheRequestType.COMMIT;
+            request.enableNullPrimaryKey = dictionary.isEnableNullPrimaryKey();
 
             Pair<Boolean, String> ret = DictionaryMgr.processDictionaryCacheInteranl(request, beNodes, null);
             error = ret.first;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2116,6 +2116,13 @@ public class OlapTable extends Table {
         return false;
     }
 
+    public Boolean enableNullPrimaryKey() {
+        if (tableProperty != null) {
+            return tableProperty.enableNullPrimaryKey();
+        }
+        return false;
+    }
+
     public int primaryIndexCacheExpireSec() {
         if (tableProperty != null) {
             return tableProperty.primaryIndexCacheExpireSec();
@@ -2197,6 +2204,15 @@ public class OlapTable extends Table {
                 .modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,
                         Boolean.valueOf(enablePersistentIndex).toString());
         tableProperty.buildEnablePersistentIndex();
+    }
+
+    public void setEnableNullPrimaryKey(boolean enableNullPrimaryKey) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY,
+                Boolean.valueOf(enableNullPrimaryKey).toString());
+        tableProperty.buildEnableNullPrimaryKey();
     }
 
     public void setPrimaryIndexCacheExpireSec(int primaryIndexCacheExpireSec) {
@@ -3187,6 +3203,7 @@ public class OlapTable extends Table {
         if (keysType == KeysType.PRIMARY_KEYS) {
             // persistent index
             properties.put(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, enablePersistentIndex().toString());
+            properties.put(PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY, enableNullPrimaryKey().toString());
 
             // index cache expire
             int indexCacheExpireSec = primaryIndexCacheExpireSec();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -250,6 +250,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     private boolean isInMemory = false;
 
+    private boolean enableNullPrimaryKey = false;
     private boolean enablePersistentIndex = false;
 
     // Only meaningful when enablePersistentIndex = true.
@@ -793,6 +794,15 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildEnableNullPrimaryKey() {
+        enableNullPrimaryKey = Config.enable_null_primary_key;
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY)) {
+            enableNullPrimaryKey = Boolean.parseBoolean(
+                    properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY));
+        }
+        return this;
+    }
+
     public TableProperty buildPrimaryIndexCacheExpireSec() {
         primaryIndexCacheExpireSec = Integer.parseInt(properties.getOrDefault(
                 PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC, "0"));
@@ -1101,6 +1111,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return enablePersistentIndex;
     }
 
+    public boolean enableNullPrimaryKey() {
+        return enableNullPrimaryKey;
+    }
+
     public boolean isFileBundling() {
         return fileBundling;
     }
@@ -1261,6 +1275,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildStorageVolume();
         buildStorageCoolDownTTL();
         buildEnablePersistentIndex();
+        buildEnableNullPrimaryKey();
         buildPersistentIndexType();
         buildPrimaryIndexCacheExpireSec();
         buildCompressionType();

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -978,6 +978,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                     .setTabletId(tabletId)
                     .setVersion(visibleVersion)
                     .setStorageMedium(TStorageMedium.HDD)
+                    .setEnableNullPrimaryKey(olapTable.enableNullPrimaryKey())
                     .setEnablePersistentIndex(olapTable.enablePersistentIndex())
                     .setPrimaryIndexCacheExpireSec(olapTable.primaryIndexCacheExpireSec())
                     .setTabletType(olapTable.getPartitionInfo().getTabletType(physicalPartition.getParentId()))

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3149,6 +3149,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_sync_publish = true;
 
+    @ConfField(mutable = true)
+    public static boolean enable_null_primary_key = false;
+
     /**
      * Normally FE will quit when replaying a bad journal. This configuration provides a bypass mechanism.
      * If this was set to a positive value, FE will skip the corresponding bad journals before it quits.

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -154,6 +154,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_INMEMORY = "in_memory";
 
+    public static final String PROPERTIES_ENABLE_NULL_PRIMARY_KEY = "enable_null_primary_key";
+
     public static final String PROPERTIES_ENABLE_PERSISTENT_INDEX = "enable_persistent_index";
 
     public static final String PROPERTIES_LABELS_LOCATION = "labels.location";
@@ -1560,6 +1562,15 @@ public class PropertyAnalyzer {
         } catch (DateTimeParseException ex) {
             throw new AnalysisException(ex.getMessage());
         }
+    }
+
+    public static boolean analyzeEnableNullPrimaryKey(Map<String, String> properties) {
+        boolean enableNullPrimaryKey = Config.enable_null_primary_key;
+        if (properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY)) {
+            enableNullPrimaryKey = Boolean.parseBoolean(
+                    properties.remove(PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY));
+        }
+        return enableNullPrimaryKey;
     }
 
     public static TPersistentIndexType analyzePersistentIndexType(Map<String, String> properties) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1222,6 +1222,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                                             .setIndexId(indexId)
                                             .setVersion(partition.getVisibleVersion())
                                             .setStorageMedium(TStorageMedium.HDD)
+                                            .setEnableNullPrimaryKey(olapTable.enableNullPrimaryKey())
                                             .setEnablePersistentIndex(olapTable.enablePersistentIndex())
                                             .setPrimaryIndexCacheExpireSec(olapTable.primaryIndexCacheExpireSec())
                                             .setTabletType(olapTable.getPartitionInfo().getTabletType(partitionId))

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -189,6 +189,7 @@ public class OlapTableSink extends DataSink {
     public void init(TUniqueId loadId, long txnId, long dbId, long loadChannelTimeoutS)
             throws AnalysisException {
         TOlapTableSink tSink = new TOlapTableSink();
+        tSink.setEnable_null_primary_key(dstTable.enableNullPrimaryKey());
         tSink.setLoad_id(loadId);
         tSink.setTxn_id(txnId);
         tSink.setNull_expr_in_auto_increment(nullExprInAutoIncrement);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -401,6 +401,8 @@ public class OlapTableFactory implements AbstractTableFactory {
                 table.setCompactionStrategy(compactionStrategy);
             }
 
+            table.setEnableNullPrimaryKey(PropertyAnalyzer.analyzeEnableNullPrimaryKey(properties));
+
             try {
                 table.setPrimaryIndexCacheExpireSec(PropertyAnalyzer.analyzePrimaryIndexCacheExpireSecProp(properties,
                         PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC, 0));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -282,6 +282,9 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Property "
                         + PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC + " must be integer: " + valStr);
             }
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY)) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                    "Property " + PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY + " cannot be modified.");
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)) {
             if (!properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX).equalsIgnoreCase("true") &&
                     !properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX).equalsIgnoreCase("false")) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -370,6 +370,13 @@ public class CreateTableAnalyzer {
             throw new SemanticException("The number of key columns should be less than the number of columns.");
         }
 
+        boolean enableNullPrimaryKey = Config.enable_null_primary_key;
+        if (stmt.getProperties() != null
+                && stmt.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY)) {
+            enableNullPrimaryKey = Boolean.parseBoolean(
+                    stmt.getProperties().get(PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY));
+        }
+
         for (int i = 0; i < keysColumnNames.size(); ++i) {
             String colName = columnDefs.get(i).getName();
             if (!keysColumnNames.get(i).equalsIgnoreCase(colName)) {
@@ -389,7 +396,7 @@ public class CreateTableAnalyzer {
             if (keysType == KeysType.PRIMARY_KEYS) {
                 ColumnDef cd = columnDefs.get(i);
                 cd.setPrimaryKeyNonNullable();
-                if (cd.isAllowNull()) {
+                if (!enableNullPrimaryKey && cd.isAllowNull()) {
                     throw new SemanticException("primary key column[" + colName + "] cannot be nullable");
                 }
                 Type t = cd.getType();

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -66,6 +66,7 @@ public class CreateReplicaTask extends AgentTask {
     private final int compressionLevel;
     private final TStorageMedium storageMedium;
     private final boolean enablePersistentIndex;
+    private final boolean enableNullPrimaryKey;
     private TPersistentIndexType persistentIndexType;
 
     private BinlogConfig binlogConfig;
@@ -99,6 +100,7 @@ public class CreateReplicaTask extends AgentTask {
         this.storageMedium = builder.getStorageMedium();
         this.latch = builder.getLatch();
         this.enablePersistentIndex = builder.isEnablePersistentIndex();
+        this.enableNullPrimaryKey = builder.isEnableNullPrimaryKey();
         this.primaryIndexCacheExpireSec = builder.getPrimaryIndexCacheExpireSec();
         this.persistentIndexType = builder.getPersistentIndexType();
         this.tabletType = builder.getTabletType();
@@ -169,6 +171,7 @@ public class CreateReplicaTask extends AgentTask {
         createTabletReq.setTablet_schema(tabletSchema);
         createTabletReq.setVersion(version);
         createTabletReq.setStorage_medium(storageMedium);
+        createTabletReq.setEnable_null_primary_key(enableNullPrimaryKey);
         createTabletReq.setEnable_persistent_index(enablePersistentIndex);
         if (persistentIndexType != null) {
             createTabletReq.setPersistent_index_type(persistentIndexType);
@@ -218,6 +221,7 @@ public class CreateReplicaTask extends AgentTask {
         private int compressionLevel;
         private TStorageMedium storageMedium;
         private boolean enablePersistentIndex;
+        private boolean enableNullPrimaryKey;
         private TPersistentIndexType persistentIndexType;
         private BinlogConfig binlogConfig;
         private FlatJsonConfig flatJsonConfig;
@@ -324,6 +328,15 @@ public class CreateReplicaTask extends AgentTask {
 
         public Builder setStorageMedium(TStorageMedium storageMedium) {
             this.storageMedium = storageMedium;
+            return this;
+        }
+
+        public boolean isEnableNullPrimaryKey() {
+            return enableNullPrimaryKey;
+        }
+
+        public Builder setEnableNullPrimaryKey(boolean enableNullPrimaryKey) {
+            this.enableNullPrimaryKey = enableNullPrimaryKey;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -278,6 +278,7 @@ public class TabletTaskExecutor {
                         .setTabletId(tablet.getId())
                         .setVersion(physicalPartition.getVisibleVersion())
                         .setStorageMedium(storageMedium)
+                        .setEnableNullPrimaryKey(table.enableNullPrimaryKey())
                         .setEnablePersistentIndex(table.enablePersistentIndex())
                         .setPersistentIndexType(table.getPersistentIndexType())
                         .setPrimaryIndexCacheExpireSec(table.primaryIndexCacheExpireSec())

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
@@ -39,6 +39,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.starrocks.common.util.PropertyAnalyzer.PROPERTIES_ENABLE_NULL_PRIMARY_KEY;
+
 public class DictionaryMgrTest {
     @Mocked
     private GlobalStateMgr globalStateMgr;
@@ -116,6 +118,20 @@ public class DictionaryMgrTest {
                 result = dictionariesMapById;
             }
         };
+    }
+
+    @Test
+    public void testDictionaryWithNullKey() throws Exception {
+        List<String> dictionaryKeys = Lists.newArrayList();
+        List<String> dictionaryValues = Lists.newArrayList();
+        dictionaryKeys.add("key");
+        dictionaryValues.add("value");
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PROPERTIES_ENABLE_NULL_PRIMARY_KEY, "true");
+        Dictionary dictionary = new Dictionary(
+                1, "dict", "t", "default_catalog", "testDb", dictionaryKeys, dictionaryValues, properties);
+        dictionary.buildDictionaryProperties();
+        Assertions.assertTrue(dictionary.isEnableNullPrimaryKey());
     }
 
     @Test

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -205,6 +205,7 @@ message PTabletWriterOpenRequest {
     // for multi olap table sink
     optional int64 sink_id = 36 [default = 0];
     optional bytes encryption_meta = 37;
+    optional bool enable_null_primary_key = 38;
 };
 
 message PTabletWriterOpenResult {
@@ -703,6 +704,7 @@ message PProcessDictionaryCacheRequest {
     optional int32 key_size = 6;
     optional bool is_cancel = 7;
     optional PProcessDictionaryCacheRequestType type = 8;
+    optional bool enable_null_primary_key = 9;
 };
 
 message PProcessDictionaryCacheResult {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -200,6 +200,7 @@ message TabletMetadataPB {
     optional CompactionStrategyPB compaction_strategy = 20;
     // flat json
     optional FlatJsonConfigPB flat_json_config = 21;
+    optional bool enable_null_primary_key = 22;
 }
 
 message MetadataUpdateInfoPB {

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -314,6 +314,7 @@ message TabletMetaPB {
     optional BinlogConfigPB binlog_config = 52;
     optional BinlogLsnPB binlog_min_lsn = 53;
     optional string storage_type = 54; // storage layout type: column[default]|column_with_row|row
+    optional bool enable_null_primary_key = 55;
     optional bool enable_shortcut_compaction = 60 [default = true];
     optional int32 primary_index_cache_expire_sec = 61 [default = 0];
     // If the tablet is replicated from another cluster, the source_schema saved the schema in the cluster

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -136,6 +136,7 @@ struct TCreateTabletReq {
     24: optional i64 gtid = 0;
     25: optional TFlatJsonConfig flat_json_config;
     26: optional TCompactionStrategy compaction_strategy;
+    27: optional bool enable_null_primary_key;
 }
 
 struct TDropTabletReq {

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -234,6 +234,7 @@ struct TOlapTableSink {
     32: optional bool dynamic_overwrite
     33: optional bool enable_data_file_bundling
     34: optional bool is_multi_statements_txn
+    35: optional bool enable_null_primary_key
 }
 
 struct TSchemaTableSink {


### PR DESCRIPTION
## Why I'm doing:

Support Null field in primary keys.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds config/table-property–gated nullable primary key support, updating PK encoding/decoding, metadata, RPCs, and write/read/compaction paths end-to-end.
> 
> - **Core Encoding/Indexing**:
>   - Extend `PrimaryKeyEncoder` APIs to handle nulls (encode marker, decode), add `get_encoded_fixed_size(..., enable_null_primary_key)`.
>   - Propagate null-PK handling through `PrimaryIndex`, `PersistentIndex`, loaders, rebuild, compaction, recover, and get/lookup paths.
> - **Write/Read Pipeline**:
>   - Thread `enable_null_primary_key` through `MemTable`, `DeltaWriter`, lake `TabletWriter` variants, PK SST writer, tablet/channel builders, and readers.
>   - Update dictionary cache encode/decode and cache instances to honor null-PK.
> - **Metadata/Config**:
>   - Add `enable_null_primary_key` to `TabletMeta`, lake `TabletMetadataPB`, and persist/serialize it; default from `config::enable_null_primary_key`.
>   - `Tablet` exposes getters/setters and passes flag to writers and index/compaction states.
> - **FE/Table Properties**:
>   - Introduce table property `enable_null_primary_key` (default from FE `Config.enable_null_primary_key`); validated on create and surfaced in show properties; disallow ALTER changes.
>   - Propagate flag via `CreateReplicaTask`, `OlapTableSink`, rollup/schema change/restore/scheduler tasks; support in `Dictionary` and `DictionaryMgr`.
> - **Protocols**:
>   - Add `enable_null_primary_key` fields to Thrift/Proto definitions (`TOlapTableSink`, `TCreateTabletReq`, `PTabletWriterOpenRequest`, `PProcessDictionaryCacheRequest`, lake `TabletMetadataPB`).
> - **Predicates/Utilities**:
>   - Update sstable key converters/predicates to decode with null-PK.
> - **Tests**:
>   - Adjust unit tests and builders to pass the new flag and verify behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 479cfd3c0b9c477d9c333767912fc575cb5c7046. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->