### PR TITLE
[BugFix] mutate input columns in functions' returning value

### DIFF
--- a/be/src/exprs/binary_functions.cpp
+++ b/be/src/exprs/binary_functions.cpp
@@ -33,7 +33,7 @@ StatusOr<ColumnPtr> BinaryFunctions::to_binary(FunctionContext* context, const C
     auto to_binary_type = state->to_binary_type;
     switch (to_binary_type) {
     case BinaryFormatType::UTF8:
-        return src_column;
+        return std::move(*src_column).mutate();
     case BinaryFormatType::ENCODE64:
         return EncryptionFunctions::from_base64(context, columns);
     default:
@@ -79,7 +79,7 @@ StatusOr<ColumnPtr> BinaryFunctions::from_binary(FunctionContext* context, const
     auto to_binary_type = state->to_binary_type;
     switch (to_binary_type) {
     case BinaryFormatType::UTF8:
-        return src_column;
+        return std::move(*src_column).mutate();
     case BinaryFormatType::ENCODE64:
         return EncryptionFunctions::to_base64(context, columns);
     default:

--- a/be/src/exprs/math_functions.h
+++ b/be/src/exprs/math_functions.h
@@ -421,7 +421,7 @@ public:
      */
     template <LogicalType Type>
     DEFINE_VECTORIZED_FN(positive) {
-        return VECTORIZED_FN_ARGS(0);
+        return std::move(*columns[0]).mutate();
     }
 
     /**
@@ -450,7 +450,7 @@ public:
     template <LogicalType Type>
     static StatusOr<ColumnPtr> least(FunctionContext* context, const Columns& columns) {
         if (columns.size() == 1) {
-            return columns[0];
+            return std::move(*columns[0]).mutate();
         }
 
         RETURN_IF_COLUMNS_ONLY_NULL(columns);
@@ -491,7 +491,7 @@ public:
     template <LogicalType Type>
     static StatusOr<ColumnPtr> greatest(FunctionContext* context, const Columns& columns) {
         if (columns.size() == 1) {
-            return columns[0];
+            return std::move(*columns[0]).mutate();
         }
 
         RETURN_IF_COLUMNS_ONLY_NULL(columns);

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -3132,7 +3132,7 @@ StatusOr<ColumnPtr> StringFunctions::concat_ws(FunctionContext* context, const C
     }
 
     if (columns.size() == 2) {
-        return columns[1];
+        return std::move(*columns[1]).mutate();
     }
 
     const auto sep_size = ColumnHelper::compute_bytes_size(columns.begin(), columns.begin() + 1);

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -3046,7 +3046,7 @@ static inline ColumnPtr concat_not_const(Columns const& columns) {
  */
 StatusOr<ColumnPtr> StringFunctions::concat(FunctionContext* context, const Columns& columns) {
     if (columns.size() == 1) {
-        return columns[0]->clone();
+        return std::move(*columns[0]).mutate();
     }
 
     RETURN_IF_COLUMNS_ONLY_NULL(columns);

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -3186,7 +3186,7 @@ Status TimeFunctions::date_trunc_prepare(FunctionContext* context, FunctionConte
 }
 
 StatusOr<ColumnPtr> TimeFunctions::date_trunc_day(FunctionContext* context, const starrocks::Columns& columns) {
-    return columns[1];
+    return std::move(*columns[1]).mutate();
 }
 
 DEFINE_UNARY_FN_WITH_IMPL(date_trunc_monthImpl, v) {

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -298,7 +298,7 @@ StatusOr<ColumnPtr> TimeFunctions::utc_time(FunctionContext* context, const Colu
 }
 
 StatusOr<ColumnPtr> TimeFunctions::timestamp(FunctionContext* context, const Columns& columns) {
-    return columns[0];
+    return std::move(*columns[0]).mutate();
 }
 
 static const std::vector<int> NOW_PRECISION_FACTORS = {1000000, 100000, 10000, 1000, 100, 10, 1};

--- a/test/sql/test_function/R/test_filter_same_columns
+++ b/test/sql/test_function/R/test_filter_same_columns
@@ -1,0 +1,41 @@
+-- name: test_filter_same_columns
+WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 10)) AS tmp(id) limit 10) SELECT col FROM input WHERE least(col) IS NOT NULL AND least(col) < 20;
+-- result:
+2
+4
+6
+8
+10
+-- !result
+WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 10)) AS tmp(id) limit 10) SELECT col FROM input WHERE greatest(col) IS NOT NULL AND greatest(col) < 20;
+-- result:
+2
+4
+6
+8
+10
+-- !result
+WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 10)) AS tmp(id) limit 10) SELECT col FROM input WHERE positive(col) IS NOT NULL AND positive(col) < 20;
+-- result:
+2
+4
+6
+8
+10
+-- !result
+WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 10)) AS tmp(id) limit 10) SELECT col FROM input WHERE coalesce(col) IS NOT NULL AND coalesce(col) < 20;
+-- result:
+2
+4
+6
+8
+10
+-- !result
+with input as (select date'2020-01-01' as dt, if(id%2, add_months(dt, 1), null) as col from table(generate_series(1, 10)) as tmp(id)) select col from input where timestamp(col) is not null and timestamp(col) > '2020-01-01';
+-- result:
+20200201000000
+20200201000000
+20200201000000
+20200201000000
+20200201000000
+-- !result

--- a/test/sql/test_function/R/test_filter_same_columns
+++ b/test/sql/test_function/R/test_filter_same_columns
@@ -23,14 +23,6 @@ WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 
 8
 10
 -- !result
-WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 10)) AS tmp(id) limit 10) SELECT col FROM input WHERE coalesce(col) IS NOT NULL AND coalesce(col) < 20;
--- result:
-2
-4
-6
-8
-10
--- !result
 with input as (select date'2020-01-01' as dt, if(id%2, add_months(dt, 1), null) as col from table(generate_series(1, 10)) as tmp(id)) select col from input where timestamp(col) is not null and timestamp(col) > '2020-01-01';
 -- result:
 20200201000000

--- a/test/sql/test_function/T/test_filter_same_columns
+++ b/test/sql/test_function/T/test_filter_same_columns
@@ -2,7 +2,4 @@
 WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 10)) AS tmp(id) limit 10) SELECT col FROM input WHERE least(col) IS NOT NULL AND least(col) < 20;
 WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 10)) AS tmp(id) limit 10) SELECT col FROM input WHERE greatest(col) IS NOT NULL AND greatest(col) < 20;
 WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 10)) AS tmp(id) limit 10) SELECT col FROM input WHERE positive(col) IS NOT NULL AND positive(col) < 20;
-
-WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 10)) AS tmp(id) limit 10) SELECT col FROM input WHERE coalesce(col) IS NOT NULL AND coalesce(col) < 20;
-
 with input as (select date'2020-01-01' as dt, if(id%2, add_months(dt, 1), null) as col from table(generate_series(1, 10)) as tmp(id)) select col from input where timestamp(col) is not null and timestamp(col) > '2020-01-01';

--- a/test/sql/test_function/T/test_filter_same_columns
+++ b/test/sql/test_function/T/test_filter_same_columns
@@ -1,0 +1,8 @@
+-- name: test_filter_same_columns
+WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 10)) AS tmp(id) limit 10) SELECT col FROM input WHERE least(col) IS NOT NULL AND least(col) < 20;
+WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 10)) AS tmp(id) limit 10) SELECT col FROM input WHERE greatest(col) IS NOT NULL AND greatest(col) < 20;
+WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 10)) AS tmp(id) limit 10) SELECT col FROM input WHERE positive(col) IS NOT NULL AND positive(col) < 20;
+
+WITH input AS (SELECT if(id%2=0, id, null) AS col FROM TABLE(generate_series(1, 10)) AS tmp(id) limit 10) SELECT col FROM input WHERE coalesce(col) IS NOT NULL AND coalesce(col) < 20;
+
+with input as (select date'2020-01-01' as dt, if(id%2, add_months(dt, 1), null) as col from table(generate_series(1, 10)) as tmp(id)) select col from input where timestamp(col) is not null and timestamp(col) > '2020-01-01';


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #62828
some functions may return the input column directly as result, because the reused result column and its source are the same underlying Column, the filter can be applied multiple times to the same data. Since filtering is in-place and not idempotent, this produces wrong results. 

we should return MutatePtr in such cases.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
