### PR TITLE
[Refactor] Split data cache engine into disk cache engine and memory cache engine.

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -848,7 +848,8 @@ void* ReportDataCacheMetricsTaskWorkerPool::_worker_thread_callback(void* arg_th
         request.__set_report_version(g_report_version.load(std::memory_order_relaxed));
 
         TDataCacheMetrics t_metrics{};
-        const LocalCacheEngine* cache = DataCache::GetInstance()->local_cache();
+        // TODO: mem_metrics + disk_metrics
+        const LocalCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();
         if (cache != nullptr && cache->is_initialized()) {
             const auto metrics = cache->cache_metrics();
             DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);

--- a/be/src/bench/object_cache_bench.cpp
+++ b/be/src/bench/object_cache_bench.cpp
@@ -129,8 +129,6 @@ void ObjectCacheBench::init_cache(CacheType cache_type) {
         _page_cache = std::make_shared<StoragePageCache>();
         _page_cache->init(_lru_cache.get());
     } else {
-        opt.engine = "starcache";
-
         _star_cache = std::make_shared<StarCacheEngine>();
         Status st = _star_cache->init(opt);
         if (!st.ok()) {

--- a/be/src/cache/block_cache/block_cache.cpp
+++ b/be/src/cache/block_cache/block_cache.cpp
@@ -36,7 +36,7 @@ BlockCache::~BlockCache() {
     (void)shutdown();
 }
 
-Status BlockCache::init(const CacheOptions& options, std::shared_ptr<LocalCacheEngine> local_cache,
+Status BlockCache::init(const BlockCacheOptions& options, std::shared_ptr<LocalCacheEngine> local_cache,
                         std::shared_ptr<RemoteCacheEngine> remote_cache) {
     _block_size = std::min(options.block_size, MAX_BLOCK_SIZE);
     _local_cache = std::move(local_cache);

--- a/be/src/cache/block_cache/block_cache.h
+++ b/be/src/cache/block_cache/block_cache.h
@@ -33,7 +33,7 @@ public:
     ~BlockCache();
 
     // Init the block cache instance
-    Status init(const CacheOptions& options, std::shared_ptr<LocalCacheEngine> local_cache,
+    Status init(const BlockCacheOptions& options, std::shared_ptr<LocalCacheEngine> local_cache,
                 std::shared_ptr<RemoteCacheEngine> remote_cache);
 
     // Write data buffer to cache, the `offset` must be aligned by block size

--- a/be/src/cache/cache_options.h
+++ b/be/src/cache/cache_options.h
@@ -42,7 +42,15 @@ struct DirSpace {
     size_t size;
 };
 
-struct CacheOptions {
+struct RemoteCacheOptions {
+    double skip_read_factor = 0;
+};
+
+struct MemCacheOptions {
+    size_t mem_space_size = 0;
+};
+
+struct DiskCacheOptions {
     // basic
     size_t mem_space_size = 0;
     std::vector<DirSpace> dir_spaces;
@@ -54,13 +62,16 @@ struct CacheOptions {
     bool enable_direct_io = false;
     bool enable_tiered_cache = true;
     bool enable_datacache_persistence = false;
-    std::string engine;
     size_t max_concurrent_inserts = 0;
     size_t max_flying_memory_mb = 0;
     double scheduler_threads_per_cpu = 0;
     double skip_read_factor = 0;
     uint32_t inline_item_count_limit = 0;
     std::string eviction_policy;
+};
+
+struct BlockCacheOptions {
+    size_t block_size = 0;
 };
 
 struct WriteCacheOptions {

--- a/be/src/cache/datacache.cpp
+++ b/be/src/cache/datacache.cpp
@@ -44,14 +44,9 @@ Status DataCache::init(const std::vector<StorePath>& store_paths) {
     _page_cache = std::make_shared<StoragePageCache>();
 
 #if defined(WITH_STARCACHE)
-    if (config::datacache_engine == "" || config::datacache_engine == "starcache") {
-        config::datacache_engine = "starcache";
-    } else {
-        config::datacache_engine = "lrucache";
-    }
-#else
-    config::datacache_engine = "lrucache";
+    _local_disk_cache_engine = "starcache";
 #endif
+    _local_mem_cache_engine = "lrucache";
 
     if (!config::datacache_enable) {
         config::disable_storage_page_cache = true;
@@ -59,22 +54,22 @@ Status DataCache::init(const std::vector<StorePath>& store_paths) {
         return Status::OK();
     }
 
-    ASSIGN_OR_RETURN(auto cache_options, _init_cache_options());
+    ASSIGN_OR_RETURN(auto mem_cache_options, _init_mem_cache_options());
 
-    if (config::datacache_engine == "starcache") {
 #if defined(WITH_STARCACHE)
-        RETURN_IF_ERROR(_init_starcache_engine(&cache_options));
-        RETURN_IF_ERROR(_init_peer_cache(cache_options));
+    ASSIGN_OR_RETURN(auto disk_cache_options, _init_disk_cache_options());
+    RETURN_IF_ERROR(_init_starcache_engine(&disk_cache_options));
 
-        if (config::block_cache_enable) {
-            RETURN_IF_ERROR(_block_cache->init(cache_options, _local_cache, _remote_cache));
-        }
-#else
-        return Status::InternalError("starcache engine is not supported");
-#endif
-    } else {
-        RETURN_IF_ERROR(_init_lrucache_engine(cache_options));
+    auto remote_cache_options = _init_remote_cache_options();
+    RETURN_IF_ERROR(_init_peer_cache(remote_cache_options));
+
+    if (config::block_cache_enable) {
+        auto block_cache_options = _init_block_cache_options();
+        RETURN_IF_ERROR(_block_cache->init(block_cache_options, _local_disk_cache, _remote_cache));
     }
+#endif
+
+    RETURN_IF_ERROR(_init_lrucache_engine(mem_cache_options));
 
     RETURN_IF_ERROR(_init_page_cache());
 
@@ -100,14 +95,15 @@ void DataCache::destroy() {
     LOG(INFO) << "pagecache shutdown successfully";
 
     _block_cache.reset();
-    _local_cache.reset();
+    _local_mem_cache.reset();
+    _local_disk_cache.reset();
     _remote_cache.reset();
     LOG(INFO) << "datacache shutdown successfully";
 }
 
 bool DataCache::adjust_mem_capacity(int64_t delta, size_t min_capacity) {
-    if (_local_cache != nullptr) {
-        Status st = _local_cache->adjust_mem_quota(delta, min_capacity);
+    if (_local_mem_cache != nullptr) {
+        Status st = _local_mem_cache->adjust_mem_quota(delta, min_capacity);
         if (st.ok()) {
             return true;
         } else {
@@ -119,52 +115,67 @@ bool DataCache::adjust_mem_capacity(int64_t delta, size_t min_capacity) {
 }
 
 size_t DataCache::get_mem_capacity() const {
-    if (_local_cache != nullptr) {
-        return _local_cache->mem_quota();
+    if (_local_mem_cache != nullptr) {
+        return _local_mem_cache->mem_quota();
     } else {
         return 0;
     }
 }
 
-Status DataCache::_init_lrucache_engine(const CacheOptions& cache_options) {
-    _local_cache = std::make_shared<LRUCacheEngine>();
-    RETURN_IF_ERROR(_local_cache->init(cache_options));
+Status DataCache::_init_lrucache_engine(const MemCacheOptions& cache_options) {
+    _local_mem_cache = std::make_shared<LRUCacheEngine>();
+    RETURN_IF_ERROR(reinterpret_cast<LRUCacheEngine*>(_local_mem_cache.get())->init(cache_options));
     LOG(INFO) << "lrucache engine init successfully";
     return Status::OK();
 }
 
 Status DataCache::_init_page_cache() {
-    _page_cache->init(_local_cache.get());
+    _page_cache->init(_local_mem_cache.get());
     _page_cache->init_metrics();
     LOG(INFO) << "storage page cache init successfully";
     return Status::OK();
 }
 
 #if defined(WITH_STARCACHE)
-Status DataCache::_init_starcache_engine(CacheOptions* cache_options) {
+Status DataCache::_init_starcache_engine(DiskCacheOptions* cache_options) {
     // init starcache & disk monitor
     // TODO: DiskSpaceMonitor needs to be decoupled from StarCacheEngine.
-    _local_cache = std::make_shared<StarCacheEngine>();
-    _disk_space_monitor = std::make_shared<DiskSpaceMonitor>(_local_cache.get());
+    _local_disk_cache = std::make_shared<StarCacheEngine>();
+    _disk_space_monitor = std::make_shared<DiskSpaceMonitor>(_local_disk_cache.get());
     RETURN_IF_ERROR(_disk_space_monitor->init(&cache_options->dir_spaces));
-    RETURN_IF_ERROR(_local_cache->init(*cache_options));
+    RETURN_IF_ERROR(reinterpret_cast<StarCacheEngine*>(_local_disk_cache.get())->init(*cache_options));
     _disk_space_monitor->start();
     return Status::OK();
 }
 
-Status DataCache::_init_peer_cache(const CacheOptions& cache_options) {
+Status DataCache::_init_peer_cache(const RemoteCacheOptions& cache_options) {
     _remote_cache = std::make_shared<PeerCacheEngine>();
     return _remote_cache->init(cache_options);
 }
 #endif
 
-StatusOr<CacheOptions> DataCache::_init_cache_options() {
-    CacheOptions cache_options;
+RemoteCacheOptions DataCache::_init_remote_cache_options() {
+    RemoteCacheOptions cache_options{.skip_read_factor = config::datacache_skip_read_factor};
+    return cache_options;
+}
+
+StatusOr<MemCacheOptions> DataCache::_init_mem_cache_options() {
+    MemCacheOptions cache_options;
     RETURN_IF_ERROR(DataCacheUtils::parse_conf_datacache_mem_size(
             config::datacache_mem_size, _global_env->process_mem_limit(), &cache_options.mem_space_size));
-    cache_options.engine = config::datacache_engine;
+    return cache_options;
+}
 
-    if (config::datacache_engine == "starcache") {
+BlockCacheOptions DataCache::_init_block_cache_options() {
+    BlockCacheOptions cache_options;
+    cache_options.block_size = config::datacache_block_size;
+    return cache_options;
+}
+
+StatusOr<DiskCacheOptions> DataCache::_init_disk_cache_options() {
+    DiskCacheOptions cache_options;
+
+    if (_local_disk_cache_engine == "starcache") {
 #ifdef USE_STAROS
         std::vector<string> corresponding_starlet_dirs;
         if (config::datacache_unified_instance_enable && !config::starlet_cache_dir.empty()) {
@@ -276,8 +287,8 @@ void DataCache::try_release_resource_before_core_dump() {
         return release_all || modules.contains(name);
     };
 
-    if (_local_cache != nullptr && need_release("data_cache")) {
-        (void)_local_cache->update_mem_quota(0, false);
+    if (_local_mem_cache != nullptr && need_release("data_cache")) {
+        (void)_local_mem_cache->update_mem_quota(0, false);
     }
 }
 

--- a/be/src/cache/datacache.h
+++ b/be/src/cache/datacache.h
@@ -23,7 +23,7 @@ namespace starrocks {
 class Status;
 class StorePath;
 class RemoteCacheEngine;
-class CacheOptions;
+class DiskCacheOptions;
 class GlobalEnv;
 class DiskSpaceMonitor;
 class MemSpaceMonitor;
@@ -39,10 +39,16 @@ public:
 
     void try_release_resource_before_core_dump();
 
-    void set_local_cache(std::shared_ptr<LocalCacheEngine> local_cache) { _local_cache = std::move(local_cache); }
+    void set_local_mem_cache(std::shared_ptr<LocalCacheEngine> local_mem_cache) {
+        _local_mem_cache = std::move(local_mem_cache);
+    }
+    void set_local_disk_cache(std::shared_ptr<LocalCacheEngine> local_disk_cache) {
+        _local_disk_cache = std::move(local_disk_cache);
+    }
     void set_page_cache(std::shared_ptr<StoragePageCache> page_cache) { _page_cache = std::move(page_cache); }
 
-    LocalCacheEngine* local_cache() { return _local_cache.get(); }
+    LocalCacheEngine* local_mem_cache() { return _local_mem_cache.get(); }
+    LocalCacheEngine* local_disk_cache() { return _local_disk_cache.get(); }
     BlockCache* block_cache() const { return _block_cache.get(); }
     void set_block_cache(std::shared_ptr<BlockCache> block_cache) { _block_cache = std::move(block_cache); }
     StoragePageCache* page_cache() const { return _page_cache.get(); }
@@ -56,19 +62,26 @@ public:
     size_t get_mem_capacity() const;
 
 private:
-    StatusOr<CacheOptions> _init_cache_options();
+    StatusOr<MemCacheOptions> _init_mem_cache_options();
+    StatusOr<DiskCacheOptions> _init_disk_cache_options();
+    RemoteCacheOptions _init_remote_cache_options();
+    BlockCacheOptions _init_block_cache_options();
+
 #if defined(WITH_STARCACHE)
-    Status _init_starcache_engine(CacheOptions* cache_options);
-    Status _init_peer_cache(const CacheOptions& cache_options);
+    Status _init_starcache_engine(DiskCacheOptions* cache_options);
+    Status _init_peer_cache(const RemoteCacheOptions& cache_options);
 #endif
-    Status _init_lrucache_engine(const CacheOptions& cache_options);
+    Status _init_lrucache_engine(const MemCacheOptions& cache_options);
     Status _init_page_cache();
 
     GlobalEnv* _global_env;
     std::vector<StorePath> _store_paths;
 
     // cache engine
-    std::shared_ptr<LocalCacheEngine> _local_cache;
+    std::string _local_mem_cache_engine;
+    std::string _local_disk_cache_engine;
+    std::shared_ptr<LocalCacheEngine> _local_mem_cache;
+    std::shared_ptr<LocalCacheEngine> _local_disk_cache;
     std::shared_ptr<RemoteCacheEngine> _remote_cache;
 
     std::shared_ptr<BlockCache> _block_cache;

--- a/be/src/cache/local_cache_engine.h
+++ b/be/src/cache/local_cache_engine.h
@@ -27,7 +27,6 @@ class LocalCacheEngine {
 public:
     virtual ~LocalCacheEngine() = default;
 
-    virtual Status init(const CacheOptions& options) = 0;
     virtual bool is_initialized() const = 0;
 
     // Write data to cache

--- a/be/src/cache/lrucache_engine.cpp
+++ b/be/src/cache/lrucache_engine.cpp
@@ -17,7 +17,7 @@
 #include <butil/fast_rand.h>
 
 namespace starrocks {
-Status LRUCacheEngine::init(const CacheOptions& options) {
+Status LRUCacheEngine::init(const MemCacheOptions& options) {
     _cache = std::make_unique<ShardedLRUCache>(options.mem_space_size);
     _initialized.store(true, std::memory_order_relaxed);
     return Status::OK();

--- a/be/src/cache/lrucache_engine.h
+++ b/be/src/cache/lrucache_engine.h
@@ -25,7 +25,7 @@ public:
     LRUCacheEngine() = default;
     virtual ~LRUCacheEngine() override = default;
 
-    Status init(const CacheOptions& options) override;
+    Status init(const MemCacheOptions& options);
     bool is_initialized() const override { return _initialized.load(std::memory_order_relaxed); }
 
     Status write(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) override;

--- a/be/src/cache/peer_cache_engine.cpp
+++ b/be/src/cache/peer_cache_engine.cpp
@@ -23,7 +23,7 @@
 
 namespace starrocks {
 
-Status PeerCacheEngine::init(const CacheOptions& options) {
+Status PeerCacheEngine::init(const RemoteCacheOptions& options) {
     _cache_adaptor.reset(starcache::create_default_adaptor(options.skip_read_factor));
     return Status::OK();
 }

--- a/be/src/cache/peer_cache_engine.h
+++ b/be/src/cache/peer_cache_engine.h
@@ -24,7 +24,7 @@ public:
     PeerCacheEngine() = default;
     ~PeerCacheEngine() override = default;
 
-    Status init(const CacheOptions& options) override;
+    Status init(const RemoteCacheOptions& options) override;
 
     Status read(const std::string& key, size_t off, size_t size, IOBuffer* buffer, ReadCacheOptions* options) override;
 

--- a/be/src/cache/remote_cache_engine.h
+++ b/be/src/cache/remote_cache_engine.h
@@ -25,7 +25,7 @@ public:
     virtual ~RemoteCacheEngine() = default;
 
     // Init remote cache
-    virtual Status init(const CacheOptions& options) = 0;
+    virtual Status init(const RemoteCacheOptions& options) = 0;
 
     // Write data to remote cache
     virtual Status write(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) = 0;

--- a/be/src/cache/starcache_engine.cpp
+++ b/be/src/cache/starcache_engine.cpp
@@ -27,7 +27,7 @@
 
 namespace starrocks {
 
-Status StarCacheEngine::init(const CacheOptions& options) {
+Status StarCacheEngine::init(const DiskCacheOptions& options) {
     starcache::CacheOptions opt;
     opt.mem_quota_bytes = options.mem_space_size;
     for (auto& dir : options.dir_spaces) {

--- a/be/src/cache/starcache_engine.h
+++ b/be/src/cache/starcache_engine.h
@@ -26,7 +26,7 @@ public:
     StarCacheEngine() = default;
     virtual ~StarCacheEngine() override = default;
 
-    Status init(const CacheOptions& options) override;
+    Status init(const DiskCacheOptions& options);
     bool is_initialized() const override { return _initialized.load(std::memory_order_relaxed); }
 
     Status write(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) override;

--- a/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
@@ -68,7 +68,7 @@ Status SchemaBeDataCacheMetricsScanner::get_next(ChunkPtr* chunk, bool* eos) {
     row.emplace_back(_be_id);
 
     // TODO: Support LRUCacheEngine
-    auto* cache = DataCache::GetInstance()->local_cache();
+    auto* cache = DataCache::GetInstance()->local_disk_cache();
     if (cache != nullptr && cache->is_initialized() && cache->engine_type() == LocalCacheEngineType::STARCACHE) {
         auto* starcache = reinterpret_cast<StarCacheEngine*>(cache);
         // retrieve different priority's used bytes from level = 2 metrics

--- a/be/src/http/action/datacache_action.h
+++ b/be/src/http/action/datacache_action.h
@@ -29,6 +29,7 @@
 namespace starrocks {
 
 class LocalCacheEngine;
+// TODO: support mem metrics
 class DataCacheAction : public HttpHandler {
 public:
     explicit DataCacheAction(LocalCacheEngine* local_cache) : _local_cache(local_cache) {}

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -115,7 +115,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             return Status::OK();
         });
         _config_callback.emplace("datacache_mem_size", [&]() -> Status {
-            LocalCacheEngine* cache = DataCache::GetInstance()->local_cache();
+            LocalCacheEngine* cache = DataCache::GetInstance()->local_mem_cache();
             if (cache == nullptr || !cache->is_initialized()) {
                 return Status::InternalError("Local cache is not initialized");
             }
@@ -130,7 +130,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             return cache->update_mem_quota(mem_size, true);
         });
         _config_callback.emplace("datacache_disk_size", [&]() -> Status {
-            LocalCacheEngine* cache = DataCache::GetInstance()->local_cache();
+            LocalCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();
             if (cache == nullptr || !cache->is_initialized()) {
                 return Status::InternalError("Local cache is not initialized");
             }
@@ -149,7 +149,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             return cache->update_disk_spaces(spaces);
         });
         _config_callback.emplace("datacache_inline_item_count_limit", [&]() -> Status {
-            LocalCacheEngine* cache = DataCache::GetInstance()->local_cache();
+            LocalCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();
             if (cache == nullptr || !cache->is_initialized()) {
                 return Status::InternalError("Local cache is not initialized");
             }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -526,7 +526,8 @@ void RuntimeState::update_load_datacache_metrics(TReportExecStatusParams* load_p
         }
 #endif // USE_STAROS
     } else {
-        const LocalCacheEngine* cache = DataCache::GetInstance()->local_cache();
+        // TODO: mem_metrics + disk_metrics
+        const LocalCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();
         if (cache != nullptr && cache->is_initialized()) {
             TDataCacheMetrics t_metrics{};
             DataCacheUtils::set_metrics_from_thrift(t_metrics, cache->cache_metrics());

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -273,7 +273,7 @@ Status HttpServiceBE::start() {
     _http_handlers.emplace_back(jit_cache_action);
 #endif
 
-    auto* datacache_action = new DataCacheAction(_cache_env->local_cache());
+    auto* datacache_action = new DataCacheAction(_cache_env->local_disk_cache());
     _ev_http_server->register_handler(HttpMethod::GET, "/api/datacache/{action}", datacache_action);
     _http_handlers.emplace_back(datacache_action);
 

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -126,7 +126,7 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     LOG(INFO) << process_name << " start step " << start_step++ << ": storage engine start bg threads successfully";
 
 #ifdef USE_STAROS
-    auto* local_cache = cache_env->local_cache();
+    auto* local_cache = cache_env->local_disk_cache();
     if (config::datacache_unified_instance_enable && local_cache && local_cache->is_initialized()) {
         auto* starcache = reinterpret_cast<StarCacheEngine*>(local_cache);
         init_staros_worker(starcache->starcache_instance());

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -301,7 +301,7 @@ void SystemMetrics::_update_datacache_mem_tracker() {
     int64_t datacache_mem_bytes = 0;
     auto* datacache_mem_tracker = GlobalEnv::GetInstance()->datacache_mem_tracker();
     if (datacache_mem_tracker) {
-        LocalCacheEngine* local_cache = DataCache::GetInstance()->local_cache();
+        LocalCacheEngine* local_cache = DataCache::GetInstance()->local_mem_cache();
         if (local_cache != nullptr && local_cache->is_initialized()) {
             auto datacache_metrics = local_cache->cache_metrics();
             datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;

--- a/be/test/cache/block_cache/block_cache_test.cpp
+++ b/be/test/cache/block_cache/block_cache_test.cpp
@@ -76,7 +76,7 @@ TEST_F(BlockCacheTest, hybrid_cache) {
     ASSERT_TRUE(fs::create_directories(cache_dir).ok());
 
     const size_t block_size = 256 * 1024;
-    CacheOptions options = TestCacheUtils::create_simple_options(block_size, 2 * MB);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size);
     options.dir_spaces.push_back({.path = cache_dir, .size = 50 * MB});
     auto cache = TestCacheUtils::create_cache(options);
 
@@ -120,7 +120,7 @@ TEST_F(BlockCacheTest, hybrid_cache) {
 TEST_F(BlockCacheTest, write_with_overwrite_option) {
     const size_t block_size = 1024 * 1024;
 
-    CacheOptions options = TestCacheUtils::create_simple_options(block_size, 20 * MB);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size);
     options.inline_item_count_limit = 1000;
     auto cache = TestCacheUtils::create_cache(options);
 
@@ -157,7 +157,7 @@ TEST_F(BlockCacheTest, read_cache_with_adaptor) {
     ASSERT_TRUE(fs::create_directories(cache_dir).ok());
 
     const size_t block_size = 1024 * 1024;
-    CacheOptions options = TestCacheUtils::create_simple_options(block_size, 0);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size);
     options.dir_spaces.push_back({.path = cache_dir, .size = 500 * MB});
     options.skip_read_factor = 1;
     auto cache = TestCacheUtils::create_cache(options);
@@ -221,14 +221,14 @@ TEST_F(BlockCacheTest, update_cache_quota) {
     std::unique_ptr<BlockCache> block_cache(new BlockCache);
     const size_t block_size = 256 * 1024;
     size_t quota = 50 * MB;
-    CacheOptions options = TestCacheUtils::create_simple_options(block_size, 1 * MB);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size);
     options.dir_spaces.push_back({.path = cache_dir, .size = quota});
     auto cache = TestCacheUtils::create_cache(options);
     auto local_cache = cache->local_cache();
 
     {
         auto metrics = local_cache->cache_metrics();
-        ASSERT_EQ(metrics.mem_quota_bytes, options.mem_space_size);
+        ASSERT_EQ(metrics.mem_quota_bytes, 0);
         ASSERT_EQ(metrics.disk_quota_bytes, quota);
     }
 
@@ -257,7 +257,7 @@ TEST_F(BlockCacheTest, clear_residual_blockfiles) {
     ASSERT_TRUE(fs::create_directories(cache_dir).ok());
 
     const size_t block_size = 256 * 1024;
-    CacheOptions options = TestCacheUtils::create_simple_options(block_size, 0);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size);
     options.dir_spaces.push_back({.path = cache_dir, .size = 50 * MB});
     auto cache = TestCacheUtils::create_cache(options);
 
@@ -294,7 +294,7 @@ TEST_F(BlockCacheTest, clear_residual_blockfiles) {
 }
 
 TEST_F(BlockCacheTest, read_peer_cache) {
-    CacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 1 * MB);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(256 * KB);
     auto cache = TestCacheUtils::create_cache(options);
 
     IOBuffer iobuf;

--- a/be/test/cache/block_cache/block_cache_test.cpp
+++ b/be/test/cache/block_cache/block_cache_test.cpp
@@ -76,7 +76,7 @@ TEST_F(BlockCacheTest, hybrid_cache) {
     ASSERT_TRUE(fs::create_directories(cache_dir).ok());
 
     const size_t block_size = 256 * 1024;
-    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size, 2 * MB);
     options.dir_spaces.push_back({.path = cache_dir, .size = 50 * MB});
     auto cache = TestCacheUtils::create_cache(options);
 
@@ -120,7 +120,7 @@ TEST_F(BlockCacheTest, hybrid_cache) {
 TEST_F(BlockCacheTest, write_with_overwrite_option) {
     const size_t block_size = 1024 * 1024;
 
-    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size, 20 * MB);
     options.inline_item_count_limit = 1000;
     auto cache = TestCacheUtils::create_cache(options);
 
@@ -157,7 +157,7 @@ TEST_F(BlockCacheTest, read_cache_with_adaptor) {
     ASSERT_TRUE(fs::create_directories(cache_dir).ok());
 
     const size_t block_size = 1024 * 1024;
-    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size, 0);
     options.dir_spaces.push_back({.path = cache_dir, .size = 500 * MB});
     options.skip_read_factor = 1;
     auto cache = TestCacheUtils::create_cache(options);
@@ -221,14 +221,14 @@ TEST_F(BlockCacheTest, update_cache_quota) {
     std::unique_ptr<BlockCache> block_cache(new BlockCache);
     const size_t block_size = 256 * 1024;
     size_t quota = 50 * MB;
-    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size, 1 * MB);
     options.dir_spaces.push_back({.path = cache_dir, .size = quota});
     auto cache = TestCacheUtils::create_cache(options);
     auto local_cache = cache->local_cache();
 
     {
         auto metrics = local_cache->cache_metrics();
-        ASSERT_EQ(metrics.mem_quota_bytes, 0);
+        ASSERT_EQ(metrics.mem_quota_bytes, options.mem_space_size);
         ASSERT_EQ(metrics.disk_quota_bytes, quota);
     }
 
@@ -257,7 +257,7 @@ TEST_F(BlockCacheTest, clear_residual_blockfiles) {
     ASSERT_TRUE(fs::create_directories(cache_dir).ok());
 
     const size_t block_size = 256 * 1024;
-    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(block_size, 0);
     options.dir_spaces.push_back({.path = cache_dir, .size = 50 * MB});
     auto cache = TestCacheUtils::create_cache(options);
 
@@ -294,7 +294,7 @@ TEST_F(BlockCacheTest, clear_residual_blockfiles) {
 }
 
 TEST_F(BlockCacheTest, read_peer_cache) {
-    DiskCacheOptions options = TestCacheUtils::create_simple_options(256 * KB);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 1 * MB);
     auto cache = TestCacheUtils::create_cache(options);
 
     IOBuffer iobuf;

--- a/be/test/cache/block_cache/test_cache_utils.h
+++ b/be/test/cache/block_cache/test_cache_utils.h
@@ -31,14 +31,11 @@ constexpr size_t GB = MB * 1024;
 
 class TestCacheUtils {
 public:
-    static CacheOptions create_simple_options(size_t block_size, size_t mem_quota, ssize_t disk_quota = -1,
-                                              const std::string& engine = "starcache") {
-        CacheOptions options;
-        options.mem_space_size = mem_quota;
+    static DiskCacheOptions create_simple_options(size_t block_size, ssize_t disk_quota = -1) {
+        DiskCacheOptions options;
         if (disk_quota > 0) {
             options.dir_spaces.push_back({.path = "./block_disk_cache", .size = (size_t)disk_quota});
         }
-        options.engine = engine;
         options.enable_checksum = false;
         options.max_concurrent_inserts = 1500000;
         options.max_flying_memory_mb = 100;
@@ -49,13 +46,17 @@ public:
         return options;
     }
 
-    static std::shared_ptr<BlockCache> create_cache(const CacheOptions& options) {
+    static std::shared_ptr<BlockCache> create_cache(const DiskCacheOptions& options) {
+        BlockCacheOptions block_cache_options;
+        block_cache_options.block_size = options.block_size;
+        RemoteCacheOptions remote_cache_options;
+        remote_cache_options.skip_read_factor = options.skip_read_factor;
         auto local_cache = std::make_shared<StarCacheEngine>();
         auto remote_cache = std::make_shared<PeerCacheEngine>();
         auto block_cache = std::make_shared<BlockCache>();
         EXPECT_OK(local_cache->init(options));
-        EXPECT_OK(remote_cache->init(options));
-        EXPECT_OK(block_cache->init(options, local_cache, remote_cache));
+        EXPECT_OK(remote_cache->init(remote_cache_options));
+        EXPECT_OK(block_cache->init(block_cache_options, local_cache, remote_cache));
         return block_cache;
     }
 };

--- a/be/test/cache/block_cache/test_cache_utils.h
+++ b/be/test/cache/block_cache/test_cache_utils.h
@@ -31,11 +31,12 @@ constexpr size_t GB = MB * 1024;
 
 class TestCacheUtils {
 public:
-    static DiskCacheOptions create_simple_options(size_t block_size, ssize_t disk_quota = -1) {
+    static DiskCacheOptions create_simple_options(size_t block_size, size_t mem_quota, ssize_t disk_quota = -1) {
         DiskCacheOptions options;
         if (disk_quota > 0) {
             options.dir_spaces.push_back({.path = "./block_disk_cache", .size = (size_t)disk_quota});
         }
+        options.mem_space_size = mem_quota;
         options.enable_checksum = false;
         options.max_concurrent_inserts = 1500000;
         options.max_flying_memory_mb = 100;

--- a/be/test/cache/disk_space_monitor_test.cpp
+++ b/be/test/cache/disk_space_monitor_test.cpp
@@ -179,7 +179,7 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_adjust_interval_seconds, 1);
     SCOPED_UPDATE(int64_t, config::datacache_disk_idle_seconds_for_expansion, 300);
 
-    auto options = TestCacheUtils::create_simple_options(kBlockSize, 20 * MB);
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 20 * MB);
     auto block_cache = TestCacheUtils::create_cache(options);
     auto local_cache = block_cache->local_cache();
 
@@ -229,7 +229,7 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota_with_limit) {
     config::datacache_disk_size = "25%";
     DeferOp defer([]() { config::datacache_disk_size = "100%"; });
 
-    auto options = TestCacheUtils::create_simple_options(kBlockSize, 20 * MB);
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 20 * MB);
     auto block_cache = TestCacheUtils::create_cache(options);
     auto local_cache = block_cache->local_cache();
 
@@ -279,7 +279,7 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_adjust_interval_seconds, 3);
     SCOPED_UPDATE(int64_t, config::datacache_disk_idle_seconds_for_expansion, 300);
 
-    auto options = TestCacheUtils::create_simple_options(kBlockSize, 50 * MB);
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 50 * MB);
     auto block_cache = TestCacheUtils::create_cache(options);
     auto local_cache = block_cache->local_cache();
 
@@ -328,7 +328,7 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota_to_zero) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_adjust_interval_seconds, 2);
     SCOPED_UPDATE(int64_t, config::datacache_disk_idle_seconds_for_expansion, 300);
 
-    auto options = TestCacheUtils::create_simple_options(kBlockSize, 50 * MB);
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 50 * MB);
     auto block_cache = TestCacheUtils::create_cache(options);
     auto local_cache = block_cache->local_cache();
 
@@ -377,7 +377,7 @@ TEST_F(DiskSpaceMonitorTest, get_directory_capacity) {
     SCOPED_UPDATE(bool, config::datacache_enable, true);
     SCOPED_UPDATE(bool, config::enable_datacache_disk_auto_adjust, false);
 
-    auto options = TestCacheUtils::create_simple_options(kBlockSize, 20 * MB);
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 20 * MB);
     auto block_cache = TestCacheUtils::create_cache(options);
     auto local_cache = block_cache->local_cache();
 

--- a/be/test/cache/disk_space_monitor_test.cpp
+++ b/be/test/cache/disk_space_monitor_test.cpp
@@ -179,7 +179,7 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_adjust_interval_seconds, 1);
     SCOPED_UPDATE(int64_t, config::datacache_disk_idle_seconds_for_expansion, 300);
 
-    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 20 * MB);
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 20 * MB);
     auto block_cache = TestCacheUtils::create_cache(options);
     auto local_cache = block_cache->local_cache();
 
@@ -229,7 +229,7 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota_with_limit) {
     config::datacache_disk_size = "25%";
     DeferOp defer([]() { config::datacache_disk_size = "100%"; });
 
-    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 20 * MB);
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 20 * MB);
     auto block_cache = TestCacheUtils::create_cache(options);
     auto local_cache = block_cache->local_cache();
 
@@ -279,7 +279,7 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_adjust_interval_seconds, 3);
     SCOPED_UPDATE(int64_t, config::datacache_disk_idle_seconds_for_expansion, 300);
 
-    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 50 * MB);
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 50 * MB);
     auto block_cache = TestCacheUtils::create_cache(options);
     auto local_cache = block_cache->local_cache();
 
@@ -328,7 +328,7 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota_to_zero) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_adjust_interval_seconds, 2);
     SCOPED_UPDATE(int64_t, config::datacache_disk_idle_seconds_for_expansion, 300);
 
-    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 50 * MB);
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 50 * MB);
     auto block_cache = TestCacheUtils::create_cache(options);
     auto local_cache = block_cache->local_cache();
 
@@ -377,7 +377,7 @@ TEST_F(DiskSpaceMonitorTest, get_directory_capacity) {
     SCOPED_UPDATE(bool, config::datacache_enable, true);
     SCOPED_UPDATE(bool, config::enable_datacache_disk_auto_adjust, false);
 
-    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 20 * MB);
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 20 * MB);
     auto block_cache = TestCacheUtils::create_cache(options);
     auto local_cache = block_cache->local_cache();
 

--- a/be/test/cache/lrucache_engine_test.cpp
+++ b/be/test/cache/lrucache_engine_test.cpp
@@ -74,7 +74,7 @@ void LRUCacheEngineTest::_check_found(int value) {
 
 void LRUCacheEngineTest::SetUp() {
     _cache = std::make_shared<LRUCacheEngine>();
-    CacheOptions opts{.mem_space_size = _capacity};
+    MemCacheOptions opts{.mem_space_size = _capacity};
     ASSERT_OK(_cache->init(opts));
 }
 

--- a/be/test/cache/peer_cache_test.cpp
+++ b/be/test/cache/peer_cache_test.cpp
@@ -15,13 +15,9 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
-#include <cstring>
-#include <filesystem>
-
 #include "cache/block_cache/io_buffer.h"
 #include "cache/cache_options.h"
 #include "cache/peer_cache_engine.h"
-#include "common/logging.h"
 #include "common/statusor.h"
 
 namespace starrocks {
@@ -44,7 +40,7 @@ TEST_F(PeerCacheTest, unsupported_op) {
 
 TEST_F(PeerCacheTest, io_adaptor) {
     PeerCacheEngine peer_cache;
-    CacheOptions options;
+    RemoteCacheOptions options;
     options.skip_read_factor = 1.0;
     Status st = peer_cache.init(options);
     ASSERT_TRUE(st.ok());

--- a/be/test/cache/starcache_engine_test.cpp
+++ b/be/test/cache/starcache_engine_test.cpp
@@ -86,7 +86,7 @@ void StarCacheEngineTest::_check_found(int value) {
 }
 
 void StarCacheEngineTest::_init_local_cache() {
-    CacheOptions options = TestCacheUtils::create_simple_options(256 * KB, _mem_quota);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(256 * KB, _mem_quota);
     options.dir_spaces.push_back({.path = _cache_dir, .size = 50 * MB});
 
     _cache = std::make_shared<StarCacheEngine>();

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -3347,7 +3347,7 @@ TEST_F(FileReaderTest, TestStructSubfieldNoDecodeNotOutput) {
 }
 
 TEST_F(FileReaderTest, TestReadFooterCache) {
-    CacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 100 * MB);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 100 * MB);
     auto local_cache = std::make_shared<StarCacheEngine>();
     ASSERT_OK(local_cache->init(options));
     auto cache = std::make_shared<StoragePageCache>(local_cache.get());

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -45,7 +45,7 @@ TEST_F(UpdateConfigActionTest, update_datacache_config) {
     ASSERT_TRUE(fs::create_directories(cache_dir).ok());
 
     auto cache = std::make_shared<StarCacheEngine>();
-    DiskCacheOptions options = TestCacheUtils::create_simple_options(256 * KB);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 0);
     options.dir_spaces.push_back({.path = cache_dir, .size = 50 * MB});
     ASSERT_OK(cache->init(options));
     DataCache::GetInstance()->set_local_disk_cache(cache);

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -45,10 +45,10 @@ TEST_F(UpdateConfigActionTest, update_datacache_config) {
     ASSERT_TRUE(fs::create_directories(cache_dir).ok());
 
     auto cache = std::make_shared<StarCacheEngine>();
-    CacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 0);
+    DiskCacheOptions options = TestCacheUtils::create_simple_options(256 * KB);
     options.dir_spaces.push_back({.path = cache_dir, .size = 50 * MB});
     ASSERT_OK(cache->init(options));
-    DataCache::GetInstance()->set_local_cache(cache);
+    DataCache::GetInstance()->set_local_disk_cache(cache);
 
     UpdateConfigAction action(ExecEnv::GetInstance());
 

--- a/be/test/http/datacache_action_test.cpp
+++ b/be/test/http/datacache_action_test.cpp
@@ -52,7 +52,7 @@ public:
 
         auto options = TestCacheUtils::create_simple_options(256 * KB, 20 * MB);
         _cache = std::make_shared<StarCacheEngine>();
-        ASSERT_OK(_cache->init(options));
+        ASSERT_OK(reinterpret_cast<StarCacheEngine*>(_cache.get())->init(options));
     }
     void TearDown() override {
         if (_evhttp_req != nullptr) {

--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -53,12 +53,9 @@ private:
 
 class CacheInputStreamTest : public ::testing::Test {
 public:
-    static CacheOptions cache_options() {
-        CacheOptions options;
-        options.mem_space_size = 100 * 1024 * 1024;
-#ifdef WITH_STARCACHE
-        options.engine = "starcache";
-#endif
+    static DiskCacheOptions cache_options() {
+        DiskCacheOptions options;
+        options.mem_space_size = 100 * MB;
         options.enable_checksum = false;
         options.max_concurrent_inserts = 1500000;
         options.max_flying_memory_mb = 100;
@@ -79,7 +76,7 @@ public:
         _saved_enable_auto_adjust = config::enable_datacache_disk_auto_adjust;
         config::enable_datacache_disk_auto_adjust = false;
 
-        CacheOptions options = cache_options();
+        DiskCacheOptions options = cache_options();
         auto block_cache = TestCacheUtils::create_cache(options);
         DataCache::GetInstance()->set_block_cache(block_cache);
     }
@@ -318,7 +315,7 @@ TEST_F(CacheInputStreamTest, test_read_with_adaptor) {
     const std::string cache_dir = "./cache_input_stream_cache_dir";
     fs::create_directories(cache_dir);
 
-    CacheOptions options = cache_options();
+    DiskCacheOptions options = cache_options();
     // Because the cache adaptor only work for disk cache.
     options.dir_spaces.push_back({.path = cache_dir, .size = 300 * 1024 * 1024});
     options.enable_tiered_cache = false;

--- a/be/test/service/service_be/internal_service_test.cpp
+++ b/be/test/service/service_be/internal_service_test.cpp
@@ -183,7 +183,7 @@ TEST_F(InternalServiceTest, test_fetch_datacache_via_brpc) {
 
     std::shared_ptr<BlockCache> cache(new BlockCache);
     {
-        CacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 20 * MB);
+        DiskCacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 20 * MB);
         options.inline_item_count_limit = 1000;
         auto cache = TestCacheUtils::create_cache(options);
 
@@ -194,8 +194,8 @@ TEST_F(InternalServiceTest, test_fetch_datacache_via_brpc) {
         ASSERT_TRUE(st.ok());
 
         DataCache* cache_env = DataCache::GetInstance();
-        cache_env->_local_cache = cache->local_cache();
-        cache_env->_block_cache = cache;
+        cache_env->set_local_disk_cache(cache->local_cache());
+        cache_env->set_block_cache(cache);
     }
 
     {

--- a/be/test/storage/rowset/page_handle_test.cpp
+++ b/be/test/storage/rowset/page_handle_test.cpp
@@ -32,7 +32,7 @@ protected:
 };
 
 void PageHandleTest::SetUp() {
-    CacheOptions options{.mem_space_size = 10 * 1024 * 1024};
+    MemCacheOptions options{.mem_space_size = 10 * 1024 * 1024};
     _cache_engine = std::make_shared<LRUCacheEngine>();
     ASSERT_OK(_cache_engine->init(options));
     _page_cache = std::make_shared<StoragePageCache>(_cache_engine.get());

--- a/be/test/storage/rowset/page_io_test.cpp
+++ b/be/test/storage/rowset/page_io_test.cpp
@@ -50,7 +50,7 @@ protected:
 
 void PageIOTest::SetUp() {
     _prev_page_cache = DataCache::GetInstance()->page_cache_ptr();
-    CacheOptions options{.mem_space_size = _cache_size};
+    MemCacheOptions options{.mem_space_size = _cache_size};
     _lru_cache = std::make_shared<LRUCacheEngine>();
     ASSERT_OK(_lru_cache->init(options));
     _page_cache = std::make_shared<StoragePageCache>(_lru_cache.get());

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -36,12 +36,10 @@
 
 #include <gtest/gtest.h>
 
-#include "cache/datacache.h"
 #include "cache/lrucache_engine.h"
 #include "cache/object_cache/page_cache.h"
 #include "common/config.h"
 #include "testutil/assert.h"
-#include "util/logging.h"
 
 namespace starrocks {
 
@@ -52,7 +50,7 @@ public:
 
 protected:
     void SetUp() override {
-        CacheOptions opts{.mem_space_size = 10 * 1024 * 1024};
+        MemCacheOptions opts{.mem_space_size = 10 * 1024 * 1024};
         _lru_cache = std::make_shared<LRUCacheEngine>();
         ASSERT_OK(_lru_cache->init(opts));
 


### PR DESCRIPTION
## Why I'm doing:

StarCacheEngine is not suitable for storing a large number of memory pages and also has some performance degradation. Therefore, I have split the data cache engine into a disk cache engine and a memory cache engine, using LRUCacheEngine as the memory cache engine and StarCacheEngine as the disk cache engine.

Before the pr:

<img width="1280" height="756" alt="image" src="https://github.com/user-attachments/assets/6befb883-575b-4cfa-8e04-d5aa3c21efbb" />

After the pr:

<img width="1136" height="554" alt="image" src="https://github.com/user-attachments/assets/c232b069-8c51-4d69-84fc-c1c815a69f84" />

## What I'm doing:

Split data cache engine into disk cache engine and memory cache engine.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
