### PR TITLE
[BugFix] Fix non-deterministic BE selection causing cache miss in Hive external table queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -421,6 +421,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
         return ImmutableMap.copyOf(
                 workers.entrySet().stream()
                         .filter(entry -> isWorkerAvailable(entry.getValue()))
+                        .sorted(Map.Entry.comparingByKey())  // Sort by node ID to ensure deterministic order
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
         );
     }


### PR DESCRIPTION
## Why I'm doing:

When executing identical queries on Hive external tables, the query performance shows significant inconsistency (e.g., 2.47s → 0.78s → 1.12s). This is caused by non-deterministic BE (Backend) node selection, which leads to cache misses and repeated cache population.

The root cause is that `HashMap.keySet()` returns nodes in non-deterministic order, causing `ConsistentHashRing` construction to vary between queries. Different hash rings lead to different BE node selections for identical queries, resulting in cache misses when queries are routed to different BE nodes.

## What I'm doing:

Sort worker nodes by ID in `DefaultWorkerProvider.filterAvailableWorkers()` method to ensure deterministic order:

```java
.sorted(Map.Entry.comparingByKey())  // Sort by node ID to ensure deterministic order
```

This ensures that identical queries consistently select the same BE nodes, improving cache hit rate and query performance stability.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3