### PR TITLE
[BugFix] Fix the bug where UserProperty priority is lower than Session Variable

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -73,7 +73,7 @@ subprojects {
         set("protobuf-java.version", "3.25.5")
         set("puppycrawl.version", "10.21.1")
         set("spark.version", "3.5.5")
-        set("staros.version", "3.5-rc2")
+        set("staros.version", "3.5-rc3")
         set("tomcat.version", "8.5.70")
         // var sync end
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -82,7 +82,6 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.UserVariable;
 import com.starrocks.sql.ast.expression.StringLiteral;
-import com.starrocks.sql.ast.expression.VariableExpr;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.dump.DumpInfo;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
@@ -545,8 +544,8 @@ public class ConnectContext {
 
     public void modifySystemVariable(SystemVariable setVar, boolean onlySetSessionVar) throws DdlException {
         globalStateMgr.getVariableMgr().setSystemVariable(sessionVariable, setVar, onlySetSessionVar);
-        if (!SetType.GLOBAL.equals(setVar.getType()) && globalStateMgr.getVariableMgr()
-                .shouldForwardToLeader(setVar.getVariable())) {
+        if (!SetType.GLOBAL.equals(setVar.getType())
+                && globalStateMgr.getVariableMgr().shouldForwardToLeader(setVar.getVariable())) {
             modifiedSessionVariables.put(setVar.getVariable(), setVar);
         }
     }
@@ -1426,37 +1425,25 @@ public class ConnectContext {
             // set session variables
             Map<String, String> sessionVariables = userProperty.getSessionVariables();
             for (Map.Entry<String, String> entry : sessionVariables.entrySet()) {
-                String currentValue = globalStateMgr.getVariableMgr().getValue(
-                        sessionVariable, new VariableExpr(entry.getKey()));
-                if (!currentValue.equalsIgnoreCase(
-                        globalStateMgr.getVariableMgr().getDefaultValue(entry.getKey()))) {
-                    // If the current session variable is not default value, we should respect it.
-                    continue;
-                }
                 SystemVariable variable = new SystemVariable(entry.getKey(), new StringLiteral(entry.getValue()));
-                modifySystemVariable(variable, true);
+                globalStateMgr.getVariableMgr().setSystemVariable(sessionVariable, variable, true);
             }
 
             // set catalog and database
-            boolean dbHasBeenSetByUser = !getCurrentCatalog().equals(
-                    globalStateMgr.getVariableMgr().getDefaultValue(SessionVariable.CATALOG))
-                    || !getDatabase().isEmpty();
-            if (!dbHasBeenSetByUser) {
-                String catalog = userProperty.getCatalog();
-                String database = userProperty.getDatabase();
-                if (catalog.equals(UserProperty.CATALOG_DEFAULT_VALUE)) {
-                    if (!database.equals(UserProperty.DATABASE_DEFAULT_VALUE)) {
-                        changeCatalogDb(userProperty.getCatalogDbName());
-                    }
-                } else {
-                    if (database.equals(UserProperty.DATABASE_DEFAULT_VALUE)) {
-                        changeCatalog(catalog);
-                    } else {
-                        changeCatalogDb(userProperty.getCatalogDbName());
-                    }
-                    SystemVariable variable = new SystemVariable(SessionVariable.CATALOG, new StringLiteral(catalog));
-                    modifySystemVariable(variable, true);
+            String catalog = userProperty.getCatalog();
+            String database = userProperty.getDatabase();
+            if (catalog.equals(UserProperty.CATALOG_DEFAULT_VALUE)) {
+                if (!database.equals(UserProperty.DATABASE_DEFAULT_VALUE)) {
+                    changeCatalogDb(userProperty.getCatalogDbName());
                 }
+            } else {
+                if (database.equals(UserProperty.DATABASE_DEFAULT_VALUE)) {
+                    changeCatalog(catalog);
+                } else {
+                    changeCatalogDb(userProperty.getCatalogDbName());
+                }
+                SystemVariable variable = new SystemVariable(SessionVariable.CATALOG, new StringLiteral(catalog));
+                globalStateMgr.getVariableMgr().setSystemVariable(sessionVariable, variable, true);
             }
         } catch (Exception e) {
             LOG.warn("set session env failed: ", e);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteAsExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteAsExecutor.java
@@ -19,7 +19,9 @@ import com.starrocks.authentication.AuthenticationHandler;
 import com.starrocks.authentication.UserProperty;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
 import com.starrocks.sql.ast.ExecuteAsStmt;
+import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.UserRef;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -28,7 +30,7 @@ import java.util.List;
 import java.util.Set;
 
 public class ExecuteAsExecutor {
-    private static final Logger LOG = LogManager.getLogger(ExecuteAsStmt.class);
+    private static final Logger LOG = LogManager.getLogger(ExecuteAsExecutor.class);
 
     /**
      * Only set current user, won't reset any other context, for example, current database.
@@ -40,14 +42,19 @@ public class ExecuteAsExecutor {
      * MySQL [test_priv]> select * from test_table2;
      * ERROR 1064 (HY000): No database selected
      */
-    public static void execute(ExecuteAsStmt stmt, ConnectContext ctx) {
+    public static void execute(ExecuteAsStmt stmt, ConnectContext ctx) throws DdlException {
         // only support WITH NO REVERT for now
         Preconditions.checkArgument(!stmt.isAllowRevert());
         LOG.info("{} EXEC AS {} from now on", ctx.getCurrentUserIdentity(), stmt.getToUser());
 
         UserRef user = stmt.getToUser();
         // Create UserIdentity with ephemeral flag for external users
-        UserIdentity userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+        UserIdentity userIdentity;
+        if (user.isExternal()) {
+            userIdentity = UserIdentity.createEphemeralUserIdent(user.getUser(), user.getHost());
+        } else {
+            userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+        }
         ctx.setCurrentUserIdentity(userIdentity);
 
         // Refresh groups and roles for all users based on security integration
@@ -57,6 +64,13 @@ public class ExecuteAsExecutor {
             UserProperty userProperty = ctx.getGlobalStateMgr().getAuthenticationMgr()
                     .getUserProperty(user.getUser());
             ctx.updateByUserProperty(userProperty);
+
+            //Execute As not affect session variables, so we need to reset the session variables
+            SetStmt setStmt = ctx.getModifiedSessionVariables();
+            if (setStmt != null) {
+                SetExecutor executor = new SetExecutor(ctx, setStmt);
+                executor.execute();
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/UserPropertyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/UserPropertyTest.java
@@ -439,19 +439,6 @@ public class UserPropertyTest {
         Assertions.assertEquals(2, context.getSessionVariable().getStatisticCollectParallelism());
 
         try {
-            // the session variable statistic_collect_parallel has been set to 2, and it is not equal to its default value 1
-            // updateByUserProperty will ignore setting the session variable statistic_collect_parallel.
-            userProperty = new UserProperty();
-            Map<String, String> sessionVariables = userProperty.getSessionVariables();
-            sessionVariables.put("statistic_collect_parallel", "100");
-            userProperty.setSessionVariables(sessionVariables);
-            context.updateByUserProperty(userProperty);
-        } catch (Exception e) {
-            throw e;
-        }
-        Assertions.assertEquals(2, context.getSessionVariable().getStatisticCollectParallelism()); // not 100
-
-        try {
             // catalog is valid
             String createExternalCatalog = "CREATE EXTERNAL CATALOG myCatalog " + "PROPERTIES( " + "   \"type\"=\"hive\", " +
                     "   \"hive.metastore.uris\"=\"thrift://xx.xx.xx.xx:9083\" " + ");";

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -677,4 +677,33 @@ public class ConnectProcessorTest extends DDLTestBase {
         TMasterOpResult result = processor.proxyExecute(request);
         Assertions.assertNotNull(result);
     }
+
+    @Test
+    public void testProxyExecuteUserIdentityIsNull() throws Exception {
+        TMasterOpRequest request = new TMasterOpRequest();
+        request.setCatalog("default");
+        request.setDb("testDb1");
+        request.setUser("root");
+        request.setSql("select 1");
+        request.setIsInternalStmt(true);
+        request.setModified_variables_sql("set query_timeout = 10");
+        request.setQueryId(UUIDUtil.genTUniqueId());
+        request.setSession_id(UUID.randomUUID().toString());
+        request.setIsLastStmt(true);
+
+        ConnectContext context = new ConnectContext();
+        ConnectProcessor processor = new ConnectProcessor(context);
+        new mockit.MockUp<StmtExecutor>() {
+            @mockit.Mock
+            public void execute() {}
+            @mockit.Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        TMasterOpResult result = processor.proxyExecute(request);
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(context.getState().isError());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ForwardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ForwardTest.java
@@ -36,6 +36,9 @@ public class ForwardTest {
         request.setDb("information_schema");
         request.setQueryId(UUIDUtil.genTUniqueId());
         final TUserIdentity userIdentity = new TUserIdentity();
+        userIdentity.setUsername("user1");
+        userIdentity.setHost("%");
+        userIdentity.setIs_ephemeral(true);
         request.setCurrent_user_ident(userIdentity);
         return request;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariablePriorityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariablePriorityTest.java
@@ -1,0 +1,272 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.authentication.AuthenticationMgr;
+import com.starrocks.authentication.UserProperty;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.ExecuteAsStmt;
+import com.starrocks.sql.ast.SetListItem;
+import com.starrocks.sql.ast.SetStmt;
+import com.starrocks.sql.ast.SystemVariable;
+import com.starrocks.sql.ast.UserRef;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.sql.parser.NodePosition;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xnio.StreamConnection;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class VariablePriorityTest {
+
+    @Mocked
+    private StreamConnection connection;
+
+    private VariableMgr variableMgr = new VariableMgr();
+    private GlobalStateMgr globalStateMgr;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        globalStateMgr = GlobalStateMgr.getCurrentState();
+    }
+
+    @Test
+    public void testVariablePriorityWithExplicitSet() throws Exception {
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        // First set user property
+        UserProperty userProperty = new UserProperty();
+        Map<String, String> sessionVars = new HashMap<>();
+        sessionVars.put("query_timeout", "300");
+        userProperty.setSessionVariables(sessionVars);
+        ctx.updateByUserProperty(userProperty);
+
+        // Verify that user property variables are applied
+        Assertions.assertEquals(300, ctx.getSessionVariable().getQueryTimeoutS());
+
+        // Then explicitly set a variable (should have higher priority)
+        SystemVariable explicitVar = new SystemVariable("query_timeout", new StringLiteral("600"));
+        ctx.modifySystemVariable(explicitVar, true);
+
+        // Verify that explicit set overrides user property
+        Assertions.assertEquals(600, ctx.getSessionVariable().getQueryTimeoutS());
+    }
+
+    @Test
+    public void testVariablePriorityWithGlobalSet() throws Exception {
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        // Set global variable (lowest priority)
+        SystemVariable globalVar = new SystemVariable("query_timeout", new StringLiteral("120"));
+        ctx.modifySystemVariable(globalVar, false);
+
+        // Set user property (medium priority)
+        UserProperty userProperty = new UserProperty();
+        Map<String, String> sessionVars = new HashMap<>();
+        sessionVars.put("query_timeout", "300");
+        userProperty.setSessionVariables(sessionVars);
+        ctx.updateByUserProperty(userProperty);
+
+        // Verify that user property overrides global
+        Assertions.assertEquals(300, ctx.getSessionVariable().getQueryTimeoutS());
+
+        // Set explicit variable (highest priority)
+        SystemVariable explicitVar = new SystemVariable("query_timeout", new StringLiteral("600"));
+        ctx.modifySystemVariable(explicitVar, true);
+
+        // Verify that explicit set overrides both global and user property
+        Assertions.assertEquals(600, ctx.getSessionVariable().getQueryTimeoutS());
+    }
+
+    @Test
+    public void testModifiedSessionVariablesTracking() throws Exception {
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        UserProperty userProperty = new UserProperty();
+        Map<String, String> sessionVars = new HashMap<>();
+        sessionVars.put("query_timeout", "300");
+        userProperty.setSessionVariables(sessionVars);
+        ctx.updateByUserProperty(userProperty);
+
+        // Set some session variables
+        SystemVariable var = new SystemVariable("sql_mode", new StringLiteral("2097152")); // STRICT_TRANS_TABLES = 1L << 21
+        ctx.modifySystemVariable(var, true);
+
+        // Get modified session variables
+        SetStmt modifiedVars = ctx.getModifiedSessionVariables();
+        Assertions.assertNotNull(modifiedVars);
+        Assertions.assertEquals(1, modifiedVars.getSetListItems().size());
+
+        // Verify the variables are tracked
+        List<SetListItem> items = modifiedVars.getSetListItems();
+        Set<String> varNames = items.stream()
+                .map(item -> ((SystemVariable) item).getVariable())
+                .collect(Collectors.toSet());
+        Assertions.assertTrue(varNames.contains("sql_mode"));
+    }
+
+    // ==================== ExecuteAsExecutor 相关测试 ====================
+
+    @Test
+    public void testExecuteAsVariablePriority() throws Exception {
+        // Create users with different user properties
+        UserProperty user1Property = new UserProperty();
+        Map<String, String> user1SessionVars = new HashMap<>();
+        user1SessionVars.put("query_timeout", "300");
+        user1Property.setSessionVariables(user1SessionVars);
+
+        UserProperty user2Property = new UserProperty();
+        Map<String, String> user2SessionVars = new HashMap<>();
+        user2SessionVars.put("query_timeout", "600");
+        user2Property.setSessionVariables(user2SessionVars);
+
+        UserProperty user3Property = new UserProperty();
+        Map<String, String> user3SessionVars = new HashMap<>();
+        user3SessionVars.put("query_timeout", "900");
+        user3Property.setSessionVariables(user3SessionVars);
+
+        // Mock authentication manager to return user properties
+        new MockUp<AuthenticationMgr>() {
+            @Mock
+            public UserProperty getUserProperty(String userName) {
+                if ("u1".equals(userName)) {
+                    return user1Property;
+                } else if ("u2".equals(userName)) {
+                    return user2Property;
+                } else if ("impersonate_user".equals(userName)) {
+                    return user3Property;
+                }
+                return new UserProperty();
+            }
+        };
+
+        // Create context and set initial user
+        ConnectContext context = new ConnectContext();
+        context.setGlobalStateMgr(globalStateMgr);
+        context.setCurrentUserIdentity(new UserIdentity("impersonate_user", "%", false));
+        context.updateByUserProperty(user3Property);
+
+        // Verify initial state
+        Assertions.assertEquals(900, context.getSessionVariable().getQueryTimeoutS());
+
+        // Execute AS u1
+        ExecuteAsStmt executeAsStmt1 = new ExecuteAsStmt(new UserRef("u1", "%"), false);
+        ExecuteAsExecutor.execute(executeAsStmt1, context);
+        // Verify that user1's properties are applied
+        Assertions.assertEquals(300, context.getSessionVariable().getQueryTimeoutS());
+
+        // Execute AS u2
+        ExecuteAsStmt executeAsStmt2 = new ExecuteAsStmt(new UserRef("u2", "%"), false);
+        ExecuteAsExecutor.execute(executeAsStmt2, context);
+        // Verify that user2's properties are applied (overriding user1's)
+        Assertions.assertEquals(600, context.getSessionVariable().getQueryTimeoutS());
+    }
+
+    @Test
+    public void testExecuteAsVariablePrioritySessionFirst() throws Exception {
+        // Create users with different user properties
+        UserProperty user1Property = new UserProperty();
+        Map<String, String> user1SessionVars = new HashMap<>();
+        user1SessionVars.put("query_timeout", "300");
+        user1Property.setSessionVariables(user1SessionVars);
+
+        UserProperty user2Property = new UserProperty();
+        Map<String, String> user2SessionVars = new HashMap<>();
+        user2SessionVars.put("query_timeout", "600");
+        user2Property.setSessionVariables(user2SessionVars);
+
+        UserProperty user3Property = new UserProperty();
+        Map<String, String> user3SessionVars = new HashMap<>();
+        user3SessionVars.put("query_timeout", "900");
+        user3Property.setSessionVariables(user3SessionVars);
+
+        // Mock authentication manager to return user properties
+        new MockUp<AuthenticationMgr>() {
+            @Mock
+            public UserProperty getUserProperty(String userName) {
+                if ("u1".equals(userName)) {
+                    return user1Property;
+                } else if ("u2".equals(userName)) {
+                    return user2Property;
+                } else if ("impersonate_user".equals(userName)) {
+                    return user3Property;
+                }
+                return new UserProperty();
+            }
+        };
+
+        // Create context and set initial user
+        ConnectContext context = new ConnectContext();
+        context.setGlobalStateMgr(globalStateMgr);
+        context.setCurrentUserIdentity(new UserIdentity("impersonate_user", "%", false));
+        context.updateByUserProperty(user3Property);
+
+        // Verify initial state
+        Assertions.assertEquals(900, context.getSessionVariable().getQueryTimeoutS());
+
+        // Set some initial session variables (simulating explicit SET)
+        SystemVariable initialVar = new SystemVariable("query_timeout", new StringLiteral("120"));
+        context.modifySystemVariable(initialVar, true);
+
+        // Verify initial state
+        Assertions.assertEquals(120, context.getSessionVariable().getQueryTimeoutS());
+
+        // Execute AS u1
+        ExecuteAsStmt executeAsStmt1 = new ExecuteAsStmt(new UserRef("u1", "%"), false);
+        ExecuteAsExecutor.execute(executeAsStmt1, context);
+        // Verify that user1's properties are applied
+        Assertions.assertEquals(120, context.getSessionVariable().getQueryTimeoutS());
+
+        // Execute AS u2
+        ExecuteAsStmt executeAsStmt2 = new ExecuteAsStmt(new UserRef("u2", "%"), false);
+        ExecuteAsExecutor.execute(executeAsStmt2, context);
+        // Verify that user2's properties are applied (overriding user1's)
+        Assertions.assertEquals(120, context.getSessionVariable().getQueryTimeoutS());
+    }
+
+    @Test
+    public void testExecuteAsWithEphemeralUser() throws Exception {
+        // Create context with ephemeral user
+        ConnectContext context = new ConnectContext();
+        context.setGlobalStateMgr(globalStateMgr);
+        UserIdentity ephemeralUser = UserIdentity.createEphemeralUserIdent("external_user", "%");
+        context.setCurrentUserIdentity(ephemeralUser);
+
+        // Set some session variables
+        SystemVariable var = new SystemVariable("query_timeout", new StringLiteral("120"));
+        context.modifySystemVariable(var, true);
+
+        // Execute AS with ephemeral user (should not apply user properties)
+        ExecuteAsStmt executeAsStmt = new ExecuteAsStmt(new UserRef("external_user", "%", false, true, NodePosition.ZERO), false);
+        ExecuteAsExecutor.execute(executeAsStmt, context);
+
+        // Verify that session variables are not modified by user properties
+        // (ephemeral users don't have user properties)
+        Assertions.assertEquals(120, context.getSessionVariable().getQueryTimeoutS());
+    }
+}

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/UserRef.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/UserRef.java
@@ -29,6 +29,8 @@ public class UserRef implements ParseNode {
     private final String user;
     private final String host;
     private final boolean isDomain;
+    private final boolean isExternal;
+
     private final NodePosition pos;
 
     public UserRef(String user, String host) {
@@ -40,9 +42,14 @@ public class UserRef implements ParseNode {
     }
 
     public UserRef(String user, String host, boolean isDomain, NodePosition pos) {
+        this(user, host, isDomain, false, pos);
+    }
+
+    public UserRef(String user, String host, boolean isDomain, boolean isExternal, NodePosition pos) {
         this.user = user;
         this.host = Strings.emptyToNull(host);
         this.isDomain = isDomain;
+        this.isExternal = isExternal;
         this.pos = pos;
     }
 
@@ -56,6 +63,10 @@ public class UserRef implements ParseNode {
 
     public boolean isDomain() {
         return isDomain;
+    }
+
+    public boolean isExternal() {
+        return isExternal;
     }
 
     @Override
@@ -89,11 +100,12 @@ public class UserRef implements ParseNode {
             return false;
         }
         UserRef user1 = (UserRef) object;
-        return isDomain == user1.isDomain && Objects.equals(user, user1.user) && Objects.equals(host, user1.host);
+        return isDomain == user1.isDomain && isExternal == user1.isExternal &&
+                Objects.equals(user, user1.user) && Objects.equals(host, user1.host);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(user, host, isDomain);
+        return Objects.hash(user, host, isDomain, isExternal);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request primarily refactors how user session variables and properties are applied and managed in the Frontend (FE) codebase, especially during user impersonation (`EXECUTE AS`) and session initialization. It simplifies the logic for updating session variables from user properties, ensures correct handling of ephemeral user identities, and improves error handling for user identity mismatches. Additionally, it updates the `staros` dependency version.

Key changes include:

**Session Variable and User Property Handling:**

* Refactored `ConnectContext.updateByUserProperty` to always apply user property session variables, removing the previous logic that skipped updates if the session variable was already set to a non-default value. This ensures user property overrides are always respected. (`[[1]](diffhunk://#diff-0070e8c9c2ba6be48f27c29bdc63ce38d1ac597317a23fc379a85a8788530a91L1429-L1444)`, `[[2]](diffhunk://#diff-0070e8c9c2ba6be48f27c29bdc63ce38d1ac597317a23fc379a85a8788530a91L1458-R1446)`)
* Updated `ExecuteAsExecutor.execute` to reset session variables after impersonation by reapplying the original session's modified variables, maintaining expected session state after `EXECUTE AS`. (`[fe/fe-core/src/main/java/com/starrocks/qe/ExecuteAsExecutor.javaR67-R73](diffhunk://#diff-179ff7123d1dd44f44001a9d495b3cdf1d54bba9a86f5fbfe60bd87f5f8523e6R67-R73)`)
* Improved the creation of ephemeral user identities for external users during `EXECUTE AS` operations, ensuring correct user context. (`[fe/fe-core/src/main/java/com/starrocks/qe/ExecuteAsExecutor.javaL43-R57](diffhunk://#diff-179ff7123d1dd44f44001a9d495b3cdf1d54bba9a86f5fbfe60bd87f5f8523e6L43-R57)`)

**Session Initialization and Proxy Execution:**

* Enhanced `ConnectProcessor.proxyExecute` to always apply user properties (including session variables) for non-ephemeral users, ensuring consistent session initialization across FE nodes. Also moved the user identity null-check earlier for clearer error handling. (`[[1]](diffhunk://#diff-5149b9bcf06c46b80a856b673aa59314130d87699216de4dacc3d730fdd19b55R813-R835)`, `[[2]](diffhunk://#diff-5149b9bcf06c46b80a856b673aa59314130d87699216de4dacc3d730fdd19b55L896-L907)`)
* Added missing import for `UserProperty` and improved code formatting and logging. (`[[1]](diffhunk://#diff-5149b9bcf06c46b80a856b673aa59314130d87699216de4dacc3d730fdd19b55R41)`, `[[2]](diffhunk://#diff-179ff7123d1dd44f44001a9d495b3cdf1d54bba9a86f5fbfe60bd87f5f8523e6L31-R33)`)

**Dependency Update:**

* Upgraded the `staros` dependency version from `3.5-rc2` to `3.5-rc3` in the Gradle build configuration. (`[fe/build.gradle.ktsL76-R76](diffhunk://#diff-711c8906780096a2b018ddab40f5bb1cffefa75869524a80859b3ea46f3c7616L76-R76)`)

**Minor Cleanup:**

* Removed unused import and redundant code in `ConnectContext` and related test files. (`[[1]](diffhunk://#diff-0070e8c9c2ba6be48f27c29bdc63ce38d1ac597317a23fc379a85a8788530a91L85)`, `[[2]](diffhunk://#diff-8a478f126ef16cbdfc678315ce98d1869a1561e40f3f6679f9927c44130e7841L441-L453)`)
* Improved formatting for readability and maintainability. (`[[1]](diffhunk://#diff-0070e8c9c2ba6be48f27c29bdc63ce38d1ac597317a23fc379a85a8788530a91L548-R548)`, `[[2]](diffhunk://#diff-5149b9bcf06c46b80a856b673aa59314130d87699216de4dacc3d730fdd19b55R788)`, `[[3]](diffhunk://#diff-179ff7123d1dd44f44001a9d495b3cdf1d54bba9a86f5fbfe60bd87f5f8523e6R22-R24)`)

These changes collectively improve session consistency, simplify the codebase, and enhance reliability during user context switches and FE upgrades.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
