### PR TITLE
[Enhancement] Support HH:mm format for cast string to time

### DIFF
--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -1564,6 +1564,32 @@ TEST_F(VectorizedCastExprTest, stringCastToTime) {
     }
 }
 
+TEST_F(VectorizedCastExprTest, stringCastToTime1) {
+    expr_node.child_type = TPrimitiveType::VARCHAR;
+    expr_node.type = gen_type_desc(TPrimitiveType::TIME);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    std::string p("15:15");
+
+    expr_node.type = gen_type_desc(expr_node.child_type);
+    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 10, Slice(p));
+
+    expr->_children.push_back(&col1);
+
+    {
+        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+
+        // right cast
+        auto v = DoubleColumn::static_pointer_cast(ptr);
+        ASSERT_EQ(10, v->size());
+
+        for (int j = 0; j < v->size(); ++j) {
+            ASSERT_EQ(54900, v->get_data()[j]);
+        }
+    }
+}
+
 TEST_F(VectorizedCastExprTest, stringCastToTimeNull1) {
     expr_node.child_type = TPrimitiveType::VARCHAR;
     expr_node.type = gen_type_desc(TPrimitiveType::TIME);
@@ -1582,7 +1608,6 @@ TEST_F(VectorizedCastExprTest, stringCastToTimeNull1) {
 
         // right cast
         auto v = ColumnHelper::as_column<NullableColumn>(ptr);
-
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1609,6 +1634,7 @@ TEST_F(VectorizedCastExprTest, stringCastToTimeNull2) {
 
         // right cast
         auto v = ColumnHelper::as_column<NullableColumn>(ptr);
+
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1618,32 +1644,6 @@ TEST_F(VectorizedCastExprTest, stringCastToTimeNull2) {
 }
 
 TEST_F(VectorizedCastExprTest, stringCastToTimeNull3) {
-    expr_node.child_type = TPrimitiveType::VARCHAR;
-    expr_node.type = gen_type_desc(TPrimitiveType::TIME);
-
-    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
-
-    std::string p("15:15");
-
-    expr_node.type = gen_type_desc(expr_node.child_type);
-    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 10, Slice(p));
-
-    expr->_children.push_back(&col1);
-
-    {
-        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
-
-        // right cast
-        auto v = ColumnHelper::as_column<NullableColumn>(ptr);
-        ASSERT_EQ(10, v->size());
-
-        for (int j = 0; j < v->size(); ++j) {
-            ASSERT_TRUE(v->is_null(j));
-        }
-    }
-}
-
-TEST_F(VectorizedCastExprTest, stringCastToTimeNull4) {
     expr_node.child_type = TPrimitiveType::VARCHAR;
     expr_node.type = gen_type_desc(TPrimitiveType::TIME);
 
@@ -1669,7 +1669,7 @@ TEST_F(VectorizedCastExprTest, stringCastToTimeNull4) {
     }
 }
 
-TEST_F(VectorizedCastExprTest, stringCastToTimeNull5) {
+TEST_F(VectorizedCastExprTest, stringCastToTimeNull4) {
     expr_node.child_type = TPrimitiveType::VARCHAR;
     expr_node.type = gen_type_desc(TPrimitiveType::TIME);
 


### PR DESCRIPTION
## Why I'm doing:
Currently when we cast('HH:mm' as time) will return null, but actually speaking we can make it return HH:mm:00.
Here I will implement it.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3