### PR TITLE
[Refactor] Refactors broker property persistence and usage

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -70,7 +70,6 @@ import com.starrocks.metric.MetricRepo;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.ast.BrokerDesc;
 import com.starrocks.sql.ast.expression.TableRefPersist;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
@@ -658,9 +657,8 @@ public class BackupJob extends AbstractJob {
                 }
                 Preconditions.checkState(brokers.size() == 1);
             } else {
-                BrokerDesc brokerDesc = new BrokerDesc(repo.getStorage().getProperties());
                 try {
-                    HdfsUtil.getTProperties(repo.getLocation(), brokerDesc, hdfsProperties);
+                    HdfsUtil.getTProperties(repo.getLocation(), repo.getStorage().getProperties(), hdfsProperties);
                 } catch (StarRocksException e) {
                     status = new Status(ErrCode.COMMON_ERROR, "Get properties from " + repo.getLocation() + " error.");
                     return;

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1368,7 +1368,7 @@ public class RestoreJob extends AbstractJob {
                     } else {
                         BrokerDesc brokerDesc = new BrokerDesc(repo.getStorage().getProperties());
                         try {
-                            HdfsUtil.getTProperties(repo.getLocation(), brokerDesc, hdfsProperties);
+                            HdfsUtil.getTProperties(repo.getLocation(), brokerDesc.getProperties(), hdfsProperties);
                         } catch (StarRocksException e) {
                             status = new Status(ErrCode.COMMON_ERROR,
                                     "Get properties from " + repo.getLocation() + " error.");

--- a/fe/fe-core/src/main/java/com/starrocks/fs/HdfsUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/HdfsUtil.java
@@ -245,15 +245,17 @@ public class HdfsUtil {
     /**
      * Delete path with broker
      *
-     * @param path
-     * @param brokerDesc
+     * @param path remote path to delete
+     * @param properties broker/hdfs properties
      * @throws StarRocksException if broker op failed
      */
-    public static void deletePath(String path, BrokerDesc brokerDesc) throws StarRocksException {
+    public static void deletePath(String path, Map<String, String> properties) throws StarRocksException {
         TBrokerDeletePathRequest tDeletePathRequest = new TBrokerDeletePathRequest(
-                    TBrokerVersion.VERSION_ONE, path, brokerDesc.getProperties());
-        hdfsService.deletePath(tDeletePathRequest);    
+                    TBrokerVersion.VERSION_ONE, path, properties);
+        hdfsService.deletePath(tDeletePathRequest);
     }
+
+    // removed BrokerDesc overload; use deletePath(String, Map<String,String>) instead
 
     public static boolean checkPathExist(String remotePath, BrokerDesc brokerDesc) throws StarRocksException {
         TBrokerCheckPathExistRequest tCheckPathExistRequest = new TBrokerCheckPathExistRequest(

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFileSystemWrap.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFileSystemWrap.java
@@ -17,7 +17,6 @@ package com.starrocks.fs.hdfs;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.fs.FileSystem;
 import com.starrocks.fs.HdfsUtil;
-import com.starrocks.sql.ast.BrokerDesc;
 import com.starrocks.thrift.THdfsProperties;
 import org.apache.hadoop.fs.FileStatus;
 
@@ -33,13 +32,13 @@ public class HdfsFileSystemWrap implements FileSystem {
 
     @Override
     public List<FileStatus> globList(String path, boolean skipDir) throws StarRocksException {
-        return HdfsUtil.listFileMeta(path, new BrokerDesc(properties), skipDir);
+        return HdfsUtil.listFileMeta(path, properties, skipDir);
     }
 
     @Override
     public THdfsProperties getHdfsProperties(String path) throws StarRocksException {
         THdfsProperties hdfsProperties = new THdfsProperties();
-        HdfsUtil.getTProperties(path, new BrokerDesc(properties), hdfsProperties);
+        HdfsUtil.getTProperties(path, properties, hdfsProperties);
         return hdfsProperties;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotUtils.java
@@ -17,7 +17,6 @@ package com.starrocks.lake.snapshot;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.fs.HdfsUtil;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.ast.BrokerDesc;
 import com.starrocks.storagevolume.StorageVolume;
 
 public class ClusterSnapshotUtils {
@@ -46,9 +45,7 @@ public class ClusterSnapshotUtils {
         }
 
         StorageVolume sv = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getStorageVolumeBySnapshotJob(job);
-        BrokerDesc brokerDesc = new BrokerDesc(sv.getProperties());
         String snapshotImagePath = getSnapshotImagePath(sv, snapshotName);
-
-        HdfsUtil.deletePath(snapshotImagePath, brokerDesc);
+        HdfsUtil.deletePath(snapshotImagePath, sv.getProperties());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
@@ -23,7 +23,6 @@ import com.starrocks.persist.Storage;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.server.StorageVolumeMgr;
-import com.starrocks.sql.ast.BrokerDesc;
 import com.starrocks.staros.StarMgrServer;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
@@ -143,7 +142,7 @@ public class RestoreClusterSnapshotMgr {
         if (snapshotImagePath.endsWith("/meta")) {
             String pathPattern = snapshotImagePath + "/image/" + ClusterSnapshotMgr.AUTOMATED_NAME_PREFIX + '*';
             List<FileStatus> fileStatusList = HdfsUtil.listFileMeta(pathPattern,
-                    new BrokerDesc(clusterSnapshot.getStorageVolume().getProperties()), false);
+                    clusterSnapshot.getStorageVolume().getProperties(), false);
             if (fileStatusList.isEmpty() || fileStatusList.get(0).isFile()) {
                 throw new StarRocksException("No cluster snapshot found in path " + pathPattern);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -67,6 +67,7 @@ import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.fs.HdfsUtil;
+import com.starrocks.persist.BrokerPropertiesPersistInfo;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.planner.DataPartition;
 import com.starrocks.planner.DescriptorTable;
@@ -157,7 +158,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
     @SerializedName("td")
     private long tableId;
     @SerializedName("bd")
-    private BrokerDesc brokerDesc;
+    private BrokerPropertiesPersistInfo brokerPersistInfo;
     // exportPath has "/" suffix
     @SerializedName("ep")
     private String exportPath;
@@ -240,7 +241,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         // try to acquire resource from warehouse
         CRAcquireContext acquireContext = CRAcquireContext.of(this.warehouseId, this.computeResource);
-        this.computeResource =  warehouseManager.acquireComputeResource(acquireContext);
+        this.computeResource = warehouseManager.acquireComputeResource(acquireContext);
 
         String dbName = stmt.getTblName().getDb();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
@@ -248,8 +249,10 @@ public class ExportJob implements Writable, GsonPostProcessable {
             throw new DdlException("Database " + dbName + " does not exist");
         }
 
-        this.brokerDesc = stmt.getBrokerDesc();
-        Preconditions.checkNotNull(brokerDesc);
+        BrokerDesc brokerDescFromStmt = stmt.getBrokerDesc();
+        this.brokerPersistInfo = brokerDescFromStmt != null ?
+                new BrokerPropertiesPersistInfo(brokerDescFromStmt.getName(), brokerDescFromStmt.getProperties()) : null;
+        Preconditions.checkNotNull(brokerDescFromStmt);
 
         this.columnSeparator = stmt.getColumnSeparator();
         this.rowDelimiter = stmt.getRowDelimiter();
@@ -278,7 +281,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
         this.tableName = stmt.getTblName();
 
         try (AutoCloseableLock ignore = new AutoCloseableLock(new Locker(), db.getId(), Lists.newArrayList(this.tableId),
-                    LockType.READ)) {
+                LockType.READ)) {
             genExecFragment(stmt);
         }
 
@@ -396,7 +399,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
         }
 
         LOG.info("total {} tablets of export job {}, and assign them to {} coordinators",
-                    tabletLocations.size(), id, fragments.size());
+                tabletLocations.size(), id, fragments.size());
     }
 
     private ScanNode genScanNode() throws StarRocksException {
@@ -425,10 +428,10 @@ public class ExportJob implements Writable, GsonPostProcessable {
 
     private OlapScanNode genOlapScanNodeByLocation(List<TScanRangeLocations> locations) {
         return OlapScanNode.createOlapScanNodeByLocation(
-                    new PlanNodeId(nextId.getAndIncrement()),
-                    exportTupleDesc,
-                    "OlapScanNodeForExport",
-                    locations,
+                new PlanNodeId(nextId.getAndIncrement()),
+                exportTupleDesc,
+                "OlapScanNodeForExport",
+                locations,
                 computeResource);
     }
 
@@ -439,11 +442,11 @@ public class ExportJob implements Writable, GsonPostProcessable {
             case OLAP:
             case CLOUD_NATIVE:
                 fragment = new PlanFragment(
-                            new PlanFragmentId(nextId.getAndIncrement()), scanNode, DataPartition.RANDOM);
+                        new PlanFragmentId(nextId.getAndIncrement()), scanNode, DataPartition.RANDOM);
                 break;
             case MYSQL:
                 fragment = new PlanFragment(
-                            new PlanFragmentId(nextId.getAndIncrement()), scanNode, DataPartition.UNPARTITIONED);
+                        new PlanFragmentId(nextId.getAndIncrement()), scanNode, DataPartition.UNPARTITIONED);
                 break;
             default:
                 break;
@@ -455,11 +458,12 @@ public class ExportJob implements Writable, GsonPostProcessable {
 
         scanNode.setFragmentId(fragment.getFragmentId());
         THdfsProperties hdfsProperties = new THdfsProperties();
-        if (!brokerDesc.hasBroker()) {
-            HdfsUtil.getTProperties(exportTempPath, brokerDesc, hdfsProperties);
+        BrokerDesc runtimeBrokerDesc = new BrokerDesc(brokerPersistInfo.getName(), brokerPersistInfo.getProperties());
+        if (!brokerPersistInfo.hasBroker()) {
+            HdfsUtil.getTProperties(exportTempPath, runtimeBrokerDesc, hdfsProperties);
         }
         fragment.setSink(new ExportSink(exportTempPath, fileNamePrefix + taskIdx + "_", columnSeparator,
-                    rowDelimiter, brokerDesc, hdfsProperties));
+                rowDelimiter, runtimeBrokerDesc, hdfsProperties));
         try {
             fragment.createDataSink(TResultSinkType.MYSQL_PROTOCAL);
         } catch (Exception e) {
@@ -495,12 +499,12 @@ public class ExportJob implements Writable, GsonPostProcessable {
             ScanNode scanNode = nodes.get(i);
             TUniqueId queryId = new TUniqueId(uuid.getMostSignificantBits() + i, uuid.getLeastSignificantBits());
             Coordinator coord = getCoordinatorFactory().createBrokerExportScheduler(
-                        id, queryId, desc, Lists.newArrayList(fragment), Lists.newArrayList(scanNode),
-                        TimeUtils.DEFAULT_TIME_ZONE, stmt.getExportStartTime(),
+                    id, queryId, desc, Lists.newArrayList(fragment), Lists.newArrayList(scanNode),
+                    TimeUtils.DEFAULT_TIME_ZONE, stmt.getExportStartTime(),
                     Maps.newHashMap(), getMemLimit(), computeResource);
             this.coordList.add(coord);
             LOG.info("split export job to tasks. job id: {}, job query id: {}, task idx: {}, task query id: {}",
-                        id, DebugUtil.printId(this.queryId), i, DebugUtil.printId(queryId));
+                    id, DebugUtil.printId(this.queryId), i, DebugUtil.printId(queryId));
         }
         LOG.info("create {} coordinators for export job: {}", coordList.size(), id);
     }
@@ -539,8 +543,8 @@ public class ExportJob implements Writable, GsonPostProcessable {
         PlanFragment newFragment = genPlanFragment(exportTable.getType(), newTaskScanNode, taskIndex);
 
         Coordinator newCoord = getCoordinatorFactory().createBrokerExportScheduler(
-                    id, newQueryId, desc, Lists.newArrayList(newFragment), Lists.newArrayList(newTaskScanNode),
-                    TimeUtils.DEFAULT_TIME_ZONE, coord.getStartTimeMs(), Maps.newHashMap(), getMemLimit(), computeResource);
+                id, newQueryId, desc, Lists.newArrayList(newFragment), Lists.newArrayList(newTaskScanNode),
+                TimeUtils.DEFAULT_TIME_ZONE, coord.getStartTimeMs(), Maps.newHashMap(), getMemLimit(), computeResource);
         this.coordList.set(taskIndex, newCoord);
         LOG.info("reset coordinator for export job: {}, taskIdx: {}", id, taskIndex);
         return newCoord;
@@ -595,11 +599,11 @@ public class ExportJob implements Writable, GsonPostProcessable {
     }
 
     public BrokerDesc getBrokerDesc() {
-        return brokerDesc;
+        return brokerPersistInfo == null ? null : new BrokerDesc(brokerPersistInfo.getName(), brokerPersistInfo.getProperties());
     }
 
     public void setBrokerDesc(BrokerDesc brokerDesc) {
-        this.brokerDesc = brokerDesc;
+        this.brokerPersistInfo = brokerDesc == null ? null : new BrokerPropertiesPersistInfo(brokerDesc.getProperties());
     }
 
     public String getExportPath() {
@@ -755,7 +759,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
         }
         if (!isReplay) {
             GlobalStateMgr.getCurrentState().getEditLog().logExportUpdateState(id, newState, stateChangeTime,
-                        snapshotPaths, exportTempPath, exportedFiles, failMsg);
+                    snapshotPaths, exportTempPath, exportedFiles, failMsg);
         }
         return true;
     }
@@ -791,9 +795,9 @@ public class ExportJob implements Writable, GsonPostProcessable {
 
             try {
                 TAgentResult result = ThriftRPCRequestExecutor.callNoRetry(
-                            ThriftConnectionPool.backendPool,
-                            new TNetworkAddress(host, port),
-                            client -> client.release_snapshot(snapshotPath.second)
+                        ThriftConnectionPool.backendPool,
+                        new TNetworkAddress(host, port),
+                        client -> client.release_snapshot(snapshotPath.second)
                 );
                 if (result.getStatus().getStatus_code() != TStatusCode.OK) {
                     continue;
@@ -820,7 +824,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
                 String host = address.getHostname();
                 int port = address.getPort();
                 ComputeNode node = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
-                            .getBackendOrComputeNodeWithBePort(host, port);
+                        .getBackendOrComputeNodeWithBePort(host, port);
                 if (!GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkNodeAvailable(node)) {
                     continue;
                 }
@@ -833,7 +837,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
                     lakeService.unlockTabletMetadata(request);
                 } catch (Throwable e) {
                     LOG.error("Fail to release metadata lock, job id {}, tablet id {}, version {}", id,
-                                tableId, internalScanRange.getVersion());
+                            tableId, internalScanRange.getVersion());
                 }
             }
         }
@@ -870,10 +874,11 @@ public class ExportJob implements Writable, GsonPostProcessable {
 
             // try to remove exported temp files
             try {
-                if (!brokerDesc.hasBroker()) {
-                    HdfsUtil.deletePath(exportTempPath, brokerDesc);
+                if (Strings.isNullOrEmpty(brokerPersistInfo.getName())) {
+                    HdfsUtil.deletePath(exportTempPath, brokerPersistInfo.getProperties());
                 } else {
-                    BrokerUtil.deletePath(exportTempPath, brokerDesc);
+                    BrokerUtil.deletePath(exportTempPath,
+                            new BrokerDesc(brokerPersistInfo.getName(), brokerPersistInfo.getProperties()));
                 }
                 LOG.info("remove export temp path success, path: {}", exportTempPath);
             } catch (StarRocksException e) {
@@ -882,10 +887,11 @@ public class ExportJob implements Writable, GsonPostProcessable {
             // try to remove exported files
             for (String exportedFile : exportedFiles) {
                 try {
-                    if (!brokerDesc.hasBroker()) {
-                        HdfsUtil.deletePath(exportedFile, brokerDesc);
+                    if (Strings.isNullOrEmpty(brokerPersistInfo.getName())) {
+                        HdfsUtil.deletePath(exportedFile, brokerPersistInfo.getProperties());
                     } else {
-                        BrokerUtil.deletePath(exportedFile, brokerDesc);
+                        BrokerUtil.deletePath(exportedFile,
+                                new BrokerDesc(brokerPersistInfo.getName(), brokerPersistInfo.getProperties()));
                     }
                     LOG.info("remove exported file success, path: {}", exportedFile);
                 } catch (StarRocksException e) {
@@ -913,10 +919,11 @@ public class ExportJob implements Writable, GsonPostProcessable {
 
             // try to remove exported temp files
             try {
-                if (!brokerDesc.hasBroker()) {
-                    HdfsUtil.deletePath(exportTempPath, brokerDesc);
+                if (Strings.isNullOrEmpty(brokerPersistInfo.getName())) {
+                    HdfsUtil.deletePath(exportTempPath, brokerPersistInfo.getProperties());
                 } else {
-                    BrokerUtil.deletePath(exportTempPath, brokerDesc);
+                    BrokerUtil.deletePath(exportTempPath,
+                            new BrokerDesc(brokerPersistInfo.getName(), brokerPersistInfo.getProperties()));
                 }
                 LOG.info("remove export temp path success, path: {}", exportTempPath);
             } catch (StarRocksException e) {
@@ -931,22 +938,20 @@ public class ExportJob implements Writable, GsonPostProcessable {
     @Override
     public String toString() {
         return "ExportJob [jobId=" + id
-                    + ", dbId=" + dbId
-                    + ", tableId=" + tableId
-                    + ", state=" + state
-                    + ", path=" + exportPath
-                    + ", partitions=(" + StringUtils.join(partitions, ",") + ")"
-                    + ", progress=" + progress
-                    + ", createTimeMs=" + TimeUtils.longToTimeString(createTimeMs)
-                    + ", exportStartTimeMs=" + TimeUtils.longToTimeString(startTimeMs)
-                    + ", exportFinishTimeMs=" + TimeUtils.longToTimeString(finishTimeMs)
-                    + ", failMsg=" + failMsg
-                    + ", tmp files=(" + StringUtils.join(exportedTempFiles, ",") + ")"
-                    + ", files=(" + StringUtils.join(exportedFiles, ",") + ")"
-                    + "]";
+                + ", dbId=" + dbId
+                + ", tableId=" + tableId
+                + ", state=" + state
+                + ", path=" + exportPath
+                + ", partitions=(" + StringUtils.join(partitions, ",") + ")"
+                + ", progress=" + progress
+                + ", createTimeMs=" + TimeUtils.longToTimeString(createTimeMs)
+                + ", exportStartTimeMs=" + TimeUtils.longToTimeString(startTimeMs)
+                + ", exportFinishTimeMs=" + TimeUtils.longToTimeString(finishTimeMs)
+                + ", failMsg=" + failMsg
+                + ", tmp files=(" + StringUtils.join(exportedTempFiles, ",") + ")"
+                + ", files=(" + StringUtils.join(exportedFiles, ",") + ")"
+                + "]";
     }
-
-
 
     /**
      * for ut only
@@ -1000,6 +1005,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
             queryId = UUID.fromString(queryIdString);
         }
         isReplayed = true;
+        // brokerDesc now built on demand from brokerPersistInfo
         GlobalStateMgr stateMgr = GlobalStateMgr.getCurrentState();
         Database db = null;
         if (stateMgr.getLocalMetastore() != null) {
@@ -1032,8 +1038,6 @@ public class ExportJob implements Writable, GsonPostProcessable {
         public JobState getState() {
             return state;
         }
-
-
 
     }
 
@@ -1074,25 +1078,22 @@ public class ExportJob implements Writable, GsonPostProcessable {
             this.failMsg = failMsg;
         }
 
-
-
-
         public List<Pair<NetworkAddress, String>> serialize(List<Pair<TNetworkAddress, String>> snapshotPaths) {
             return snapshotPaths
-                        .stream()
-                        .map(snapshotPath
-                                    -> Pair.create(new NetworkAddress(snapshotPath.first.hostname, snapshotPath.first.port),
-                                    snapshotPath.second))
-                        .collect(Collectors.toList());
+                    .stream()
+                    .map(snapshotPath
+                            -> Pair.create(new NetworkAddress(snapshotPath.first.hostname, snapshotPath.first.port),
+                            snapshotPath.second))
+                    .collect(Collectors.toList());
         }
 
         public List<Pair<TNetworkAddress, String>> deserialize(List<Pair<NetworkAddress, String>> snapshotPaths) {
             return snapshotPaths
-                        .stream()
-                        .map(snapshotPath
-                                    -> Pair.create(new TNetworkAddress(snapshotPath.first.hostname, snapshotPath.first.port),
-                                    snapshotPath.second))
-                        .collect(Collectors.toList());
+                    .stream()
+                    .map(snapshotPath
+                            -> Pair.create(new TNetworkAddress(snapshotPath.first.hostname, snapshotPath.first.port),
+                            snapshotPath.second))
+                    .collect(Collectors.toList());
         }
     }
 
@@ -1130,8 +1131,8 @@ public class ExportJob implements Writable, GsonPostProcessable {
         @Override
         public boolean equals(Object obj) {
             return obj instanceof NetworkAddress
-                        && NetUtils.isSameIP(this.hostname, ((NetworkAddress) obj).hostname)
-                        && this.port == ((NetworkAddress) obj).port;
+                    && NetUtils.isSameIP(this.hostname, ((NetworkAddress) obj).hostname)
+                    && this.port == ((NetworkAddress) obj).port;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -65,6 +65,7 @@ import com.starrocks.metric.MetricRepo;
 import com.starrocks.metric.TableMetricsEntity;
 import com.starrocks.metric.TableMetricsRegistry;
 import com.starrocks.persist.AlterLoadJobOperationLog;
+import com.starrocks.persist.BrokerPropertiesPersistInfo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.scheduler.Coordinator;
@@ -120,9 +121,8 @@ public class BrokerLoadJob extends BulkLoadJob {
             throws MetaNotFoundException {
         super(dbId, label, stmt != null ? stmt.getOrigStmt() : null);
         this.timeoutSecond = Config.broker_load_default_timeout_second;
-        this.brokerPersistInfo = brokerDesc != null
-                ? new com.starrocks.persist.BrokerPropertiesPersistInfo(brokerDesc.getName(), brokerDesc.getProperties())
-                : null;
+        this.brokerPersistInfo =
+                brokerDesc != null ? new BrokerPropertiesPersistInfo(brokerDesc.getName(), brokerDesc.getProperties()) : null;
         this.jobType = EtlJobType.BROKER;
         this.context = context;
         this.stmt = stmt;
@@ -176,7 +176,8 @@ public class BrokerLoadJob extends BulkLoadJob {
     @Override
     protected void unprotectedExecuteJob() throws LoadException {
         LoadTask task = new BrokerLoadPendingTask(this, fileGroupAggInfo.getAggKeyToFileGroups(),
-                brokerPersistInfo == null ? null : new BrokerDesc(brokerPersistInfo.getProperties()));
+                brokerPersistInfo == null ? null :
+                        new BrokerDesc(brokerPersistInfo.getName(), brokerPersistInfo.getProperties()));
         idToTasks.put(task.getSignature(), task);
         submitTask(GlobalStateMgr.getCurrentState().getPendingLoadTaskScheduler(), task);
     }
@@ -292,7 +293,8 @@ public class BrokerLoadJob extends BulkLoadJob {
                 LoadLoadingTask task = new LoadLoadingTask.Builder()
                         .setDb(db)
                         .setTable(table)
-                        .setBrokerDesc(brokerPersistInfo == null ? null : new BrokerDesc(brokerPersistInfo.getProperties()))
+                        .setBrokerDesc(brokerPersistInfo == null ? null :
+                                new BrokerDesc(brokerPersistInfo.getName(), brokerPersistInfo.getProperties()))
                         .setFileGroups(brokerFileGroups)
                         .setJobDeadlineMs(getDeadlineMs())
                         .setExecMemLimit(loadMemLimit)

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -120,7 +120,9 @@ public class BrokerLoadJob extends BulkLoadJob {
             throws MetaNotFoundException {
         super(dbId, label, stmt != null ? stmt.getOrigStmt() : null);
         this.timeoutSecond = Config.broker_load_default_timeout_second;
-        this.brokerDesc = brokerDesc;
+        this.brokerPersistInfo = brokerDesc != null
+                ? new com.starrocks.persist.BrokerPropertiesPersistInfo(brokerDesc.getName(), brokerDesc.getProperties())
+                : null;
         this.jobType = EtlJobType.BROKER;
         this.context = context;
         this.stmt = stmt;
@@ -173,7 +175,8 @@ public class BrokerLoadJob extends BulkLoadJob {
 
     @Override
     protected void unprotectedExecuteJob() throws LoadException {
-        LoadTask task = new BrokerLoadPendingTask(this, fileGroupAggInfo.getAggKeyToFileGroups(), brokerDesc);
+        LoadTask task = new BrokerLoadPendingTask(this, fileGroupAggInfo.getAggKeyToFileGroups(),
+                brokerPersistInfo == null ? null : new BrokerDesc(brokerPersistInfo.getProperties()));
         idToTasks.put(task.getSignature(), task);
         submitTask(GlobalStateMgr.getCurrentState().getPendingLoadTaskScheduler(), task);
     }
@@ -289,7 +292,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                 LoadLoadingTask task = new LoadLoadingTask.Builder()
                         .setDb(db)
                         .setTable(table)
-                        .setBrokerDesc(brokerDesc)
+                        .setBrokerDesc(brokerPersistInfo == null ? null : new BrokerDesc(brokerPersistInfo.getProperties()))
                         .setFileGroups(brokerFileGroups)
                         .setJobDeadlineMs(getDeadlineMs())
                         .setExecMemLimit(loadMemLimit)

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadPendingTask.java
@@ -93,7 +93,7 @@ public class BrokerLoadPendingTask extends LoadTask {
                     if (brokerDesc.hasBroker()) {
                         BrokerUtil.parseFile(path, brokerDesc, fileStatuses);
                     } else {
-                        HdfsUtil.parseFile(path, brokerDesc, fileStatuses);
+                        HdfsUtil.parseFile(path, brokerDesc.getProperties(), fileStatuses);
                     }
                 }
                 fileStatusList.add(fileStatuses);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -52,13 +52,13 @@ import com.starrocks.load.BrokerFileGroup;
 import com.starrocks.load.BrokerFileGroupAggInfo;
 import com.starrocks.load.FailMsg;
 import com.starrocks.load.routineload.TxnStatusChangeReason;
+import com.starrocks.persist.BrokerPropertiesPersistInfo;
 import com.starrocks.persist.OriginStatementInfo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
-import com.starrocks.sql.ast.BrokerDesc;
 import com.starrocks.sql.ast.DataDescription;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.OriginStatement;
@@ -81,7 +81,7 @@ public abstract class BulkLoadJob extends LoadJob {
 
     // input params
     @SerializedName("bds")
-    protected BrokerDesc brokerDesc;
+    protected BrokerPropertiesPersistInfo brokerPersistInfo;
     // this param is used to persist the expr of columns
     // the origin stmt is persisted instead of columns expr
     // the expr of columns will be reanalyze when the log is replayed

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkEtlJobHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkEtlJobHandler.java
@@ -139,7 +139,7 @@ public class SparkEtlJobHandler {
             if (brokerDesc.hasBroker()) {
                 BrokerUtil.writeFile(configData, jobConfigHdfsPath, brokerDesc);
             } else {
-                HdfsUtil.writeFile(configData, jobConfigHdfsPath, brokerDesc);
+                HdfsUtil.writeFile(configData, jobConfigHdfsPath, brokerDesc.getProperties());
             }
         } catch (StarRocksException e) {
             throw new LoadException(e.getMessage());
@@ -311,7 +311,7 @@ public class SparkEtlJobHandler {
                 if (brokerDesc.hasBroker()) {
                     data = BrokerUtil.readFile(dppResultFilePath, brokerDesc);
                 } else {
-                    data = HdfsUtil.readFile(dppResultFilePath, brokerDesc);
+                    data = HdfsUtil.readFile(dppResultFilePath, brokerDesc.getProperties());
                 }
                 String dppResultStr = new String(data, StandardCharsets.UTF_8);
                 DppResult dppResult = new Gson().fromJson(dppResultStr, DppResult.class);
@@ -360,7 +360,7 @@ public class SparkEtlJobHandler {
             if (brokerDesc.hasBroker()) {
                 BrokerUtil.parseFile(etlFilePaths, brokerDesc, fileStatuses);
             } else {
-                HdfsUtil.parseFile(etlFilePaths, brokerDesc, fileStatuses);
+                HdfsUtil.parseFile(etlFilePaths, brokerDesc.getProperties(), fileStatuses);
             }
         } catch (StarRocksException e) {
             throw new Exception(e);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkEtlJobHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkEtlJobHandler.java
@@ -390,7 +390,7 @@ public class SparkEtlJobHandler {
             if (brokerDesc.hasBroker()) {
                 BrokerUtil.deletePath(outputPath, brokerDesc);
             } else {
-                HdfsUtil.deletePath(outputPath, brokerDesc);
+                HdfsUtil.deletePath(outputPath, brokerDesc.getProperties());
             }
             LOG.info("delete path success. path: {}", outputPath);
         } catch (StarRocksException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkRepository.java
@@ -174,7 +174,7 @@ public class SparkRepository {
             if (brokerDesc.hasBroker()) {
                 result = BrokerUtil.checkPathExist(remotePath, brokerDesc);
             } else {
-                result = HdfsUtil.checkPathExist(remotePath, brokerDesc);
+                result = HdfsUtil.checkPathExist(remotePath, brokerDesc.getProperties());
             }
             LOG.info("check archive exists in repository, {}", result);
         } catch (StarRocksException e) {
@@ -241,7 +241,7 @@ public class SparkRepository {
             if (brokerDesc.hasBroker()) {
                 BrokerUtil.parseFile(remoteArchivePath + "/*", brokerDesc, fileStatuses);
             } else {
-                HdfsUtil.parseFile(remoteArchivePath + "/*", brokerDesc, fileStatuses);
+                HdfsUtil.parseFile(remoteArchivePath + "/*", brokerDesc.getProperties(), fileStatuses);
             }
         } catch (StarRocksException e) {
             throw new LoadException(e.getMessage());
@@ -309,7 +309,7 @@ public class SparkRepository {
             if (brokerDesc.hasBroker()) {
                 BrokerUtil.writeFile(srcFilePath, destFilePath, brokerDesc);
             } else {
-                HdfsUtil.writeFile(srcFilePath, destFilePath, brokerDesc);
+                HdfsUtil.writeFile(srcFilePath, destFilePath, brokerDesc.getProperties());
             }
             LOG.info("finished to upload file, localPath={}, remotePath={}", srcFilePath, destFilePath);
         } catch (StarRocksException e) {
@@ -323,7 +323,7 @@ public class SparkRepository {
             if (brokerDesc.hasBroker()) {
                 BrokerUtil.rename(origFilePath, destFilePath, brokerDesc);
             } else {
-                HdfsUtil.rename(origFilePath, destFilePath, brokerDesc);
+                HdfsUtil.rename(origFilePath, destFilePath, brokerDesc.getProperties());
             }
             LOG.info("finished to rename file, originPath={}, destPath={}", origFilePath, destFilePath);
         } catch (StarRocksException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkRepository.java
@@ -190,7 +190,7 @@ public class SparkRepository {
                 if (brokerDesc.hasBroker()) {
                     BrokerUtil.deletePath(remoteArchivePath, brokerDesc);
                 } else {
-                    HdfsUtil.deletePath(remoteArchivePath, brokerDesc);
+                    HdfsUtil.deletePath(remoteArchivePath, brokerDesc.getProperties());
                 }
                 currentArchive.libraries.clear();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/FilePipeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/FilePipeSource.java
@@ -87,7 +87,7 @@ public class FilePipeSource implements GsonPostProcessable {
         if (CollectionUtils.isEmpty(fileListRepo.listFilesByState(FileListRepo.PipeFileState.UNLOADED, 1))) {
             BrokerDesc brokerDesc = new BrokerDesc(tableProperties);
             try {
-                List<FileStatus> files = HdfsUtil.listFileMeta(path, brokerDesc, true);
+                List<FileStatus> files = HdfsUtil.listFileMeta(path, brokerDesc.getProperties(), true);
                 List<PipeFileRecord> records =
                         ListUtils.emptyIfNull(files).stream()
                                 .map(PipeFileRecord::fromHdfsFile)

--- a/fe/fe-core/src/main/java/com/starrocks/persist/BrokerPropertiesPersistInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/BrokerPropertiesPersistInfo.java
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.common.base.Strings;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Map;
+
+/**
+ * Persistence-only DTO for broker properties.
+ * Avoids using AST class {@code com.starrocks.sql.ast.BrokerDesc} in metadata serialization.
+ */
+public class BrokerPropertiesPersistInfo {
+
+    @SerializedName("n")
+    private String name;
+    @SerializedName("p")
+    private Map<String, String> properties;
+
+    // for deserialization
+    public BrokerPropertiesPersistInfo() {
+    }
+
+    public BrokerPropertiesPersistInfo(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    public BrokerPropertiesPersistInfo(String name, Map<String, String> properties) {
+        this.name = name;
+        this.properties = properties;
+    }
+
+    public boolean hasBroker() {
+        return !Strings.isNullOrEmpty(name);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+}
+
+

--- a/fe/fe-core/src/main/java/com/starrocks/persist/BrokerPropertiesPersistInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/BrokerPropertiesPersistInfo.java
@@ -34,10 +34,6 @@ public class BrokerPropertiesPersistInfo {
     public BrokerPropertiesPersistInfo() {
     }
 
-    public BrokerPropertiesPersistInfo(Map<String, String> properties) {
-        this.properties = properties;
-    }
-
     public BrokerPropertiesPersistInfo(String name, Map<String, String> properties) {
         this.name = name;
         this.properties = properties;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -297,7 +297,7 @@ public class FileScanNode extends LoadScanNode {
             String path = filePaths.get(0);
             if (fileScanType == TFileScanType.LOAD) {
                 THdfsProperties hdfsProperties = new THdfsProperties();
-                HdfsUtil.getTProperties(path, brokerDesc, hdfsProperties);
+                HdfsUtil.getTProperties(path, brokerDesc.getProperties(), hdfsProperties);
                 params.setHdfs_properties(hdfsProperties);
             } else {
                 // FILES_INSERT, FILES_QUERY
@@ -503,7 +503,7 @@ public class FileScanNode extends LoadScanNode {
                     if (brokerDesc.hasBroker()) {
                         BrokerUtil.parseFile(path, brokerDesc, fileStatuses);
                     } else {
-                        HdfsUtil.parseFile(path, brokerDesc, fileStatuses);
+                        HdfsUtil.parseFile(path, brokerDesc.getProperties(), fileStatuses);
                     }
                 }
                 fileStatusesList.add(fileStatuses);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/OutFileClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/OutFileClause.java
@@ -428,7 +428,7 @@ public class OutFileClause implements ParseNode {
                 sinkOptions.setHdfs_write_buffer_size_kb(Config.hdfs_write_buffer_size_kb);
                 THdfsProperties hdfsProperties = new THdfsProperties();
                 try {
-                    HdfsUtil.getTProperties(filePath, brokerDesc, hdfsProperties);
+                    HdfsUtil.getTProperties(filePath, brokerDesc.getProperties(), hdfsProperties);
                 } catch (StarRocksException e) {
                     throw new SemanticException(e.getMessage());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -29,6 +29,7 @@ import com.starrocks.sql.ast.AlterUserStmt;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.BaseGrantRevokePrivilegeStmt;
 import com.starrocks.sql.ast.BaseGrantRevokeRoleStmt;
+import com.starrocks.sql.ast.BrokerDesc;
 import com.starrocks.sql.ast.CTERelation;
 import com.starrocks.sql.ast.CleanTemporaryTableStmt;
 import com.starrocks.sql.ast.CreateCatalogStmt;
@@ -426,7 +427,14 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
         sb.append(")");
 
         if (stmt.getBrokerDesc() != null) {
-            sb.append(stmt.getBrokerDesc());
+            BrokerDesc brokerDesc = stmt.getBrokerDesc();
+            sb.append(" WITH BROKER ").append(brokerDesc.getName());
+            Map<String, String> properties = brokerDesc.getProperties();
+
+            if (properties != null && !properties.isEmpty()) {
+                PrintableMap<String, String> printableMap = new PrintableMap<>(properties, " = ", true, false, true);
+                sb.append(" (").append(printableMap.toString()).append(")");
+            }
         }
 
         if (stmt.getCluster() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
@@ -240,13 +240,13 @@ public class ExportExportingTask extends PriorityLeaderTask {
                 try {
                     // check export file exist
                     if (!job.getBrokerDesc().hasBroker()) {
-                        if (HdfsUtil.checkPathExist(exportedFile, job.getBrokerDesc())) {
+                        if (HdfsUtil.checkPathExist(exportedFile, job.getBrokerDesc().getProperties())) {
                             failMsg = exportedFile + " already exist";
                             LOG.warn("move {} to {} fail. job id: {}, retry: {}, msg: {}",
                                     exportedTempFile, exportedFile, job.getId(), i, failMsg);
                             break;
                         }
-                        if (!HdfsUtil.checkPathExist(exportedTempFile, job.getBrokerDesc())) {
+                        if (!HdfsUtil.checkPathExist(exportedTempFile, job.getBrokerDesc().getProperties())) {
                             failMsg = exportedFile + " temp file not exist";
                             LOG.warn("move {} to {} fail. job id: {}, retry: {}, msg: {}",
                                     exportedTempFile, exportedFile, job.getId(), i, failMsg);
@@ -270,7 +270,7 @@ public class ExportExportingTask extends PriorityLeaderTask {
                     // move
                     int timeoutMs = Math.min(Math.max(1, getLeftTimeSecond()), 3600) * 1000;
                     if (!job.getBrokerDesc().hasBroker()) {
-                        HdfsUtil.rename(exportedTempFile, exportedFile, job.getBrokerDesc(), timeoutMs);
+                        HdfsUtil.rename(exportedTempFile, exportedFile, job.getBrokerDesc().getProperties(), timeoutMs);
                     } else {
                         BrokerUtil.rename(exportedTempFile, exportedFile, job.getBrokerDesc(), timeoutMs);
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -213,7 +213,8 @@ public class TableFunctionTableTest {
     public void testNoFilesFound() throws DdlException {
         new MockUp<HdfsUtil>() {
             @Mock
-            public List<FileStatus> listFileMeta(String path, BrokerDesc brokerDesc, boolean skipDir) throws StarRocksException {
+            public static List<FileStatus> listFileMeta(String path, Map<String, String> properties, boolean skipDir)
+                    throws StarRocksException {
                 return Lists.newArrayList();
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/fs/HdfsUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/HdfsUtilTest.java
@@ -20,7 +20,6 @@ package com.starrocks.fs;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.fs.hdfs.HdfsFs;
 import com.starrocks.fs.hdfs.HdfsFsManager;
-import com.starrocks.sql.ast.BrokerDesc;
 import com.starrocks.thrift.THdfsProperties;
 import mockit.Mock;
 import mockit.MockUp;
@@ -69,10 +68,10 @@ public class HdfsUtilTest {
                 HdfsUtil.deletePath("hdfs://abc/dbf", new HashMap<>()));
 
         Assertions.assertThrows(StarRocksException.class, () ->
-                HdfsUtil.rename("hdfs://abc/dbf", "hdfs://abc/dba", new BrokerDesc(new HashMap<>()), 1000));
+                HdfsUtil.rename("hdfs://abc/dbf", "hdfs://abc/dba", new HashMap<>(), 1000));
 
         Assertions.assertThrows(StarRocksException.class, () ->
-                HdfsUtil.checkPathExist("hdfs://abc/dbf", new BrokerDesc(new HashMap<>())));
+                HdfsUtil.checkPathExist("hdfs://abc/dbf", new HashMap<>()));
 
         HdfsFsManager fileSystemManager = new HdfsFsManager();
         Assertions.assertThrows(StarRocksException.class, () ->

--- a/fe/fe-core/src/test/java/com/starrocks/fs/HdfsUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/HdfsUtilTest.java
@@ -66,7 +66,7 @@ public class HdfsUtilTest {
         };
 
         Assertions.assertThrows(StarRocksException.class, () ->
-                HdfsUtil.deletePath("hdfs://abc/dbf", new BrokerDesc(new HashMap<>())));
+                HdfsUtil.deletePath("hdfs://abc/dbf", new HashMap<>()));
 
         Assertions.assertThrows(StarRocksException.class, () ->
                 HdfsUtil.rename("hdfs://abc/dbf", "hdfs://abc/dba", new BrokerDesc(new HashMap<>()), 1000));

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportJobTest.java
@@ -30,6 +30,7 @@ import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.persist.BrokerPropertiesPersistInfo;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ScanNode;
@@ -37,7 +38,6 @@ import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.planner.TupleId;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
-import com.starrocks.sql.ast.BrokerDesc;
 import com.starrocks.task.ExportExportingTask;
 import com.starrocks.thrift.TInternalScanRange;
 import com.starrocks.thrift.TNetworkAddress;
@@ -81,7 +81,7 @@ public class ExportJobTest {
                                          @Mocked Tablet tablet,
                                          @Mocked OlapScanNode scanNode,
                                          @Mocked PlanFragment fragment,
-                                         @Mocked BrokerDesc brokerDesc) {
+                                         @Mocked BrokerPropertiesPersistInfo brokerDescPersistInfo) {
         // tabletId  backendId  dataSize
         //     1        0           1
         //     2        0           2
@@ -97,7 +97,7 @@ public class ExportJobTest {
                 result = tabletMeta;
                 tablet.getDataSize(true);
                 returns(1L, 2L, 3L, 4L, 5L);
-                brokerDesc.hasBroker();
+                brokerDescPersistInfo.hasBroker();
                 result = true;
             }
         };
@@ -119,12 +119,11 @@ public class ExportJobTest {
         }
 
 
-
         ExportJob job = new ExportJob(0, UUIDUtil.genUUID());
         Deencapsulation.setField(job, "tabletLocations", locationsList);
         Deencapsulation.setField(job, "exportTable", table);
         Deencapsulation.setField(job, "exportTupleDesc", new TupleDescriptor(new TupleId(0)));
-        Deencapsulation.setField(job, "brokerDesc", brokerDesc);
+        Deencapsulation.setField(job, "brokerPersistInfo", brokerDescPersistInfo);
 
         // 1 task: (1,2,3,4,5)
         List<PlanFragment> fragments = Lists.newArrayList();
@@ -160,7 +159,7 @@ public class ExportJobTest {
                                          @Mocked Tablet tablet,
                                          @Mocked OlapScanNode scanNode,
                                          @Mocked PlanFragment fragment,
-                                         @Mocked BrokerDesc brokerDesc) {
+                                         @Mocked BrokerPropertiesPersistInfo brokerDesc) {
         // tabletId  backendId  dataSize
         //     1        0           1
         //     2        0           2
@@ -208,7 +207,7 @@ public class ExportJobTest {
         Deencapsulation.setField(job, "tabletLocations", locationsList);
         Deencapsulation.setField(job, "exportTable", table);
         Deencapsulation.setField(job, "exportTupleDesc", new TupleDescriptor(new TupleId(0)));
-        Deencapsulation.setField(job, "brokerDesc", brokerDesc);
+        Deencapsulation.setField(job, "brokerPersistInfo", brokerDesc);
         Assertions.assertEquals(WarehouseManager.DEFAULT_RESOURCE, job.getComputeResource());
 
         // 1 task: (1,2,3,4,5)

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadPendingTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadPendingTaskTest.java
@@ -78,7 +78,7 @@ public class BrokerLoadPendingTaskTest {
         };
         new MockUp<HdfsUtil>() {
             @Mock
-            public void parseFile(String path, BrokerDesc brokerDesc, List<TBrokerFileStatus> fileStatuses) {
+            public void parseFile(String path, Map<String, String> properties, List<TBrokerFileStatus> fileStatuses) {
                 fileStatuses.add(tBrokerFileStatus);
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadJobTest.java
@@ -214,9 +214,9 @@ public class SparkLoadJobTest {
             Assertions.assertEquals(-1L, sparkLoadJob.getEtlStartTimestamp());
 
             // check update spark resource properties
-            Assertions.assertEquals(broker, bulkLoadJob.brokerDesc.getName());
-            Assertions.assertEquals("user0", bulkLoadJob.brokerDesc.getProperties().get("username"));
-            Assertions.assertEquals("password0", bulkLoadJob.brokerDesc.getProperties().get("password"));
+            Assertions.assertEquals(broker, bulkLoadJob.brokerPersistInfo.getName());
+            Assertions.assertEquals("user0", bulkLoadJob.brokerPersistInfo.getProperties().get("username"));
+            Assertions.assertEquals("password0", bulkLoadJob.brokerPersistInfo.getProperties().get("password"));
             SparkResource sparkResource = Deencapsulation.getField(sparkLoadJob, "sparkResource");
             Assertions.assertTrue(sparkResource.getSparkConfigs().containsKey("spark.executor.memory"));
             Assertions.assertEquals("1g", sparkResource.getSparkConfigs().get("spark.executor.memory"));
@@ -287,7 +287,8 @@ public class SparkLoadJobTest {
         Deencapsulation.setField(job, "etlOutputPath", etlOutputPath);
         Deencapsulation.setField(job, "sparkResource", resource);
         BrokerDesc brokerDesc = new BrokerDesc(broker, Maps.newHashMap());
-        job.brokerDesc = brokerDesc;
+        job.brokerPersistInfo =
+                new com.starrocks.persist.BrokerPropertiesPersistInfo(brokerDesc.getName(), brokerDesc.getProperties());
         return job;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ExportHandleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ExportHandleTest.java
@@ -24,7 +24,6 @@ import com.starrocks.load.ExportJob;
 import com.starrocks.load.ExportMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AuthorizerStmtVisitor;
-import com.starrocks.sql.ast.BrokerDesc;
 import com.starrocks.sql.ast.ExportStmt;
 import com.starrocks.thrift.THdfsProperties;
 import com.starrocks.utframe.StarRocksAssert;
@@ -37,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class ExportHandleTest {
     private static ConnectContext connectContext;
@@ -89,7 +89,7 @@ public class ExportHandleTest {
         };
         new MockUp<HdfsUtil>() {
             @Mock
-            public void getTProperties(String path, BrokerDesc brokerDesc, THdfsProperties tProperties) throws
+            public void getTProperties(String path, Map<String, String> properties, THdfsProperties tProperties) throws
                     StarRocksException {
             }
         };

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/BrokerDesc.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/BrokerDesc.java
@@ -19,32 +19,15 @@ package com.starrocks.sql.ast;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
-import com.google.gson.annotations.SerializedName;
-import com.starrocks.common.util.PrintableMap;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Map;
 
-// Broker descriptor
-//
-// Broker example:
-// WITH BROKER "broker0"
-// (
-//   "username" = "user0",
-//   "password" = "password0"
-// )
 public class BrokerDesc implements ParseNode {
-    @SerializedName("n")
-    private String name;
-    @SerializedName("p")
+    private final String name;
     private Map<String, String> properties;
 
     private final NodePosition pos;
-
-    // Only used for recovery
-    private BrokerDesc() {
-        pos = NodePosition.ZERO;
-    }
 
     public BrokerDesc(Map<String, String> properties) {
         this(properties, NodePosition.ZERO);
@@ -81,26 +64,6 @@ public class BrokerDesc implements ParseNode {
 
     public Map<String, String> getProperties() {
         return properties;
-    }
-
-    public String getMergeConditionStr() {
-        if (properties.containsKey(LoadStmt.MERGE_CONDITION)) {
-            return properties.get(LoadStmt.MERGE_CONDITION);
-        }
-        return "";
-    }
-
-
-
-
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(" WITH BROKER ").append(name);
-        if (properties != null && !properties.isEmpty()) {
-            PrintableMap<String, String> printableMap = new PrintableMap<>(properties, " = ", true, false, true);
-            sb.append(" (").append(printableMap.toString()).append(")");
-        }
-        return sb.toString();
     }
 
     @Override

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/BrokerDesc.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/BrokerDesc.java
@@ -36,6 +36,7 @@ public class BrokerDesc implements ParseNode {
     public BrokerDesc(String name, Map<String, String> properties) {
         this(name, properties, NodePosition.ZERO);
     }
+
     public BrokerDesc(String name, Map<String, String> properties, NodePosition pos) {
         this.pos = pos;
         this.name = name;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request refactors how broker properties are persisted and used in the backup and export modules. It replaces direct usage of `BrokerDesc` with a new `BrokerPropertiesPersistInfo` class for serialization and persistence, and introduces runtime conversion methods to construct `BrokerDesc` objects only when needed. This change improves code maintainability and consistency in handling broker properties across various operations.

**Persistence and Broker Property Handling:**
* Replaced persistent `BrokerDesc` fields with `BrokerPropertiesPersistInfo` in `BlobStorage`, `ExportJob`, and `BrokerLoadJob` classes, ensuring that only serializable broker properties are stored and runtime objects are constructed as needed. [[1]](diffhunk://#diff-5d37bda6796646900dcc4a0ee586678f4e0eac9bcc4f3c8f61c6351d70f659daL110-R111) [[2]](diffhunk://#diff-4a144556c56e7e9ec6f0722d37a3bbe13a69afa661608d4a6c16dd7c36b46fb0L160-R161) [[3]](diffhunk://#diff-dd27a8ecf3ddceb2d3d7cc2dc8c7713333377b0efb690111cbc18f1ea2eb4f3eL123-R125)
* Added helper methods (e.g., `toRuntimeBrokerDesc`) to convert persisted properties into `BrokerDesc` objects for runtime operations, decoupling persistence from runtime logic.

**API and Method Updates:**
* Updated all usages of broker-related HDFS utility methods to use runtime `BrokerDesc` objects or raw properties, rather than persisted `BrokerDesc` instances. This includes file operations such as read, write, rename, delete, and path existence checks. [[1]](diffhunk://#diff-5d37bda6796646900dcc4a0ee586678f4e0eac9bcc4f3c8f61c6351d70f659daL326-R327) [[2]](diffhunk://#diff-5d37bda6796646900dcc4a0ee586678f4e0eac9bcc4f3c8f61c6351d70f659daL439-R440) [[3]](diffhunk://#diff-5d37bda6796646900dcc4a0ee586678f4e0eac9bcc4f3c8f61c6351d70f659daL574-R575) [[4]](diffhunk://#diff-5d37bda6796646900dcc4a0ee586678f4e0eac9bcc4f3c8f61c6351d70f659daL659-R660) [[5]](diffhunk://#diff-5d37bda6796646900dcc4a0ee586678f4e0eac9bcc4f3c8f61c6351d70f659daL704-R705) [[6]](diffhunk://#diff-5d37bda6796646900dcc4a0ee586678f4e0eac9bcc4f3c8f61c6351d70f659daL758-R759) [[7]](diffhunk://#diff-5d37bda6796646900dcc4a0ee586678f4e0eac9bcc4f3c8f61c6351d70f659daL811-R812)
* Refactored `HdfsUtil.deletePath` to accept a properties map instead of a `BrokerDesc`, simplifying the interface and removing the overloaded method.

**Export and Load Job Logic:**
* Updated export and broker load job logic to use the new persistence model for broker properties, including changes to job setup, cancellation, and file cleanup routines. These now construct `BrokerDesc` objects on demand from persisted properties. [[1]](diffhunk://#diff-4a144556c56e7e9ec6f0722d37a3bbe13a69afa661608d4a6c16dd7c36b46fb0L251-R255) [[2]](diffhunk://#diff-4a144556c56e7e9ec6f0722d37a3bbe13a69afa661608d4a6c16dd7c36b46fb0L457-R465) [[3]](diffhunk://#diff-4a144556c56e7e9ec6f0722d37a3bbe13a69afa661608d4a6c16dd7c36b46fb0L597-R605) [[4]](diffhunk://#diff-4a144556c56e7e9ec6f0722d37a3bbe13a69afa661608d4a6c16dd7c36b46fb0L872-R880) [[5]](diffhunk://#diff-4a144556c56e7e9ec6f0722d37a3bbe13a69afa661608d4a6c16dd7c36b46fb0L884-R893) [[6]](diffhunk://#diff-4a144556c56e7e9ec6f0722d37a3bbe13a69afa661608d4a6c16dd7c36b46fb0L915-R925) [[7]](diffhunk://#diff-dd27a8ecf3ddceb2d3d7cc2dc8c7713333377b0efb690111cbc18f1ea2eb4f3eL176-R179)

**Code Cleanup and Consistency:**
* Removed unused imports and cleaned up redundant code in affected classes, improving readability and maintainability. [[1]](diffhunk://#diff-b5b68d32c98d394297acb983bf5f0c91dd8196291e469ab2b4f84fcb8a54bb05L20) [[2]](diffhunk://#diff-4a144556c56e7e9ec6f0722d37a3bbe13a69afa661608d4a6c16dd7c36b46fb0L948-L949) [[3]](diffhunk://#diff-4a144556c56e7e9ec6f0722d37a3bbe13a69afa661608d4a6c16dd7c36b46fb0L1035-L1036) [[4]](diffhunk://#diff-4a144556c56e7e9ec6f0722d37a3bbe13a69afa661608d4a6c16dd7c36b46fb0L1076-L1078)
* Updated snapshot utility logic to use the new properties-based interface for HDFS deletion.

These changes collectively standardize broker property persistence and usage, making the codebase more robust and easier to extend.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace persisted BrokerDesc with BrokerPropertiesPersistInfo and update HDFS/broker callers to use properties or build BrokerDesc at runtime.
> 
> - **Persistence/DTO**:
>   - Introduce `BrokerPropertiesPersistInfo` and replace persisted `BrokerDesc` fields in `BlobStorage`, `ExportJob`, `BrokerLoadJob`, `BulkLoadJob`, and Spark load paths.
> - **FS API changes**:
>   - Refactor `HdfsUtil` to accept raw `Map<String,String>` properties (read/write/list/rename/delete/check/open) and adjust `HdfsReader/HdfsWriter` accordingly.
>   - Update callers across backup/restore (`BackupJob`, `RestoreJob`), lake snapshot utils, `FileScanNode`, `HdfsFileSystemWrap`, `SparkEtlJobHandler`, `SparkRepository`, `FilePipeSource`, export tasks, and tests to pass properties or reconstruct `BrokerDesc` only at runtime.
> - **Planner/Formatter**:
>   - Use properties-based HDFS props in `OutFileClause`/`FileScanNode`; tweak `AST2StringVisitor` to render broker clause explicitly.
> - **Tests**:
>   - Adjust unit tests to new signatures and properties-based calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ceb266c269cb1d6ad094682f055b11d83135424b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->