### PR TITLE
[Enhancement] generate cloud native pk index sst files when tablet write

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -414,6 +414,8 @@ CONF_Bool(enable_event_based_compaction_framework, "true");
 
 CONF_Bool(enable_size_tiered_compaction_strategy, "true");
 CONF_mBool(enable_pk_size_tiered_compaction_strategy, "true");
+// Enable parallel execution within tablet for primary key tables.
+CONF_mBool(enable_pk_parallel_execution, "false");
 // We support real-time compaction strategy for primary key tables in shared-data mode.
 // This real-time compaction strategy enables compacting rowsets across multiple levels simultaneously.
 // The parameter `size_tiered_max_compaction_level` defines the maximum compaction level allowed in a single compaction task.

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -194,6 +194,7 @@ set(STORAGE_FILES
     lake/vacuum_full.cpp
     lake/general_tablet_writer.cpp
     lake/pk_tablet_writer.cpp
+    lake/pk_tablet_sst_writer.cpp
     lake/primary_key_compaction_policy.cpp
     lake/replication_txn_manager.cpp
     lake/rowset.cpp

--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -80,6 +80,12 @@ Status CompactionTask::fill_compaction_segment_info(TxnLogPB_OpCompaction* op_co
         op_compaction->mutable_output_rowset()->set_data_size(writer->data_size());
         op_compaction->mutable_output_rowset()->set_overlapped(false);
         op_compaction->mutable_output_rowset()->set_next_compaction_offset(0);
+        for (auto& sst : writer->ssts()) {
+            auto* file_meta = op_compaction->add_ssts();
+            file_meta->set_name(sst.path);
+            file_meta->set_size(sst.size.value());
+            file_meta->set_encryption_meta(sst.encryption_meta);
+        }
     }
     return Status::OK();
 }

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -628,6 +628,12 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
             return Status::InternalError(fmt::format("unknown file {}", f.path));
         }
     }
+    for (auto& sst : _tablet_writer->ssts()) {
+        auto* file_meta = op_write->add_ssts();
+        file_meta->set_name(sst.path);
+        file_meta->set_size(sst.size.value());
+        file_meta->set_encryption_meta(sst.encryption_meta);
+    }
     op_write->mutable_rowset()->set_num_rows(_tablet_writer->num_rows());
     op_write->mutable_rowset()->set_data_size(_tablet_writer->data_size());
     op_write->mutable_rowset()->set_overlapped(op_write->rowset().segments_size() > 1);

--- a/be/src/storage/lake/general_tablet_writer.h
+++ b/be/src/storage/lake/general_tablet_writer.h
@@ -78,7 +78,7 @@ public:
     RowsetTxnMetaPB* rowset_txn_meta() override { return nullptr; }
 
 protected:
-    Status reset_segment_writer(bool eos);
+    virtual Status reset_segment_writer(bool eos);
     virtual Status flush_segment_writer(SegmentPB* segment = nullptr);
 
     std::unique_ptr<SegmentWriter> _seg_writer;

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -156,7 +156,7 @@ LakePersistentIndex::LakePersistentIndex(TabletManager* tablet_mgr, int64_t tabl
         : PersistentIndex(""), _tablet_mgr(tablet_mgr), _tablet_id(tablet_id) {}
 
 LakePersistentIndex::~LakePersistentIndex() {
-    if (_memtable) {
+    if (_memtable != nullptr) {
         _memtable->clear();
     }
     _sstables.clear();

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -156,7 +156,7 @@ LakePersistentIndex::LakePersistentIndex(TabletManager* tablet_mgr, int64_t tabl
         : PersistentIndex(""), _tablet_mgr(tablet_mgr), _tablet_id(tablet_id) {}
 
 LakePersistentIndex::~LakePersistentIndex() {
-    if (_memtable != nullptr) {
+    if (_memtable) {
         _memtable->clear();
     }
     _sstables.clear();

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -282,7 +282,7 @@ Status LakePrimaryIndex::erase(const TabletMetadataPtr& metadata, const Column& 
         if (lake_persistent_index != nullptr) {
             std::vector<Slice> keys;
             std::vector<uint64_t> old_values(pks.size(), NullIndexValue);
-            const Slice* vkeys = _build_persistent_keys(pks, 0, pks.size(), &keys);
+            const Slice* vkeys = build_persistent_keys(pks, _key_size, 0, pks.size(), &keys);
             // Cloud native index need to setup rowset id as rebuild point when erase.
             RETURN_IF_ERROR(lake_persistent_index->erase(pks.size(), vkeys,
                                                          reinterpret_cast<IndexValue*>(old_values.data()), rowset_id));

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -114,8 +114,8 @@ size_t PersistentIndexSstable::memory_usage() const {
 }
 
 PersistentIndexSstableStreamBuilder::PersistentIndexSstableStreamBuilder(std::unique_ptr<WritableFile> wf,
-                                                                         const std::string& encryption_meta)
-        : _wf(std::move(wf)), _finished(false), _encryption_meta(encryption_meta) {
+                                                                         std::string encryption_meta)
+        : _wf(std::move(wf)), _finished(false), _encryption_meta(std::move(encryption_meta)) {
     _filter_policy.reset(const_cast<sstable::FilterPolicy*>(sstable::NewBloomFilterPolicy(10)));
     sstable::Options options;
     options.filter_policy = _filter_policy.get();

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -17,6 +17,9 @@
 #include <butil/time.h> // NOLINT
 
 #include "fs/fs.h"
+#include "fs/key_cache.h"
+#include "gen_cpp/types.pb.h"
+#include "storage/lake/lake_delvec_loader.h"
 #include "storage/lake/utils.h"
 #include "storage/sstable/table_builder.h"
 #include "util/trace.h"
@@ -108,6 +111,68 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
 
 size_t PersistentIndexSstable::memory_usage() const {
     return (_sst != nullptr) ? _sst->memory_usage() : 0;
+}
+
+PersistentIndexSstableStreamBuilder::PersistentIndexSstableStreamBuilder(std::unique_ptr<WritableFile> wf,
+                                                                         const std::string& encryption_meta)
+        : _wf(std::move(wf)), _finished(false), _encryption_meta(encryption_meta) {
+    _filter_policy.reset(const_cast<sstable::FilterPolicy*>(sstable::NewBloomFilterPolicy(10)));
+    sstable::Options options;
+    options.filter_policy = _filter_policy.get();
+    _table_builder = std::make_unique<sstable::TableBuilder>(options, _wf.get());
+}
+
+Status PersistentIndexSstableStreamBuilder::add(const Slice& key) {
+    if (_finished) {
+        return Status::InvalidArgument("Builder already finished");
+    }
+
+    if (!_status.ok()) {
+        return _status;
+    }
+
+    IndexValuesWithVerPB index_value_pb;
+    auto* val = index_value_pb.add_values();
+    val->set_rowid(_sst_rowid++);
+
+    _table_builder->Add(key, Slice(index_value_pb.SerializeAsString()));
+    _status = _table_builder->status();
+    return _status;
+}
+
+Status PersistentIndexSstableStreamBuilder::finish(uint64_t* file_size) {
+    if (_finished) {
+        return Status::InvalidArgument("Builder already finished");
+    }
+
+    if (!_status.ok()) {
+        return _status;
+    }
+
+    _status = _table_builder->Finish();
+    if (_status.ok()) {
+        _finished = true;
+        if (file_size != nullptr) {
+            *file_size = _table_builder->FileSize();
+        }
+    }
+    return _status;
+}
+
+uint64_t PersistentIndexSstableStreamBuilder::num_entries() const {
+    return _table_builder ? _table_builder->NumEntries() : 0;
+}
+
+FileInfo PersistentIndexSstableStreamBuilder::file_info() const {
+    FileInfo file_info;
+    file_info.path = file_name(_wf->filename());
+    file_info.size = _table_builder ? _wf->size() : 0;
+    file_info.encryption_meta = _encryption_meta;
+    return file_info;
+}
+
+Status PersistentIndexSstableStreamBuilder::status() const {
+    return _status;
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -166,7 +166,7 @@ uint64_t PersistentIndexSstableStreamBuilder::num_entries() const {
 FileInfo PersistentIndexSstableStreamBuilder::file_info() const {
     FileInfo file_info;
     file_info.path = file_name(_wf->filename());
-    file_info.size = _table_builder ? _wf->size() : 0;
+    file_info.size = _table_builder ? _table_builder->FileSize() : 0;
     file_info.encryption_meta = _encryption_meta;
     return file_info;
 }

--- a/be/src/storage/lake/persistent_index_sstable.h
+++ b/be/src/storage/lake/persistent_index_sstable.h
@@ -76,7 +76,7 @@ private:
 
 class PersistentIndexSstableStreamBuilder {
 public:
-    explicit PersistentIndexSstableStreamBuilder(std::unique_ptr<WritableFile> wf, const std::string& encryption_meta);
+    explicit PersistentIndexSstableStreamBuilder(std::unique_ptr<WritableFile> wf, std::string encryption_meta);
 
     Status add(const Slice& key);
     Status finish(uint64_t* file_size = nullptr);

--- a/be/src/storage/lake/persistent_index_sstable.h
+++ b/be/src/storage/lake/persistent_index_sstable.h
@@ -14,7 +14,9 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
+#include <vector>
 
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/persistent_index.h"
@@ -27,6 +29,11 @@ namespace starrocks {
 
 class WritableFile;
 class PersistentIndexSstablePB;
+
+namespace sstable {
+class TableBuilder;
+class FilterPolicy;
+} // namespace sstable
 
 namespace lake {
 using KeyIndex = size_t;
@@ -65,6 +72,28 @@ private:
     std::unique_ptr<sstable::FilterPolicy> _filter_policy{nullptr};
     std::unique_ptr<RandomAccessFile> _rf{nullptr};
     PersistentIndexSstablePB _sstable_pb;
+};
+
+class PersistentIndexSstableStreamBuilder {
+public:
+    explicit PersistentIndexSstableStreamBuilder(std::unique_ptr<WritableFile> wf, const std::string& encryption_meta);
+
+    Status add(const Slice& key);
+    Status finish(uint64_t* file_size = nullptr);
+
+    uint64_t num_entries() const;
+    FileInfo file_info() const;
+    Status status() const;
+    std::string file_path() const { return _wf->filename(); }
+
+private:
+    std::unique_ptr<sstable::TableBuilder> _table_builder;
+    std::unique_ptr<sstable::FilterPolicy> _filter_policy;
+    std::unique_ptr<WritableFile> _wf;
+    Status _status;
+    bool _finished;
+    std::string _encryption_meta;
+    uint32_t _sst_rowid = 0;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/pk_tablet_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_sst_writer.cpp
@@ -1,0 +1,91 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/pk_tablet_sst_writer.h"
+
+#include <fmt/format.h>
+
+#include "column/chunk.h"
+#include "common/config.h"
+#include "fs/bundle_file.h"
+#include "fs/fs_util.h"
+#include "fs/key_cache.h"
+#include "runtime/current_thread.h"
+#include "serde/column_array_serde.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/filenames.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/primary_index.h"
+#include "storage/primary_key_encoder.h"
+#include "storage/rowset/segment_writer.h"
+#include "storage/sstable/table_builder.h"
+
+namespace starrocks::lake {
+
+Status PkTabletSSTWriter::append_sst_record(const Chunk& data) {
+    if (_pk_sst_builder == nullptr) {
+        return Status::InternalError("pk sst writer not initialized");
+    }
+    if (_pk_column == nullptr) {
+        vector<uint32_t> pk_columns;
+        for (size_t i = 0; i < _tablet_schema_ptr->num_key_columns(); i++) {
+            pk_columns.push_back((uint32_t)i);
+        }
+        _pkey_schema = ChunkHelper::convert_schema(_tablet_schema_ptr, pk_columns);
+        RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(_pkey_schema, &_pk_column));
+        _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pkey_schema);
+    }
+    auto clone_pk_column = _pk_column->clone_empty();
+    TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(_pkey_schema, data, 0, data.num_rows(), clone_pk_column.get()));
+    std::vector<Slice> keys;
+    const Slice* vkeys =
+            PrimaryIndex::build_persistent_keys(*clone_pk_column, _key_size, 0, clone_pk_column->size(), &keys);
+    for (size_t i = 0; i < clone_pk_column->size(); i++) {
+        RETURN_IF_ERROR(_pk_sst_builder->add(vkeys[i]));
+    }
+    return Status::OK();
+}
+
+Status PkTabletSSTWriter::reset_sst_writer(const std::shared_ptr<LocationProvider>& location_provider,
+                                           const std::shared_ptr<FileSystem>& fs) {
+    WritableFileOptions wopts;
+    std::string encryption_meta;
+    if (config::enable_transparent_data_encryption) {
+        ASSIGN_OR_RETURN(auto pair, KeyCache::instance().create_encryption_meta_pair_using_current_kek());
+        wopts.encryption_info = pair.info;
+        encryption_meta = std::move(pair.encryption_meta);
+    }
+    std::unique_ptr<WritableFile> sst_wf;
+    if (location_provider && fs) {
+        ASSIGN_OR_RETURN(sst_wf,
+                         fs->new_writable_file(wopts, location_provider->sst_location(_tablet_id, gen_sst_filename())));
+    } else {
+        ASSIGN_OR_RETURN(sst_wf,
+                         fs::new_writable_file(wopts, _tablet_mgr->sst_location(_tablet_id, gen_sst_filename())));
+    }
+    _pk_sst_builder = std::make_unique<PersistentIndexSstableStreamBuilder>(std::move(sst_wf), encryption_meta);
+    return Status::OK();
+}
+
+StatusOr<FileInfo> PkTabletSSTWriter::flush_sst_writer() {
+    if (_pk_sst_builder == nullptr) {
+        return Status::InternalError("pk sst writer not initialized");
+    }
+    RETURN_IF_ERROR(_pk_sst_builder->finish());
+    auto sst_file_info = _pk_sst_builder->file_info();
+    _pk_sst_builder.reset();
+    return sst_file_info;
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/pk_tablet_sst_writer.h
+++ b/be/src/storage/lake/pk_tablet_sst_writer.h
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <future>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gutil/macros.h"
+#include "runtime/global_dict/types_fwd_decl.h"
+#include "storage/lake/persistent_index_sstable.h"
+#include "storage/lake/tablet_writer.h"
+#include "storage/sstable/table_builder.h"
+
+namespace starrocks::lake {
+
+class PersistentIndexSstableStreamBuilder;
+
+class PkTabletSSTWriter {
+public:
+    PkTabletSSTWriter(const TabletSchemaCSPtr& tablet_schema_ptr, TabletManager* tablet_mgr, int64_t tablet_id)
+            : _tablet_schema_ptr(tablet_schema_ptr), _tablet_mgr(tablet_mgr), _tablet_id(tablet_id) {}
+    virtual ~PkTabletSSTWriter() = default;
+    Status append_sst_record(const Chunk& data);
+    Status reset_sst_writer(const std::shared_ptr<LocationProvider>& location_provider,
+                            const std::shared_ptr<FileSystem>& fs);
+    StatusOr<FileInfo> flush_sst_writer();
+
+private:
+    std::unique_ptr<PersistentIndexSstableStreamBuilder> _pk_sst_builder;
+    MutableColumnPtr _pk_column;
+    Schema _pkey_schema;
+    size_t _key_size = 0;
+    TabletSchemaCSPtr _tablet_schema_ptr;
+    TabletManager* _tablet_mgr;
+    int64_t _tablet_id;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -22,6 +22,7 @@
 #include "runtime/exec_env.h"
 #include "serde/column_array_serde.h"
 #include "storage/lake/filenames.h"
+#include "storage/lake/pk_tablet_sst_writer.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/rows_mapper.h"
 #include "storage/rowset/segment_writer.h"
@@ -50,8 +51,19 @@ HorizontalPkTabletWriter::~HorizontalPkTabletWriter() = default;
 Status HorizontalPkTabletWriter::write(const Chunk& data, const std::vector<uint64_t>& rssid_rowids,
                                        SegmentPB* segment) {
     RETURN_IF_ERROR(HorizontalGeneralTabletWriter::write(data, segment));
+    if (_pk_sst_writer != nullptr) {
+        RETURN_IF_ERROR(_pk_sst_writer->append_sst_record(data));
+    }
     if (_rows_mapper_builder != nullptr) {
         RETURN_IF_ERROR(_rows_mapper_builder->append(rssid_rowids));
+    }
+    return Status::OK();
+}
+
+Status HorizontalPkTabletWriter::write(const Chunk& data, SegmentPB* segment, bool eos) {
+    RETURN_IF_ERROR(HorizontalGeneralTabletWriter::write(data, segment, eos));
+    if (_pk_sst_writer != nullptr) {
+        RETURN_IF_ERROR(_pk_sst_writer->append_sst_record(data));
     }
     return Status::OK();
 }
@@ -79,6 +91,18 @@ Status HorizontalPkTabletWriter::flush_del_file(const Column& deletes) {
     RETURN_IF_ERROR(of->append(Slice(content.data(), content.size())));
     RETURN_IF_ERROR(of->close());
     _files.emplace_back(FileInfo{std::move(name), content.size(), encryption_meta});
+    return Status::OK();
+}
+
+Status HorizontalPkTabletWriter::reset_segment_writer(bool eos) {
+    RETURN_IF_ERROR(HorizontalGeneralTabletWriter::reset_segment_writer(eos));
+    // reset sst file writer
+    if (_pk_sst_writer == nullptr && enable_pk_parallel_execution()) {
+        _pk_sst_writer = std::make_unique<PkTabletSSTWriter>(tablet_schema(), _tablet_mgr, _tablet_id);
+    }
+    if (_pk_sst_writer != nullptr) {
+        RETURN_IF_ERROR(_pk_sst_writer->reset_sst_writer(_location_provider, _fs));
+    }
     return Status::OK();
 }
 
@@ -111,6 +135,11 @@ Status HorizontalPkTabletWriter::flush_segment_writer(SegmentPB* segment) {
         }
         _seg_writer.reset();
     }
+    if (_pk_sst_writer != nullptr) {
+        ASSIGN_OR_RETURN(auto sst_file_info, _pk_sst_writer->flush_sst_writer());
+        _ssts.emplace_back(sst_file_info);
+        _pk_sst_writer.reset();
+    }
     return Status::OK();
 }
 
@@ -142,6 +171,14 @@ Status VerticalPkTabletWriter::write_columns(const Chunk& data, const std::vecto
     // Save rssid_rowids only when writing key columns
     DCHECK(is_key);
     RETURN_IF_ERROR(VerticalGeneralTabletWriter::write_columns(data, column_indexes, is_key));
+    if (_pk_sst_writers.size() <= _current_writer_index && enable_pk_parallel_execution()) {
+        auto sst_writer = std::make_unique<PkTabletSSTWriter>(tablet_schema(), _tablet_mgr, _tablet_id);
+        RETURN_IF_ERROR(sst_writer->reset_sst_writer(_location_provider, _fs));
+        _pk_sst_writers.emplace_back(std::move(sst_writer));
+    }
+    if (!_pk_sst_writers.empty()) {
+        RETURN_IF_ERROR(_pk_sst_writers[_current_writer_index]->append_sst_record(data));
+    }
     if (_rows_mapper_builder != nullptr) {
         RETURN_IF_ERROR(_rows_mapper_builder->append(rssid_rowids));
     }
@@ -149,6 +186,11 @@ Status VerticalPkTabletWriter::write_columns(const Chunk& data, const std::vecto
 }
 
 Status VerticalPkTabletWriter::finish(SegmentPB* segment) {
+    for (auto& sst_writer : _pk_sst_writers) {
+        ASSIGN_OR_RETURN(auto sst_file_info, sst_writer->flush_sst_writer());
+        _ssts.emplace_back(sst_file_info);
+    }
+    _pk_sst_writers.clear();
     if (_rows_mapper_builder != nullptr) {
         RETURN_IF_ERROR(_rows_mapper_builder->finalize());
     }

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -176,7 +176,7 @@ Status VerticalPkTabletWriter::write_columns(const Chunk& data, const std::vecto
         RETURN_IF_ERROR(sst_writer->reset_sst_writer(_location_provider, _fs));
         _pk_sst_writers.emplace_back(std::move(sst_writer));
     }
-    if (!_pk_sst_writers.empty()) {
+    if (_pk_sst_writers.size() > _current_writer_index) {
         RETURN_IF_ERROR(_pk_sst_writers[_current_writer_index]->append_sst_record(data));
     }
     if (_rows_mapper_builder != nullptr) {

--- a/be/src/storage/lake/pk_tablet_writer.h
+++ b/be/src/storage/lake/pk_tablet_writer.h
@@ -29,6 +29,8 @@ class BundleWritableFileContext;
 
 namespace starrocks::lake {
 
+class PkTabletSSTWriter;
+
 class HorizontalPkTabletWriter : public HorizontalGeneralTabletWriter {
 public:
     explicit HorizontalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
@@ -43,6 +45,8 @@ public:
 
     Status write(const Chunk& data, const std::vector<uint64_t>& rssid_rowids, SegmentPB* segment = nullptr) override;
 
+    Status write(const Chunk& data, SegmentPB* segment = nullptr, bool eos = false) override;
+
     Status flush_del_file(const Column& deletes) override;
 
     Status flush_columns() override {
@@ -54,11 +58,13 @@ public:
     RowsetTxnMetaPB* rowset_txn_meta() override { return _rowset_txn_meta.get(); }
 
 protected:
+    Status reset_segment_writer(bool eos) override;
     Status flush_segment_writer(SegmentPB* segment = nullptr) override;
 
 private:
     std::unique_ptr<RowsetTxnMetaPB> _rowset_txn_meta;
     std::unique_ptr<RowsMapperBuilder> _rows_mapper_builder;
+    std::unique_ptr<PkTabletSSTWriter> _pk_sst_writer;
 };
 
 class VerticalPkTabletWriter : public VerticalGeneralTabletWriter {
@@ -87,6 +93,7 @@ public:
 
 private:
     std::unique_ptr<RowsMapperBuilder> _rows_mapper_builder;
+    std::vector<std::unique_ptr<PkTabletSSTWriter>> _pk_sst_writers;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -151,7 +151,11 @@ public:
             return false;
         }
         // For primary key table with single key column and the type is not VARCHAR/CHAR,
-        // we can't enable pk parrallel execution.
+        // we can't enable pk parrallel execution. The reason is that, in the current implementation,
+        // when encoding a single-key column of a non-binary type, big-endian encoding is not used,
+        // which may result in incorrect ordering between sst and segment files.
+        // This is a legacy bug, but for compatibility reasons, it will not be supported in the first phase.
+        // Will fix it later.
         if (tablet_schema()->num_key_columns() > 1 || tablet_schema()->column(0).type() == LogicalType::TYPE_VARCHAR ||
             tablet_schema()->column(0).type() == LogicalType::TYPE_CHAR) {
             return true;

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -49,7 +49,9 @@ public:
               _schema(std::move(schema)),
               _txn_id(txn_id),
               _flush_pool(flush_pool),
-              _is_compaction(is_compaction) {}
+              _is_compaction(is_compaction) {
+        decide_pk_parallel_execution();
+    }
 
     virtual ~TabletWriter() = default;
 
@@ -145,10 +147,10 @@ public:
 
     const DictColumnsValidMap& global_dict_columns_valid_info() const { return _global_dict_columns_valid_info; }
 
-    bool enable_pk_parallel_execution() {
+    void decide_pk_parallel_execution() {
         if (!config::enable_pk_parallel_execution || _schema->keys_type() != KeysType::PRIMARY_KEYS ||
             _schema->has_separate_sort_key()) {
-            return false;
+            return;
         }
         // For primary key table with single key column and the type is not VARCHAR/CHAR,
         // we can't enable pk parrallel execution. The reason is that, in the current implementation,
@@ -156,12 +158,14 @@ public:
         // which may result in incorrect ordering between sst and segment files.
         // This is a legacy bug, but for compatibility reasons, it will not be supported in the first phase.
         // Will fix it later.
-        if (tablet_schema()->num_key_columns() > 1 || tablet_schema()->column(0).type() == LogicalType::TYPE_VARCHAR ||
-            tablet_schema()->column(0).type() == LogicalType::TYPE_CHAR) {
-            return true;
+        if (_schema->num_key_columns() > 1 || _schema->column(0).type() == LogicalType::TYPE_VARCHAR ||
+            _schema->column(0).type() == LogicalType::TYPE_CHAR) {
+            _enable_pk_parallel_execution = true;
         }
-        return false;
+        return;
     }
+
+    bool enable_pk_parallel_execution() const { return _enable_pk_parallel_execution; }
 
 protected:
     TabletManager* _tablet_mgr;
@@ -182,6 +186,7 @@ protected:
 
     bool _is_compaction = false;
     DictColumnsValidMap _global_dict_columns_valid_info;
+    bool _enable_pk_parallel_execution = false;
 };
 
 } // namespace lake

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1302,17 +1302,17 @@ Status PrimaryIndex::_build_persistent_values(uint32_t rssid, const vector<uint3
     return Status::OK();
 }
 
-const Slice* PrimaryIndex::_build_persistent_keys(const Column& pks, uint32_t idx_begin, uint32_t idx_end,
-                                                  std::vector<Slice>* key_slices) const {
+const Slice* PrimaryIndex::build_persistent_keys(const Column& pks, size_t key_size, uint32_t idx_begin,
+                                                 uint32_t idx_end, std::vector<Slice>* key_slices) {
     if (pks.is_binary() || pks.is_large_binary()) {
         const Slice* vkeys = reinterpret_cast<const Slice*>(pks.raw_data());
         return vkeys + idx_begin;
     } else {
-        DCHECK(_key_size > 0);
-        const uint8_t* keys = pks.raw_data() + idx_begin * _key_size;
+        DCHECK(key_size > 0);
+        const uint8_t* keys = pks.raw_data() + idx_begin * key_size;
         for (size_t i = idx_begin; i < idx_end; i++) {
-            key_slices->emplace_back(keys, _key_size);
-            keys += _key_size;
+            key_slices->emplace_back(keys, key_size);
+            keys += key_size;
         }
         return reinterpret_cast<const Slice*>(key_slices->data());
     }
@@ -1323,7 +1323,7 @@ Status PrimaryIndex::_insert_into_persistent_index(uint32_t rssid, const vector<
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     RETURN_IF_ERROR(_build_persistent_values(rssid, rowids, 0, pks.size(), &values));
-    const Slice* vkeys = _build_persistent_keys(pks, 0, pks.size(), &keys);
+    const Slice* vkeys = build_persistent_keys(pks, _key_size, 0, pks.size(), &keys);
     RETURN_IF_ERROR(_persistent_index->insert(pks.size(), vkeys, reinterpret_cast<IndexValue*>(values.data()), true));
     return Status::OK();
 }
@@ -1338,7 +1338,7 @@ Status PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowi
     std::vector<uint64_t> values;
     values.reserve(n);
     std::vector<uint64_t> old_values(n, NullIndexValue);
-    const Slice* vkeys = _build_persistent_keys(pks, idx_begin, idx_end, &keys);
+    const Slice* vkeys = build_persistent_keys(pks, _key_size, idx_begin, idx_end, &keys);
     RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, idx_begin, idx_end, &values));
     RETURN_IF_ERROR(_persistent_index->upsert(n, vkeys, reinterpret_cast<IndexValue*>(values.data()),
                                               reinterpret_cast<IndexValue*>(old_values.data()), stat));
@@ -1354,7 +1354,7 @@ Status PrimaryIndex::_erase_persistent_index(const Column& key_col, DeletesMap* 
     Status st;
     std::vector<Slice> keys;
     std::vector<uint64_t> old_values(key_col.size(), NullIndexValue);
-    const Slice* vkeys = _build_persistent_keys(key_col, 0, key_col.size(), &keys);
+    const Slice* vkeys = build_persistent_keys(key_col, _key_size, 0, key_col.size(), &keys);
     st = _persistent_index->erase(key_col.size(), vkeys, reinterpret_cast<IndexValue*>(old_values.data()));
     if (!st.ok()) {
         LOG(WARNING) << "erase persistent index failed";
@@ -1369,7 +1369,7 @@ Status PrimaryIndex::_erase_persistent_index(const Column& key_col, DeletesMap* 
 
 Status PrimaryIndex::_get_from_persistent_index(const Column& key_col, std::vector<uint64_t>* rowids) const {
     std::vector<Slice> keys;
-    const Slice* vkeys = _build_persistent_keys(key_col, 0, key_col.size(), &keys);
+    const Slice* vkeys = build_persistent_keys(key_col, _key_size, 0, key_col.size(), &keys);
     Status st = _persistent_index->get(key_col.size(), vkeys, reinterpret_cast<IndexValue*>(rowids->data()));
     if (!st.ok()) {
         LOG(WARNING) << "failed get value from persistent index";
@@ -1385,7 +1385,7 @@ Status PrimaryIndex::_get_from_persistent_index(const Column& key_col, std::vect
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
-    Status st = _persistent_index->try_replace(pks.size(), _build_persistent_keys(pks, 0, pks.size(), &keys),
+    Status st = _persistent_index->try_replace(pks.size(), build_persistent_keys(pks, _key_size, 0, pks.size(), &keys),
                                                reinterpret_cast<IndexValue*>(values.data()), src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
@@ -1399,7 +1399,7 @@ Status PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_st
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
-    Status st = _persistent_index->try_replace(pks.size(), _build_persistent_keys(pks, 0, pks.size(), &keys),
+    Status st = _persistent_index->try_replace(pks.size(), build_persistent_keys(pks, _key_size, 0, pks.size(), &keys),
                                                reinterpret_cast<IndexValue*>(values.data()), max_src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
@@ -1459,7 +1459,7 @@ Status PrimaryIndex::_replace_persistent_index_by_indexes(uint32_t rssid, uint32
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
-    Status st = _persistent_index->replace(pks.size(), _build_persistent_keys(pks, 0, pks.size(), &keys),
+    Status st = _persistent_index->replace(pks.size(), build_persistent_keys(pks, _key_size, 0, pks.size(), &keys),
                                            reinterpret_cast<IndexValue*>(values.data()), replace_indexes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -165,11 +165,12 @@ public:
         _status = st;
     }
 
+    // Return the pointer of specific position of slice array.
+    static const Slice* build_persistent_keys(const Column& pks, size_t key_size, uint32_t idx_begin, uint32_t idx_end,
+                                              std::vector<Slice>* key_slices);
+
 protected:
     void _set_schema(const Schema& pk_schema);
-    // Return the pointer of specific position of slice array.
-    const Slice* _build_persistent_keys(const Column& pks, uint32_t idx_begin, uint32_t idx_end,
-                                        std::vector<Slice>* key_slices) const;
 
 private:
     Status _do_load(Tablet* tablet);
@@ -206,9 +207,9 @@ protected:
     Status _status;
     int64_t _tablet_id = 0;
     std::shared_ptr<PersistentIndex> _persistent_index;
+    size_t _key_size = 0;
 
 private:
-    size_t _key_size = 0;
     int64_t _table_id = 0;
     Schema _pk_schema;
     LogicalType _enc_pk_type = TYPE_UNKNOWN;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -264,7 +264,6 @@ set(EXEC_FILES
         ./io/shared_buffered_input_stream_test.cpp
         ./io/spill_test.cpp
         ./io/spill_block_manager_test.cpp
-     
         ./runtime/agg_state_desc_test.cpp
         ./runtime/arrow_result_writer_test.cpp
         ./runtime/buffer_control_block_test.cpp
@@ -500,6 +499,7 @@ SET(DW_TEST_FILES
     ./storage/lake/tablet_test.cpp
     ./storage/lake/tablet_writer_test.cpp
     ./storage/lake/transactions_test.cpp
+    ./storage/lake/pk_tablet_sst_writer_test.cpp
     ./storage/lake/txn_log_applier_test.cpp
     ./storage/lake/vacuum_test.cpp
     ./storage/lake/write_combined_txn_log_test.cpp

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -469,4 +469,117 @@ TEST_F(PersistentIndexSstableTest, test_ioerror_inject) {
     }
 }
 
+TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable_stream_builder) {
+    const int N = 1000;
+    const std::string filename = "test_stream_builder.sst";
+    const std::string encryption_meta = "";
+    
+    // 1. Create stream builder and add keys
+    ASSIGN_OR_ABORT(auto file, fs::new_writable_file(lake::join_path(kTestDir, filename)));
+    auto builder = std::make_unique<PersistentIndexSstableStreamBuilder>(std::move(file), encryption_meta);
+    
+    // Test initial state
+    ASSERT_EQ(0, builder->num_entries());
+    ASSERT_OK(builder->status());
+    ASSERT_FALSE(builder->file_path().empty());
+    
+    // Add keys in order
+    std::vector<std::string> keys;
+    for (int i = 0; i < N; i++) {
+        std::string key = fmt::format("test_key_{:016X}", i);
+        keys.push_back(key);
+        ASSERT_OK(builder->add(Slice(key)));
+    }
+    
+    // Check state after adding keys
+    ASSERT_EQ(N, builder->num_entries());
+    ASSERT_OK(builder->status());
+    
+    // 2. Finish building
+    uint64_t file_size = 0;
+    ASSERT_OK(builder->finish(&file_size));
+    ASSERT_GT(file_size, 0);
+    ASSERT_EQ(N, builder->num_entries());
+    
+    // Test file_info
+    FileInfo info = builder->file_info();
+    ASSERT_EQ(filename, info.path);
+    ASSERT_EQ(file_size, info.size);
+    ASSERT_EQ(encryption_meta, info.encryption_meta);
+    
+    // Test that adding after finish fails
+    ASSERT_ERROR(builder->add(Slice("should_fail")));
+    ASSERT_ERROR(builder->finish());
+    
+    // 3. Read back and verify the sstable
+    std::unique_ptr<PersistentIndexSstable> sst = std::make_unique<PersistentIndexSstable>();
+    ASSIGN_OR_ABORT(auto read_file, fs::new_random_access_file(lake::join_path(kTestDir, filename)));
+    std::unique_ptr<Cache> cache_ptr;
+    cache_ptr.reset(new_lru_cache(100));
+    PersistentIndexSstablePB sstable_pb;
+    sstable_pb.set_filename(filename);
+    sstable_pb.set_filesize(file_size);
+    ASSERT_OK(sst->init(std::move(read_file), sstable_pb, cache_ptr.get()));
+    
+    // 4. Iterate and verify all keys
+    sstable::ReadIOStat stat;
+    sstable::ReadOptions options;
+    options.stat = &stat;
+    sstable::Iterator* iter = sst->new_iterator(options);
+    
+    iter->SeekToFirst();
+    int count = 0;
+    for (; iter->Valid() && iter->status().ok(); iter->Next()) {
+        ASSERT_EQ(iter->key().to_string(), keys[count]);
+        
+        // Parse and verify the value
+        IndexValuesWithVerPB index_value_with_ver_pb;
+        ASSERT_TRUE(index_value_with_ver_pb.ParseFromArray(iter->value().data, iter->value().size));
+        ASSERT_EQ(1, index_value_with_ver_pb.values_size());
+        ASSERT_EQ(count, index_value_with_ver_pb.values(0).rowid());
+        count++;
+    }
+    ASSERT_OK(iter->status());
+    ASSERT_EQ(N, count);
+    delete iter;
+    
+    // 5. Test seeking to specific keys
+    iter = sst->new_iterator(options);
+    for (int i = 0; i < 10; i++) {
+        int r = rand() % N;
+        iter->Seek(keys[r]);
+        ASSERT_TRUE(iter->Valid());
+        ASSERT_EQ(iter->key().to_string(), keys[r]);
+        
+        IndexValuesWithVerPB index_value_with_ver_pb;
+        ASSERT_TRUE(index_value_with_ver_pb.ParseFromArray(iter->value().data, iter->value().size));
+        ASSERT_EQ(r, index_value_with_ver_pb.values(0).rowid());
+    }
+    delete iter;
+}
+
+TEST_F(PersistentIndexSstableTest, test_stream_builder_error_handling) {
+    const std::string filename = "test_stream_builder_error.sst";
+    const std::string encryption_meta = "";
+    
+    // Test with invalid file (simulate error)
+    ASSIGN_OR_ABORT(auto file, fs::new_writable_file(lake::join_path(kTestDir, filename)));
+    auto builder = std::make_unique<PersistentIndexSstableStreamBuilder>(std::move(file), encryption_meta);
+    
+    // Add some keys
+    ASSERT_OK(builder->add(Slice("key1")));
+    ASSERT_OK(builder->add(Slice("key2")));
+    
+    // Test double finish
+    uint64_t file_size = 0;
+    ASSERT_OK(builder->finish(&file_size));
+    ASSERT_GT(file_size, 0);
+    
+    // Second finish should fail
+    ASSERT_ERROR(builder->finish(&file_size));
+    
+    // Adding after finish should fail
+    ASSERT_ERROR(builder->add(Slice("key3")));
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -473,16 +473,16 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable_stream_builder)
     const int N = 1000;
     const std::string filename = "test_stream_builder.sst";
     const std::string encryption_meta = "";
-    
+
     // 1. Create stream builder and add keys
     ASSIGN_OR_ABORT(auto file, fs::new_writable_file(lake::join_path(kTestDir, filename)));
     auto builder = std::make_unique<PersistentIndexSstableStreamBuilder>(std::move(file), encryption_meta);
-    
+
     // Test initial state
     ASSERT_EQ(0, builder->num_entries());
     ASSERT_OK(builder->status());
     ASSERT_FALSE(builder->file_path().empty());
-    
+
     // Add keys in order
     std::vector<std::string> keys;
     for (int i = 0; i < N; i++) {
@@ -490,27 +490,27 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable_stream_builder)
         keys.push_back(key);
         ASSERT_OK(builder->add(Slice(key)));
     }
-    
+
     // Check state after adding keys
     ASSERT_EQ(N, builder->num_entries());
     ASSERT_OK(builder->status());
-    
+
     // 2. Finish building
     uint64_t file_size = 0;
     ASSERT_OK(builder->finish(&file_size));
     ASSERT_GT(file_size, 0);
     ASSERT_EQ(N, builder->num_entries());
-    
+
     // Test file_info
     FileInfo info = builder->file_info();
     ASSERT_EQ(filename, info.path);
     ASSERT_EQ(file_size, info.size);
     ASSERT_EQ(encryption_meta, info.encryption_meta);
-    
+
     // Test that adding after finish fails
     ASSERT_ERROR(builder->add(Slice("should_fail")));
     ASSERT_ERROR(builder->finish());
-    
+
     // 3. Read back and verify the sstable
     std::unique_ptr<PersistentIndexSstable> sst = std::make_unique<PersistentIndexSstable>();
     ASSIGN_OR_ABORT(auto read_file, fs::new_random_access_file(lake::join_path(kTestDir, filename)));
@@ -520,18 +520,18 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable_stream_builder)
     sstable_pb.set_filename(filename);
     sstable_pb.set_filesize(file_size);
     ASSERT_OK(sst->init(std::move(read_file), sstable_pb, cache_ptr.get()));
-    
+
     // 4. Iterate and verify all keys
     sstable::ReadIOStat stat;
     sstable::ReadOptions options;
     options.stat = &stat;
     sstable::Iterator* iter = sst->new_iterator(options);
-    
+
     iter->SeekToFirst();
     int count = 0;
     for (; iter->Valid() && iter->status().ok(); iter->Next()) {
         ASSERT_EQ(iter->key().to_string(), keys[count]);
-        
+
         // Parse and verify the value
         IndexValuesWithVerPB index_value_with_ver_pb;
         ASSERT_TRUE(index_value_with_ver_pb.ParseFromArray(iter->value().data, iter->value().size));
@@ -542,7 +542,7 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable_stream_builder)
     ASSERT_OK(iter->status());
     ASSERT_EQ(N, count);
     delete iter;
-    
+
     // 5. Test seeking to specific keys
     iter = sst->new_iterator(options);
     for (int i = 0; i < 10; i++) {
@@ -550,7 +550,7 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable_stream_builder)
         iter->Seek(keys[r]);
         ASSERT_TRUE(iter->Valid());
         ASSERT_EQ(iter->key().to_string(), keys[r]);
-        
+
         IndexValuesWithVerPB index_value_with_ver_pb;
         ASSERT_TRUE(index_value_with_ver_pb.ParseFromArray(iter->value().data, iter->value().size));
         ASSERT_EQ(r, index_value_with_ver_pb.values(0).rowid());
@@ -561,23 +561,23 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable_stream_builder)
 TEST_F(PersistentIndexSstableTest, test_stream_builder_error_handling) {
     const std::string filename = "test_stream_builder_error.sst";
     const std::string encryption_meta = "";
-    
+
     // Test with invalid file (simulate error)
     ASSIGN_OR_ABORT(auto file, fs::new_writable_file(lake::join_path(kTestDir, filename)));
     auto builder = std::make_unique<PersistentIndexSstableStreamBuilder>(std::move(file), encryption_meta);
-    
+
     // Add some keys
     ASSERT_OK(builder->add(Slice("key1")));
     ASSERT_OK(builder->add(Slice("key2")));
-    
+
     // Test double finish
     uint64_t file_size = 0;
     ASSERT_OK(builder->finish(&file_size));
     ASSERT_GT(file_size, 0);
-    
+
     // Second finish should fail
     ASSERT_ERROR(builder->finish(&file_size));
-    
+
     // Adding after finish should fail
     ASSERT_ERROR(builder->add(Slice("key3")));
 }

--- a/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
+++ b/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
@@ -1,0 +1,255 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/pk_tablet_sst_writer.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "column/binary_column.h"
+#include "column/chunk.h"
+#include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "common/logging.h"
+#include "fs/fs_util.h"
+#include "runtime/mem_tracker.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/delta_writer.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/txn_log.h"
+#include "storage/rowset/segment.h"
+#include "storage/rowset/segment_options.h"
+#include "storage/tablet_schema.h"
+#include "test_util.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+#include "testutil/sync_point.h"
+
+namespace starrocks::lake {
+
+using namespace starrocks;
+
+inline std::shared_ptr<TabletMetadataPB> generate_tablet_metadata(KeysType keys_type) {
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(next_id());
+    metadata->set_version(1);
+    metadata->set_cumulative_point(0);
+    metadata->set_next_rowset_id(1);
+    //
+    //  | column | type | KEY | NULL |
+    //  +--------+------+-----+------+
+    //  |   c0   |  VARCHAR | YES |  NO  |
+    //  |   c1   |  INT | NO  |  NO  |
+    auto schema = metadata->mutable_schema();
+    schema->set_keys_type(keys_type);
+    schema->set_id(next_id());
+    schema->set_num_short_key_columns(1);
+    schema->set_num_rows_per_row_block(65535);
+    auto c0 = schema->add_column();
+    {
+        c0->set_unique_id(next_id());
+        c0->set_name("c0");
+        c0->set_type("VARCHAR");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+    }
+    auto c1 = schema->add_column();
+    {
+        c1->set_unique_id(next_id());
+        c1->set_name("c1");
+        c1->set_type("INT");
+        c1->set_is_key(false);
+        c1->set_is_nullable(false);
+        c1->set_aggregation(keys_type == DUP_KEYS ? "NONE" : "REPLACE");
+    }
+    return metadata;
+}
+
+class PkTabletSSTWriterTest : public TestBase {
+public:
+    PkTabletSSTWriterTest() : TestBase(kTestDirectory) {
+        _tablet_metadata = generate_tablet_metadata(PRIMARY_KEYS);
+        _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+        ASSIGN_OR_ABORT(_fs, FileSystem::CreateSharedFromString(kTestDirectory));
+    }
+
+protected:
+    void SetUp() override {
+        clear_and_init_test_dir();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+    Chunk generate_data(int64_t chunk_size, int64_t start_index = 0) {
+        std::vector<std::pair<std::string, int>> data(chunk_size);
+        for (int i = 0; i < chunk_size; i++) {
+            data[i] = {fmt::format("key_{:10d}", start_index + i), (start_index + i) * 3};
+        }
+
+        auto c0 = BinaryColumn::create();
+        auto c1 = Int32Column::create();
+        for (const auto& [key, value] : data) {
+            c0->append(key);
+            c1->append(value);
+        }
+        return Chunk({std::move(c0), std::move(c1)}, _schema);
+    }
+
+    constexpr static const char* const kTestDirectory = "test_pk_tablet_sst_writer";
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+    int64_t _partition_id = 456;
+    RuntimeProfile _dummy_runtime_profile{"dummy"};
+    std::shared_ptr<FileSystem> _fs;
+};
+
+TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_basic_operations) {
+    const int64_t tablet_id = 12345;
+
+    // Create PkTabletSSTWriter
+    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+
+    // Test reset_sst_writer
+    auto location_provider = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    ASSERT_OK(pk_sst_writer->reset_sst_writer(location_provider, _fs));
+
+    // Generate test data
+    const int64_t chunk_size = 100;
+    auto chunk = generate_data(chunk_size);
+
+    // Test append_sst_record
+    ASSERT_OK(pk_sst_writer->append_sst_record(chunk));
+
+    // Add more data
+    auto chunk2 = generate_data(50, chunk_size);
+    ASSERT_OK(pk_sst_writer->append_sst_record(chunk2));
+
+    // Test flush_sst_writer
+    ASSIGN_OR_ABORT(auto file_info, pk_sst_writer->flush_sst_writer());
+
+    // Verify file info
+    ASSERT_FALSE(file_info.path.empty());
+    ASSERT_GT(file_info.size, 0);
+    ASSERT_TRUE(file_info.path.ends_with(".sst"));
+}
+
+TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_multiple_chunks) {
+    const int64_t tablet_id = 67890;
+
+    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+
+    // Reset writer
+    auto location_provider = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    ASSERT_OK(pk_sst_writer->reset_sst_writer(location_provider, _fs));
+
+    // Add multiple chunks with different sizes
+    std::vector<int64_t> chunk_sizes = {10, 50, 100, 25};
+    int64_t start_index = 0;
+    for (auto size : chunk_sizes) {
+        auto chunk = generate_data(size, start_index);
+        ASSERT_OK(pk_sst_writer->append_sst_record(chunk));
+        start_index += size;
+    }
+
+    // Flush and get result
+    ASSIGN_OR_ABORT(auto file_info, pk_sst_writer->flush_sst_writer());
+
+    // Verify results
+    ASSERT_FALSE(file_info.path.empty());
+    ASSERT_GT(file_info.size, 0);
+}
+
+TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_error_handling) {
+    const int64_t tablet_id = 11111;
+
+    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+
+    // Test append_sst_record before reset - should fail
+    auto chunk = generate_data(10);
+    ASSERT_ERROR(pk_sst_writer->append_sst_record(chunk));
+
+    // Test flush_sst_writer before reset - should fail
+    ASSERT_ERROR(pk_sst_writer->flush_sst_writer());
+
+    // Reset writer
+    auto location_provider = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    ASSERT_OK(pk_sst_writer->reset_sst_writer(location_provider, _fs));
+
+    // Now operations should work
+    ASSERT_OK(pk_sst_writer->append_sst_record(chunk));
+    ASSIGN_OR_ABORT(auto file_info, pk_sst_writer->flush_sst_writer());
+    ASSERT_FALSE(file_info.path.empty());
+}
+
+TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_empty_chunk) {
+    const int64_t tablet_id = 22222;
+
+    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+
+    // Reset writer
+    auto location_provider = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    ASSERT_OK(pk_sst_writer->reset_sst_writer(location_provider, _fs));
+
+    // Create empty chunk
+    auto empty_chunk = generate_data(0);
+    ASSERT_OK(pk_sst_writer->append_sst_record(empty_chunk));
+
+    // Add some real data
+    auto chunk = generate_data(50);
+    ASSERT_OK(pk_sst_writer->append_sst_record(chunk));
+
+    // Flush
+    ASSIGN_OR_ABORT(auto file_info, pk_sst_writer->flush_sst_writer());
+    ASSERT_FALSE(file_info.path.empty());
+    ASSERT_GT(file_info.size, 0);
+}
+
+TEST_F(PkTabletSSTWriterTest, test_pk_tablet_sst_writer_reuse) {
+    const int64_t tablet_id = 33333;
+
+    auto pk_sst_writer = std::make_unique<PkTabletSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+
+    // First use
+    auto location_provider = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    ASSERT_OK(pk_sst_writer->reset_sst_writer(location_provider, _fs));
+
+    auto chunk1 = generate_data(30);
+    ASSERT_OK(pk_sst_writer->append_sst_record(chunk1));
+
+    ASSIGN_OR_ABORT(auto file_info1, pk_sst_writer->flush_sst_writer());
+    ASSERT_FALSE(file_info1.path.empty());
+
+    // Reuse the writer for a second file
+    ASSERT_OK(pk_sst_writer->reset_sst_writer(location_provider, _fs));
+
+    auto chunk2 = generate_data(40, 30);
+    ASSERT_OK(pk_sst_writer->append_sst_record(chunk2));
+
+    ASSIGN_OR_ABORT(auto file_info2, pk_sst_writer->flush_sst_writer());
+    ASSERT_FALSE(file_info2.path.empty());
+
+    // The two files should be different
+    ASSERT_NE(file_info1.path, file_info2.path);
+}
+
+} // namespace starrocks::lake

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -45,6 +45,7 @@ message FileMetaPB {
     optional int64 size = 2;
     // Whether this file shared by multiple tablets
     optional bool shared = 3 [default=false];
+    optional bytes encryption_meta = 4;
 }
 
 message DelvecMetadataPB {
@@ -202,6 +203,7 @@ message TxnLogPB {
         // for partial update, record dest rewrite segment names to avoid gc
         repeated string rewrite_segments = 4;
         repeated bytes del_encryption_metas = 5;
+        repeated FileMetaPB ssts = 6;
     }
 
     message OpCompaction {
@@ -219,6 +221,7 @@ message TxnLogPB {
         // x and y might be new segments
         optional int32 new_segment_offset = 6;
         optional int32 new_segment_count = 7;
+        repeated FileMetaPB ssts = 8;
     }
 
     message OpSchemaChange {

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -233,7 +233,7 @@ message PersistentIndexSstablePB {
     optional uint32 shared_rssid = 8;
     optional int64 shared_version = 9;
     // For sstable generated during compaction process.
-    optional bool need_delvec = 10;
+    optional bool has_delvec = 10;
 }
 
 message PersistentIndexSstableMetaPB {

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -229,6 +229,11 @@ message PersistentIndexSstablePB {
     // Filter out rows which do not satisfy the predicate
     // when reading this specific sstable
     optional PersistentIndexSstablePredicatePB predicate = 7;
+    // For sstable generated during data write & compaction process.
+    optional uint32 shared_rssid = 8;
+    optional int64 shared_version = 9;
+    // For sstable generated during compaction process.
+    optional bool need_delvec = 10;
 }
 
 message PersistentIndexSstableMetaPB {


### PR DESCRIPTION
## Why I'm doing:
In the current implementation, the primary key index files of a primary key table are always generated during the publish phase. Since publish is executed serially, this impacts the primary key model’s parallel processing capability when handling large imports (see #62740). This PR is the first part of the overall optimization, primarily implementing the generation of SST index files during the import phase.

## What I'm doing:
This pull request introduces support for parallel SST file writing for primary key tables in the storage layer, enabling more efficient parallel execution and compaction. The changes add a new `PkTabletSSTWriter` class and integrate it into the tablet writer workflow, allowing the system to generate and manage multiple SST files concurrently when the new configuration flag is enabled. There are also improvements to metadata handling and code structure to support these features.

**Parallel SST File Writing for Primary Key Tables:**

- Added a new configuration flag `enable_pk_parallel_execution` to control parallel SST file writing for primary key tables (`be/src/common/config.h`).
- Introduced the `PkTabletSSTWriter` class, which handles the creation, writing, and flushing of SST files for primary key tables (`be/src/storage/lake/pk_tablet_sst_writer.h`, `be/src/storage/lake/pk_tablet_sst_writer.cpp`). [[1]](diffhunk://#diff-e88a778af67dc6d399d6804df3cef6f37045fdac5db5f5c3a066dbbf69222406R1-R91) [[2]](diffhunk://#diff-0c130188b5e66e3518bd9620fd5b3ecce2091ee9a7d95a3278b02af4258882a4R1-R52)
- Integrated `PkTabletSSTWriter` into both horizontal and vertical primary key tablet writers, enabling parallel SST file creation and management during data writes and segment flushes (`be/src/storage/lake/pk_tablet_writer.h`, `be/src/storage/lake/pk_tablet_writer.cpp`). [[1]](diffhunk://#diff-a05518f862ddddbebd78e597360277ba9d483fac610a693c7bd6c5263816c076R32-R33) [[2]](diffhunk://#diff-a05518f862ddddbebd78e597360277ba9d483fac610a693c7bd6c5263816c076R48-R49) [[3]](diffhunk://#diff-a05518f862ddddbebd78e597360277ba9d483fac610a693c7bd6c5263816c076R61-R67) [[4]](diffhunk://#diff-a915fbf31d5ce885015bb08d9025089b3f4d6d1d99d4dc034b925d45b1ee2073R54-R70) [[5]](diffhunk://#diff-a915fbf31d5ce885015bb08d9025089b3f4d6d1d99d4dc034b925d45b1ee2073R97-R108) [[6]](diffhunk://#diff-a915fbf31d5ce885015bb08d9025089b3f4d6d1d99d4dc034b925d45b1ee2073R138-R142) [[7]](diffhunk://#diff-a915fbf31d5ce885015bb08d9025089b3f4d6d1d99d4dc034b925d45b1ee2073R174-R193)

**Metadata and File Information Enhancements:**

- Extended the compaction and delta writer logic to record SST file metadata (such as file name, size, and encryption meta) in transaction logs and compaction tasks (`be/src/storage/lake/compaction_task.cpp`, `be/src/storage/lake/delta_writer.cpp`). [[1]](diffhunk://#diff-1e439ad0c5ae3d3e0348c25088f3a55097dbfa2a1f5932a330ee7ba947e67164R83-R88) [[2]](diffhunk://#diff-24e44403f5e4c75144f9645f2fcff77dcdd9269836bafd5b79d5b2d6589e49fdR631-R636)
- Added the `PersistentIndexSstableStreamBuilder` utility for incremental SST file building and metadata tracking (`be/src/storage/lake/persistent_index_sstable.h`, `be/src/storage/lake/persistent_index_sstable.cpp`). [[1]](diffhunk://#diff-730a4bbffe684fca8ff8657698ba70e972f7cfb2001abb5f5393ccfc95709baeR77-R98) [[2]](diffhunk://#diff-944f1a344f7f65e05aa9a179b3c047563225c2658b39f4c4129abfb919a2f402R116-R177)

**Build and Dependency Updates:**

- Registered the new `pk_tablet_sst_writer.cpp` source file in the build system (`be/src/storage/CMakeLists.txt`).
- Updated includes and forward declarations to support new classes and dependencies (`be/src/storage/lake/persistent_index_sstable.h`, `be/src/storage/lake/persistent_index_sstable.cpp`). [[1]](diffhunk://#diff-730a4bbffe684fca8ff8657698ba70e972f7cfb2001abb5f5393ccfc95709baeR17-R19) [[2]](diffhunk://#diff-730a4bbffe684fca8ff8657698ba70e972f7cfb2001abb5f5393ccfc95709baeR33-R37) [[3]](diffhunk://#diff-944f1a344f7f65e05aa9a179b3c047563225c2658b39f4c4129abfb919a2f402R20-R22)

**Miscellaneous Improvements and Fixes:**

- Minor code quality and bug fixes, including safer pointer checks and correct key building in primary index operations (`be/src/storage/lake/lake_persistent_index.cpp`, `be/src/storage/lake/lake_primary_index.cpp`). [[1]](diffhunk://#diff-687a9117869c9c3cb509971cb9da3d4c7c6e484c64f1bcf0ea476e5bc57f63f1L159-R159) [[2]](diffhunk://#diff-4181f67216e63b0c7f50c678c4b72730534e5049d33bfa10ec6d012148eb192dL285-R285)
- Made `reset_segment_writer` virtual in the general tablet writer for better extensibility (`be/src/storage/lake/general_tablet_writer.h`).

Fix #62740

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
