### PR TITLE
[Tool] simplify meta_tool help message

### DIFF
--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -117,6 +117,8 @@ DEFINE_string(audit_file, "", "audit file path");
 DEFINE_bool(do_delete, false, "do delete files");
 
 // flag defined in gflags library
+DECLARE_bool(help);
+DECLARE_bool(helpfull);
 DECLARE_bool(helpshort);
 
 std::string get_usage(const std::string& progname) {
@@ -1096,7 +1098,18 @@ int meta_tool_main(int argc, char** argv) {
     bool empty_args = (argc <= 1);
     std::string usage = get_usage(argv[0]);
     gflags::SetUsageMessage(usage);
-    google::ParseCommandLineFlags(&argc, &argv, true);
+    google::ParseCommandLineNonHelpFlags(&argc, &argv, true);
+    if (FLAGS_help || FLAGS_helpfull) {
+        // process `--help`, `--helpfull` as if it were `--helpshort`,
+        // avoid printing out all available gflags from all modules
+        FLAGS_help = false;
+        FLAGS_helpfull = false;
+        show_usage();
+        return 0;
+    } else {
+        // process other help flags as usual, may exit.
+        google::HandleCommandLineHelpFlags();
+    }
     starrocks::date::init_date_cache();
     starrocks::config::disable_storage_page_cache = true;
     starrocks::MemChunkAllocator::init_metrics();


### PR DESCRIPTION
## Why I'm doing:

```
meta_tool: 
  meta_tool is the StarRocks BE Meta tool.
    [CAUTION] Stop BE first before using this tool if modification will be made.

  Usage:
    get_meta:
      meta_tool --operation=get_meta --root_path=</path/to/storage/path> --tablet_id=<tabletid> [--schema_hash=<schemahash>]
    load_meta:
      meta_tool --operation=load_meta --root_path=</path/to/storage/path> --json_meta_path=<path>
    delete_meta:
      meta_tool --operation=delete_meta --root_path=</path/to/storage/path> --tablet_id=<tabletid> [--schema_hash=<schemahash>]
      meta_tool --operation=delete_meta --root_path=</path/to/storage/path> --table_id=<tableid>
      meta_tool --operation=delete_meta --tablet_file=<file_path>
    delete_rowset_meta:
      meta_tool --operation=delete_rowset_meta --root_path=</path/to/storage/path> --tablet_uid=<tablet_uid> --rowset_id=<rowset_id>
    get_persistent_index_meta:
      meta_tool --operation=get_persistent_index_meta --root_path=</path/to/storage/path> --tablet_id=<tabletid>
    delete_persistent_index_meta:
      meta_tool --operation=delete_persistent_index_meta --root_path=</path/to/storage/path> --tablet_id=<tabletid>
      meta_tool --operation=delete_persistent_index_meta --root_path=</path/to/storage/path> --table_id=<tableid>
    compact_meta:
      meta_tool --operation=compact_meta --root_path=</path/to/storage/path>
    get_meta_stats:
      meta_tool --operation=get_meta_stats --root_path=</path/to/storage/path>
    ls:
      meta_tool --operation=ls --root_path=</path/to/storage/path>
    show_meta:
      meta_tool --operation=show_meta --pb_meta_path=<path>
    show_segment_footer:
      meta_tool --operation=show_segment_footer --file=</path/to/segment/file>
    dump_segment_data:
      meta_tool --operation=dump_segment_data --file=</path/to/segment/file>
    dump_column_size:
      meta_tool --operation=dump_column_size --file=</path/to/segment/file>
    print_pk_dump:
      meta_tool --operation=print_pk_dump --file=</path/to/pk/dump/file>
    dump_short_key_index:
      meta_tool --operation=dump_short_key_index --file=</path/to/segment/file> --key_column_count=<2>
    calc_checksum:
      meta_tool --operation=calc_checksum [--column_index=<index>] --file=</path/to/segment/file>
    check_table_meta_consistency:
      meta_tool --operation=check_table_meta_consistency --root_path=</path/to/storage/path> --table_id=<tableid>
    scan_dcgs:
      meta_tool --operation=scan_dcgs --root_path=</path/to/storage/path> --tablet_id=<tabletid>
    print_lake_metadata:
      cat <tablet_meta_file.meta> | meta_tool --operation=print_lake_metadata
    print_lake_bundle_metadata:
      cat <tablet_meta_file.meta> | meta_tool --operation=print_lake_bundle_metadata
    print_lake_txn_log:
      cat <tablet_transaction_log_file.log> | meta_tool --operation=print_lake_txn_log
    print_lake_schema:
      cat <tablet_schema_file> | meta_tool --operation=print_lake_schema
    lake_datafile_gc:
      meta_tool --operation=lake_datafile_gc --root_path=<path> --expired_sec=<86400> --conf_file=<path> --audit_file=<path> --do_delete=<true|false>
    

  Flags from ./gflags-2.2.2/src/gflags.cc:
    -flagfile (load flags from file) type: string default: ""
    -fromenv (set flags from the environment [use 'export FLAGS_flag1=value'])
      type: string default: ""
    -tryfromenv (set flags from the environment if present) type: string
      default: ""
    -undefok (comma-separated list of flag names that it is okay to specify on
      the command line even if the program does not define a flag with that
      name.  IMPORTANT: flags in this list that have arguments MUST use the
      flag=value format) type: string default: ""

  Flags from ./gflags-2.2.2/src/gflags_completions.cc:
    -tab_completion_columns (Number of columns to use in output for tab
      completion) type: int32 default: 80
    -tab_completion_word (If non-empty, HandleCommandLineCompletions() will
      hijack the process and attempt to do bash-style command line flag
      completion on this value.) type: string default: ""

...

  Flags from src/mcpack2pb/mcpack2pb.cpp:
    -mcpack2pb_absent_field_is_error (Parsing fails if the field in
      compack/mcpack does not exist in protobuf) type: bool default: false
```

```
$ ./be/bin/meta_tool.sh --help 2>&1 | grep 'Flags from' | wc -l
81
```

## What I'm doing:

Simplify the gflags output, only print the gflags in meta_tool.cpp

```
meta_tool: 
  meta_tool is the StarRocks BE Meta tool.
    [CAUTION] Stop BE first before using this tool if modification will be made.

  Usage:
    get_meta:
      meta_tool --operation=get_meta --root_path=</path/to/storage/path> --tablet_id=<tabletid> [--schema_hash=<schemahash>]
    load_meta:
      meta_tool --operation=load_meta --root_path=</path/to/storage/path> --json_meta_path=<path>
    delete_meta:
      meta_tool --operation=delete_meta --root_path=</path/to/storage/path> --tablet_id=<tabletid> [--schema_hash=<schemahash>]
      meta_tool --operation=delete_meta --root_path=</path/to/storage/path> --table_id=<tableid>
      meta_tool --operation=delete_meta --tablet_file=<file_path>
    delete_rowset_meta:
      meta_tool --operation=delete_rowset_meta --root_path=</path/to/storage/path> --tablet_uid=<tablet_uid> --rowset_id=<rowset_id>
    get_persistent_index_meta:
      meta_tool --operation=get_persistent_index_meta --root_path=</path/to/storage/path> --tablet_id=<tabletid>
    delete_persistent_index_meta:
      meta_tool --operation=delete_persistent_index_meta --root_path=</path/to/storage/path> --tablet_id=<tabletid>
      meta_tool --operation=delete_persistent_index_meta --root_path=</path/to/storage/path> --table_id=<tableid>
    compact_meta:
      meta_tool --operation=compact_meta --root_path=</path/to/storage/path>
    get_meta_stats:
      meta_tool --operation=get_meta_stats --root_path=</path/to/storage/path>
    ls:
      meta_tool --operation=ls --root_path=</path/to/storage/path>
    show_meta:
      meta_tool --operation=show_meta --pb_meta_path=<path>
    show_segment_footer:
      meta_tool --operation=show_segment_footer --file=</path/to/segment/file>
    dump_segment_data:
      meta_tool --operation=dump_segment_data --file=</path/to/segment/file>
    dump_column_size:
      meta_tool --operation=dump_column_size --file=</path/to/segment/file>
    print_pk_dump:
      meta_tool --operation=print_pk_dump --file=</path/to/pk/dump/file>
    dump_short_key_index:
      meta_tool --operation=dump_short_key_index --file=</path/to/segment/file> --key_column_count=<2>
    calc_checksum:
      meta_tool --operation=calc_checksum [--column_index=<index>] --file=</path/to/segment/file>
    check_table_meta_consistency:
      meta_tool --operation=check_table_meta_consistency --root_path=</path/to/storage/path> --table_id=<tableid>
    scan_dcgs:
      meta_tool --operation=scan_dcgs --root_path=</path/to/storage/path> --tablet_id=<tabletid>
    print_lake_metadata:
      cat <tablet_meta_file.meta> | meta_tool --operation=print_lake_metadata
    print_lake_bundle_metadata:
      cat <tablet_meta_file.meta> | meta_tool --operation=print_lake_bundle_metadata
    print_lake_txn_log:
      cat <tablet_transaction_log_file.log> | meta_tool --operation=print_lake_txn_log
    print_lake_schema:
      cat <tablet_schema_file> | meta_tool --operation=print_lake_schema
    lake_datafile_gc:
      meta_tool --operation=lake_datafile_gc --root_path=<path> --expired_sec=<86400> --conf_file=<path> --audit_file=<path> --do_delete=<true|false>
    

  Flags from be/src/tools/meta_tool.cpp:
    -audit_file (audit file path) type: string default: ""
    -column_index (column index) type: int32 default: -1
    -conf_file (conf file path) type: string default: ""
    -do_delete (do delete files) type: bool default: false
    -expired_sec (expired seconds) type: int64 default: 86400
    -file (segment file path) type: string default: ""
    -json_meta_path (absolute json meta file path) type: string default: ""
    -key_column_count (key column count) type: int32 default: 0
    -operation (valid operation: get_meta, flag, load_meta, delete_meta,
      delete_rowset_meta, get_persistent_index_meta,
      delete_persistent_index_meta, show_meta, check_table_meta_consistency,
      print_lake_metadata, print_lake_bundle_metadata, print_lake_txn_log,
      print_lake_schema) type: string default: ""
    -pb_meta_path (pb meta file path) type: string default: ""
    -root_path (storage root path) type: string default: ""
    -rowset_id (rowset_id) type: string default: ""
    -schema_hash (schema_hash for tablet meta) type: int32 default: 0
    -table_id (table id for table meta) type: int64 default: 0
    -tablet_file (file to save a set of tablets) type: string default: ""
    -tablet_id (tablet_id for tablet meta) type: int64 default: 0
    -tablet_uid (tablet_uid for tablet meta) type: string default: ""
```
```
$ ./be/bin/meta_tool.sh --help 2>&1 | grep 'Flags from' | wc -l
1
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
