### PR TITLE
[BugFix] Fix incompatible zonemap reuse for fast schema evolution in shared-data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -61,6 +61,7 @@ import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.SchemaChangeTypeCompatibility;
 import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.StructField;
 import com.starrocks.catalog.StructType;
@@ -910,6 +911,10 @@ public class SchemaChangeHandler extends AlterHandler {
             if (column.isKey()) {
                 return false;
             }
+        }
+
+        if (!SchemaChangeTypeCompatibility.canReuseZonemapIndex(oriColumn.getType(), modColumn.getType())) {
+            fastSchemaEvolution = false;
         }
 
         return fastSchemaEvolution;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -500,7 +500,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
             throw new DdlException("Dest column name is empty");
         }
 
-        if (!ColumnType.isSchemaChangeAllowed(type, other.type)) {
+        if (!SchemaChangeTypeCompatibility.isSchemaChangeAllowed(type, other.type)) {
             throw new DdlException("Can not change " + getType() + " to " + other.getType());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaChangeTypeCompatibility.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaChangeTypeCompatibility.java
@@ -36,7 +36,7 @@ package com.starrocks.catalog;
 
 import com.starrocks.mysql.MysqlCodec;
 
-public abstract class ColumnType {
+public class SchemaChangeTypeCompatibility {
     private static Boolean[][] schemaChangeMatrix;
 
     static {
@@ -152,11 +152,98 @@ public abstract class ColumnType {
         return false;
     }
 
-    static boolean isSchemaChangeAllowed(Type lhs, Type rhs) {
+    public static boolean isSchemaChangeAllowed(Type lhs, Type rhs) {
         if (lhs.isDecimalV3() || rhs.isDecimalV3()) {
             return isSchemaChangeAllowedInvolvingDecimalV3(lhs, rhs);
         }
         return schemaChangeMatrix[lhs.getPrimitiveType().ordinal()][rhs.getPrimitiveType().ordinal()];
+    }
+
+    /**
+     * Matrix defining allowed type conversions for ZoneMap index reuse during schema change.
+     * ZoneMap indexes store min/max values and nullability information (has_null, has_not_null) for data blocks.
+     * For a ZoneMap index to be reusable after a type conversion, the following conditions must be met:
+     * 1. The type conversion must be monotonically non-decreasing, ensuring that the original min/max values remain valid
+     *    min/max boundaries after conversion.
+     * 2. The type conversion must not change non-null values to null, ensuring that has_null/has_not_null metadata
+     *    remains accurate.
+     *
+     * For example, converting a `STRING` column to an `INT` column can not reuse zonemap index:
+     * - Min/Max change: For values like "16", "423", "5", "97" in string format, min is "16" and max is "97".
+     *   After conversion to integers (5, 16, 97, 423), the min becomes 5 and max becomes 423. The original zonemap
+     *   (min="16", max="97") would incorrectly prune valid data (e.g., a query for `WHERE col = 5`).
+     * - Nullability change: If the string column contains values like "abc", converting it to `INT` would result in `NULL`.
+     *   If the original column had `has_null=false`, this conversion would make the zonemap's nullability metadata incorrect.
+     */
+    private static final Boolean[][] ZONEMAP_REUSE_COMPATIBILITY_MATRIX;
+
+    static {
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX = new Boolean[PrimitiveType.values().length][PrimitiveType.values().length];
+        for (int i = 0; i < ZONEMAP_REUSE_COMPATIBILITY_MATRIX.length; i++) {
+            for (int j = 0; j < ZONEMAP_REUSE_COMPATIBILITY_MATRIX[i].length; j++) {
+                ZONEMAP_REUSE_COMPATIBILITY_MATRIX[i][j] = (i > 0 && i == j); // 0 is PrimitiveType.INVALID_TYPE
+            }
+        }
+
+        // Integer family
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.TINYINT.ordinal()][PrimitiveType.SMALLINT.ordinal()] = true;
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.TINYINT.ordinal()][PrimitiveType.INT.ordinal()] = true;
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.TINYINT.ordinal()][PrimitiveType.BIGINT.ordinal()] = true;
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.TINYINT.ordinal()][PrimitiveType.LARGEINT.ordinal()] = true;
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.TINYINT.ordinal()][PrimitiveType.DOUBLE.ordinal()] = true;
+
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.SMALLINT.ordinal()][PrimitiveType.INT.ordinal()] = true;
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.SMALLINT.ordinal()][PrimitiveType.BIGINT.ordinal()] = true;
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.SMALLINT.ordinal()][PrimitiveType.LARGEINT.ordinal()] = true;
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.SMALLINT.ordinal()][PrimitiveType.DOUBLE.ordinal()] = true;
+
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.INT.ordinal()][PrimitiveType.BIGINT.ordinal()] = true;
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.INT.ordinal()][PrimitiveType.LARGEINT.ordinal()] = true;
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.INT.ordinal()][PrimitiveType.DOUBLE.ordinal()] = true;
+
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.BIGINT.ordinal()][PrimitiveType.LARGEINT.ordinal()] = true;
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.BIGINT.ordinal()][PrimitiveType.DOUBLE.ordinal()] = true;
+
+        // Floating-point family
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.FLOAT.ordinal()][PrimitiveType.DOUBLE.ordinal()] = true;
+
+        // Decimal family
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.DECIMALV2.ordinal()][PrimitiveType.DECIMAL128.ordinal()] = true;
+
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.DECIMAL32.ordinal()][PrimitiveType.DECIMAL64.ordinal()] = true;
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.DECIMAL32.ordinal()][PrimitiveType.DECIMAL128.ordinal()] = true;
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.DECIMAL32.ordinal()][PrimitiveType.DECIMAL256.ordinal()] = true;
+
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.DECIMAL64.ordinal()][PrimitiveType.DECIMAL128.ordinal()] = true;
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.DECIMAL64.ordinal()][PrimitiveType.DECIMAL256.ordinal()] = true;
+
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.DECIMAL128.ordinal()][PrimitiveType.DECIMAL256.ordinal()] = true;
+
+        // Date/Datetime family
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.DATE.ordinal()][PrimitiveType.DATETIME.ordinal()] = true;
+
+        // String family
+        ZONEMAP_REUSE_COMPATIBILITY_MATRIX[PrimitiveType.CHAR.ordinal()][PrimitiveType.VARCHAR.ordinal()] = true;
+    }
+
+    /**
+     * Determines if a type conversion allows ZoneMap indexes to be reused.
+     * <p>
+     * This method evaluates two conditions:
+     * 1. If the source type does not support ZoneMap, no index exists to reuse, so it returns true.
+     * 2. For ZoneMap-supported source types, it checks if the target type is within the predefined compatibility matrix.
+     * <p>
+     * It assumes {@link #isSchemaChangeAllowed(Type, Type)} has been checked.
+     *
+     * @param fromType The original column type.
+     * @param toType   The new column type.
+     * @return True if the ZoneMap index can be reused for the type promotion, or if ZoneMap is not applicable; otherwise, false.
+     */
+    public static boolean canReuseZonemapIndex(Type fromType, Type toType) {
+        if (!fromType.supportZonemap()) {
+            return true;
+        }
+        return ZONEMAP_REUSE_COMPATIBILITY_MATRIX[fromType.getPrimitiveType().ordinal()][toType.getPrimitiveType().ordinal()];
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaChangeTypeCompatibility.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaChangeTypeCompatibility.java
@@ -240,7 +240,7 @@ public class SchemaChangeTypeCompatibility {
      * @return True if the ZoneMap index can be reused for the type promotion, or if ZoneMap is not applicable; otherwise, false.
      */
     public static boolean canReuseZonemapIndex(Type fromType, Type toType) {
-        if (!fromType.supportZonemap()) {
+        if (!fromType.supportZoneMap()) {
             return true;
         }
         return ZONEMAP_REUSE_COMPATIBILITY_MATRIX[fromType.getPrimitiveType().ordinal()][toType.getPrimitiveType().ordinal()];

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -903,6 +903,10 @@ public abstract class Type implements Cloneable {
                 !isJsonType() && !isOnlyMetricType() && !isFunctionType() && !isBinaryType();
     }
 
+    public boolean supportZonemap() {
+        return isScalarType() && (isNumericType() || isDateType() || isStringType());
+    }
+
     public static final String NOT_SUPPORT_JOIN_ERROR_MSG =
             "Type (nested) percentile/hll/bitmap/json not support join";
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -903,7 +903,7 @@ public abstract class Type implements Cloneable {
                 !isJsonType() && !isOnlyMetricType() && !isFunctionType() && !isBinaryType();
     }
 
-    public boolean supportZonemap() {
+    public boolean supportZoneMap() {
         return isScalarType() && (isNumericType() || isDateType() || isStringType());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -266,15 +266,23 @@ public class LakeTableAsyncFastSchemaChangeJobTest extends StarRocksTestBase {
     @Test
     public void testModifyColumnType() throws Exception {
         LakeTable table = createTable(connectContext, "CREATE TABLE t_modify_type" +
-                    "(c0 INT, c1 INT, c2 VARCHAR(5), c3 DATE)" +
-                    "DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) " +
-                    "BUCKETS 1 PROPERTIES('fast_schema_evolution'='true')");
+                "(c0 INT, c1 INT, c2 FLOAT, c3 DATE, c4 VARCHAR(10))" +
+                "DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) " +
+                "BUCKETS 1 PROPERTIES('fast_schema_evolution'='true')");
         long oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
+
+        // zonemap index can be reused
         {
-            executeAlterAndWaitFinish(table, "ALTER TABLE t_modify_type MODIFY COLUMN c1 BIGINT, MODIFY COLUMN c2 VARCHAR(10)," +
-                        "MODIFY COLUMN c3 DATETIME", true);
+            String alterSql = """
+                        ALTER TABLE t_modify_type 
+                            MODIFY COLUMN c1 BIGINT,
+                            MODIFY COLUMN c2 DOUBLE,
+                            MODIFY COLUMN c3 DATETIME,
+                            MODIFY COLUMN c4 VARCHAR(20)
+                        """;
+            executeAlterAndWaitFinish(table, alterSql, true);
             List<Column> columns = table.getBaseSchema();
-            Assertions.assertEquals(4, columns.size());
+            Assertions.assertEquals(5, columns.size());
 
             Assertions.assertEquals("c0", columns.get(0).getName());
             Assertions.assertEquals(0, columns.get(0).getUniqueId());
@@ -286,15 +294,28 @@ public class LakeTableAsyncFastSchemaChangeJobTest extends StarRocksTestBase {
 
             Assertions.assertEquals("c2", columns.get(2).getName());
             Assertions.assertEquals(2, columns.get(2).getUniqueId());
-            Assertions.assertEquals(PrimitiveType.VARCHAR, columns.get(2).getType().getPrimitiveType());
-            Assertions.assertEquals(10, ((ScalarType) columns.get(2).getType()).getLength());
+            Assertions.assertEquals(ScalarType.DOUBLE, columns.get(2).getType());
 
             Assertions.assertEquals("c3", columns.get(3).getName());
             Assertions.assertEquals(3, columns.get(3).getUniqueId());
             Assertions.assertEquals(ScalarType.DATETIME, columns.get(3).getType());
 
+            Assertions.assertEquals("c4", columns.get(4).getName());
+            Assertions.assertEquals(4, columns.get(4).getUniqueId());
+            Assertions.assertEquals(PrimitiveType.VARCHAR, columns.get(4).getType().getPrimitiveType());
+            Assertions.assertEquals(20, ((ScalarType) columns.get(4).getType()).getLength());
+
             Assertions.assertTrue(table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId() > oldSchemaId);
             Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+        }
+
+        // zonemap index can not be reused
+        {
+            executeAlterAndWaitFinish(table, "ALTER TABLE t_modify_type MODIFY COLUMN c3 DATE", false);
+            Assertions.assertEquals(ScalarType.DATE, table.getBaseSchema().get(3).getType());
+
+            executeAlterAndWaitFinish(table, "ALTER TABLE t_modify_type MODIFY COLUMN c4 INT", false);
+            Assertions.assertEquals(ScalarType.INT, table.getBaseSchema().get(4).getType());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/SchemaChangeTypeCompatibilityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/SchemaChangeTypeCompatibilityTest.java
@@ -1,0 +1,113 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import static com.starrocks.catalog.SchemaChangeTypeCompatibility.canReuseZonemapIndex;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SchemaChangeTypeCompatibilityTest {
+
+    @Test
+    public void testZoneMapIndexReuse() {
+        assertTrue(canReuseZonemapIndex(Type.TINYINT, Type.TINYINT));
+        assertTrue(canReuseZonemapIndex(Type.TINYINT, Type.SMALLINT));
+        assertTrue(canReuseZonemapIndex(Type.TINYINT, Type.INT));
+        assertTrue(canReuseZonemapIndex(Type.TINYINT, Type.BIGINT));
+        assertTrue(canReuseZonemapIndex(Type.TINYINT, Type.LARGEINT));
+        assertTrue(canReuseZonemapIndex(Type.TINYINT, Type.DOUBLE));
+
+        assertTrue(canReuseZonemapIndex(Type.SMALLINT, Type.SMALLINT));
+        assertTrue(canReuseZonemapIndex(Type.SMALLINT, Type.INT));
+        assertTrue(canReuseZonemapIndex(Type.SMALLINT, Type.BIGINT));
+        assertTrue(canReuseZonemapIndex(Type.SMALLINT, Type.LARGEINT));
+        assertTrue(canReuseZonemapIndex(Type.SMALLINT, Type.DOUBLE));
+
+        assertTrue(canReuseZonemapIndex(Type.INT, Type.INT));
+        assertTrue(canReuseZonemapIndex(Type.INT, Type.BIGINT));
+        assertTrue(canReuseZonemapIndex(Type.INT, Type.LARGEINT));
+        assertTrue(canReuseZonemapIndex(Type.INT, Type.DOUBLE));
+
+        assertTrue(canReuseZonemapIndex(Type.BIGINT, Type.BIGINT));
+        assertTrue(canReuseZonemapIndex(Type.BIGINT, Type.LARGEINT));
+        assertTrue(canReuseZonemapIndex(Type.BIGINT, Type.DOUBLE));
+
+        assertTrue(canReuseZonemapIndex(Type.LARGEINT, Type.LARGEINT));
+
+        assertTrue(canReuseZonemapIndex(Type.FLOAT, Type.FLOAT));
+        assertTrue(canReuseZonemapIndex(Type.FLOAT, Type.DOUBLE));
+
+        assertTrue(canReuseZonemapIndex(Type.DOUBLE, Type.DOUBLE));
+
+        assertTrue(canReuseZonemapIndex(Type.DECIMALV2, Type.DECIMALV2));
+        assertTrue(canReuseZonemapIndex(Type.DECIMALV2, Type.DECIMAL128));
+
+        assertTrue(canReuseZonemapIndex(Type.DECIMAL32, Type.DECIMAL32));
+        assertTrue(canReuseZonemapIndex(Type.DECIMAL32, Type.DECIMAL64));
+        assertTrue(canReuseZonemapIndex(Type.DECIMAL32, Type.DECIMAL128));
+        assertTrue(canReuseZonemapIndex(Type.DECIMAL32, Type.DECIMAL256));
+
+        assertTrue(canReuseZonemapIndex(Type.DECIMAL64, Type.DECIMAL64));
+        assertTrue(canReuseZonemapIndex(Type.DECIMAL64, Type.DECIMAL128));
+        assertTrue(canReuseZonemapIndex(Type.DECIMAL64, Type.DECIMAL256));
+
+        assertTrue(canReuseZonemapIndex(Type.DECIMAL128, Type.DECIMAL128));
+        assertTrue(canReuseZonemapIndex(Type.DECIMAL128, Type.DECIMAL256));
+
+        assertTrue(canReuseZonemapIndex(Type.DECIMAL256, Type.DECIMAL256));
+
+        assertTrue(canReuseZonemapIndex(Type.DATE, Type.DATE));
+        assertTrue(canReuseZonemapIndex(Type.DATE, Type.DATETIME));
+
+        assertTrue(canReuseZonemapIndex(Type.DATETIME, Type.DATETIME));
+
+        ScalarType char10 = ScalarType.createCharType(10);
+        ScalarType varchar20 = ScalarType.createVarcharType(20);
+        assertTrue(canReuseZonemapIndex(char10, char10));
+        assertTrue(canReuseZonemapIndex(char10, varchar20));
+
+        ScalarType varchar30 = ScalarType.createVarcharType(30);
+        assertTrue(canReuseZonemapIndex(varchar20, varchar30));
+    }
+
+    @Test
+    public void testZoneMapIndexNotReuse() {
+        // decreasing width
+        assertFalse(canReuseZonemapIndex(Type.INT, Type.SMALLINT));
+        assertFalse(canReuseZonemapIndex(Type.BIGINT, Type.INT));
+
+        // integer to float is not in allowed matrix (only float->double allowed)
+        assertFalse(canReuseZonemapIndex(Type.INT, Type.FLOAT));
+
+        // double to float narrowing not allowed
+        assertFalse(canReuseZonemapIndex(Type.DOUBLE, Type.FLOAT));
+
+        // decimal narrowing
+        assertFalse(canReuseZonemapIndex(Type.DECIMAL128, Type.DECIMAL64));
+
+        assertFalse(canReuseZonemapIndex(Type.DATETIME, Type.DATE));
+
+        // varchar to char not allowed by reuse matrix
+        ScalarType varchar20 = ScalarType.createVarcharType(20);
+        ScalarType char10 = ScalarType.createCharType(10);
+        assertFalse(canReuseZonemapIndex(varchar20, char10));
+
+        // string <-> int not allowed
+        assertFalse(canReuseZonemapIndex(varchar20, Type.INT));
+        assertFalse(canReuseZonemapIndex(Type.INT, varchar20));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -418,4 +418,40 @@ public class TypeTest {
             Assertions.assertTrue(Type.canCastTo(jsonType, mapType));
         }
     }
+
+    @Test
+    public void testSupportZonemap() {
+        // Positive cases: Scalar types that are numeric, date, or string
+        Assertions.assertTrue(Type.TINYINT.supportZonemap());
+        Assertions.assertTrue(Type.SMALLINT.supportZonemap());
+        Assertions.assertTrue(Type.INT.supportZonemap());
+        Assertions.assertTrue(Type.BIGINT.supportZonemap());
+        Assertions.assertTrue(Type.LARGEINT.supportZonemap());
+        Assertions.assertTrue(Type.FLOAT.supportZonemap());
+        Assertions.assertTrue(Type.DOUBLE.supportZonemap());
+        Assertions.assertTrue(Type.DATE.supportZonemap());
+        Assertions.assertTrue(Type.DATETIME.supportZonemap());
+        Assertions.assertTrue(Type.VARCHAR.supportZonemap());
+        Assertions.assertTrue(Type.CHAR.supportZonemap());
+        Assertions.assertTrue(Type.DEFAULT_DECIMALV2.supportZonemap());
+        Assertions.assertTrue(Type.DECIMAL32.supportZonemap());
+        Assertions.assertTrue(Type.DECIMAL64.supportZonemap());
+        Assertions.assertTrue(Type.DECIMAL128.supportZonemap());
+        Assertions.assertTrue(Type.DECIMAL256.supportZonemap());
+        Assertions.assertTrue(ScalarType.createVarcharType(10).supportZonemap());
+        Assertions.assertTrue(ScalarType.createCharType(5).supportZonemap());
+
+        // Negative cases: Non-scalar types or scalar types that are not numeric, date, or string
+        Assertions.assertFalse(Type.NULL.supportZonemap());
+        Assertions.assertFalse(Type.BOOLEAN.supportZonemap()); // Boolean is not numeric, date or string
+        Assertions.assertFalse(Type.HLL.supportZonemap());
+        Assertions.assertFalse(Type.BITMAP.supportZonemap());
+        Assertions.assertFalse(Type.PERCENTILE.supportZonemap());
+        Assertions.assertFalse(Type.JSON.supportZonemap());
+        Assertions.assertFalse(Type.FUNCTION.supportZonemap());
+        Assertions.assertFalse(Type.VARBINARY.supportZonemap());
+        Assertions.assertFalse(Type.ARRAY_INT.supportZonemap());
+        Assertions.assertFalse(Type.MAP_VARCHAR_VARCHAR.supportZonemap());
+        Assertions.assertFalse(new StructType(Lists.newArrayList(Type.INT)).supportZonemap());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -422,36 +422,36 @@ public class TypeTest {
     @Test
     public void testSupportZonemap() {
         // Positive cases: Scalar types that are numeric, date, or string
-        Assertions.assertTrue(Type.TINYINT.supportZonemap());
-        Assertions.assertTrue(Type.SMALLINT.supportZonemap());
-        Assertions.assertTrue(Type.INT.supportZonemap());
-        Assertions.assertTrue(Type.BIGINT.supportZonemap());
-        Assertions.assertTrue(Type.LARGEINT.supportZonemap());
-        Assertions.assertTrue(Type.FLOAT.supportZonemap());
-        Assertions.assertTrue(Type.DOUBLE.supportZonemap());
-        Assertions.assertTrue(Type.DATE.supportZonemap());
-        Assertions.assertTrue(Type.DATETIME.supportZonemap());
-        Assertions.assertTrue(Type.VARCHAR.supportZonemap());
-        Assertions.assertTrue(Type.CHAR.supportZonemap());
-        Assertions.assertTrue(Type.DEFAULT_DECIMALV2.supportZonemap());
-        Assertions.assertTrue(Type.DECIMAL32.supportZonemap());
-        Assertions.assertTrue(Type.DECIMAL64.supportZonemap());
-        Assertions.assertTrue(Type.DECIMAL128.supportZonemap());
-        Assertions.assertTrue(Type.DECIMAL256.supportZonemap());
-        Assertions.assertTrue(ScalarType.createVarcharType(10).supportZonemap());
-        Assertions.assertTrue(ScalarType.createCharType(5).supportZonemap());
+        Assertions.assertTrue(Type.TINYINT.supportZoneMap());
+        Assertions.assertTrue(Type.SMALLINT.supportZoneMap());
+        Assertions.assertTrue(Type.INT.supportZoneMap());
+        Assertions.assertTrue(Type.BIGINT.supportZoneMap());
+        Assertions.assertTrue(Type.LARGEINT.supportZoneMap());
+        Assertions.assertTrue(Type.FLOAT.supportZoneMap());
+        Assertions.assertTrue(Type.DOUBLE.supportZoneMap());
+        Assertions.assertTrue(Type.DATE.supportZoneMap());
+        Assertions.assertTrue(Type.DATETIME.supportZoneMap());
+        Assertions.assertTrue(Type.VARCHAR.supportZoneMap());
+        Assertions.assertTrue(Type.CHAR.supportZoneMap());
+        Assertions.assertTrue(Type.DEFAULT_DECIMALV2.supportZoneMap());
+        Assertions.assertTrue(Type.DECIMAL32.supportZoneMap());
+        Assertions.assertTrue(Type.DECIMAL64.supportZoneMap());
+        Assertions.assertTrue(Type.DECIMAL128.supportZoneMap());
+        Assertions.assertTrue(Type.DECIMAL256.supportZoneMap());
+        Assertions.assertTrue(ScalarType.createVarcharType(10).supportZoneMap());
+        Assertions.assertTrue(ScalarType.createCharType(5).supportZoneMap());
 
         // Negative cases: Non-scalar types or scalar types that are not numeric, date, or string
-        Assertions.assertFalse(Type.NULL.supportZonemap());
-        Assertions.assertFalse(Type.BOOLEAN.supportZonemap()); // Boolean is not numeric, date or string
-        Assertions.assertFalse(Type.HLL.supportZonemap());
-        Assertions.assertFalse(Type.BITMAP.supportZonemap());
-        Assertions.assertFalse(Type.PERCENTILE.supportZonemap());
-        Assertions.assertFalse(Type.JSON.supportZonemap());
-        Assertions.assertFalse(Type.FUNCTION.supportZonemap());
-        Assertions.assertFalse(Type.VARBINARY.supportZonemap());
-        Assertions.assertFalse(Type.ARRAY_INT.supportZonemap());
-        Assertions.assertFalse(Type.MAP_VARCHAR_VARCHAR.supportZonemap());
-        Assertions.assertFalse(new StructType(Lists.newArrayList(Type.INT)).supportZonemap());
+        Assertions.assertFalse(Type.NULL.supportZoneMap());
+        Assertions.assertFalse(Type.BOOLEAN.supportZoneMap()); // Boolean is not numeric, date or string
+        Assertions.assertFalse(Type.HLL.supportZoneMap());
+        Assertions.assertFalse(Type.BITMAP.supportZoneMap());
+        Assertions.assertFalse(Type.PERCENTILE.supportZoneMap());
+        Assertions.assertFalse(Type.JSON.supportZoneMap());
+        Assertions.assertFalse(Type.FUNCTION.supportZoneMap());
+        Assertions.assertFalse(Type.VARBINARY.supportZoneMap());
+        Assertions.assertFalse(Type.ARRAY_INT.supportZoneMap());
+        Assertions.assertFalse(Type.MAP_VARCHAR_VARCHAR.supportZoneMap());
+        Assertions.assertFalse(new StructType(Lists.newArrayList(Type.INT)).supportZoneMap());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Fast schema evolution in shared-data modifies a column's type without rewriting data files, and the existing zonemap index is reused for the new type. However, this reuse is not always safe. For certain type conversions, the min/max values stored in the zonemap are no longer valid under the new type's comparison rules, leading to incorrect query results.

For example, when changing a column from `INT` to `STRING`, the numeric ordering (`9 < 123`) differs from the lexicographical ordering (`"123" < "9"`). Reusing the integer-based zonemap for string-based comparisons will cause the query engine to prune data incorrectly. This issue can be reproduced with the following steps:
```
create table t (c0 int, c1 int) duplicate key (c0);

insert into t values (1, 123), (2, 9);

select * from t where c1 = 123;             -- expect one row. correct
+------+------+
| c0   | c1   |
+------+------+
|    1 |  123 |
+------+------+
1 row in set (0.02 sec)

alter table t modify column c1 string;

select * from t where c1 = "123";           -- expect one row, but is empty. wrong
Empty set (0.01 sec)
```

From the profile, we can observe that the zonemap filter unexpectedly pruned all rows.

<img width="468" height="100" alt="image" src="https://github.com/user-attachments/assets/3af79d1a-3e5c-4d35-98d6-318203a7a7c4" />

This PR wants to fix the issue.

## What I'm doing:

### Conditions for Zonemap Index Reuse
The zonemap index mechanism is briefly illustrated below. The type conversion that wants to safely reuse the existing zonemap index must meet two conditions simultaneously:
* The type conversion must be monotonically non-decreasing. This ensures that the original min/max values remain valid boundaries after the conversion.
* The type conversion must not change non-null values to null. This is required to keep the has_null and has_not_null metadata accurate.

<img width="1130" height="435" alt="image" src="https://github.com/user-attachments/assets/c19fd7a0-39c2-493e-a4b1-70498ee1f2b0" />

Based on these conditions, the following is the compatibility matrix defining which type conversions can safely reuse the zonemap index.
- Schema Change Conversion Prohibited: ⚪
- Zonmap Index can be reused:  ✅
- Zonmap Index can not be reused:  ❌
<img width="1395" height="709" alt="image" src="https://github.com/user-attachments/assets/3e2bfe75-03ee-48c1-956f-2943f8ba9268" />

### Solution

To address this issue, two potential solutions were considered:

**Option 1: Prohibit Incompatible Fast Schema Evolution (FE-side Check)**

This approach involves enhancing the validation logic in the Frontend (FE). Before a fast schema evolution is executed, the system checks if the proposed type change is compatible with zonemap index reuse. If the conversion is not on the approved list, fast schema evolution is disallowed, and the operation falls back to the traditional method of rewriting data and rebuilding the index.

   *   **Pros:** Guarantees that zonemap indexes are always valid and can be used by the query optimizer, ensuring consistent and predictable performance.
   *   **Cons:** A subset of type changes (primarily conversions to/from `VARCHAR`) will not be able to use the fast schema evolution feature. Based on experience, these types of conversions are infrequent.

**Option 2: Conditionally Disable Zonemap Index at Query Time (BE-side Logic)**

This alternative would allow all type conversions to proceed with fast schema evolution. The Backend (BE) would then be responsible for detecting incompatible conversions at query time and disabling the use of the zonemap index for those specific columns.

   *   **Pros:** Allows all type modifications to benefit from fast schema evolution, avoiding data rewrites.
   *   **Cons:** May lead to significant and unpredictable performance degradation for queries, as the optimizer would be unable to use the zonemap for pruning.

**Decision**

Query performance is a critical priority. The zonemap index is a widely used and highly effective optimization, and disabling it could have a severe, hard-to-predict impact. Therefore, **choose Option 1** to guarantee index correctness and consistent query performance. The trade-off of disallowing fast schema evolution for a small number of less common type conversions is acceptable to avoid this risk.

### Code Changes
- Add `ZONEMAP_SCHEMA_CHANGE_MATRIX` and `canReuseZonemapIndex(fromType, toType)` to `SchemaChangeTypeCompatibility`, with clear docs on reuse principles.
- Integrate reuse check into FE fast schema evolution path:
  - In schema change planning, for shared-data fast path, validate each altered column via `canReuseZonemapIndex`.
  - If any column is incompatible, disable fast schema evolution and fall back to data rewrite (rebuild zonemap index).
- Tests:
  - Add/extend unit tests for the compatibility matrix and edge cases.
  - Add/adjust schema change tests to verify fallback behavior under incompatible conversions (e.g., VARCHAR↔INT).

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.0
  - [X] 3.5
  - [X] 3.4
  - [X] 3.3
