### PR TITLE
[UT] Optimize FE tests' logging output

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
@@ -49,6 +49,7 @@ import com.starrocks.sql.ast.ShowAlterStmt;
 import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -60,7 +61,7 @@ import java.util.Map;
 
 import static com.starrocks.sql.optimizer.MVTestUtils.waitForSchemaChangeAlterJobFinish;
 
-public class AlterJobV2Test {
+public class AlterJobV2Test extends StarRocksTestBase {
     private static ConnectContext connectContext;
 
     private static StarRocksAssert starRocksAssert;
@@ -127,8 +128,8 @@ public class AlterJobV2Test {
         ShowAlterStmt showAlterStmt =
                     (ShowAlterStmt) UtFrameUtils.parseStmtWithNewParser(showAlterStmtStr, connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showAlterStmt, connectContext);
-        System.out.println(showResultSet.getMetaData());
-        System.out.println(showResultSet.getResultRows());
+        logSysInfo(showResultSet.getMetaData());
+        logSysInfo(showResultSet.getResultRows());
     }
 
     @Test
@@ -141,11 +142,11 @@ public class AlterJobV2Test {
         Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
         for (AlterJobV2 alterJobV2 : alterJobs.values()) {
             while (!alterJobV2.getJobState().isFinalState()) {
-                System.out.println(
+                logSysInfo(
                             "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
                 Thread.sleep(1000);
             }
-            System.out.println("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
+            logSysInfo("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
             Assertions.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
         }
         // 3. check show alter table column
@@ -153,8 +154,8 @@ public class AlterJobV2Test {
         ShowAlterStmt showAlterStmt =
                     (ShowAlterStmt) UtFrameUtils.parseStmtWithNewParser(showAlterStmtStr, connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showAlterStmt, connectContext);
-        System.out.println(showResultSet.getMetaData());
-        System.out.println(showResultSet.getResultRows());
+        logSysInfo(showResultSet.getMetaData());
+        logSysInfo(showResultSet.getResultRows());
     }
 
     @Test
@@ -171,8 +172,8 @@ public class AlterJobV2Test {
         ShowCreateTableStmt showCreateTableStmt =
                     (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateTableStr, connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
-        System.out.println(showResultSet.getMetaData());
-        System.out.println(showResultSet.getResultRows());
+        logSysInfo(showResultSet.getMetaData());
+        logSysInfo(showResultSet.getResultRows());
 
         // 4. process a modify table properties job(in_memory)
         String alterStmtStr2 = "alter table test.properties_change_test set ('in_memory' = 'true');";
@@ -186,8 +187,8 @@ public class AlterJobV2Test {
         showCreateTableStmt =
                     (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateTableStr, connectContext);
         showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
-        System.out.println(showResultSet.getMetaData());
-        System.out.println(showResultSet.getResultRows());
+        logSysInfo(showResultSet.getMetaData());
+        logSysInfo(showResultSet.getResultRows());
     }
 
     @Test
@@ -347,7 +348,7 @@ public class AlterJobV2Test {
                 MaterializedView mv = (MaterializedView) GlobalStateMgr
                             .getCurrentState().getLocalMetastore().getDb("test").getTable("mv4");
                 Assertions.assertFalse(mv.isActive());
-                System.out.println(mv.getInactiveReason());
+                logSysInfo(mv.getInactiveReason());
                 Assertions.assertTrue(mv.getInactiveReason().contains("base table schema changed for columns: k2"));
             }
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
@@ -38,6 +38,7 @@ import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -49,7 +50,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class AlterTableTest {
+public class AlterTableTest extends StarRocksTestBase {
     private static ConnectContext connectContext;
     private static StarRocksAssert starRocksAssert;
 
@@ -323,7 +324,7 @@ public class AlterTableTest {
 
         // add label to backend
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
-        System.out.println(systemInfoService.getBackends());
+        logSysInfo(systemInfoService.getBackends());
         List<Long> backendIds = systemInfoService.getBackendIds();
         Backend backend = systemInfoService.getBackend(backendIds.get(0));
         String modifyBackendPropSqlStr = "alter system modify backend '" + backend.getHost() +
@@ -378,7 +379,7 @@ public class AlterTableTest {
         localMetastoreFollower.replayModifyTableProperty(OperationType.OP_ALTER_TABLE_PROPERTIES, info);
         OlapTable olapTable = (OlapTable) localMetastoreFollower.getDb("test")
                     .getTable("test_location_alter");
-        System.out.println(olapTable.getLocation());
+        logSysInfo(olapTable.getLocation());
         Assertions.assertEquals(1, olapTable.getLocation().size());
         Assertions.assertTrue(olapTable.getLocation().containsKey("rack"));
 
@@ -388,7 +389,7 @@ public class AlterTableTest {
         localMetastoreFollower.replayModifyTableProperty(OperationType.OP_ALTER_TABLE_PROPERTIES, info);
         olapTable = (OlapTable) localMetastoreFollower.getDb("test")
                     .getTable("test_location_alter");
-        System.out.println(olapTable.getLocation());
+        logSysInfo(olapTable.getLocation());
         Assertions.assertNull(olapTable.getLocation());
     }
 
@@ -398,7 +399,7 @@ public class AlterTableTest {
 
         // add label to backend
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
-        System.out.println(systemInfoService.getBackends());
+        logSysInfo(systemInfoService.getBackends());
         List<Long> backendIds = systemInfoService.getBackendIds();
         Backend backend = systemInfoService.getBackend(backendIds.get(0));
         String modifyBackendPropSqlStr = "alter system modify backend '" + backend.getHost() +
@@ -439,7 +440,7 @@ public class AlterTableTest {
 
         // add label to backend
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
-        System.out.println(systemInfoService.getBackends());
+        logSysInfo(systemInfoService.getBackends());
         List<Long> backendIds = systemInfoService.getBackendIds();
         Backend backend = systemInfoService.getBackend(backendIds.get(0));
         String modifyBackendPropSqlStr = "alter system modify backend '" + backend.getHost() +
@@ -469,7 +470,7 @@ public class AlterTableTest {
         try {
             DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(sql, connectContext), connectContext);
         } catch (DdlException e) {
-            System.out.println(e.getMessage());
+            logSysInfo(e.getMessage());
             Assertions.assertTrue(e.getMessage().contains("table has location property and cannot be colocated"));
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeSyncMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeSyncMaterializedViewTest.java
@@ -33,6 +33,7 @@ import com.starrocks.sql.ast.ShowMaterializedViewsStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -50,7 +51,7 @@ import java.util.Set;
 import static com.starrocks.sql.optimizer.MVTestUtils.waitingRollupJobV2Finish;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase.executeInsertSql;
 
-public class LakeSyncMaterializedViewTest {
+public class LakeSyncMaterializedViewTest extends StarRocksTestBase {
 
     
     public String name;
@@ -769,7 +770,8 @@ public class LakeSyncMaterializedViewTest {
     }
 
     @BeforeEach
-    public void setup(TestInfo testInfo) {
+    public void setup(TestInfo testInfo) throws Exception {
+        super.before();
         Optional<Method> testMethod = testInfo.getTestMethod();
         if (testMethod.isPresent()) {
             this.name = testMethod.get().getName();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -34,6 +34,7 @@ import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -43,7 +44,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class LakeTableAsyncFastSchemaChangeJobTest {
+public class LakeTableAsyncFastSchemaChangeJobTest extends StarRocksTestBase {
     private static ConnectContext connectContext;
     private static final String DB_NAME = "test_lake_fast_schema_evolution";
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -68,7 +68,7 @@ public class AlterMaterializedViewTest extends MVTestBase  {
     }
 
     @BeforeEach
-    public void before() {
+    public void before() throws Exception {
         super.before();
         connectContext.setThreadLocalInfo();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewStatementTest.java
@@ -118,7 +118,6 @@ public class RefreshMaterializedViewStatementTest {
 
         MaterializedView.MvRefreshScheme refreshScheme = mv1.getRefreshScheme();
         Assertions.assertNotNull(refreshScheme);
-        System.out.println("visibleVersionMap:" + refreshScheme.getAsyncRefreshContext().getBaseTableVisibleVersionMap());
         Assertions.assertTrue(refreshScheme.getAsyncRefreshContext().getBaseTableVisibleVersionMap().containsKey(table.getId()));
         Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap =
                 refreshScheme.getAsyncRefreshContext().getBaseTableVisibleVersionMap().get(table.getId());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -317,10 +317,10 @@ public class RefreshMaterializedViewTest extends MVTestBase {
         } else {
             // publish version is async, so version update may be late
             // for debug
-            System.out.println("p1 visible version:" + p1.getDefaultPhysicalPartition().getVisibleVersion());
-            System.out.println("p2 visible version:" + p2.getDefaultPhysicalPartition().getVisibleVersion());
-            System.out.println("mv1 refresh context" + mv1.getRefreshScheme().getAsyncRefreshContext());
-            System.out.println("mv2 refresh context" + mv2.getRefreshScheme().getAsyncRefreshContext());
+            logSysInfo("p1 visible version:" + p1.getDefaultPhysicalPartition().getVisibleVersion());
+            logSysInfo("p2 visible version:" + p2.getDefaultPhysicalPartition().getVisibleVersion());
+            logSysInfo("mv1 refresh context" + mv1.getRefreshScheme().getAsyncRefreshContext());
+            logSysInfo("mv2 refresh context" + mv2.getRefreshScheme().getAsyncRefreshContext());
         }
     }
 
@@ -1182,7 +1182,7 @@ public class RefreshMaterializedViewTest extends MVTestBase {
                 Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                 MaterializedView mv =
                         (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv1");
-                System.out.println(mv.getPartitionNames());
+                logSysInfo(mv.getPartitionNames());
             });
         }
         starRocksAssert.dropTable("t1");
@@ -1234,7 +1234,7 @@ public class RefreshMaterializedViewTest extends MVTestBase {
                 MaterializedView mv =
                         (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv1");
                 Assertions.assertEquals(2, mv.getPartitionExprMaps().size());
-                System.out.println(mv.getPartitionNames());
+                logSysInfo(mv.getPartitionNames());
             });
         }
         starRocksAssert.dropTable("t1");
@@ -1283,9 +1283,9 @@ public class RefreshMaterializedViewTest extends MVTestBase {
                 Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                 MaterializedView mv =
                         (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv1");
-                System.out.println(mv.getPartitionExprMaps());
+                logSysInfo(mv.getPartitionExprMaps());
                 Assertions.assertEquals(2, mv.getPartitionExprMaps().size());
-                System.out.println(mv.getPartitionNames());
+                logSysInfo(mv.getPartitionNames());
             });
         }
         starRocksAssert.dropTable("t1");

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
@@ -64,6 +64,7 @@ import com.starrocks.thrift.THdfsProperties;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTaskType;
+import com.starrocks.utframe.StarRocksTestBase;
 import mockit.Delegate;
 import mockit.Expectations;
 import mockit.Injectable;
@@ -96,7 +97,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class RestoreJobMaterializedViewTest {
+public class RestoreJobMaterializedViewTest extends StarRocksTestBase {
 
     private Database db;
 
@@ -230,7 +231,7 @@ public class RestoreJobMaterializedViewTest {
                 minTimes = 0;
                 result = new Delegate() {
                     public void logBackupJob(BackupJob job) {
-                        System.out.println("log backup job: " + job);
+                        logSysInfo("log backup job: " + job);
                     }
                 };
             }

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRefreshConcurrencyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRefreshConcurrencyTest.java
@@ -115,9 +115,9 @@ public class MvRefreshConcurrencyTest extends MVTestBase {
             List<MaterializedView> mvs = Lists.newArrayList();
             try {
                 for (int i = 0; i < mvNum; i++) {
-                    System.out.println("create mv " + i);
+                    logSysInfo("create mv " + i);
                     String sql = buildMV(rnd, tables, i);
-                    System.out.println(sql);
+                    logSysInfo(sql);
                     starRocksAssert.withMaterializedView(sql);
 
                     Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRewritePerfTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRewritePerfTest.java
@@ -76,7 +76,7 @@ public class MvRewritePerfTest extends MVTestBase {
     }
 
     @BeforeEach
-    public void before() {
+    public void before() throws Exception {
         super.before();
         starRocksAssert.getCtx().getSessionVariable().setEnableQueryDump(false);
         starRocksAssert.getCtx().getSessionVariable().setCboMaterializedViewRewriteRuleOutputLimit(

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/ViewBasedMvRewritePerfTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/ViewBasedMvRewritePerfTest.java
@@ -92,7 +92,7 @@ public class ViewBasedMvRewritePerfTest extends MVTestBase {
     }
 
     @BeforeEach
-    public void before() {
+    public void before() throws Exception {
         super.before();
         starRocksAssert.getCtx().getSessionVariable().setEnableQueryDump(false);
         connectContext.getSessionVariable().setEnableViewBasedMvRewrite(true);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -66,6 +66,7 @@ import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
@@ -79,7 +80,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class CreateTableTest {
+public class CreateTableTest extends StarRocksTestBase {
     private static ConnectContext connectContext;
     private static StarRocksAssert starRocksAssert;
 
@@ -758,7 +759,7 @@ public class CreateTableTest {
         final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore().getDb(connectContext.getDatabase())
                 .getTable("aggregate_table_sum");
         String columns = table.getColumns().toString();
-        System.out.println("columns = " + columns);
+        logSysInfo("columns = " + columns);
         Assertions.assertTrue(columns.contains("`sum_decimal` decimal(38, 4) SUM"));
         Assertions.assertTrue(columns.contains("`sum_bigint` bigint(20) SUM "));
     }
@@ -921,7 +922,7 @@ public class CreateTableTest {
 
         // add label to backend
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
-        System.out.println(systemInfoService.getBackends());
+        logSysInfo(systemInfoService.getBackends());
         List<Long> backendIds = systemInfoService.getBackendIds();
         Backend backend = systemInfoService.getBackend(backendIds.get(0));
         String modifyBackendPropSqlStr = "alter system modify backend '" + backend.getHost() +
@@ -946,7 +947,7 @@ public class CreateTableTest {
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .getTable(testDb.getFullName(), "test_location_no_prop");
         Assertions.assertNotNull(table.getLocation());
-        System.out.println(table.getLocation());
+        logSysInfo(table.getLocation());
         Assertions.assertTrue(table.getLocation().containsKey("*"));
 
         // verify the location property in show create table result, should be "*"
@@ -955,7 +956,7 @@ public class CreateTableTest {
                 connectContext);
 
         ShowResultSet showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
-        System.out.println(showResultSet.getResultRows());
+        logSysInfo(showResultSet.getResultRows());
         Assertions.assertTrue(showResultSet.getResultRows().get(0).toString().contains("\"" +
                 PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"*\""));
 
@@ -987,7 +988,7 @@ public class CreateTableTest {
         showCreateTableStmt = (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showSql,
                 connectContext);
         showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
-        System.out.println(showResultSet.getResultRows());
+        logSysInfo(showResultSet.getResultRows());
         Assertions.assertFalse(showResultSet.getResultRows().get(0).toString().contains("\"" +
                 PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"*\""));
 
@@ -1006,7 +1007,7 @@ public class CreateTableTest {
 
         for (int i = 0; i < 5; i++) {
             backend = systemInfoService.getBackend(backendIds.get(i));
-            System.out.println("backend " + backend.getId() + " location: " + backend.getLocation());
+            logSysInfo("backend " + backend.getId() + " location: " + backend.getLocation());
         }
 
         // **test create table with valid/invalid location property format
@@ -1018,7 +1019,7 @@ public class CreateTableTest {
                 null, "", null, null, null, null, null};
         for (int i = 0; i < tableLocationProps.length; i++) {
             String tableLocationProp = tableLocationProps[i];
-            System.out.println(tableLocationProp);
+            logSysInfo(tableLocationProp);
             String expectedAnalyzedProp = expectedAnalyzedProps[i];
             String createTableSql = "CREATE TABLE test.`test_location_prop_" + i + "` (\n" +
                     "    k1 int,\n" +
@@ -1051,7 +1052,7 @@ public class CreateTableTest {
                     continue;
                 }
                 Assertions.assertNotNull(table.getLocation());
-                System.out.println(table.getLocation());
+                logSysInfo(table.getLocation());
                 Assertions.assertEquals(PropertyAnalyzer.convertLocationMapToString(table.getLocation()),
                         expectedAnalyzedProp);
 
@@ -1060,7 +1061,7 @@ public class CreateTableTest {
                 showCreateTableStmt = (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showSql,
                         connectContext);
                 showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
-                System.out.println(showResultSet.getResultRows());
+                logSysInfo(showResultSet.getResultRows());
                 Assertions.assertTrue(showResultSet.getResultRows().get(0).toString().contains("\"" +
                         PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"" + expectedAnalyzedProp + "\""));
             }
@@ -1078,7 +1079,7 @@ public class CreateTableTest {
     public void testCreateTableLocationPropPersist() throws Exception {
         // add label to backend
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
-        System.out.println(systemInfoService.getBackends());
+        logSysInfo(systemInfoService.getBackends());
         List<Long> backendIds = systemInfoService.getBackendIds();
         Backend backend = systemInfoService.getBackend(backendIds.get(0));
         String modifyBackendPropSqlStr = "alter system modify backend '" + backend.getHost() +
@@ -1116,7 +1117,7 @@ public class CreateTableTest {
         localMetastoreFollower.replayCreateTable(info);
         OlapTable olapTable = (OlapTable) localMetastoreFollower.getDb("test")
                 .getTable("test_location_persist_t1");
-        System.out.println(olapTable.getLocation());
+        logSysInfo(olapTable.getLocation());
         Assertions.assertEquals(1, olapTable.getLocation().size());
         Assertions.assertTrue(olapTable.getLocation().containsKey("rack"));
 
@@ -1125,7 +1126,7 @@ public class CreateTableTest {
         localMetastoreLeader.load(finalImage.getMetaBlockReader());
         olapTable = (OlapTable) localMetastoreLeader.getDb("test")
                 .getTable("test_location_persist_t1");
-        System.out.println(olapTable.getLocation());
+        logSysInfo(olapTable.getLocation());
         Assertions.assertEquals(1, olapTable.getLocation().size());
         Assertions.assertTrue(olapTable.getLocation().containsKey("rack"));
     }
@@ -1924,7 +1925,7 @@ public class CreateTableTest {
         starRocksAssert.withTable(sql2);
 
         List<List<String>> result = GlobalStateMgr.getCurrentState().getColocateTableIndex().getInfos();
-        System.out.println(result);
+        logSysInfo(result);
         List<String> groupIds = new ArrayList<>();
         for (List<String> e : result) {
             if (e.get(1).contains("ship_id_public")) {
@@ -1932,7 +1933,7 @@ public class CreateTableTest {
             }
         }
         Assertions.assertEquals(2, groupIds.size());
-        System.out.println(groupIds);
+        logSysInfo(groupIds);
         // colocate groups in different db should have same `GroupId.grpId`
         Assertions.assertEquals(groupIds.get(0).split("\\.")[1], groupIds.get(1).split("\\.")[1]);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MVPartitionExprResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MVPartitionExprResolverTest.java
@@ -203,7 +203,6 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                         ") t group by k1",
         };
         for (String sql : sqls) {
-            System.out.println(sql);
             checkMVPartitionExprs(sql, slot, 2);
         }
     }
@@ -496,7 +495,6 @@ public class MVPartitionExprResolverTest extends MVTestBase {
 
                     MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                     Set<String> mvPartitionsToRefresh = processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh();
-                    System.out.println(mvPartitionsToRefresh);
                     Assertions.assertTrue(mvPartitionsToRefresh.contains("p20220101_20220102"));
                     Map<String, Set<String>> refBasePartitionsToRefreshMap =
                             processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -671,8 +671,8 @@ public class MaterializedViewTest extends StarRocksTestBase {
         ShowCreateTableStmt showCreateTableStmt =
                 (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateSql, connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
-        System.out.println(showResultSet.getMetaData().toString());
-        System.out.println(showResultSet.getResultRows());
+        logSysInfo(showResultSet.getMetaData().toString());
+        logSysInfo(showResultSet.getResultRows());
     }
 
     @Test
@@ -720,7 +720,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
         ShowCreateTableStmt showCreateTableStmt =
                 (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateSql, connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
-        System.out.println(showResultSet.getResultRows());
+        logSysInfo(showResultSet.getResultRows());
     }
 
     private String getShowMVResult(String mvName) throws Exception {
@@ -728,11 +728,11 @@ public class MaterializedViewTest extends StarRocksTestBase {
         ShowCreateTableStmt showCreateTableStmt =
                 (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateSql, connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
-        System.out.println(showResultSet.getResultRows());
+        logSysInfo(showResultSet.getResultRows());
         List<List<String>> result = showResultSet.getResultRows();
         Assertions.assertEquals(1, result.size());
         String actual = result.get(0).get(1);
-        System.out.println(actual);
+        logSysInfo(actual);
         return actual;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MetadataViewerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MetadataViewerTest.java
@@ -133,7 +133,6 @@ public class MetadataViewerTest {
                 null};
         List<List<String>> result = (List<List<String>>) getTabletStatusMethod.invoke(null, args);
         Assertions.assertEquals(3, result.size());
-        System.out.println(result);
 
         args = new Object[] {CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME, partitions, ReplicaStatus.DEAD,
                 BinaryType.EQ};
@@ -152,7 +151,6 @@ public class MetadataViewerTest {
         Object[] args = new Object[] {CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME, null};
         List<List<String>> result = (List<List<String>>) getTabletDistributionMethod.invoke(null, args);
         Assertions.assertEquals(3, result.size());
-        System.out.println(result);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
@@ -51,6 +51,7 @@ import com.starrocks.sql.ast.ShowPartitionsStmt;
 import com.starrocks.sql.ast.ShowTabletStmt;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -63,7 +64,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-public class TempPartitionTest {
+public class TempPartitionTest extends StarRocksTestBase {
 
     private static String tempPartitionFile = "./TempPartitionTest";
     private static String tblFile = "./tblFile";
@@ -120,7 +121,7 @@ public class TempPartitionTest {
             }
         } catch (Exception e) {
             if (expectedException) {
-                System.out.println("got exception: " + e.getMessage());
+                logSysInfo("got exception: " + e.getMessage());
             } else {
                 throw e;
             }
@@ -419,8 +420,8 @@ public class TempPartitionTest {
         getPartitionNameToTabletIdMap("db2.tbl2", true, tempPartitionTabletIds);
         Assertions.assertEquals(3, tempPartitionTabletIds.keySet().size());
 
-        System.out.println("partition tablets: " + originPartitionTabletIds);
-        System.out.println("temp partition tablets: " + tempPartitionTabletIds);
+        logSysInfo("partition tablets: " + originPartitionTabletIds);
+        logSysInfo("temp partition tablets: " + tempPartitionTabletIds);
 
         // drop non exist temp partition
         stmtStr = "alter table db2.tbl2 drop temporary partition tp4;";
@@ -473,8 +474,8 @@ public class TempPartitionTest {
         Assertions.assertEquals(3, tempPartitionTabletIds2.keySet().size());
 
         // Here, we should have 3 partitions p1,p2,p3, and 3 temp partitions tp1,tp2,tp3
-        System.out.println("we have partition tablets: " + originPartitionTabletIds2);
-        System.out.println("we have temp partition tablets: " + tempPartitionTabletIds2);
+        logSysInfo("we have partition tablets: " + originPartitionTabletIds2);
+        logSysInfo("we have temp partition tablets: " + tempPartitionTabletIds2);
 
         stmtStr = "alter table db2.tbl2 replace partition(p1, p2) with temporary partition(tp2, tp3);";
         alterTableWithNewAnalyzer(stmtStr, true);
@@ -580,8 +581,8 @@ public class TempPartitionTest {
         Assertions.assertEquals(1, tempPartitionTabletIds2.keySet().size());
 
         // for now , we have 3 partitions: tp1, tp2, tp3, 1 temp partition: p1
-        System.out.println("we have partition tablets: " + originPartitionTabletIds2);
-        System.out.println("we have temp partition tablets: " + tempPartitionTabletIds2);
+        logSysInfo("we have partition tablets: " + originPartitionTabletIds2);
+        logSysInfo("we have temp partition tablets: " + tempPartitionTabletIds2);
 
         stmtStr = "alter table db2.tbl2 add rollup r1(k1);";
         alterTableWithNewAnalyzer(stmtStr, true);
@@ -602,11 +603,11 @@ public class TempPartitionTest {
         Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
         for (AlterJobV2 alterJobV2 : alterJobs.values()) {
             while (!alterJobV2.getJobState().isFinalState()) {
-                System.out.println(
+                logSysInfo(
                         "alter job " + alterJobV2.getDbId() + " is running. state: " + alterJobV2.getJobState());
                 Thread.sleep(5000);
             }
-            System.out.println("alter job " + alterJobV2.getDbId() + " is done. state: " + alterJobV2.getJobState());
+            logSysInfo("alter job " + alterJobV2.getDbId() + " is done. state: " + alterJobV2.getJobState());
             Assertions.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/MD5Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/MD5Test.java
@@ -17,6 +17,7 @@
 
 package com.starrocks.common;
 
+import com.starrocks.utframe.StarRocksTestBase;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,7 +29,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-public class MD5Test {
+public class MD5Test extends StarRocksTestBase {
 
     private static String fileName = "job_info.txt";
 
@@ -63,14 +64,14 @@ public class MD5Test {
             e.printStackTrace();
         }
 
-        System.out.println(md5sum);
+        logSysInfo(md5sum);
         String fullName = fileName + "__" + md5sum;
-        System.out.println(fullName);
+        logSysInfo(fullName);
 
-        System.out.println(fullName.lastIndexOf("__"));
-        System.out.println(fullName.substring(fullName.lastIndexOf("__") + 2));
-        System.out.println(fullName.substring(0, fullName.lastIndexOf("__")));
-        System.out.println(md5sum.length());
+        logSysInfo(fullName.lastIndexOf("__"));
+        logSysInfo(fullName.substring(fullName.lastIndexOf("__") + 2));
+        logSysInfo(fullName.substring(0, fullName.lastIndexOf("__")));
+        logSysInfo(md5sum.length());
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/PListCellTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PListCellTest.java
@@ -29,7 +29,6 @@ public class PListCellTest {
         {
             PListCell s1 = new PListCell(ImmutableList.of(ImmutableList.of("2024-01-01")));
             String ser = s1.serialize();
-            System.out.println(ser);
             PListCell s2 = PListCell.deserialize(ser);
             Assertions.assertEquals(s1, s2);
         }
@@ -37,7 +36,6 @@ public class PListCellTest {
         {
             PListCell s1 = new PListCell(ImmutableList.of(ImmutableList.of("beijing", "2024-01-01")));
             String ser = s1.serialize();
-            System.out.println(ser);
             PListCell s2 = PListCell.deserialize(ser);
             Assertions.assertEquals(s1, s2);
         }
@@ -48,7 +46,6 @@ public class PListCellTest {
                     ImmutableList.of("shanghai", "2024-01-02")
             ));
             String ser = s1.serialize();
-            System.out.println(ser);
             PListCell s2 = PListCell.deserialize(ser);
             Assertions.assertEquals(s1, s2);
         }
@@ -64,7 +61,6 @@ public class PListCellTest {
                             new PListCell(ImmutableList.of(ImmutableList.of("2024-01-02")))
                     );
             String ser = PListCell.batchSerialize(s1);
-            System.out.println(ser);
             Set<PListCell> s2 = PListCell.batchDeserialize(ser);
             Assertions.assertEquals(s1, s2);
         }
@@ -76,7 +72,6 @@ public class PListCellTest {
                             new PListCell(ImmutableList.of(ImmutableList.of("beijing", "2024-01-02")))
                     );
             String ser = PListCell.batchSerialize(s1);
-            System.out.println(ser);
             Set<PListCell> s2 = PListCell.batchDeserialize(ser);
             Assertions.assertEquals(s1, s2);
         }
@@ -87,7 +82,6 @@ public class PListCellTest {
                     ImmutableList.of("shanghai", "2024-01-02")
             ));
             String ser = s1.serialize();
-            System.out.println(ser);
             PListCell s2 = PListCell.deserialize(ser);
             Assertions.assertEquals(s1, s2);
         }
@@ -104,7 +98,6 @@ public class PListCellTest {
                             ))
                     );
             String ser = PListCell.batchSerialize(s1);
-            System.out.println(ser);
             Set<PListCell> s2 = PListCell.batchDeserialize(ser);
             Assertions.assertEquals(s1, s2);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
@@ -64,6 +64,7 @@ import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
@@ -80,7 +81,7 @@ import java.util.Map;
 
 import static com.starrocks.sql.optimizer.MVTestUtils.waitForSchemaChangeAlterJobFinish;
 
-public class LakeMaterializedViewTest {
+public class LakeMaterializedViewTest extends StarRocksTestBase {
     private static final String DB = "db_for_lake_mv";
 
     private static ConnectContext connectContext;
@@ -237,7 +238,7 @@ public class LakeMaterializedViewTest {
 
         // show create materialized view
         String ddlStmt = lakeMv.getMaterializedViewDdlStmt(true);
-        System.out.println(ddlStmt);
+        logSysInfo(ddlStmt);
         Assertions.assertTrue(ddlStmt.contains("\"replication_num\" = \"1\""));
         Assertions.assertTrue(ddlStmt.contains("\"datacache.enable\" = \"true\""));
         Assertions.assertTrue(ddlStmt.contains("\"enable_async_write_back\" = \"false\""));
@@ -346,7 +347,7 @@ public class LakeMaterializedViewTest {
             starRocksAssert.dropTable("base_table4");
             Assertions.assertNull(GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "base_table4"));
         } catch (Exception e) {
-            System.out.println(e);
+            logSysInfo(e);
             Assertions.fail();
         }
     }
@@ -378,7 +379,7 @@ public class LakeMaterializedViewTest {
             starRocksAssert.dropTable("base_table5");
             Assertions.assertNull(GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "base_table5"));
         } catch (Exception e) {
-            System.out.println(e);
+            logSysInfo(e);
             Assertions.fail();
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
@@ -22,6 +22,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.proc.JvmMonitorProcDir;
 import com.starrocks.monitor.jvm.JvmStatCollector;
 import com.starrocks.monitor.jvm.JvmStats;
+import com.starrocks.utframe.StarRocksTestBase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 
-public class MetricsTest {
+public class MetricsTest extends StarRocksTestBase {
 
     @BeforeAll
     public static void setUp() {
@@ -65,7 +66,7 @@ public class MetricsTest {
         JvmStats jvmStats = jvmStatCollector.stats();
         jsonMetricVisitor.visitJvm(jvmStats);
         String output = jsonMetricVisitor.build();
-        System.out.println(output);
+        logSysInfo(output);
         List<String> metricNames = Arrays.asList(
                 "jvm_old_gc",
                 "jvm_young_gc",
@@ -83,11 +84,11 @@ public class MetricsTest {
     public void testPrometheusJvmStats() {
         PrometheusMetricVisitor prometheusMetricVisitor = new PrometheusMetricVisitor("sr_fe_jvm_stat_test");
         JvmStatCollector jvmStatCollector = new JvmStatCollector();
-        System.out.println(jvmStatCollector.toString());
+        logSysInfo(jvmStatCollector.toString());
         JvmStats jvmStats = jvmStatCollector.stats();
         prometheusMetricVisitor.visitJvm(jvmStats);
         String output = prometheusMetricVisitor.build();
-        System.out.println(output);
+        logSysInfo(output);
         List<String> metricNames = Arrays.asList(
                 "jvm_old_gc",
                 "jvm_young_gc",
@@ -115,7 +116,7 @@ public class MetricsTest {
     public void testProcDirJvmStats() throws AnalysisException {
         JvmMonitorProcDir jvmMonitorProcDir = new JvmMonitorProcDir();
         List<List<String>> rows = jvmMonitorProcDir.fetchResult().getRows();
-        System.out.println(rows);
+        logSysInfo(rows);
         List<String> metricNames = Arrays.asList(
                 "gc old collection count",
                 "gc old collection time",
@@ -125,7 +126,7 @@ public class MetricsTest {
                 "mem pool old used"
         );
         for (String metricName : metricNames) {
-            System.out.println(metricName);
+            logSysInfo(metricName);
             Assertions.assertTrue(jvmProcDirResultRowsContains(rows, metricName));
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewAggPushDownRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewAggPushDownRewriteTest.java
@@ -1134,7 +1134,6 @@ public class MaterializedViewAggPushDownRewriteTest extends MaterializedViewTest
         String query = "SELECT SUM((gmv+gmv2)*0.01)\n" +
                 "FROM test_pt8 WHERE pt = '20241126' AND id IN ( SELECT id FROM test_pt9 WHERE id = '1' )";
         String plan = getQueryPlan(query, TExplainLevel.VERBOSE);
-        System.out.println(plan);
         starRocksAssert.dropTable("test_pt8");
         starRocksAssert.dropTable("test_pt9");
         starRocksAssert.dropMaterializedView("test_pt8_mv");

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -137,7 +137,7 @@ public class MaterializedViewTestBase extends PlanTestBase {
                     String mvName = getMVName();
                     String mvSQL = String.format("CREATE MATERIALIZED VIEW %s \n" +
                             " REFRESH MANUAL \n%s AS %s", mvName, properties, mv);
-                    System.out.println(mvSQL);
+                    logSysInfo(mvSQL);
                     starRocksAssert.withMaterializedView(mvSQL);
                 }
 
@@ -149,7 +149,7 @@ public class MaterializedViewTestBase extends PlanTestBase {
                     this.rewritePlan = planAndTrace.first.getExplainString(TExplainLevel.NORMAL);
                 }
                 if (!Strings.isNullOrEmpty(traceLogModule)) {
-                    System.out.println(this.rewritePlan);
+                    logSysInfo(this.rewritePlan);
                 }
                 this.traceLog = planAndTrace.second;
             } catch (Exception e) {
@@ -157,7 +157,7 @@ public class MaterializedViewTestBase extends PlanTestBase {
                 this.exception = e;
             } finally {
                 if (!Strings.isNullOrEmpty(traceLogModule)) {
-                    System.out.println(traceLog);
+                    logSysInfo(traceLog);
                 }
                 if (mv != null && !mv.isEmpty()) {
                     try {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PlanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PlanNodeTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.utframe.StarRocksTestBase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 
-public class PlanNodeTest {
+public class PlanNodeTest extends StarRocksTestBase {
 
     @BeforeAll
     public static void beforeClass() throws Exception {
@@ -64,8 +65,8 @@ public class PlanNodeTest {
 
     boolean slotRefsEqualTo(List<Expr> slotRefs, List<Integer> expect) {
         List<Integer> slotRefsToInt = slotRefsToInt(slotRefs);
-        System.out.println("slotRefs:" + slotRefsToInt(slotRefs));
-        System.out.println("expect:" + expect);
+        logSysInfo("slotRefs:" + slotRefsToInt(slotRefs));
+        logSysInfo("expect:" + expect);
         if (slotRefsToInt.size() != expect.size()) {
             return false;
         }
@@ -81,12 +82,12 @@ public class PlanNodeTest {
     public void testPermutaionsOfPartitionByExprs1() throws Exception {
         List<List<Expr>> slotRefs = createSlotRefArray(2, 3);
         for (List<Expr> refs: slotRefs) {
-            System.out.println(slotRefsToInt(refs));
+            logSysInfo(slotRefsToInt(refs));
         }
         List<List<Expr>> newSlotRefs = PlanNode.candidateOfPartitionByExprs(slotRefs);
         Assertions.assertTrue(newSlotRefs.size() == 8);
         for (List<Expr> candidates: newSlotRefs) {
-            System.out.println(slotRefsToInt(candidates));
+            logSysInfo(slotRefsToInt(candidates));
         }
         int k = 0;
         for (int i = 0; i < 3; i++) {
@@ -101,12 +102,12 @@ public class PlanNodeTest {
     public void testPermutaionsOfPartitionByExprs2() throws Exception {
         List<List<Expr>> slotRefs = createSlotRefArray(1, 3);
         for (List<Expr> refs: slotRefs) {
-            System.out.println(slotRefsToInt(refs));
+            logSysInfo(slotRefsToInt(refs));
         }
         List<List<Expr>> newSlotRefs = PlanNode.candidateOfPartitionByExprs(slotRefs);
         Assertions.assertTrue(newSlotRefs.size() == 3);
         for (List<Expr> candidates: newSlotRefs) {
-            System.out.println(slotRefsToInt(candidates));
+            logSysInfo(slotRefsToInt(candidates));
         }
 
         Assertions.assertTrue(slotRefsEqualTo(newSlotRefs.get(0), Arrays.asList(0)));
@@ -118,12 +119,12 @@ public class PlanNodeTest {
     public void testPermutaionsOfPartitionByExprs3() throws Exception {
         List<List<Expr>> slotRefs = createSlotRefArray(4, 5);
         for (List<Expr> refs: slotRefs) {
-            System.out.println(slotRefsToInt(refs));
+            logSysInfo(slotRefsToInt(refs));
         }
         List<List<Expr>> newSlotRefs = PlanNode.candidateOfPartitionByExprs(slotRefs);
         Assertions.assertTrue (newSlotRefs.size() == 8);
         for (List<Expr> candidates: newSlotRefs) {
-            System.out.println(slotRefsToInt(candidates));
+            logSysInfo(slotRefsToInt(candidates));
         }
         Assertions.assertTrue(slotRefsEqualTo(newSlotRefs.get(0), Arrays.asList(0, 5, 10, 15)));
         Assertions.assertTrue(slotRefsEqualTo(newSlotRefs.get(1), Arrays.asList(0, 5, 10, 16)));

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheAndMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheAndMVTest.java
@@ -200,7 +200,6 @@ public class QueryCacheAndMVTest extends MVTestBase {
         Assertions.assertTrue(optFragment.isPresent());
         PlanFragment fragment = optFragment.get();
         String expectRange = "[]";
-        System.out.println(fragment.getCacheParam().getRegion_map().values());
         boolean exists = fragment.getCacheParam().getRegion_map()
                 .values().stream().anyMatch(value -> value.equals(expectRange));
         Assertions.assertTrue(exists);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
@@ -85,7 +85,7 @@ public class MVMetaVersionRepairerTest extends MVTestBase {
                                 mv1.getRefreshScheme().getAsyncRefreshContext();
                         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                                 asyncRefreshContext.getBaseTableVisibleVersionMap();
-                        System.out.println(baseTableVisibleVersionMap);
+                        logSysInfo(baseTableVisibleVersionMap);
 
                         // check mv version map before
                         Assertions.assertEquals(1, baseTableVisibleVersionMap.size());
@@ -143,7 +143,7 @@ public class MVMetaVersionRepairerTest extends MVTestBase {
                                 mv1.getRefreshScheme().getAsyncRefreshContext();
                         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                                 asyncRefreshContext.getBaseTableVisibleVersionMap();
-                        System.out.println(baseTableVisibleVersionMap);
+                        logSysInfo(baseTableVisibleVersionMap);
 
                         // check mv version map before
                         Assertions.assertEquals(0, baseTableVisibleVersionMap.size());
@@ -190,7 +190,7 @@ public class MVMetaVersionRepairerTest extends MVTestBase {
                                 mv1.getRefreshScheme().getAsyncRefreshContext();
                         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                                 asyncRefreshContext.getBaseTableVisibleVersionMap();
-                        System.out.println(baseTableVisibleVersionMap);
+                        logSysInfo(baseTableVisibleVersionMap);
 
                         // repair base table version changes
                         Table m1 = getTable("test", "m1");
@@ -225,7 +225,7 @@ public class MVMetaVersionRepairerTest extends MVTestBase {
                         Assertions.assertEquals(baseTableId, baseTableVisibleVersionMap.keySet().iterator().next());
                         Map<String, MaterializedView.BasePartitionInfo> basePartitionInfoMap = baseTableVisibleVersionMap.get(m1.getId());
                         Assertions.assertEquals(1, basePartitionInfoMap.size());
-                        System.out.println(basePartitionInfoMap);
+                        logSysInfo(basePartitionInfoMap);
                         // p2 should not be in the version map
                         Assertions.assertFalse(basePartitionInfoMap.containsKey("p2"));
                     });
@@ -255,7 +255,7 @@ public class MVMetaVersionRepairerTest extends MVTestBase {
                                 mv1.getRefreshScheme().getAsyncRefreshContext();
                         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                                 asyncRefreshContext.getBaseTableVisibleVersionMap();
-                        System.out.println(baseTableVisibleVersionMap);
+                        logSysInfo(baseTableVisibleVersionMap);
 
                         // repair base table version changes
                         Table m1 = getTable("test", "m1");
@@ -293,7 +293,7 @@ public class MVMetaVersionRepairerTest extends MVTestBase {
                         Assertions.assertEquals(baseTableId, baseTableVisibleVersionMap.keySet().iterator().next());
                         Map<String, MaterializedView.BasePartitionInfo> basePartitionInfoMap = baseTableVisibleVersionMap.get(m1.getId());
                         Assertions.assertEquals(1, basePartitionInfoMap.size());
-                        System.out.println(basePartitionInfoMap);
+                        logSysInfo(basePartitionInfoMap);
                         basePartitionInfo = basePartitionInfoMap.get("p1");
                         // p1 should not been updated since it has been updated
                         Assertions.assertEquals(basePartitionInfo.getVersion(), lastRefreshVersion);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/AuditEventProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/AuditEventProcessorTest.java
@@ -40,6 +40,7 @@ import com.starrocks.plugin.AuditEvent;
 import com.starrocks.plugin.AuditEvent.EventType;
 import com.starrocks.plugin.PluginInfo;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,7 +48,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-public class AuditEventProcessorTest {
+public class AuditEventProcessorTest extends StarRocksTestBase {
 
     @BeforeAll
     public static void beforeClass() throws Exception {
@@ -157,7 +158,7 @@ public class AuditEventProcessorTest {
                 }
             }
             long total = System.currentTimeMillis() - start;
-            System.out.println("total(ms): " + total + ", avg: " + total / 10000.0);
+            logSysInfo("total(ms): " + total + ", avg: " + total / 10000.0);
         }
     }
 
@@ -182,6 +183,6 @@ public class AuditEventProcessorTest {
             processor.handleAuditEvent(event);
         }
         long total = System.currentTimeMillis() - start;
-        System.out.println("total(ms): " + total + ", avg: " + total / 10000.0);
+        logSysInfo("total(ms): " + total + ", avg: " + total / 10000.0);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectionTest.java
@@ -114,7 +114,6 @@ public class ConnectionTest {
         result = ExecuteEnv.getInstance().getScheduler()
                 .registerConnection(createConnectContextForUser("test"));
         Assertions.assertFalse(result.first);
-        System.out.println(result.second);
         Assertions.assertTrue(result.second.contains("Reach user-level"));
     }
 
@@ -163,7 +162,6 @@ public class ConnectionTest {
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, starRocksAssert.getCtx());
         starRocksAssert.getCtx().setCurrentUserIdentity(new UserIdentity("test", "%"));
         ShowResultSet resultSet = ShowExecutor.execute(stmt, starRocksAssert.getCtx());
-        System.out.println(resultSet.getResultRows());
         Assertions.assertEquals(1, resultSet.getResultRows().size());
         Assertions.assertTrue(resultSet.getResultRows().get(0).contains("test"));
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/JournalObservableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/JournalObservableTest.java
@@ -19,12 +19,13 @@ package com.starrocks.qe;
 
 import com.google.common.collect.Multiset;
 import com.google.common.collect.TreeMultiset;
+import com.starrocks.utframe.StarRocksTestBase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 
-public class JournalObservableTest {
+public class JournalObservableTest extends StarRocksTestBase {
     @Test
     public void testUpperBound() {
         Multiset<JournalObserver> elements = TreeMultiset.create();
@@ -58,7 +59,7 @@ public class JournalObservableTest {
             elements.add(ovserver42);
 
             for (JournalObserver journalObserver : elements) {
-                System.out.println(journalObserver);
+                logSysInfo(journalObserver);
             }
 
             int size = elements.size();
@@ -98,9 +99,9 @@ public class JournalObservableTest {
             elements.add(ovserver6);
             elements.add(ovserver6);
             int size = elements.size();
-            //            System.out.println("size=" + size);
+            //            logSysInfo("size=" + size);
             //            for(int i = 0; i < size; i ++) {
-            //                System.out.println("array " + i + " = " + ((MasterOpExecutor)elements.get(i)).getTargetJournalId());
+            //                logSysInfo("array " + i + " = " + ((MasterOpExecutor)elements.get(i)).getTargetJournalId());
             //            }
             Assertions.assertEquals(0, JournalObservable.upperBound(elements.toArray(), size, 1L));
             Assertions.assertEquals(2, JournalObservable.upperBound(elements.toArray(), size, 2L));
@@ -131,18 +132,18 @@ public class JournalObservableTest {
         }
         {
             CountDownLatch latch = new CountDownLatch(1);
-            System.out.println(latch.getCount());
+            logSysInfo(latch.getCount());
 
             latch.countDown();
-            System.out.println(latch.getCount());
+            logSysInfo(latch.getCount());
 
             latch.countDown();
-            System.out.println(latch.getCount());
+            logSysInfo(latch.getCount());
 
             latch.countDown();
-            System.out.println(latch.getCount());
+            logSysInfo(latch.getCount());
         }
-        System.out.println("success");
+        logSysInfo("success");
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SetExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SetExecutorTest.java
@@ -277,7 +277,6 @@ public class SetExecutorTest {
         for (int i = 0; i < 1023; ++i) {
             ctx.getUserVariables().put(String.valueOf(i), new UserVariable(null, null, null));
         }
-        System.out.println(ctx.getUserVariables().keySet().size());
         try {
             sql = "set @aVar = 6, @bVar = @aVar + 1, @cVar = @bVar + 1";
             stmt = (SetStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/IncrementalDeployHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/IncrementalDeployHiveTest.java
@@ -62,7 +62,7 @@ public class IncrementalDeployHiveTest extends SchedulerConnectorTestBase {
         new MockUp<Deployer>() {
             @Mock
             public void deployFragments(DeployState deployState) {
-                System.out.println("----- deploy fragments ------");
+                logSysInfo("----- deploy fragments ------");
                 final List<List<FragmentInstanceExecState>> state =
                         deployState.getThreeStageExecutionsToDeploy();
                 int scanRangeNumber = 0;
@@ -76,7 +76,7 @@ public class IncrementalDeployHiveTest extends SchedulerConnectorTestBase {
                             }
                             for (List<TScanRangeParams> v : params.getPer_node_scan_ranges().values()) {
                                 for (TScanRangeParams p : v) {
-                                    System.out.println(p + ", " + System.identityHashCode(p));
+                                    logSysInfo(p + ", " + System.identityHashCode(p));
                                 }
                             }
                         }
@@ -106,11 +106,11 @@ public class IncrementalDeployHiveTest extends SchedulerConnectorTestBase {
         Assertions.assertEquals(workload.size(), 3);
         Map<String, List<THdfsScanRange>> fileRangesMap = new HashMap<>();
         for (Map.Entry<TUniqueId, List<TScanRangeParams>> kv : workload.entrySet()) {
-            System.out.println("----- checking fragment: " + kv.getKey() + "-----");
+            logSysInfo("----- checking fragment: " + kv.getKey() + "-----");
             List<TScanRangeParams> v = kv.getValue();
             for (int index = 0; index < v.size(); index++) {
                 TScanRangeParams p = v.get(index);
-                System.out.println(p + ", " + System.identityHashCode(p));
+                logSysInfo(p + ", " + System.identityHashCode(p));
                 if (p.isEmpty()) {
                     if (!p.has_more) {
                         Assertions.assertTrue((index + 1) == v.size());
@@ -125,7 +125,7 @@ public class IncrementalDeployHiveTest extends SchedulerConnectorTestBase {
         }
 
         for (Map.Entry<String, List<THdfsScanRange>> kv : fileRangesMap.entrySet()) {
-            System.out.println("----- checking file: " + kv.getKey() + "-----");
+            logSysInfo("----- checking file: " + kv.getKey() + "-----");
             List<THdfsScanRange> fileRangess = kv.getValue();
             fileRangess.sort(new Comparator<THdfsScanRange>() {
                 @Override

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/plan/SchedulerColocateSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/plan/SchedulerColocateSetTest.java
@@ -175,7 +175,6 @@ public class SchedulerColocateSetTest extends SchedulerTestBase {
                 "select L_ORDERKEY, sum(L_QUANTITY)\n" +
                 "from cte\n" +
                 "group by L_ORDERKEY;\n";
-        System.out.println(sql);
         runFileUnitTestHelper(sql, "scheduler/colocate_set/except_q2");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -1565,11 +1565,9 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
         executeInsertSql(sql2);
 
         List<String> s1PartitionNames = extractColumnValues(sql1, 0);
-        System.out.println(s1PartitionNames);
         addListPartition("s1", s1PartitionNames);
 
         List<String> s2PartitionNames = extractColumnValues(sql2, 0);
-        System.out.println(s2PartitionNames);
         addListPartition("s2", s2PartitionNames);
         starRocksAssert.withRefreshedMaterializedView(String.format("CREATE MATERIALIZED VIEW %s\n" +
                         "PARTITION BY col1\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -224,7 +224,6 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
-        System.out.println(execPlan);
         assertPlanContains(execPlan, "3: ts >= '2020-01-01 00:00:00', 3: ts < '2021-01-01 00:00:00'");
 
         // test rewrite
@@ -258,7 +257,6 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
         Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
         Assertions.assertEquals(5, partitions.size());
 
-        System.out.println(partitions.stream().map(Partition::getName).collect(Collectors.toList()));
         Set<String> expectedPartitionNames = ImmutableSet.of("p20220301000000", "p20220101000000", "p20220401000000",
                 "p20220201000000", "p20220501000000");
         Assertions.assertEquals(expectedPartitionNames,

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -505,7 +505,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 TUniqueId loadId = UUIDUtil.genTUniqueId();
                 TUniqueId queryId = UUIDUtil.toTUniqueId(execPlan.getConnectContext().getQueryId());
-                System.out.println("register query id: " + DebugUtil.printId(queryId));
+                logSysInfo("register query id: " + DebugUtil.printId(queryId));
                 LoadPlanner loadPlanner = new LoadPlanner(1, loadId, 1, 1, materializedView,
                         false, "UTC", 10, System.currentTimeMillis(),
                         false, connectContext, null, 10,
@@ -518,7 +518,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         String insertSql = "insert into tbl3 values('2021-12-01', 2, 10);";
         executeInsertSql(connectContext, insertSql);
         refreshMVRange(materializedView.getName(), false);
-        System.out.println("unregister query id: " + DebugUtil.printId(connectContext.getExecutionId()));
+        logSysInfo("unregister query id: " + DebugUtil.printId(connectContext.getExecutionId()));
         Assertions.assertNull(QeProcessorImpl.INSTANCE.getCoordinator(connectContext.getExecutionId()));
     }
 
@@ -1671,7 +1671,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                         MvTaskRunContext mvContext =
                                 processor.getMvContext();
                         Assertions.assertTrue(mvContext.hasNextBatchPartition());
-                        System.out.println(processor.getMVTaskRunExtraMessage());
+                        logSysInfo(processor.getMVTaskRunExtraMessage());
                         Assertions.assertEquals(Sets.newHashSet("p1"),
                                 processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
 
@@ -1679,7 +1679,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                 materializedView.getRefreshScheme().getAsyncRefreshContext();
                         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                                 asyncRefreshContext.getBaseTableVisibleVersionMap();
-                        System.out.println(baseTableVisibleVersionMap);
+                        logSysInfo(baseTableVisibleVersionMap);
 
                         Assertions.assertTrue(baseTableVisibleVersionMap.containsKey(tbl1.getId()));
                         Assertions.assertTrue(baseTableVisibleVersionMap.get(tbl1.getId()).containsKey("p1"));
@@ -1695,7 +1695,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                         MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                         MvTaskRunContext mvContext = processor.getMvContext();
                         Assertions.assertTrue(!mvContext.hasNextBatchPartition());
-                        System.out.println(processor.getMVTaskRunExtraMessage());
+                        logSysInfo(processor.getMVTaskRunExtraMessage());
                         Assertions.assertEquals(Sets.newHashSet("p2"),
                                 processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
 
@@ -1703,7 +1703,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                 materializedView.getRefreshScheme().getAsyncRefreshContext();
                         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                                 asyncRefreshContext.getBaseTableVisibleVersionMap();
-                        System.out.println(baseTableVisibleVersionMap);
+                        logSysInfo(baseTableVisibleVersionMap);
 
                         Assertions.assertTrue(baseTableVisibleVersionMap.containsKey(tbl1.getId()));
                         Assertions.assertTrue(baseTableVisibleVersionMap.get(tbl1.getId()).containsKey("p1"));
@@ -1784,7 +1784,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                     MvTaskRunContext mvContext = processor.getMvContext();
                                     Assertions.assertTrue(isEnd ? !mvContext.hasNextBatchPartition()
                                             : mvContext.hasNextBatchPartition());
-                                    System.out.println(processor.getMVTaskRunExtraMessage());
+                                    logSysInfo(processor.getMVTaskRunExtraMessage());
                                     Assertions.assertEquals(Sets.newHashSet(tt1Partition),
                                             processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
 
@@ -1793,7 +1793,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                     Map<Long, Map<String, MaterializedView.BasePartitionInfo>>
                                             baseTableVisibleVersionMap =
                                             asyncRefreshContext.getBaseTableVisibleVersionMap();
-                                    System.out.println(baseTableVisibleVersionMap);
+                                    logSysInfo(baseTableVisibleVersionMap);
 
                                     Assertions.assertTrue(baseTableVisibleVersionMap.containsKey(tbl1.getId()));
                                     Assertions.assertTrue(
@@ -1863,7 +1863,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                         MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                         MvTaskRunContext mvContext = processor.getMvContext();
                         Assertions.assertTrue(mvContext.hasNextBatchPartition());
-                        System.out.println(processor.getMVTaskRunExtraMessage());
+                        logSysInfo(processor.getMVTaskRunExtraMessage());
                         Assertions.assertEquals(Sets.newHashSet("p0"),
                                 processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
 
@@ -1871,7 +1871,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                 materializedView.getRefreshScheme().getAsyncRefreshContext();
                         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                                 asyncRefreshContext.getBaseTableVisibleVersionMap();
-                        System.out.println(baseTableVisibleVersionMap);
+                        logSysInfo(baseTableVisibleVersionMap);
 
                         Assertions.assertTrue(baseTableVisibleVersionMap.containsKey(tbl1.getId()));
                         Assertions.assertTrue(baseTableVisibleVersionMap.get(tbl1.getId()).containsKey("p0"));
@@ -1888,7 +1888,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                         MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                         MvTaskRunContext mvContext = processor.getMvContext();
                         Assertions.assertTrue(!mvContext.hasNextBatchPartition());
-                        System.out.println(processor.getMVTaskRunExtraMessage());
+                        logSysInfo(processor.getMVTaskRunExtraMessage());
                         Assertions.assertEquals(Sets.newHashSet("p1"),
                                 processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
 
@@ -1896,7 +1896,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                 materializedView.getRefreshScheme().getAsyncRefreshContext();
                         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                                 asyncRefreshContext.getBaseTableVisibleVersionMap();
-                        System.out.println(baseTableVisibleVersionMap);
+                        logSysInfo(baseTableVisibleVersionMap);
 
                         Assertions.assertTrue(baseTableVisibleVersionMap.containsKey(tbl1.getId()));
                         Assertions.assertTrue(baseTableVisibleVersionMap.get(tbl1.getId()).containsKey("p0"));
@@ -1977,7 +1977,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                             tableSnapshotInfo.getRefreshedPartitionInfos().keySet());
 
                                     MVTaskRunExtraMessage extraMessage = processor.getMVTaskRunExtraMessage();
-                                    System.out.println(processor.getMVTaskRunExtraMessage());
+                                    logSysInfo(processor.getMVTaskRunExtraMessage());
                                     Assertions.assertEquals(Sets.newHashSet("p202107_202108", "p202108_202109"),
                                             extraMessage.getMvPartitionsToRefresh());
                                     Assertions.assertEquals(Sets.newHashSet("p0", "p1", "p2", "p3"),
@@ -2004,12 +2004,12 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                                     GlobalStateMgr.getCurrentState().getLocalMetastore()
                                                             .getTable(testDb.getFullName(), "mock_tbl")
                                                             .getId());
-                                    System.out.println(processor.getMVTaskRunExtraMessage());
+                                    logSysInfo(processor.getMVTaskRunExtraMessage());
                                     Assertions.assertEquals(Sets.newHashSet("p0", "p1", "p2", "p3"),
                                             tableSnapshotInfo.getRefreshedPartitionInfos().keySet());
 
                                     MVTaskRunExtraMessage extraMessage = processor.getMVTaskRunExtraMessage();
-                                    System.out.println(processor.getMVTaskRunExtraMessage());
+                                    logSysInfo(processor.getMVTaskRunExtraMessage());
                                     Assertions.assertEquals(Sets.newHashSet("p202107_202108", "p202108_202109"),
                                             extraMessage.getMvPartitionsToRefresh());
                                     Assertions.assertEquals(Sets.newHashSet("p0", "p1", "p2", "p3"),
@@ -2077,7 +2077,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                             tableSnapshotInfo.getRefreshedPartitionInfos().keySet());
 
                                     MVTaskRunExtraMessage extraMessage = processor.getMVTaskRunExtraMessage();
-                                    System.out.println(processor.getMVTaskRunExtraMessage());
+                                    logSysInfo(processor.getMVTaskRunExtraMessage());
                                     Assertions.assertTrue(
                                             extraMessage.getMvPartitionsToRefresh().contains("p20210723_20210724"));
                                     Assertions.assertEquals(Sets.newHashSet("p0"),
@@ -2102,12 +2102,12 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                                     GlobalStateMgr.getCurrentState().getLocalMetastore()
                                                             .getTable(testDb.getFullName(), "mock_tbl")
                                                             .getId());
-                                    System.out.println(processor.getMVTaskRunExtraMessage());
+                                    logSysInfo(processor.getMVTaskRunExtraMessage());
                                     Assertions.assertEquals(Sets.newHashSet("p1", "p2"),
                                             tableSnapshotInfo.getRefreshedPartitionInfos().keySet());
 
                                     MVTaskRunExtraMessage extraMessage = processor.getMVTaskRunExtraMessage();
-                                    System.out.println(processor.getMVTaskRunExtraMessage());
+                                    logSysInfo(processor.getMVTaskRunExtraMessage());
                                     Assertions.assertTrue(
                                             extraMessage.getMvPartitionsToRefresh().contains("p20210811_20210812"));
                                     Assertions.assertEquals(Sets.newHashSet("p1", "p2"),
@@ -2184,7 +2184,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                 ShowMaterializedViewStatus status =
                                         new ShowMaterializedViewStatus(materializedView.getId(), DB_NAME,
                                                 materializedView.getName());
-                                System.out.println(status);
+                                logSysInfo(status);
                                 status.setLastJobTaskRunStatus(taskRunStatuses);
                                 ShowMaterializedViewStatus.RefreshJobStatus refreshJobStatus =
                                         status.getRefreshJobStatus();
@@ -2192,7 +2192,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                 if (!refreshJobStatus.isRefreshFinished()) {
                                     return;
                                 }
-                                System.out.println(refreshJobStatus);
+                                logSysInfo(refreshJobStatus);
                                 Assertions.assertEquals(refreshJobStatus.isForce(), false);
                                 Assertions.assertEquals(refreshJobStatus.isRefreshFinished(), true);
                                 Assertions.assertEquals(refreshJobStatus.getRefreshState(), Constants.TaskRunState.SUCCESS);
@@ -2273,7 +2273,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
                                 Map<String, List<TaskRunStatus>> taskNameJobStatusMap =
                                         tm.listMVRefreshedTaskRunStatus(DB_NAME, Set.of(mvTaskName));
-                                System.out.println(taskNameJobStatusMap);
+                                logSysInfo(taskNameJobStatusMap);
                                 if (taskNameJobStatusMap.isEmpty()) {
                                     return;
                                 }
@@ -2293,7 +2293,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                 if (!refreshJobStatus.isRefreshFinished()) {
                                     return;
                                 }
-                                System.out.println(refreshJobStatus);
+                                logSysInfo(refreshJobStatus);
                                 Assertions.assertEquals(refreshJobStatus.isForce(), false);
                                 Assertions.assertEquals(refreshJobStatus.isRefreshFinished(), true);
                                 Assertions.assertEquals(refreshJobStatus.getRefreshState(), Constants.TaskRunState.SUCCESS);
@@ -2364,7 +2364,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                 Assertions.assertFalse(tm.listMVRefreshedTaskRunStatus(DB_NAME, null).isEmpty());
                                 Map<String, List<TaskRunStatus>> taskNameJobStatusMap =
                                         tm.listMVRefreshedTaskRunStatus(DB_NAME, Set.of(mvTaskName));
-                                System.out.println(taskNameJobStatusMap);
+                                logSysInfo(taskNameJobStatusMap);
                                 Assertions.assertFalse(taskNameJobStatusMap.isEmpty());
                                 Assertions.assertEquals(1, taskNameJobStatusMap.size());
 
@@ -2374,7 +2374,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                 status.setLastJobTaskRunStatus(taskNameJobStatusMap.get(mvTaskName));
                                 ShowMaterializedViewStatus.RefreshJobStatus refreshJobStatus =
                                         status.getRefreshJobStatus();
-                                System.out.println(refreshJobStatus);
+                                logSysInfo(refreshJobStatus);
                                 Assertions.assertEquals(refreshJobStatus.isForce(), true);
                                 Assertions.assertEquals(refreshJobStatus.isRefreshFinished(), true);
                                 Assertions.assertEquals(refreshJobStatus.getRefreshState(), Constants.TaskRunState.SUCCESS);
@@ -2469,7 +2469,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                     jobID = taskRunStatus.getStartTaskRunId();
                                     {
                                         MVTaskRunExtraMessage extraMessage = taskRunStatus.getMvTaskRunExtraMessage();
-                                        System.out.println(extraMessage);
+                                        logSysInfo(extraMessage);
                                         Assertions.assertTrue(extraMessage != null);
                                         Assertions.assertTrue(extraMessage.getPartitionStart() == null);
                                         Assertions.assertTrue(extraMessage.getPartitionEnd() == null);
@@ -2505,7 +2505,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                     Assertions.assertEquals(jobID, taskRunStatus.getStartTaskRunId());
                                     {
                                         MVTaskRunExtraMessage extraMessage = taskRunStatus.getMvTaskRunExtraMessage();
-                                        System.out.println(extraMessage);
+                                        logSysInfo(extraMessage);
                                         Assertions.assertTrue(extraMessage != null);
                                         Assertions.assertEquals(extraMessage.getPartitionStart(), "2022-02-01");
                                         Assertions.assertEquals(extraMessage.getPartitionEnd(), "2022-03-01");
@@ -2608,7 +2608,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                 taskRunStatus.setState(Constants.TaskRunState.FAILED);
 
                                 MVTaskRunExtraMessage extraMessage = taskRunStatus.getMvTaskRunExtraMessage();
-                                System.out.println(extraMessage);
+                                logSysInfo(extraMessage);
                                 Assertions.assertTrue(extraMessage != null);
                                 Assertions.assertTrue(extraMessage.getPartitionStart() == null);
                                 Assertions.assertTrue(extraMessage.getPartitionEnd() == null);
@@ -2689,7 +2689,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                             "MVQueryCacheStats"
                     );
                     for (Map.Entry<String, String> e : result.entrySet()) {
-                        System.out.println(e.getKey() + ": " + e.getValue());
+                        logSysInfo(e.getKey() + ": " + e.getValue());
                         Assertions.assertTrue(mvRefreshProfileKeys.stream().anyMatch(k -> e.getKey().contains(k)),
                                 "not expected: " + e.getKey());
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorPaimonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorPaimonTest.java
@@ -101,7 +101,6 @@ public class PartitionBasedMvRefreshProcessorPaimonTest extends MVTestBase {
                     String query = "SELECT d, count(pk) FROM " +
                             "`paimon0`.`pmn_db1`.`partitioned_table` as a group by d;";
                     String plan = getFragmentPlan(query);
-                    System.out.println(plan);
                     PlanTestBase.assertContains(plan, "     TABLE: paimon_parttbl_mv1\n" +
                             "     PREAGGREGATION: ON\n" +
                             "     partitions=10/10\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
@@ -155,7 +155,7 @@ public class PartitionBasedMvRefreshTest extends MVTestBase {
                             if (i == 0) {
                                 taskRun = TaskRunBuilder.newBuilder(task).build();
                             }
-                            System.out.println("start to execute task run:" + i);
+                            logSysInfo("start to execute task run:" + i);
                             Assertions.assertTrue(taskRun != null);
                             initAndExecuteTaskRun(taskRun);
                             MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
@@ -230,7 +230,7 @@ public class PartitionBasedMvRefreshTest extends MVTestBase {
                             if (i == 0) {
                                 taskRun = TaskRunBuilder.newBuilder(task).build();
                             }
-                            System.out.println("start to execute task run:" + i);
+                            logSysInfo("start to execute task run:" + i);
                             Assertions.assertTrue(taskRun != null);
                             initAndExecuteTaskRun(taskRun);
                             MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
@@ -275,7 +275,7 @@ public class PartitionBasedMvRefreshTest extends MVTestBase {
                         List<Integer> t2PartitionNums = ImmutableList.of(1, 1, 1);
                         TaskRun taskRun = null;
                         for (int i = 0; i < mvRefreshTimes; i++) {
-                            System.out.println("start to execute task run:" + i);
+                            logSysInfo("start to execute task run:" + i);
                             if (i == 0) {
                                 taskRun = TaskRunBuilder.newBuilder(task).build();
                                 initAndExecuteTaskRun(taskRun, "2020-10-12", "2020-10-23");
@@ -373,7 +373,7 @@ public class PartitionBasedMvRefreshTest extends MVTestBase {
                                 "JOIN join_base_t2 t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2")
         );
         // TODO(fix me): throw a better stack
-        System.out.println(e.getMessage());
+        logSysInfo(e.getMessage());
         Assertions.assertTrue(e.getMessage().contains("Must be range partitioned table"));
 
         starRocksAssert.dropTable("join_base_t1");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerTest.java
@@ -106,7 +106,6 @@ public class TaskRunManagerTest {
             // no matter whether force is true or not, we always clear running and pending task run
             taskRunManager.killTaskRun(taskId, force);
 
-            System.out.println("force:" + force);
             Assertions.assertTrue(CollectionUtils.isEmpty(scheduler.getPendingTaskRunsByTaskId(taskId)));
             if (force) {
                 Assertions.assertTrue(scheduler.getRunningTaskRun(taskId) == null);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
@@ -197,7 +197,6 @@ public class TaskRunSchedulerTest {
         Assertions.assertTrue(scheduler.getRunningTaskCount() == 1);
         Assertions.assertTrue(scheduler.getPendingQueueCount() == 9);
 
-        System.out.println(scheduler);
         for (int i = 0; i < 1; i++) {
             Assertions.assertTrue(scheduler.getRunnableTaskRun(1).equals(taskRuns.get(i)));
         }
@@ -294,7 +293,6 @@ public class TaskRunSchedulerTest {
         }
         long pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();
         long runningTaskRunsCount = taskRunScheduler.getRunningTaskCount();
-        System.out.println(taskRunScheduler);
         Assertions.assertEquals(N, pendingTaskRunsCount + runningTaskRunsCount);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -344,9 +344,7 @@ public class TaskRunHistoryTest {
         properties.put("datacache", "{\"enable\": \"true\"}");
         status.setProperties(properties);
         String json = GsonUtils.GSON.toJson(status);
-        System.out.println(json);
         TaskRunStatus dst = GsonUtils.GSON.fromJson(json, TaskRunStatus.class);
-        System.out.println(dst);
         Assertions.assertEquals(json, GsonUtils.GSON.toJson(status));
     }
     @Test
@@ -356,9 +354,7 @@ public class TaskRunHistoryTest {
         properties.put("datacache", "{\"enable\": \"true\"}");
         status.setProperties(properties);
         String json = GsonUtils.GSON.toJson(status);
-        System.out.println(json);
         String res = MessageFormat.format("{0}", Strings.quote(status.toJSON()));
-        System.out.println(res);
         Assertions.assertTrue(res.contains("\"datacache\":\"{\\\"enable\\\": \\\"true\\\"}\""));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMTestBase.java
@@ -20,7 +20,6 @@ import com.starrocks.load.loadv2.IVMInsertLoadTxnCallback;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import com.starrocks.sql.plan.ExecPlan;
-import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -60,7 +59,6 @@ public abstract class MVIVMTestBase extends MVTestBase {
         MaterializedView mv = getMv("test_mv1");
         ExecPlan execPlan = getIVMRefreshedExecPlan(mv);
         Assertions.assertTrue(execPlan != null);
-        System.out.println(execPlan.getExplainString(TExplainLevel.NORMAL));
     }
 
     protected void doTestWith3RunsNoCheckRewrite(String mvQuery,
@@ -90,13 +88,11 @@ public abstract class MVIVMTestBase extends MVTestBase {
         {
             ExecPlan execPlan = getIVMRefreshedExecPlan(mv);
             Assertions.assertTrue(execPlan != null);
-            System.out.println(execPlan.getExplainString(TExplainLevel.NORMAL));
             run1.check(execPlan);
         }
         // test mv rewrite
         {
             String plan = getFragmentPlan(mvQuery, "MV");
-            System.out.println(plan);
             if (isCheckRewrite) {
                 Assertions.assertTrue(plan.contains("test_mv1"));
             }
@@ -111,7 +107,6 @@ public abstract class MVIVMTestBase extends MVTestBase {
         {
             ExecPlan execPlan = getIVMRefreshedExecPlan(mv);
             Assertions.assertTrue(execPlan != null);
-            System.out.println(execPlan.getExplainString(TExplainLevel.NORMAL));
             run3.check(execPlan);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AlterSystemStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AlterSystemStmtAnalyzerTest.java
@@ -31,6 +31,7 @@ import com.starrocks.sql.ast.ShowBackendsStmt;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
@@ -45,7 +46,7 @@ import java.util.List;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class AlterSystemStmtAnalyzerTest {
+public class AlterSystemStmtAnalyzerTest extends StarRocksTestBase {
     private static StarRocksAssert starRocksAssert;
     private static ConnectContext connectContext;
 
@@ -123,11 +124,11 @@ public class AlterSystemStmtAnalyzerTest {
         for (String loc : testLocs) {
             String stmtStr = "alter system modify backend '127.0.0.1:9091' set ('" +
                     AlterSystemStmtAnalyzer.PROP_KEY_LOCATION + "' = '" + loc + "')";
-            System.out.println(stmtStr);
+            logSysInfo(stmtStr);
             try {
                 UtFrameUtils.parseStmtWithNewParser(stmtStr, connectContext);
             } catch (Exception e) {
-                System.out.println(e.getMessage());
+                logSysInfo(e.getMessage());
                 Assertions.assertFalse(analyzeSuccess[i++]);
                 continue;
             }
@@ -137,18 +138,18 @@ public class AlterSystemStmtAnalyzerTest {
 
         String stmtStr = "alter system modify backend '127.0.0.1:9091'" +
                 " set ('invalid_prop_key' = 'val', '" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION +  "' = 'a:b')";
-        System.out.println(stmtStr);
+        logSysInfo(stmtStr);
         try {
             UtFrameUtils.parseStmtWithNewParser(stmtStr, connectContext);
         } catch (Exception e) {
-            System.out.println(e.getMessage());
+            logSysInfo(e.getMessage());
             Assertions.assertTrue(e.getMessage().contains("unsupported property: invalid_prop_key"));
         }
     }
 
     private void modifyBackendLocation(String location) throws Exception {
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
-        System.out.println(systemInfoService.getBackends());
+        logSysInfo(systemInfoService.getBackends());
         List<Long> backendIds = systemInfoService.getBackendIds();
         Backend backend = systemInfoService.getBackend(backendIds.get(0));
         String modifyBackendPropSqlStr = "alter system modify backend '" + backend.getHost() +
@@ -165,7 +166,7 @@ public class AlterSystemStmtAnalyzerTest {
         ShowBackendsStmt showBackendsStmt = (ShowBackendsStmt) UtFrameUtils.parseStmtWithNewParser(showBackendLocationSqlStr,
                 connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showBackendsStmt, connectContext);
-        System.out.println(showResultSet.getResultRows());
+        logSysInfo(showResultSet.getResultRows());
         Assertions.assertTrue(showResultSet.getResultRows().get(0).toString().contains("a:b"));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -116,6 +116,7 @@ import com.starrocks.thrift.TGetGrantsToRolesOrUserRequest;
 import com.starrocks.thrift.TGetGrantsToRolesOrUserResponse;
 import com.starrocks.thrift.TGrantsToType;
 import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import mockit.Expectations;
@@ -139,7 +140,7 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.eq;
 
-public class PrivilegeCheckerTest {
+public class PrivilegeCheckerTest extends StarRocksTestBase {
     private static StarRocksAssert starRocksAssert;
     private static UserRef user;
     private static UserIdentity testUser;
@@ -338,7 +339,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, ctx);
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage() + ", sql: " + sql);
+            logSysInfo(e.getMessage() + ", sql: " + sql);
             Assertions.assertTrue(e.getMessage().contains(expectError), e.getMessage());
         }
         return statement;
@@ -371,7 +372,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, starRocksAssert.getCtx());
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage() + ", sql: " + sql);
+            logSysInfo(e.getMessage() + ", sql: " + sql);
             Assertions.assertTrue(e.getMessage().contains(expectError));
         }
     }
@@ -390,7 +391,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, starRocksAssert.getCtx());
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage() + ", sql: " + sql);
+            logSysInfo(e.getMessage() + ", sql: " + sql);
             Assertions.assertTrue(e.getMessage().contains(expectError2nd));
         }
 
@@ -402,7 +403,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, starRocksAssert.getCtx());
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage() + ", sql: " + sql);
+            logSysInfo(e.getMessage() + ", sql: " + sql);
             Assertions.assertTrue(e.getMessage().contains(expectError1st));
         }
     }
@@ -418,7 +419,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, ctx);
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage() + ", sql: " + sql);
+            logSysInfo(e.getMessage() + ", sql: " + sql);
             Assertions.assertTrue(e.getMessage().contains(expectError));
         }
 
@@ -452,7 +453,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, starRocksAssert.getCtx());
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage() + ", sql: " + sql);
+            logSysInfo(e.getMessage() + ", sql: " + sql);
             Assertions.assertTrue(e.getMessage().contains(expectError));
         }
     }
@@ -470,7 +471,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, starRocksAssert.getCtx());
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage());
+            logSysInfo(e.getMessage());
             Assertions.assertTrue(e.getMessage().contains(expectError));
         }
     }
@@ -484,7 +485,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, ctx);
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage() + ", sql: " + sql);
+            logSysInfo(e.getMessage() + ", sql: " + sql);
             Assertions.assertTrue(e.getMessage().contains(
                     "Access denied; you need (at least one of) the USAGE privilege(s) on RESOURCE my_spark for this operation"
             ));
@@ -551,7 +552,7 @@ public class PrivilegeCheckerTest {
         ctxToTestUser();
         ShowResultSet res = ShowExecutor.execute(
                 (ShowStmt) UtFrameUtils.parseStmtWithNewParser("SHOW catalogs", ctx), ctx);
-        System.out.println(res.getResultRows());
+        logSysInfo(res.getResultRows());
         Assertions.assertEquals(2, res.getResultRows().size());
         Assertions.assertEquals("test_ex_catalog3", res.getResultRows().get(1).get(0));
     }
@@ -593,7 +594,7 @@ public class PrivilegeCheckerTest {
         try {
             TablePEntryObject.generate(Arrays.asList("resource_mapping_inside_catalog_iceberg0", "db1", "tbl1"));
         } catch (PrivObjNotFoundException e) {
-            System.out.println(e.getMessage());
+            logSysInfo(e.getMessage());
             e.getMessage().contains("cannot find table tbl1 in db db1, msg: test");
         }
     }
@@ -772,7 +773,7 @@ public class PrivilegeCheckerTest {
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
                 StatsConstants.ScheduleStatus.FINISH, LocalDateTime.MIN);
         List<String> showResult = ShowAnalyzeJobStmt.showAnalyzeJobs(ctx, nativeAnalyzeJob);
-        System.out.println(showResult);
+        logSysInfo(showResult);
         // can show result for analyze job with all type
         Assertions.assertNotNull(showResult);
 
@@ -785,7 +786,7 @@ public class PrivilegeCheckerTest {
             new StmtExecutor(ctx, new KillAnalyzeStmt(0L)).checkPrivilegeForKillAnalyzeStmt(ctx,
                     nativeAnalyzeJob.getId());
         } catch (Exception e) {
-            System.out.println(e.getMessage());
+            logSysInfo(e.getMessage());
             Assertions.assertTrue(e.getMessage().contains("Access denied;"));
         }
         grantRevokeSqlAsRoot("grant SELECT,INSERT on db2.tbl1 to test");
@@ -801,7 +802,7 @@ public class PrivilegeCheckerTest {
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
                 StatsConstants.ScheduleStatus.FINISH, LocalDateTime.MIN);
         showResult = ShowAnalyzeJobStmt.showAnalyzeJobs(ctx, nativeAnalyzeJob);
-        System.out.println(showResult);
+        logSysInfo(showResult);
         // can show result for analyze job with db.*
         Assertions.assertNotNull(showResult);
 
@@ -824,7 +825,7 @@ public class PrivilegeCheckerTest {
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
                 StatsConstants.ScheduleStatus.FINISH, LocalDateTime.MIN);
         showResult = ShowAnalyzeJobStmt.showAnalyzeJobs(ctx, nativeAnalyzeJob);
-        System.out.println(showResult);
+        logSysInfo(showResult);
         // can show result for analyze job on table that user has any privilege on
         Assertions.assertNotNull(showResult);
         Assertions.assertEquals("tbl1", showResult.get(3));
@@ -847,7 +848,7 @@ public class PrivilegeCheckerTest {
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
                 StatsConstants.ScheduleStatus.FINISH, LocalDateTime.MIN);
         showResult = ShowAnalyzeJobStmt.showAnalyzeJobs(ctx, nativeAnalyzeJob);
-        System.out.println(showResult);
+        logSysInfo(showResult);
         // cannot show result for analyze job on table that user doesn't have any privileges on
         Assertions.assertNull(showResult);
         grantRevokeSqlAsRoot("revoke DROP on db1.tbl1 from test");
@@ -874,7 +875,7 @@ public class PrivilegeCheckerTest {
         analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FINISH);
         analyzeStatus.setReason("Test Success");
         List<String> showResult = ShowAnalyzeStatusStmt.showAnalyzeStatus(ctx, analyzeStatus);
-        System.out.println(showResult);
+        logSysInfo(showResult);
         // can show result for analyze status on table that user has any privilege on
         Assertions.assertNotNull(showResult);
         Assertions.assertEquals("tbl1", showResult.get(2));
@@ -894,7 +895,7 @@ public class PrivilegeCheckerTest {
                 StatsConstants.AnalyzeType.FULL,
                 LocalDateTime.of(2020, 1, 1, 1, 1), Maps.newHashMap());
         showResult = ShowBasicStatsMetaStmt.showBasicStatsMeta(ctx, basicStatsMeta);
-        System.out.println(showResult);
+        logSysInfo(showResult);
         // can show result for stats on table that user has any privilege on
         Assertions.assertNotNull(showResult);
 
@@ -903,7 +904,7 @@ public class PrivilegeCheckerTest {
                 LocalDateTime.of(2020, 1, 1, 1, 1),
                 Maps.newHashMap());
         showResult = ShowHistogramStatsMetaStmt.showHistogramStatsMeta(ctx, histogramStatsMeta);
-        System.out.println(showResult);
+        logSysInfo(showResult);
         // can show result for stats on table that user has any privilege on
         Assertions.assertNotNull(showResult);
 
@@ -914,7 +915,7 @@ public class PrivilegeCheckerTest {
                 StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
                 LocalDateTime.of(2020, 1, 1, 1, 1));
         showResult = ShowAnalyzeStatusStmt.showAnalyzeStatus(ctx, analyzeStatus);
-        System.out.println(showResult);
+        logSysInfo(showResult);
         // cannot show result for analyze status on table that user doesn't have any privileges on
         Assertions.assertNull(showResult);
 
@@ -922,7 +923,7 @@ public class PrivilegeCheckerTest {
                 StatsConstants.AnalyzeType.FULL,
                 LocalDateTime.of(2020, 1, 1, 1, 1), Maps.newHashMap());
         showResult = ShowBasicStatsMetaStmt.showBasicStatsMeta(ctx, basicStatsMeta);
-        System.out.println(showResult);
+        logSysInfo(showResult);
         // cannot show result for stats on table that user doesn't have any privilege on
         Assertions.assertNull(showResult);
 
@@ -931,7 +932,7 @@ public class PrivilegeCheckerTest {
                 LocalDateTime.of(2020, 1, 1, 1, 1),
                 Maps.newHashMap());
         showResult = ShowHistogramStatsMetaStmt.showHistogramStatsMeta(ctx, histogramStatsMeta);
-        System.out.println(showResult);
+        logSysInfo(showResult);
         // cannot show result for stats on table that user doesn't have any privilege on
         Assertions.assertNull(showResult);
         grantRevokeSqlAsRoot("revoke DROP on db1.tbl1 from test");
@@ -1216,7 +1217,7 @@ public class PrivilegeCheckerTest {
         ShowResultSet showResultSet = ShowExecutor.execute((ShowStmt) statement, ctx);
         grantRevokeSqlAsRoot("revoke SELECT on db1.tbl2 from test");
         List<List<String>> resultRows = showResultSet.getResultRows();
-        System.out.println(resultRows);
+        logSysInfo(resultRows);
         Assertions.assertEquals(1, resultRows.size());
         Assertions.assertEquals("tbl2", resultRows.get(0).get(0));
 
@@ -1270,7 +1271,7 @@ public class PrivilegeCheckerTest {
         ShowResultSet showResultSet = ShowExecutor.execute((ShowStmt) statement, ctx);
         grantRevokeSqlAsRoot("revoke SELECT on db1.tbl1 from test");
         List<List<String>> resultRows = showResultSet.getResultRows();
-        System.out.println(resultRows);
+        logSysInfo(resultRows);
         Assertions.assertEquals(1, resultRows.size());
         Assertions.assertEquals("tbl1", resultRows.get(0).get(0));
     }
@@ -1327,7 +1328,7 @@ public class PrivilegeCheckerTest {
         ctxToTestUser();
         List<List<String>> results = GlobalStateMgr.getCurrentState().getResourceMgr().getResourcesInfo();
         grantRevokeSqlAsRoot("revoke alter on resource 'hive1' from test");
-        System.out.println(results);
+        logSysInfo(results);
         Assertions.assertTrue(results.size() > 0);
         Assertions.assertTrue(results.stream().anyMatch(m -> m.contains("hive1")));
         Assertions.assertFalse(results.stream().anyMatch(m -> m.contains("hive0")));
@@ -1374,7 +1375,7 @@ public class PrivilegeCheckerTest {
         List<ConnectContext.ThreadInfo> results = connectScheduler.listConnection(connectContext, null);
         long nowMs = System.currentTimeMillis();
         for (ConnectContext.ThreadInfo threadInfo : results) {
-            System.out.println(threadInfo.toRow(nowMs, true));
+            logSysInfo(threadInfo.toRow(nowMs, true));
         }
         Assertions.assertEquals(1, results.size());
         Assertions.assertEquals("test", results.get(0).toRow(nowMs, true).get(1));
@@ -1383,7 +1384,7 @@ public class PrivilegeCheckerTest {
         grantRevokeSqlAsRoot("grant operate on system to test");
         results = connectScheduler.listConnection(connectContext, null);
         for (ConnectContext.ThreadInfo threadInfo : results) {
-            System.out.println(threadInfo.toRow(nowMs, true));
+            logSysInfo(threadInfo.toRow(nowMs, true));
         }
         Assertions.assertEquals(2, results.size());
         Assertions.assertEquals("test2", results.get(01).toRow(nowMs, true).get(1));
@@ -1845,7 +1846,7 @@ public class PrivilegeCheckerTest {
         // test OPERATE priv, can show tablet, ip:port is not hidden
         grantRevokeSqlAsRoot("grant OPERATE on SYSTEM to test");
         showResultSet = ShowExecutor.execute((ShowStmt) showTabletStmt, starRocksAssert.getCtx());
-        System.out.println(showResultSet.getResultRows().get(0));
+        logSysInfo(showResultSet.getResultRows().get(0));
         Assertions.assertTrue(showResultSet.getResultRows().get(0).toString().contains("127.0.0.1"));
 
         grantRevokeSqlAsRoot("revoke OPERATE on SYSTEM from test");
@@ -1855,18 +1856,18 @@ public class PrivilegeCheckerTest {
         showTabletSql = "show tablet " + tabletId;
         showTabletStmt = UtFrameUtils.parseStmtWithNewParser(showTabletSql, starRocksAssert.getCtx());
         showResultSet = ShowExecutor.execute((ShowStmt) showTabletStmt, starRocksAssert.getCtx());
-        System.out.println(showResultSet.getResultRows().get(0));
+        logSysInfo(showResultSet.getResultRows().get(0));
         String detailCmd = showResultSet.getResultRows().get(0).get(9);
-        System.out.println(detailCmd);
+        logSysInfo(detailCmd);
         showTabletStmt = UtFrameUtils.parseStmtWithNewParser(detailCmd, starRocksAssert.getCtx());
         showResultSet = ShowExecutor.execute((ShowStmt) showTabletStmt, starRocksAssert.getCtx());
-        System.out.println(showResultSet.getResultRows().get(0));
+        logSysInfo(showResultSet.getResultRows().get(0));
         Assertions.assertTrue(showResultSet.getResultRows().get(0).toString().contains("*:0"));
 
         // test OPERATE priv
         grantRevokeSqlAsRoot("grant OPERATE on SYSTEM to test");
         showResultSet = ShowExecutor.execute((ShowStmt) showTabletStmt, starRocksAssert.getCtx());
-        System.out.println(showResultSet.getResultRows().get(0));
+        logSysInfo(showResultSet.getResultRows().get(0));
         Assertions.assertTrue(showResultSet.getResultRows().get(0).toString().contains("127.0.0.1"));
 
         // clean
@@ -2071,7 +2072,7 @@ public class PrivilegeCheckerTest {
         stmtExecutor = new StmtExecutor(starRocksAssert.getCtx(), killStatement);
         stmtExecutor.execute();
         Assertions.assertTrue(ctx.getState().isError());
-        System.out.println(ctx.getState().getErrorMessage());
+        logSysInfo(ctx.getState().getErrorMessage());
         Assertions.assertTrue(ctx.getState().getErrorMessage().contains(
                 "Access denied;"));
 
@@ -2124,7 +2125,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, ctx);
             Assertions.fail();
         } catch (SemanticException e) {
-            System.out.println(e.getMessage() + ", sql: " + alterSql);
+            logSysInfo(e.getMessage() + ", sql: " + alterSql);
             Assertions.assertTrue(
                     e.getMessage().contains("Routine load job [" + jobName + "] not found when checking privilege"));
         }
@@ -2267,7 +2268,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, ctx);
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage() + ", sql: " + createSql);
+            logSysInfo(e.getMessage() + ", sql: " + createSql);
             Assertions.assertTrue(e.getMessage().contains(
                     "Access denied; you need (at least one of) the USAGE privilege(s) on RESOURCE my_spark for this operation"
             ));
@@ -2455,7 +2456,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, starRocksAssert.getCtx());
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage() + ", sql: " + createBackupSql);
+            logSysInfo(e.getMessage() + ", sql: " + createBackupSql);
             Assertions.assertTrue(e.getMessage().contains(expectError));
         }
 
@@ -2469,7 +2470,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, starRocksAssert.getCtx());
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage() + ", sql: " + createBackupSql);
+            logSysInfo(e.getMessage() + ", sql: " + createBackupSql);
             Assertions.assertTrue(e.getMessage().contains(expectError));
         }
 
@@ -2548,7 +2549,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, starRocksAssert.getCtx());
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage() + ", sql: " + restoreSql);
+            logSysInfo(e.getMessage() + ", sql: " + restoreSql);
             Assertions.assertTrue(e.getMessage().contains(expectError));
         }
         ctxToRoot();
@@ -2560,7 +2561,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, starRocksAssert.getCtx());
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage() + ", sql: " + restoreSql);
+            logSysInfo(e.getMessage() + ", sql: " + restoreSql);
             Assertions.assertTrue(e.getMessage().contains(expectError));
         }
         ctxToRoot();
@@ -2731,7 +2732,7 @@ public class PrivilegeCheckerTest {
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore().dropMaterializedView(statement);
         } catch (Exception e) {
-            System.out.println(e.getMessage());
+            logSysInfo(e.getMessage());
             Assertions.assertTrue(e.getMessage().contains(
                     "Access denied; you need (at least one of) the DROP privilege(s)"));
         }
@@ -2840,7 +2841,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, starRocksAssert.getCtx());
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage());
+            logSysInfo(e.getMessage());
             Assertions.assertTrue(e.getMessage().contains(
                     "Access denied; you need (at least one of) the SELECT privilege(s) on TABLE tbl1 for this operation"));
         }
@@ -2890,7 +2891,7 @@ public class PrivilegeCheckerTest {
             UtFrameUtils.parseStmtWithNewParser("select my_udf_json_get('a', 'b')",
                     starRocksAssert.getCtx());
         } catch (Exception e) {
-            System.out.println(e.getMessage());
+            logSysInfo(e.getMessage());
             Assertions.assertTrue(e.getMessage().contains(
                     "Access denied; you need (at least one of) the USAGE privilege(s) on GLOBAL FUNCTION " +
                             "my_udf_json_get(VARCHAR,VARCHAR)"));
@@ -2964,7 +2965,7 @@ public class PrivilegeCheckerTest {
             Authorizer.check(statement, starRocksAssert.getCtx());
             Assertions.fail();
         } catch (ErrorReportException e) {
-            System.out.println(e.getMessage() + ", sql: " + selectSQL);
+            logSysInfo(e.getMessage() + ", sql: " + selectSQL);
             Assertions.assertTrue(
                     e.getMessage().contains("Access denied; you need (at least one of) the USAGE privilege(s) " +
                             "on GLOBAL FUNCTION my_udf_json_get(VARCHAR,VARCHAR) for this operation"));
@@ -3321,21 +3322,21 @@ public class PrivilegeCheckerTest {
         ctxToTestUser();
         ShowResultSet res =
                 ShowExecutor.execute((ShowStmt) UtFrameUtils.parseStmtWithNewParser("SHOW tables from db1", ctx), ctx);
-        System.out.println(res.getResultRows());
+        logSysInfo(res.getResultRows());
         Assertions.assertEquals(1, res.getResultRows().size());
         Assertions.assertEquals("tbl1", res.getResultRows().get(0).get(0));
 
         // can show mv if we have any privilege on it
         grantRevokeSqlAsRoot("grant alter on materialized view db1.mv5 to test");
         res = ShowExecutor.execute((ShowStmt) UtFrameUtils.parseStmtWithNewParser("SHOW tables from db1", ctx), ctx);
-        System.out.println(res.getResultRows());
+        logSysInfo(res.getResultRows());
         Assertions.assertEquals(2, res.getResultRows().size());
         Assertions.assertEquals("mv5", res.getResultRows().get(0).get(0));
 
         // can show view if we have any privilege on it
         grantRevokeSqlAsRoot("grant drop on view db1.view5 to test");
         res = ShowExecutor.execute((ShowStmt) UtFrameUtils.parseStmtWithNewParser("SHOW tables from db1", ctx), ctx);
-        System.out.println(res.getResultRows());
+        logSysInfo(res.getResultRows());
         Assertions.assertEquals(3, res.getResultRows().size());
         Assertions.assertEquals("view5", res.getResultRows().get(2).get(0));
         grantRevokeSqlAsRoot("revoke drop on view db1.view5 from test");
@@ -3877,7 +3878,7 @@ public class PrivilegeCheckerTest {
         context.setCurrentRoleIds(userIdentity);
         context.setThreadLocalInfo();
         String msg = restBaseAction.getErrorRespWhenUnauthorized(new AccessDeniedException());
-        System.out.println(msg);
+        logSysInfo(msg);
         Assertions.assertTrue(msg.contains("Current role(s): [role_x_11]. Inactivated role(s): [role_x_12]."));
         starRocksAssert.getCtx().setThreadLocalInfo();
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/ShowDataDistributionStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/ShowDataDistributionStmtTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.pseudocluster.PseudoCluster;
+import com.starrocks.utframe.StarRocksTestBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -26,7 +27,7 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
 
-public class ShowDataDistributionStmtTest {
+public class ShowDataDistributionStmtTest extends StarRocksTestBase {
     @BeforeAll
     public static void setUp() throws Exception {
         PseudoCluster.getOrCreateWithRandomPort(true, 1);
@@ -68,15 +69,15 @@ public class ShowDataDistributionStmtTest {
             for (String sql : validSqls) {
                 Assertions.assertTrue(stmt.execute(sql));
             }
-            System.out.println("testShowDataDistributionFromPartitionTable: 2.0 check valid sql done!");
+            logSysInfo("testShowDataDistributionFromPartitionTable: 2.0 check valid sql done!");
 
             // 2.1 check value: partition table
             stmt.execute("select count(*) from partition_table;");
             if (stmt.getResultSet().next()) {
-                System.out.println("testShowDataDistributionFromPartitionTable: begin check value: partition table");
+                logSysInfo("testShowDataDistributionFromPartitionTable: begin check value: partition table");
                 //check insert data success and wait table meta update
                 int count = stmt.getResultSet().getInt(1);
-                System.out.println("testShowDataDistributionFromPartitionTable: partition_table row count = " + count);
+                logSysInfo("testShowDataDistributionFromPartitionTable: partition_table row count = " + count);
                 Assertions.assertEquals(count, 6);
                 Thread.sleep(60000);
 
@@ -90,7 +91,7 @@ public class ShowDataDistributionStmtTest {
                 stmt.execute("show data distribution from partition_table partition(p20240920,p20240921);");
                 checkExpAndActValPartitionTable(stmt.getResultSet());
             }
-            System.out.println("testShowDataDistributionFromPartitionTable: 2.1 check partition table done!");
+            logSysInfo("testShowDataDistributionFromPartitionTable: 2.1 check partition table done!");
 
             // 2.2 check: db not exist
             try {
@@ -99,7 +100,7 @@ public class ShowDataDistributionStmtTest {
                 String exp = "Database no_exist_db does not exist";
                 Assertions.assertTrue(e.getMessage().contains(exp));
             }
-            System.out.println("testShowDataDistributionFromPartitionTable: 2.2 check db not exist done!");
+            logSysInfo("testShowDataDistributionFromPartitionTable: 2.2 check db not exist done!");
 
             // 2.3 check: table not exist
             try {
@@ -108,7 +109,7 @@ public class ShowDataDistributionStmtTest {
                 String exp = "Table does not exist";
                 Assertions.assertTrue(e.getMessage().contains(exp));
             }
-            System.out.println("testShowDataDistributionFromPartitionTable: 2.3 check table not exist done!");
+            logSysInfo("testShowDataDistributionFromPartitionTable: 2.3 check table not exist done!");
 
             // 2.4 check: partition not exist
             try {
@@ -117,7 +118,7 @@ public class ShowDataDistributionStmtTest {
                 String exp = "Partition does not exist";
                 Assertions.assertTrue(e.getMessage().contains(exp));
             }
-            System.out.println("testShowDataDistributionFromPartitionTable: 2.4 check partition not exist done!");
+            logSysInfo("testShowDataDistributionFromPartitionTable: 2.4 check partition not exist done!");
 
             // 2.5 check: privilege
             // create user and grant select privilege on other db
@@ -133,7 +134,7 @@ public class ShowDataDistributionStmtTest {
                         "on TABLE partition_table for this operation";
                 Assertions.assertTrue(e.getMessage().contains(exp));
             }
-            System.out.println("testShowDataDistributionFromPartitionTable: 2.5 check privilege done!");
+            logSysInfo("testShowDataDistributionFromPartitionTable: 2.5 check privilege done!");
 
             // 2.6 check: invalid sql
             List<String> invalidSqls = Arrays.asList("show data distribution from partition_table partition1(p20240920);");
@@ -145,9 +146,9 @@ public class ShowDataDistributionStmtTest {
                     Assertions.assertTrue(e.getMessage().contains(exp));
                 }
             }
-            System.out.println("testShowDataDistributionFromPartitionTable: 2.6 check invalid sql done!");
+            logSysInfo("testShowDataDistributionFromPartitionTable: 2.6 check invalid sql done!");
         } finally {
-            System.out.println("testShowDataDistributionFromPartitionTable: 2.check done!");
+            logSysInfo("testShowDataDistributionFromPartitionTable: 2.check done!");
             stmt.close();
             connection.close();
         }
@@ -178,15 +179,15 @@ public class ShowDataDistributionStmtTest {
             for (String sql : validSqls) {
                 Assertions.assertTrue(stmt.execute(sql));
             }
-            System.out.println("testShowDataDistributionFromUnPartitionTable: 2.0 check valid sql done!");
+            logSysInfo("testShowDataDistributionFromUnPartitionTable: 2.0 check valid sql done!");
 
             // 2.1 check value: unpartition table
             stmt.execute("select count(*) from unpartition_table;");
             if (stmt.getResultSet().next()) {
-                System.out.println("testShowDataDistributionFromUnPartitionTable: begin check value: unpartition table");
+                logSysInfo("testShowDataDistributionFromUnPartitionTable: begin check value: unpartition table");
                 //check insert data success and wait table meta update
                 int count = stmt.getResultSet().getInt(1);
-                System.out.println("testShowDataDistributionFromUnPartitionTable: unpartition_table row count = " + count);
+                logSysInfo("testShowDataDistributionFromUnPartitionTable: unpartition_table row count = " + count);
                 Assertions.assertEquals(count, 3);
                 Thread.sleep(60000);
 
@@ -195,7 +196,7 @@ public class ShowDataDistributionStmtTest {
                 stmt.execute("show data distribution from unpartition_table partition(unpartition_table);");
                 checkExpAndActValUnPartitionTable(stmt.getResultSet());
             }
-            System.out.println("testShowDataDistributionFromUnPartitionTable: 2.1 check unpartition table done!");
+            logSysInfo("testShowDataDistributionFromUnPartitionTable: 2.1 check unpartition table done!");
 
             // 2.2 check: invalid sql
             List<String> invalidSqls = Arrays.asList(
@@ -211,9 +212,9 @@ public class ShowDataDistributionStmtTest {
                     Assertions.assertTrue(e.getMessage().contains(exp));
                 }
             }
-            System.out.println("testShowDataDistributionFromUnPartitionTable: 2.2 check invalid sql done!");
+            logSysInfo("testShowDataDistributionFromUnPartitionTable: 2.2 check invalid sql done!");
         } finally {
-            System.out.println("testShowDataDistributionFromUnPartitionTable: 2.check done!");
+            logSysInfo("testShowDataDistributionFromUnPartitionTable: 2.check done!");
             stmt.close();
             connection.close();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -43,6 +43,7 @@ import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.optimizer.statistics.EmptyStatisticStorage;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -51,7 +52,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class MVRewriteTest {
+public class MVRewriteTest extends StarRocksTestBase {
     private static final String EMPS_TABLE_NAME = "emps";
     private static final String EMPS_MV_NAME = "emps_mv";
     private static final String HR_DB_NAME = "db1";
@@ -835,7 +836,7 @@ public class MVRewriteTest {
             starRocksAssert.withMaterializedView(createMVSQL);
             Assertions.fail();
         } catch (Exception e) {
-            System.out.println(e.getMessage());
+            logSysInfo(e.getMessage());
         }
     }
 
@@ -1777,7 +1778,6 @@ public class MVRewriteTest {
 
         String query = "select k1, sum(k3) from t1 where k1 = '2024-06-12' group by k1";
         String plan = UtFrameUtils.getFragmentPlan(connectContext, query);
-        System.out.println(plan);
         PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: 1: k1 = '2024-06-12'\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVTestUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVTestUtils.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer;
 import com.starrocks.alter.AlterJobV2;
 import com.starrocks.common.util.ThreadUtil;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.StarRocksTestBase;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Assertions;
 import java.util.Map;
 import java.util.Optional;
 
-public class MVTestUtils {
+public class MVTestUtils extends StarRocksTestBase {
     private static final Logger LOG = LogManager.getLogger(MVTestUtils.class);
 
     public static void waitingRollupJobV2Finish() {
@@ -37,7 +38,7 @@ public class MVTestUtils {
                 continue;
             }
             while (!alterJobV2.getJobState().isFinalState()) {
-                System.out.println(
+                logSysInfo(
                         "rollup job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
                 ThreadUtil.sleepAtLeastIgnoreInterrupts(1000L);
             }
@@ -55,7 +56,7 @@ public class MVTestUtils {
                         "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
                 ThreadUtil.sleepAtLeastIgnoreInterrupts(100);
             }
-            System.out.println("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
+            logSysInfo("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
             Assertions.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
         }
     }
@@ -77,7 +78,7 @@ public class MVTestUtils {
                     "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
             ThreadUtil.sleepAtLeastIgnoreInterrupts(100);
         }
-        System.out.println("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
+        logSysInfo("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
         Assertions.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
         return true;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -175,7 +175,7 @@ public abstract class MVTestBase extends StarRocksTestBase {
         Pair<ExecPlan, String> execPlanWithQuery = result.second;
         String traceLog = execPlanWithQuery.second;
         if (!Strings.isNullOrEmpty(traceLog)) {
-            System.out.println(traceLog);
+            logSysInfo(traceLog);
         }
         return execPlanWithQuery.first.getExplainString(level);
     }
@@ -484,7 +484,7 @@ public abstract class MVTestBase extends StarRocksTestBase {
         try {
             String addPartitionSql = String.format("ALTER TABLE %s ADD " +
                     "PARTITION %s VALUES [(%s),(%s))", tbl, pName, toPartitionVal(pVal1), toPartitionVal(pVal2));
-            System.out.println(addPartitionSql);
+            logSysInfo(addPartitionSql);
             starRocksAssert.alterTable(addPartitionSql);
 
             // insert values

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteListPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteListPartitionTest.java
@@ -331,7 +331,7 @@ public class MvRewriteListPartitionTest extends MVTestBase {
                                 "SELECT * from mv1 where province = 'guangdong'",
                         };
                         for (String query : sqls) {
-                            System.out.println("start to check: " + query);
+                            logSysInfo("start to check: " + query);
                             String plan = getFragmentPlan(query);
                             PlanTestBase.assertContains(plan, "UNION", "mv1", "t2");
                         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMetricsTest.java
@@ -216,7 +216,7 @@ public class MvRewriteMetricsTest extends MVTestBase {
                 JsonMetricVisitor visitor = new JsonMetricVisitor("starrocks_fe");
                 MaterializedViewMetricsRegistry.collectMaterializedViewMetrics(visitor, true);
                 String json = visitor.build();
-                System.out.println(json);
+                logSysInfo(json);
                 Assertions.assertTrue(json.contains("mv_refresh_jobs"));
                 Assertions.assertTrue(json.contains("mv_refresh_total_success_jobs"));
                 Assertions.assertTrue(json.contains("mv_refresh_total_retry_meta_count"));
@@ -229,7 +229,7 @@ public class MvRewriteMetricsTest extends MVTestBase {
                 JsonMetricVisitor visitor = new JsonMetricVisitor("starrocks_fe");
                 MaterializedViewMetricsRegistry.collectMaterializedViewMetrics(visitor, true);
                 String json = visitor.build();
-                System.out.println(json);
+                logSysInfo(json);
                 Assertions.assertTrue(json.contains("mv_refresh_jobs"));
                 Assertions.assertTrue(json.contains("mv_refresh_total_success_jobs"));
                 Assertions.assertTrue(json.contains("mv_refresh_total_retry_meta_count"));
@@ -260,7 +260,7 @@ public class MvRewriteMetricsTest extends MVTestBase {
                 JsonMetricVisitor visitor = new JsonMetricVisitor("starrocks_fe");
                 MaterializedViewMetricsRegistry.collectMaterializedViewMetrics(visitor, true);
                 String json = visitor.build();
-                System.out.println(json);
+                logSysInfo(json);
                 Assertions.assertTrue(json.contains("mv_refresh_jobs"));
                 Assertions.assertTrue(json.contains("mv_refresh_total_success_jobs"));
                 Assertions.assertTrue(json.contains("mv_refresh_total_empty_jobs"));
@@ -281,7 +281,7 @@ public class MvRewriteMetricsTest extends MVTestBase {
         JsonMetricVisitor visitor = new JsonMetricVisitor("starrocks_fe");
         MaterializedViewMetricsRegistry.collectMaterializedViewMetrics(visitor, true);
         String json = visitor.build();
-        System.out.println(json);
+        logSysInfo(json);
         Assertions.assertTrue(json.equals("[]"));
     }
 
@@ -294,7 +294,7 @@ public class MvRewriteMetricsTest extends MVTestBase {
             JsonMetricVisitor visitor = new JsonMetricVisitor("starrocks_fe");
             MaterializedViewMetricsRegistry.collectMaterializedViewMetrics(visitor, true);
             String json = visitor.build();
-            System.out.println(json);
+            logSysInfo(json);
             Assertions.assertTrue(json.equals("[]"));
         }
 
@@ -312,7 +312,7 @@ public class MvRewriteMetricsTest extends MVTestBase {
             JsonMetricVisitor visitor = new JsonMetricVisitor("starrocks_fe");
             MaterializedViewMetricsRegistry.collectMaterializedViewMetrics(visitor, true);
             String json = visitor.build();
-            System.out.println(json);
+            logSysInfo(json);
             Assertions.assertEquals("[]", json);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartitionTest.java
@@ -636,7 +636,7 @@ public class MvRewritePartitionTest extends MVTestBase {
                     cluster.runSql("test", String.format("refresh materialized view %s partition " +
                             "start('%s') end('%s') with sync mode;", mvName, param.refreshStart, param.refreshEnd));
                     for (PCompensateExpect expect : param.expectPartitionPredicates) {
-                        System.out.println(expect);
+                        logSysInfo(expect);
                         if (!Strings.isNullOrEmpty(expect.partitionPredicate)) {
                             String query = String.format("select a.t1a, a.id_date, sum(a.t1b), sum(b.t1b) \n" +
                                     "from table_with_day_partition a\n" +
@@ -705,7 +705,7 @@ public class MvRewritePartitionTest extends MVTestBase {
                 )
         );
         for (PartitionCompensateParam param : params) {
-            System.out.println(param);
+            logSysInfo(param);
             testRefreshAndRewriteWithMultiJoinMV(param);
         }
         connectContext.getSessionVariable().setEnableMaterializedViewTransparentUnionRewrite(true);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -1738,7 +1738,6 @@ public class MvRewriteTest extends MVTestBase {
                     "on a.v1=b.v1 " +
                     "where a.v1=1 and b.v2=1 ;";
             String plan = getFragmentPlan(query);
-            System.out.println(plan);
             PlanTestBase.assertContains(plan, " TABLE: test_partition_tbl_mv3\n" +
                     "     PREAGGREGATION: ON\n" +
                     "     PREDICATES: 8: a_v1 = 1, 12: b_v2 = 1\n" +
@@ -1768,7 +1767,6 @@ public class MvRewriteTest extends MVTestBase {
                     "on a.v1=b.v1 " +
                     "where a.v1=1 and b.v2=1 ;";
             String plan = getFragmentPlan(query);
-            System.out.println(plan);
             PlanTestBase.assertNotContains(plan, "PREDICATES: 8: a_v1 = 1, 11: b_v1 = 1, 12: b_v2 = 1\n" +
                     "     partitions=6/6\n" +
                     "     rollup: test_partition_tbl_mv3");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
@@ -418,7 +418,7 @@ public class MvRewriteUnionTest extends MVTestBase {
                         );
                         for (Pair<String, String> p : sqls) {
                             String query = p.first;
-                            System.out.println(query);
+                            logSysInfo(query);
                             String plan = getFragmentPlan(query);
                             PlanTestBase.assertContains(plan, ":UNION");
                             PlanTestBase.assertContainsIgnoreColRefs(plan, "union_mv0", p.second);
@@ -450,7 +450,7 @@ public class MvRewriteUnionTest extends MVTestBase {
                                 );
                         for (Pair<String, String> p : sqls) {
                             String query = p.first;
-                            System.out.println(query);
+                            logSysInfo(query);
                             String plan = getFragmentPlan(query);
                             PlanTestBase.assertContains(plan, ":UNION");
                             PlanTestBase.assertContainsIgnoreColRefs(plan, "union_mv0", p.second);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithHiveTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithHiveTableTest.java
@@ -118,7 +118,7 @@ public class MvTransparentRewriteWithHiveTableTest extends MVTestBase {
                                 "l_suppkey + 2 >1000;",
                 };
                 for (String query : sqls) {
-                    System.out.println(query);
+                    logSysInfo(query);
                     String plan = getFragmentPlan(query);
                     PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
                 }
@@ -208,7 +208,7 @@ public class MvTransparentRewriteWithHiveTableTest extends MVTestBase {
                         "SELECT * FROM mv0 WHERE l_shipdate <= '1998-01-05' and l_suppkey > 100;",
                 };
                 for (String query : sqls) {
-                    System.out.println(query);
+                    logSysInfo(query);
                     String plan = getFragmentPlan(query);
                     // transparent plan will contain union, but it can be pruned
                     PlanTestBase.assertNotContains(plan, "UNION");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
@@ -1301,7 +1301,6 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                                     "from mock_tbl1\n" +
                                     "group by date_trunc('day', data_date)";
                             String plan = getFragmentPlan(query, TExplainLevel.VERBOSE);
-                            System.out.println(plan);
                             PlanTestBase.assertContains(plan, "test_mv1");
                             PlanTestBase.assertContains(plan, " 0:UNION\n" +
                                     "  |  output exprs:\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteHiveTest.java
@@ -163,7 +163,7 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                                 "     rollup: mv0", // case 3
                 };
                 for (int i = 0; i < sqls.length; i++) {
-                    System.out.println("start to test case " + i);
+                    logSysInfo("start to test case " + i);
                     String query = sqls[i];
                     String plan = getFragmentPlan(query);
                     PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
@@ -309,7 +309,7 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                 };
                 // lineitem and order have no intersected dates.
                 for (String query : sqls) {
-                    System.out.println(query);
+                    logSysInfo(query);
                     String plan = getFragmentPlan(query);
                     PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
                 }
@@ -328,7 +328,7 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                 };
                 // lineitem and order have no intersected dates.
                 for (String query : sqls) {
-                    System.out.println(query);
+                    logSysInfo(query);
                     String plan = getFragmentPlan(query);
                     PlanTestBase.assertContains(plan, ": lineitem_par");
                     PlanTestBase.assertNotContains(plan, ":UNION", ": mv0");
@@ -385,7 +385,7 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                                         "     rollup: mv0", // case 3
                         };
                         for (int i = 0; i < sqls.length; i++) {
-                            System.out.println("start to test case " + i);
+                            logSysInfo("start to test case " + i);
                             String query = sqls[i];
                             String plan = getFragmentPlan(query);
                             PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteOlapTest.java
@@ -198,7 +198,7 @@ public class MvTransparentUnionRewriteOlapTest extends MVTestBase {
                                 "     tabletRatio=3/3",
                 };
                 for (int i = 0; i < sqls.length; i++) {
-                    System.out.println("start to test " + i);
+                    logSysInfo("start to test " + i);
                     String query = sqls[i];
                     String plan = getFragmentPlan(query);
                     PlanTestBase.assertNotContains(plan, "mv0");
@@ -245,7 +245,7 @@ public class MvTransparentUnionRewriteOlapTest extends MVTestBase {
                                 "     tabletRatio=3/3", // case 3
                 };
                 for (int i = 0; i < sqls.length; i++) {
-                    System.out.println("start to test " + i);
+                    logSysInfo("start to test " + i);
                     String query = sqls[i];
                     String plan = getFragmentPlan(query);
                     PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": m1");
@@ -547,7 +547,7 @@ public class MvTransparentUnionRewriteOlapTest extends MVTestBase {
                 };
                 for (int i = 0; i < sqls.length; i++) {
                     String query = sqls[i];
-                    System.out.println("start to check:" + query);
+                    logSysInfo("start to check:" + query);
                     String plan = getFragmentPlan(query);
                     PlanTestBase.assertContains(plan, "mv2");
                 }
@@ -669,7 +669,7 @@ public class MvTransparentUnionRewriteOlapTest extends MVTestBase {
 
                         String query = "SELECT k1, k2, sum(v1), count(v2) from m1 group by k1, k2 order by k1, k2";
                         String plan = getFragmentPlan(query, "MV");
-                        System.out.println(plan);
+                        logSysInfo(plan);
                     });
         });
         connectContext.getSessionVariable().setEnableMaterializedViewTextMatchRewrite(false);
@@ -694,7 +694,7 @@ public class MvTransparentUnionRewriteOlapTest extends MVTestBase {
 
                         String query = "select * from m1;";
                         String plan = getFragmentPlan(query, "MV");
-                        System.out.println(plan);
+                        logSysInfo(plan);
                     });
         });
         connectContext.getSessionVariable().setEnableMaterializedViewTextMatchRewrite(false);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1352,7 +1352,7 @@ public class AggregateTest extends PlanTestBase {
                 "select count(distinct t1b), count(distinct t1c), count(distinct t1.a), count(distinct t2.b) " +
                 "from test_all_type join tmp1 t1 join tmp2 t2 join tmp1 t3 join tmp2 t4";
         Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
-        System.out.println(pair.first);
+        logSysInfo(pair.first);
         assertContains(pair.first, "CTEAnchor(cteid=1)");
         FeConstants.runningUnitTest = false;
     }
@@ -2653,7 +2653,7 @@ public class AggregateTest extends PlanTestBase {
                 "order by round(count(t1e) * 100.0 / min(t1f) / min(t1f), 4), min(t1f), abs(t1f)";
 
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
+        logSysInfo(plan);
         assertCContains(plan, "1:AGGREGATE (update finalize)\n" +
                         "  |  output: count(5: t1e), min(6: t1f)\n" +
                         "  |  group by: 1: t1a, 2: t1b",
@@ -2883,7 +2883,6 @@ public class AggregateTest extends PlanTestBase {
     public void testCountIfTypeCheck() throws Exception {
         String sql = "select count_if(v1 is null) from t0";
         String plan = getVerboseExplain(sql);
-        System.out.println(plan);
         assertContains(plan, "aggregate: count_if[(1, [4: expr, BOOLEAN, false]); " +
                 "args: TINYINT,BOOLEAN; result: BIGINT; args nullable: false; result nullable: false]");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
@@ -190,7 +190,7 @@ public class FilterUnusedColumnTest extends PlanTestBase {
             // tags_id is can be pushdown, and only used by the pushdownable predicate.
             String sql = "select timestamp from primary_table where k3 = \"test\" and tags_id = 1;";
             String plan = getThriftPlan(sql);
-            System.out.println(plan);
+            logSysInfo(plan);
             assertContains(plan, "unused_output_column_name:[tags_id]");
         }
         {
@@ -198,7 +198,7 @@ public class FilterUnusedColumnTest extends PlanTestBase {
             // but it also be the output column.
             String sql = "select tags_id from primary_table where k3 = \"test\" and tags_id = 1;";
             String plan = getThriftPlan(sql);
-            System.out.println(plan);
+            logSysInfo(plan);
             assertContains(plan, "unused_output_column_name:[]");
         }
         {
@@ -206,7 +206,7 @@ public class FilterUnusedColumnTest extends PlanTestBase {
             // but it also be used by the non-pushdownable predicate.
             String sql = "select k3 from primary_table where timestamp + tags_id = \"test\" and tags_id = 1;";
             String plan = getThriftPlan(sql);
-            System.out.println(plan);
+            logSysInfo(plan);
             assertContains(plan, "unused_output_column_name:[]");
         }
         {
@@ -214,7 +214,7 @@ public class FilterUnusedColumnTest extends PlanTestBase {
             // but it also be used by the non-pushdownable predicate.
             String sql = "select timestamp from primary_table where k3 + tags_id = \"test\" and tags_id = 1;";
             String plan = getThriftPlan(sql);
-            System.out.println(plan);
+            logSysInfo(plan);
             assertContains(plan, "unused_output_column_name:[]");
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -88,7 +88,6 @@ public class GroupingSetsTest extends PlanTestBase {
         String sql = "select v1, grouping(v1) as b, sum(v3) " +
                 "   from t0 group by grouping sets((), (v1)) order by v1, b";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assertions.assertTrue(plan.contains("14:Project\n" +
                 "  |  <slot 12> : 12: v1\n" +
                 "  |  <slot 14> : 14: sum\n" +
@@ -114,7 +113,6 @@ public class GroupingSetsTest extends PlanTestBase {
         String sql = "select v1, v2, grouping_id(v1, v2) as b, sum(v3) " +
                 "from t0 group by grouping sets((), (v1, v2)) order by v1, b";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assertions.assertTrue(plan.contains("14:Project\n" +
                 "  |  <slot 13> : 13: v1\n" +
                 "  |  <slot 14> : 14: v2\n" +
@@ -151,7 +149,6 @@ public class GroupingSetsTest extends PlanTestBase {
         String sql = "select v1, v2, sum(v3) " +
                 "from t0 group by grouping sets((), (v1, v2)) order by v1, v2";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assertions.assertTrue(plan.contains("  7:Project\n" +
                 "  |  <slot 7> : 7: sum\n" +
                 "  |  <slot 8> : NULL\n" +
@@ -171,7 +168,6 @@ public class GroupingSetsTest extends PlanTestBase {
         String sql = "select v1, grouping(v1) as b, sum(v3) " +
                 "   from t0 group by rollup(v1, v2) order by v1, b";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assertions.assertTrue(plan.contains("21:Project\n" +
                 "  |  <slot 19> : 19: v1\n" +
                 "  |  <slot 22> : 22: sum\n" +
@@ -193,7 +189,6 @@ public class GroupingSetsTest extends PlanTestBase {
         String sql = "select v1, grouping_id(v1) as b, count(1) " +
                 "   from t0 group by rollup(v1, v2, v3) order by v1, b";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assertions.assertTrue(plan.contains("  1:UNION\n" +
                 "  |  \n" +
                 "  |----15:EXCHANGE\n" +
@@ -339,7 +334,6 @@ public class GroupingSetsTest extends PlanTestBase {
             String sql = "select t1b, t1c, t1d, sum(id_decimal) " +
                     "   from test_all_type group by rollup(t1b, t1c, t1d)";
             String plan = getCostExplain(sql);
-            System.out.println(plan);
             assertContains(plan, "  8:AGGREGATE (update serialize)\n" +
                     "  |  STREAMING\n" +
                     "  |  aggregate: sum[([13: sum, DECIMAL128(38,2), true]); args: DECIMAL128; " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -479,7 +479,6 @@ public class LowCardinalityTest extends PlanTestBase {
 
         sql = "select count(distinct S_NATIONKEY) from supplier group by S_ADDRESS";
         plan = getThriftPlan(sql);
-        System.out.println(plan);
         Assertions.assertTrue(plan.contains(
                 "partition:TDataPartition(type:RANDOM, partition_exprs:[]), " +
                         "query_global_dicts:[TGlobalDict(columnId:10, strings:[6D 6F 63 6B], ids:[1]"), plan);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -569,7 +569,6 @@ public class LowCardinalityTest2 extends PlanTestBase {
 
             sql = "select count(distinct S_NATIONKEY) from supplier group by S_ADDRESS";
             plan = getThriftPlan(sql);
-            System.out.println(plan);
             Assertions.assertTrue(plan.contains(
                     "partition:TDataPartition(type:RANDOM, partition_exprs:[]), " +
                             "query_global_dicts:[TGlobalDict(columnId:10, strings:[6D 6F 63 6B], ids:[1]"), plan);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -389,7 +389,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "join t0 on t1.v4 = t0.v2 " +
                 "join t2 on t1.v5 = t2.v8 ";
         String planFragment = getFragmentPlan(sql);
-        System.out.println(planFragment);
         Assertions.assertTrue(planFragment.contains("2:OlapScanNode\n" +
                 "     TABLE: t0"));
         Assertions.assertTrue(planFragment.contains("|----3:EXCHANGE\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -771,7 +771,7 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
 
         String sql = "select * from t0 join[shuffle] t1 on t0.v2 = t1.v5 and t0.v3 = t1.v6";
         String plan = getVerboseExplain(sql);
-        System.out.println(plan);
+        logSysInfo(plan);
 
         assertContains(plan, "  |  build runtime filters:\n" +
                 "  |  - filter_id = 0, build_expr = (5: v5), remote = true\n" +
@@ -801,7 +801,7 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
         String sql = "select * from (select t1.v5 as v5, t0.v3 as v3 from t0 join[shuffle] t1 on t0.v2 = " +
                 "t1.v5 and t0.v3 = t1.v6) tt join[shuffle] t2 on tt.v5 = t2.v8 and tt.v3 = t2.v7";
         String plan = getVerboseExplain(sql);
-        System.out.println(plan);
+        logSysInfo(plan);
 
         assertContains(plan, "  |  - filter_id = 0, build_expr = (5: v5), remote = true\n" +
                 "  |  - filter_id = 1, build_expr = (6: v6), remote = true");
@@ -1234,7 +1234,7 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
 
         String sql = "select * from t0 join[shuffle] t1 on t0.v2 = t1.v5 and t0.v3 = t1.v6";
         String plan = getVerboseExplain(sql);
-        System.out.println(plan);
+        logSysInfo(plan);
 
         assertContains(plan, "  Input Partition: RANDOM\n" +
                 "  OutPut Partition: HASH_PARTITIONED: 2: v2\n" +
@@ -1801,7 +1801,7 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
                 "    AND v1 = 99))\n" +
                 "   AND v1 = 100";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
+        logSysInfo(plan);
     }
 
     @Test
@@ -2274,7 +2274,7 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
                     "  |  1 <-> [1: v1, BIGINT, true]\n" +
                     "  |  4 <-> [4: t1a, VARCHAR, true]\n" +
                     "  |  cardinality: 10000");
-            System.out.println(plan);
+            logSysInfo(plan);
             assertContains(plan, "PLAN COST\n" +
                     "  CPU: 4.80001312001E11\n" +
                     "  Memory: 320201.0");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -41,6 +41,7 @@ import com.starrocks.sql.optimizer.LogicalPlanPrinter;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import kotlin.text.Charsets;
 import org.apache.commons.collections4.CollectionUtils;
@@ -71,7 +72,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PlanTestNoneDBBase {
+public class PlanTestNoneDBBase extends StarRocksTestBase {
     // use a unique dir so that it won't be conflict with other unit test which
     // may also start a Mocked Frontend
     public static ConnectContext connectContext;
@@ -288,7 +289,7 @@ public class PlanTestNoneDBBase {
         Pair<ExecPlan, String> execPlanWithQuery = result.second;
         String traceLog = execPlanWithQuery.second;
         if (!Strings.isNullOrEmpty(traceLog)) {
-            System.out.println(traceLog);
+            logSysInfo(traceLog);
         }
         return execPlanWithQuery.first.getExplainString(TExplainLevel.NORMAL);
     }
@@ -381,8 +382,8 @@ public class PlanTestNoneDBBase {
             } catch (IOException e) {
                 e.printStackTrace();
             }
-            System.out.println("DEBUG MODE!");
-            System.out.println("DEBUG FILE: " + debugFile.getPath());
+            logSysInfo("DEBUG MODE!");
+            logSysInfo("DEBUG FILE: " + debugFile.getPath());
         }
 
         Pattern regex = Pattern.compile("\\[plan-(\\d+)]");
@@ -419,7 +420,7 @@ public class PlanTestNoneDBBase {
                         // will create new file
                         if (null == writer) {
                             writer = new BufferedWriter(new FileWriter(debugFile, true));
-                            System.out.println("DEBUG MODE!");
+                            logSysInfo("DEBUG MODE!");
                         }
                         continue;
                     case "[planCount]":
@@ -511,7 +512,7 @@ public class PlanTestNoneDBBase {
                 }
             }
         } catch (Exception e) {
-            System.out.println(sql);
+            logSysInfo(sql);
             e.printStackTrace();
             Assertions.fail();
         }
@@ -567,7 +568,7 @@ public class PlanTestNoneDBBase {
 
             ExecPlan execPlan = pair.second.first;
             if (debugOptions.isEnableQueryTraceLog()) {
-                System.out.println(pair.second.second);
+                logSysInfo(pair.second.second);
             }
             if (hasResult && !isDebug) {
                 checkWithIgnoreTabletList(result.toString().trim(), pair.first.trim());
@@ -838,7 +839,7 @@ public class PlanTestNoneDBBase {
 
     protected static void createTables(String dirName, List<String> fileNames) {
         getSqlList(dirName, fileNames).forEach(createTblSql -> {
-            System.out.println("create table sql:" + createTblSql);
+            logSysInfo("create table sql:" + createTblSql);
             try {
                 starRocksAssert.withTable(createTblSql);
             } catch (Exception e) {
@@ -849,7 +850,7 @@ public class PlanTestNoneDBBase {
 
     protected static void createMaterializedViews(String dirName, List<String> fileNames) {
         getSqlList(dirName, fileNames).forEach(sql -> {
-            System.out.println("create mv sql:" + sql);
+            logSysInfo("create mv sql:" + sql);
             try {
                 starRocksAssert.withMaterializedView(sql);
             } catch (Exception e) {
@@ -861,7 +862,7 @@ public class PlanTestNoneDBBase {
     protected static List<String> getSqlList(String dirName, List<String> fileNames) {
         ClassLoader loader = PlanTestBase.class.getClassLoader();
         List<String> createTableSqlList = fileNames.stream().map(n -> {
-            System.out.println("file name:" + n);
+            logSysInfo("file name:" + n);
             try {
                 return CharStreams.toString(
                         new InputStreamReader(
@@ -877,7 +878,7 @@ public class PlanTestNoneDBBase {
 
     public static String getFileContent(String fileName) throws Exception {
         ClassLoader loader = PlanTestNoneDBBase.class.getClassLoader();
-        System.out.println("file name:" + fileName);
+        logSysInfo("file name:" + fileName);
         String content = "";
         try {
             content = CharStreams.toString(

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneUKFKJoinRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneUKFKJoinRuleTest.java
@@ -81,11 +81,11 @@ public class PruneUKFKJoinRuleTest extends TPCDSPlanTestBase {
     private void assertPlans(String query, boolean equals, String... patterns) throws Exception {
         connectContext.getSessionVariable().setEnableUKFKOpt(false);
         String planDisabled = getFragmentPlan(query);
-        System.out.println(planDisabled);
-        System.out.println("===================");
+        logSysInfo(planDisabled);
+        logSysInfo("===================");
         connectContext.getSessionVariable().setEnableUKFKOpt(true);
         String planEnabled = getFragmentPlan(query);
-        System.out.println(planEnabled);
+        logSysInfo(planEnabled);
         if (equals) {
             Assertions.assertEquals(planDisabled, planEnabled);
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -751,7 +751,6 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/pushdown_distinct_agg_below_window2"),
                         null, TExplainLevel.NORMAL);
-        System.out.println(replayPair.second);
         Assertions.assertTrue(replayPair.second.contains("  3:ANALYTIC\n" +
                 "  |  functions: [, sum(5: sum), ]\n" +
                 "  |  partition by: 1: TIME\n" +
@@ -1107,7 +1106,6 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         QueryDumpInfo queryDumpInfo = getDumpInfoFromJson(dumpString);
         Pair<QueryDumpInfo, String> replayPair = getPlanFragment(dumpString, queryDumpInfo.getSessionVariable(),
                 TExplainLevel.NORMAL);
-        System.out.println(Tracers.printScopeTimer());
         String ss = Tracers.printScopeTimer();
         int start = ss.indexOf("PhysicalRewrite[") + "PhysicalRewrite[".length();
         int end = ss.indexOf("]", start);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -1054,7 +1054,6 @@ public class SubqueryTest extends PlanTestBase {
                     "t0.v1 = (exists (select v7 from t2 where t2.v8 = t1.v5)) " +
                     "and t0.v2 = (not exists(select v11 from t3 where t3.v10 = t0.v1))";
             String plan = getFragmentPlan(sql);
-            System.out.println(plan);
             assertContains(plan, "HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSCTERatioTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSCTERatioTest.java
@@ -106,7 +106,7 @@ public class TPCDSCTERatioTest extends TPCDS1TTestBase {
             actual.add(inline.getExplainString(StatementBase.ExplainLevel.NORMAL).contains("MultiCastDataSinks"));
         }
 
-        System.out.println();
+        logSysInfo();
         print(expect, actual);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
@@ -132,7 +132,7 @@ public class TPCDSPushAggTest extends TPCDS1TTestBase {
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(3000000000L);
         String sql = "Q75";
         String plan = getPlan(1, sql);
-        System.out.println(plan);
+        logSysInfo(plan);
     }
 
     private int getAggNum(int cboPushDownAggregateMode, String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
@@ -47,8 +47,8 @@ public class ViewPlanTest extends PlanTestBase {
         String sqlPlan = getFragmentPlan(sql);
         String viewPlan = getFragmentPlan("select * from " + viewName);
 
-        System.out.println(sqlPlan);
-        System.out.println(viewPlan);
+        logSysInfo(sqlPlan);
+        logSysInfo(viewPlan);
 
         sqlPlan = sqlPlan.replaceAll("bitmap_union_count\\(", "count");
         viewPlan = viewPlan.replaceAll("bitmap_union_count\\(", "count");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCDSBindTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCDSBindTest.java
@@ -114,9 +114,9 @@ public class SPMTPCDSBindTest extends TPCDSPlanTestBase {
         String bindSQL = generator.getBindSql();
         String planSQL = generator.getPlanStmtSQL();
 
-        System.out.println(bindSQL);
-        System.out.println("\n\n====================================\n\n");
-        System.out.println(planSQL);
+        logSysInfo(bindSQL);
+        logSysInfo("\n\n====================================\n\n");
+        logSysInfo(planSQL);
     }
 
     public static List<Arguments> testCases() {

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksTestBase.java
@@ -40,13 +40,16 @@ import java.util.Set;
 public abstract class StarRocksTestBase {
     protected static final Logger LOG = LogManager.getLogger(StarRocksTestBase.class);
 
+    // Whether print log to system out
+    protected static boolean isOutputSystemOut = false;
+
     // StarRocksAssert is a class that provides methods to interact with StarRocks.
     protected static StarRocksAssert starRocksAssert;
     // existedTables is a set that contains all tables that have been created.
     protected static Set<Table> existedTables = Sets.newHashSet();
 
     @BeforeEach
-    public void before() {
+    public void before() throws Exception {
         if (starRocksAssert != null) {
             collectTables(starRocksAssert, existedTables);
         }
@@ -60,6 +63,54 @@ public abstract class StarRocksTestBase {
             } catch (Exception e) {
                 // ignore exception
             }
+        }
+    }
+
+    public static void logSysInfo(boolean info) {
+        if (isOutputSystemOut || LOG.isInfoEnabled()) {
+            System.out.println(info);
+        }
+    }
+
+    public static void logSysInfo(int info) {
+        if (isOutputSystemOut || LOG.isInfoEnabled()) {
+            System.out.println(info);
+        }
+    }
+
+    public static void logSysInfo(long info) {
+        if (isOutputSystemOut || LOG.isInfoEnabled()) {
+            System.out.println(info);
+        }
+    }
+
+    public static void logSysInfo(float info) {
+        if (isOutputSystemOut || LOG.isInfoEnabled()) {
+            System.out.println(info);
+        }
+    }
+
+    public static void logSysInfo(double info) {
+        if (isOutputSystemOut || LOG.isInfoEnabled()) {
+            System.out.println(info);
+        }
+    }
+
+    public static void logSysInfo(char[] info) {
+        if (isOutputSystemOut || LOG.isInfoEnabled()) {
+            System.out.println(info);
+        }
+    }
+
+    public static void logSysInfo(String info) {
+        if (isOutputSystemOut || LOG.isInfoEnabled()) {
+            System.out.println(info);
+        }
+    }
+
+    public static void logSysInfo(Object... info) {
+        if (isOutputSystemOut || LOG.isInfoEnabled()) {
+            System.out.println(info);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -588,7 +588,7 @@ public class UtFrameUtils {
             } finally {
                 String pr = Tracers.printLogs();
                 if (!Strings.isNullOrEmpty(pr)) {
-                    System.out.println(pr);
+                    StarRocksTestBase.logSysInfo(pr);
                 }
                 Tracers.close();
             }

--- a/fe/fe-core/src/test/java/com/starrocks/warehouse/WarehouseTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/warehouse/WarehouseTestBase.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public abstract class WarehouseTestBase extends StarRocksTestBase {
     @BeforeEach
-    public void before() {
+    public void before() throws Exception {
         new MockUp<RunMode>() {
             @Mock
             public RunMode getCurrentRunMode() {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- reduce FE UT's logging output
- Only output `System.out.println` only in `INFO` level, not output logs in `WARN`(current defualt) level. 

You can output `System.out` to console by following:

Method 1: Change `log4j.xml` log level:

```
❯ git diff fe-core/src/test/resources/log4j2.xml
diff --git a/fe/fe-core/src/test/resources/log4j2.xml b/fe/fe-core/src/test/resources/log4j2.xml
index a853d755c4..37d2b207df 100644
--- a/fe/fe-core/src/test/resources/log4j2.xml
+++ b/fe/fe-core/src/test/resources/log4j2.xml
@@ -16,7 +16,7 @@

     </Appenders>
     <Loggers>
-        <Root level="WARN">
+        <Root level="INFO">
             <AppenderRef ref="Console" />
             <AppenderRef ref="RollingFile" />
         </Root>

```

Method2:
```
isOutputSystemOut = true;

logSysInfo(xxx);
```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
