### PR TITLE
[BugFix] fix NPE of analyze profile

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -2147,6 +2147,10 @@ public class StmtExecutor {
                         .build();
         sendMetaData(metaData);
 
+        if (explainString == null) {
+            explainString = "Profile analysis failed or not available";
+        }
+
         if (isProxy) {
             proxyResultSet = new ShowResultSet(metaData,
                     Arrays.stream(explainString.split("\n")).map(Collections::singletonList).collect(


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

The ExplainAnalyzer.analyze() method returns null when any of these conditions are met:
- plan == null
- summaryProfile == null
- executionProfile == null

When this null value was passed to the handleExplainStmt() method, it tried to call .split("\n") on a null string, causing the NullPointerException.

- Prevents crashes:  The `ANALYZE PROFILE` statement will no longer crash with a NullPointerException
- User-friendly error message: Instead of a cryptic null pointer error, users will see a clear message "Profile analysis failed or not available"



Fixes #https://github.com/StarRocks/starrocks/issues/62383

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
