### PR TITLE
[Feature] Mapped ldap groups with db roles if exists

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
@@ -54,6 +54,7 @@ import com.starrocks.sql.ast.RevokePrivilegeStmt;
 import com.starrocks.sql.ast.RevokeRoleStmt;
 import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.parser.NodePosition;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -67,6 +68,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -1133,14 +1135,19 @@ public class AuthorizationMgr {
         }
     }
 
-    public UserPrivilegeCollectionV2 getUserPrivilegeCollectionUnlocked(UserIdentity userIdentity)
+    public UserPrivilegeCollectionV2 getUserPrivilegeCollectionUnlocked(UserIdentity userIdentity, boolean exceptionIfNotExists)
             throws PrivilegeException {
         UserPrivilegeCollectionV2 userCollection = userToPrivilegeCollection.get(userIdentity);
-        if (userCollection == null) {
+        if (userCollection == null && exceptionIfNotExists) {
             throw new PrivilegeException("cannot find user " + (userIdentity == null ? "null" :
-                    userIdentity.toString()));
+                userIdentity.toString()));
         }
         return userCollection;
+    }
+
+    public UserPrivilegeCollectionV2 getUserPrivilegeCollectionUnlocked(UserIdentity userIdentity)
+            throws PrivilegeException {
+        return getUserPrivilegeCollectionUnlocked(userIdentity, true);
     }
 
     public List<String> getAllUsers() {
@@ -1296,7 +1303,7 @@ public class AuthorizationMgr {
     public List<String> getGranteeRoleForUser(UserIdentity userIdentity) {
         userReadLock();
         try {
-            Set<Long> allRoles = getRoleIdsByUserUnlocked(userIdentity);
+            Set<Long> allRoles = getRoleIdsByUserUnlocked(userIdentity, Set.of());
 
             roleReadLock();
             try {
@@ -1556,7 +1563,7 @@ public class AuthorizationMgr {
         }
     }
 
-    protected Set<Long> getRoleIdsByUserUnlocked(UserIdentity user) throws PrivilegeException {
+    protected Set<Long> getRoleIdsByUserUnlocked(UserIdentity user, Set<String> userGroups) throws PrivilegeException {
         Set<Long> ret = new HashSet<>();
 
         for (long roleId : getUserPrivilegeCollectionUnlocked(user).getAllRoles()) {
@@ -1565,16 +1572,27 @@ public class AuthorizationMgr {
                 ret.add(roleId);
             }
         }
+
+        if (CollectionUtils.isNotEmpty(userGroups)) {
+            for (String roleName : userGroups) {
+                Optional.ofNullable(getRoleIdByNameNoLock(roleName)).ifPresent(ret::add);
+            }
+        }
+
         return ret;
     }
 
     // used in executing `set role` statement
     public Set<Long> getRoleIdsByUser(UserIdentity user) throws PrivilegeException {
+        return getRoleIdsByUser(user, Set.of());
+    }
+
+    public Set<Long> getRoleIdsByUser(UserIdentity user, Set<String> userGroups) throws PrivilegeException {
         userReadLock();
         try {
             roleReadLock();
             try {
-                return getRoleIdsByUserUnlocked(user);
+                return getRoleIdsByUserUnlocked(user, userGroups);
             } finally {
                 roleReadUnlock();
             }
@@ -1584,15 +1602,29 @@ public class AuthorizationMgr {
     }
 
     public Set<Long> getDefaultRoleIdsByUser(UserIdentity user) throws PrivilegeException {
+        return getDefaultRoleIdsByUser(user, Set.of());
+    }
+
+    public Set<Long> getDefaultRoleIdsByUser(UserIdentity user, Set<String> userGroups) throws PrivilegeException {
         userReadLock();
         try {
             Set<Long> ret = new HashSet<>();
             roleReadLock();
             try {
-                for (long roleId : getUserPrivilegeCollectionUnlocked(user).getDefaultRoleIds()) {
-                    // role may be removed
-                    if (getRolePrivilegeCollectionUnlocked(roleId, false) != null) {
-                        ret.add(roleId);
+                UserPrivilegeCollectionV2 privileges = getUserPrivilegeCollectionUnlocked(user, false);
+
+                if (privileges != null) {
+                    for (long roleId : privileges.getDefaultRoleIds()) {
+                        // role may be removed
+                        if (getRolePrivilegeCollectionUnlocked(roleId, false) != null) {
+                            ret.add(roleId);
+                        }
+                    }
+                }
+
+                if (CollectionUtils.isNotEmpty(userGroups)) {
+                    for (String roleName : userGroups) {
+                        Optional.ofNullable(getRoleIdByNameNoLock(roleName)).ifPresent(ret::add);
                     }
                 }
                 return ret;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -513,9 +513,9 @@ public class ConnectContext {
             try {
                 Set<Long> defaultRoleIds;
                 if (GlobalVariable.isActivateAllRolesOnLogin()) {
-                    defaultRoleIds = globalStateMgr.getAuthorizationMgr().getRoleIdsByUser(user);
+                    defaultRoleIds = globalStateMgr.getAuthorizationMgr().getRoleIdsByUser(user, getGroups());
                 } else {
-                    defaultRoleIds = globalStateMgr.getAuthorizationMgr().getDefaultRoleIdsByUser(user);
+                    defaultRoleIds = globalStateMgr.getAuthorizationMgr().getDefaultRoleIdsByUser(user, getGroups());
                 }
                 return defaultRoleIds;
             } catch (PrivilegeException e) {
@@ -546,7 +546,6 @@ public class ConnectContext {
     }
 
     public void setAuthPlugin(String authPlugin) {
-        accessControlContext.setAuthPlugin(authPlugin);
     }
 
     public String getAuthPlugin() {


### PR DESCRIPTION
## Why I'm doing:
Currently, StarRocks requires manual user creation and role assignment when using LDAP integration. This is not scalable and creates overhead for managing security. While Apache Ranger can solve this, it’s a heavy solution for teams who only need a simple mapping between LDAP groups and StarRocks roles.

By enabling direct mapping of LDAP user groups to StarRocks roles (when the group exists in StarRocks), we can simplify security integration and remove the need for repetitive manual steps.

## What I'm doing:
	•	Adding support to map LDAP user groups directly to StarRocks roles if they exist.
	•	Ensuring that when a user authenticates via LDAP, their roles in StarRocks are automatically inferred from their LDAP group memberships.

Fixes #62689

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3