### PR TITLE
[BugFix] Fix secondary replicas continue waiting because of wrong timestamp

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -396,6 +396,17 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
         response->mutable_status()->add_error_msgs("no packet_seq in PTabletWriterAddChunkRequest");
         return;
     }
+    if (UNLIKELY(!request.has_timeout_ms())) {
+        response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
+        response->mutable_status()->add_error_msgs("missing timeout_ms in PTabletWriterAddChunkRequest");
+        return;
+    }
+    if (UNLIKELY(request.timeout_ms() < 0)) {
+        response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
+        response->mutable_status()->add_error_msgs(fmt::format(
+                "negtive timeout_ms {} in PTabletWriterAddChunkRequest", request.timeout_ms()));
+        return;
+    }
 
     auto& sender = _senders[request.sender_id()];
 

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -403,8 +403,8 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
     }
     if (UNLIKELY(request.timeout_ms() < 0)) {
         response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
-        response->mutable_status()->add_error_msgs(fmt::format(
-                "negtive timeout_ms {} in PTabletWriterAddChunkRequest", request.timeout_ms()));
+        response->mutable_status()->add_error_msgs(
+                fmt::format("negtive timeout_ms {} in PTabletWriterAddChunkRequest", request.timeout_ms()));
         return;
     }
 

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -206,8 +206,8 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     }
     if (UNLIKELY(request.timeout_ms() < 0)) {
         response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
-        response->mutable_status()->add_error_msgs(fmt::format(
-                "negtive timeout_ms {} in PTabletWriterAddChunkRequest", request.timeout_ms()));
+        response->mutable_status()->add_error_msgs(
+                fmt::format("negtive timeout_ms {} in PTabletWriterAddChunkRequest", request.timeout_ms()));
         return;
     }
 

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -199,6 +199,17 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
         response->mutable_status()->add_error_msgs("no packet_seq in PTabletWriterAddChunkRequest");
         return;
     }
+    if (UNLIKELY(!request.has_timeout_ms())) {
+        response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
+        response->mutable_status()->add_error_msgs("missing timeout_ms in PTabletWriterAddChunkRequest");
+        return;
+    }
+    if (UNLIKELY(request.timeout_ms() < 0)) {
+        response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
+        response->mutable_status()->add_error_msgs(fmt::format(
+                "negtive timeout_ms {} in PTabletWriterAddChunkRequest", request.timeout_ms()));
+        return;
+    }
 
     {
         std::lock_guard lock(_senders[request.sender_id()].lock);
@@ -362,7 +373,8 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
         }
         int64_t start_wait_time = MonotonicMillis();
         for (auto& [node_id, delta_writers] : unfinished_replicas_grouped_by_primary_node) {
-            int64_t left_timeout_ms = std::max((uint64_t)0, request.timeout_ms() - watch.elapsed_time() / 1000000);
+            int64_t elapsed_ms = static_cast<int64_t>(watch.elapsed_time() / NANOSECS_PER_MILLIS);
+            int64_t left_timeout_ms = std::max<int64_t>(0, request.timeout_ms() - elapsed_ms);
             SecondaryReplicasWaiter waiter(request.id(), _txn_id, request.sink_id(), left_timeout_ms, start_wait_time,
                                            delta_writers);
             Status status = waiter.wait();
@@ -1247,7 +1259,7 @@ SecondaryReplicasWaiter::SecondaryReplicasWaiter(PUniqueId load_id, int64_t txn_
         : _load_id(std::move(load_id)),
           _txn_id(txn_id),
           _sink_id(sink_id),
-          _timeout_ns(timeout_ms * NANOSECS_PER_MILLIS),
+          _timeout_ns(std::max((int64_t)0, timeout_ms) * NANOSECS_PER_MILLIS),
           _delta_writers(std::move(delta_writers)),
           _eos_time_ms(eos_time_ms),
           _last_get_replica_status_time_ms(eos_time_ms) {}
@@ -1442,7 +1454,7 @@ void SecondaryReplicasWaiter::_try_diagnose_stack_strace_on_primary(int unfinish
     SET_IGNORE_OVERCROWDED(closure->cntl, load);
     PLoadDiagnoseRequest request;
     request.mutable_id()->set_hi(_load_id.hi());
-    request.mutable_id()->set_hi(_load_id.lo());
+    request.mutable_id()->set_lo(_load_id.lo());
     request.set_txn_id(_txn_id);
     request.set_stack_trace(true);
     closure->ref();

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -281,6 +281,7 @@ TEST_F(LakeTabletsChannelTest, test_simple_write) {
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_eos(false);
     add_chunk_request.set_packet_seq(0);
+    add_chunk_request.set_timeout_ms(60000);
 
     for (int i = 0; i < kChunkSize; i++) {
         int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
@@ -345,6 +346,7 @@ TEST_F(LakeTabletsChannelTest, test_simple_write) {
     finish_request.set_sender_id(0);
     finish_request.set_eos(true);
     finish_request.set_packet_seq(1);
+    finish_request.set_timeout_ms(60000);
     finish_request.add_partition_ids(10);
     finish_request.add_partition_ids(11);
 
@@ -395,6 +397,7 @@ TEST_F(LakeTabletsChannelTest, test_write_partial_partition) {
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_eos(false);
     add_chunk_request.set_packet_seq(0);
+    add_chunk_request.set_timeout_ms(60000);
 
     for (int i = 0; i < kChunkSize; i++) {
         int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
@@ -416,6 +419,7 @@ TEST_F(LakeTabletsChannelTest, test_write_partial_partition) {
     finish_request.set_sender_id(0);
     finish_request.set_eos(true);
     finish_request.set_packet_seq(1);
+    finish_request.set_timeout_ms(60000);
     // Does not contain partition 11
     finish_request.add_partition_ids(10);
 
@@ -459,6 +463,7 @@ TEST_F(LakeTabletsChannelTest, test_write_bundling_file) {
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_eos(false);
     add_chunk_request.set_packet_seq(0);
+    add_chunk_request.set_timeout_ms(60000);
 
     for (int i = 0; i < kChunkSize; i++) {
         int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
@@ -480,6 +485,7 @@ TEST_F(LakeTabletsChannelTest, test_write_bundling_file) {
     finish_request.set_sender_id(0);
     finish_request.set_eos(true);
     finish_request.set_packet_seq(1);
+    finish_request.set_timeout_ms(60000);
     finish_request.add_partition_ids(10);
     finish_request.add_partition_ids(11);
 
@@ -530,6 +536,7 @@ TEST_F(LakeTabletsChannelTest, test_write_concurrently) {
             add_chunk_request.set_sender_id(sender_id);
             add_chunk_request.set_eos(false);
             add_chunk_request.set_packet_seq(i);
+            add_chunk_request.set_timeout_ms(60000);
 
             for (int j = 0; j < kChunkSize; j++) {
                 int64_t tablet_id = 10086 + (j / kChunkSizePerTablet);
@@ -551,6 +558,7 @@ TEST_F(LakeTabletsChannelTest, test_write_concurrently) {
         finish_request.set_sender_id(sender_id);
         finish_request.set_eos(true);
         finish_request.set_packet_seq(kLookCount);
+        finish_request.set_timeout_ms(60000);
         finish_request.add_partition_ids(10);
         finish_request.add_partition_ids(11);
 
@@ -598,6 +606,7 @@ TEST_F(LakeTabletsChannelTest, DISABLED_test_abort) {
             add_chunk_request.set_sender_id(0);
             add_chunk_request.set_eos(false);
             add_chunk_request.set_packet_seq(packet_seq++);
+            add_chunk_request.set_timeout_ms(60000);
 
             for (int i = 0; i < kChunkSize; i++) {
                 int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
@@ -623,6 +632,7 @@ TEST_F(LakeTabletsChannelTest, DISABLED_test_abort) {
         finish_request.set_packet_seq(packet_seq++);
         finish_request.add_partition_ids(10);
         finish_request.add_partition_ids(11);
+        finish_request.set_timeout_ms(60000);
         _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
         ASSERT_NE(TStatusCode::OK, finish_response.status().status_code());
         ASSERT_TRUE(close_channel);
@@ -659,7 +669,7 @@ TEST_F(LakeTabletsChannelTest, test_write_failed) {
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_eos(false);
     add_chunk_request.set_packet_seq(0);
-
+    add_chunk_request.set_timeout_ms(60000);
     for (int i = 0; i < kChunkSize; i++) {
         int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
         add_chunk_request.add_tablet_ids(tablet_id);
@@ -705,6 +715,7 @@ TEST_F(LakeTabletsChannelTest, test_tablet_not_existed) {
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_eos(false);
     add_chunk_request.set_packet_seq(0);
+    add_chunk_request.set_timeout_ms(60000);
 
     for (int i = 0; i < kChunkSize; i++) {
         int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
@@ -744,6 +755,7 @@ TEST_F(LakeTabletsChannelTest, test_empty_tablet) {
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_eos(false);
     add_chunk_request.set_packet_seq(0);
+    add_chunk_request.set_timeout_ms(60000);
 
     // Only tablet 10086 has data
     for (int i = 0; i < kChunkSize; i++) {
@@ -767,6 +779,7 @@ TEST_F(LakeTabletsChannelTest, test_empty_tablet) {
     finish_request.set_packet_seq(1);
     finish_request.add_partition_ids(10);
     finish_request.add_partition_ids(11);
+    finish_request.set_timeout_ms(60000);
 
     _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
     ASSERT_TRUE(finish_response.status().status_code() == TStatusCode::OK);
@@ -812,6 +825,7 @@ TEST_F(LakeTabletsChannelTest, test_finish_failed) {
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_eos(false);
     add_chunk_request.set_packet_seq(0);
+    add_chunk_request.set_timeout_ms(60000);
 
     // Only tablet 10086 has data
     for (int i = 0; i < kChunkSize; i++) {
@@ -838,6 +852,7 @@ TEST_F(LakeTabletsChannelTest, test_finish_failed) {
     finish_request.set_packet_seq(1);
     finish_request.add_partition_ids(10);
     finish_request.add_partition_ids(11);
+    finish_request.set_timeout_ms(60000);
 
     _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
     ASSERT_NE(TStatusCode::OK, finish_response.status().status_code());
@@ -861,6 +876,7 @@ TEST_F(LakeTabletsChannelTest, test_finish_after_abort) {
         add_chunk_request.set_sender_id(0);
         add_chunk_request.set_eos(true);
         add_chunk_request.set_packet_seq(0);
+        add_chunk_request.set_timeout_ms(60000);
 
         for (int i = 0; i < kChunkSize; i++) {
             int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
@@ -889,6 +905,7 @@ TEST_F(LakeTabletsChannelTest, test_finish_after_abort) {
         finish_request.set_sender_id(1);
         finish_request.set_eos(true);
         finish_request.set_packet_seq(0);
+        finish_request.set_timeout_ms(60000);
 
         bool close_channel;
         _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
@@ -921,6 +938,7 @@ TEST_F(LakeTabletsChannelTest, test_profile) {
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_eos(true);
     add_chunk_request.set_packet_seq(0);
+    add_chunk_request.set_timeout_ms(60000);
 
     for (int i = 0; i < kChunkSize; i++) {
         int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -280,6 +280,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_simple_write) {
         add_chunk_request.mutable_id()->set_hi(0);
         add_chunk_request.mutable_id()->set_lo(0);
         add_chunk_request.set_sink_id(0);
+        add_chunk_request.set_timeout_ms(60000);
 
         ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
         add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
@@ -308,6 +309,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_simple_write) {
     finish_request.set_packet_seq(1);
     finish_request.add_partition_ids(10);
     finish_request.add_partition_ids(11);
+    finish_request.set_timeout_ms(60000);
 
     _load_channel->add_chunk(finish_request, &finish_response);
     ASSERT_EQ(TStatusCode::OK, finish_response.status().status_code());
@@ -360,6 +362,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_write_concurrently) {
             add_chunk_request.mutable_id()->set_hi(0);
             add_chunk_request.mutable_id()->set_lo(0);
             add_chunk_request.set_sink_id(0);
+            add_chunk_request.set_timeout_ms(60000);
 
             for (int j = 0; j < kChunkSize; j++) {
                 int64_t tablet_id = 10086 + (j / kChunkSizePerTablet);
@@ -384,6 +387,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_write_concurrently) {
         finish_request.set_packet_seq(kLookCount);
         finish_request.add_partition_ids(10);
         finish_request.add_partition_ids(11);
+        finish_request.set_timeout_ms(60000);
 
         _load_channel->add_chunk(finish_request, &finish_response);
         ASSERT_EQ(TStatusCode::OK, finish_response.status().status_code()) << finish_response.status().error_msgs()[0];
@@ -428,6 +432,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_abort) {
             add_chunk_request.mutable_id()->set_hi(0);
             add_chunk_request.mutable_id()->set_lo(0);
             add_chunk_request.set_sink_id(0);
+            add_chunk_request.set_timeout_ms(60000);
 
             for (int i = 0; i < kChunkSize; i++) {
                 int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
@@ -452,6 +457,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_abort) {
         finish_request.set_packet_seq(packet_seq++);
         finish_request.add_partition_ids(10);
         finish_request.add_partition_ids(11);
+        finish_request.set_timeout_ms(60000);
         _load_channel->add_chunk(finish_request, &finish_response);
         ASSERT_NE(TStatusCode::OK, finish_response.status().status_code());
         stopped.store(true);
@@ -624,6 +630,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_final_profile) {
         add_chunk_request.mutable_id()->set_hi(0);
         add_chunk_request.mutable_id()->set_lo(0);
         add_chunk_request.set_sink_id(0);
+        add_chunk_request.set_timeout_ms(60000);
 
         ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
         add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
@@ -773,6 +780,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_load_diagnose) {
         add_chunk_request.mutable_id()->set_hi(0);
         add_chunk_request.mutable_id()->set_lo(0);
         add_chunk_request.set_sink_id(0);
+        add_chunk_request.set_timeout_ms(60000);
 
         ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
         add_chunk_request.mutable_chunk()->Swap(&chunk_pb);

--- a/be/test/runtime/local_tablets_channel_test.cpp
+++ b/be/test/runtime/local_tablets_channel_test.cpp
@@ -245,6 +245,7 @@ TEST_F(LocalTabletsChannelTest, test_add_chunk_not_exist_tablet) {
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_eos(true);
     add_chunk_request.set_packet_seq(0);
+    add_chunk_request.set_timeout_ms(60000);
 
     auto non_exist_tablet_id = _tablets[0]->tablet_id() + 1;
     add_chunk_request.add_tablet_ids(non_exist_tablet_id);

--- a/be/test/runtime/local_tablets_channel_test.cpp
+++ b/be/test/runtime/local_tablets_channel_test.cpp
@@ -270,6 +270,7 @@ TEST_F(LocalTabletsChannelTest, diagnose_stack_trace) {
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_eos(true);
     add_chunk_request.set_packet_seq(0);
+    add_chunk_request.set_timeout_ms(100);
 
     auto old_threshold = config::load_diagnose_rpc_timeout_stack_trace_threshold_ms;
     DeferOp defer([&]() {
@@ -314,6 +315,7 @@ TEST_F(LocalTabletsChannelTest, test_primary_replica_profile) {
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_eos(true);
     add_chunk_request.set_packet_seq(0);
+    add_chunk_request.set_timeout_ms(60000);
 
     int chunk_size = 16;
     auto chunk = _generate_data(chunk_size, tablet->tablet_schema());
@@ -382,6 +384,7 @@ void LocalTabletsChannelTest::test_cancel_secondary_replica_base(bool is_empty_t
     add_chunk_request.set_eos(true);
     add_chunk_request.set_packet_seq(0);
     add_chunk_request.set_wait_all_sender_close(true);
+    add_chunk_request.set_timeout_ms(60000);
 
     auto chunk = _generate_data(1, tablet->tablet_schema());
     ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
@@ -447,6 +450,7 @@ TEST_F(LocalTabletsChannelTest, test_cancel_secondary_replica_rpc_fail) {
     add_chunk_request.set_eos(true);
     add_chunk_request.set_packet_seq(0);
     add_chunk_request.set_wait_all_sender_close(true);
+    add_chunk_request.set_timeout_ms(60000);
 
     DeferOp defer([&]() {
         SyncPoint::GetInstance()->ClearCallBack("LocalTabletsChannel::rpc::tablet_writer_cancel");
@@ -744,6 +748,7 @@ TEST_F(LocalTabletsChannelTest, test_get_replica_status) {
     add_chunk_request.set_eos(true);
     add_chunk_request.set_packet_seq(0);
     add_chunk_request.set_wait_all_sender_close(true);
+    add_chunk_request.set_timeout_ms(60000);
     auto chunk = _generate_data(2, _tablets[0]->tablet_schema());
     ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
     add_chunk_request.mutable_chunk()->Swap(&chunk_pb);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -2142,6 +2142,7 @@ TEST_F(LakeServiceTest, test_abort_txn2) {
             add_chunk_request.set_sender_id(0);
             add_chunk_request.set_eos(false);
             add_chunk_request.set_packet_seq(i);
+            add_chunk_request.set_timeout_ms(60000);
 
             for (int j = 0; j < chunk_size; j++) {
                 add_chunk_request.add_tablet_ids(_tablet_id);


### PR DESCRIPTION
## Why I'm doing:
- The test `LocalTabletsChannelTest.diagnose_stack_trace` hangs inside `SecondaryReplicasWaiter::wait()`. Logs repeatedly show “timeout: -1 ms” until the CI kills the process because of timeout.
```
 [ RUN      ] LocalTabletsChannelTest.diagnose_stack_trace
 I20250905 09:43:06.192314 139980464982720 tablet_manager.cpp:261] Created tablet 432327279, cost 6ms.
 I20250905 09:43:06.193215 139980464982720 local_tablets_channel.cpp:780] LocalTabletsChannel txn_id: 10000 load_id: 00000000-0006-f855-0000-0000000f1206 sink_id: 1 open 1 delta writer: [432327279:2]0 failed_tablets:  _num_remaining_senders: 1
 I20250905 09:43:06.193287 139980464982720 local_tablets_channel.cpp:643] LocalTabletsChannel txn_id: 10000 load_id: 00000000-0006-f855-0000-0000000f1206 sink_id: 1 commit 0 tablets:
 I20250905 09:43:06.206415 139980464982720 local_tablets_channel.cpp:1445] send request to diagnose primary replica, txn_id: 10000, load_id: 00000000-0006-f855-0000-0000000f1206, primary_replica: [127.0.0.0:8060]
 I20250905 09:43:21.202282 139980464982720 local_tablets_channel.cpp:1347] send request to get load replica status, txn_id: 10000, load_id: 00000000-0006-f855-0000-0000000f1206, primary replica: [127.0.0.0:8060], num unfinished tablets: 1
 W20250905 09:43:36.198584 139980464982720 local_tablets_channel.cpp:1269] waiting secondary replicas too long, load_id: 00000000-0006-f855-0000-0000000f1206, txn_id: 10000, timeout: -1 ms, elapsed time: 30004 ms, primary replica host: 127.0.0.0, num finished tablets: 0, num unfinished tablets: 1, last unfinished     tablet: [tablet_id: 432327279, state 1]
 
 UNKNOWN RELEASE (build UNKNOWN distro ubuntu arch x86_64)
 query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000
 *** Aborted at 1757065685 (unix time) try "date -d @1757065685" if you are using GNU date ***
 PC: @     0x7f4fbdce57f8 clock_nanosleep
 *** SIGTERM (@0x27d2) received by PID 913852 (TID 0x7f4fbde40ac0) LWP(913852) from PID 10194; stack trace: ***
     @     0x7f4fbdc99ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
     @         0x18e3cd18 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
     @     0x7f4fbdc42520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
     @     0x7f4fbdce57f8 clock_nanosleep
     @     0x7f4fbdcea677 __nanosleep
     @     0x7f4fbdd1bf2f usleep
     @         0x190414b7 bthread_usleep
     @         0x149cd537 starrocks::SecondaryReplicasWaiter::wait()
     @         0x149d08a9 starrocks::LocalTabletsChannel::add_chunk(starrocks::Chunk*, starrocks::PTabletWriterAddChunkRequest const&, starrocks::PTabletWriterAddBatchResult*, bool*)
     @          0xd9b707b starrocks::LocalTabletsChannelTest_diagnose_stack_trace_Test::TestBody()
```

- Why “-1 ms” causes a hang:
  -  In `SecondaryReplicasWaiter::wait()`, the loop breaks on `watch.elapsed_time() > _timeout_ns`
  - `watch.elapsed_time()` is `uint64_t` and `_timeout_ns` is `int64_t`. When `_timeout_ns` is negative, it’s implicitly converted to a huge `uint64_t`, so `elapsed > timeout` is never true. The loop logs periodically and never exits.

- Why timeout became “-1”:
  - The `PTabletWriterAddChunkRequest` in test `LocalTabletsChannelTest.diagnose_stack_trace`  didn’t explicitly set `timeout_ms`, and there was no guard. 
  - Remaining time was computed with mixed signed/unsigned arithmetic in `LocalTabletsChannel::add_chunk`
with `int64_t left_timeout_ms = std::max((uint64_t)0, request.timeout_ms() - watch.elapsed_time() / 1000000)`
  - With a missing/zero `timeout_ms`, subtracting a positive elapsed time underflowed in unsigned math, producing a very large value that, when stored in `int64_t`, became negative (effectively “-1” semantics). No clamping existed in the waiter either.

### What I’m doing
- Validate inputs: require `timeout_ms` of `PTabletWriterAddChunkRequest` to be present and non-negative in `add_chunk()` (local and lake), rejecting invalid requests.
- Fix remaining-time math: compute elapsed in signed ms and clamp `left_timeout_ms` to ≥ 0; clamp `_timeout_ns` in `SecondaryReplicasWaiter` to ≥ 0 to ensure the elapsed > timeout check works.
- Make tests explicit: set a reasonable `timeout_ms` to ensure waits time out deterministically instead of hanging.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
