### PR TITLE
[Enhancement] Add fragment instance exec state report thread pool metrics

### DIFF
--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -24,6 +24,7 @@
 #include "runtime/exec_env.h"
 #include "service/backend_options.h"
 #include "util/network_util.h"
+#include "util/starrocks_metrics.h"
 #include "util/thrift_rpc_helper.h"
 
 namespace starrocks::pipeline {
@@ -247,7 +248,7 @@ Status ExecStateReporter::report_epoch(const TMVMaintenanceTasks& params, ExecEn
 }
 
 ExecStateReporter::ExecStateReporter(const CpuUtil::CpuIds& cpuids) {
-    auto status = ThreadPoolBuilder("ex_state_report") // exec state reporter
+    auto status = ThreadPoolBuilder("exec_state_report") // exec state reporter
                           .set_min_threads(1)
                           .set_max_threads(2)
                           .set_max_queue_size(1000)
@@ -257,8 +258,9 @@ ExecStateReporter::ExecStateReporter(const CpuUtil::CpuIds& cpuids) {
     if (!status.ok()) {
         LOG(FATAL) << "Cannot create thread pool for ExecStateReport: error=" << status.to_string();
     }
+    REGISTER_THREAD_POOL_METRICS(exec_state_report, _thread_pool);
 
-    status = ThreadPoolBuilder("priority_ex_state_report") // priority exec state reporter with infinite queue
+    status = ThreadPoolBuilder("priority_exec_state_report") // priority exec state reporter with infinite queue
                      .set_min_threads(1)
                      .set_max_threads(2)
                      .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
@@ -267,6 +269,7 @@ ExecStateReporter::ExecStateReporter(const CpuUtil::CpuIds& cpuids) {
     if (!status.ok()) {
         LOG(FATAL) << "Cannot create thread pool for priority ExecStateReport: error=" << status.to_string();
     }
+    REGISTER_THREAD_POOL_METRICS(priority_exec_state_report, _priority_thread_pool);
 }
 
 void ExecStateReporter::submit(std::function<void()>&& report_task, bool priority) {

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -375,6 +375,8 @@ public:
     METRICS_DEFINE_THREAD_POOL(compact_pool);
     METRICS_DEFINE_THREAD_POOL(pindex_load);
     METRICS_DEFINE_THREAD_POOL(put_aggregate_metadata);
+    METRICS_DEFINE_THREAD_POOL(exec_state_report);
+    METRICS_DEFINE_THREAD_POOL(priority_exec_state_report);
 
     METRIC_DEFINE_UINT_GAUGE(load_rpc_threadpool_size, MetricUnit::NOUNIT);
 

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -362,6 +362,8 @@ TEST_F(StarRocksMetricsTest, test_metrics_register) {
     assert_threadpool_metrics_register("replicate_snapshot", instance);
     assert_threadpool_metrics_register("load_channel", instance);
     assert_threadpool_metrics_register("merge_commit", instance);
+    assert_threadpool_metrics_register("exec_state_report", instance);
+    assert_threadpool_metrics_register("priority_exec_state_report", instance);
     ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_total"));
     ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_eos_total"));
     ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_duration_us"));

--- a/docs/zh/administration/management/monitoring/metrics.md
+++ b/docs/zh/administration/management/monitoring/metrics.md
@@ -1634,6 +1634,46 @@ displayed_sidebar: docs
 - 单位：个
 - 描述：Pipeline Prepare 线程池中排队的任务数量（瞬时值）。
 
+### starrocks_be_exec_state_report_active_threads
+
+- 单位：个
+- 描述：汇报 Fragment 实例执行状态的线程池中正在执行的任务数（瞬时值）。
+
+### starrocks_be_exec_state_report_running_threads
+
+- 单位：个
+- 描述：汇报 Fragment 实例执行状态的线程池的线程数（瞬时值），最小为 1，最大为 2。
+
+### starrocks_be_exec_state_report_threadpool_size
+
+- 单位：个
+- 描述：汇报 Fragment 实例执行状态的线程池的最大线程数（瞬时值），默认为 2。
+
+### starrocks_be_exec_state_report_queue_count
+
+- 单位：个
+- 描述：汇报 Fragment 实例执行状态的线程池中排队的任务数（瞬时值），最大为 1000。
+
+### starrocks_be_priority_exec_state_report_active_threads
+
+- 单位：个
+- 描述：汇报 Fragment 实例最终执行状态的线程池中正在执行的任务数（瞬时值）。
+
+### starrocks_be_priority_exec_state_report_running_threads
+
+- 单位：个
+- 描述：汇报 Fragment 实例最终执行状态的线程池的线程数（瞬时值），最小为 1，最大为 2。
+
+### starrocks_be_priority_exec_state_report_threadpool_size
+
+- 单位：个
+- 描述：汇报 Fragment 实例最终执行状态的线程池的最大线程数（瞬时值），默认为 2。
+
+### starrocks_be_priority_exec_state_report_queue_count
+
+- 单位：个
+- 描述：汇报 Fragment 实例最终执行状态的线程池中排队的任务数（瞬时值），最大为 2147483647。
+
 ### starrocks_fe_routine_load_jobs
 
 - 单位：个


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
# TYPE starrocks_be_exec_state_report_active_threads gauge
starrocks_be_exec_state_report_active_threads 0
# TYPE starrocks_be_exec_state_report_queue_count gauge
starrocks_be_exec_state_report_queue_count 0
# TYPE starrocks_be_exec_state_report_running_threads gauge
starrocks_be_exec_state_report_running_threads 1
# TYPE starrocks_be_exec_state_report_threadpool_size gauge
starrocks_be_exec_state_report_threadpool_size 2
# TYPE starrocks_be_priority_exec_state_report_active_threads gauge
starrocks_be_priority_exec_state_report_active_threads 0
# TYPE starrocks_be_priority_exec_state_report_queue_count gauge
starrocks_be_priority_exec_state_report_queue_count 0
# TYPE starrocks_be_priority_exec_state_report_running_threads gauge
starrocks_be_priority_exec_state_report_running_threads 1
# TYPE starrocks_be_priority_exec_state_report_threadpool_size gauge
starrocks_be_priority_exec_state_report_threadpool_size 2
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
