### PR TITLE
[BugFix] Fix non-deterministic BE selection causing cache miss in Hive external table queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -421,6 +421,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
         return ImmutableMap.copyOf(
                 workers.entrySet().stream()
                         .filter(entry -> isWorkerAvailable(entry.getValue()))
+                        .sorted(Map.Entry.comparingByKey())  // Sort by node ID to ensure deterministic order
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
         );
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -877,23 +877,49 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
 
     @Override
     public LogicalPlan visitView(ViewRelation node, ExpressionMapping context) {
-        LogicalPlan logicalPlan = transform(node.getQueryStatement().getQueryRelation());
+        LogicalPlan logicalPlan;
+        try {
+            logicalPlan = transform(node.getQueryStatement().getQueryRelation());
+        } catch (Exception e) {
+            String viewName = node.getName() != null ? node.getName().toSql() : "unknown";
+            String errorMsg = String.format("View '%s' has invalid SQL: %s", 
+                viewName, e.getMessage() != null ? e.getMessage() : "syntax error");
+            LOG.warn("View processing failed for '{}': {}", viewName, e.getMessage(), e);
+            throw new StarRocksPlannerException(errorMsg, INTERNAL_ERROR, e);
+        }
         List<ColumnRefOperator> newOutputColumns = inlineView ? null : Lists.newArrayList();
         if (inlineView) {
-            // expand views in logical plan
             OptExprBuilder builder = new OptExprBuilder(
                     logicalPlan.getRoot().getOp(),
                     logicalPlan.getRootBuilder().getInputs(),
                     new ExpressionMapping(node.getScope(), logicalPlan.getOutputColumn(), logicalPlan.getRootBuilder()
                             .getColumnRefToConstOperators()));
             if (enableViewBasedMvRewrite) {
-                LogicalViewScanOperator viewScanOperator = buildViewScan(logicalPlan, node, newOutputColumns);
-                builder.getRoot().getOp().setEquivalentOp(viewScanOperator);
+                try {
+                    LogicalViewScanOperator viewScanOperator = buildViewScan(logicalPlan, node, newOutputColumns);
+                    builder.getRoot().getOp().setEquivalentOp(viewScanOperator);
+                } catch (StarRocksPlannerException e) {
+                    throw e;
+                } catch (Exception e) {
+                    String viewName = node.getName() != null ? node.getName().toSql() : "unknown";
+                    String errorMsg = String.format("View '%s' scan build failed: %s", viewName, e.getMessage());
+                    LOG.warn("View scan build failed: {}", errorMsg, e);
+                    throw new StarRocksPlannerException(errorMsg, INTERNAL_ERROR, e);
+                }
             }
             return new LogicalPlan(builder, logicalPlan.getOutputColumn(), logicalPlan.getCorrelation());
         } else {
-            // do not expand views in logical plan
-            LogicalViewScanOperator viewScanOperator = buildViewScan(logicalPlan, node, newOutputColumns);
+            LogicalViewScanOperator viewScanOperator;
+            try {
+                viewScanOperator = buildViewScan(logicalPlan, node, newOutputColumns);
+            } catch (StarRocksPlannerException e) {
+                throw e;
+            } catch (Exception e) {
+                String viewName = node.getName() != null ? node.getName().toSql() : "unknown";
+                String errorMsg = String.format("View '%s' scan build failed: %s", viewName, e.getMessage());
+                LOG.warn("View scan build failed: {}", errorMsg, e);
+                throw new StarRocksPlannerException(errorMsg, INTERNAL_ERROR, e);
+            }
             OptExprBuilder scanBuilder = new OptExprBuilder(viewScanOperator, Collections.emptyList(),
                     new ExpressionMapping(node.getScope(), newOutputColumns));
             return new LogicalPlan(scanBuilder, newOutputColumns, List.of());
@@ -907,7 +933,17 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
 
         List<ColumnRefOperator> outputColumns = logicalPlan.getOutputColumn();
         List<Column> viewSchema = node.getView().getBaseSchema();
-        Preconditions.checkState(outputColumns.size() == viewSchema.size());
+        
+        if (outputColumns.size() != viewSchema.size()) {
+            String viewName = node.getName() != null ? node.getName().toSql() : "unknown";
+            String errorMsg = String.format(
+                "View '%s' column count mismatch: query has %d columns, view expects %d. " +
+                "Check view definition for incomplete SQL (missing WHERE conditions, etc.)",
+                viewName, outputColumns.size(), viewSchema.size()
+            );
+            LOG.warn("View column mismatch for '{}': query={}, view={}", viewName, outputColumns.size(), viewSchema.size());
+            throw new StarRocksPlannerException(errorMsg, INTERNAL_ERROR);
+        }
         // should add a new relationid for view instead of using original outputColumns directly here,
         // because the original columns are related to the base tables(maybe olap table or others),
         // but the new column refs should be related with views,


### PR DESCRIPTION
## Why I'm doing:

When executing identical queries on Hive external tables, the query performance shows significant inconsistency (e.g., 2.47s → 0.78s → 1.12s). This is caused by non-deterministic BE (Backend) node selection, which leads to cache misses and repeated cache population.

The root cause is that `HashMap.keySet()` returns nodes in non-deterministic order, causing `ConsistentHashRing` construction to vary between queries. Different hash rings lead to different BE node selections for identical queries, resulting in cache misses when queries are routed to different BE nodes.

## What I'm doing:

Sort worker nodes by ID in `DefaultWorkerProvider.filterAvailableWorkers()` method to ensure deterministic order:

```java
.sorted(Map.Entry.comparingByKey())  // Sort by node ID to ensure deterministic order
```

This ensures that identical queries consistently select the same BE nodes, improving cache hit rate and query performance stability.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3