### PR TITLE
[BugFix] Fix delta lake table can not find partition column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
@@ -39,7 +39,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
-import java.util.Locale;
 
 import static com.starrocks.catalog.Column.COLUMN_UNIQUE_ID_INIT_VALUE;
 import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
@@ -97,7 +96,7 @@ public class DeltaUtils {
             String partitionColName = partitionColNameVector.getString(i);
             Preconditions.checkArgument(partitionColName != null && !partitionColName.isEmpty(),
                     "Expected non-null and non-empty partition column name");
-            partitionColumnNames.add(partitionColName.toLowerCase(Locale.ROOT));
+            partitionColumnNames.add(partitionColName);
         }
         return partitionColumnNames;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
@@ -19,6 +19,8 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.connector.metastore.MetastoreTable;
 import com.starrocks.sql.optimizer.validate.ValidateException;
+import io.delta.kernel.data.ArrayValue;
+import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Metadata;
@@ -99,5 +101,139 @@ public class DeltaUtilsTest {
         Assertions.assertEquals("catalog0", deltaLakeTable.getCatalogName());
         Assertions.assertEquals("db0", deltaLakeTable.getCatalogDBName());
         Assertions.assertEquals("table0", deltaLakeTable.getCatalogTableName());
+    }
+
+    @Test
+    public void testLoadPartitionColumnNamesEmptyPartitions(@Mocked SnapshotImpl snapshot,
+                                                            @Mocked Metadata metadata,
+                                                            @Mocked ArrayValue partitionColumns,
+                                                            @Mocked ColumnVector columnVector) {
+        new Expectations() {
+            {
+                snapshot.getMetadata();
+                result = metadata;
+
+                metadata.getPartitionColumns();
+                result = partitionColumns;
+
+                partitionColumns.getSize();
+                result = 0;
+
+                partitionColumns.getElements();
+                result = columnVector;
+            }
+        };
+
+        List<String> result = DeltaUtils.loadPartitionColumnNames(snapshot);
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testLoadPartitionColumnNamesMultiplePartitions(@Mocked SnapshotImpl snapshot,
+                                                               @Mocked Metadata metadata,
+                                                               @Mocked ArrayValue partitionColumns,
+                                                               @Mocked ColumnVector columnVector) {
+        new Expectations() {
+            {
+                snapshot.getMetadata();
+                result = metadata;
+
+                metadata.getPartitionColumns();
+                result = partitionColumns;
+
+                partitionColumns.getSize();
+                result = 3;
+
+                partitionColumns.getElements();
+                result = columnVector;
+
+                columnVector.isNullAt(0);
+                result = false;
+                columnVector.getString(0);
+                result = "year";
+
+                columnVector.isNullAt(1);
+                result = false;
+                columnVector.getString(1);
+                result = "month";
+
+                columnVector.isNullAt(2);
+                result = false;
+                columnVector.getString(2);
+                result = "day";
+            }
+        };
+
+        List<String> result = DeltaUtils.loadPartitionColumnNames(snapshot);
+        Assertions.assertEquals(3, result.size());
+        Assertions.assertEquals("year", result.get(0));
+        Assertions.assertEquals("month", result.get(1));
+        Assertions.assertEquals("day", result.get(2));
+    }
+
+    @Test
+    public void testLoadPartitionColumnNames_NullPartitionColumn(@Mocked SnapshotImpl snapshot,
+                                                                 @Mocked Metadata metadata,
+                                                                 @Mocked ArrayValue partitionColumns,
+                                                                 @Mocked ColumnVector columnVector) {
+        new Expectations() {
+            {
+                snapshot.getMetadata();
+                result = metadata;
+
+                metadata.getPartitionColumns();
+                result = partitionColumns;
+
+                partitionColumns.getSize();
+                result = 1;
+
+                partitionColumns.getElements();
+                result = columnVector;
+
+                columnVector.isNullAt(0);
+                result = true;
+            }
+        };
+
+        Throwable exception = assertThrows(IllegalArgumentException.class, () ->
+                DeltaUtils.loadPartitionColumnNames(snapshot));
+        assertThat(exception.getMessage(), containsString("Expected a non-null partition column name"));
+    }
+
+    @Test
+    public void testLoadPartitionColumnNamesUpperCasePartitionColumn(@Mocked SnapshotImpl snapshot,
+                                                                     @Mocked Metadata metadata,
+                                                                     @Mocked ArrayValue partitionColumns,
+                                                                     @Mocked ColumnVector columnVector) {
+        new Expectations() {
+            {
+                snapshot.getMetadata();
+                result = metadata;
+
+                metadata.getPartitionColumns();
+                result = partitionColumns;
+
+                partitionColumns.getSize();
+                result = 2;
+
+                partitionColumns.getElements();
+                result = columnVector;
+
+                columnVector.isNullAt(0);
+                result = false;
+                columnVector.getString(0);
+                result = "YEAR";
+
+                columnVector.isNullAt(1);
+                result = false;
+                columnVector.getString(1);
+                result = "MONTH";
+            }
+        };
+
+        List<String> result = DeltaUtils.loadPartitionColumnNames(snapshot);
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertEquals("YEAR", result.get(0));
+        Assertions.assertEquals("MONTH", result.get(1));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
#62945
## What I'm doing:
This pull request updates how partition column names are handled in the `DeltaUtils` utility and expands the corresponding unit tests in `DeltaUtilsTest`. The most significant change is that partition column names are no longer automatically converted to lowercase, and comprehensive tests have been added to cover various scenarios, including empty, multiple, null, and uppercase partition columns.

**Partition Column Name Handling:**

* The conversion of partition column names to lowercase in `DeltaUtils.loadPartitionColumnNames` has been removed, so names are now returned in their original case.
* The unused import of `java.util.Locale` was removed from `DeltaUtils.java`.

**Unit Test Enhancements:**

* Added new tests in `DeltaUtilsTest` to verify behavior for empty partition columns, multiple partition columns, handling of null partition column names, and preservation of uppercase partition column names.
* Added necessary imports for `ArrayValue` and `ColumnVector` to support the new test cases.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
