### PR TITLE
[Tool] Add CLEANUP block to SQL-tester for reliable per-case teardown

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -475,3 +475,28 @@ CONCURRENCY {
 
 } END CONCURRENCY
 ```
+
+### 10. CLEANUP
+
+Custom cleanup statements that run in tearDown for each case, regardless of pass/fail. This is useful for deleting objects (tables/databases/catalogs) or removing external side-effects.
+
+* Usage:
+
+```sql
+-- name: ${case name}
+...
+
+CLEANUP {
+  -- SQL statements must end with ';'
+  DROP TABLE IF EXISTS t1;
+  DROP DATABASE IF EXISTS db_${uuid0};
+
+  -- You can also run shell or function statements
+  shell: echo "cleanup ${uuid0}"
+  function: your_python_helper("arg1")
+} END CLEANUP
+```
+
+* Notes:
+* The framework's built-in cleanup (dropping parsed DATABASE/RESOURCE) still runs; CLEANUP is an addition for fine-grained or external cleanup.
+* Results in CLEANUP are not validated; failures will be logged but do not block other cleanup steps.

--- a/test/lib/__init__.py
+++ b/test/lib/__init__.py
@@ -44,6 +44,10 @@ PROPERTY_FLAG = "PROPERTY: "
 CONCURRENCY_FLAG = "CONCURRENCY"
 END_CONCURRENCY_FLAG = "END CONCURRENCY"
 
+# cleanup -- end cleanup
+CLEANUP_FLAG = "CLEANUP"
+END_CLEANUP_FLAG = "END CLEANUP"
+
 
 def close_conn(conn, conn_type):
     log.info(f"Try to close {conn_type} connection...")

--- a/test/lib/choose_cases.py
+++ b/test/lib/choose_cases.py
@@ -45,7 +45,7 @@ LOG_FILTERED_WARN = "You can use `--log_filtered` to show the details..."
 
 class ChooseCase(object):
     class CaseTR(object):
-        def __init__(self, ctx, name, file, sql, result, info):
+        def __init__(self, ctx, name, file, sql, result, info, cleanup=None):
             """init"""
             super().__init__()
             self.ctx = ctx
@@ -55,6 +55,8 @@ class ChooseCase(object):
             self.sql: List = sql
             self.ori_sql: List = copy.deepcopy(sql)
             self.result: List = result
+            # custom cleanup commands
+            self.cleanup: List = cleanup or []
 
             # # get db from lines
             # self.db = set()
@@ -177,6 +179,9 @@ class ChooseCase(object):
                     tools.assert_in("thread", each_stat, "CONCURRENCY THREAD FORMAT ERROR!")
                     for each_thread in each_stat["thread"]:
                         _case_sqls.extend(each_thread["cmd"])
+                elif isinstance(each_stat, dict) and each_stat.get("type", "") == CLEANUP_FLAG:
+                    tools.assert_in("cmd", each_stat, "CLEANUP STATEMENT FORMAT ERROR!")
+                    _case_sqls.extend(each_stat["cmd"])
                 else:
                     tools.ok_(False, "Init data error!")
 
@@ -375,6 +380,8 @@ class ChooseCase(object):
         in_loop_flag = False
 
         tmp_con_stat = []
+        # cleanup blocks for current case
+        tmp_cleanup_stat = []
 
         while line_id < len(f_lines):
             line_content = f_lines[line_id].rstrip("\n")
@@ -404,7 +411,15 @@ class ChooseCase(object):
                         pass
                     else:
                         self.case_list.append(
-                            ChooseCase.CaseTR(self, name, file, copy.deepcopy(tmp_sql), copy.deepcopy(tmp_res), info)
+                            ChooseCase.CaseTR(
+                                self,
+                                name,
+                                file,
+                                copy.deepcopy(tmp_sql),
+                                copy.deepcopy(tmp_res),
+                                info,
+                                cleanup=copy.deepcopy(tmp_cleanup_stat),
+                            )
                         )
 
                 info = line_content
@@ -415,6 +430,7 @@ class ChooseCase(object):
 
                 tmp_sql.clear()
                 tmp_res.clear()
+                tmp_cleanup_stat.clear()
 
                 line_id += 1
                 continue
@@ -546,6 +562,33 @@ class ChooseCase(object):
                     "thread": concurrency_t_list
                 })
 
+            elif line_content.startswith(CLEANUP_FLAG):
+                # CLEANUP { ... } END CLEANUP
+                tools.ok_(not in_loop_flag, "CLEANUP block must not be inside LOOP!")
+                tools.assert_true(
+                    re.compile(f'{CLEANUP_FLAG}(\\s)*{{(\\s)*').fullmatch(line_content) is not None,
+                    f"Cleanup struct illegal: file: {file}, line: {line_id}"
+                )
+                l_cleanup_line = line_id
+                line_id += 1
+                # read cleanup statements (no result expected)
+                tmp_cleanup_lines = []
+                while line_id < len(f_lines) and not re.compile(f'}}(\\s)*{END_CLEANUP_FLAG}').fullmatch(f_lines[line_id].strip()):
+                    line_content = f_lines[line_id].strip()
+                    line_id = __read_single_stat_and_result(line_content, line_id, tmp_cleanup_lines, [])
+                tools.assert_less(line_id, len(f_lines), "CLEANUP FORMAT ERROR!")
+                r_cleanup_line = line_id
+                # collect for execution in tearDown
+                tmp_cleanup_stat.extend(tmp_cleanup_lines)
+                # also keep position for recording into R at the same place
+                tmp_sql.append({
+                    "type": CLEANUP_FLAG,
+                    "cmd": tmp_cleanup_lines,
+                    "ori": f_lines[l_cleanup_line: r_cleanup_line + 1]
+                })
+                tmp_res.append(None)
+                line_id += 1
+
             else:
                 # 1st line of command, SQL/SHELL/FUNCTION
                 line_id = __read_single_stat_and_result(line_content, line_id, tmp_sql, tmp_res, in_loop_flag)
@@ -564,7 +607,15 @@ class ChooseCase(object):
                 pass
             else:
                 self.case_list.append(
-                    ChooseCase.CaseTR(self, name, file, copy.deepcopy(tmp_sql), copy.deepcopy(tmp_res), info)
+                    ChooseCase.CaseTR(
+                        self,
+                        name,
+                        file,
+                        copy.deepcopy(tmp_sql),
+                        copy.deepcopy(tmp_res),
+                        info,
+                        cleanup=copy.deepcopy(tmp_cleanup_stat),
+                    )
                 )
 
 

--- a/test/lib/choose_cases.py
+++ b/test/lib/choose_cases.py
@@ -260,6 +260,9 @@ class ChooseCase(object):
                     tools.assert_in("thread", each_stat, "CONCURRENCY THREAD FORMAT ERROR!")
                     for each_thread in each_stat["thread"]:
                         _case_sqls.extend(each_thread["cmd"])
+                elif isinstance(each_stat, dict) and each_stat.get("type", "") == CLEANUP_FLAG:
+                    tools.assert_in("cmd", each_stat, "CLEANUP STATEMENT FORMAT ERROR!")
+                    _case_sqls.extend(each_stat["cmd"])
                 else:
                     tools.ok_(False, "Init data error!")
 

--- a/test/sql/test_profile/R/test_load_brpc_reached_timeout
+++ b/test/sql/test_profile/R/test_load_brpc_reached_timeout
@@ -122,9 +122,7 @@ shell: env mysql_cmd="${mysql_cmd} -Ddb_${uuid0}" label="label_${uuid2}" bash ${
 Analyze profile succeeded
 Analyze profile succeeded
 -- !result
-admin disable failpoint "node_channel_set_brpc_timeout";
--- result:
--- !result
-admin disable failpoint "tablets_channel_add_chunk_wait_write_block";
--- result:
--- !result
+CLEANUP {
+    admin disable failpoint "node_channel_set_brpc_timeout";
+    admin disable failpoint "tablets_channel_add_chunk_wait_write_block";
+} END CLEANUP

--- a/test/sql/test_profile/R/test_load_channel_profile
+++ b/test/sql/test_profile/R/test_load_channel_profile
@@ -59,6 +59,11 @@ shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid0}" bash ${roo
 Analyze profile succeeded
 Analyze profile succeeded
 -- !result
+CLEANUP {
+  function: disable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
+  function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 0)
+} END CLEANUP
+
 function: enable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
 -- result:
 None
@@ -84,7 +89,3 @@ shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid1}" bash ${roo
 Analyze profile succeeded
 Analyze profile succeeded
 -- !result
-CLEANUP {
-function: disable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
-function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 0)
-} END CLEANUP

--- a/test/sql/test_profile/R/test_load_channel_profile
+++ b/test/sql/test_profile/R/test_load_channel_profile
@@ -84,11 +84,7 @@ shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid1}" bash ${roo
 Analyze profile succeeded
 Analyze profile succeeded
 -- !result
+CLEANUP {
 function: disable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
--- result:
-None
--- !result
 function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 0)
--- result:
-None
--- !result
+} END CLEANUP

--- a/test/sql/test_profile/T/test_load_brpc_reached_timeout
+++ b/test/sql/test_profile/T/test_load_brpc_reached_timeout
@@ -59,5 +59,7 @@ function: wait_load_finish("label_${uuid2}")
 select instr(error_msg, '[E1008]Reached timeout=2000ms') > 0 from information_schema.loads where label="label_${uuid2}";
 shell: env mysql_cmd="${mysql_cmd} -Ddb_${uuid0}" label="label_${uuid2}" bash ${root_path}/sql/test_profile/T/test_load_profile_analysis.sh
 
-admin disable failpoint "node_channel_set_brpc_timeout";
-admin disable failpoint "tablets_channel_add_chunk_wait_write_block";
+CLEANUP {
+    admin disable failpoint "node_channel_set_brpc_timeout";
+    admin disable failpoint "tablets_channel_add_chunk_wait_write_block";
+} END CLEANUP

--- a/test/sql/test_profile/T/test_load_channel_profile
+++ b/test/sql/test_profile/T/test_load_channel_profile
@@ -41,12 +41,14 @@ SET enable_async_profile=false;
 INSERT INTO test_load_channel_profile WITH LABEL label_${uuid0} SELECT * FROM test_load_channel_profile;
 shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid0}" bash ${root_path}/sql/test_profile/T/test_load_profile_analysis.sh
 
+CLEANUP {
+  function: disable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
+  function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 0)
+} END CLEANUP
+
 function: enable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
 function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 1)
 
 alter table test_load_channel_profile set('enable_load_profile'='true');
 shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label: "label_${uuid1}"" -H "column_separator: ," -d '1,2,3' -X PUT ${url}/api/${db[0]}/test_load_channel_profile/_stream_load
 shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid1}" bash ${root_path}/sql/test_profile/T/test_load_profile_analysis.sh
-
-function: disable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
-function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 0)


### PR DESCRIPTION
## Why I’m doing
- Tests often enable temporary configs, create transient objects, or invoke external side-effects. When a test fails mid-way, ad-hoc cleanup embedded in the test body may be skipped, leaving residue that causes flakiness and cross-test interference.
- This change provides a first-class, always-run teardown mechanism that executes after each case, regardless of pass/fail, improving test reliability and isolation, and simplifying test authoring.

## What I’m doing
- Introduce a CLEANUP block to SQL-tester that defines statements to run in tearDown for each case.
- Semantics:
  - CLEANUP runs unconditionally in tearDown after each case (pass/fail/timeout).
  - Results in CLEANUP are not validated; failures are logged but do not prevent later cleanup steps.
  - Existing built-in cleanup (e.g., dropping parsed DATABASE/RESOURCE) still runs; CLEANUP is additive.
  - In record mode, the CLEANUP block is preserved in-place in the generated R file.
- Syntax and example:
```sql
-- name: my_case
...
CLEANUP {
  -- SQL must end with ';'
  DROP TABLE IF EXISTS t1;
  DROP DATABASE IF EXISTS db_${uuid0};
  -- shell and function are allowed
  shell: echo "cleanup ${uuid0}"
  function: restore_env("arg1")
} END CLEANUP
```

**Code changes**
- test/README.md
  - Document the CLEANUP grammar, usage, semantics, and example.
- test/lib/__init__.py
  - Add CLEANUP/END CLEANUP flags.
- test/lib/choose_cases.py
  - Parse CLEANUP blocks, collect commands, validate format, include in case model, support variable/uuid replacement, and record block in-place during -r mode.
- test/test_sql_cases.py
  - Execute collected CLEANUP commands in tearDown unconditionally; keep record-mode output aligned; ensure built-in database/resource cleanup still runs.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [X] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
