### PR TITLE
[BugFix] Fix collecting stream load profile failed

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -318,6 +318,12 @@ void FragmentExecState::coordinator_callback(const Status& status, RuntimeProfil
             [&res, &params](FrontendServiceConnection& client) { client->reportExecStatus(res, params); },
             config::thrift_rpc_timeout_ms);
 
+    VLOG(1) << "report exec status, fragment_instance_id: " << print_id(_runtime_state->fragment_instance_id())
+            << ", has_profile: " << params.__isset.profile
+            << ", has_load_channel_profile: " << params.__isset.load_channel_profile
+            << ", rpc_status: " << rpc_status.to_string()
+            << ", result: " << apache::thrift::ThriftDebugString(res).c_str();
+
     if (rpc_status.ok()) {
         rpc_status = Status(res.status);
     }

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -174,6 +174,8 @@ private:
     // then profile will not be reported to FE even though enable_profile=true
     int32_t load_profile_collect_second = -1;
 
+    int64_t _start_time_ms;
+
     // If this is set to false, and 'enable_profile' is false as well,
     // This executor will not report status to FE on being cancelled.
     bool _is_report_on_cancel;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -178,15 +178,19 @@ public class ProfileManager implements MemoryTrackable {
                     + "may be forget to insert 'QUERY_ID' column into infoStrings");
         }
 
+        String removedQueryId = null;
         writeLock.lock();
         try {
             profileMap.put(queryId, element);
             if (profileMap.size() > Config.profile_info_reserved_num) {
-                profileMap.remove(profileMap.keySet().iterator().next());
+                removedQueryId = profileMap.keySet().iterator().next();
+                profileMap.remove(removedQueryId);
             }
         } finally {
             writeLock.unlock();
         }
+
+        LOG.debug("push profile for query: {}, remove profile for query: {}", queryId, removedQueryId);
 
         return profileString;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1174,6 +1174,9 @@ public class StreamLoadTask extends AbstractStreamLoadTask {
         // sync stream load collect profile, here we collect profile only when be has reported
         if (isSyncStreamLoad() && coord != null && coord.isProfileAlreadyReported()) {
             collectProfile(false);
+        } else {
+            LOG.debug("stream load does not collect profile, txn_id: {}, label: {}, load id: {}",
+                    txnId, label, DebugUtil.printId(loadId));
         }
 
         writeLock();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -200,7 +200,7 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
             LOG.debug("ReportExecStatus(): fragment_instance_id={}, query_id={}, backend num: {}, ip: {}",
                     DebugUtil.printId(params.fragment_instance_id), DebugUtil.printId(params.query_id),
                     params.backend_num, beAddr);
-            LOG.debug("params: {}", params);
+            LOG.trace("params: {}", params);
         }
         final TReportExecStatusResult result = new TReportExecStatusResult();
         final QueryInfo info = coordinatorMap.get(params.query_id);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -96,7 +96,7 @@ public class QueryRuntimeProfile {
      * if the time costs of stream load is less than {@link Config#stream_load_profile_collect_threshold_second},
      * the profile will not be reported to FE to reduce the overhead of profile under high-frequency import
      */
-    private boolean profileAlreadyReported = false;
+    private volatile boolean profileAlreadyReported = false;
 
     private RuntimeProfile queryProfile;
     private List<RuntimeProfile> fragmentProfiles;

--- a/test/sql/test_profile/R/test_load_channel_profile
+++ b/test/sql/test_profile/R/test_load_channel_profile
@@ -1,5 +1,5 @@
--- name: test_load_channel_profile
-CREATE TABLE `t0` (
+-- name: test_load_channel_profile @sequential
+CREATE TABLE `test_load_channel_profile` (
   `v1` int(11) NOT NULL,
   `v2` int(11) NOT NULL,
   `v3` int(11) NOT NULL
@@ -12,7 +12,7 @@ PROPERTIES (
 -- result:
 -- !result
 CREATE MATERIALIZED VIEW `mv1` AS
-SELECT `v1`, SUM(`v2`) FROM `t0`
+SELECT `v1`, SUM(`v2`) FROM `test_load_channel_profile`
 GROUP BY `v1`;
 -- result:
 -- !result
@@ -21,7 +21,7 @@ function: wait_materialized_view_finish()
 None
 -- !result
 CREATE MATERIALIZED VIEW `mv2` AS
-SELECT `v1`, MAX(`v3`) FROM `t0`
+SELECT `v1`, MAX(`v3`) FROM `test_load_channel_profile`
 GROUP BY `v1`;
 -- result:
 -- !result
@@ -29,7 +29,7 @@ function: wait_materialized_view_finish()
 -- result:
 None
 -- !result
-INSERT INTO `t0` (v1, v2, v3) values
+INSERT INTO `test_load_channel_profile` (v1, v2, v3) values
     (1, 1, 1),
     (1, 1, 2),
     (1, 1, 3),
@@ -50,7 +50,7 @@ SET enable_profile=true;
 SET enable_async_profile=false;
 -- result:
 -- !result
-INSERT INTO t0 WITH LABEL label_${uuid0} SELECT * FROM t0;
+INSERT INTO test_load_channel_profile WITH LABEL label_${uuid0} SELECT * FROM test_load_channel_profile;
 -- result:
 -- !result
 shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid0}" bash ${root_path}/sql/test_profile/T/test_load_profile_analysis.sh
@@ -59,10 +59,18 @@ shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid0}" bash ${roo
 Analyze profile succeeded
 Analyze profile succeeded
 -- !result
-alter table t0 set('enable_load_profile'='true');
+function: enable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
+-- result:
+None
+-- !result
+function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 1)
+-- result:
+None
+-- !result
+alter table test_load_channel_profile set('enable_load_profile'='true');
 -- result:
 -- !result
-shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label: "label_${uuid1}"" -H "column_separator: ," -d '1,2,3' -X PUT ${url}/api/${db[0]}/t0/_stream_load
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label: "label_${uuid1}"" -H "column_separator: ," -d '1,2,3' -X PUT ${url}/api/${db[0]}/test_load_channel_profile/_stream_load
 -- result:
 0
 {
@@ -75,4 +83,12 @@ shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid1}" bash ${roo
 0
 Analyze profile succeeded
 Analyze profile succeeded
+-- !result
+function: disable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
+-- result:
+None
+-- !result
+function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 0)
+-- result:
+None
 -- !result

--- a/test/sql/test_profile/T/test_load_channel_profile
+++ b/test/sql/test_profile/T/test_load_channel_profile
@@ -1,5 +1,5 @@
--- name: test_load_channel_profile
-CREATE TABLE `t0` (
+-- name: test_load_channel_profile @sequential
+CREATE TABLE `test_load_channel_profile` (
   `v1` int(11) NOT NULL,
   `v2` int(11) NOT NULL,
   `v3` int(11) NOT NULL
@@ -11,18 +11,18 @@ PROPERTIES (
 );
 
 CREATE MATERIALIZED VIEW `mv1` AS
-SELECT `v1`, SUM(`v2`) FROM `t0`
+SELECT `v1`, SUM(`v2`) FROM `test_load_channel_profile`
 GROUP BY `v1`;
 
 function: wait_materialized_view_finish()
 
 CREATE MATERIALIZED VIEW `mv2` AS
-SELECT `v1`, MAX(`v3`) FROM `t0`
+SELECT `v1`, MAX(`v3`) FROM `test_load_channel_profile`
 GROUP BY `v1`;
 
 function: wait_materialized_view_finish()
 
-INSERT INTO `t0` (v1, v2, v3) values
+INSERT INTO `test_load_channel_profile` (v1, v2, v3) values
     (1, 1, 1),
     (1, 1, 2),
     (1, 1, 3),
@@ -38,9 +38,15 @@ INSERT INTO `t0` (v1, v2, v3) values
 
 SET enable_profile=true;
 SET enable_async_profile=false;
-INSERT INTO t0 WITH LABEL label_${uuid0} SELECT * FROM t0;
+INSERT INTO test_load_channel_profile WITH LABEL label_${uuid0} SELECT * FROM test_load_channel_profile;
 shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid0}" bash ${root_path}/sql/test_profile/T/test_load_profile_analysis.sh
 
-alter table t0 set('enable_load_profile'='true');
-shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label: "label_${uuid1}"" -H "column_separator: ," -d '1,2,3' -X PUT ${url}/api/${db[0]}/t0/_stream_load
+function: enable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
+function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 1)
+
+alter table test_load_channel_profile set('enable_load_profile'='true');
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label: "label_${uuid1}"" -H "column_separator: ," -d '1,2,3' -X PUT ${url}/api/${db[0]}/test_load_channel_profile/_stream_load
 shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid1}" bash ${root_path}/sql/test_profile/T/test_load_profile_analysis.sh
+
+function: disable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
+function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 0)


### PR DESCRIPTION
## Why I'm doing:
sql test test_load_channel_profile fails occasionally because can't find the profile of stream load although we have enable it.  From `information_schema.loads`, the profile id is NULL. 

```
ID LABEL PROFILE_ID DB_NAME TABLE_NAME USER WAREHOUSE STATE PROGRESS TYPE PRIORITY SCAN_ROWS SCAN_BYTES FILTERED_ROWS UNSELECTED_ROWS SINK_ROWS RUNTIME_DETAILS CREATE_TIME LOAD_START_TIME LOAD_COMMIT_TIME LOAD_FINISH_TIME PROPERTIES ERROR_MSG TRACKING_SQL REJECTED_RECORD_PATH JOB_ID
96443 label_3608587b015b430f9e734097a47d04c0 NULL test_db_dd84e7e2aa5e45a5aef31e34764ec4cc t0 root NULL FINISHED 100% STREAM_LOAD NORMAL 0 77 0 0 1 {"begin_txn_time_ms": 1, "client_ip": "172.21.252.72", "load_id": "5d425179-c340-dda1-7ade-513aad3ee5b9", "plan_time_ms": 2, "receive_data_time_ms": 0, "txn_id": 5051} 2025-09-05 18:36:47 NULL 2025-09-05 18:36:47 2025-09-05 18:36:47 {"timeout": 6000} NULL NULL 96443
```

Still can't find the reason 100% after some investigation according to the current logs, and reproduce it locally. This PR fixes some potential issues, and print more logs when running the test for debug.

## What I'm doing:

1. Potential fixes
   - BE: Switch profile-report gating to monotonic elapsed time
     - Use elapsed time derived from a monotonic clock to decide whether to skip reporting under the configured threshold, instead of wall-clock based calculations. This avoids clock drift/offset issues that could incorrectly skip short stream loads.
     - Clarify separation of concerns: `RuntimeState.timestamp_ms()` remains for SQL time functions (now()/current_timestamp), and is not used for runtime elapsed calculations.
   - FE: Strengthen profile visibility across threads
     - Mark `profileAlreadyReported` as volatile so that, once any BE instance reports a profile, other threads can observe the change promptly. This improves the correctness of profile collection flow (e.g., stream load committing logic that depends on whether profiles have been reported).

2. Observability
   - Add targeted logs to diagnose profile reporting
     - BE prints the concrete reason when profile reporting is skipped (threshold vs. elapsed seconds), along with the fragment instance id and timing numbers.
     - FE emits debug logs around profile updates and stream load profile collection, making it easier to trace when/what got reported.
   - Make tests more diagnosable by enabling verbose logging during execution
     - During test runs, turn on FE debug logs for `QeProcessorImpl`, `QueryRuntimeProfile`, `StreamLoadTask`, and `ProfileManager`, and raise BE vlog levels for `fragment_mgr*` and `plan_fragment_executor*`. This provides end-to-end visibility for triage and confirms that LoadChannel profiles are populated as expected.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
