### PR TITLE
[Enhancement] Make gen_build_version.py robust when JAVA_HOME is unset

### DIFF
--- a/build-support/gen_build_version.py
+++ b/build-support/gen_build_version.py
@@ -86,11 +86,19 @@ def get_build_arch():
 
 def get_java_version():
     java_home = os.getenv("JAVA_HOME")
-    java_res = subprocess.Popen([java_home + "/bin/java", "-fullversion"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    out, err = java_res.communicate()
-
-    if java_res.returncode == 0:
-        return out.decode('utf-8').replace("\"", "\\\"").strip()
+    java_cmd = None
+    if java_home:
+        java_cmd = java_home + "/bin/java"
+    else:
+        # Fallback to system java on PATH
+        java_cmd = "java"
+    try:
+        java_res = subprocess.Popen([java_cmd, "-fullversion"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        out, _ = java_res.communicate()
+        if java_res.returncode == 0:
+            return out.decode('utf-8').replace("\"", "\\\"").strip()
+    except Exception:
+        pass
     return "unknown jdk"
 
 def get_fingerprint(items):


### PR DESCRIPTION
## Why I'm doing:
Highlights improved robustness across environments
Lists specific use cases (CI/CD, Docker, development machines)
Emphasizes graceful degradation vs. complete failure
## What I'm doing:
This pull request improves the robustness of the `get_java_version()` function in `gen_build_version.py` by making it more resilient to missing environment variables and potential errors during Java version detection.

Enhancements to Java version detection:

* Updated `get_java_version()` to fall back to the system `java` executable if `JAVA_HOME` is not set, instead of failing.
* Wrapped the Java version detection logic in a try/except block to gracefully handle exceptions and return `"unknown jdk"` if an error occurs.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
