### PR TITLE
[BugFix] Resolve authentication problem in security integration for manually added users.

### DIFF
--- a/docs/en/administration/user_privs/authentication/security_integration.md
+++ b/docs/en/administration/user_privs/authentication/security_integration.md
@@ -135,6 +135,11 @@ For more details, see the DN matching mechanism in [Authenticate User Groups](..
 - Required: No
 - Description: The description of the security integration.
 
+## Add a User with Security Integration
+```SQL
+CREATE USER testuser IDENTIFIED WITH security_integration;
+```
+
 <SecurityIntegrationJWT />
 
 <SecurityIntegrationOAuth />

--- a/docs/en/sql-reference/sql-statements/account-management/ALTER_USER.md
+++ b/docs/en/sql-reference/sql-statements/account-management/ALTER_USER.md
@@ -32,7 +32,7 @@ ALTER USER user_identity
         IDENTIFIED WITH mysql_native_password BY 'auth_string'
         IDENTIFIED WITH mysql_native_password AS 'auth_string'
         IDENTIFIED WITH authentication_ldap_simple AS 'auth_string'
-        
+        IDENTIFIED WITH security_integration AS 'auth_string'
     }
     ```
 
@@ -42,6 +42,7 @@ ALTER USER user_identity
     | `mysql_native_password BY`   | Plaintext                      | Plaintext              |
     | `mysql_native_password WITH` | Ciphertext                     | Plaintext              |
     | `authentication_ldap_simple` | Plaintext                      | Plaintext              |
+    | `security_integration`       | Plaintext                      | Plaintext              |
 
 > Note: StarRocks encrypts users' passwords before storing them.
 

--- a/docs/en/sql-reference/sql-statements/account-management/SHOW_AUTHENTICATION.md
+++ b/docs/en/sql-reference/sql-statements/account-management/SHOW_AUTHENTICATION.md
@@ -35,7 +35,7 @@ SHOW [ALL] AUTHENTICATION [FOR USERNAME]
 | ----------------- | ------------------------------------------------------------ |
 | UserIdentity      | The user identity.                                           |
 | Password          | Whether a password is used to log in to the StarRocks cluster.<ul><li>`Yes`: A password is used.</li><li>`No`: No password is used.</li></ul> |
-| AuthPlugin        | The interface that is used for authentication. Valid values: `MYSQL_NATIVE_PASSWORD` and `AUTHENTICATION_LDAP_SIMPLE`. If no interface is used, `NULL` is returned. |
+| AuthPlugin        | The interface that is used for authentication. Valid values: `MYSQL_NATIVE_PASSWORD`, `SECURITY_INTEGRATION` and `AUTHENTICATION_LDAP_SIMPLE`. If no interface is used, `NULL` is returned. |
 | UserForAuthPlugin | The name of the user using the LDAP or Kerberos authentication. If no authentication is used, `NULL` is returned. |
 
 ## Examples

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
@@ -83,7 +83,11 @@ public class AuthenticationHandler {
 
         Map.Entry<UserIdentity, UserAuthenticationInfo> matchedUserIdentity =
                 authenticationMgr.getBestMatchedUserIdentity(user, remoteHost);
-        if (matchedUserIdentity == null) {
+        if (matchedUserIdentity == null
+                || matchedUserIdentity
+                    .getValue()
+                    .getAuthPlugin()
+                    .equalsIgnoreCase(AuthPlugin.Server.SECURITY_INTEGRATION.name())) {
             if (Config.enable_auth_check) {
                 LOG.debug("cannot find user {}@{}", user, remoteHost);
                 return null;

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthPlugin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthPlugin.java
@@ -33,6 +33,7 @@ public class AuthPlugin {
     public enum Server {
         MYSQL_NATIVE_PASSWORD,
         AUTHENTICATION_LDAP_SIMPLE,
+        SECURITY_INTEGRATION,   // To pass auth call to SECURITY_INTEGRATION
         AUTHENTICATION_JWT,
         AUTHENTICATION_OAUTH2;
 
@@ -58,6 +59,9 @@ public class AuthPlugin {
                             authString);
                 }
 
+                case SECURITY_INTEGRATION -> {
+                    return null;
+                }
                 case AUTHENTICATION_JWT -> {
                     JSONObject authStringJSON = new JSONObject(authString == null ? "{}" : authString);
 


### PR DESCRIPTION
## Why I'm doing:
When security integration is enabled, manually created users (CREATE USER) fail to authenticate correctly.
This causes issues in scenarios where certain accounts need to exist locally (such as service or admin users) and require role assignments.

This PR addresses the authentication failure by ensuring manually created users with CREATE USER are correctly handled when security integration is active.

## What I'm doing:
Added new Auth plugin of type `SECURITY_INTEGRATION` to pass authentication call to security integration

Fixes #62692

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [X] 4.0
  - [X] 3.5
  - [ ] 3.4
  - [ ] 3.3