### PR TITLE
[BugFix] Fix stream load exec status update NPE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -294,6 +294,11 @@ public class JobSpec {
             TExecPlanFragmentParams params = planner.getExecPlanFragmentParams();
             TUniqueId queryId = params.getParams().getFragment_instance_id();
 
+            // Build minimal query options for sync stream load to avoid null dereference
+            TQueryOptions queryOptions = new TQueryOptions();
+            queryOptions.setQuery_type(TQueryType.LOAD);
+            queryOptions.setLoad_job_type(TLoadJobType.STREAM_LOAD);
+
             return new Builder()
                     .queryId(queryId)
                     .fragments(Collections.emptyList())
@@ -303,7 +308,7 @@ public class JobSpec {
                     .isBlockQuery(true)
                     .needReport(true)
                     .queryGlobals(null)
-                    .queryOptions(null)
+                    .queryOptions(queryOptions)
                     .enablePipeline(false)
                     .resourceGroup(null)
                     .computeResource(planner.getComputeResource())


### PR DESCRIPTION
## Why I'm doing:
introduced by https://github.com/StarRocks/starrocks/pull/58753. JobSpec for stream load does not construct a TQueryOptions, so exception is thrown when visiting it.

<img width="565" height="73" alt="image" src="https://github.com/user-attachments/assets/263bb817-a408-4a16-898c-87faf74034cd" />

```
2025-09-10 16:03:46.125+08:00 WARN (thrift-server-pool-34|208) [DefaultCoordinator.lambda$updateFragmentExecStatus$9():1134] Error occurred during fragment exec status update 95454bcb-5fcc-5196-33c1-85d9183d189b
java.util.concurrent.CompletionException: java.lang.NullPointerException: Cannot invoke "com.starrocks.thrift.TQueryOptions.getQuery_type()" because "this.queryOptions" is null
        at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[?:?]
        at java.util.concurrent.CompletableFuture.uniRunNow(CompletableFuture.java:823) ~[?:?]
        at java.util.concurrent.CompletableFuture.uniRunStage(CompletableFuture.java:803) ~[?:?]
        at java.util.concurrent.CompletableFuture.thenRun(CompletableFuture.java:2195) ~[?:?]
        at com.starrocks.qe.DefaultCoordinator.updateFragmentExecStatus(DefaultCoordinator.java:1125) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.QeProcessorImpl.reportExecStatus(QeProcessorImpl.java:221) ~[starrocks-fe.jar:?]
        at com.starrocks.service.FrontendServiceImpl.reportExecStatus(FrontendServiceImpl.java:974) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$reportExecStatus.getResult(FrontendService.java:5765) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$reportExecStatus.getResult(FrontendService.java:5742) ~[starrocks-fe.jar:?]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40) ~[libthrift-0.20.0.jar:0.20.0]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40) ~[libthrift-0.20.0.jar:0.20.0]
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:840) ~[?:?]
Caused by: java.lang.NullPointerException: Cannot invoke "com.starrocks.thrift.TQueryOptions.getQuery_type()" because "this.queryOptions" is null
        at com.starrocks.qe.scheduler.dag.JobSpec.isLoadType(JobSpec.java:398) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator.updateFinishInstance(DefaultCoordinator.java:1200) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator.lambda$updateFragmentExecStatus$8(DefaultCoordinator.java:1128) ~[starrocks-fe.jar:?]
        at java.util.concurrent.CompletableFuture.uniRunNow(CompletableFuture.java:819) ~[?:?]
        ... 13 more
```


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
