### PR TITLE
[BugFix] Fix improper BE selection causing ineffective rebalance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -654,10 +654,22 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
             }
             // neither the number of tablets select in high load BE nor low load BE exceeds limit,
             // change group index in succession.
-            if ((h + l) % 2 == 0) {
+            // If either highGroup or lowGroup has only one backend, we always move the other index.
+            // This prevents getting stuck in an infinite loop due to modulo operation with size 1.
+            // Otherwise, we alternate h and l based on (h + l) % 2 to iterate through both groups.
+            if (highGroup.size() == 1) {
+                // Only one backend in highGroup, so increment lowGroup index
+                l++;
+            } else if (lowGroup.size() == 1) {
+                // Only one backend in lowGroup, so increment highGroup index
                 h++;
             } else {
-                l++;
+                // Both groups have multiple backends, alternate selection to balance iteration
+                if ((h + l) % 2 == 0) {
+                    h++;
+                } else {
+                    l++;
+                }
             }
         }
 


### PR DESCRIPTION
## Why I'm doing:
The current iteration logic for selecting source (h) and target (l) backends during disk balancing has an issue. The code:
```
if ((h + l) % 2 == 0) {
    h++;
} else {
    l++;
}

h %= highGroup.size();
l %= lowGroup.size();

```
can get stuck in certain scenarios. For example, when a new backend is added and `lowGroup.size()` is 1, the expression `l %= lowGroup.size()`always evaluates to **0**. If `highGroup.size()` is 12, the iteration may look like this:
```
Init: h = 0, l = 0

Round 1: h -> 1, l -> 0

Round 2: h -> 2, l -> 0

Round 3: h -> 2, l -> 1 -> 0

…

Round 13: h -> 2, l -> 0
```
As a result, only the first two high-load backends (h) are ever selected, while the rest are effectively ignored, preventing proper balancing across all backends.


## What I'm doing:
To avoid the issue where h and l get stuck, the iteration logic was modified to handle cases where highGroup or lowGroup has only one backend separately. In these cases, we increment only the non-singleton group, ensuring that the iteration progresses correctly and all backends have a chance to be selected for balancing.
```
if (highGroup.size() == 1) {
      // Only one backend in highGroup, so increment lowGroup index
      l++;
  } else if (lowGroup.size() == 1) {
      // Only one backend in lowGroup, so increment highGroup index
      h++;
  } else {
      // Both groups have multiple backends, alternate selection to balance iteration
      if ((h + l) % 2 == 0) {
          h++;
      } else {
          l++;
      }
  }
 ```

Fixes [#62541](https://github.com/StarRocks/starrocks/issues/62541)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
