### PR TITLE
[BugFix] Use session default db in show create routine load if unspecified

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
@@ -64,6 +64,7 @@ import com.starrocks.sql.ast.ShowBasicStatsMetaStmt;
 import com.starrocks.sql.ast.ShowColumnStmt;
 import com.starrocks.sql.ast.ShowCreateDbStmt;
 import com.starrocks.sql.ast.ShowCreateExternalCatalogStmt;
+import com.starrocks.sql.ast.ShowCreateRoutineLoadStmt;
 import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.sql.ast.ShowDataDistributionStmt;
 import com.starrocks.sql.ast.ShowDataStmt;
@@ -232,6 +233,14 @@ public class ShowStmtAnalyzer {
 
         @Override
         public Void visitShowRoutineLoadStatement(ShowRoutineLoadStmt node, ConnectContext context) {
+            String dbName = node.getDbFullName();
+            dbName = getDatabaseName(dbName, context);
+            node.setDb(dbName);
+            return null;
+        }
+
+        @Override
+        public Void visitShowCreateRoutineLoadStatement(ShowCreateRoutineLoadStmt node, ConnectContext context) {
             String dbName = node.getDbFullName();
             dbName = getDatabaseName(dbName, context);
             node.setDb(dbName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowCreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowCreateRoutineLoadStmt.java
@@ -37,8 +37,8 @@ public class ShowCreateRoutineLoadStmt extends ShowStmt {
         return labelName.getDbName();
     }
 
-    public void setLabelName(LabelName labelName) {
-        this.labelName = labelName;
+    public void setDb(String db) {
+        labelName.setDbName(db);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateRoutineLoadStmtTest.java
@@ -58,4 +58,14 @@ public class ShowCreateRoutineLoadStmtTest {
         Assertions.assertEquals("testDb", stmt.getDbFullName());
         Assertions.assertEquals("rl_test", stmt.getName());
     }
+
+    @Test
+    public void testNoDb() {
+        ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setDatabase("testDb2");
+        ShowCreateRoutineLoadStmt stmt = new ShowCreateRoutineLoadStmt(new LabelName(null, "testJob2"));
+        com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
+        Assertions.assertEquals("testJob2", stmt.getName());
+        Assertions.assertEquals("testDb2", stmt.getDbFullName());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

when executing `show create routine load job1`, db is null in the statement and FE will get routine load job with `job1` from all databases, causing wrong `create routine load` result.

## What I'm doing:

use session default db in `show create routine load` if db is unspecified.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
