### PR TITLE
[BugFix] Fix fail to get splits from morsel queue introduces crash of be

### DIFF
--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -94,17 +94,19 @@ Status ScanNode::prepare(RuntimeState* state) {
 }
 
 // Distribute morsels from a single queue to multiple queues
-static std::map<int, pipeline::MorselQueuePtr> uniform_distribute_morsels(pipeline::MorselQueuePtr morsel_queue,
-                                                                          int dop) {
+static StatusOr<std::map<int, pipeline::MorselQueuePtr>> uniform_distribute_morsels(
+        pipeline::MorselQueuePtr morsel_queue, int dop) {
+    std::map<int, pipeline::MorselQueuePtr> queue_per_driver;
     std::map<int, pipeline::Morsels> morsels_per_driver;
     int driver_seq = 0;
     while (!morsel_queue->empty()) {
-        auto maybe_morsel = morsel_queue->try_get();
-        DCHECK(maybe_morsel.ok());
-        morsels_per_driver[driver_seq].push_back(std::move(maybe_morsel.value()));
+        auto maybe_morsel_status_or = morsel_queue->try_get();
+        if (UNLIKELY(!maybe_morsel_status_or.ok())) {
+            return maybe_morsel_status_or.status();
+        }
+        morsels_per_driver[driver_seq].push_back(std::move(maybe_morsel_status_or.value()));
         driver_seq = (driver_seq + 1) % dop;
     }
-    std::map<int, pipeline::MorselQueuePtr> queue_per_driver;
 
     auto morsel_queue_type = morsel_queue->type();
     DCHECK(morsel_queue_type == pipeline::MorselQueue::Type::FIXED ||
@@ -144,7 +146,7 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
         // If not so much morsels, try to assign morsel uniformly among operators to avoid data skew
         if (!always_shared_scan() && scan_dop > 1 && is_fixed_or_dynamic_morsel_queue &&
             morsel_queue->num_original_morsels() <= io_parallelism) {
-            auto morsel_queue_map = uniform_distribute_morsels(std::move(morsel_queue), scan_dop);
+            ASSIGN_OR_RETURN(auto morsel_queue_map, uniform_distribute_morsels(std::move(morsel_queue), scan_dop));
             return std::make_unique<pipeline::IndividualMorselQueueFactory>(std::move(morsel_queue_map),
                                                                             /*could_local_shuffle*/ true);
         } else {

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -170,7 +170,18 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
         split_morsel_queue->set_tablet_schema(_tablet_schema);
 
         while (true) {
-            auto split = split_morsel_queue->try_get().value();
+            auto split_status_or = split_morsel_queue->try_get();
+            if (UNLIKELY(!split_status_or.ok())) {
+                LOG(WARNING) << "failed to get split morsel: " << split_status_or.status()
+                             << ", query_id: " << print_id(read_params.runtime_state->query_id())
+                             << ", tablet_id: " << tablet_shared_ptr->tablet_id();
+                // clear split tasks, and fallback to non-split mode
+                _split_tasks.clear();
+                _need_split = false;
+                return init_collector(read_params);
+            }
+
+            auto split = std::move(split_status_or.value());
             if (split != nullptr) {
                 auto ctx = std::make_unique<pipeline::LakeSplitContext>();
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #62529

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds error handling around `MorselQueue::try_get` in scan distribution and lake splitting, returning statuses and falling back to non-split to avoid crashes.
> 
> - **Execution Pipeline**:
>   - `be/src/exec/scan_node.cpp`: Change `uniform_distribute_morsels` to return `StatusOr<std::map<int, pipeline::MorselQueuePtr>>`; propagate failure from `morsel_queue->try_get()` and update caller with `ASSIGN_OR_RETURN`.
> - **Lake Storage**:
>   - `be/src/storage/lake/tablet_reader.cpp`: Safely handle `split_morsel_queue->try_get()` failures by logging, clearing `_split_tasks`, disabling `_need_split`, and `return init_collector(read_params)` to fallback to non-split mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dee91ebefd5ca7b35c5963b1984b6bd7b2a9e7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->