### PR TITLE
[BugFix] FE audit log missing Client for submit-task flows

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/SqlTaskRunProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/SqlTaskRunProcessorTest.java
@@ -1,4 +1,16 @@
 // Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package com.starrocks.scheduler;
 
@@ -24,17 +36,24 @@ public class SqlTaskRunProcessorTest {
 
     @Test
     public void testAuditClientIpSetForSubmitTaskInsert(@Mocked StatementBase mockStmt,
-                                                        @Mocked com.starrocks.mysql.MysqlChannel mockChannel) throws Exception {
+                                                        @Mocked com.starrocks.mysql.MysqlChannel mockChannel)
+            throws Exception {
         // Prepare a parent session simulating the submitter connection
         ConnectContext parentCtx = new ConnectContext(null);
 
         // Mock parentCtx.getMysqlChannel() to return a channel with a concrete remote host:port
         final String expectedRemoteHostPort = "10.1.2.3:7777";
         new Expectations(parentCtx) {{
-            parentCtx.getMysqlChannel(); result = mockChannel; minTimes = 0;
-            mockChannel.getRemoteHostPortString(); result = expectedRemoteHostPort; minTimes = 0;
-            mockChannel.getRemoteIp(); result = "10.1.2.3"; minTimes = 0;
-        }};
+                parentCtx.getMysqlChannel();
+                result = mockChannel;
+                minTimes = 0;
+                mockChannel.getRemoteHostPortString();
+                result = expectedRemoteHostPort;
+                minTimes = 0;
+                mockChannel.getRemoteIp();
+                result = "10.1.2.3";
+                minTimes = 0;
+            }};
 
         // Build a minimal Task and TaskRun
         Task task = new Task("task_insert_select");
@@ -66,14 +85,24 @@ public class SqlTaskRunProcessorTest {
                 // Return a lightweight real instance; below we mock its heavy methods to no-op
                 return new StmtExecutor(c, s);
             }
+
             @Mock
-            public void addRunningQueryDetail(StatementBase s) { }
+            public void addRunningQueryDetail(StatementBase s) {
+            }
+
             @Mock
-            public void execute() { }
+            public void execute() {
+            }
+
             @Mock
-            public StatementBase getParsedStmt() { return null; }
+            public StatementBase getParsedStmt() {
+                return null;
+            }
+
             @Mock
-            public com.starrocks.proto.PQueryStatistics getQueryStatisticsForAuditLog() { return null; }
+            public com.starrocks.proto.PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
         };
 
         // Execute the processor; it should set clientIp from TaskRunContext.remoteIp

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/SqlTaskRunProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/SqlTaskRunProcessorTest.java
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.UUID;
+
+/**
+ * Verify that submit task based SQL records client IP into audit log via SqlTaskRunProcessor
+ * and that TaskRunContext propagates the remote host:port from the submitter.
+ */
+public class SqlTaskRunProcessorTest {
+
+    @Test
+    public void testAuditClientIpSetForSubmitTaskInsert(@Mocked StatementBase mockStmt,
+                                                        @Mocked com.starrocks.mysql.MysqlChannel mockChannel) throws Exception {
+        // Prepare a parent session simulating the submitter connection
+        ConnectContext parentCtx = new ConnectContext(null);
+
+        // Mock parentCtx.getMysqlChannel() to return a channel with a concrete remote host:port
+        final String expectedRemoteHostPort = "10.1.2.3:7777";
+        new Expectations(parentCtx) {{
+            parentCtx.getMysqlChannel(); result = mockChannel; minTimes = 0;
+            mockChannel.getRemoteHostPortString(); result = expectedRemoteHostPort; minTimes = 0;
+            mockChannel.getRemoteIp(); result = "10.1.2.3"; minTimes = 0;
+        }};
+
+        // Build a minimal Task and TaskRun
+        Task task = new Task("task_insert_select");
+        task.setCatalogName("internal");
+        task.setDbName("db1");
+        task.setDefinition("INSERT INTO t SELECT 1");
+
+        TaskRun taskRun = new TaskRun();
+        taskRun.setTask(task);
+        taskRun.setConnectContext(parentCtx);
+        // Initialize properties map to avoid NPE inside buildTaskRunContext
+        taskRun.setProperties(new java.util.HashMap<>());
+        taskRun.initStatus(UUID.randomUUID().toString(), System.currentTimeMillis());
+
+        // Build the TaskRunContext and ensure the remote host:port is propagated
+        TaskRunContext trc = taskRun.buildTaskRunContext();
+        Assertions.assertEquals(expectedRemoteHostPort, trc.getRemoteIp());
+
+        // Mock parsing and execution to avoid heavy dependencies using MockUp
+        new MockUp<SqlParser>() {
+            @Mock
+            public java.util.List<StatementBase> parse(String sql, com.starrocks.qe.SessionVariable sv) {
+                return Collections.singletonList(mockStmt);
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public static StmtExecutor newInternalExecutor(ConnectContext c, StatementBase s) {
+                // Return a lightweight real instance; below we mock its heavy methods to no-op
+                return new StmtExecutor(c, s);
+            }
+            @Mock
+            public void addRunningQueryDetail(StatementBase s) { }
+            @Mock
+            public void execute() { }
+            @Mock
+            public StatementBase getParsedStmt() { return null; }
+            @Mock
+            public com.starrocks.proto.PQueryStatistics getQueryStatisticsForAuditLog() { return null; }
+        };
+
+        // Execute the processor; it should set clientIp from TaskRunContext.remoteIp
+        SqlTaskRunProcessor processor = new SqlTaskRunProcessor();
+        processor.processTaskRun(trc);
+
+        String clientIpInAudit = trc.getCtx().getAuditEventBuilder().build().clientIp;
+        Assertions.assertEquals(expectedRemoteHostPort, clientIpInAudit);
+    }
+}


### PR DESCRIPTION
Bug
- Normal SELECT audit logs contain Client, but submit-task INSERT SELECT/CTAS/DataCache Select miss Client in fe.audit.log.

Root Cause
- SqlTaskRunProcessor sets AuditEvent.clientIp from TaskRunContext.remoteIp.
- TaskRun.buildTaskRunContext() used runCtx.getMysqlChannel().getRemoteHostPortString() on an internal ConnectContext (no real connection), producing empty string.

Fix
- Propagate submitter's remote address from parent ConnectContext:
  - In buildTaskRunConnectContext(): copy parent remoteIP into internal ConnectContext for downstream logic.
  - In buildTaskRunContext(): set remoteIp preferring parent MysqlChannel host:port, then parent remoteIP, then runCtx host:port.
- This makes SqlTaskRunProcessor write correct Client for submit-task flows.

Test
- Add SqlTaskRunProcessorTest to verify TaskRunContext.remoteIp propagates submitter host:port and AuditEvent.clientIp equals it after processing.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
