### PR TITLE
[BugFix] Fix null exception during remove expired load job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -391,14 +391,15 @@ public class LoadMgr implements MemoryTrackable {
         // 2. remove from dbIdToLabelToLoadJobs
         Map<String, List<LoadJob>> labelToLoadJobs = dbIdToLabelToLoadJobs.get(dbId);
         List<LoadJob> sameLabelJobs = labelToLoadJobs.get(label);
-        sameLabelJobs.remove(job);
-        if (sameLabelJobs.isEmpty()) {
-            labelToLoadJobs.remove(label);
+        if (sameLabelJobs != null) {
+            sameLabelJobs.remove(job);
+            if (sameLabelJobs.isEmpty()) {
+                labelToLoadJobs.remove(label);
+            }
+            if (labelToLoadJobs.isEmpty()) {
+                dbIdToLabelToLoadJobs.remove(dbId);
+            }
         }
-        if (labelToLoadJobs.isEmpty()) {
-            dbIdToLabelToLoadJobs.remove(dbId);
-        }
-
         // 3. remove spark launcher log
         if (job instanceof SparkLoadJob) {
             ((SparkLoadJob) job).clearSparkLauncherLog();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -330,7 +330,12 @@ public class LoadMgr implements MemoryTrackable {
                 .build());
         if (isJobExpired(job, System.currentTimeMillis())) {
             LOG.info("remove expired job: {}", job);
-            unprotectedRemoveJobReleatedMeta(job);
+            writeLock();
+            try {
+                unprotectedRemoveJobReleatedMeta(job);
+            } finally {
+                writeUnlock();
+            }
         }
     }
 
@@ -346,7 +351,12 @@ public class LoadMgr implements MemoryTrackable {
 
         if (isJobExpired(job, System.currentTimeMillis())) {
             LOG.info("remove expired job: {}", job);
-            unprotectedRemoveJobReleatedMeta(job);
+            writeLock();
+            try {
+                unprotectedRemoveJobReleatedMeta(job);
+            } finally {
+                writeUnlock();
+            }
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
The `unprotectedRemoveJobReleatedMeta` method in `LoadMgr `was throwing NullPointerException when trying to remove expired load jobs. The issue occurred when sameLabelJobs was null, expired LoadJobs fail to be cleaned up, which in turn leads to high memory usage on the FE.
### Root Cause Analysis
The null pointer exception was caused by a race condition between two concurrent operations:
1. Periodic cleanup thread: LoadLabelCleaner daemon that runs every label_clean_interval_second seconds
2. Journal replay thread: replayer daemon that processes journal logs without proper synchronization
Specific scenarios that triggered the issue:
+ Duplicate cleanup: The same job could be cleaned up by both the periodic cleaner and journal replay simultaneously
+ Data inconsistency: idToLoadJob and dbIdToLabelToLoadJobs could become inconsistent during concurrent modifications
+ Missing synchronization: Journal replay operations (replayEndLoadJob, replayUpdateLoadJobStateInfo) were not protected by locks, while periodic cleanup used write locks

Timeline of the race condition:
```
T1: Cleanup thread acquires write lock, removes job from idToLoadJob
T2: Cleanup thread removes job from dbIdToLabelToLoadJobs  
T3: Journal replay thread processes END_LOAD_JOB log for the same job
T4: Journal replay calls unprotectedRemoveJobReleatedMeta(job)
T5: sameLabelJobs = labelToLoadJobs.get(label) returns null ❌
T6: NullPointerException when calling sameLabelJobs.remove(job)
```

## What I'm doing:
Added null safety checks in unprotectedRemoveJobReleatedMeta method to prevent NullPointerException:


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
