### PR TITLE
test topk filter storage pushdown

### DIFF
--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -369,9 +369,10 @@ Status ChunkPredicateBuilder<E, Type>::_build_bitset_in_predicates(PredicateComp
         if (slot_desc == nullptr) {
             continue;
         }
-        if (desc->is_stream_build_filter()) {
-            continue;
-        }
+        // Enable TopN/Aggregate filters for storage-level optimization
+        // if (desc->is_stream_build_filter()) {
+        //     continue;
+        // }
 
         // The un-arrived runtime filter will not be added to the predicate tree,
         // but will be added to `RuntimeFilterPredicates` by `get_runtime_filter_predicates`.
@@ -1163,9 +1164,10 @@ Status ChunkPredicateBuilder<E, Type>::_get_column_predicates(PredicateParser* p
             if (slot_desc == nullptr) {
                 continue;
             }
-            if (desc->is_stream_build_filter()) {
-                continue;
-            }
+            // Enable TopN/Aggregate filters for storage-level optimization
+            // if (desc->is_stream_build_filter()) {
+            //     continue;
+            // }
 
             auto column_id = parser->column_id(*slot_desc);
             // Connector scan only use parsed predicate_tree to filter with statistics but not with data rows,
@@ -1369,9 +1371,10 @@ StatusOr<RuntimeFilterPredicates> ScanConjunctsManager::get_runtime_filter_predi
         if (slot_desc == nullptr) {
             continue;
         }
-        if (desc->is_stream_build_filter()) {
-            continue;
-        }
+        // Enable TopN/Aggregate filters for storage-level optimization
+        // if (desc->is_stream_build_filter()) {
+        //     continue;
+        // }
         // If the runtime filter's partition-by-exprs's size is greater than 1, skip to push it down to storage engine.
         if (desc->num_partition_by_exprs() > 1) {
             continue;


### PR DESCRIPTION
## Why I'm doing:
topk filter pushdown to scannode

## What I'm doing:
Seems like all the things for topk rf pushdown is there. Just commenting out skip checks.
Fixes https://github.com/StarRocks/starrocks/issues/63030

table with 200kk rows
```
select id from transactions order by amount limit 10;
10 rows in set (0.30 sec)
```
profile info:
```
                 - RemainingRowsAfterShortKeyFilter: 218.027M (218027066)
                   - __MAX_OF_RemainingRowsAfterShortKeyFilter: 7.845M (7845024)
                   - __MIN_OF_RemainingRowsAfterShortKeyFilter: 5.470M (5469606)
                 - SegmentRuntimeZoneMapFilterRows: 215.232M (215231880)
                   - __MAX_OF_SegmentRuntimeZoneMapFilterRows: 7.794M (7794253)
                   - __MIN_OF_SegmentRuntimeZoneMapFilterRows: 5.453M (5453222)
             - RawRowsRead: 2.795M (2795186)
               - __MAX_OF_RawRowsRead: 278.528K (278528)
               - __MIN_OF_RawRowsRead: 0
             - ReadPagesNum: 699
               - __MAX_OF_ReadPagesNum: 70
               - __MIN_OF_ReadPagesNum: 0
             - RowsRead: 2.092M (2091647)
               - __MAX_OF_RowsRead: 262.147K (262147)
               - __MIN_OF_RowsRead: 0
             - RuntimeFilterEvalTime: 44.925us
               - __MAX_OF_RuntimeFilterEvalTime: 248.173us
               - __MIN_OF_RuntimeFilterEvalTime: 0ns
             - RuntimeFilterInputRows: 2.795M (2795186)
               - __MAX_OF_RuntimeFilterInputRows: 278.528K (278528)
               - __MIN_OF_RuntimeFilterInputRows: 0
             - RuntimeFilterOutputRows: 2.092M (2091647)
               - __MAX_OF_RuntimeFilterOutputRows: 262.147K (262147)
               - __MIN_OF_RuntimeFilterOutputRows: 0
```
So we read almost 3kk rows, chuck level rf is reported as RuntimeFilterInputRows and RuntimeFilterOutputRows
Storage level is done all the work SegmentRuntimeZoneMapFilterRows 215.232M

So the question is can we safely enable the optimisation and how do we want to update explain analyze output for RuntimeFilter row?

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows stream-build (TopN/Aggregate) runtime filters to be pushed down to storage, including bitset filters and placeholder predicates.
> 
> - **Runtime filter pushdown (storage)**:
>   - Enable handling of `is_stream_build_filter` descriptors in `be/src/exec/olap_scan_prepare.cpp` by removing skip checks.
>   - Include BITSET runtime filters in predicate tree construction and mark as index-only where applicable.
>   - Add placeholder predicates and set `has_push_down_to_storage` for these filters during scan preparation.
>   - Apply same enablement when collecting runtime filter predicates (skipping only multi-partition filters).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 661a5e68a50a99b96ba47958f6f6ca3fb53bbd7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->