### PR TITLE
Document show table status command

### DIFF
--- a/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/SHOW_TABLE_STATUS.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/SHOW_TABLE_STATUS.md
@@ -4,35 +4,73 @@ displayed_sidebar: docs
 
 # SHOW TABLE STATUS
 
-SHOW TABLE STATUS is used to view some of the information in Table.
+## Description
+
+SHOW TABLE STATUS returns metadata for each table or materialized view in a database.
+It follows MySQL's SHOW TABLE STATUS for compatibility. Not all columns are
+meaningful in StarRocks; some values are empty strings or NULL.
 
 :::tip
 
-This operation does not require privileges.
+You do not need an explicit privilege to run this statement. Results include only
+tables or views on which you have any privilege.
 
 :::
 
 ## Syntax
 
 ```sql
-SHOW TABLE STATUS
-[FROM db] [LIKE "pattern"]
+SHOW TABLE STATUS [FROM db | IN db] [LIKE "pattern" | WHERE expr]
 ```
 
-> Note
->
-> This statement is mainly compatible with MySQL syntax. At present, it only shows a few information, such as Comment.
+- db: Target database. Defaults to the current database if omitted.
+- pattern: MySQL LIKE pattern using % and _ to filter table names.
+- expr: Boolean filter over returned column names, for example
+  `WHERE Name = 't1' AND Rows > 0`.
+
+## Returned columns
+
+- Name: Table or materialized view name.
+- Engine: Storage engine type (for example, OLAP).
+- Version: Always NULL.
+- Row_format: Empty string.
+- Rows: Estimated number of rows.
+- Avg_row_length: Estimated average row length in bytes.
+- Data_length: Approximate data size in bytes.
+- Max_data_length: NULL.
+- Index_length: NULL.
+- Data_free: NULL.
+- Auto_increment: NULL.
+- Create_time: Creation time, formatted in the session time zone.
+- Update_time: Last update time if available; may be NULL or empty for some table types.
+- Check_time: NULL.
+- Collation: utf8_general_ci.
+- Checksum: NULL.
+- Create_options: Empty string.
+- Comment: Table comment or description.
 
 ## Examples
 
-1. View all the information of tables under the current database.
+1. List all tables in the current database.
 
     ```SQL
     SHOW TABLE STATUS;
     ```
 
-2. View all the information of tables whose names contain example and who are under specified databases.
+2. List tables in a specific database whose names contain "example".
 
     ```SQL
     SHOW TABLE STATUS FROM db LIKE "%example%";
+    ```
+
+3. Filter by returned columns using WHERE.
+
+    ```SQL
+    SHOW TABLE STATUS WHERE Name = 't1';
+    ```
+
+4. Combine filters.
+
+    ```SQL
+    SHOW TABLE STATUS IN db WHERE Engine = 'OLAP' AND Rows > 0;
     ```


### PR DESCRIPTION
## Why I'm doing:

To provide comprehensive and accurate documentation for the `SHOW TABLE STATUS` command, which was previously incomplete regarding its syntax, output, and filtering capabilities.

## What I'm doing:

- Enhanced `docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/SHOW_TABLE_STATUS.md`.
- Added full syntax, including `FROM/IN` and `LIKE/WHERE` clauses.
- Documented privilege behavior for result filtering.
- Listed and described all returned columns, noting StarRocks-specific behaviors (NULL/empty).
- Added examples for various filtering scenarios.

Fixes #issue (If there's an issue number for the doc task, add it here)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-289e0921-1b1c-416f-9463-217f413c9951">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-289e0921-1b1c-416f-9463-217f413c9951">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>