### PR TITLE
[Refactor] Refactors the Frontend (FE) module structure versioning management

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -170,7 +170,14 @@ mkdir -p ${meta_dir:-"$STARROCKS_HOME/meta"}
 for f in $STARROCKS_HOME/lib/*.jar; do
   CLASSPATH=$f:${CLASSPATH};
 done
-export CLASSPATH=${STARROCKS_HOME}/lib/starrocks-hadoop-ext.jar:${CLASSPATH}:${STARROCKS_HOME}/lib:${STARROCKS_HOME}/conf
+# Explicitly put fe-core-main.jar at the front of classpath to ensure StarRocks' 
+# customized classes (e.g., HiveMetaStoreClient) are loaded before the original 
+# ones from third-party JARs (e.g., hive-apache-3.1.2-22.jar).
+# This prevents ClassLoader conflicts where the original HiveMetaStoreClient 
+# (which uses old thrift paths like org.apache.thrift.transport.TFramedTransport)
+# might be loaded instead of StarRocks' version (which uses the correct new paths
+# like org.apache.thrift.transport.layered.TFramedTransport).
+export CLASSPATH=${STARROCKS_HOME}/lib/fe-core-main.jar:${STARROCKS_HOME}/lib/starrocks-hadoop-ext.jar:${CLASSPATH}:${STARROCKS_HOME}/lib:${STARROCKS_HOME}/conf
 
 pidfile=$PID_DIR/fe.pid
 

--- a/build.sh
+++ b/build.sh
@@ -511,7 +511,7 @@ if [ ${BUILD_FE} -eq 1 ] || [ ${BUILD_SPARK_DPP} -eq 1 ] || [ ${BUILD_HIVE_UDF} 
         FE_MODULES="fe-testing,plugin/hive-udf"
     fi
     if [ ${BUILD_FE} -eq 1 ]; then
-        FE_MODULES="plugin/hive-udf,fe-testing,plugin/spark-dpp,fe-core"
+        FE_MODULES="plugin/hive-udf,fe-testing,plugin/spark-dpp,fe-server"
     fi
 fi
 
@@ -552,8 +552,8 @@ if [ ${BUILD_FE} -eq 1 -o ${BUILD_SPARK_DPP} -eq 1 ]; then
         cp -r -p ${STARROCKS_HOME}/conf/cluster_snapshot.yaml ${STARROCKS_OUTPUT}/fe/conf/
 
         rm -rf ${STARROCKS_OUTPUT}/fe/lib/*
-        cp -r -p ${STARROCKS_HOME}/fe/fe-core/target/lib/* ${STARROCKS_OUTPUT}/fe/lib/
-        cp -r -p ${STARROCKS_HOME}/fe/fe-core/target/starrocks-fe.jar ${STARROCKS_OUTPUT}/fe/lib/
+        cp -r -p ${STARROCKS_HOME}/fe/fe-server/target/lib/* ${STARROCKS_OUTPUT}/fe/lib/
+        cp -r -p ${STARROCKS_HOME}/fe/fe-server/target/starrocks-fe.jar ${STARROCKS_OUTPUT}/fe/lib/
         cp -r -p ${STARROCKS_HOME}/java-extensions/hadoop-ext/target/starrocks-hadoop-ext.jar ${STARROCKS_OUTPUT}/fe/lib/
         cp -r -p ${STARROCKS_HOME}/webroot/* ${STARROCKS_OUTPUT}/fe/webroot/
         cp -r -p ${STARROCKS_HOME}/fe/plugin/spark-dpp/target/spark-dpp-*-jar-with-dependencies.jar ${STARROCKS_OUTPUT}/fe/spark-dpp/

--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 
 allprojects {
     group = "com.starrocks"
-    version = "3.4.0"
+    version = "main"
 
     repositories {
         mavenCentral()

--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -412,6 +412,8 @@ tasks.register<Task>("generateByScripts") {
 // Add source generation tasks to the build process
 tasks.compileJava {
     dependsOn("generateThriftSources", "generateProtoSources", "generateByScripts")
+    // Add explicit dependency on hive-udf shadowJar task
+    dependsOn(":plugin:hive-udf:shadowJar")
 }
 
 tasks.named<PrecompileTask>("jprotobuf_precompile") {

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>3.4.0</version>
+        <version>main</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -892,7 +892,6 @@ under the License.
     </dependencies>
 
     <build>
-        <finalName>starrocks-fe</finalName>
         <plugins>
             <!-- fe proto precompile plugin-->
             <plugin>
@@ -1099,30 +1098,6 @@ under the License.
                 </executions>
             </plugin>
 
-            <!-- copy all dependency libs to target lib dir -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                            <skip>${skip.plugin}</skip>
-                            <!-- exclude test only jars(junit&mysql-connector), GPL jar(mysql-connector) must be excluded in release package -->
-                            <includeScope>runtime</includeScope>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/JwkMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/JwkMgr.java
@@ -15,7 +15,7 @@
 package com.starrocks.authentication;
 
 import com.nimbusds.jose.jwk.JWKSet;
-import com.starrocks.StarRocksFE;
+import com.starrocks.common.Config;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -30,7 +30,7 @@ public class JwkMgr {
             if (jwksUrl.startsWith("http://") || jwksUrl.startsWith("https://")) {
                 jwksInputStream = new URL(jwksUrl).openStream();
             } else {
-                String filePath = StarRocksFE.STARROCKS_HOME_DIR + "/conf/" + jwksUrl;
+                String filePath = Config.STARROCKS_HOME_DIR + "/conf/" + jwksUrl;
                 jwksInputStream = new FileInputStream(filePath);
             }
             return JWKSet.load(jwksInputStream);

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/SecurityIntegration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/SecurityIntegration.java
@@ -25,6 +25,7 @@ import java.util.Map;
  * Authentication for this integration is provided by corresponding `getAuthenticationProvider()`.
  */
 public abstract class SecurityIntegration {
+    public static final String AUTHENTICATION_CHAIN_MECHANISM_NATIVE = "native";
     public static final String SECURITY_INTEGRATION_PROPERTY_TYPE_KEY = "type";
     public static final String SECURITY_INTEGRATION_PROPERTY_GROUP_PROVIDER = "group_provider";
     public static final String SECURITY_INTEGRATION_GROUP_ALLOWED_LOGIN = "permitted_groups";

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -34,7 +34,7 @@
 
 package com.starrocks.common;
 
-import com.starrocks.StarRocksFE;
+import com.starrocks.authentication.SecurityIntegration;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.Replica;
 import com.starrocks.qe.scheduler.slot.QueryQueueOptions;
@@ -45,6 +45,11 @@ import static java.lang.Math.max;
 import static java.lang.Runtime.getRuntime;
 
 public class Config extends ConfigBase {
+
+    /**
+     *  STARROCKS_HOME is the root dir of starrocks installation.
+     */
+    public static final String STARROCKS_HOME_DIR = System.getenv("STARROCKS_HOME");
 
     /**
      * The max size of one sys log and audit log
@@ -87,7 +92,7 @@ public class Config extends ConfigBase {
      *      default is false. if true, then compress fe.log & fe.warn.log by gzip
      */
     @ConfField
-    public static String sys_log_dir = StarRocksFE.STARROCKS_HOME_DIR + "/log";
+    public static String sys_log_dir = Config.STARROCKS_HOME_DIR + "/log";
     @ConfField
     public static String sys_log_level = "INFO";
     @ConfField
@@ -159,7 +164,7 @@ public class Config extends ConfigBase {
     @ConfField
     public static boolean enable_sql_desensitize_in_log = false;
     @ConfField
-    public static String audit_log_dir = StarRocksFE.STARROCKS_HOME_DIR + "/log";
+    public static String audit_log_dir = Config.STARROCKS_HOME_DIR + "/log";
     @ConfField
     public static int audit_log_roll_num = 90;
     @ConfField
@@ -197,7 +202,7 @@ public class Config extends ConfigBase {
      * This specifies FE MV/Statistics log dir.
      */
     @ConfField
-    public static String internal_log_dir = StarRocksFE.STARROCKS_HOME_DIR + "/log";
+    public static String internal_log_dir = Config.STARROCKS_HOME_DIR + "/log";
     @ConfField
     public static int internal_log_roll_num = 90;
     @ConfField
@@ -231,7 +236,7 @@ public class Config extends ConfigBase {
      * 120s    120 seconds
      */
     @ConfField
-    public static String dump_log_dir = StarRocksFE.STARROCKS_HOME_DIR + "/log";
+    public static String dump_log_dir = Config.STARROCKS_HOME_DIR + "/log";
     @ConfField
     public static int dump_log_roll_num = 10;
     @ConfField
@@ -271,7 +276,7 @@ public class Config extends ConfigBase {
      * 120s    120 seconds
      */
     @ConfField
-    public static String big_query_log_dir = StarRocksFE.STARROCKS_HOME_DIR + "/log";
+    public static String big_query_log_dir = Config.STARROCKS_HOME_DIR + "/log";
     @ConfField
     public static int big_query_log_roll_num = 10;
     @ConfField
@@ -303,7 +308,7 @@ public class Config extends ConfigBase {
     @ConfField
     public static boolean enable_profile_log = true;
     @ConfField
-    public static String profile_log_dir = StarRocksFE.STARROCKS_HOME_DIR + "/log";
+    public static String profile_log_dir = Config.STARROCKS_HOME_DIR + "/log";
     @ConfField
     public static int profile_log_roll_num = 5;
     @ConfField
@@ -451,14 +456,14 @@ public class Config extends ConfigBase {
      * 2. Safe (RAID)
      */
     @ConfField
-    public static String meta_dir = StarRocksFE.STARROCKS_HOME_DIR + "/meta";
+    public static String meta_dir = Config.STARROCKS_HOME_DIR + "/meta";
 
     /**
      * temp dir is used to save intermediate results of some process, such as backup and restore process.
      * file in this dir will be cleaned after these process is finished.
      */
     @ConfField
-    public static String tmp_dir = StarRocksFE.STARROCKS_HOME_DIR + "/temp_dir";
+    public static String tmp_dir = Config.STARROCKS_HOME_DIR + "/temp_dir";
 
     /**
      * Edit log type.
@@ -1126,7 +1131,7 @@ public class Config extends ConfigBase {
      * Default spark dpp version
      */
     @ConfField
-    public static String spark_dpp_version = "3.4.0";
+    public static String spark_dpp_version = "main";
     /**
      * Default spark load timeout
      */
@@ -1137,7 +1142,7 @@ public class Config extends ConfigBase {
      * Default spark home dir
      */
     @ConfField
-    public static String spark_home_default_dir = StarRocksFE.STARROCKS_HOME_DIR + "/lib/spark2x";
+    public static String spark_home_default_dir = Config.STARROCKS_HOME_DIR + "/lib/spark2x";
 
     /**
      * Default spark dependencies path
@@ -1155,7 +1160,7 @@ public class Config extends ConfigBase {
      * Default yarn client path
      */
     @ConfField
-    public static String yarn_client_path = StarRocksFE.STARROCKS_HOME_DIR + "/lib/yarn-client/hadoop/bin/yarn";
+    public static String yarn_client_path = Config.STARROCKS_HOME_DIR + "/lib/yarn-client/hadoop/bin/yarn";
 
     /**
      * Default yarn config file directory
@@ -1163,7 +1168,7 @@ public class Config extends ConfigBase {
      * config file exists under this path, and if not, create them.
      */
     @ConfField
-    public static String yarn_config_dir = StarRocksFE.STARROCKS_HOME_DIR + "/lib/yarn-config";
+    public static String yarn_config_dir = Config.STARROCKS_HOME_DIR + "/lib/yarn-config";
 
     /**
      * Default number of waiting jobs for routine load and version 2 of load
@@ -1889,7 +1894,7 @@ public class Config extends ConfigBase {
      * Save small files
      */
     @ConfField
-    public static String small_file_dir = StarRocksFE.STARROCKS_HOME_DIR + "/small_files";
+    public static String small_file_dir = Config.STARROCKS_HOME_DIR + "/small_files";
 
     /**
      * control rollup job concurrent limit
@@ -1926,7 +1931,7 @@ public class Config extends ConfigBase {
      * {@link com.starrocks.authentication.SecurityIntegration}
      */
     @ConfField(mutable = true)
-    public static String[] authentication_chain = {AUTHENTICATION_CHAIN_MECHANISM_NATIVE};
+    public static String[] authentication_chain = {SecurityIntegration.AUTHENTICATION_CHAIN_MECHANISM_NATIVE};
 
     /**
      * If set to true, the granularity of auth check extends to the column level
@@ -2522,7 +2527,7 @@ public class Config extends ConfigBase {
      * iceberg metadata cache dir
      */
     @ConfField(mutable = true)
-    public static String iceberg_metadata_cache_disk_path = StarRocksFE.STARROCKS_HOME_DIR + "/caches/iceberg";
+    public static String iceberg_metadata_cache_disk_path = Config.STARROCKS_HOME_DIR + "/caches/iceberg";
 
     /**
      * iceberg metadata memory cache total size, default 0MB (turn off)
@@ -2632,7 +2637,7 @@ public class Config extends ConfigBase {
     public static int query_cost_predictor_healthchk_interval = 30;
 
     @ConfField
-    public static String feature_log_dir = StarRocksFE.STARROCKS_HOME_DIR + "/log";
+    public static String feature_log_dir = Config.STARROCKS_HOME_DIR + "/log";
     @ConfField
     public static String feature_log_roll_interval = "DAY";
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/common/ConfigBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ConfigBase.java
@@ -36,6 +36,7 @@ package com.starrocks.common;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.starrocks.authentication.SecurityIntegration;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.Util;
 import com.starrocks.qe.ConnectContext;
@@ -77,8 +78,6 @@ import java.util.regex.Pattern;
 
 public class ConfigBase {
     private static final Logger LOG = LogManager.getLogger(ConfigBase.class);
-
-    public static final String AUTHENTICATION_CHAIN_MECHANISM_NATIVE = "native";
 
     @Retention(RetentionPolicy.RUNTIME)
     public @interface ConfField {
@@ -235,7 +234,7 @@ public class ConfigBase {
                 Set<String> argsSet = new HashSet<>(Arrays.asList(arrayArgs));
                 if (!f.getType().equals(String[].class)
                         || argsSet.size() != arrayArgs.length
-                        || !argsSet.contains(AUTHENTICATION_CHAIN_MECHANISM_NATIVE)) {
+                        || !argsSet.contains(SecurityIntegration.AUTHENTICATION_CHAIN_MECHANISM_NATIVE)) {
                     throw new InvalidConfException("'authentication_chain' configuration invalid, " +
                             "'native' must be in the list, and cannot have duplicates, current value: "
                             + confVal);

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/StaticResourceAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/StaticResourceAction.java
@@ -36,7 +36,7 @@ package com.starrocks.http.action;
 
 import com.google.common.base.Strings;
 import com.google.re2j.Pattern;
-import com.starrocks.StarRocksFE;
+import com.starrocks.common.Config;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -130,7 +130,7 @@ public class StaticResourceAction extends WebBaseAction {
     }
 
     public static void registerAction(ActionController controller) throws IllegalArgException {
-        String httpDir = StarRocksFE.STARROCKS_HOME_DIR + "/webroot";
+        String httpDir = Config.STARROCKS_HOME_DIR + "/webroot";
         StaticResourceAction action = new StaticResourceAction(controller, httpDir + "/static");
         controller.registerHandler(HttpMethod.GET, "/static/js", action);
         controller.registerHandler(HttpMethod.GET, "/static/css", action);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/StopFeAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/StopFeAction.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.http.rest;
 
-import com.starrocks.StarRocksFE;
+import com.starrocks.StarRocksFEServer;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.http.ActionController;
@@ -42,10 +42,10 @@ public class StopFeAction extends RestBaseAction {
         response.setContentType("application/json");
         RestResult result = new RestResult();
 
-        if (StarRocksFE.stopped) {
+        if (StarRocksFEServer.stopped) {
             result.addResultEntry("Message", "FE is shutting down");
         } else {
-            StarRocksFE.stopped = true;
+            StarRocksFEServer.stopped = true;
             result.addResultEntry("Message", "Stop success");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkRepository.java
@@ -38,7 +38,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.starrocks.StarRocksFE;
 import com.starrocks.common.Config;
 import com.starrocks.common.LoadException;
 import com.starrocks.common.StarRocksException;
@@ -102,7 +101,7 @@ public class SparkRepository {
         this.brokerDesc = brokerDesc;
         this.currentDppVersion = Config.spark_dpp_version;
         this.currentArchive = new SparkArchive(getRemoteArchivePath(currentDppVersion), currentDppVersion);
-        this.localDppPath = StarRocksFE.STARROCKS_HOME_DIR + DPP_RESOURCE_DIR + SPARK_DPP_JAR;
+        this.localDppPath = Config.STARROCKS_HOME_DIR + DPP_RESOURCE_DIR + SPARK_DPP_JAR;
         if (!Strings.isNullOrEmpty(Config.spark_resource_path)) {
             this.localSpark2xPath = Config.spark_resource_path;
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
@@ -43,7 +43,6 @@ import com.starrocks.authentication.SecurityIntegration;
 import com.starrocks.authentication.UserAuthenticationInfo;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
-import com.starrocks.common.ConfigBase;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -301,7 +300,7 @@ public class MysqlProto {
             provider = AuthenticationProviderFactory.create(authInfo.getAuthPlugin(), authInfo.getAuthString());
         } else {
             for (String authMechanism : Config.authentication_chain) {
-                if (authMechanism.equals(ConfigBase.AUTHENTICATION_CHAIN_MECHANISM_NATIVE)) {
+                if (authMechanism.equals(SecurityIntegration.AUTHENTICATION_CHAIN_MECHANISM_NATIVE)) {
                     continue;
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/GroovyUDSServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/GroovyUDSServer.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.service;
 
-import com.starrocks.StarRocksFE;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.Daemon;
 import com.starrocks.server.GlobalStateMgr;
 import groovy.lang.Binding;
@@ -44,7 +44,7 @@ public class GroovyUDSServer extends Daemon {
     }
 
     private String socketPath =
-            (StarRocksFE.STARROCKS_HOME_DIR == null ? "/tmp" : StarRocksFE.STARROCKS_HOME_DIR) + "/groovy_debug.sock";
+            (Config.STARROCKS_HOME_DIR == null ? "/tmp" : Config.STARROCKS_HOME_DIR) + "/groovy_debug.sock";
 
     GroovyUDSServer() {
         super("GroovyUDSServer");

--- a/fe/fe-grammar/pom.xml
+++ b/fe/fe-grammar/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>3.4.0</version>
+        <version>main</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-parser/pom.xml
+++ b/fe/fe-parser/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>3.4.0</version>
+        <version>main</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -20,6 +20,10 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.starrocks</groupId>
+            <artifactId>fe-grammar</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>

--- a/fe/fe-server/build.gradle.kts
+++ b/fe/fe-server/build.gradle.kts
@@ -12,16 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-rootProject.name = "starrocks-fe"
+plugins {
+    java
+    `maven-publish`
+}
 
-include(
-    "fe-grammar",
-    "fe-parser",
-    "fe-spi",
-    "fe-utils",
-    "fe-testing",
-    "plugin:spark-dpp",
-    "plugin:hive-udf",
-    "fe-core",
-    "fe-server"
-)
+dependencies {
+    implementation(project(":fe-core"))
+
+    implementation("com.google.guava:guava")
+    implementation("commons-cli:commons-cli")
+
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+tasks.jar {
+    archiveBaseName.set("starrocks-fe")
+    manifest {
+        attributes(
+            "Main-Class" to "com.starrocks.StarRocksFE"
+        )
+    }
+}
+
+tasks.register<Copy>("copyDependencies") {
+    from(configurations.runtimeClasspath)
+    into("${layout.buildDirectory.get()}/lib")
+}
+
+tasks.build {
+    dependsOn("copyDependencies")
+}

--- a/fe/fe-server/pom.xml
+++ b/fe/fe-server/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.starrocks</groupId>
+        <artifactId>starrocks-fe</artifactId>
+        <version>main</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>fe-server</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.starrocks</groupId>
+            <artifactId>fe-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>starrocks-fe</finalName>
+        <plugins>
+            <!-- copy all dependency libs to target lib dir -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <skip>${skip.plugin}</skip>
+                            <!-- exclude test only jars(junit&mysql-connector), GPL jar(mysql-connector) must be excluded in release package -->
+                            <includeScope>runtime</includeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/fe/fe-server/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-server/src/main/java/com/starrocks/StarRocksFE.java
@@ -1,0 +1,188 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks;
+
+import com.google.common.base.Strings;
+import com.starrocks.common.CommandLineOptions;
+import com.starrocks.journal.bdbje.BDBToolOptions;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+public class StarRocksFE {
+    public static void main(String[] args) {
+        CommandLineOptions options = parseArgs(args);
+        StarRocksFEServer.start(options);
+    }
+
+    /*
+     * -v --version
+     *      Print the version of StarRocks Frontend
+     * -h --helper
+     *      Specify the helper node when joining a bdb je replication group
+     * -b --bdb
+     *      Run bdbje debug tools
+     *
+     *      -l --listdb
+     *          List all database names in bdbje
+     *      -d --db
+     *          Specify a database in bdbje
+     *
+     *          -s --stat
+     *              Print statistic of a database, including count, first key, last key
+     *          -f --from
+     *              Specify the start scan key
+     *          -t --to
+     *              Specify the end scan key
+     *          -m --metaversion
+     *              Specify the meta version to decode log value, separated by ',', first
+     *              is community meta version, second is StarRocks meta version
+     * -rs --cluster_snapshot
+     *      Specify fe start to restore from a cluster snapshot
+     * -ht --host_type
+     *      Specify fe start use ip or fqdn
+     * -fp --failpoint
+     *      Enable fail point
+     */
+    protected static CommandLineOptions parseArgs(String[] args) {
+        CommandLineParser commandLineParser = new DefaultParser();
+        Options options = getOptions();
+
+        CommandLine cmd = null;
+        try {
+            cmd = commandLineParser.parse(options, args);
+        } catch (final ParseException e) {
+            System.err.println("Failed to parse command line. exit now");
+            System.exit(-1);
+        }
+
+        CommandLineOptions commandLineOptions = new CommandLineOptions();
+        // -v --version
+        if (cmd.hasOption('v') || cmd.hasOption("version")) {
+            commandLineOptions.setVersion(true);
+        }
+        // -b --bdb
+        if (cmd.hasOption('b') || cmd.hasOption("bdb")) {
+            if (cmd.hasOption('l') || cmd.hasOption("listdb")) {
+                // list bdb je databases
+                BDBToolOptions bdbOpts = new BDBToolOptions(true, "", false, "", "", 0, 0);
+                commandLineOptions.setBdbToolOpts(bdbOpts);
+            } else if (cmd.hasOption('d') || cmd.hasOption("db")) {
+                // specify a database
+                String dbName = cmd.getOptionValue("db");
+                if (Strings.isNullOrEmpty(dbName)) {
+                    System.err.println("BDBJE database name is missing");
+                    System.exit(-1);
+                }
+
+                if (cmd.hasOption('s') || cmd.hasOption("stat")) {
+                    BDBToolOptions bdbOpts = new BDBToolOptions(false, dbName, true, "", "", 0, 0);
+                    commandLineOptions.setBdbToolOpts(bdbOpts);
+                } else {
+                    String fromKey = "";
+                    String endKey = "";
+                    int metaVersion = 0;
+                    int starrocksMetaVersion = 0;
+                    if (cmd.hasOption('f') || cmd.hasOption("from")) {
+                        fromKey = cmd.getOptionValue("from");
+                        if (Strings.isNullOrEmpty(fromKey)) {
+                            System.err.println("from key is missing");
+                            System.exit(-1);
+                        }
+                    }
+                    if (cmd.hasOption('t') || cmd.hasOption("to")) {
+                        endKey = cmd.getOptionValue("to");
+                        if (Strings.isNullOrEmpty(endKey)) {
+                            System.err.println("end key is missing");
+                            System.exit(-1);
+                        }
+                    }
+                    if (cmd.hasOption('m') || cmd.hasOption("metaversion")) {
+                        try {
+                            String version = cmd.getOptionValue("metaversion");
+                            String[] vs = version.split(",");
+                            if (vs.length != 2) {
+                                System.err.println("invalid meta version format");
+                                System.exit(-1);
+                            }
+                            metaVersion = Integer.parseInt(vs[0]);
+                            starrocksMetaVersion = Integer.parseInt(vs[1]);
+                        } catch (NumberFormatException e) {
+                            System.err.println("Invalid meta version format");
+                            System.exit(-1);
+                        }
+                    }
+
+                    BDBToolOptions bdbOpts =
+                            new BDBToolOptions(false, dbName, false, fromKey, endKey, metaVersion,
+                                    starrocksMetaVersion);
+                    commandLineOptions.setBdbToolOpts(bdbOpts);
+                }
+            } else {
+                System.err.println("Invalid options when running bdb je tools");
+                System.exit(-1);
+            }
+        }
+        // -h --helper
+        if (cmd.hasOption('h') || cmd.hasOption("helper")) {
+            String helperNode = cmd.getOptionValue("helper");
+            if (Strings.isNullOrEmpty(helperNode)) {
+                System.err.println("Missing helper node value");
+                System.exit(-1);
+            }
+            commandLineOptions.setHelpers(helperNode);
+        }
+        // -ht --host_type
+        if (cmd.hasOption("ht") || cmd.hasOption("host_type")) {
+            String hostType = cmd.getOptionValue("host_type");
+            if (Strings.isNullOrEmpty(hostType)) {
+                System.err.println("Missing host type value");
+                System.exit(-1);
+            }
+            commandLineOptions.setHostType(hostType);
+        }
+        // -rs --cluster_snapshot
+        if (cmd.hasOption("rs") || cmd.hasOption("cluster_snapshot")) {
+            commandLineOptions.setStartFromSnapshot(true);
+        }
+        // -fp --failpoint
+        if (cmd.hasOption("fp") || cmd.hasOption("failpoint")) {
+            commandLineOptions.setEnableFailPoint(true);
+        }
+
+        return commandLineOptions;
+    }
+
+    private static Options getOptions() {
+        Options options = new Options();
+        options.addOption("ht", "host_type", true, "Specify fe start use ip or fqdn");
+        options.addOption("rs", "cluster_snapshot", false, "Specify fe start to restore from a cluster snapshot");
+        options.addOption("v", "version", false, "Print the version of StarRocks Frontend");
+        options.addOption("h", "helper", true, "Specify the helper node when joining a bdb je replication group");
+        options.addOption("b", "bdb", false, "Run bdbje debug tools");
+        options.addOption("l", "listdb", false, "Print the list of databases in bdbje");
+        options.addOption("d", "db", true, "Specify a database in bdbje");
+        options.addOption("s", "stat", false, "Print statistic of a database, including count, first key, last key");
+        options.addOption("f", "from", true, "Specify the start scan key");
+        options.addOption("t", "to", true, "Specify the end scan key");
+        options.addOption("m", "metaversion", true,
+                "Specify the meta version to decode log value, separated by ',', first is community meta" +
+                        " version, second is StarRocks meta version");
+        options.addOption("fp", "failpoint", false, "enable fail point");
+        return options;
+    }
+}

--- a/fe/fe-server/src/test/java/com/starrocks/StarRocksFETest.java
+++ b/fe/fe-server/src/test/java/com/starrocks/StarRocksFETest.java
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package com.starrocks;
 
 import com.starrocks.common.CommandLineOptions;

--- a/fe/fe-spi/pom.xml
+++ b/fe/fe-spi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>3.4.0</version>
+        <version>main</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-testing/pom.xml
+++ b/fe/fe-testing/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>3.4.0</version>
+        <version>main</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-utils/pom.xml
+++ b/fe/fe-utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>starrocks-fe</artifactId>
         <groupId>com.starrocks</groupId>
-        <version>3.4.0</version>
+        <version>main</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/plugin/hive-udf/pom.xml
+++ b/fe/plugin/hive-udf/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>starrocks-fe</artifactId>
         <groupId>com.starrocks</groupId>
-        <version>3.4.0</version>
+        <version>main</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/fe/plugin/spark-dpp/pom.xml
+++ b/fe/plugin/spark-dpp/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>3.4.0</version>
+        <version>main</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
     <groupId>com.starrocks</groupId>
     <artifactId>starrocks-fe</artifactId>
-    <version>3.4.0</version>
+    <version>main</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -37,6 +37,7 @@ under the License.
         <module>plugin/spark-dpp</module>
         <module>plugin/hive-udf</module>
         <module>fe-core</module>
+        <module>fe-server</module>
     </modules>
 
     <name>starrocks-fe</name>
@@ -212,6 +213,16 @@ under the License.
             <dependency>
                 <groupId>com.starrocks</groupId>
                 <artifactId>hive-udf</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.starrocks</groupId>
+                <artifactId>fe-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.starrocks</groupId>
+                <artifactId>fe-server</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue
This pull request refactors the Frontend (FE) module structure, updates versioning, and improves configuration management by centralizing environment variable usage. The changes move the main FE entry point from `fe-core` to `fe-server`, update build and packaging scripts accordingly, and replace direct environment variable references with a single source of truth in the `Config` class. Additionally, version numbers are updated to use the `"main"` branch, and some obsolete Maven plugin configurations are removed.

**Frontend module restructuring and build updates:**
- The main FE module is switched from `fe-core` to `fe-server` in both the build script and artifact packaging, ensuring that builds now reference and package the correct module (`build.sh`, `fe/build.gradle.kts`). [[1]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L514-R514) [[2]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L555-R556)
- The FE entry point class is renamed from `StarRocksFE` to `StarRocksFEServer`, and related references are updated throughout the codebase to reflect this change (`fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java` → `StarRocksFEServer.java`). [[1]](diffhunk://#diff-4b3e09ec4eb1308ed216e98e8d99479b0f869894ddeb4390212f72b2116b16f5L57) [[2]](diffhunk://#diff-4b3e09ec4eb1308ed216e98e8d99479b0f869894ddeb4390212f72b2116b16f5L74-L78) [[3]](diffhunk://#diff-4b3e09ec4eb1308ed216e98e8d99479b0f869894ddeb4390212f72b2116b16f5L93-R96)

**Configuration and environment variable management:**
- All references to the `STARROCKS_HOME` environment variable are centralized in the `Config` class as `Config.STARROCKS_HOME_DIR`, replacing previous direct usage and static fields in the old `StarRocksFE` class. This affects log directory paths and other configuration settings (`Config.java`, `JwkMgr.java`). [[1]](diffhunk://#diff-c4dd949472990c944bb229f17a8fda3b329551819852735b5a7d7ae75aab1e18R49-R53) [[2]](diffhunk://#diff-c4dd949472990c944bb229f17a8fda3b329551819852735b5a7d7ae75aab1e18L90-R95) [[3]](diffhunk://#diff-c4dd949472990c944bb229f17a8fda3b329551819852735b5a7d7ae75aab1e18L162-R167) [[4]](diffhunk://#diff-c4dd949472990c944bb229f17a8fda3b329551819852735b5a7d7ae75aab1e18L200-R205) [[5]](diffhunk://#diff-c4dd949472990c944bb229f17a8fda3b329551819852735b5a7d7ae75aab1e18L234-R239) [[6]](diffhunk://#diff-c4dd949472990c944bb229f17a8fda3b329551819852735b5a7d7ae75aab1e18L274-R279) [[7]](diffhunk://#diff-c7939538e27903f8a2b73e0a08173207308bc0d6fd01640b3f8dba53a1210e74L18-R18) [[8]](diffhunk://#diff-c7939538e27903f8a2b73e0a08173207308bc0d6fd01640b3f8dba53a1210e74L33-R33)

**Build and dependency management improvements:**
- The FE module version is updated from a fixed version (`3.4.0`) to `"main"` in both Gradle and Maven files, aligning with branch-based versioning (`fe/build.gradle.kts`, `fe/fe-core/pom.xml`). [[1]](diffhunk://#diff-711c8906780096a2b018ddab40f5bb1cffefa75869524a80859b3ea46f3c7616L22-R22) [[2]](diffhunk://#diff-2b120d7920d8f6dc0232fe8bb5d82565e5afedd8a5e1c6d2027f20a76a8475c6L29-R29)
- The Maven dependency plugin configuration that copied dependencies to the target lib directory is removed from `fe-core/pom.xml`, as this responsibility is now handled in the new module structure. [[1]](diffhunk://#diff-2b120d7920d8f6dc0232fe8bb5d82565e5afedd8a5e1c6d2027f20a76a8475c6L1102-L1125) [[2]](diffhunk://#diff-2b120d7920d8f6dc0232fe8bb5d82565e5afedd8a5e1c6d2027f20a76a8475c6L895)
- The FE build process now explicitly depends on the `hive-udf` shadowJar task, ensuring correct build order (`fe/fe-core/build.gradle.kts`).

**Other improvements:**
- A new constant, `AUTHENTICATION_CHAIN_MECHANISM_NATIVE`, is added to `SecurityIntegration` for improved authentication mechanism clarity (`SecurityIntegration.java`).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
