### PR TITLE
[BugFix] call addWorker on non-leaders to handle stale cached workerid issues when CN are restarted

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -220,10 +220,10 @@ public class HeartbeatMgr extends FrontendDaemon {
                     } else {
                         if (RunMode.isSharedDataMode() && 
                                 (!isReplay || !GlobalStateMgr.getCurrentState().isLeader())) {
-                            // Observer FEs maintain StarOSAgent worker map fields via journal replay.
-                            // When CNs restart, they get new WorkerIds. Observer FEs (which can never
-                            // become leaders) must refresh their cached workers during replay to avoid incorrectly
-                            // identifying primary CNs as unavailable and triggering backup CN selection.
+                            // Non-leader FEs maintain StarOSAgent worker map fields via journal replay.
+                            // When CNs restart, they get new WorkerIds. Non-leader FEs must refresh
+                            // their cached workers during replay to avoid incorrectly identifying primary
+                            // CNs as unavailable and triggering backup CN selection.
                             int starletPort = computeNode.getStarletPort();
                             if (starletPort != 0) {
                                 String workerAddr = NetUtils.getHostPortInAccessibleFormat(computeNode.getHost(),


### PR DESCRIPTION
## Why I'm doing:
In shared-data deployments, Observer nodes experienced stale `StarOSAgent.workerToId` issues that caused queries to use backup Compute Nodes instead of optimal primary nodes, resulting in performance degradation.
Problem Timeline:
1. Compute Nodes restart and receive new WorkerID assignments from StarMgr
2. Leader FE processes heartbeats and updates its internal cache with new WorkerIDs
3. Non-leader FEs replay heartbeat events from the journal but skip cache updates due to replay logic
4. Non-leader FE cache contains outdated WorkerID mappings
5. Query scheduling uses stale WorkerIDs, causing primary CNs to appear unavailable
6. System falls back to backup CN selection, impacting query performance
Symptoms observed:
* Queries routed to Observer FEs perform poorly due to backup CN usage
* Issue persists until Observer FE restart (which clears the stale cache)
* Inconsistent WorkerID values between Leader and Observer FEs
## What I'm doing:
Modified heartbeat processing logic to allow FEs to update their WorkerID cache during journal replay, ensuring all FE nodes maintain synchronized compute node mappings.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
