### PR TITLE
[Enhancement] Support Azure Workload Identity authentication for Azure Data Lake Storage Gen2 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfigurationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfigurationProvider.java
@@ -30,6 +30,7 @@ import static com.starrocks.connector.share.credential.CloudConfigurationConstan
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ID;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_SECRET;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TENANT_ID;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TOKEN_FILE;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_SAS_TOKEN;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY;
@@ -99,7 +100,8 @@ public class AzureCloudConfigurationProvider implements CloudConfigurationProvid
                 properties.getOrDefault(AZURE_ADLS2_SHARED_KEY, ""),
                 properties.getOrDefault(AZURE_ADLS2_SAS_TOKEN, ""),
                 properties.getOrDefault(AZURE_ADLS2_OAUTH2_CLIENT_SECRET, ""),
-                properties.getOrDefault(AZURE_ADLS2_OAUTH2_CLIENT_ENDPOINT, "")
+                properties.getOrDefault(AZURE_ADLS2_OAUTH2_CLIENT_ENDPOINT, ""),
+                properties.getOrDefault(AZURE_ADLS2_OAUTH2_TOKEN_FILE, "")
         );
         if (adls2.validate()) {
             return new AzureCloudConfiguration(adls2);

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/CloudConfigurationConstants.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/CloudConfigurationConstants.java
@@ -106,6 +106,7 @@ public class CloudConfigurationConstants {
     public static final String AZURE_ADLS2_SAS_TOKEN = "azure.adls2.sas_token";
     public static final String AZURE_ADLS2_OAUTH2_CLIENT_SECRET = "azure.adls2.oauth2_client_secret";
     public static final String AZURE_ADLS2_OAUTH2_CLIENT_ENDPOINT = "azure.adls2.oauth2_client_endpoint";
+    public static final String AZURE_ADLS2_OAUTH2_TOKEN_FILE = "azure.adls2.oauth2_token_file";
 
     // Credential for Google Cloud Platform (GCP)
     // For Google Cloud Storage (GCS)


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Support Azure Workload Identity authentication for Azure Data Lake Storage Gen2 by configuring `hadoop-azure` with the necessary parameters:
- `fs.azure.account.oauth.provider.type` 
- `fs.azure.account.oauth2.msi.tenant` - `hadoop-azure` specifies that this parameter is optional, but it is in fact mandatory
- `fs.azure.account.oauth2.client.id` - `hadoop-azure` specifies that this parameter is optional, but it is in fact mandatory
- `fs.azure.account.oauth2.token.file`

Fixes #62743 

## Outstanding TODOs before merge:
- [ ] update documentation with the `azure.adls2.oauth2_token_file` new parameter introduced by this PR
- [ ] `AzureADLS2CloudCredential.toFileStoreInfo` is not updated because it depends on `com.staros`, which I cannot find the source code of. It is unclear to me what are the implications on not having the `oauth2TokenFile` being part of it.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
