### PR TITLE
[BugFix] fix non-deterministic predicate push down problem

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -838,16 +838,23 @@ public class Utils {
     }
 
     public static boolean hasNonDeterministicFunc(ScalarOperator operator) {
-        for (ScalarOperator child : operator.getChildren()) {
-            if (child instanceof CallOperator) {
-                CallOperator call = (CallOperator) child;
-                String fnName = call.getFnName();
-                if (FunctionSet.nonDeterministicFunctions.contains(fnName)) {
-                    return true;
-                }
-            }
+        if (hasNonDeterministicFuncImpl(operator)) {
+            return true;
+        }
 
+        for (ScalarOperator child : operator.getChildren()) {
             if (hasNonDeterministicFunc(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasNonDeterministicFuncImpl(ScalarOperator operator) {
+        if (operator instanceof CallOperator) {
+            CallOperator call = (CallOperator) operator;
+            String fnName = call.getFnName();
+            if (FunctionSet.nonDeterministicFunctions.contains(fnName)) {
                 return true;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
@@ -38,7 +38,6 @@ import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
@@ -99,6 +100,12 @@ public class PushDownPredicateProjectRule extends TransformationRule {
                     return Lists.newArrayList();
                 }
             }
+        }
+
+        // Check if the filter's predicate contains non-deterministic functions
+        // If it does, don't push down the predicate to avoid incorrect results
+        if (Utils.hasNonDeterministicFunc(filter.getPredicate())) {
+            return Lists.newArrayList();
         }
 
         ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(project.getColumnRefMap());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
@@ -25,6 +25,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
@@ -36,9 +37,12 @@ import com.starrocks.sql.optimizer.rewrite.scalar.ScalarOperatorRewriteRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public class PushDownPredicateProjectRule extends TransformationRule {
     private static final List<ScalarOperatorRewriteRule> PROJECT_REWRITE_PREDICATE_RULE = Lists.newArrayList(
@@ -103,13 +107,37 @@ public class PushDownPredicateProjectRule extends TransformationRule {
         }
 
         // Check if the filter's predicate contains non-deterministic functions
-        // If it does, don't push down the predicate to avoid incorrect results
-        if (Utils.hasNonDeterministicFunc(filter.getPredicate())) {
+        // If it does, don't push down the predicate below project to avoid incorrect results
+        List<ScalarOperator> compoundAndPredicates = Utils.extractConjuncts(filter.getPredicate());
+        Set<ScalarOperator> deterministicPredicates = new HashSet<>();
+        Set<ScalarOperator> nonDeterministicPredicates = new HashSet<>();
+        for (var entry : project.getColumnRefMap().entrySet()) {
+            if (Utils.hasNonDeterministicFunc(entry.getValue())) {
+                compoundAndPredicates.forEach(scalarOperator -> {
+                    if (scalarOperator.getUsedColumns().contains(entry.getKey())) {
+                        nonDeterministicPredicates.add(scalarOperator);
+                    }
+                });
+            }
+        }
+        compoundAndPredicates.forEach(predicate -> {
+            if (!nonDeterministicPredicates.contains(predicate)) {
+                deterministicPredicates.add(predicate);
+            }
+        });
+
+        // if all non-deterministic predicate, do not push down!
+        if (deterministicPredicates.isEmpty()) {
             return Lists.newArrayList();
         }
 
+        ScalarOperator deterministicPredicateTree =
+                Utils.createCompound(CompoundPredicateOperator.CompoundType.AND, deterministicPredicates);
+        ScalarOperator nonDeterministicPredicateTree =
+                Utils.createCompound(CompoundPredicateOperator.CompoundType.AND, nonDeterministicPredicates);
+
         ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(project.getColumnRefMap());
-        ScalarOperator newPredicate = rewriter.rewrite(filter.getPredicate());
+        ScalarOperator newPredicate = rewriter.rewrite(deterministicPredicateTree);
 
         // try rewrite new predicate
         // e.g. : select 1 as b, MIN(v1) from t0 having (b + 1) != b;
@@ -120,6 +148,15 @@ public class PushDownPredicateProjectRule extends TransformationRule {
         newFilter.getInputs().addAll(child.getInputs());
 
         OptExpression newProject = OptExpression.create(project, newFilter);
-        return Lists.newArrayList(newProject);
+        OptExpression root;
+        if (!nonDeterministicPredicates.isEmpty()) {
+            OptExpression nonDeterministicFilter =
+                    OptExpression.create(new LogicalFilterOperator(nonDeterministicPredicateTree), newProject);
+            root = nonDeterministicFilter;
+        } else {
+            root = newProject;
+        }
+
+        return Lists.newArrayList(root);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
@@ -130,8 +130,14 @@ public class PushDownPredicateProjectRule extends TransformationRule {
             return Lists.newArrayList();
         }
 
-        ScalarOperator deterministicPredicateTree =
-                Utils.createCompound(CompoundPredicateOperator.CompoundType.AND, deterministicPredicates);
+        ScalarOperator deterministicPredicateTree;
+        if (nonDeterministicPredicates.isEmpty()) {
+            deterministicPredicateTree = filter.getPredicate();
+        } else {
+            deterministicPredicateTree =
+                    Utils.createCompound(CompoundPredicateOperator.CompoundType.AND, deterministicPredicates);
+        }
+
         ScalarOperator nonDeterministicPredicateTree =
                 Utils.createCompound(CompoundPredicateOperator.CompoundType.AND, nonDeterministicPredicates);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PredicatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PredicatePushDownTest.java
@@ -153,15 +153,17 @@ public class PredicatePushDownTest extends PlanTestBase {
         // The plan should not push down the predicate through the project that contains rand()
         // Instead, the filter should remain above the project
         // The filter should not be pushed down to the scan level
-        assertContains(plan, " 2:Project\n" +
+        assertContains(plan, "3:Project\n" +
                 "  |  <slot 1> : 1: v1\n" +
-                "  |  <slot 4> : 6: rand\n" +
-                "  |  <slot 5> : 6: rand < 0.5\n" +
-                "  |  common expressions:\n" +
-                "  |  <slot 6> : rand()\n" +
+                "  |  <slot 4> : 4: rand\n" +
+                "  |  <slot 5> : 4: rand < 0.5\n" +
                 "  |  \n" +
-                "  1:SELECT\n" +
-                "  |  predicates: rand() < 0.5\n" +
+                "  2:SELECT\n" +
+                "  |  predicates: 4: rand < 0.5\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 4> : rand()\n" +
                 "  |  \n" +
                 "  0:OlapScanNode");
     }


### PR DESCRIPTION
## Why I'm doing:

```
mysql> WITH input AS (SELECT id, rand() AS rn FROM ids) SELECT id, rn, rn < 0.5 FROM input WHERE rn < 0.5;
+------+---------------------+----------+
| id   | rn                  | rn < 0.5 |
+------+---------------------+----------+
|    3 |  0.8151751183886273 |        0 |
|    6 | 0.24553562768643275 |        1 |
|    9 | 0.39361390426104703 |        1 |
+------+---------------------+----------+
```
for such query, after inline cte, plan will be like :
```
Project (id, rn, rn < 0.5)
  └── Filter (rn < 0.5)
      └── Project (id, rand() AS rn)
          └── Scan (ids)
```
and  PushDownPredicateProjectRule will push filter after second project, cause  rand calculate twice
```
Project (id, rn, rn < 0.5)
  └── Project (id, rand() AS rn)
      └── Filter (rand() < 0.5)  // rand will calculate twice
          └── Scan (ids)

```

## What I'm doing:
when have non-deterministic function  in project, and Filter above the project use the non-deterministic function's output,
 do not push down the Filter below Project

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
