### PR TITLE
[BugFix] Support table level scan metrics in shared-data cluster.

### DIFF
--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -14,9 +14,12 @@
 
 #include "exec/pipeline/scan/connector_scan_operator.h"
 
+#include "connector/lake_connector.h"
 #include "exec/connector_scan_node.h"
 #include "exec/pipeline/pipeline_driver.h"
 #include "exec/pipeline/scan/balanced_chunk_buffer.h"
+#include "runtime/descriptors.h"
+#include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {
@@ -578,6 +581,27 @@ Status ConnectorScanOperator::append_morsels(std::vector<MorselPtr>&& morsels) {
     }
     RETURN_IF_ERROR(_morsel_queue->append_morsels(std::move(morsels)));
     return Status::OK();
+}
+
+int64_t ConnectorScanOperator::get_scan_table_id() const {
+    auto* scan_node = down_cast<ConnectorScanNode*>(_scan_node);
+
+    if (scan_node->connector_type() != connector::ConnectorType::LAKE) {
+        return -1;
+    }
+
+    const auto& tuple_ids = scan_node->get_tuple_ids();
+    if (tuple_ids.empty()) {
+        return -1;
+    }
+
+    TupleId tuple_id = tuple_ids[0];
+    const TupleDescriptor* tuple_desc = runtime_state()->desc_tbl().get_tuple_descriptor(tuple_id);
+    if (tuple_desc != nullptr && tuple_desc->table_desc() != nullptr) {
+        return tuple_desc->table_desc()->table_id();
+    }
+
+    return -1;
 }
 
 // ==================== ConnectorChunkSource ====================

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -129,6 +129,8 @@ public:
     std::string get_name() const override;
     bool need_notify_all() override;
 
+    int64_t get_scan_table_id() const override;
+
 private:
     int64_t _adjust_scan_mem_limit(int64_t old_chunk_source_mem_bytes, int64_t new_chunk_source_mem_bytes);
     mutable ConnectorScanOperatorAdaptiveProcessor* _adaptive_processor;


### PR DESCRIPTION
## Why I'm doing:
Table level scan metrics is missed in shared-data cluster. Only query level metrics is shown. This PR implements `ConnectorScanOperator::get_scan_table_id()` to support get table id when collecting query scan metrics. 
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `ConnectorScanOperator::get_scan_table_id()` to return the table ID for LAKE connectors, enabling table-level scan metrics collection.
> 
> - **Backend**:
>   - **ConnectorScanOperator**: Implements `get_scan_table_id()` to derive table ID from `TupleDescriptor` when `connector_type` is `LAKE`.
>   - **API**: Declares `get_scan_table_id()` override in `ConnectorScanOperator` header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 068a520ee23cb4b1133dc32ed1637f3f84e4dba2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->