### PR TITLE
[Tool] compile with line-table-only

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -772,7 +772,7 @@ set(CXX_FLAGS_DEBUG "${CXX_GCC_FLAGS} -ggdb -O0 -gdwarf-5 -DDEBUG")
 # For CMAKE_BUILD_TYPE=Release
 #   -O3: Enable all compiler optimizations
 #   -DNDEBUG: Turn off dchecks/asserts/debug only code.
-set(CXX_FLAGS_RELEASE "${CXX_GCC_FLAGS} -O3 -gdwarf-4 -DNDEBUG")
+set(CXX_FLAGS_RELEASE "${CXX_GCC_FLAGS} -O3 -gdwarf-4 -gline-tables-only -DNDEBUG")
 
 SET(CXX_FLAGS_ASAN "${CXX_GCC_FLAGS} -ggdb3 -O0 -gdwarf-5 -fsanitize=address -DADDRESS_SANITIZER")
 SET(CXX_FLAGS_LSAN "${CXX_GCC_FLAGS} -ggdb3 -O0 -gdwarf-5 -fsanitize=leak -DLEAK_SANITIZER")


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
The compiler flag `-gline-tables-only` tells the compiler to generate only line number tables (address ↔ source file:line mappings) without emitting full DWARF debug information such as variable details, type descriptions, or local symbol data.

What it retains:
- Essential `.debug_line` sections.
- Sufficient data for tools like `addr2line`, `llvm-symbolizer`, `perf`, or `pprof` to map crash addresses to corresponding source lines.

What it removes:
- Variable names and their scopes.
- Detailed type information.
- Complete DWARF sections (e.g., `.debug_info`, `.debug_var`, etc.), which are mainly required for interactive debugging with tools like GDB or LLDB.


**Result**

- without `-gline-tables-only`: starrocks_be=426M,  starrocks_be.debuginfo=955M
- with `-gline-tables-only`: starrocks_be=425M, starrocks_be.debuginfo=640M
- after decompressing(`objcopy --decompress-debug-sections starrocks_be.debuginfo starrocks_be.debuginfo.uncompressed`): starrocks_be.debuginfo.uncompressed=1.7G

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
