### PR TITLE
[DSR-Enhancement-216] reset default catalog when enable presto sql dialect

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3882,4 +3882,7 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true, comment = "Enable desensitize sql in query dump")
     public static boolean enable_desensitize_query_dump = false;
+
+    @ConfField(mutable = true, comment = "default presto catalog when sql_dialect=presto")
+    public static String default_presto_catalog = "unified_catalog_hms";
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1439,7 +1439,7 @@ public class QueryAnalyzer {
     public Table resolveTable(TableRelation tableRelation) {
         TableName tableName = tableRelation.getName();
         try {
-            tableName.normalization(session);
+            tableName.normalizationOnlyQuery(session);
             String catalogName = tableName.getCatalog();
             String dbName = tableName.getDb();
             String tbName = tableName.getTbl();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/MetaUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/MetaUtilTest.java
@@ -17,6 +17,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -25,9 +26,12 @@ import com.starrocks.catalog.StructField;
 import com.starrocks.catalog.StructType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
+import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
@@ -146,5 +150,27 @@ public class MetaUtilTest {
                 MetaUtils.getColumnIdsByColumnNames(olapTable, Lists.newArrayList("b")).get(0));
         Assertions.assertEquals(ColumnId.create("c"),
                 MetaUtils.getColumnIdsByColumnNames(olapTable, Lists.newArrayList("c")).get(0));
+    }
+
+
+    public void testGetCatalogName() {
+        TableName informationTableName = new TableName(InfoSchemaDb.DATABASE_NAME, "task_runs");
+        informationTableName.normalizationOnlyQuery(connectContext);
+        Assertions.assertEquals(informationTableName.getCatalog(), InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+
+        TableName starrocksTableName = new TableName("test", "t0");
+        starrocksTableName.normalizationOnlyQuery(connectContext);
+        Assertions.assertEquals(starrocksTableName.getCatalog(), InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
+        sessionVariable.setSqlDialect("trino");
+        connectContext.setSessionVariable(sessionVariable);
+
+        starrocksTableName.normalizationOnlyQuery(connectContext);
+        Assertions.assertEquals(informationTableName.getCatalog(), InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+
+        starrocksTableName.normalizationOnlyQuery(connectContext);
+        Assertions.assertEquals(starrocksTableName.getCatalog(), InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME));
+
     }
 }


### PR DESCRIPTION
#62997

## Why I'm doing:

## What I'm doing:

Fixes #62997

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3