### PR TITLE
[BugFix] Fix mv repair hive base table bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1499,6 +1499,10 @@ public class Config extends ConfigBase {
     )
     public static String mv_rewrite_consider_data_layout_mode = "enable";
 
+    @ConfField(mutable = true, comment = "Whether to enable automatic repairing of materialized views " +
+            "that are broken due to base table schema changes")
+    public static boolean enable_mv_automatic_repairing_for_broken_base_tables = true;
+
     /**
      * The number of query retries.
      * A query may retry if we encounter RPC exception and no result has been sent to user.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
@@ -14,12 +14,14 @@
 package com.starrocks.scheduler.mv;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -63,7 +65,7 @@ public class MVPCTMetaRepairer {
      */
     public static void repairMetaIfNeeded(Database db, MaterializedView mv,
                                           List<Pair<Table, BaseTableInfo>> toRepairTables) throws DmlException {
-        if (toRepairTables.isEmpty()) {
+        if (!Config.enable_mv_automatic_repairing_for_broken_base_tables || toRepairTables.isEmpty()) {
             return;
         }
         Optional<Pair<Table, BaseTableInfo>> nonSupportedTableOpt =
@@ -99,6 +101,13 @@ public class MVPCTMetaRepairer {
         }
         if (baseTable.getTableIdentifier().equals(baseTableInfo.getTableIdentifier())) {
             return true;
+        }
+        return isTableSupportedPCTRepair(baseTable);
+    }
+
+    public static boolean isTableSupportedPCTRepair(Table baseTable) {
+        if (baseTable == null) {
+            return false;
         }
         return baseTable instanceof HiveTable;
     }
@@ -194,6 +203,37 @@ public class MVPCTMetaRepairer {
             MVMetaVersionRepairer.repairExternalBaseTableInfo(mv, oldBaseTableInfo, newTable, updatedPartitionNames);
         } finally {
             locker.unLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.WRITE);
+        }
+    }
+
+    /**
+     * Collect the repair info for the partition of the table, including last file modified time and file number.
+     */
+    public static void collectTableRepairInfo(Table table,
+                                              String partitionName,
+                                              MaterializedView.BasePartitionInfo basePartitionInfo) {
+        if (!Config.enable_mv_automatic_repairing_for_broken_base_tables || table == null
+                || !MVPCTMetaRepairer.isTableSupportedPCTRepair(table)) {
+            return;
+        }
+
+        // collect repair info for partition should not affect the main flow since the table may not need repair.
+        try {
+            TableUpdateArbitrator.UpdateContext updateContext = new TableUpdateArbitrator.UpdateContext(
+                    table, -1, Lists.newArrayList(partitionName));
+            TableUpdateArbitrator arbitrator = TableUpdateArbitrator.create(updateContext);
+            if (arbitrator != null) {
+                Map<String, Optional<HivePartitionDataInfo>> partitionDataInfos = arbitrator.getPartitionDataInfos();
+                Preconditions.checkState(partitionDataInfos.size() == 1);
+                if (partitionDataInfos.get(partitionName).isPresent()) {
+                    HivePartitionDataInfo hivePartitionDataInfo = partitionDataInfos.get(partitionName).get();
+                    basePartitionInfo.setExtLastFileModifiedTime(hivePartitionDataInfo.getLastFileModifiedTime());
+                    basePartitionInfo.setFileNumber(hivePartitionDataInfo.getFileNumber());
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("collect partition repair info failed, table:{}, partition:{}",
+                    table.getName(), partitionName, e);
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

https://github.com/StarRocks/starrocks/pull/45118 introduces an automatic repair mechasim for  hive table changes(drop & recreate) during mv refresh. But `updatePCTExternalPartitionInfos` may be thrown exception if partition data has no data in lower version(v3.3) but this should not affect mv refresh if base table has not changed.

## What I'm doing:
- Add try-catch in collectTableRepairInfo to avoid affecting main flow.
- Add a config to control whether to repair mvs if  base tables changed.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
