### PR TITLE
[Enhancement] support desensitize explain

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -330,27 +330,27 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
         if (nameDetail != null) {
             output.append(detailPrefix).append(nameDetail).append("\n");
         }
-        if (aggInfo.getAggregateExprs() != null && aggInfo.getMaterializedAggregateExprs().size() > 0) {
+        if (aggInfo.getAggregateExprs() != null && !aggInfo.getMaterializedAggregateExprs().isEmpty()) {
             if (detailLevel == TExplainLevel.VERBOSE) {
                 output.append(detailPrefix).append("aggregate: ");
             } else {
                 output.append(detailPrefix).append("output: ");
             }
-            output.append(getVerboseExplain(aggInfo.getAggregateExprs(), detailLevel)).append("\n");
+            output.append(explainExpr(detailLevel, aggInfo.getAggregateExprs())).append("\n");
         }
         // TODO: unify them
         if (detailLevel == TExplainLevel.VERBOSE) {
             if (CollectionUtils.isNotEmpty(aggInfo.getGroupingExprs())) {
                 output.append(detailPrefix).append("group by: ").append(
-                        getVerboseExplain(aggInfo.getGroupingExprs(), detailLevel)).append("\n");
+                        explainExpr(detailLevel, aggInfo.getGroupingExprs())).append("\n");
             }
         } else {
             output.append(detailPrefix).append("group by: ").append(
-                    getVerboseExplain(aggInfo.getGroupingExprs(), detailLevel)).append("\n");
+                    explainExpr(detailLevel, aggInfo.getGroupingExprs())).append("\n");
         }
 
         if (!conjuncts.isEmpty()) {
-            output.append(detailPrefix).append("having: ").append(getVerboseExplain(conjuncts, detailLevel))
+            output.append(detailPrefix).append("having: ").append(explainExpr(detailLevel, conjuncts))
                     .append("\n");
         }
         if (useSortAgg) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AnalyticEvalNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AnalyticEvalNode.java
@@ -222,9 +222,9 @@ public class AnalyticEvalNode extends PlanNode {
         for (Expr fnCall : analyticFnCalls) {
             strings.add("[");
             if (detailLevel.equals(TExplainLevel.NORMAL)) {
-                strings.add(fnCall.toSql());
+                strings.add(explainExpr(fnCall));
             } else {
-                strings.add(fnCall.explain());
+                strings.add(explainExpr(TExplainLevel.VERBOSE, List.of(fnCall)));
             }
             strings.add("]");
         }
@@ -238,9 +238,9 @@ public class AnalyticEvalNode extends PlanNode {
 
             for (Expr partitionExpr : partitionExprs) {
                 if (detailLevel.equals(TExplainLevel.NORMAL)) {
-                    strings.add(partitionExpr.toSql());
+                    strings.add(explainExpr(partitionExpr));
                 } else {
-                    strings.add(partitionExpr.explain());
+                    strings.add(explainExpr(TExplainLevel.VERBOSE, List.of(partitionExpr)));
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
@@ -90,7 +90,7 @@ public class DecodeNode extends PlanNode {
                 output.append("<function id ").
                         append(kv.getKey()).
                         append("> : ").
-                        append(kv.getValue().toSql()).
+                        append(explainExpr(kv.getValue())).
                         append("\n");
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -138,19 +138,19 @@ public class DeltaLakeScanNode extends ScanNode {
         }
         if (!scanNodePredicates.getPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getNonPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("NON-PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getNonPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getNonPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getNoEvalPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("NO EVAL-PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getNoEvalPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getNoEvalPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getMinMaxConjuncts().isEmpty()) {
             output.append(prefix).append("MIN/MAX PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getMinMaxConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getMinMaxConjuncts())).append("\n");
         }
 
         output.append(prefix).append(String.format("cardinality=%s", cardinality));

--- a/fe/fe-core/src/main/java/com/starrocks/planner/EsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/EsScanNode.java
@@ -266,19 +266,19 @@ public class EsScanNode extends ScanNode {
 
         if (conjuncts.isEmpty()) {
             output.append(prefix).append("PREDICATES: ").append(
-                    getExplainString(conjuncts)).append("\n");
+                    explainExpr(conjuncts)).append("\n");
             output.append(prefix).append("ES_QUERY_DSL: ").append("{\"match_all\": {}}").append("\n");
         } else {
             QueryConverter queryConverter = new QueryConverter();
             QueryBuilders.QueryBuilder queryBuilder = queryConverter.convert(getConjuncts());
             output.append(prefix).append("PREDICATES: ").append(
-                    getExplainString(conjuncts)).append("\n");
+                    explainExpr(conjuncts)).append("\n");
             // reserved for later using: LOCAL_PREDICATES is processed by StarRocks EsScanNode
             output.append(prefix).append("LOCAL_PREDICATES: ")
-                    .append(getExplainString(queryConverter.localConjuncts()))
+                    .append(explainExpr(queryConverter.localConjuncts()))
                     .append("\n");
             output.append(prefix).append("REMOTE_PREDICATES: ")
-                    .append(getExplainString(queryConverter.remoteConjuncts()))
+                    .append(explainExpr(queryConverter.remoteConjuncts()))
                     .append("\n");
             output.append(prefix)
                     .append("ES_QUERY_DSL: ")

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
@@ -230,7 +230,7 @@ public class ExchangeNode extends PlanNode {
             if (CollectionUtils.isNotEmpty(partitionExprs)) {
                 output.append(detailPrefix)
                         .append("partition exprs: ")
-                        .append(getVerboseExplain(partitionExprs, detailLevel))
+                        .append(explainExpr(detailLevel, partitionExprs))
                         .append('\n');
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
@@ -135,11 +135,11 @@ public class FileTableScanNode extends ScanNode {
 
         if (!scanNodePredicates.getNonPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("NON-PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getNonPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getNonPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getMinMaxConjuncts().isEmpty()) {
             output.append(prefix).append("MIN/MAX PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getMinMaxConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getMinMaxConjuncts())).append("\n");
         }
 
         output.append(prefix).append(String.format("cardinality=%s", cardinality));

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -132,19 +132,19 @@ public class HdfsScanNode extends ScanNode {
         }
         if (!scanNodePredicates.getPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getNonPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("NON-PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getNonPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getNonPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getNoEvalPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("NO EVAL-PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getNoEvalPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getNoEvalPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getMinMaxConjuncts().isEmpty()) {
             output.append(prefix).append("MIN/MAX PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getMinMaxConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getMinMaxConjuncts())).append("\n");
         }
 
         output.append(prefix).append(

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
@@ -97,15 +97,15 @@ public class HudiScanNode extends ScanNode {
         }
         if (!scanNodePredicates.getPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getNonPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("NON-PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getNonPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getNonPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getMinMaxConjuncts().isEmpty()) {
             output.append(prefix).append("MIN/MAX PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getMinMaxConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getMinMaxConjuncts())).append("\n");
         }
 
         output.append(prefix).append(

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -295,11 +295,11 @@ public class IcebergScanNode extends ScanNode {
         }
         if (!conjuncts.isEmpty()) {
             output.append(prefix).append("PREDICATES: ").append(
-                    getExplainString(conjuncts)).append("\n");
+                    explainExpr(conjuncts)).append("\n");
         }
         if (!scanNodePredicates.getMinMaxConjuncts().isEmpty()) {
             output.append(prefix).append("MIN/MAX PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getMinMaxConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getMinMaxConjuncts())).append("\n");
         }
         if (tvrVersionRange != null) {
             output.append(prefix).append("TABLE VERSION: ").append(

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
@@ -55,7 +55,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -515,27 +514,27 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
         for (BinaryPredicate eqJoinPredicate : eqJoinConjuncts) {
             output.append(detailPrefix).append("equal join conjunct: ");
             if (detailLevel.equals(TExplainLevel.VERBOSE)) {
-                output.append(eqJoinPredicate.explain());
+                output.append(explainExpr(detailLevel, List.of(eqJoinPredicate)));
             } else {
-                output.append(eqJoinPredicate.toSql());
+                output.append(explainExpr(eqJoinPredicate));
             }
             output.append("\n");
         }
         if (!otherJoinConjuncts.isEmpty()) {
-            output.append(detailPrefix + "other join predicates: ").append(
-                    getVerboseExplain(otherJoinConjuncts, detailLevel) + "\n");
+            output.append(detailPrefix).append("other join predicates: ")
+                    .append(explainExpr(detailLevel, otherJoinConjuncts)).append("\n");
         }
         if (!conjuncts.isEmpty()) {
             output.append(detailPrefix).append("other predicates: ")
-                    .append(getVerboseExplain(conjuncts, detailLevel))
+                    .append(explainExpr(detailLevel, conjuncts))
                     .append("\n");
         }
 
         if (commonSlotMap != null && !commonSlotMap.isEmpty()) {
-            output.append(detailPrefix + "  common sub expr:" + "\n");
+            output.append(detailPrefix).append("  common sub expr:").append("\n");
             for (Map.Entry<SlotId, Expr> entry : commonSlotMap.entrySet()) {
-                output.append(detailPrefix + "  <slot " + entry.getKey().toString() + "> : "
-                        + getExplainString(Arrays.asList(entry.getValue())) + "\n");
+                output.append(detailPrefix).append("  <slot ").append(entry.getKey().toString()).append("> : ")
+                        .append(explainExpr(entry.getValue())).append("\n");
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/KuduScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/KuduScanNode.java
@@ -176,19 +176,19 @@ public class KuduScanNode extends ScanNode {
         }
         if (!scanNodePredicates.getPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getNonPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("NON-PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getNonPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getNonPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getNoEvalPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("NO EVAL-PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getNoEvalPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getNoEvalPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getMinMaxConjuncts().isEmpty()) {
             output.append(prefix).append("MIN/MAX PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getMinMaxConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getMinMaxConjuncts())).append("\n");
         }
 
         // TODO: support it in verbose

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -845,7 +845,7 @@ public class OlapScanNode extends ScanNode {
             }
             if (!conjuncts.isEmpty()) {
                 output.append(prefix).append("PREDICATES: ").append(
-                        getExplainString(conjuncts)).append("\n");
+                        explainExpr(conjuncts)).append("\n");
             }
         } else {
             if (isPreAggregation) {
@@ -855,7 +855,7 @@ public class OlapScanNode extends ScanNode {
                         .append("\n");
             }
             if (!conjuncts.isEmpty()) {
-                output.append(prefix).append("Predicates: ").append(getVerboseExplain(conjuncts)).append("\n");
+                output.append(prefix).append("Predicates: ").append(explainExpr(TExplainLevel.VERBOSE, conjuncts)).append("\n");
             }
             if (!dictStringIdToIntIds.isEmpty()) {
                 List<String> flatDictList = dictStringIdToIntIds.entrySet().stream().limit(5)

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -349,19 +349,19 @@ public class PaimonScanNode extends ScanNode {
         }
         if (!scanNodePredicates.getPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getNonPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("NON-PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getNonPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getNonPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getNoEvalPartitionConjuncts().isEmpty()) {
             output.append(prefix).append("NO EVAL-PARTITION PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getNoEvalPartitionConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getNoEvalPartitionConjuncts())).append("\n");
         }
         if (!scanNodePredicates.getMinMaxConjuncts().isEmpty()) {
             output.append(prefix).append("MIN/MAX PREDICATES: ").append(
-                    getExplainString(scanNodePredicates.getMinMaxConjuncts())).append("\n");
+                    explainExpr(scanNodePredicates.getMinMaxConjuncts())).append("\n");
         }
 
         List<String> partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
@@ -88,7 +88,7 @@ public class ProjectNode extends PlanNode {
                 output.append("<slot ").
                         append(kv.first).
                         append("> : ").
-                        append(kv.second.toSql()).
+                        append(explainExpr(kv.second)).
                         append("\n");
             }
         }
@@ -103,7 +103,7 @@ public class ProjectNode extends PlanNode {
                     output.append("<slot ").
                             append(kv.getKey()).
                             append("> : ").
-                            append(kv.getValue().toSql()).
+                            append(explainExpr(kv.getValue())).
                             append("\n");
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RepeatNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RepeatNode.java
@@ -134,7 +134,7 @@ public class RepeatNode extends PlanNode {
         output.append("\n");
         if (!conjuncts.isEmpty()) {
             output.append(detailPrefix).append("PREDICATES: ").append(
-                    getExplainString(conjuncts)).append("\n");
+                    explainExpr(conjuncts)).append("\n");
         }
 
         if (CollectionUtils.isNotEmpty(outputTupleDesc.getSlots()) &&

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SelectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SelectNode.java
@@ -46,7 +46,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -98,12 +97,12 @@ public class SelectNode extends PlanNode {
     protected String getNodeExplainString(String prefix, TExplainLevel detailLevel) {
         StringBuilder output = new StringBuilder();
         if (!conjuncts.isEmpty()) {
-            output.append(prefix + "predicates: " + getExplainString(conjuncts) + "\n");
+            output.append(prefix + "predicates: " + explainExpr(conjuncts) + "\n");
             if (commonSlotMap != null && !commonSlotMap.isEmpty()) {
                 output.append(prefix + "  common sub expr:" + "\n");
                 for (Map.Entry<SlotId, Expr> entry : commonSlotMap.entrySet()) {
                     output.append(prefix + "  <slot " + entry.getKey().toString() + "> : "
-                            + getExplainString(Arrays.asList(entry.getValue())) + "\n");
+                            + explainExpr(entry.getValue()) + "\n");
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SetOperationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SetOperationNode.java
@@ -215,12 +215,12 @@ public abstract class SetOperationNode extends PlanNode {
         // A SetOperationNode may have predicates if a union is set operation inside an inline view,
         // and the enclosing select stmt has predicates referring to the inline view.
         if (CollectionUtils.isNotEmpty(conjuncts)) {
-            output.append(prefix).append("predicates: ").append(getExplainString(conjuncts)).append("\n");
+            output.append(prefix).append("predicates: ").append(explainExpr(conjuncts)).append("\n");
         }
         if (CollectionUtils.isNotEmpty(constExprLists_)) {
             output.append(prefix).append("constant exprs: ").append("\n");
             for (List<Expr> exprs : constExprLists_) {
-                output.append(prefix).append("    ").append(exprs.stream().map(Expr::toSql)
+                output.append(prefix).append("    ").append(exprs.stream().map(this::explainExpr)
                         .collect(Collectors.joining(" | "))).append("\n");
             }
         }
@@ -228,15 +228,20 @@ public abstract class SetOperationNode extends PlanNode {
             if (CollectionUtils.isNotEmpty(setOperationOutputList)) {
                 output.append(prefix).append("output exprs:").append("\n");
                 output.append(prefix).append("    ")
-                        .append(setOperationOutputList.stream().map(Expr::explain).collect(
-                                Collectors.joining(" | "))).append("\n");
+                        .append(setOperationOutputList.stream()
+                                .map(c -> explainExpr(detailLevel, List.of(c)))
+                                .collect(Collectors.joining(" | ")))
+                        .append("\n");
             }
 
             if (CollectionUtils.isNotEmpty(materializedResultExprLists_)) {
                 output.append(prefix).append("child exprs:").append("\n");
                 for (List<Expr> exprs : materializedResultExprLists_) {
-                    output.append(prefix).append("    ").append(exprs.stream().map(Expr::explain)
-                            .collect(Collectors.joining(" | "))).append("\n");
+                    output.append(prefix).append("    ")
+                            .append(exprs.stream()
+                                    .map(c -> explainExpr(detailLevel, List.of(c)))
+                                    .collect(Collectors.joining(" | ")))
+                            .append("\n");
                 }
             }
             List<String> passThroughNodeIds = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -292,9 +292,9 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
                 output.append(", ");
             }
             if (detailLevel.equals(TExplainLevel.NORMAL)) {
-                output.append(partitionExpr.next().toSql()).append(" ");
+                output.append(explainExpr(partitionExpr.next())).append(" ");
             } else {
-                output.append(partitionExpr.next().explain()).append(" ");
+                output.append(explainExpr(TExplainLevel.VERBOSE, List.of(partitionExpr.next()))).append(" ");
             }
         }
         if (!start) {
@@ -312,9 +312,9 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
                 output.append(", ");
             }
             if (detailLevel.equals(TExplainLevel.NORMAL)) {
-                output.append(orderExpr.next().toSql()).append(" ");
+                output.append(explainExpr(orderExpr.next())).append(" ");
             } else {
-                output.append(orderExpr.next().explain()).append(" ");
+                output.append(explainExpr(TExplainLevel.VERBOSE, List.of(orderExpr.next()))).append(" ");
             }
             output.append(isAsc.next() ? "ASC" : "DESC");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/stream/StreamAggNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/stream/StreamAggNode.java
@@ -58,23 +58,23 @@ public class StreamAggNode extends PlanNode {
         if (CollectionUtils.isNotEmpty(aggInfo.getMaterializedAggregateExprs())) {
             output.append(detailPrefix)
                     .append("output: ")
-                    .append(getExplainString(aggInfo.getAggregateExprs()))
+                    .append(explainExpr(aggInfo.getAggregateExprs()))
                     .append("\n");
         }
         output.append(detailPrefix)
                 .append("group_by: ")
-                .append(getExplainString(aggInfo.getGroupingExprs()))
+                .append(explainExpr(aggInfo.getGroupingExprs()))
                 .append("\n");
         if (!conjuncts.isEmpty()) {
-            output.append(detailPrefix).append("having: ").append(getExplainString(conjuncts)).append("\n");
+            output.append(detailPrefix).append("having: ").append(explainExpr(conjuncts)).append("\n");
         }
 
         if (detailLevel == TExplainLevel.VERBOSE) {
             if (detailImt != null) {
-                output.append(detailPrefix).append("detail_imt: ").append(detailImt.toString()).append("\n");
+                output.append(detailPrefix).append("detail_imt: ").append(detailImt).append("\n");
             }
             if (aggImt != null) {
-                output.append(detailPrefix).append("agg_imt: ").append(aggImt.toString()).append("\n");
+                output.append(detailPrefix).append("agg_imt: ").append(aggImt).append("\n");
             }
         }
         return output.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -955,6 +955,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_DROP_TABLE_CHECK_MV_DEPENDENCY = "enable_drop_table_check_mv_dependency";
 
+    public static final String ENABLE_DESENSITIZE_EXPLAIN = "enable_desensitize_explain";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1930,6 +1932,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_DEFER_PROJECT_AFTER_TOPN)
     private boolean enableDeferProjectAfterTopN = true;
 
+    @VarAttr(name = ENABLE_DESENSITIZE_EXPLAIN)
+    private boolean enableDesensitizeExplain = false;
+
     // When this variable is enabled, the limits of consumers a CTE are pushed down to the producer of the CTE.
     // The limits can then be applied before the exchange.
     // For example:
@@ -1946,6 +1951,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_DROP_TABLE_CHECK_MV_DEPENDENCY)
     public boolean enableDropTableCheckMvDependency = false;
+
+    public boolean isEnableDesensitizeExplain() {
+        return enableDesensitizeExplain;
+    }
+
+    public void setEnableDesensitizeExplain(boolean enableDesensitizeExplain) {
+        this.enableDesensitizeExplain = enableDesensitizeExplain;
+    }
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/ExprExplainVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/ExprExplainVisitor.java
@@ -76,10 +76,14 @@ import java.util.stream.Collectors;
  * @Todo: merge with AST2StringVisitor
  */
 public class ExprExplainVisitor implements AstVisitorExtendInterface<String, Void> {
-    private final FormatOptions options = FormatOptions.allEnable();
+    private FormatOptions options = FormatOptions.allEnable();
 
     public ExprExplainVisitor() {
         options.setEnableDigest(false);
+    }
+
+    public ExprExplainVisitor(FormatOptions options) {
+        this.options = options;
     }
 
     // ========================================= Helper Methods =========================================

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/ExprVerboseVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/ExprVerboseVisitor.java
@@ -22,6 +22,14 @@ import java.util.stream.Collectors;
 
 public class ExprVerboseVisitor extends ExprExplainVisitor {
 
+    public ExprVerboseVisitor() {
+        super();
+    }
+
+    public ExprVerboseVisitor(FormatOptions options) {
+        super(options);
+    }
+
     @Override
     public String visitFunctionCall(FunctionCallExpr node, Void context) {
         StringBuilder sb = new StringBuilder();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1191,7 +1191,7 @@ public class LowCardinalityTest extends PlanTestBase {
         assertContains(plan, "  2:SORT\n" +
                 "  |  order by: [20, INT, false] ASC, [2, INT, false] ASC");
         Assertions.assertTrue(plan.contains("  1:PARTITION-TOP-N\n" +
-                "  |  partition by: [20: L_COMMENT, INT, false] "));
+                "  |  partition by: [20: L_COMMENT, INT, false] "), plan);
         Assertions.assertTrue(plan.contains("  |  order by: [20, INT, false] ASC, [2, INT, false] ASC"));
 
         // row number

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ParseNode.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ParseNode.java
@@ -27,6 +27,6 @@ public interface ParseNode {
     NodePosition getPos();
 
     default <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        throw new RuntimeException(this.toSql() + " Not implement accept function");
+        throw new RuntimeException(this.getClass().getName() + " Not implement accept function");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

* add `enable_desensitize_explain` to control explain desensitizion

```
MySQL td> set enable_desensitize_explain=false
Query OK, 0 rows affected
Time: 0.002s
MySQL td> explain select * from t1 where v2 = 2;
+-----------------------------+
| Explain String              |
+-----------------------------+
| PLAN FRAGMENT 0             |
|  OUTPUT EXPRS:1: v1 | 2: v2 |
|   PARTITION: RANDOM         |
|                             |
|   RESULT SINK               |
|                             |
|   0:OlapScanNode            |
|      TABLE: t1              |
|      PREAGGREGATION: ON     |
|      PREDICATES: 2: v2 = 2  |
|      partitions=1/1         |
|      rollup: t1             |
|      tabletRatio=1/1        |
|      tabletList=74058       |
|      cardinality=1          |
|      avgRowSize=8.0         |
+-----------------------------+
16 rows in set
Time: 0.013s
MySQL td> set enable_desensitize_explain=true
Query OK, 0 rows affected
Time: 0.002s
MySQL td> explain select * from t1 where v2 = 2;
+-----------------------------+
| Explain String              |
+-----------------------------+
| PLAN FRAGMENT 0             |
|  OUTPUT EXPRS:1: v1 | 2: v2 |
|   PARTITION: RANDOM         |
|                             |
|   RESULT SINK               |
|                             |
|   0:OlapScanNode            |
|      TABLE: t1              |
|      PREAGGREGATION: ON     |
|      PREDICATES: 2: v2 = ?  |
|      partitions=1/1         |
|      rollup: t1             |
|      tabletRatio=1/1        |
|      tabletList=74058       |
|      cardinality=1          |
|      avgRowSize=8.0         |
+-----------------------------+
16 rows in set
Time: 0.015s
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
