### PR TITLE
[Enhancement] support common expr reuse in complex case-when expr in scan predicates

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithCaseWhenTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithCaseWhenTest.java
@@ -639,6 +639,18 @@ class SelectStmtWithCaseWhenTest {
                 "FROM cte01\n" +
                 "WHERE len_bucket IS NOT NULL;";
         String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
-        Assert.assertTrue(plan.contains("CASE WHEN array_length"));
+        Assert.assertTrue(plan.contains("  2:SELECT\n" +
+                "  |  predicates: 3: case IS NOT NULL\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  output columns:\n" +
+                "  |  1 <-> [1: id, VARCHAR, false]\n" +
+                "  |  3 <-> CASE WHEN 5: array_length < 2 THEN 'bucket1' " +
+                "WHEN (5: array_length >= 2) AND (5: array_length < 4) THEN 'bucket2' ELSE NULL END\n" +
+                "  |  4 <-> [5: array_length, INT, true]\n" +
+                "  |  common expressions:\n" +
+                "  |  5 <-> array_length[([2: col_arr, ARRAY<VARCHAR(100)>, true]); " +
+                "args: INVALID_TYPE; result: INT; args nullable: true; result nullable: true]"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithCaseWhenTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithCaseWhenTest.java
@@ -613,11 +613,8 @@ class SelectStmtWithCaseWhenTest {
         } else {
             Assertions.assertTrue(patterns.stream().anyMatch(plan::contains), joiner.toString());
         }
+        starRocksAssert.getCtx().getSessionVariable().setEnablePredicateExprReuse(true);
 
-        //        String code = "{\n\"" + sql.replace("\n", " ") + "\",\n" + Arrays.stream(plan.split("\n"))
-        //                .filter(c -> c.contains("PREDICATES:")).map(c -> c.replace("PREDICATES:", "").trim())
-        //                .collect(Collectors.joining(", ", "\"", "\"")) + "},";
-        //        System.out.println(code);
     }
 
     @Test
@@ -646,8 +643,8 @@ class SelectStmtWithCaseWhenTest {
                 "  1:Project\n" +
                 "  |  output columns:\n" +
                 "  |  1 <-> [1: id, VARCHAR, false]\n" +
-                "  |  3 <-> CASE WHEN 5: array_length < 2 THEN 'bucket1' " +
-                "WHEN (5: array_length >= 2) AND (5: array_length < 4) THEN 'bucket2' ELSE NULL END\n" +
+                "  |  3 <-> CASE WHEN [5: array_length, INT, true] < 2 THEN 'bucket1' " +
+                "WHEN ([5: array_length, INT, true] >= 2) AND ([5: array_length, INT, true] < 4) THEN 'bucket2' ELSE NULL END\n" +
                 "  |  4 <-> [5: array_length, INT, true]\n" +
                 "  |  common expressions:\n" +
                 "  |  5 <-> array_length[([2: col_arr, ARRAY<VARCHAR(100)>, true]); " +


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

adjust the TableScanPredicateExtracter strategy so that complex case when expressions can be extracted from ScanNode, thereby having the opportunity to reuse some common expressions

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
