### PR TITLE
[BugFix] change tuning guide format

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/OperatorTuningGuides.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/OperatorTuningGuides.java
@@ -19,6 +19,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.qe.feedback.guide.TuningGuide;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -136,17 +137,17 @@ public class OperatorTuningGuides {
     public String getTuneGuidesInfo(boolean isFull) {
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<Integer, OperatorGuideInfo> entry : operatorIdToTuningGuideInfo.entrySet()) {
-            sb.append("PlanNode ").append(entry.getValue().nodeId).append(":").append("\n");
+            sb.append("[PlanNode ").append(entry.getValue().nodeId).append("] ");
             for (TuningGuide guide : entry.getValue().tuningGuides) {
-                sb.append(guide.getClass().getSimpleName()).append("\n");
+                sb.append("(").append(guide.getClass().getSimpleName()).append(") ");
                 if (isFull) {
-                    sb.append(guide.getDescription()).append("\n");
-                    sb.append(guide.getAdvice()).append("\n");
+                    sb.append("(").append(guide.getDescription()).append(") ");
+                    sb.append("(").append(guide.getAdvice()).append(") ");
                 }
             }
-            sb.append("\n");
+            sb.append(" ");
         }
-        return sb.toString();
+        return StringUtils.trim(sb.toString());
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

The PlanTuningGuide produces unrecognized strings in the query profile, leading to a failure in the `analyze profile` function. This results in an error stating, `Cannot invoke 'String.split(String)' because 'explainString' is null.`

To resolve this, we need to convert these strings into a recognizable format.


example:
```
     - DeployWaitTime[9] 26ms
     - DeployDataSize: 53419
     - BuildTuningGuides: PlanNode 12:
RightChildEstimationErrorTuningGuide
Reason: Right child statistics of JoinNode 12 hadbeen underestimated.
Advice: Adjust the distribution join executiontype and join plan to improve the performance. 

PlanNode 7:
RightChildEstimationErrorTuningGuide
Reason: Right child statistics of JoinNode 7 had been underestimated.
Advice: Adjust the distribution join execution type and join plan to improve the performance.
```


Fixes #62383

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
