### PR TITLE
[Refactor] Refactors the authentication and authorization context handling in the codebase 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
@@ -60,12 +60,12 @@ public class AuthenticationHandler {
          * For example, a meaningless authentication of OAuth2 may cause a long wait.
          */
         AuthenticationResult authenticationResult;
-        authenticationResult = authenticateWithNative(context.getAuthenticationContext(), user, remoteHost, authResponse);
+        authenticationResult = authenticateWithNative(context.getAccessControlContext(), user, remoteHost, authResponse);
 
         // If the user does not exist in the native authentication method, authentication is performed in Security Integration
         if (authenticationResult == null) {
             authenticationResult =
-                    authenticateWithSecurityIntegration(context.getAuthenticationContext(), user, remoteHost, authResponse);
+                    authenticateWithSecurityIntegration(context.getAccessControlContext(), user, remoteHost, authResponse);
         }
 
         if (authenticationResult == null) {
@@ -76,7 +76,7 @@ public class AuthenticationHandler {
         return authenticationResult.authenticatedUser;
     }
 
-    private static AuthenticationResult authenticateWithNative(AuthenticationContext authContext, String user, String remoteHost,
+    private static AuthenticationResult authenticateWithNative(AccessControlContext authContext, String user, String remoteHost,
                                                                byte[] authResponse)
             throws AuthenticationException {
         AuthenticationMgr authenticationMgr = GlobalStateMgr.getCurrentState().getAuthenticationMgr();
@@ -119,7 +119,7 @@ public class AuthenticationHandler {
         }
     }
 
-    private static AuthenticationResult authenticateWithSecurityIntegration(AuthenticationContext authContext,
+    private static AuthenticationResult authenticateWithSecurityIntegration(AccessControlContext authContext,
                                                                             String user,
                                                                             String remoteHost,
                                                                             byte[] authResponse) throws AuthenticationException {

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/JWTAuthenticationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/JWTAuthenticationProvider.java
@@ -41,7 +41,7 @@ public class JWTAuthenticationProvider implements AuthenticationProvider {
     }
 
     @Override
-    public void authenticate(AuthenticationContext authContext, UserIdentity userIdentity, byte[] authResponse)
+    public void authenticate(AccessControlContext authContext, UserIdentity userIdentity, byte[] authResponse)
             throws AuthenticationException {
         try {
             ByteBuffer authBuffer = ByteBuffer.wrap(authResponse);

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPAuthProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPAuthProvider.java
@@ -71,7 +71,7 @@ public class LDAPAuthProvider implements AuthenticationProvider {
     }
 
     @Override
-    public void authenticate(AuthenticationContext authContext, UserIdentity userIdentity, byte[] authResponse)
+    public void authenticate(AccessControlContext authContext, UserIdentity userIdentity, byte[] authResponse)
             throws AuthenticationException {
         //clear password terminate string
         byte[] clearPassword = authResponse;

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/OAuth2AuthenticationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/OAuth2AuthenticationProvider.java
@@ -42,7 +42,7 @@ public class OAuth2AuthenticationProvider implements AuthenticationProvider {
     }
 
     @Override
-    public void authenticate(AuthenticationContext authContext, UserIdentity userIdentity, byte[] authResponse)
+    public void authenticate(AccessControlContext authContext, UserIdentity userIdentity, byte[] authResponse)
             throws AuthenticationException {
         /*
           If the auth plugin used by the client for this authentication is not AUTHENTICATION_OAUTH2_CLIENT,
@@ -80,7 +80,7 @@ public class OAuth2AuthenticationProvider implements AuthenticationProvider {
     }
 
     @Override
-    public byte[] authMoreDataPacket(AuthenticationContext authContext, String user, String host) {
+    public byte[] authMoreDataPacket(AccessControlContext authContext, String user, String host) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         byte[] bytes = oAuth2Context.authServerUrl().getBytes(StandardCharsets.UTF_8);
         MysqlCodec.writeInt2(outputStream, bytes.length);
@@ -98,12 +98,12 @@ public class OAuth2AuthenticationProvider implements AuthenticationProvider {
     }
 
     @Override
-    public byte[] authSwitchRequestPacket(AuthenticationContext authContext, String user, String host) {
+    public byte[] authSwitchRequestPacket(AccessControlContext authContext, String user, String host) {
         return authMoreDataPacket(authContext, user, host);
     }
 
     @Override
-    public void checkLoginSuccess(int connectionId, AuthenticationContext context) throws AuthenticationException {
+    public void checkLoginSuccess(int connectionId, AccessControlContext context) throws AuthenticationException {
         if (context.getAuthToken() == null) {
             String authUrl = oAuth2Context.authServerUrl() +
                     "?response_type=code" +

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/PlainPasswordAuthenticationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/PlainPasswordAuthenticationProvider.java
@@ -30,7 +30,7 @@ public class PlainPasswordAuthenticationProvider implements AuthenticationProvid
 
     @Override
     public void authenticate(
-            AuthenticationContext authContext,
+            AccessControlContext authContext,
             UserIdentity userIdentity,
             byte[] authResponse) throws AuthenticationException {
         String usePassword = authResponse.length == 0 ? "NO" : "YES";
@@ -57,7 +57,7 @@ public class PlainPasswordAuthenticationProvider implements AuthenticationProvid
     }
 
     @Override
-    public byte[] authSwitchRequestPacket(AuthenticationContext authContext, String user, String host)
+    public byte[] authSwitchRequestPacket(AccessControlContext authContext, String user, String host)
             throws AuthenticationException {
         return authContext.getAuthDataSalt();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -215,7 +215,7 @@ public class MaterializedViewsSystemTable extends SystemTable {
         // database privs should be checked in analysis phrase
         long limit = params.isSetLimit() ? params.getLimit() : -1;
         if (params.isSetCurrent_user_ident()) {
-            context.setAuthInfoFromThrift(params.getCurrent_user_ident());
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.getCurrent_user_ident());
         } else {
             UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
             context.setCurrentUserIdentity(currentUser);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
@@ -25,7 +25,6 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.Config;
@@ -74,19 +73,12 @@ public class SysFeLocks {
     @VisibleForTesting
     public static TFeLocksRes listLocks(TFeLocksReq request, boolean authenticate) throws TException {
         TAuthInfo auth = request.getAuth_info();
-        UserIdentity currentUser;
-        if (auth.isSetCurrent_user_ident()) {
-            currentUser = UserIdentityUtils.fromThrift(auth.getCurrent_user_ident());
-        } else {
-            currentUser = UserIdentity.createAnalyzedUserIdentWithIp(auth.getUser(), auth.getUser_ip());
-        }
+        ConnectContext context = new ConnectContext();
+        UserIdentityUtils.setAuthInfoFromThrift(context, auth);
 
         // authorize
         try {
             if (authenticate) {
-                ConnectContext context = new ConnectContext();
-                context.setCurrentUserIdentity(currentUser);
-                context.setCurrentRoleIds(currentUser);
                 Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
             }
         } catch (AccessDeniedException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeMemoryUsage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeMemoryUsage.java
@@ -20,7 +20,6 @@ import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.memory.MemoryUsageTracker;
@@ -52,17 +51,9 @@ public class SysFeMemoryUsage {
 
     public static TFeMemoryRes listFeMemoryUsage(TFeMemoryReq request) throws TException {
         TAuthInfo auth = request.getAuth_info();
-        UserIdentity currentUser;
-        if (auth.isSetCurrent_user_ident()) {
-            currentUser = UserIdentityUtils.fromThrift(auth.getCurrent_user_ident());
-        } else {
-            currentUser = UserIdentity.createAnalyzedUserIdentWithIp(auth.getUser(), auth.getUser_ip());
-        }
-
+        ConnectContext context = new ConnectContext();
+        UserIdentityUtils.setAuthInfoFromThrift(context, auth);
         try {
-            ConnectContext context = new ConnectContext();
-            context.setCurrentUserIdentity(currentUser);
-            context.setCurrentRoleIds(currentUser);
             Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
         } catch (AccessDeniedException e) {
             throw new TException(e.getMessage(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
@@ -325,7 +325,7 @@ public class MysqlProto {
             MysqlCodec.writeNulTerminateString(outputStream, switchAuthPlugin);
 
             byte[] authSwitchRequestPacket =
-                    provider.authSwitchRequestPacket(context.getAuthenticationContext(), user,
+                    provider.authSwitchRequestPacket(context.getAccessControlContext(), user,
                             context.getMysqlChannel().getRemoteIp());
             if (authSwitchRequestPacket != null) {
                 MysqlCodec.writeBytes(outputStream, authSwitchRequestPacket);
@@ -333,7 +333,7 @@ public class MysqlProto {
             MysqlCodec.writeInt1(outputStream, 0);
         } else {
             // AuthMoreData Packet
-            byte[] authMoreDataPacket = provider.authMoreDataPacket(context.getAuthenticationContext(), user,
+            byte[] authMoreDataPacket = provider.authMoreDataPacket(context.getAccessControlContext(), user,
                     context.getMysqlChannel().getRemoteIp());
             if (authMoreDataPacket != null) {
                 MysqlCodec.writeInt1(outputStream, (byte) 0x01);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -40,9 +40,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.starrocks.authentication.AuthenticationContext;
+import com.starrocks.authentication.AccessControlContext;
 import com.starrocks.authentication.AuthenticationProvider;
-import com.starrocks.authentication.UserIdentityUtils;
 import com.starrocks.authentication.UserProperty;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.ObjectType;
@@ -89,10 +88,8 @@ import com.starrocks.sql.optimizer.dump.DumpInfo;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.spm.SQLPlanStorage;
-import com.starrocks.thrift.TAuthInfo;
 import com.starrocks.thrift.TPipelineProfileLevel;
 import com.starrocks.thrift.TUniqueId;
-import com.starrocks.thrift.TUserIdentity;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -169,17 +166,8 @@ public class ConnectContext {
     // Db
     protected String currentDb = "";
 
-    // Authentication context that encapsulates authentication and authorization information
-    protected AuthenticationContext authenticationContext = new AuthenticationContext();
-
-    // currentRoleIds is the role that has taken effect in the current session.
-    // Note that this set is not all roles belonging to the current user.
-    // `execute as` will modify currentRoleIds and assign the active role of the impersonate user to currentRoleIds.
-    // For specific logic, please refer to setCurrentRoleIds.
-    private Set<Long> currentRoleIds = new HashSet<>();
-
-    // groups of current user
-    private Set<String> groups = new HashSet<>();
+    // Unified access control context holding authentication and authorization information
+    protected AccessControlContext accessControlContext = new AccessControlContext();
 
     // Serializer used to pack MySQL packet.
     protected MysqlSerializer serializer;
@@ -227,9 +215,6 @@ public class ConnectContext {
 
     protected boolean isMetadataContext = false;
     protected boolean needQueued = true;
-
-    // Bypass the authorizer check for certain cases
-    protected boolean bypassAuthorizerCheck = false;
 
     protected DumpInfo dumpInfo;
 
@@ -458,36 +443,36 @@ public class ConnectContext {
     }
 
     public String getQualifiedUser() {
-        return authenticationContext.getQualifiedUser();
+        return accessControlContext.getQualifiedUser();
     }
 
     public void setQualifiedUser(String qualifiedUser) {
-        authenticationContext.setQualifiedUser(qualifiedUser);
+        accessControlContext.setQualifiedUser(qualifiedUser);
     }
 
     public UserIdentity getCurrentUserIdentity() {
-        return authenticationContext.getCurrentUserIdentity();
+        return accessControlContext.getCurrentUserIdentity();
     }
 
     public void setCurrentUserIdentity(UserIdentity currentUserIdentity) {
-        authenticationContext.setCurrentUserIdentity(currentUserIdentity);
+        accessControlContext.setCurrentUserIdentity(currentUserIdentity);
     }
 
     public void setDistinguishedName(String distinguishedName) {
-        authenticationContext.setDistinguishedName(distinguishedName);
+        accessControlContext.setDistinguishedName(distinguishedName);
     }
 
     public String getDistinguishedName() {
-        return authenticationContext.getDistinguishedName();
+        return accessControlContext.getDistinguishedName();
     }
 
     public Set<Long> getCurrentRoleIds() {
-        return currentRoleIds;
+        return accessControlContext.getCurrentRoleIds();
     }
 
     public void setCurrentRoleIds(UserIdentity user) {
         if (user.isEphemeral()) {
-            this.currentRoleIds = new HashSet<>();
+            accessControlContext.setCurrentRoleIds(new HashSet<>());
         } else {
             try {
                 Set<Long> defaultRoleIds;
@@ -496,84 +481,66 @@ public class ConnectContext {
                 } else {
                     defaultRoleIds = globalStateMgr.getAuthorizationMgr().getDefaultRoleIdsByUser(user);
                 }
-                this.currentRoleIds = defaultRoleIds;
+                accessControlContext.setCurrentRoleIds(defaultRoleIds);
             } catch (PrivilegeException e) {
                 LOG.warn("Set current role fail : {}", e.getMessage());
             }
         }
     }
 
-    public void setCurrentRoleIds(Set<Long> roleIds) {
-        this.currentRoleIds = roleIds;
-    }
-
     public void setCurrentRoleIds(UserIdentity userIdentity, Set<String> groups) {
         setCurrentRoleIds(userIdentity);
     }
 
-    public void setAuthInfoFromThrift(TAuthInfo authInfo) {
-        if (authInfo.isSetCurrent_user_ident()) {
-            setAuthInfoFromThrift(authInfo.getCurrent_user_ident());
-        } else {
-            setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp(authInfo.user, authInfo.user_ip));
-            setCurrentRoleIds(getCurrentUserIdentity());
-        }
-    }
-
-    public void setAuthInfoFromThrift(TUserIdentity tUserIdent) {
-        setCurrentUserIdentity(UserIdentityUtils.fromThrift(tUserIdent));
-        if (tUserIdent.isSetCurrent_role_ids()) {
-            setCurrentRoleIds(new HashSet<>(tUserIdent.current_role_ids.getRole_id_list()));
-        } else {
-            setCurrentRoleIds(getCurrentUserIdentity());
-        }
+    public void setCurrentRoleIds(Set<Long> roleIds) {
+        accessControlContext.setCurrentRoleIds(roleIds);
     }
 
     public Set<String> getGroups() {
-        return groups;
+        return accessControlContext.getGroups();
     }
 
     public void setGroups(Set<String> groups) {
-        this.groups = groups;
+        accessControlContext.setGroups(groups);
     }
 
     public String getAuthToken() {
-        return authenticationContext.getAuthToken();
+        return accessControlContext.getAuthToken();
     }
 
     public void setAuthToken(String authToken) {
-        authenticationContext.setAuthToken(authToken);
+        accessControlContext.setAuthToken(authToken);
     }
 
     public AuthenticationProvider getAuthenticationProvider() {
-        return authenticationContext.getAuthenticationProvider();
+        return accessControlContext.getAuthenticationProvider();
     }
 
     public void setAuthPlugin(String authPlugin) {
-        authenticationContext.setAuthPlugin(authPlugin);
+        accessControlContext.setAuthPlugin(authPlugin);
     }
 
     public String getAuthPlugin() {
-        return authenticationContext.getAuthPlugin();
+        return accessControlContext.getAuthPlugin();
     }
 
     public void setAuthDataSalt(byte[] authDataSalt) {
-        authenticationContext.setAuthDataSalt(authDataSalt);
+        accessControlContext.setAuthDataSalt(authDataSalt);
     }
 
     public String getSecurityIntegration() {
-        return authenticationContext.getSecurityIntegration();
+        return accessControlContext.getSecurityIntegration();
     }
 
     public void setSecurityIntegration(String securityIntegration) {
-        authenticationContext.setSecurityIntegration(securityIntegration);
+        accessControlContext.setSecurityIntegration(securityIntegration);
     }
 
     /**
      * Get the authentication context for this connection
      */
-    public AuthenticationContext getAuthenticationContext() {
-        return authenticationContext;
+    public AccessControlContext getAccessControlContext() {
+        return accessControlContext;
     }
 
     public void modifySystemVariable(SystemVariable setVar, boolean onlySetSessionVar) throws DdlException {
@@ -1095,11 +1062,11 @@ public class ConnectContext {
     }
 
     public boolean isBypassAuthorizerCheck() {
-        return bypassAuthorizerCheck;
+        return accessControlContext.isBypassAuthorizerCheck();
     }
 
     public void setBypassAuthorizerCheck(boolean value) {
-        this.bypassAuthorizerCheck = value;
+        accessControlContext.setBypassAuthorizerCheck(value);
     }
 
     public ConnectContext getParent() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -421,7 +421,7 @@ public class ConnectProcessor {
                         return;
                     }
 
-                    authenticationProvider.checkLoginSuccess(ctx.getConnectionId(), ctx.getAuthenticationContext());
+                    authenticationProvider.checkLoginSuccess(ctx.getConnectionId(), ctx.getAccessControlContext());
                 } catch (AuthenticationException authenticationException) {
                     if (authenticationException.getErrorCode() != null) {
                         ErrorReport.report(authenticationException.getErrorCode(), authenticationException.getMessage());

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationHandlerTest.java
@@ -98,7 +98,7 @@ public class AuthenticationHandlerTest {
         ldapGroupProvider.setUserToGroupCache(groups);
 
         ConnectContext context = new ConnectContext();
-        AuthenticationContext authCtx = context.getAuthenticationContext();
+        AccessControlContext authCtx = context.getAccessControlContext();
         AuthenticationHandler.authenticate(context, "ldap_user", "%", "\0".getBytes(StandardCharsets.UTF_8));
 
         Assertions.assertEquals("ldap_user", authCtx.getQualifiedUser());

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationManagerTest.java
@@ -124,7 +124,7 @@ public class AuthenticationManagerTest {
                 masterManager.getBestMatchedUserIdentity(testUser.getUser(), "10.1.1.2");
         PlainPasswordAuthenticationProvider provider = new PlainPasswordAuthenticationProvider(entry.getValue().getPassword());
         Assertions.assertThrows(AuthenticationException.class, () ->
-                provider.authenticate(ctx.getAuthenticationContext(), entry.getKey(), scramble));
+                provider.authenticate(ctx.getAccessControlContext(), entry.getKey(), scramble));
 
         // start to replay
         AuthenticationMgr followerManager = new AuthenticationMgr();
@@ -168,7 +168,7 @@ public class AuthenticationManagerTest {
         Map.Entry<UserIdentity, UserAuthenticationInfo> entry1 =
                 followerManager.getBestMatchedUserIdentity(testUser.getUser(), "10.1.1.2");
         Assertions.assertThrows(AuthenticationException.class, () ->
-                provider.authenticate(ctx.getAuthenticationContext(), entry1.getKey(), scramble));
+                provider.authenticate(ctx.getAccessControlContext(), entry1.getKey(), scramble));
 
         // purely loaded from image
         AuthenticationMgr imageManager = new AuthenticationMgr();
@@ -181,7 +181,7 @@ public class AuthenticationManagerTest {
         Map.Entry<UserIdentity, UserAuthenticationInfo> entry2 =
                 followerManager.getBestMatchedUserIdentity(testUser.getUser(), "10.1.1.2");
         Assertions.assertThrows(AuthenticationException.class, () ->
-                provider.authenticate(ctx.getAuthenticationContext(), entry2.getKey(), scramble));
+                provider.authenticate(ctx.getAccessControlContext(), entry2.getKey(), scramble));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationProviderTest.java
@@ -68,7 +68,7 @@ public class AuthenticationProviderTest {
                     .create(info.getAuthPlugin(), new String(info.getPassword()));
 
             byte[] scramble = MysqlPassword.scramble(seed, password);
-            provider.authenticate(ctx.getAuthenticationContext(), testUserIdentity, scramble);
+            provider.authenticate(ctx.getAccessControlContext(), testUserIdentity, scramble);
         }
 
         // no password
@@ -76,11 +76,11 @@ public class AuthenticationProviderTest {
         UserAuthOptionAnalyzer.analyzeAuthOption(testUser, null);
         UserAuthenticationInfo info = new UserAuthenticationInfo(testUser, null);
         ctx.setAuthDataSalt(new byte[0]);
-        provider.authenticate(ctx.getAuthenticationContext(), testUserIdentity, new byte[0]);
+        provider.authenticate(ctx.getAccessControlContext(), testUserIdentity, new byte[0]);
         try {
             ctx.setAuthDataSalt("x".getBytes(StandardCharsets.UTF_8));
             provider.authenticate(
-                    ctx.getAuthenticationContext(),
+                    ctx.getAccessControlContext(),
                     testUserIdentity,
                     "xx".getBytes(StandardCharsets.UTF_8));
             Assertions.fail();
@@ -98,7 +98,7 @@ public class AuthenticationProviderTest {
         try {
             ctx.setAuthDataSalt(seed);
             provider.authenticate(
-                    ctx.getAuthenticationContext(),
+                    ctx.getAccessControlContext(),
                     testUserIdentity,
                     MysqlPassword.scramble(seed, "xx"));
             Assertions.fail();
@@ -109,7 +109,7 @@ public class AuthenticationProviderTest {
         try {
             ctx.setAuthDataSalt(seed);
             provider.authenticate(
-                    ctx.getAuthenticationContext(),
+                    ctx.getAccessControlContext(),
                     testUserIdentity,
                     MysqlPassword.scramble(seed, "bb"));
 
@@ -121,7 +121,7 @@ public class AuthenticationProviderTest {
             byte[] remotePassword = "bb".getBytes(StandardCharsets.UTF_8);
             ctx.setAuthDataSalt(null);
             provider.authenticate(
-                    ctx.getAuthenticationContext(),
+                    ctx.getAccessControlContext(),
                     testUserIdentity,
                     remotePassword);
 

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/ExecuteAsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/ExecuteAsExecutorTest.java
@@ -104,7 +104,7 @@ public class ExecuteAsExecutorTest {
         ConnectContext context = new ConnectContext();
         AuthenticationHandler.authenticate(context, "impersonate_user", "%", MysqlPassword.EMPTY_PASSWORD);
 
-        Assertions.assertEquals("impersonate_user", context.getAuthenticationContext().getQualifiedUser());
+        Assertions.assertEquals("impersonate_user", context.getAccessControlContext().getQualifiedUser());
         Assertions.assertEquals(Set.of("group1", "group2"), context.getGroups());
 
         ExecuteAsStmt executeAsStmt = new ExecuteAsStmt(new UserRef("u1", "%"), false);

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPAuthProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPAuthProviderTest.java
@@ -95,7 +95,7 @@ class LDAPAuthProviderTest {
                 "ou=People,dc=starrocks,dc=com", "uid",
                 providedDN);
 
-        AuthenticationContext authCtx = new AuthenticationContext();
+        AccessControlContext authCtx = new AccessControlContext();
         UserIdentity user = UserIdentity.createEphemeralUserIdent("ldap_user", "%");
         byte[] authResponse = "password\0".getBytes(StandardCharsets.UTF_8);
 
@@ -114,7 +114,7 @@ class LDAPAuthProviderTest {
                 /* ldapUserDN */ null
         );
 
-        AuthenticationContext authCtx = new AuthenticationContext();
+        AccessControlContext authCtx = new AccessControlContext();
         UserIdentity user = UserIdentity.createEphemeralUserIdent("ldap_user", "%");
         byte[] authResponse = "password\0".getBytes(StandardCharsets.UTF_8);
 

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/OpenIdConnectAuthenticationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/OpenIdConnectAuthenticationTest.java
@@ -46,7 +46,7 @@ public class OpenIdConnectAuthenticationTest {
         serializer.writeInt1(0);
         serializer.writeLenEncodedString(openIdConnectJson);
         try {
-            provider.authenticate(new ConnectContext().getAuthenticationContext(), new UserIdentity("harbor", "%"),
+            provider.authenticate(new ConnectContext().getAccessControlContext(), new UserIdentity("harbor", "%"),
                     serializer.toArray());
         } catch (Exception e) {
             Assertions.fail(e.getMessage());

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/SecurityIntegrationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/SecurityIntegrationTest.java
@@ -211,7 +211,7 @@ public class SecurityIntegrationTest {
 
         Assertions.assertThrows(AuthenticationException.class, () ->
                 ldapAuthProviderForNative.authenticate(
-                        context.getAuthenticationContext(),
+                        context.getAccessControlContext(),
                         new UserIdentity("admin", "%"),
                         "x".getBytes(StandardCharsets.UTF_8)));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/OAuth2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/OAuth2Test.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.http.rest;
 
-import com.starrocks.authentication.AuthenticationContext;
+import com.starrocks.authentication.AccessControlContext;
 import com.starrocks.authentication.AuthenticationException;
 import com.starrocks.authentication.OAuth2AuthenticationProvider;
 import com.starrocks.authentication.OAuth2Context;
@@ -42,7 +42,7 @@ public class OAuth2Test {
     private OAuth2Context oAuth2Context;
     private OAuth2AuthenticationProvider oAuth2Provider;
     private OAuth2Action oAuth2Action;
-    private AuthenticationContext authContext;
+    private AccessControlContext authContext;
     private UserIdentity userIdentity;
 
     @BeforeEach
@@ -65,7 +65,7 @@ public class OAuth2Test {
 
         oAuth2Provider = new OAuth2AuthenticationProvider(oAuth2Context);
         oAuth2Action = new OAuth2Action(null);
-        authContext = new AuthenticationContext();
+        authContext = new AccessControlContext();
         userIdentity = UserIdentity.createEphemeralUserIdent("testuser", "localhost");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -37,7 +37,7 @@ package com.starrocks.qe;
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.AccessTestUtil;
-import com.starrocks.authentication.AuthenticationContext;
+import com.starrocks.authentication.AccessControlContext;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.authentication.PlainPasswordAuthenticationProvider;
 import com.starrocks.authorization.PrivilegeBuiltinConstants;
@@ -320,9 +320,9 @@ public class ConnectProcessorTest extends DDLTestBase {
                 minTimes = 0;
                 result = MysqlCapability.DEFAULT_CAPABILITY;
 
-                context.getAuthenticationContext();
+                context.getAccessControlContext();
                 minTimes = 0;
-                result = new AuthenticationContext();
+                result = new AccessControlContext();
 
                 context.getAuthenticationProvider();
                 minTimes = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectionTest.java
@@ -241,7 +241,7 @@ public class ConnectionTest {
         TAuthInfo tAuthInfo = new TAuthInfo();
         tAuthInfo.setUser("user");
         tAuthInfo.setUser_ip("%");
-        context.setAuthInfoFromThrift(tAuthInfo);
+        UserIdentityUtils.setAuthInfoFromThrift(context, tAuthInfo);
         Assertions.assertEquals("user", context.getCurrentUserIdentity().getUser());
     }
 

--- a/fe/fe-spi/src/main/java/com/starrocks/authentication/AccessControlContext.java
+++ b/fe/fe-spi/src/main/java/com/starrocks/authentication/AccessControlContext.java
@@ -16,11 +16,17 @@ package com.starrocks.authentication;
 
 import com.starrocks.catalog.UserIdentity;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
- * AuthenticationContext encapsulates authentication and authorization information for a connection session.
+ * AccessControlContext encapsulates authentication and authorization information for a connection session.
  * This includes user identity, roles, groups, and authentication-related metadata.
+ * <p>
+ * AccessControlContext unifies both the previous AuthenticationContext and AuthorizationContext
+ * so that identity, auth metadata, role/group memberships, and access-control flags live together.
  */
-public class AuthenticationContext {
+public class AccessControlContext {
     // `qualifiedUser` is the user used when the user establishes connection and authentication.
     // It is the real user used for this connection.
     // Different from the `currentUserIdentity` authentication user of execute as,
@@ -56,7 +62,16 @@ public class AuthenticationContext {
     // Auth Data salt generated at mysql negotiate used for password salting
     private byte[] authDataSalt = null;
 
-    public AuthenticationContext() {
+    // groups of current user
+    private Set<String> groups = new HashSet<>();
+
+    // currentRoleIds is the role that has taken effect in the current session.
+    private Set<Long> currentRoleIds = new HashSet<>();
+
+    // Bypass the authorizer check for certain cases
+    private boolean bypassAuthorizerCheck = false;
+
+    public AccessControlContext() {
         // Default constructor
     }
 
@@ -123,4 +138,30 @@ public class AuthenticationContext {
     public void setSecurityIntegration(String securityIntegration) {
         this.securityIntegration = securityIntegration;
     }
+
+    public Set<Long> getCurrentRoleIds() {
+        return currentRoleIds;
+    }
+
+    public void setCurrentRoleIds(Set<Long> currentRoleIds) {
+        this.currentRoleIds = currentRoleIds;
+    }
+
+    public Set<String> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(Set<String> groups) {
+        this.groups = groups;
+    }
+
+    public boolean isBypassAuthorizerCheck() {
+        return bypassAuthorizerCheck;
+    }
+
+    public void setBypassAuthorizerCheck(boolean bypassAuthorizerCheck) {
+        this.bypassAuthorizerCheck = bypassAuthorizerCheck;
+    }
 }
+
+

--- a/fe/fe-spi/src/main/java/com/starrocks/authentication/AuthenticationProvider.java
+++ b/fe/fe-spi/src/main/java/com/starrocks/authentication/AuthenticationProvider.java
@@ -26,14 +26,14 @@ public interface AuthenticationProvider {
      * @param authResponse auth response received by mysql protocol
      * @throws AuthenticationException when authentication fail
      */
-    void authenticate(AuthenticationContext authContext, UserIdentity userIdentity, byte[] authResponse)
+    void authenticate(AccessControlContext authContext, UserIdentity userIdentity, byte[] authResponse)
             throws AuthenticationException;
 
     /**
      * Some special Authentication Methods need to pass more information, and authMoreDataPacket is a unified interface.
      * <a href="https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_auth_more_data.html">...</a>
      */
-    default byte[] authMoreDataPacket(AuthenticationContext authContext, String user, String host)
+    default byte[] authMoreDataPacket(AccessControlContext authContext, String user, String host)
             throws AuthenticationException {
         return null;
     }
@@ -44,12 +44,12 @@ public interface AuthenticationProvider {
      * server can send this packet tp ask client to use another authentication method.
      * <a href="https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_auth_switch_request.html">...</a>
      */
-    default byte[] authSwitchRequestPacket(AuthenticationContext authContext, String user, String host)
+    default byte[] authSwitchRequestPacket(AccessControlContext authContext, String user, String host)
             throws AuthenticationException {
         return null;
     }
 
-    default void checkLoginSuccess(int connectionId, AuthenticationContext authContext) throws AuthenticationException {
+    default void checkLoginSuccess(int connectionId, AccessControlContext authContext) throws AuthenticationException {
         // do nothing
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request refactors the authentication and authorization context handling in the codebase by replacing the use of `AuthenticationContext` with a new, unified `AccessControlContext`. It updates method signatures, provider interfaces, and the way authentication information is set and used throughout the system. Additionally, it introduces utility methods to streamline setting authentication info from Thrift objects and simplifies related code in system tables.

### Refactoring and Unification of Contexts

* Replaced all usages of `AuthenticationContext` with `AccessControlContext` in method signatures and class members, including in `ConnectContext`, authentication providers (e.g., `JWTAuthenticationProvider`, `LDAPAuthProvider`, `OAuth2AuthenticationProvider`, `PlainPasswordAuthenticationProvider`), and authentication handler methods. [[1]](diffhunk://#diff-0070e8c9c2ba6be48f27c29bdc63ce38d1ac597317a23fc379a85a8788530a91L43-L45) [[2]](diffhunk://#diff-0070e8c9c2ba6be48f27c29bdc63ce38d1ac597317a23fc379a85a8788530a91L172-R170) [[3]](diffhunk://#diff-3a756dfcdd4cc419aaa07b9394b9e711fba3b4f40703a439eaa59b0ea391d636L63-R68) [[4]](diffhunk://#diff-3a756dfcdd4cc419aaa07b9394b9e711fba3b4f40703a439eaa59b0ea391d636L79-R79) [[5]](diffhunk://#diff-3a756dfcdd4cc419aaa07b9394b9e711fba3b4f40703a439eaa59b0ea391d636L122-R122) [[6]](diffhunk://#diff-c74837d1f448ebc1e01a351497c5eef24df9aa367f61759bca80503ed0104ba5L44-R44) [[7]](diffhunk://#diff-9d3d171afafe2a9443850833032fc0e3c0c421e8a61a88de96f1cc9febe1ae32L74-R74) [[8]](diffhunk://#diff-4ab47b6988d005638cea62623f9069210cfba68d408f24731922241fbadd9a0bL45-R45) [[9]](diffhunk://#diff-4ab47b6988d005638cea62623f9069210cfba68d408f24731922241fbadd9a0bL83-R83) [[10]](diffhunk://#diff-4ab47b6988d005638cea62623f9069210cfba68d408f24731922241fbadd9a0bL101-R106) [[11]](diffhunk://#diff-a14d9609df43f634e4cf2f03fc08cc38f77cd67208b12135e781b05618e0e0f9L33-R33) [[12]](diffhunk://#diff-a14d9609df43f634e4cf2f03fc08cc38f77cd67208b12135e781b05618e0e0f9L60-R60) [[13]](diffhunk://#diff-425c24ba273152074cc685586d97a79f50272457b996cfb3b8909d2b78a301fdL328-R336)

### Utility Improvements

* Added `UserIdentityUtils.setAuthInfoFromThrift` methods to standardize and simplify the process of setting authentication and role information in `ConnectContext` from Thrift objects.

### System Table and Authorization Simplification

* Updated system tables (`SysFeLocks`, `SysFeMemoryUsage`, `SysObjectDependencies`, etc.) to use the new utility methods for setting authentication info, reducing duplicate code and improving clarity. [[1]](diffhunk://#diff-22bf6dac8cd1dbc1233d7f1cf9dd850344a00e7146da71a8bcce98e6e48bc8b1L218-R218) [[2]](diffhunk://#diff-dd13ef4480f0b5e7b13ab84d157bb3a012b9096b01ca8fd94dba30bb5ccf7122L77-L89) [[3]](diffhunk://#diff-a69d9c44891410a35ae9f0c0cf9c366779dd635b4f15292e2a4836084fbbb386L55-R56) [[4]](diffhunk://#diff-e7d9f4c653b61159f2c96e34113af9c97891257d7c515011b201616bc0d460d3L73-R73) [[5]](diffhunk://#diff-e7d9f4c653b61159f2c96e34113af9c97891257d7c515011b201616bc0d460d3L95-L97)

### Code Cleanup

* Removed unnecessary imports and old context/role management code, further simplifying the codebase. [[1]](diffhunk://#diff-0070e8c9c2ba6be48f27c29bdc63ce38d1ac597317a23fc379a85a8788530a91L92-L95) [[2]](diffhunk://#diff-dd13ef4480f0b5e7b13ab84d157bb3a012b9096b01ca8fd94dba30bb5ccf7122L28) [[3]](diffhunk://#diff-a69d9c44891410a35ae9f0c0cf9c366779dd635b4f15292e2a4836084fbbb386L23) [[4]](diffhunk://#diff-e7d9f4c653b61159f2c96e34113af9c97891257d7c515011b201616bc0d460d3L25) [[5]](diffhunk://#diff-0070e8c9c2ba6be48f27c29bdc63ce38d1ac597317a23fc379a85a8788530a91L231-L233)

These changes collectively improve the maintainability and clarity of authentication and authorization handling in the system by consolidating context management and reducing code duplication.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
