### PR TITLE
[UT] add log to help identifying who is the chaos monkey

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
@@ -41,21 +41,34 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 public class CatalogRecycleBinLakeTableTest {
+    private static final Logger LOG = LogManager.getLogger(CatalogRecycleBinLakeTableTest.class);
+
+    private String currentCaseName = "";
+
     @BeforeAll
     public static void beforeClass() {
         UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
         GlobalStateMgr.getCurrentState().getWarehouseMgr().initDefaultWarehouse();
         GlobalStateMgr.getCurrentState().getRecycleBin().setStop();
+    }
+
+    @BeforeEach
+    void setUp(TestInfo testInfo) {
+        currentCaseName = testInfo.getDisplayName();
     }
 
     private static Table createTable(ConnectContext connectContext, String sql) throws Exception {
@@ -178,6 +191,7 @@ public class CatalogRecycleBinLakeTableTest {
 
     @Test
     public void testRecycleLakeTable(@Mocked LakeService lakeService) throws Exception {
+        LOG.warn("Start test: {}, lakeService={}", currentCaseName, lakeService);
         CatalogRecycleBin recycleBin = GlobalStateMgr.getCurrentState().getRecycleBin();
         ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
         // create database
@@ -295,6 +309,7 @@ public class CatalogRecycleBinLakeTableTest {
 
     @Test
     public void testReplayRecycleLakeTable(@Mocked LakeService lakeService) throws Exception {
+        LOG.warn("Start test: {}, lakeService={}", currentCaseName, lakeService);
         final String dbName = "replay_recycle_lake_table_test";
         CatalogRecycleBin recycleBin = GlobalStateMgr.getCurrentState().getRecycleBin();
         ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
@@ -321,6 +336,7 @@ public class CatalogRecycleBinLakeTableTest {
 
     @Test
     public void testRecycleLakeDatabase(@Mocked LakeService lakeService) throws Exception {
+        LOG.warn("Start test: {}, lakeService={}", currentCaseName, lakeService);
         final String dbName = "recycle_lake_database_test";
         CatalogRecycleBin recycleBin = GlobalStateMgr.getCurrentState().getRecycleBin();
         ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
@@ -385,6 +401,7 @@ public class CatalogRecycleBinLakeTableTest {
 
     @Test
     public void testRecycleLakePartition(@Mocked LakeService lakeService) throws Exception {
+        LOG.warn("Start test: {}, lakeService={}", currentCaseName, lakeService);
         final String dbName = "recycle_lake_partition_test";
         CatalogRecycleBin recycleBin = GlobalStateMgr.getCurrentState().getRecycleBin();
         ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
@@ -551,6 +568,7 @@ public class CatalogRecycleBinLakeTableTest {
 
     @Test
     public void testRecycleLakePartitionWithSharedDirectory(@Mocked LakeService lakeService) throws Exception {
+        LOG.warn("Start test: {}, lakeService={}", currentCaseName, lakeService);
         final String dbName = "recycle_partition_shared_directory_test";
         CatalogRecycleBin recycleBin = GlobalStateMgr.getCurrentState().getRecycleBin();
         ConnectContext connectContext = UtFrameUtils.createDefaultCtx();


### PR DESCRIPTION
## Why I'm doing:

```
CatalogRecycleBinLakeTableTest.testRecycleLakeDatabase(LakeService)

Unexpected invocation to:
com.starrocks.rpc.LakeService#dropTable(com.starrocks.proto.DropTableRequest@5f1ee6db)
   on mock instance: com.starrocks.rpc.$Impl_LakeService@3bf40c74
	at com.starrocks.lake.LakeTableHelper.removeShardRootDirectory(LakeTableHelper.java:107)
	at com.starrocks.lake.LakeTableCleaner.cleanTable(LakeTableCleaner.java:53)
	at com.starrocks.lake.LakeTableHelper.deleteTableFromRecycleBin(LakeTableHelper.java:76)
	at com.starrocks.lake.LakeTable.deleteFromRecycleBin(LakeTable.java:124)
	at com.starrocks.catalog.CatalogRecycleBin.lambda$eraseTable$6(CatalogRecycleBin.java:597)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: Unexpected invocation
	at com.starrocks.catalog.CatalogRecycleBinLakeTableTest$4.<init>(CatalogRecycleBinLakeTableTest.java:368)
	at com.starrocks.catalog.CatalogRecycleBinLakeTableTest.testRecycleLakeDatabase(CatalogRecycleBinLakeTableTest.java:366)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
