### PR TITLE
[BugFix] Remove the deregister logic from container

### DIFF
--- a/docker/dockerfiles/be/cn_entrypoint.sh
+++ b/docker/dockerfiles/be/cn_entrypoint.sh
@@ -163,9 +163,13 @@ if [[ "x$LOG_CONSOLE" == "x1" ]] ; then
     addition_args="--logconsole"
 fi
 $STARROCKS_HOME/bin/start_cn.sh $addition_args
+ret=$?
 
 # The reason why we need to sleep here is to avoid the pod being killed by k8s
 # before the preStop hook is exited.
 # If the CN subprocess fails to start, we also want the entrypoint script to exit as soon as possible.
 # Taking all the above into consideration, we set it to five seconds.
 sleep 5
+
+# keep the same return code from start_cn.sh
+exit $ret

--- a/docker/dockerfiles/be/cn_entrypoint.sh
+++ b/docker/dockerfiles/be/cn_entrypoint.sh
@@ -164,7 +164,8 @@ if [[ "x$LOG_CONSOLE" == "x1" ]] ; then
 fi
 $STARROCKS_HOME/bin/start_cn.sh $addition_args
 
-# the reason why we need to sleep here is to avoid the pod being killed by k8s
+# The reason why we need to sleep here is to avoid the pod being killed by k8s
 # before the preStop hook is exited.
-# 120 is the default value of terminationGracePeriodSeconds
-sleep 120
+# If the CN subprocess fails to start, we also want the entrypoint script to exit as soon as possible.
+# Taking all the above into consideration, we set it to five seconds.
+sleep 5

--- a/docker/dockerfiles/be/cn_entrypoint.sh
+++ b/docker/dockerfiles/be/cn_entrypoint.sh
@@ -165,11 +165,11 @@ fi
 $STARROCKS_HOME/bin/start_cn.sh $addition_args
 ret=$?
 
-# The reason why we need to sleep here is to avoid the pod being killed by k8s
-# before the preStop hook is exited.
-# If the CN subprocess fails to start, we also want the entrypoint script to exit as soon as possible.
-# Taking all the above into consideration, we set it to five seconds.
-sleep 5
+if [[ $ret -eq 0 || $ret -eq 137 ]] ; then
+    # The reason why we need to sleep here is to avoid the pod being killed by k8s before the preStop hook is exited.
+    # If the CN subprocess fails to start, we also want the entrypoint script to exit as soon as possible.
+    sleep 5
+fi
 
 # keep the same return code from start_cn.sh
 exit $ret


### PR DESCRIPTION
## Why I'm doing:

There are two different scenarios of CN pod exit.

1. POD restart (due to config update or version upgrade) or crash
2. POD scale in

It is not necessary to deregister the CN POD in the first scenario while it is needed in the second scenario.

The operator will know the scale in op and do the deregistration, user should use the >= v1.11.1 operator version.

## What I'm doing:

Fixes #62915

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
