### PR TITLE
[BugFix] Revert Add transaction error message to loads internal table (#61364)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/LoadConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/LoadConstants.java
@@ -29,7 +29,6 @@ public class LoadConstants {
     public static final String RUNTIME_DETAILS_PLAN_TIME_MS = "plan_time_ms";
     public static final String RUNTIME_DETAILS_RECEIVE_DATA_TIME_MS = "receive_data_time_ms";
     public static final String RUNTIME_DETAILS_BEGIN_TXN_TIME_MS = "begin_txn_time_ms";
-    public static final String RUNTIME_DETAILS_TXN_ERROR_MSG = "txn_error_msg";
 
     public static final String PROPERTIES_TIMEOUT = "timeout";
     public static final String PROPERTIES_MAX_FILTER_RATIO = "max_filter_ratio";

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -927,16 +927,6 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         }
         runtimeDetails.put(LoadConstants.RUNTIME_DETAILS_LOAD_ID, Joiner.on(", ").join(loadIds));
         runtimeDetails.put(LoadConstants.RUNTIME_DETAILS_TXN_ID, transactionId);
-        TransactionState txnState = GlobalStateMgr.getCurrentState()
-                .getGlobalTransactionMgr().getTransactionState(dbId, transactionId);
-        if (txnState != null) {
-            txnState.writeLock();
-            try {
-                runtimeDetails.put(LoadConstants.RUNTIME_DETAILS_TXN_ERROR_MSG, txnState.getErrMsg());
-            } finally {
-                txnState.writeUnlock();
-            }
-        }
         runtimeDetails.putAll(loadingStatus.getLoadStatistic().toRuntimeDetails());
         Gson gson = new Gson();
         return gson.toJson(runtimeDetails);

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1631,15 +1631,6 @@ public class StreamLoadTask extends AbstractStreamLoadTask {
         runtimeDetails.put(LoadConstants.RUNTIME_DETAILS_BEGIN_TXN_TIME_MS, beginTxnTimeMs);
         runtimeDetails.put(LoadConstants.RUNTIME_DETAILS_RECEIVE_DATA_TIME_MS, receiveDataTimeMs);
         runtimeDetails.put(LoadConstants.RUNTIME_DETAILS_PLAN_TIME_MS, planTimeMs);
-        TransactionState txnState = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionState(dbId, txnId);
-        if (txnState != null) {
-            txnState.writeLock();
-            try {
-                runtimeDetails.put(LoadConstants.RUNTIME_DETAILS_TXN_ERROR_MSG, txnState.getErrMsg());
-            } finally {
-                txnState.writeUnlock();
-            }
-        }
         Gson gson = new Gson();
         return gson.toJson(runtimeDetails);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -616,15 +616,6 @@ public class PublishVersionDaemon extends FrontendDaemon {
                 stateBatch.putBeTablets(partitionId, nodeToTablets);
             }
         } catch (Exception e) {
-            for (int i = 0; i < transactionStates.size(); i++) {
-                TransactionState txnState = transactionStates.get(i);
-                txnState.writeLock();
-                try {
-                    txnState.setErrorMsg("Fail to publish partition " + partitionId + " error " + e.getMessage());
-                } finally {
-                    txnState.writeUnlock();
-                }
-            }
             LOG.error("Fail to publish partition {} of txnIds {}:", partitionId,
                     txnInfos.stream().map(i -> i.txnId).collect(Collectors.toList()), e);
             return false;
@@ -904,13 +895,6 @@ public class PublishVersionDaemon extends FrontendDaemon {
             }
             return true;
         } catch (Throwable e) {
-            txnState.writeLock();
-            try {
-                txnState.setErrorMsg("Fail to publish partition " + partitionCommitInfo.getPhysicalPartitionId()
-                        + " error " + e.getMessage());
-            } finally {
-                txnState.writeUnlock();
-            }
             // prevent excessive logging
             if (partitionCommitInfo.getVersionTime() < 0 &&
                     Math.abs(partitionCommitInfo.getVersionTime()) + 10000 < System.currentTimeMillis()) {


### PR DESCRIPTION
This reverts commit 94cbc177c50c1a6be5612042e4a0842ef74b6297.

## Why I'm doing:

dead lock between load job lock and transaction state lock.

```
"PUBLISH_VERSION" #25 daemon prio=5 os_prio=0 cpu=2087472.61ms elapsed=17302.20s tid=0x00002b31c867f5c0 nid=0xd71 waiting on condition  [0x00002b31a7220000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@17.0.13/Native Method)
        - parking to wait for  <0x00000005930c7a00> (a java.util.concurrent.locks.ReentrantReadWriteLock$FairSync)
        at java.util.concurrent.locks.LockSupport.park(java.base@17.0.13/LockSupport.java:211)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@17.0.13/AbstractQueuedSynchronizer.java:715)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@17.0.13/AbstractQueuedSynchronizer.java:938)
        at java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock(java.base@17.0.13/ReentrantReadWriteLock.java:959)
        at com.starrocks.load.loadv2.LoadJob.writeLock(LoadJob.java:232)
        at com.starrocks.load.loadv2.LoadJob.updateState(LoadJob.java:603)
        at com.starrocks.load.loadv2.LoadJob.afterVisible(LoadJob.java:1208)
        at com.starrocks.load.loadv2.BrokerLoadJob.afterVisible(BrokerLoadJob.java:392)
        at com.starrocks.transaction.TransactionState.afterStateTransform(TransactionState.java:730)
        at com.starrocks.transaction.DatabaseTransactionMgr.finishTransaction(DatabaseTransactionMgr.java:1309)
        at com.starrocks.transaction.GlobalTransactionMgr.finishTransaction(GlobalTransactionMgr.java:601)
        at com.starrocks.transaction.PublishVersionDaemon.publishVersionForOlapTable(PublishVersionDaemon.java:336)
        at com.starrocks.transaction.PublishVersionDaemon.runAfterCatalogReady(PublishVersionDaemon.java:148)
        at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:78)
        at com.starrocks.common.util.Daemon.run(Daemon.java:98)


"thrift-server-pool-988" #32468 daemon prio=5 os_prio=0 cpu=2295.67ms elapsed=4474.77s tid=0x00002b31eccc1ee0 nid=0xf3ee waiting on condition  [0x00002b327e7e4000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@17.0.13/Native Method)
        - parking to wait for  <0x000000059320abc0> (a java.util.concurrent.locks.ReentrantReadWriteLock$FairSync)
        at java.util.concurrent.locks.LockSupport.park(java.base@17.0.13/LockSupport.java:211)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@17.0.13/AbstractQueuedSynchronizer.java:715)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@17.0.13/AbstractQueuedSynchronizer.java:938)
        at java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock(java.base@17.0.13/ReentrantReadWriteLock.java:959)
        at com.starrocks.transaction.TransactionState.writeLock(TransactionState.java:370)
        at com.starrocks.load.loadv2.LoadJob.toRuntimeDetails(LoadJob.java:933)
        at com.starrocks.load.loadv2.LoadJob.toThrift(LoadJob.java:1021)
        at com.starrocks.service.FrontendServiceImpl$$Lambda$1097/0x00002b3161a5c678.apply(Unknown Source)
        at java.util.stream.ReferencePipeline$3$1.accept(java.base@17.0.13/ReferencePipeline.java:197)
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(java.base@17.0.13/ArrayList.java:1625)
        at java.util.stream.AbstractPipeline.copyInto(java.base@17.0.13/AbstractPipeline.java:509)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(java.base@17.0.13/AbstractPipeline.java:499)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(java.base@17.0.13/ReduceOps.java:921)
        at java.util.stream.AbstractPipeline.evaluate(java.base@17.0.13/AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.collect(java.base@17.0.13/ReferencePipeline.java:682)
        at com.starrocks.service.FrontendServiceImpl.getLoads(FrontendServiceImpl.java:2577)
        at com.starrocks.thrift.FrontendService$Processor$getLoads.getResult(FrontendService.java:5889)
        at com.starrocks.thrift.FrontendService$Processor$getLoads.getResult(FrontendService.java:5866)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40)
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.13/ThreadPoolExecutor.java:1136)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.13/ThreadPoolExecutor.java:635)
        at java.lang.Thread.run(java.base@17.0.13/Thread.java:840)
```

https://github.com/StarRocks/starrocks/pull/61364

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
