### PR TITLE
[BugFix][CVE-2025-58056] bump io.netty version to 4.1.125.Final

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -59,7 +59,7 @@ subprojects {
         set("hive-apache.version", "3.1.2-22")
         set("hudi.version", "1.0.2")
         set("iceberg.version", "1.9.0")
-        set("io.netty.version", "4.1.124.Final")
+        set("io.netty.version", "4.1.125.Final")
         set("jackson.version", "2.15.2")
         set("jetty.version", "9.4.57.v20241219")
         set("jprotobuf-starrocks.version", "1.0.0")

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -65,7 +65,7 @@ under the License.
         <kafka-clients.version>3.4.0</kafka-clients.version>
         <arrow.version>18.0.0</arrow.version>
         <grpc.version>1.63.0</grpc.version>
-        <io.netty.version>4.1.124.Final</io.netty.version>
+        <io.netty.version>4.1.125.Final</io.netty.version>
         <puppycrawl.version>10.21.1</puppycrawl.version>
         <aws-v2-sdk.version>2.29.52</aws-v2-sdk.version>
         <avro.version>1.12.0</avro.version>

--- a/fs_brokers/apache_hdfs_broker/src/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/src/pom.xml
@@ -50,7 +50,7 @@ under the License.
         <jackson.version>2.18.3</jackson.version>
         <avro.version>1.11.4</avro.version>
         <jetty.version>9.4.57.v20241219</jetty.version>
-        <io.netty.version>4.1.124.Final</io.netty.version>
+        <io.netty.version>4.1.125.Final</io.netty.version>
     </properties>
 
     <profiles>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -41,7 +41,7 @@
         <jni-connector.version>1.0.0</jni-connector.version>
         <hadoop-ext.version>1.0.0</hadoop-ext.version>
         <java-utils.version>1.0.0</java-utils.version>
-        <io.netty.version>4.1.124.Final</io.netty.version>
+        <io.netty.version>4.1.125.Final</io.netty.version>
         <protobuf-java.version>3.25.5</protobuf-java.version>
         <nimbusds.version>9.37.2</nimbusds.version>
         <commons-io.version>2.14.0</commons-io.version>


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #62795

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
