### PR TITLE
[Enhancement] Support type hints and dataclass compatibility for Python under 3.10

### DIFF
--- a/contrib/starrocks-python-client/starrocks/dialect.py
+++ b/contrib/starrocks-python-client/starrocks/dialect.py
@@ -15,6 +15,7 @@
 import re
 from textwrap import dedent
 import time
+from typing import Union
 
 from sqlalchemy import Connection, exc, schema as sa_schema
 from sqlalchemy.dialects.mysql.pymysql import MySQLDialect_pymysql
@@ -423,7 +424,7 @@ class StarRocksDialect(MySQLDialect_pymysql):
         return _reflection.StarRocksTableDefinitionParser(self, preparer)
 
     def _read_from_information_schema(
-        self, connection: Connection, inf_sch_table: str, charset: str | None = None, **kwargs
+        self, connection: Connection, inf_sch_table: str, charset: Union[str, None] = None, **kwargs
     ):
         def escape_single_quote(s):
             return s.replace("'", "\\'")
@@ -449,7 +450,7 @@ class StarRocksDialect(MySQLDialect_pymysql):
         return rows
     
     @reflection.cache
-    def _setup_parser(self, connection: Connection, table_name: str, schema: str | None = None, **kw):
+    def _setup_parser(self, connection: Connection, table_name: str, schema: Union[str, None] = None, **kw):
         charset = self._connection_charset
         parser = self._tabledef_parser
 

--- a/contrib/starrocks-python-client/starrocks/reflection.py
+++ b/contrib/starrocks-python-client/starrocks/reflection.py
@@ -27,8 +27,15 @@ from sqlalchemy import log
 from sqlalchemy import types as sqltypes
 from sqlalchemy import util
 
-
-@dataclasses.dataclass(kw_only=True)
+# kw_only is added in python 3.10
+# https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass
+# To support python 3.9, we need to check if kw_only is in dataclasses.__all__
+# If it is, we can use it, otherwise we can't
+# This is a workaround for the lack of kw_only in python 3.9
+# We use a dict to pass the kw_only argument if it is available
+# This way, we can keep the code compatible with both python 3.9 and 3.10+
+# This is a temporary solution until we drop support for python 3.9 in the future
+@dataclasses.dataclass(**dict(kw_only=True) if 'KW_ONLY' in dataclasses.__all__ else {})
 class ReflectedState(object):
     """Stores informations about table or view."""
 

--- a/contrib/starrocks-python-client/starrocks/reflection.py
+++ b/contrib/starrocks-python-client/starrocks/reflection.py
@@ -16,7 +16,7 @@
 import dataclasses
 import json
 import re
-from typing import Any
+from typing import Any, Union
 
 from sqlalchemy.dialects.mysql.types import DATETIME
 from sqlalchemy.dialects.mysql.types import TIME
@@ -32,7 +32,7 @@ from sqlalchemy import util
 class ReflectedState(object):
     """Stores informations about table or view."""
 
-    table_name: str | None = None
+    table_name: Union[str, None] = None
     columns: list[dict] = dataclasses.field(default_factory=list)
     table_options: dict[str, str] = dataclasses.field(default_factory=dict)
     keys: list[dict] = dataclasses.field(default_factory=list)

--- a/contrib/starrocks-python-client/starrocks/reflection.py
+++ b/contrib/starrocks-python-client/starrocks/reflection.py
@@ -29,12 +29,6 @@ from sqlalchemy import util
 
 # kw_only is added in python 3.10
 # https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass
-# To support python 3.9, we need to check if kw_only is in dataclasses.__all__
-# If it is, we can use it, otherwise we can't
-# This is a workaround for the lack of kw_only in python 3.9
-# We use a dict to pass the kw_only argument if it is available
-# This way, we can keep the code compatible with both python 3.9 and 3.10+
-# This is a temporary solution until we drop support for python 3.9 in the future
 @dataclasses.dataclass(**dict(kw_only=True) if 'KW_ONLY' in dataclasses.__all__ else {})
 class ReflectedState(object):
     """Stores informations about table or view."""


### PR DESCRIPTION
## Why I'm doing:

`starrocks-python-client` support most of the python3 version, but there are some new features that is not compatibility for Python under 3.10

## What I'm doing:

- use `Union` for supporting type hints in python under 3.10
- not setting `kw_only` for dataclasses in python under 3.10


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
