### PR TITLE
[BugFix] fix iceberg manifest cache npe in data race condition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
@@ -17,6 +17,7 @@ package org.apache.iceberg;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.PlanMode;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -256,12 +257,12 @@ public class StarRocksIcebergTableScan
     }
 
     private CloseableIterable<FileScanTask> planTaskWithCache(List<ManifestFile> dataManifests) {
-        List<ManifestFile> dataManifestWithCache = new ArrayList<>();
+        List<Pair<ManifestFile, Set<DataFile>>> dataManifestWithCache = new ArrayList<>();
         List<ManifestFile> dataManifestWithoutCache = new ArrayList<>();
         for (ManifestFile manifestFile : dataManifests) {
             Set<DataFile> dataFiles = dataFileCache.getIfPresent(manifestFile.path());
             if (dataFiles != null && !dataFiles.isEmpty()) {
-                dataManifestWithCache.add(manifestFile);
+                dataManifestWithCache.add(new Pair(manifestFile, dataFiles));
                 scanMetrics().scannedDataManifests().increment();
             } else {
                 if (!onlyReadCache) {
@@ -284,20 +285,19 @@ public class StarRocksIcebergTableScan
         }
     }
 
-    private CloseableIterable<FileScanTask> filterDataFiles(ManifestFile manifestFile) {
-        CloseableIterable<DataFile> matchedDataFiles = CloseableIterable.withNoopClose(
-                dataFileCache.getIfPresent(manifestFile.path()));
+    private CloseableIterable<FileScanTask> filterDataFiles(Pair<ManifestFile, Set<DataFile>> manifestFile) {
+        CloseableIterable<DataFile> matchedDataFiles = CloseableIterable.withNoopClose(manifestFile.second);
 
         if (filter() != Expressions.alwaysTrue()) {
-            matchedDataFiles =  CloseableIterable.filter(
+            matchedDataFiles = CloseableIterable.filter(
                     scanMetrics().skippedDataFiles(),
-                    CloseableIterable.withNoopClose(dataFileCache.getIfPresent(manifestFile.path())),
+                    CloseableIterable.withNoopClose(manifestFile.second),
                     file -> partitionEvaluatorCache.get(file.specId()).eval(file.partition()));
         }
 
         if (dataFileCacheWithMetrics ||
                 (!tableSchema().identifierFieldIds().isEmpty() && enableCacheDataFileIdentifierColumnMetrics)) {
-            matchedDataFiles =  CloseableIterable.filter(
+            matchedDataFiles = CloseableIterable.filter(
                     scanMetrics().skippedDataFiles(),
                     matchedDataFiles,
                     file -> inclusiveMetricsEvaluatorCache.get(file.specId()).eval(file));


### PR DESCRIPTION
## Why I'm doing:

I spot the problem of NPE. and this NPE happens in data race condition.

And this is the java exception

```
2025-09-11 13:46:58.800+08:00 WARN (starrocks-mysql-nio-pool-5|2097) [StmtExecutor.execute():916] execute Exception, sql: {}, select count(*) from iceberg.zya.bigmeta version as of 8776018871460644152
java.lang.NullPointerException: Cannot invoke "java.lang.Iterable.iterator()" because "this.val$iterable" is null
        at org.apache.iceberg.io.CloseableIterable$1.iterator(CloseableIterable.java:71) ~[iceberg-api-1.9.0.jar:?]
        at org.apache.iceberg.io.CloseableIterable$7$1.<init>(CloseableIterable.java:205) ~[iceberg-api-1.9.0.jar:?]
        at org.apache.iceberg.io.CloseableIterable$7.iterator(CloseableIterable.java:204) ~[iceberg-api-1.9.0.jar:?]
        at org.apache.iceberg.io.CloseableIterable$7.iterator(CloseableIterable.java:196) ~[iceberg-api-1.9.0.jar:?]
        at org.apache.iceberg.util.ParallelIterable$Task.get(ParallelIterable.java:280) ~[iceberg-core-1.9.0.jar:?]
        at org.apache.iceberg.util.ParallelIterable$Task.get(ParallelIterable.java:244) ~[iceberg-core-1.9.0.jar:?]
        at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

And the root cause if during the check and use of manifest cache,  cache item could be evicted already.

## What I'm doing:

keep the cached result in the following stage, to avoid data race condition.

Fixes #62995

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
