### PR TITLE
[BugFix] Fix cache env init order

### DIFF
--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -107,16 +107,18 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     CHECK(global_vars->is_init()) << "global variables not initialized";
     LOG(INFO) << process_name << " start step " << start_step++ << ": global variables init successfully";
 
-    auto* storage_engine = init_storage_engine(global_env, paths, as_cn);
-    LOG(INFO) << process_name << " start step " << start_step++ << ": storage engine init successfully";
-
+    // cache env should be initialized before init_storage_engine,
+    // because apply task is triggered in init_storage_engine and needs cache env.
     auto* cache_env = DataCache::GetInstance();
     EXIT_IF_ERROR(cache_env->init(paths));
     LOG(INFO) << process_name << " start step " << start_step++ << ": cache env init successfully";
 
+    auto* storage_engine = init_storage_engine(global_env, paths, as_cn);
+    LOG(INFO) << process_name << " start step " << start_step++ << ": storage engine init successfully";
+
     auto* exec_env = ExecEnv::GetInstance();
     EXIT_IF_ERROR(exec_env->init(paths, as_cn));
-    LOG(INFO) << process_name << " start step " << start_step++ << ": exec engine init successfully";
+    LOG(INFO) << process_name << " start step " << start_step++ << ": exec env init successfully";
 
     // Start all background threads of storage engine.
     // SHOULD be called after exec env is initialized.


### PR DESCRIPTION
## Why I'm doing:

the apply task is triggered in `init_storage_engine`, but `cache env` is not initialized.

```
start time: Wed Sep  3 11:11:01 CST 2025, server uptime:  11:11:01 up  7:08,  1 user,  load average: 1.64, 1.92, 2.07
Run with JEMALLOC_CONF: 'percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false'
Duplicate assignment to config 'be_http_port', previous assignment will be ignored
branch-3.5.5 RELEASE (build 76bf5b9 distro centos arch x86_64)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000
*** Aborted at 1756869061 (unix time) try "date -d @1756869061" if you are using GNU date ***
PC: @          0x776e5de starrocks::StoragePageCache::lookup(starrocks::StoragePageCache::CacheKey const&, starrocks::PageCacheHandle*)
*** SIGSEGV (@0x8) received by PID 1299 (TID 0x7fa789d77700) LWP(2195) from PID 8; stack trace: ***
    @     0x7fa7b731b20b __pthread_once_slow
    @          0xbe6dd14 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fa7b7324630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0x776e5de starrocks::StoragePageCache::lookup(starrocks::StoragePageCache::CacheKey const&, starrocks::PageCacheHandle*)
    @          0x825811a starrocks::PageIO::read_and_decompress_page(starrocks::PageReadOptions const&, starrocks::PageHandle*, starrocks::Slice*, starrocks::PageFooterPB*)
    @          0x81d85ad starrocks::ColumnReader::read_page(starrocks::ColumnIteratorOptions const&, starrocks::PagePointer const&, starrocks::PageHandle*, starrocks::Slice*, starrocks::PageFooterPB*)
    @          0x823d1b2 starrocks::ScalarColumnIterator::_read_data_page(starrocks::OrdinalPageIndexIterator const&)
    @          0x823d70c starrocks::ScalarColumnIterator::seek_to_ordinal(unsigned long)
    @          0x823e510 starrocks::ScalarColumnIterator::fetch_values_by_rowid(unsigned int const*, unsigned long, starrocks::Column*)
    @          0x78a6aad starrocks::TabletUpdates::get_column_values(std::vector<unsigned int, std::allocator<unsigned int> > const&, long, bool, std::map<unsigned int, std::vector<unsigned int, std::allocator<unsigned int> >, std::less<unsigned int>, std::allocator<std::pair<unsi@
    @          0x81ad910 starrocks::RowsetUpdateState::_prepare_partial_update_states(starrocks::Tablet*, starrocks::Rowset*, unsigned int, bool, std::shared_ptr<starrocks::TabletSchema const> const&)
    @          0x81af455 starrocks::RowsetUpdateState::_do_load(starrocks::Tablet*, starrocks::Rowset*)
    @          0x81af79a starrocks::RowsetUpdateState::load(starrocks::Tablet*, starrocks::Rowset*)::{lambda()#1}::operator()() const
    @     0x7fa7b731b20b __pthread_once_slow
    @          0x81a6fb0 starrocks::RowsetUpdateState::load(starrocks::Tablet*, starrocks::Rowset*)
    @          0x78ba691 starrocks::TabletUpdates::_apply_normal_rowset_commit(starrocks::EditVersionInfo const&, std::shared_ptr<starrocks::Rowset> const&)
    @          0x78bfb0d starrocks::TabletUpdates::_apply_rowset_commit(starrocks::EditVersionInfo const&)
    @          0x78bfece starrocks::TabletUpdates::do_apply()
    @          0x45c18bf starrocks::ThreadPool::dispatch_thread()
    @          0x45b86b0 starrocks::Thread::supervise_thread(void*)
    @     0x7fa7b731cea5 start_thread
    @     0x7fa7b4e87b0d __clone
```

## What I'm doing:

https://github.com/StarRocks/StarRocksTest/issues/10206

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
