### PR TITLE
[BugFix] Fix cte reuse plan extract error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalNoCTEOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalNoCTEOperator.java
@@ -67,4 +67,9 @@ public class PhysicalNoCTEOperator extends PhysicalOperator {
     public int hashCode() {
         return Objects.hash(super.hashCode(), cteId);
     }
+
+    @Override
+    public String toString() {
+        return "PhysicalNoCTEOperator[" + cteId + "]";
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -47,6 +47,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -193,6 +194,10 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
 
             // Successfully optimize all child group
             if (curChildIndex == groupExpression.getInputs().size()) {
+                // check required CTE
+                if (!checkChildrenHasRequiredCTE(groupExpression, context.getRequiredProperty(), childrenOutputProperties)) {
+                    break;
+                }
                 // before we compute the property, here need to make sure that the plan is legal
                 ChildOutputPropertyGuarantor childOutputPropertyGuarantor = new ChildOutputPropertyGuarantor(context,
                         groupExpression,
@@ -230,6 +235,31 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
 
     private void recordLowerBoundCost(double cost) {
         groupExpression.getGroup().setCostLowerBound(context.getRequiredProperty(), cost);
+    }
+
+    private boolean checkChildrenHasRequiredCTE(GroupExpression groupExpression, PhysicalPropertySet requiredProperty,
+                                                List<PhysicalPropertySet> childrenOutputProperties) {
+        OperatorType operatorType = groupExpression.getOp().getOpType();
+        switch (operatorType) {
+            case PHYSICAL_CTE_ANCHOR:
+            case PHYSICAL_NO_CTE:
+                Set<Integer> requiredCTE = requiredProperty.getCteProperty().getCteIds();
+                Set<Integer> groupUseCTE = groupExpression.getGroup().getLogicalProperty().getUsedCTEs().getCteIds();
+                if (groupUseCTE.stream().anyMatch(requiredCTE::contains)) {
+                    Set<Integer> childrenUseCteIds = childrenOutputProperties.stream()
+                            .map(prop -> prop.getCteProperty().getCteIds())
+                            .flatMap(Set::stream)
+                            .collect(Collectors.toSet());
+                    for (Integer CteId : requiredCTE) {
+                        if (groupUseCTE.contains(CteId) && !childrenUseCteIds.contains(CteId)) {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            default:
+                return true;
+        }
     }
 
     private boolean checkCTEPropertyValid(GroupExpression groupExpression, PhysicalPropertySet requiredPropertySet) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -250,8 +250,8 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
                             .map(prop -> prop.getCteProperty().getCteIds())
                             .flatMap(Set::stream)
                             .collect(Collectors.toSet());
-                    for (Integer CteId : requiredCTE) {
-                        if (groupUseCTE.contains(CteId) && !childrenUseCteIds.contains(CteId)) {
+                    for (Integer cteId : requiredCTE) {
+                        if (groupUseCTE.contains(cteId) && !childrenUseCteIds.contains(cteId)) {
                             return false;
                         }
                     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
the question CTE Plan:
```
             CTEAnchor(cteid = 3)
            /                   \
    CTEProducer-3               CTEAnchor(cteid = 2)
                               /                   \
                  CTEProducer-2                   CTEAnchor(cteid = 1)
                       /                          /                   \
                     AGG                  CTEProducer-1                JOIN
                      |                        |                    /       \
                 CTEConsume-3                 AGG           CTEConsume-1    JOIN
                                               |                          /      \
                                          CTEConsume-3               JOIN         CTEConsume-2
                                                                    /   \           
                                                       CTEConsume-1    CTEConsume-2
```

In memo and meet some condititions:
* SR required CTE-3 must reuse
* CTE-1 & CTE-2 to compute isn't reuse by cost model

when CTE-1 & CTE-2 decide use inline plan, the CTEAnchor-1 and CTEAnchor-2 will be not choose, but the the CTEAnchor-3 required reuse, then the sr will extract an error plan: CTEAnchor-3 is exists but CTEConsume-3 was removed

why the CTEAnchor(cteid = 2)/CTEAnchor(cteid = 1) will choose inline not reuse?
because not all join chlidren contains CTEConsume-3, it's normally, so the non-CTE-3 chlidren meet the CTE-3 property required too...... and the CTEAnchor-1/CTEAnchor-2 don't know the children is can't support the CTE-3 property or is don't need the CTE-3 property

this fix:
when the parent CTE required reuse, his children plan must staisfy the required


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
