### PR TITLE
[BugFix] fix iceberg table scan exception during scan range deploy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -76,10 +76,13 @@ import java.util.Map;
 
 public class HDFSBackendSelector implements BackendSelector {
     public static final Logger LOG = LogManager.getLogger(HDFSBackendSelector.class);
-    // be -> assigned scans
-    Map<ComputeNode, Long> assignedScansPerComputeNode = Maps.newHashMap();
-    // be -> re-balance bytes
-    Map<ComputeNode, Long> reBalanceBytesPerComputeNode = Maps.newHashMap();
+    // be -> assigned bytes
+    Map<ComputeNode, Long> assignedBytesPerComputeNode = Maps.newHashMap();
+    // be -> re-balanced bytes
+    Map<ComputeNode, Long> reBalancedBytesPerComputeNode = Maps.newHashMap();
+    // be -> assigned scan ranges
+    Map<ComputeNode, Long> assignedScanRangesPerComputeNode = Maps.newHashMap();
+
     private final ScanNode scanNode;
     private final List<TScanRangeLocations> locations;
     private final FragmentScanRangeAssignment assignment;
@@ -211,7 +214,7 @@ public class HDFSBackendSelector implements BackendSelector {
         SessionVariable sessionVariable = connectContext.getSessionVariable();
         boolean forceReBalance = sessionVariable.getHdfsBackendSelectorForceRebalance();
         boolean enableDataCache = sessionVariable.isEnableScanDataCache();
-        // If force-rebalancing is not specified and cache is used, skip the rebalancing directly.
+        // If force re-balancing is not specified and cache is used, skip the rebalancing directly.
         if (!forceReBalance && enableDataCache) {
             return backends.get(0);
         }
@@ -219,7 +222,7 @@ public class HDFSBackendSelector implements BackendSelector {
         ComputeNode node = null;
         long addedScans = scanRangeLocations.scan_range.hdfs_scan_range.length;
         for (ComputeNode backend : backends) {
-            long assignedScanRanges = assignedScansPerComputeNode.get(backend);
+            long assignedScanRanges = assignedBytesPerComputeNode.get(backend);
             if (assignedScanRanges + addedScans < avgNodeScanRangeBytes * kMaxImbalanceRatio) {
                 node = backend;
                 break;
@@ -326,8 +329,9 @@ public class HDFSBackendSelector implements BackendSelector {
         long totalSize = computeTotalSize();
         long avgNodeScanRangeBytes = totalSize / Math.max(workerProvider.getAllWorkers().size(), 1) + 1;
         for (ComputeNode computeNode : workerProvider.getAllWorkers()) {
-            assignedScansPerComputeNode.put(computeNode, 0L);
-            reBalanceBytesPerComputeNode.put(computeNode, 0L);
+            assignedBytesPerComputeNode.put(computeNode, 0L);
+            assignedScanRangesPerComputeNode.put(computeNode, 0L);
+            reBalancedBytesPerComputeNode.put(computeNode, 0L);
         }
 
         // schedule scan ranges to co-located backends.
@@ -341,7 +345,7 @@ public class HDFSBackendSelector implements BackendSelector {
         }
 
         // use consistent hashing to schedule remote scan ranges
-        HashRing hashRing = makeHashRing(assignedScansPerComputeNode.keySet());
+        HashRing hashRing = makeHashRing(assignedBytesPerComputeNode.keySet());
         HashRing candidateHashRing = null;
         if (candidateWorkerProvider != null) {
             Collection<ComputeNode> candidateWorkers = candidateWorkerProvider.getAllWorkers();
@@ -365,7 +369,7 @@ public class HDFSBackendSelector implements BackendSelector {
             ComputeNode candidateNode = null;
             if (candidateHashRing != null) {
                 List<ComputeNode> candidateBackends = candidateHashRing.get(scanRangeLocations, kCandidateNumber);
-                // if datacache is enable, skip rebalance because it make the cache position undefined.
+                // if data cache is enabled, skip re-balancing because it makes the cache position undefined.
                 candidateNode = candidateBackends.get(0);
             }
             recordScanRangeAssignment(node, candidateNode, backends, scanRangeLocations);
@@ -381,11 +385,11 @@ public class HDFSBackendSelector implements BackendSelector {
 
         // update statistic
         long addedScans = scanRangeLocations.scan_range.hdfs_scan_range.length;
-        assignedScansPerComputeNode.put(worker, assignedScansPerComputeNode.get(worker) + addedScans);
+        assignedBytesPerComputeNode.put(worker, assignedBytesPerComputeNode.get(worker) + addedScans);
         // the fist item in backends will be assigned if there is no re-balance, we compute re-balance bytes
         // if the worker is not the first item in backends.
         if (worker != backends.get(0)) {
-            reBalanceBytesPerComputeNode.put(worker, reBalanceBytesPerComputeNode.get(worker) + addedScans);
+            reBalancedBytesPerComputeNode.put(worker, reBalancedBytesPerComputeNode.get(worker) + addedScans);
         }
 
         // add scan range params
@@ -396,21 +400,30 @@ public class HDFSBackendSelector implements BackendSelector {
                     String.format("%s:%d", candidateWorker.getHost(), candidateWorker.getBrpcPort()));
         }
         assignment.put(worker.getId(), scanNode.getId().asInt(), scanRangeParams);
+        assignedScanRangesPerComputeNode.put(worker,
+                assignedScanRangesPerComputeNode.get(worker) + 1);
     }
 
     private void recordScanRangeStatistic() {
         // record scan range size for each backend
-        for (Map.Entry<ComputeNode, Long> entry : assignedScansPerComputeNode.entrySet()) {
+        for (Map.Entry<ComputeNode, Long> entry : assignedBytesPerComputeNode.entrySet()) {
             String host = entry.getKey().getAddress().hostname.replace('.', '_');
             long value = entry.getValue();
             String key = String.format("Placement.%s.assign.%s", scanNode.getTableName(), host);
             Tracers.count(Tracers.Module.EXTERNAL, key, value);
         }
         // record re-balance bytes for each backend
-        for (Map.Entry<ComputeNode, Long> entry : reBalanceBytesPerComputeNode.entrySet()) {
+        for (Map.Entry<ComputeNode, Long> entry : reBalancedBytesPerComputeNode.entrySet()) {
             String host = entry.getKey().getAddress().hostname.replace('.', '_');
             long value = entry.getValue();
             String key = String.format("Placement.%s.balance.%s", scanNode.getTableName(), host);
+            Tracers.count(Tracers.Module.EXTERNAL, key, value);
+        }
+        // record split number for each backend
+        for (Map.Entry<ComputeNode, Long> entry : assignedScanRangesPerComputeNode.entrySet()) {
+            String host = entry.getKey().getAddress().hostname.replace('.', '_');
+            long value = entry.getValue();
+            String key = String.format("Placement.%s.split.%s", scanNode.getTableName(), host);
             Tracers.count(Tracers.Module.EXTERNAL, key, value);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
@@ -88,7 +88,8 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
                 for (DeployState state : states) {
                     deployer.deployFragments(state);
                 }
-            } catch (StarRocksException | RpcException e) {
+            } catch (Exception e) {
+                // there could be a lot of reasons to fail, just cancel the query
                 LOG.warn("Failed to assign incremental scan ranges to deploy states", e);
                 coordinator.cancel(PPlanFragmentCancelReason.INTERNAL_ERROR, e.getMessage());
                 throw new RuntimeException(e);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
@@ -225,7 +225,7 @@ public class HDFSBackendSelectorTest {
 
         variance = 0.4 / 100 * scanRangeNumber * scanRangeSize;
         double actual = 0;
-        for (Map.Entry<ComputeNode, Long> entry : selector.reBalanceBytesPerComputeNode.entrySet()) {
+        for (Map.Entry<ComputeNode, Long> entry : selector.reBalancedBytesPerComputeNode.entrySet()) {
             System.out.printf("%s -> %d bytes re-balance\n", entry.getKey(), entry.getValue());
             actual = actual + entry.getValue();
         }


### PR DESCRIPTION
## Why I'm doing:

I spot a exception when get files scan from iceberg table scan

```
2025-09-11 13:46:58.800+08:00 WARN (starrocks-mysql-nio-pool-5|2097) [StmtExecutor.execute():916] execute Exception, sql: {}, select count(*) from iceberg.zya.bigmeta version as of 8776018871460644152
java.lang.NullPointerException: Cannot invoke "java.lang.Iterable.iterator()" because "this.val$iterable" is null
        at org.apache.iceberg.io.CloseableIterable$1.iterator(CloseableIterable.java:71) ~[iceberg-api-1.9.0.jar:?]
        at org.apache.iceberg.io.CloseableIterable$7$1.<init>(CloseableIterable.java:205) ~[iceberg-api-1.9.0.jar:?]
        at org.apache.iceberg.io.CloseableIterable$7.iterator(CloseableIterable.java:204) ~[iceberg-api-1.9.0.jar:?]
        at org.apache.iceberg.io.CloseableIterable$7.iterator(CloseableIterable.java:196) ~[iceberg-api-1.9.0.jar:?]
        at org.apache.iceberg.util.ParallelIterable$Task.get(ParallelIterable.java:280) ~[iceberg-core-1.9.0.jar:?]
        at org.apache.iceberg.util.ParallelIterable$Task.get(ParallelIterable.java:244) ~[iceberg-core-1.9.0.jar:?]
        at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

but that exception is not caught during deploy scan range. We just caught `StarocksException` and `RpcException`.

## What I'm doing:

Caught general exception during scan range deploy.

Besides that, I add a metric to see "how many scan ranges has been deployed on one BE node".

Fixes #62995

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
