### PR TITLE
[Enhancement] Improve fragment instance exec state report

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -358,9 +358,10 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
     }
 
     auto exec_env = fragment_ctx->runtime_state()->exec_env();
-    auto fragment_id = fragment_ctx->fragment_instance_id();
+    auto instance_id = fragment_ctx->fragment_instance_id();
+    auto query_id = fragment_ctx->query_id();
 
-    auto report_task = [params, exec_env, fe_addr, fragment_id]() {
+    auto report_task = [params, exec_env, fe_addr, instance_id, query_id]() {
         int retry_times = 0;
         int max_retry_times = config::report_exec_rpc_request_retry_num;
         while (retry_times++ < max_retry_times) {
@@ -374,20 +375,20 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
 
             if (!status.ok()) {
                 if (status.is_not_found()) {
-                    VLOG(1) << "[Driver] Fail to report exec state due to query not found: fragment_instance_id="
-                            << print_id(fragment_id);
+                    VLOG(1) << "[Driver] Fail to report exec state due to query not found. fragment_instance_id="
+                            << print_id(instance_id) << ", query_id=" << print_id(query_id);
                 } else {
-                    LOG(WARNING) << "[Driver] Fail to report exec state: fragment_instance_id=" << print_id(fragment_id)
-                                 << ", status: " << status.to_string() << ", retry_times=" << retry_times
-                                 << ", max_retry_times=" << max_retry_times;
+                    LOG(WARNING) << "[Driver] Fail to report exec state. fragment_instance_id=" << print_id(instance_id)
+                                 << ", query_id=" << print_id(query_id) << ", status: " << status.to_string()
+                                 << ", retry_times=" << retry_times << ", max_retry_times=" << max_retry_times;
                     // if it is done exec state report, we should retry
                     if (params->__isset.done && params->done) {
                         continue;
                     }
                 }
             } else {
-                VLOG(1) << "[Driver] Succeed to report exec state: fragment_instance_id=" << print_id(fragment_id)
-                        << ", is_done=" << params->done;
+                VLOG(1) << "[Driver] Succeed to report exec state. fragment_instance_id=" << print_id(instance_id)
+                        << ", query_id=" << print_id(query_id) << ", is_done=" << params->done;
             }
             break;
         }
@@ -395,10 +396,11 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
 
     // if it is done exec state report, We need to ensure that this report is executed with priority
     // and is retried as much as possible to ensure success.
-    // Otherwise, it may result in the query or ingestion status getting stuck.
-    this->_exec_state_reporter->submit(std::move(report_task), done);
-    VLOG(2) << "[Driver] Submit exec state report task: fragment_instance_id=" << print_id(fragment_id)
-            << ", is_done=" << done;
+    // Otherwise, it may result in the ingestion status getting stuck.
+    bool priority = done && fragment_ctx->runtime_state()->query_options().query_type == TQueryType::LOAD;
+    this->_exec_state_reporter->submit(std::move(report_task), priority);
+    VLOG(2) << "[Driver] Submit exec state report task. fragment_instance_id=" << print_id(instance_id)
+            << ", query_id=" << print_id(query_id) << ", is_done=" << done;
 }
 
 void GlobalDriverExecutor::report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1060,6 +1060,10 @@ public class DefaultCoordinator extends Coordinator {
             // count down to zero to notify all objects waiting for this
             if (!connectContext.isProfileEnabled()) {
                 queryProfile.finishAllInstances(Status.OK);
+                List<String> unFinishedInstanceIds = queryProfile.getUnfinishedInstanceIds();
+                if (!unFinishedInstanceIds.isEmpty()) {
+                    LOG.info("query: {} has unfinished instances: {}", connectContext.queryId, unFinishedInstanceIds);
+                }
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -684,7 +684,11 @@ public class QueryRuntimeProfile {
         return matcher.matches() ? Optional.of(matcher.group(1)) : Optional.empty();
     }
 
-    private List<String> getUnfinishedInstanceIds() {
+    public List<String> getUnfinishedInstanceIds() {
+        if (profileDoneSignal == null) {
+            return Lists.newArrayList();
+        }
+
         return profileDoneSignal.getLeftMarks().stream()
                 .map(Map.Entry::getKey)
                 .map(DebugUtil::printId)


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. only ingestion final fragment instance exec state report task will be executed in priority thread pool.
2. add query id in BE log.
3. add unfinished instances log in FE log.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
