### PR TITLE
[BugFix] Fix invalid ProjectOperator above table-pruning frontier CTEConsumperOperator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CPJoinGardener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CPJoinGardener.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
@@ -50,6 +51,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -1060,7 +1062,18 @@ public class CPJoinGardener extends OptExpressionVisitor<Boolean, Void> {
         frontier = grafter.graft(frontier).orElse(frontier);
 
         // step4: (Top-down) remove the unused ColumnRefOperators.
-        colRefMap.replaceAll((k, v) -> pruner.columnRefRewriter.rewrite(v));
+        // if Frontier is LogicalCTEConsumerOperator, getRowOutputInfo().getColumnRefMap() returns
+        // LogicalCTEConsumerOperator.cteOutputColumnRefMap, the input ColumnRefOperators in this map
+        // are output ColumnRefOperators of LogicalCTEProducerOperator, thus these ColumnRefOperators
+        // are dangling, so when we create a LogicalProjectOperator above LogicalCTEConsumerOperator,we
+        // just need map output ColumnRefOperators to themselves.
+        //LogicalCTEConsumeOperator cteConsumeOperator = frontier.getOp().cast();
+        if (frontier.getOp() instanceof LogicalCTEConsumeOperator) {
+            colRefMap = colRefMap.keySet().stream()
+                    .collect(Collectors.toMap(Function.identity(), Function.identity()));
+        } else {
+            colRefMap.replaceAll((k, v) -> pruner.columnRefRewriter.rewrite(v));
+        }
         LogicalProjectOperator projectOperator = new LogicalProjectOperator(colRefMap);
         frontier = OptExpression.create(projectOperator, frontier);
         Cleaner cleaner = new Cleaner(columnRefFactory);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningCTETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningCTETest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.starrocks.sql.optimizer.statistics.CachedStatisticStorageTest.DEFAULT_CREATE_TABLE_TEMPLATE;
 
@@ -401,5 +403,48 @@ public class TablePruningCTETest extends TablePruningTestBase {
                 "inner join cte6 d on \n" +
                 "   a.l_orderkey = d.l_orderkey and a.l_partkey = d.l_partkey and a.l_suppkey = d.l_suppkey;";
         checkHashJoinCountWithBothRBOAndCBO(sql, 3);
+    }
+
+    @Test
+    public void testCteConsumerAsPruneFrontier() throws Exception {
+        String subquery = getSqlList("sql/tpch_pk_tables/", "lineitem_flat_subquery").get(0);
+        String viewSql = "CREATE VIEW lineitem_flat_view AS " + subquery;
+        starRocksAssert.withView(viewSql);
+
+        String cte = getSqlList("sql/tpch_pk_tables/", "lineitem_flat_cte").get(0);
+        String sql = String.format("with lineitem_flat as (select * from lineitem_flat_view),\n" +
+                "cteA as (\n" +
+                "select l_orderkey,l_partkey,l_suppkey,sum(l_quantity) as sum_qty\n" +
+                "from lineitem_flat \n" +
+                "group by l_orderkey,l_partkey,l_suppkey\n" +
+                "),\n" +
+                "cteB as(\n" +
+                "select l_orderkey,l_partkey,avg(l_quantity) as avg_qty\n" +
+                "from lineitem_flat \n" +
+                "group by l_orderkey,l_partkey\n" +
+                "),\n" +
+                "cteC as(\n" +
+                "select \n" +
+                "   l_orderkey,\n" +
+                "   count(distinct l_partkey) as uniq_partkey, \n" +
+                "   count(distinct l_suppkey) as uniq_suppkey, \n" +
+                "   count(distinct l_quantity) as uniq_qty\n" +
+                "from lineitem_flat \n" +
+                "group by l_orderkey\n" +
+                ")\n" +
+                "\n" +
+                "select /*+SET_VAR(enable_cbo_table_prune=true,enable_rbo_table_prune=true)*/\n" +
+                "t.l_orderkey, t.l_partkey, t.l_suppkey, sum_qty, avg_qty, uniq_partkey, uniq_suppkey, uniq_qty\n" +
+                "from lineitem_flat t\n" +
+                "     join cteA a on t.l_orderkey = a.l_orderkey AND t.l_partkey = a.l_partkey " +
+                "           AND t.l_suppkey = a.l_suppkey\n" +
+                "     join cteB b on t.l_orderkey = b.l_orderkey AND t.l_partkey = b.l_partkey\n" +
+                "     join cteC c on t.l_orderkey = c.l_orderkey\n", cte);
+        String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
+        List<String> tables = Stream.of(plan.split("\n"))
+                .filter(ln -> ln.matches("^\\s*table:\\s*\\S+,.*$"))
+                .collect(Collectors.toList());
+        Assertions.assertTrue(tables.size() > 0, plan);
+        Assertions.assertTrue(tables.stream().allMatch(ln -> ln.contains("lineitem")), plan);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

For table-pruning frontier, a project operator is constructed above it.
when frontier is LogicalCTEConsumerOperator, getRowOutputInfo().getColumnRefMap() returns LogicalCTEConsumerOperator.cteOutputColumnRefMap, the input ColumnRefOperators in this map are output ColumnRefOperators of LogicalCTEProducerOperator, thus these ColumnRefOperators are dangling, so when we create a LogicalProjectOperator above LogicalCTEConsumerOperator, we just need map output ColumnRefOperators to themselves instead of these dangling ColumnRefOperators. 

Error reports as follows
```
2025-09-10 11:29:43 [main] WARN  Utils:855 - [query=643743bd-8df6-11f0-98db-b2ba9d8e8ab7] Failed to calculate statistics for expression: LogicalProjectOperator [499: l_orderkey, 500: l_partkey, 501: l_suppkey, 503: l_quantity] child size 1
com.starrocks.sql.common.StarRocksPlannerException: only found column statistics: {499: l_orderkey, 500: l_partkey, 501: l_suppkey, 503: l_quantity}, but missing statistic of col: 1: l_orderkey.
	at com.starrocks.sql.optimizer.statistics.Statistics.getColumnStatistic(Statistics.java:93) ~[classes/:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitVariableReference(ExpressionStatisticCalculator.java:82) ~[classes/:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitVariableReference(ExpressionStatisticCalculator.java:61) ~[classes/:?]
	at com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator.accept(ColumnRefOperator.java:131) ~[classes/:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator.calculate(ExpressionStatisticCalculator.java:58) ~[classes/:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator.calculate(ExpressionStatisticCalculator.java:50) ~[classes/:?]
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.computeProjectNode(StatisticsCalculator.java:928) ~[classes/:?]
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalProject(StatisticsCalculator.java:898) ~[classes/:?]
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalProject(StatisticsCalculator.java:179) ~[classes/:?]
	at com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator.accept(LogicalProjectOperator.java:98) ~[classes/:?]
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.estimatorStats(StatisticsCalculator.java:202) ~[classes/:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:853) ~[classes/:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:842) ~[classes/:?]
	at com.starrocks.sql.optimizer.rule.transformation.RewriteMultiDistinctRule.isCTEMoreEfficient(RewriteMultiDistinctRule.java:200) ~[classes/:?]
	at com.starrocks.sql.optimizer.rule.transformation.RewriteMultiDistinctRule.useCteToRewrite(RewriteMultiDistinctRule.java:167) ~[classes/:?]
	at com.starrocks.sql.optimizer.rule.transformation.RewriteMultiDistinctRule.transform(RewriteMultiDistinctRule.java:92) ~[classes/:?]
	at com.starrocks.sql.optimizer.task.RewriteTreeTask.rewrite(RewriteTreeTask.java:80) ~[classes/:?]
	at com.starrocks.sql.optimizer.task.RewriteTreeTask.rewrite(RewriteTreeTask.java:98) ~[classes/:?]
	at com.starrocks.sql.optimizer.task.RewriteTreeTask.rewrite(RewriteTreeTask.java:98) ~[classes/:?]
	at com.starrocks.sql.optimizer.task.RewriteTreeTask.rewrite(RewriteTreeTask.java:98) ~[classes/:?]
	at com.starrocks.sql.optimizer.task.RewriteTreeTask.execute(RewriteTreeTask.java:58) ~[classes/:?]
	at com.starrocks.sql.optimizer.task.SeriallyTaskScheduler.executeTasks(SeriallyTaskScheduler.java:65) ~[classes/:?]
	at com.starrocks.sql.optimizer.Optimizer.ruleRewriteIterative(Optimizer.java:1012) ~[classes/:?]
	at com.starrocks.sql.optimizer.Optimizer.logicalRuleRewrite(Optimizer.java:634) ~[classes/:?]
	at com.starrocks.sql.optimizer.Optimizer.rewriteAndValidatePlan(Optimizer.java:763) ~[classes/:?]
	at com.starrocks.sql.optimizer.Optimizer.optimizeByCost(Optimizer.java:248) ~[classes/:?]
	at com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:196) ~[classes/:?]
	at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:365) ~[classes/:?]
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:141) ~[classes/:?]
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:98) ~[classes/:?]
	at com.starrocks.utframe.UtFrameUtils.buildPlan(UtFrameUtils.java:538) ~[test-classes/:?]
	at com.starrocks.utframe.UtFrameUtils.getPlanAndFragment(UtFrameUtils.java:614) ~[test-classes/:?]
	at com.starrocks.utframe.UtFrameUtils.getVerboseFragmentPlan(UtFrameUtils.java:1088) ~[test-classes/:?]
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
