### PR TITLE
[Enhancement] add timer to measure tablet meta init cost

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -45,6 +45,10 @@ std::string LakeDataSource::name() const {
 }
 
 Status LakeDataSource::open(RuntimeState* state) {
+    auto ds_open_timer = ADD_TIMER(_runtime_profile, "LakeDataSourceOpenTime");
+    auto tablet_open_timer = ADD_TIMER(_runtime_profile, "LakeTabletReaderOpenTime");
+
+    SCOPED_TIMER(ds_open_timer);
     _runtime_state = state;
     const TLakeScanNode& thrift_lake_scan_node = _provider->_t_lake_scan_node;
     TupleDescriptor* tuple_desc = state->desc_tbl().get_tuple_descriptor(thrift_lake_scan_node.tuple_id);
@@ -113,6 +117,7 @@ Status LakeDataSource::open(RuntimeState* state) {
 
     RETURN_IF_ERROR(build_scan_range(_runtime_state));
 
+    SCOPED_TIMER(tablet_open_timer);
     RETURN_IF_ERROR(init_tablet_reader(_runtime_state));
     return Status::OK();
 }

--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -188,8 +188,6 @@ public:
         if (_opened) return Status::OK();
 
         _scan_timer = ADD_TIMER(_runtime_profile, "ScanTime");
-        ADD_TIMER(_runtime_profile, "IOTaskWaitTime");
-        ADD_TIMER(_runtime_profile, "IOTaskExecTime");
         SCOPED_TIMER(_scan_timer);
         RETURN_IF_ERROR(_data_source->open(state));
         _opened = true;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Add two timers to measure the LakeDataSource and LakeTabletInit time cost.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds profiling timers for LakeDataSource and LakeTabletReader open phases and removes unused I/O task timers in ConnectorScanNode.
> 
> - **Profiling**:
>   - Add `LakeDataSourceOpenTime` and `LakeTabletReaderOpenTime` timers in `connector/lake_connector.cpp` with scoped timing around open and tablet reader initialization.
> - **Cleanup**:
>   - Remove unused `IOTaskWaitTime` and `IOTaskExecTime` timers from `exec/connector_scan_node.cpp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b06919aa89e354599ee43f8b9fe97154f8a0c53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->