### PR TITLE
[Refactor] Remove the useless AlterOpType for ALTER AUTO_INCREMENT counter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterOpType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterOpType.java
@@ -40,7 +40,6 @@ import com.starrocks.sql.ast.AddFieldClause;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AddRollupClause;
 import com.starrocks.sql.ast.AlterClause;
-import com.starrocks.sql.ast.AlterTableAutoIncrementClause;
 import com.starrocks.sql.ast.CreateIndexClause;
 import com.starrocks.sql.ast.DropColumnClause;
 import com.starrocks.sql.ast.DropFieldClause;
@@ -61,8 +60,6 @@ public enum AlterOpType {
     ADD_PARTITION,
     // Optimize table
     OPTIMIZE,
-    // ALTER AUTO_INCREMENT counter
-    ALTER_AUTO_INCREMENT,
     // ALTER_OTHER must be the last one
     ALTER_OTHER,
     // INVALID_OP must be the last one
@@ -113,8 +110,6 @@ public enum AlterOpType {
             return DROP_ROLLUP;
         } else if (alterClause instanceof OptimizeClause) {
             return OPTIMIZE;
-        } else if (alterClause instanceof AlterTableAutoIncrementClause) {
-            return ALTER_AUTO_INCREMENT;
         }
 
         return ALTER_OTHER;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
