### PR TITLE
[BugFix] fix nullptr delta writer in local tablet channel

### DIFF
--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -391,7 +391,17 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
 
     std::set<long> immutable_tablet_ids;
     for (auto tablet_id : request.tablet_ids()) {
-        auto& writer = _delta_writers[tablet_id];
+        auto it = _delta_writers.find(tablet_id);
+        if (it == _delta_writers.end()) {
+            LOG(WARNING) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
+                         << " not found tablet_id: " << tablet_id;
+            response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
+            response->mutable_status()->add_error_msgs(
+                    fmt::format("Failed to add_chunk since tablet_id {} does not exist, txn_id: {}, load_id: {}",
+                                tablet_id, _txn_id, print_id(request.id())));
+            return;
+        }
+        auto& writer = it->second;
         if (writer->is_immutable() && immutable_tablet_ids.count(tablet_id) == 0) {
             response->add_immutable_tablet_ids(tablet_id);
             response->add_immutable_partition_ids(writer->partition_id());


### PR DESCRIPTION
* shall not directly derefence the delta writers hash map by tablet_id because the tablet_id may not exist in the map.

## Why I'm doing:

v3.3.16
```
*** Aborted at 1756964668 (unix time) try "date -d @1756964668" if you are using GNU date ***
PC: @          0x382ee16 starrocks::LocalTabletsChannel::add_chunk(starrocks::Chunk*, starrocks::PTabletWriterAddChunkRequest const&, starrocks::PTabletWriterAddBatchResult*)
*** SIGSEGV (@0x0) received by PID 177299 (TID 0x148e49590640) from PID 0; stack trace: ***
    @     0x149797e8ef38 __pthread_once_slow
    @          0x7dbe140 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x149798e2b9b9 os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x149798e31c7a JVM_handle_linux_signal
    @     0x149798e23a4c signalHandler(int, siginfo_t*, void*)
    @     0x149797e3e730 (/usr/lib64/libc.so.6+0x3e72f)
    @          0x382ee16 starrocks::LocalTabletsChannel::add_chunk(starrocks::Chunk*, starrocks::PTabletWriterAddChunkRequest const&, starrocks::PTabletWriterAddBatchResult*)
    @          0x3820f99 starrocks::LoadChannel::_add_chunk(starrocks::Chunk*, starrocks::PTabletWriterAddChunkRequest const&, starrocks::PTabletWriterAddBatchResult*)
    @          0x382218c starrocks::LoadChannel::add_chunks(starrocks::PTabletWriterAddChunksRequest const&, starrocks::PTabletWriterAddBatchResult*)
    @          0x381b823 starrocks::LoadChannelMgr::add_chunks(starrocks::PTabletWriterAddChunksRequest const&, starrocks::PTabletWriterAddBatchResult*)
    @          0x38dcb8b starrocks::BackendInternalServiceImpl<starrocks::PInternalService>::tablet_writer_add_chunks(google::protobuf::RpcController*, starrocks::PTabletWriterAddChunksRequest const*, starrocks::PTabletWriterAddBatchResult*, google::protob
uf::Closure*)
    @          0x804af14 brpc::policy::ProcessRpcRequest(brpc::InputMessageBase*)
    @          0x7f772b7 brpc::ProcessInputMessage(void*)
    @          0x7f78635 brpc::InputMessenger::OnNewMessages(brpc::Socket*)
    @          0x7f6692e brpc::Socket::ProcessEvent(void*)
    @          0x7f379b2 bthread::TaskGroup::task_runner(long)
    @          0x808ce41 bthread_make_fcontext
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
