### PR TITLE
[BugFix] Fix JSON extraction null column consistency and add validation checks

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -37,12 +37,12 @@ void BinaryColumnBase<T>::check_or_die() const {
     CHECK_EQ(_bytes.size(), _offsets.back());
     size_t size = this->size();
     for (size_t i = 0; i < size; i++) {
-        CHECK_GE(_offsets[i + 1], _offsets[i]);
+        DCHECK_GE(_offsets[i + 1], _offsets[i]);
     }
     if (_slices_cache) {
         for (size_t i = 0; i < size; i++) {
-            CHECK_EQ(_slices[i].data, get_slice(i).data);
-            CHECK_EQ(_slices[i].size, get_slice(i).size);
+            DCHECK_EQ(_slices[i].data, get_slice(i).data);
+            DCHECK_EQ(_slices[i].size, get_slice(i).size);
         }
     }
 }

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -574,6 +574,7 @@ static StatusOr<ColumnPtr> _extract_with_hyper(NativeJsonState* state, const std
     RETURN_IF_ERROR(transform.trans(json_column->get_flat_fields_ptrs()));
     auto res = transform.mutable_result();
     DCHECK_EQ(1, res.size());
+    res[0]->check_or_die();
     return res[0];
 }
 
@@ -657,13 +658,21 @@ StatusOr<ColumnPtr> JsonFunctions::_flat_json_query_impl(FunctionContext* contex
 
     } else {
         // full match
+        StatusOr<ColumnPtr> ret;
         if (ResultType != state->flat_column_type) {
             DCHECK(state->cast_expr != nullptr);
             Chunk chunk;
             chunk.append_column(flat_column, 0);
-            return state->cast_expr->evaluate_checked(nullptr, &chunk);
+            ret = state->cast_expr->evaluate_checked(nullptr, &chunk);
+        } else {
+            ret = std::move(flat_column->clone());
         }
-        return Column::mutate(std::move(flat_column));
+        if (ret.ok()) {
+            ret.value()->check_or_die();
+            return Column::mutate(std::move(ret.value()));
+        } else {
+            return ret;
+        }
     }
 }
 

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -218,8 +218,6 @@ Status JsonFlatColumnIterator::next_batch(size_t* n, Column* dst) {
     if (_null_iter != nullptr) {
         RETURN_IF_ERROR(_null_iter->next_batch(n, null_column));
         down_cast<NullableColumn*>(dst)->update_has_null();
-    } else if (dst->is_nullable()) {
-        null_column->append_value_multiple_times(&DATUM_NOT_NULL, *n);
     }
 
     // 2. Read flat column
@@ -246,8 +244,6 @@ Status JsonFlatColumnIterator::next_batch(const SparseRange<>& range, Column* ds
     if (_null_iter != nullptr) {
         RETURN_IF_ERROR(_null_iter->next_batch(range, null_column));
         down_cast<NullableColumn*>(dst)->update_has_null();
-    } else if (dst->is_nullable()) {
-        null_column->append_value_multiple_times(&DATUM_NOT_NULL, range.span_size());
     }
 
     // 2. Read flat column

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -218,11 +218,15 @@ Status JsonFlatColumnIterator::next_batch(size_t* n, Column* dst) {
     if (_null_iter != nullptr) {
         RETURN_IF_ERROR(_null_iter->next_batch(n, null_column));
         down_cast<NullableColumn*>(dst)->update_has_null();
+    } else if (dst->is_nullable()) {
+        null_column->append_value_multiple_times(&DATUM_NOT_NULL, *n);
     }
 
     // 2. Read flat column
     auto read = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(n, column); };
-    return _read(json_column, read);
+    auto ret = _read(json_column, read);
+    dst->check_or_die();
+    return ret;
 }
 
 Status JsonFlatColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
@@ -242,11 +246,15 @@ Status JsonFlatColumnIterator::next_batch(const SparseRange<>& range, Column* ds
     if (_null_iter != nullptr) {
         RETURN_IF_ERROR(_null_iter->next_batch(range, null_column));
         down_cast<NullableColumn*>(dst)->update_has_null();
+    } else if (dst->is_nullable()) {
+        null_column->append_value_multiple_times(&DATUM_NOT_NULL, range.span_size());
     }
 
     // 2. Read flat column
     auto read = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(range, column); };
-    return _read(json_column, read);
+    auto ret = _read(json_column, read);
+    dst->check_or_die();
+    return ret;
 }
 
 Status JsonFlatColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
@@ -266,7 +274,9 @@ Status JsonFlatColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size
     // 2. Read flat column
     auto read = [&](ColumnIterator* iter, Column* column) { return iter->fetch_values_by_rowid(rowids, size, column); };
 
-    return _read(json_column, read);
+    auto ret = _read(json_column, read);
+    values->check_or_die();
+    return ret;
 }
 
 Status JsonFlatColumnIterator::seek_to_first() {
@@ -398,6 +408,7 @@ Status JsonDynamicFlatIterator::_dynamic_flat(Column* output, FUNC read_fn) {
     _flattener->flatten(proxy.get());
     auto result = _flattener->mutable_result();
     json_data->set_flat_columns(_target_paths, _target_types, std::move(result));
+    output->check_or_die();
     return Status::OK();
 }
 
@@ -552,7 +563,9 @@ Status JsonMergeIterator::next_batch(size_t* n, Column* dst) {
     }
 
     auto func = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(n, column); };
-    return _merge(json_column, func);
+    auto ret = _merge(json_column, func);
+    dst->check_or_die();
+    return ret;
 }
 
 Status JsonMergeIterator::next_batch(const SparseRange<>& range, Column* dst) {
@@ -575,7 +588,9 @@ Status JsonMergeIterator::next_batch(const SparseRange<>& range, Column* dst) {
     }
 
     auto func = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(range, column); };
-    return _merge(json_column, func);
+    auto ret = _merge(json_column, func);
+    dst->check_or_die();
+    return ret;
 }
 
 Status JsonMergeIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* dst) {
@@ -598,7 +613,9 @@ Status JsonMergeIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t si
     }
 
     auto func = [&](ColumnIterator* iter, Column* column) { return iter->fetch_values_by_rowid(rowids, size, column); };
-    return _merge(json_column, func);
+    auto ret = _merge(json_column, func);
+    dst->check_or_die();
+    return ret;
 }
 
 Status JsonMergeIterator::seek_to_first() {

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -87,9 +87,8 @@ void extract_bool(const vpack::Slice* json, NullableColumn* result) {
         if (json->isNone() || json->isNull()) {
             result->append_nulls(1);
         } else if (json->isBool()) {
-            result->null_column()->append(0);
             auto res = json->getBool();
-            down_cast<RunTimeColumnType<TYPE_BOOLEAN>*>(result->data_column().get())->append(res);
+            result->append_datum(res);
         } else if (json->isString()) {
             vpack::ValueLength len;
             const char* str = json->getStringUnchecked(len);
@@ -100,15 +99,14 @@ void extract_bool(const vpack::Slice* json, NullableColumn* result) {
                 if (parseResult != StringParser::PARSE_SUCCESS) {
                     result->append_nulls(1);
                 } else {
-                    down_cast<RunTimeColumnType<TYPE_BOOLEAN>*>(result->data_column().get())->append(b);
+                    result->append_datum(b);
                 }
             } else {
-                down_cast<RunTimeColumnType<TYPE_BOOLEAN>*>(result->data_column().get())->append(r != 0);
+                result->append_datum(r != 0);
             }
         } else if (json->isNumber()) {
-            result->null_column()->append(0);
             auto res = json->getNumber<double>();
-            down_cast<RunTimeColumnType<TYPE_BOOLEAN>*>(result->data_column().get())->append(res != 0);
+            result->append_datum(res != 0);
         } else {
             result->append_nulls(1);
         }

--- a/be/src/util/json_flattener.h
+++ b/be/src/util/json_flattener.h
@@ -351,10 +351,4 @@ private:
     int64_t _merge_ms = 0;
 };
 
-// Extract functions for different JSON types
-void extract_bool(const vpack::Slice* json, NullableColumn* result);
-void extract_number(const vpack::Slice* json, NullableColumn* result);
-void extract_string(const vpack::Slice* json, NullableColumn* result);
-void extract_json(const vpack::Slice* json, NullableColumn* result);
-
 } // namespace starrocks

--- a/be/src/util/json_flattener.h
+++ b/be/src/util/json_flattener.h
@@ -351,4 +351,10 @@ private:
     int64_t _merge_ms = 0;
 };
 
+// Extract functions for different JSON types
+void extract_bool(const vpack::Slice* json, NullableColumn* result);
+void extract_number(const vpack::Slice* json, NullableColumn* result);
+void extract_string(const vpack::Slice* json, NullableColumn* result);
+void extract_json(const vpack::Slice* json, NullableColumn* result);
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:


**crash stack:**
```
PC: @     0x7fb6522127cd (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1a07cc)
*** SIGSEGV (@0x0) received by PID 47 (TID 0x7fb553fbc640) from PID 0; stack trace: ***
    @     0x7fb65210bee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xa37c109 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fb652f9f526 os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x7fb652fa521b JVM_handle_linux_signal
    @     0x7fb652f9807c signalHandler(int, siginfo_t*, void*)
    @     0x7fb6520b4520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7fb6522127cd (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1a07cc)
    @          0x5529d47 starrocks::FixedLengthColumnBase<unsigned char>::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0x550f18e starrocks::NullableColumn::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0x5467dea starrocks::Chunk::append(starrocks::Chunk const&, unsigned long, unsigned long)
    @          0x548090f starrocks::ChunkPipelineAccumulator::push(std::shared_ptr<starrocks::Chunk> const&)
    @          0x76f3eb0 starrocks::pipeline::ChunkAccumulateOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0x544d355 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x7ebcf08 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x8c00c23 starrocks::ThreadPool::dispatch_thread()
    @          0x8bf8279 starrocks::Thread::supervise_thread(void*)
    @     0x7fb652106ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7fb652198850 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x12684f)
```

**Bug Description:**
- The `extract_bool` function in `be/src/util/json_flattener.cpp` constructs a `NullableColumn` where the `data_column` is inconsistent with the `null_column`. This discrepancy leads to a crash during the subsequent execution of the `NullableColumn::append` function.
- Instead of appending both the data and null values to the column as expected, the function only appends to the `data_column`.

**Reproduction Case:**
- Activate the FlatJSON feature.
- Include non-boolean data within the JSON boolean field.
- Executing `get_json_bool` under these conditions triggers the crash.

**Workaround:**
- To bypass the issue, disable subfield pruning by using the following setting: `set cbo_prune_json_subfield=false`.

## What I'm doing:


This commit consolidates fixes for `get_json_bool` extraction issues:
1. Fix `extract_bool` function null column handling inconsistency:
   - Resolve mismatch between manual null column handling (bool/number types) 
     and append_datum() automatic handling (string types)
2. Add validation checks for JSON column operations:
	- Introduced `check_or_die()` calls to ensure column consistency. To maintain efficiency, the function has been optimized for minimal overhead. Specifically, `BinaryColumn::check_or_die()` now performs a lightweight validation using `DCHECK`, while other implementations utilize `DCHECK` for intensive checks and `CHECK` for simpler validations.   
	- Improve null handling in FlatJsonColumnIterator
   - Enhance error checking in JSON functions

The fixes ensure consistent null column and data column sizes across all JSON type extractions, preventing potential crashes and data corruption.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
