### PR TITLE
[BugFix] skip combine txnlog when handle non-pk table deletion

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -259,6 +259,11 @@ public class LakeTableHelper {
                 sourceType == TransactionState.LoadJobSourceType.BATCH_LOAD_JOB;
     }
 
+    // for now, only loading txn and compaction txn support combined txn log
+    public static boolean isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType sourceType) {
+        return isLoadingTransaction(sourceType) || sourceType == TransactionState.LoadJobSourceType.LAKE_COMPACTION;
+    }
+
     // if one of the tables in tableIdList is LakeTable with file bundling, return true
     // else return false
     public static boolean fileBundling(long dbId, List<Long> tableIdList) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -185,7 +185,7 @@ public class DatabaseTransactionMgr {
 
         long tid = globalStateMgr.getGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
         boolean combinedTxnLog = LakeTableHelper.supportCombinedTxnLog(sourceType);
-        boolean fileBundling = LakeTableHelper.fileBundling(dbId, tableIdList);
+        boolean fileBundling = LakeTableHelper.fileBundling(dbId, tableIdList) && LakeTableHelper.isTransactionSupportCombinedTxnLog(sourceType);
         LOG.info("begin transaction: txn_id: {} with label {} from coordinator {}, listner id: {}",
                 tid, label, coordinator, callbackId);
         TransactionState transactionState = new TransactionState(dbId, tableIdList, tid, label, requestId, sourceType,

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -185,7 +185,8 @@ public class DatabaseTransactionMgr {
 
         long tid = globalStateMgr.getGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
         boolean combinedTxnLog = LakeTableHelper.supportCombinedTxnLog(sourceType);
-        boolean fileBundling = LakeTableHelper.fileBundling(dbId, tableIdList) && LakeTableHelper.isTransactionSupportCombinedTxnLog(sourceType);
+        boolean fileBundling = LakeTableHelper.fileBundling(dbId, tableIdList)
+                && LakeTableHelper.isTransactionSupportCombinedTxnLog(sourceType);
         LOG.info("begin transaction: txn_id: {} with label {} from coordinator {}, listner id: {}",
                 tid, label, coordinator, callbackId);
         TransactionState transactionState = new TransactionState(dbId, tableIdList, tid, label, requestId, sourceType,

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -250,4 +250,17 @@ public class LakeTableHelperTest {
         Assertions.assertTrue(result.isPresent());
         Assertions.assertEquals(12345L, result.get().longValue());
     }
+
+    @Test
+    public void testIsTransactionSupportCombinedTxnLog() {
+        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.BACKEND_STREAMING));
+        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK));
+        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.INSERT_STREAMING));
+        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.BATCH_LOAD_JOB));
+        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.LAKE_COMPACTION));
+        Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.FRONTEND_STREAMING));
+        Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.BYPASS_WRITE));
+        Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.DELETE));
+        Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.MV_REFRESH));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -253,14 +253,23 @@ public class LakeTableHelperTest {
 
     @Test
     public void testIsTransactionSupportCombinedTxnLog() {
-        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.BACKEND_STREAMING));
-        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK));
-        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.INSERT_STREAMING));
-        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.BATCH_LOAD_JOB));
-        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.LAKE_COMPACTION));
-        Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.FRONTEND_STREAMING));
-        Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.BYPASS_WRITE));
-        Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.DELETE));
-        Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType.MV_REFRESH));
+        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(
+                    TransactionState.LoadJobSourceType.BACKEND_STREAMING));
+        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(
+                    TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK));
+        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(
+                    TransactionState.LoadJobSourceType.INSERT_STREAMING));
+        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(
+                    TransactionState.LoadJobSourceType.BATCH_LOAD_JOB));
+        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(
+                    TransactionState.LoadJobSourceType.LAKE_COMPACTION));
+        Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(
+                    TransactionState.LoadJobSourceType.FRONTEND_STREAMING));
+        Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(
+                    TransactionState.LoadJobSourceType.BYPASS_WRITE));
+        Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(
+                    TransactionState.LoadJobSourceType.DELETE));
+        Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(
+                    TransactionState.LoadJobSourceType.MV_REFRESH));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
We do not support combine txnlog when handle non-pk table deletion yet, so need to skip set `UseCombinedTxnLog` to these transactions when begin transaction.

## What I'm doing:
This pull request introduces a new utility method to determine whether a transaction supports combined transaction logs and updates the transaction initialization logic to use this method. It also adds corresponding unit tests to ensure the new logic is correct.

**Support for combined transaction logs:**

* Added `isTransactionSupportCombinedTxnLog` method to `LakeTableHelper`, which returns true if the transaction source type supports combined transaction logs (i.e., loading or compaction transactions).

**Transaction initialization logic:**

* Updated the `beginTransaction` method in `DatabaseTransactionMgr` to only enable file bundling if the transaction supports combined transaction logs, making the logic more robust and consistent.

**Testing:**

* Added a unit test for `isTransactionSupportCombinedTxnLog` in `LakeTableHelperTest` to verify support for each relevant transaction source type.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
