### PR TITLE
[BugFix] fix NPE of information_schema.analyze_status when db is dropped

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
@@ -101,7 +101,6 @@ public class AnalyzeStatusSystemTable extends SystemTable {
                 }
             }
             TAnalyzeStatusItem item = new TAnalyzeStatusItem();
-            itemList.add(item);
             item.setCatalog_name("");
             item.setDatabase_name("");
             item.setTable_name("");
@@ -136,6 +135,7 @@ public class AnalyzeStatusSystemTable extends SystemTable {
             item.setEnd_time(DateUtils.formatDateTimeUnix(analyze.getEndTime()));
             item.setProperties(analyze.getProperties() == null ? "{}" : analyze.getProperties().toString());
             item.setReason(analyze.getReason());
+            itemList.add(item);
         }
 
         return res;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
@@ -118,6 +118,7 @@ public class AnalyzeStatusSystemTable extends SystemTable {
                     continue;
                 }
             } catch (MetaNotFoundException ignored) {
+                continue;
             }
 
             String columnStr = "ALL";

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.system.information.AnalyzeStatusSystemTable;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.persist.OperationType;
@@ -28,9 +29,11 @@ import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.optimizer.statistics.CachedStatisticStorage;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.thrift.TAnalyzeStatusReq;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.InsertTxnCommitAttachment;
 import com.starrocks.transaction.TransactionState;
+import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
@@ -319,4 +322,32 @@ public class AnalyzeMgrTest {
         transactionState.setTxnCommitAttachment(new InsertTxnCommitAttachment(0));
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().updateLoadRows(transactionState);
     }
+
+    @Test
+    public void testQuery() throws Exception {
+        final String dbName = "db_analyze_status";
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+
+        starRocksAssert
+                .withDatabase(dbName)
+                .useDatabase(dbName)
+                .withTable("create table t1 (c1 int, c2 int) properties('replication_num'='1')");
+        UtFrameUtils.mockDML();
+        starRocksAssert.getCtx().executeSql("insert into t1 values (1,1)");
+        starRocksAssert.getCtx().executeSql("analyze table t1 with sync mode");
+
+        // Add the analyze status but drop the table
+        Database db = starRocksAssert.getDb(dbName);
+        Table table = starRocksAssert.getTable(dbName, "t1");
+        AnalyzeStatus analyzeStatus = new NativeAnalyzeStatus(100,
+                db.getId(), table.getId(),
+                ImmutableList.of("c1", "c2"), StatsConstants.AnalyzeType.FULL,
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now());
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
+        starRocksAssert.dropDatabase(dbName).withDatabase(dbName);
+
+        TAnalyzeStatusReq request = new TAnalyzeStatusReq();
+        AnalyzeStatusSystemTable.query(request);
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Case:
- The db is dropped, but the analyze status is still there
- Select `information_schema.analyze_status`


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
