### PR TITLE
[Enhancement] reduce the threshold of tablet internal parallel scan

### DIFF
--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -22,6 +22,7 @@
 #include "column/column_access_path.h"
 #include "column/type_traits.h"
 #include "common/compiler_util.h"
+#include "common/config.h"
 #include "common/status.h"
 #include "exec/olap_scan_prepare.h"
 #include "exec/pipeline/limit_operator.h"
@@ -474,7 +475,7 @@ StatusOr<bool> OlapScanNode::_could_tablet_internal_parallel(
     }
     bool force_split = tablet_internal_parallel_mode == TTabletInternalParallelMode::type::FORCE_SPLIT;
     // The enough number of tablets shouldn't use tablet internal parallel.
-    if (!force_split && num_total_scan_ranges >= pipeline_dop) {
+    if (!force_split && num_total_scan_ranges >= pipeline_dop * config::io_tasks_per_scan_operator) {
         return false;
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

The PhysicalSplit scan strategy becomes less effective when there are too many tablets, and the current threshold is set too high, preventing some advantageous scenarios.

To address this, the strategy has been updated:
- Previously: The `PhysicalSplit` strategy was not selected if the number of tablets exceeded `pipeline_dop`.
- Now: The `PhysicalSplit` strategy will not be selected if the number of tablets exceeds `pipeline_dop * 4`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3