### PR TITLE
[BugFix] Enhance group provider with DnName support for scenarios where group members lack usernames

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
@@ -17,6 +17,7 @@ package com.starrocks.authentication;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.catalog.UserIdentityWithDnName;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.Pair;
@@ -149,16 +150,17 @@ public class AuthenticationHandler {
                 continue;
             }
 
+            UserIdentity userIdentity = UserIdentityWithDnName.createEphemeralUserIdent(user, remoteHost);
+
             try {
                 authContext.setAuthenticationProvider(provider);
-                provider.authenticate(authContext, UserIdentity.createEphemeralUserIdent(user, remoteHost), authResponse);
+                provider.authenticate(authContext, userIdentity, authResponse);
             } catch (AuthenticationException e) {
                 exceptions.add(new Pair<>(authMechanism, e));
                 continue;
             }
 
-            authenticationResult = new AuthenticationResult(
-                    UserIdentity.createEphemeralUserIdent(user, remoteHost),
+            authenticationResult = new AuthenticationResult(userIdentity,
                     securityIntegration.getGroupProviderName() == null ?
                             List.of(Config.group_provider) : securityIntegration.getGroupProviderName(),
                     securityIntegration.getGroupAllowedLoginList());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/UserIdentityWithDnName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/UserIdentityWithDnName.java
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/analysis/UserIdentity.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.catalog;
+
+import org.apache.commons.lang3.StringUtils;
+
+
+public class UserIdentityWithDnName extends UserIdentity {
+    private String dnName;
+
+    public UserIdentityWithDnName(boolean ephemeral, String user, String host) {
+        super(ephemeral, user, host);
+    }
+
+    public String getDnName() {
+        return this.dnName;
+    }
+
+    public void setDnName(String dnName) {
+        if (StringUtils.isNotEmpty(dnName)) {
+            this.dnName = dnName;
+        }
+    }
+
+    public static UserIdentity createEphemeralUserIdent(String user, String host) {
+        return new UserIdentityWithDnName(true, user, host);
+    }
+}


### PR DESCRIPTION
Enhance group provider with DnName support for scenarios where group members lack usernames (e.g., Microsoft AD groups).

## Why I'm doing:
Currently, when using LDAP with Microsoft Active Directory, group membership resolution fails because AD stores group members as Distinguished Names (DNs) and do not include usernames. This causes issues when mapping users to permitted groups, since the existing logic expects usernames only.

## What I'm doing:
Passed DNName along with UserIdentity for group resolution.

Fixes #62694

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3