### PR TITLE
[Doc] Format setting names in README as inline code

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,11 +33,11 @@ Before contributing, please read this article carefully to quickly understand th
    Long lists of settings like this do not index well in search, and the reader will not find the information even when they type in the exact name of a setting:
 
    ```markdown
-   - setting_name_foo
+   - `setting_name_foo`
 
      Details for foo
 
-   - setting_name_bar
+   - `setting_name_bar`
      Details for bar
    ...
    ```
@@ -45,11 +45,11 @@ Before contributing, please read this article carefully to quickly understand th
    Instead, use a section heading (e.g., `###`) for the setting name and remove the indent for the text:
 
    ```markdown
-   ### setting_name_foo
+   ### `setting_name_foo`
 
    Details for foo
 
-   ### setting_name_bar
+   ### `setting_name_bar`
    Details for bar
    ...
    ```


### PR DESCRIPTION
Updated README to format setting names as code.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
