### PR TITLE
[BugFix] Unblock repair when source replica is marked DECOMMISSION during migration

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -254,7 +254,7 @@ public class TabletChecker extends FrontendDaemon {
                 // in this case, we need to forcefully create an empty replica to recover
                 return true;
             } else {
-                return !tabletCtx.getHealthyReplicas().isEmpty();
+                return !tabletCtx.getHealthyReplicas(false).isEmpty();
             }
         } else {
             return true;


### PR DESCRIPTION
## Why I'm doing:
A tablet becomes unrepaired (stuck in VERSION_INCOMPLETE) after balance-triggered migration when the only valid source replica is marked DECOMMISSION.

### Scenario
1. Tablet x created on BE1 (single-replica table); ingestion starts.
2. Cluster balance migrates the tablet to BE2; old replica on BE1 becomes DECOMMISSION after migration.
3. During migration, ingestion on BE1 was still running; max committed version at that moment was 1, so the replica on BE2 is version 1.
4. Ingestion then finishes successfully on BE1 and advances its replica to version 2.
5. Replica on BE2 remains version 1 and is marked VERSION_INCOMPLETE.
6. Repair on BE2 fails because its only source (BE1) is in DECOMMISSION, so no eligible source is available → tablet cannot repair.


## What I'm doing:

Allow DECOMMISSION replicas to serve as temporary repair sources while they are healthy and accessible, until the target catches up or the replica is actually dropped.
Tighten source selection predicates: prefer latest, healthy replicas; include DECOMMISSION replicas as sources only when they are the sole candidates and have newer versions.
Ensure version reconciliation runs before finalizing decommission of the source replica.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
