### PR TITLE
[Doc] fixed hardcoded outdated JDBC link to general Tableau JDBC marketplace link

### DIFF
--- a/docs/en/integrations/BI_integrations/Tableau_Desktop.md
+++ b/docs/en/integrations/BI_integrations/Tableau_Desktop.md
@@ -71,7 +71,7 @@ Before proceeding, make sure the following requirements are met:
 
    :::
 
-3. Download the [StarRocks Tableau JDBC Connector file](https://releases.starrocks.io/resources/starrocks_jdbc-v1.2.0_signed.taco).
+3. Download the [StarRocks Tableau JDBC Connector file](https://exchange.tableau.com/products/1079).
 4. Store the connector file in the following directory of each node:
 
    - Linux: `/opt/tableau/connectors`

--- a/docs/ja/integrations/BI_integrations/Tableau_Desktop.md
+++ b/docs/ja/integrations/BI_integrations/Tableau_Desktop.md
@@ -71,7 +71,7 @@ StarRocks Tableau JDBC Connector は、Tableau Desktop および Tableau Server 
 
    :::
 
-3. [StarRocks Tableau JDBC Connector file](https://releases.starrocks.io/resources/starrocks_jdbc-v1.2.0_signed.taco) をダウンロードします。
+3. [StarRocks Tableau JDBC Connector file](https://exchange.tableau.com/products/1079) をダウンロードします。
 4. 各ノードの以下のディレクトリにコネクタファイルを保存します：
 
    - Linux: `/opt/tableau/connectors`

--- a/docs/zh/integrations/BI_integrations/Tableau_Desktop.md
+++ b/docs/zh/integrations/BI_integrations/Tableau_Desktop.md
@@ -71,7 +71,7 @@ StarRocks Tableau JDBC Connector 是一个用于 Tableau Desktop 和 Tableau Ser
 
    :::
 
-3. 下载 [StarRocks JDBC Connector](https://releases.starrocks.io/resources/starrocks_jdbc-v1.2.0_signed.taco) 文件。
+3. 下载 [StarRocks JDBC Connector](https://exchange.tableau.com/products/1079) 文件。
 4. 将连接器文件存放在每个节点的以下目录：
 
    - Linux: `/opt/tableau/connectors`


### PR DESCRIPTION
## Why I'm doing:

Tableau JDBC connector link is outdated on docs to be on v1.2.0, but the marketplace is now on v2.1.0. This value is hardcoded. The SQL JDBC driver points to the general download page.

## What I'm doing:

Pointing the JDBC connector link to the general marketplace link, so users can download the updated jdbc connector accordingly. Tableau complains when you use this outdated one. Its important to keep users updated.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
