### PR TITLE
[Enhancement] add inspect_minmax & invalidate meta functions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -64,12 +64,16 @@ import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.base.ColumnIdentifier;
 import com.starrocks.sql.optimizer.dump.QueryDumper;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.rewrite.ConstantFunction;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.statistics.CacheDictManager;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
+import com.starrocks.sql.optimizer.statistics.IMinMaxStatsMgr;
+import com.starrocks.sql.optimizer.statistics.StatsVersion;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.thrift.TResultBatch;
 import com.starrocks.type.VarcharType;
 import io.netty.buffer.ByteBuf;
@@ -796,19 +800,25 @@ public class MetaFunctions {
     }
 
     /**
+     * Resolve an OLAP table for the global-dict / min-max meta functions. Goes through
+     * {@link #inspectTable} so table-level privileges are enforced -- these functions must not
+     * disclose or mutate metadata for tables the caller has no access to.
+     */
+    private static OlapTable inspectOlapTable(ConstantOperator tableName) {
+        Table table = inspectTable(TableName.fromString(tableName.getVarchar())).getRight();
+        if (!(table instanceof OlapTable)) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER, "must be OLAP_TABLE");
+        }
+        return (OlapTable) table;
+    }
+
+    /**
      * Inspect global dictionary table, and return the content in JSON format.
      */
     @ConstantFunction(name = "inspect_global_dict", argTypes = {VARCHAR,
             VARCHAR}, returnType = VARCHAR, isMetaFunction = true)
     public static ConstantOperator inspectGlobalDict(ConstantOperator tableName, ConstantOperator columnName) {
-        TableName tableNameValue = TableName.fromString(tableName.getVarchar());
-        Optional<Table> maybeTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                .getTable(new ConnectContext(), tableNameValue);
-        maybeTable.orElseThrow(() -> ErrorReport.buildSemanticException(ErrorCode.ERR_BAD_TABLE_ERROR, tableNameValue));
-        if (!(maybeTable.get() instanceof OlapTable)) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER, "must be OLAP_TABLE");
-        }
-        OlapTable table = (OlapTable) maybeTable.get();
+        OlapTable table = inspectOlapTable(tableName);
         String column = columnName.getVarchar();
 
         CacheDictManager instance = CacheDictManager.getInstance();
@@ -834,6 +844,80 @@ public class MetaFunctions {
             return ConstantOperator.createNull(VarcharType.VARCHAR);
         }
         return ConstantOperator.createVarchar(lastQueryId.toString());
+    }
+
+    /**
+     * Invalidate global dictionary for a column, and return the result status.
+     */
+    @ConstantFunction(name = "invalidate_global_dict", argTypes = {VARCHAR,
+            VARCHAR}, returnType = VARCHAR, isMetaFunction = true)
+    public static ConstantOperator invalidateGlobalDict(ConstantOperator tableName, ConstantOperator columnName) {
+        authOperatorPrivilege();
+
+        OlapTable table = inspectOlapTable(tableName);
+        String column = columnName.getVarchar();
+
+        CacheDictManager instance = CacheDictManager.getInstance();
+        ColumnId columnId = ColumnId.create(column);
+
+        // Check if global dict exists before attempting to invalidate
+        if (!instance.hasGlobalDict(table.getId(), columnId)) {
+            return ConstantOperator.createVarchar("No global dictionary found for column: " + column);
+        }
+
+        try {
+            instance.removeGlobalDict(table, columnId);
+        } catch (Exception e) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_UNKNOWN_ERROR,
+                    "Failed to invalidate global dictionary: " + e.getMessage());
+        }
+        return ConstantOperator.createVarchar("invalidated column dict");
+    }
+
+    /**
+     * Inspect the MinMaxStats of a column
+     */
+    @ConstantFunction(name = "inspect_minmax",
+            argTypes = {VARCHAR, VARCHAR}, returnType = VARCHAR, isMetaFunction = true)
+    public static ConstantOperator inspectMinMax(ConstantOperator tableName, ConstantOperator columnName) {
+        OlapTable table = inspectOlapTable(tableName);
+        ColumnId columnId = ColumnId.create(columnName.getVarchar());
+        // getTableLastUpdateTimestamp may return null (table never updated); treat as version 0 to
+        // avoid an auto-unboxing NPE when constructing StatsVersion.
+        Long lastUpdateTime = StatisticUtils.getTableLastUpdateTimestamp(table);
+        long version = lastUpdateTime == null ? 0L : lastUpdateTime;
+
+        Optional<IMinMaxStatsMgr.ColumnMinMax> minMax = IMinMaxStatsMgr.internalInstance()
+                .getStatsSync(new ColumnIdentifier(table.getId(), columnId),
+                        new StatsVersion(-1, version));
+
+        return minMax.map(columnMinMax -> ConstantOperator.createVarchar(columnMinMax.toString()))
+                .orElseGet(() -> ConstantOperator.createNull(VarcharType.VARCHAR));
+    }
+
+    /**
+     * Invalidate MinMax statistics for a column, and return the result status.
+     */
+    @ConstantFunction(name = "invalidate_minmax", argTypes = {VARCHAR,
+            VARCHAR}, returnType = VARCHAR, isMetaFunction = true)
+    public static ConstantOperator invalidateMinMax(ConstantOperator tableName, ConstantOperator columnName) {
+        authOperatorPrivilege();
+
+        OlapTable table = inspectOlapTable(tableName);
+        ColumnId columnId = ColumnId.create(columnName.getVarchar());
+        ColumnIdentifier columnIdentifier = new ColumnIdentifier(table.getId(), columnId);
+
+        // getTableLastUpdateTimestamp may return null; treat as version 0 to avoid an auto-unboxing NPE.
+        Long lastUpdateTime = StatisticUtils.getTableLastUpdateTimestamp(table);
+        StatsVersion version = new StatsVersion(-1, lastUpdateTime == null ? 0L : lastUpdateTime);
+
+        try {
+            IMinMaxStatsMgr.internalInstance().removeStats(columnIdentifier, version);
+        } catch (Exception e) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_UNKNOWN_ERROR,
+                    "Failed to invalidate MinMax statistics: " + e.getMessage());
+        }
+        return ConstantOperator.createVarchar("invalidated column minmax");
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnMinMaxMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnMinMaxMgr.java
@@ -101,6 +101,24 @@ public class ColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable {
     }
 
     @Override
+    public Optional<ColumnMinMax> getStatsSync(ColumnIdentifier identifier, StatsVersion version) {
+        try {
+            CompletableFuture<Optional<CacheValue>> future = cache.get(identifier);
+            Optional<CacheValue> cacheValue = future.get();
+            if (cacheValue.isPresent()) {
+                CacheValue value = cacheValue.get();
+                if (value.version().getVersion() >= version.getVersion()) {
+                    return Optional.of(value.minMax());
+                }
+                cache.synchronous().invalidate(identifier);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to get MinMax for column: {}, version: {}", identifier, version, e);
+        }
+        return Optional.empty();
+    }
+
+    @Override
     public void removeStats(ColumnIdentifier identifier, StatsVersion version) {
         // skip dictionary operator in checkpoint thread
         if (GlobalStateMgr.isCheckpointThread()) {
@@ -110,10 +128,7 @@ public class ColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable {
             // If the identifier is already in the cache, we do not need to update it.
             return;
         }
-        Optional<ColumnMinMax> minMax = getStats(identifier, version);
-        if (minMax.isPresent()) {
-            cache.synchronous().invalidate(identifier);
-        }
+        cache.synchronous().invalidate(identifier);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IMinMaxStatsMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IMinMaxStatsMgr.java
@@ -22,6 +22,8 @@ public interface IMinMaxStatsMgr {
 
     Optional<ColumnMinMax> getStats(ColumnIdentifier identifier, StatsVersion version);
 
+    Optional<ColumnMinMax> getStatsSync(ColumnIdentifier identifier, StatsVersion version);
+
     void removeStats(ColumnIdentifier identifier, StatsVersion version);
 
     static IMinMaxStatsMgr internalInstance() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IcebergColumnMinMaxMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IcebergColumnMinMaxMgr.java
@@ -86,6 +86,21 @@ public class IcebergColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable 
     }
 
     @Override
+    public Optional<ColumnMinMax> getStatsSync(ColumnIdentifier identifier, StatsVersion version) {
+        if (!ConnectContext.get().getSessionVariable().isEnableMinMaxOptimization()) {
+            return Optional.empty();
+        }
+
+        try {
+            CompletableFuture<Optional<ColumnMinMax>> result = cache.get(new CacheKey(identifier, version.getVersion()));
+            return result.get();
+        } catch (Exception e) {
+            LOG.warn("Failed to get MinMax for column: {}, version: {}", identifier, version, e);
+        }
+        return Optional.empty();
+    }
+
+    @Override
     public void removeStats(ColumnIdentifier identifier, StatsVersion version) {
         throw new SemanticException("Iceberg column min/max stats unsupported the method");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -134,22 +135,30 @@ public class MetaFunctionsTest extends MVTestBase {
 
     @Test
     public void testInspectTableAccessDeniedException() {
+        UserIdentity currentUserIdentity = connectContext.getCurrentUserIdentity();
+        Set<Long> currentRoleIds = connectContext.getCurrentRoleIds();
         assertThrows(ErrorReportException.class, () -> {
             connectContext.setCurrentUserIdentity(testUser);
             connectContext.setCurrentRoleIds(testUser);
             connectContext.setThreadLocalInfo();
             MetaFunctions.inspectTable(new TableName("test", "tbl1"));
         });
+        connectContext.setCurrentUserIdentity(currentUserIdentity);
+        connectContext.setCurrentRoleIds(currentRoleIds);
     }
 
     @Test
     public void testInspectExternalTableAccessDeniedException() {
+        UserIdentity currentUserIdentity = connectContext.getCurrentUserIdentity();
+        Set<Long> currentRoleIds = connectContext.getCurrentRoleIds();
         assertThrows(ErrorReportException.class, () -> {
             connectContext.setCurrentUserIdentity(testUser);
             connectContext.setCurrentRoleIds(testUser);
             connectContext.setThreadLocalInfo();
             MetaFunctions.inspectTable(new TableName("test", "mysql_external_table"));
         });
+        connectContext.setCurrentUserIdentity(currentUserIdentity);
+        connectContext.setCurrentRoleIds(currentRoleIds);
     }
 
     private String lookupString(String tableName, String key, String column) {
@@ -591,5 +600,128 @@ public class MetaFunctionsTest extends MVTestBase {
             connectContext.setCurrentRoleIds(UserIdentity.ROOT);
             connectContext.setThreadLocalInfo();
         }
+    }
+
+    @Test
+    public void testInvalidateGlobalDict() throws Exception {
+        // Test with non-existent table
+        assertThrows(SemanticException.class, () -> {
+            MetaFunctions.invalidateGlobalDict(
+                    ConstantOperator.createVarchar("test.non_existent_table"),
+                    ConstantOperator.createVarchar("k1"));
+        });
+
+        // Test with non-OLAP table
+        assertThrows(SemanticException.class, () -> {
+            MetaFunctions.invalidateGlobalDict(
+                    ConstantOperator.createVarchar("test.mysql_external_table"),
+                    ConstantOperator.createVarchar("k1"));
+        });
+
+        // Whether tbl1.k1 currently has a global dict depends on cache state left by earlier tests,
+        // so accept either valid outcome -- both mean invalidate_global_dict behaved correctly.
+        ConstantOperator result = MetaFunctions.invalidateGlobalDict(
+                ConstantOperator.createVarchar("test.tbl1"),
+                ConstantOperator.createVarchar("k1"));
+        Assertions.assertNotNull(result);
+        String msg = result.getVarchar();
+        Assertions.assertTrue(
+                msg.equals("invalidated column dict")
+                        || msg.equals("No global dictionary found for column: k1"), msg);
+        // After invalidation any dict is gone, so a second call deterministically reports none found.
+        ConstantOperator second = MetaFunctions.invalidateGlobalDict(
+                ConstantOperator.createVarchar("test.tbl1"),
+                ConstantOperator.createVarchar("k1"));
+        Assertions.assertEquals("No global dictionary found for column: k1", second.getVarchar());
+    }
+
+    @Test
+    public void testInvalidateMinMax() throws Exception {
+        // Test with non-existent table
+        assertThrows(SemanticException.class, () -> {
+            MetaFunctions.invalidateMinMax(
+                    ConstantOperator.createVarchar("test.non_existent_table"),
+                    ConstantOperator.createVarchar("k1"));
+        });
+
+        // Test with non-OLAP table
+        assertThrows(SemanticException.class, () -> {
+            MetaFunctions.invalidateMinMax(
+                    ConstantOperator.createVarchar("test.mysql_external_table"),
+                    ConstantOperator.createVarchar("k1"));
+        });
+
+        // Test with valid table and column
+        ConstantOperator result = MetaFunctions.invalidateMinMax(
+                ConstantOperator.createVarchar("test.tbl1"),
+                ConstantOperator.createVarchar("k1"));
+        Assertions.assertTrue(result.getVarchar().contains("invalidated column minmax"), result.getVarchar());
+    }
+
+    @Test
+    public void testInspectMinMax() throws Exception {
+        // Test with non-existent table
+        assertThrows(SemanticException.class, () -> {
+            MetaFunctions.inspectMinMax(
+                    ConstantOperator.createVarchar("test.non_existent_table"),
+                    ConstantOperator.createVarchar("k1"));
+        });
+
+        // Test with non-OLAP table
+        assertThrows(SemanticException.class, () -> {
+            MetaFunctions.inspectMinMax(
+                    ConstantOperator.createVarchar("test.mysql_external_table"),
+                    ConstantOperator.createVarchar("k1"));
+        });
+
+        // Test with valid table and column (should return null since no MinMax stats exist)
+        ConstantOperator result = MetaFunctions.inspectMinMax(
+                ConstantOperator.createVarchar("test.tbl1"),
+                ConstantOperator.createVarchar("k1"));
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isNull());
+    }
+
+    @Test
+    public void testInspectGlobalDict() throws Exception {
+        // Test with non-existent table
+        assertThrows(SemanticException.class, () -> {
+            MetaFunctions.inspectGlobalDict(
+                    ConstantOperator.createVarchar("test.non_existent_table"),
+                    ConstantOperator.createVarchar("k1"));
+        });
+
+        // Test with non-OLAP table
+        assertThrows(SemanticException.class, () -> {
+            MetaFunctions.inspectGlobalDict(
+                    ConstantOperator.createVarchar("test.mysql_external_table"),
+                    ConstantOperator.createVarchar("k1"));
+        });
+
+        // Test with valid table and column (should return null since no global dict exists)
+        ConstantOperator result = MetaFunctions.inspectGlobalDict(
+                ConstantOperator.createVarchar("test.tbl1"),
+                ConstantOperator.createVarchar("k1"));
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isNull());
+    }
+
+    @Test
+    public void testInspectMinMaxRequiresTablePrivilege() {
+        // inspect_minmax must enforce table privileges so it cannot disclose min/max for a table
+        // the caller has no access to.
+        UserIdentity currentUserIdentity = connectContext.getCurrentUserIdentity();
+        Set<Long> currentRoleIds = connectContext.getCurrentRoleIds();
+        assertThrows(ErrorReportException.class, () -> {
+            connectContext.setCurrentUserIdentity(testUser);
+            connectContext.setCurrentRoleIds(testUser);
+            connectContext.setThreadLocalInfo();
+            MetaFunctions.inspectMinMax(
+                    ConstantOperator.createVarchar("test.tbl1"),
+                    ConstantOperator.createVarchar("k1"));
+        });
+        connectContext.setCurrentUserIdentity(currentUserIdentity);
+        connectContext.setCurrentRoleIds(currentRoleIds);
+        connectContext.setThreadLocalInfo();
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


Add meta functions for global dict & minmax:
- inspect_global_dict
- invalidate_global_dict
- inspect_minmax
- invalidate_minmax

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
