### PR TITLE
[BugFix] Fix use-after-free on pipeline timer during shutdown

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -765,6 +765,9 @@ void ExecEnv::destroy() {
     // _query_pool_mem_tracker.
     SAFE_DELETE(_runtime_filter_cache);
     SAFE_DELETE(_driver_limiter);
+    if (HttpBrpcStubCache::getInstance() != nullptr) {
+        HttpBrpcStubCache::getInstance()->shutdown();
+    }
     if (LakeServiceBrpcStubCache::getInstance() != nullptr) {
         LakeServiceBrpcStubCache::getInstance()->shutdown();
     }

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -765,6 +765,9 @@ void ExecEnv::destroy() {
     // _query_pool_mem_tracker.
     SAFE_DELETE(_runtime_filter_cache);
     SAFE_DELETE(_driver_limiter);
+    if (LakeServiceBrpcStubCache::getInstance() != nullptr) {
+        LakeServiceBrpcStubCache::getInstance()->shutdown();
+    }
     SAFE_DELETE(_pipeline_timer);
     SAFE_DELETE(_broker_client_cache);
     SAFE_DELETE(_frontend_client_cache);

--- a/be/src/util/brpc_stub_cache.cpp
+++ b/be/src/util/brpc_stub_cache.cpp
@@ -137,10 +137,6 @@ HttpBrpcStubCache::HttpBrpcStubCache() {
 }
 
 HttpBrpcStubCache::~HttpBrpcStubCache() {
-    shutdown();
-}
-
-void HttpBrpcStubCache::shutdown() {
     std::vector<std::shared_ptr<EndpointCleanupTask<HttpBrpcStubCache>>> task_to_cleanup;
 
     {
@@ -150,25 +146,12 @@ void HttpBrpcStubCache::shutdown() {
         }
     }
 
-<<<<<<< HEAD
     for (auto& task : task_to_cleanup) {
         _pipeline_timer->unschedule(task.get());
     }
 
     std::lock_guard<SpinLock> l(_lock);
     _stub_map.clear();
-=======
-    if (_pipeline_timer != nullptr) {
-        for (auto& task : task_to_cleanup) {
-            task->unschedule(_pipeline_timer);
-        }
-    }
-
-    {
-        std::lock_guard<SpinLock> l(_lock);
-        _stub_map.clear();
-    }
->>>>>>> 11c9afadbb (fix memory use-after-free)
 }
 
 StatusOr<std::shared_ptr<PInternalService_RecoverableStub>> HttpBrpcStubCache::get_http_stub(

--- a/be/src/util/brpc_stub_cache.cpp
+++ b/be/src/util/brpc_stub_cache.cpp
@@ -137,6 +137,10 @@ HttpBrpcStubCache::HttpBrpcStubCache() {
 }
 
 HttpBrpcStubCache::~HttpBrpcStubCache() {
+    shutdown();
+}
+
+void HttpBrpcStubCache::shutdown() {
     std::vector<std::shared_ptr<EndpointCleanupTask<HttpBrpcStubCache>>> task_to_cleanup;
 
     {
@@ -146,12 +150,25 @@ HttpBrpcStubCache::~HttpBrpcStubCache() {
         }
     }
 
+<<<<<<< HEAD
     for (auto& task : task_to_cleanup) {
         _pipeline_timer->unschedule(task.get());
     }
 
     std::lock_guard<SpinLock> l(_lock);
     _stub_map.clear();
+=======
+    if (_pipeline_timer != nullptr) {
+        for (auto& task : task_to_cleanup) {
+            task->unschedule(_pipeline_timer);
+        }
+    }
+
+    {
+        std::lock_guard<SpinLock> l(_lock);
+        _stub_map.clear();
+    }
+>>>>>>> 11c9afadbb (fix memory use-after-free)
 }
 
 StatusOr<std::shared_ptr<PInternalService_RecoverableStub>> HttpBrpcStubCache::get_http_stub(
@@ -217,6 +234,10 @@ LakeServiceBrpcStubCache::LakeServiceBrpcStubCache() {
 }
 
 LakeServiceBrpcStubCache::~LakeServiceBrpcStubCache() {
+    shutdown();
+}
+
+void LakeServiceBrpcStubCache::shutdown() {
     std::vector<std::shared_ptr<EndpointCleanupTask<LakeServiceBrpcStubCache>>> task_to_cleanup;
 
     {
@@ -226,12 +247,16 @@ LakeServiceBrpcStubCache::~LakeServiceBrpcStubCache() {
         }
     }
 
-    for (auto& task : task_to_cleanup) {
-        _pipeline_timer->unschedule(task.get());
+    if (_pipeline_timer != nullptr) {
+        for (auto& task : task_to_cleanup) {
+            task->unschedule(_pipeline_timer);
+        }
     }
 
-    std::lock_guard<SpinLock> l(_lock);
-    _stub_map.clear();
+    {
+        std::lock_guard<SpinLock> l(_lock);
+        _stub_map.clear();
+    }
 }
 
 DEFINE_FAIL_POINT(get_stub_return_nullptr);

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -95,6 +95,7 @@ public:
     static HttpBrpcStubCache* getInstance();
     StatusOr<std::shared_ptr<PInternalService_RecoverableStub>> get_http_stub(const TNetworkAddress& taddr);
     void cleanup_expired(const butil::EndPoint& endpoint);
+    void shutdown();
 
 private:
     HttpBrpcStubCache();

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -114,6 +114,7 @@ public:
     static LakeServiceBrpcStubCache* getInstance();
     StatusOr<std::shared_ptr<starrocks::LakeService_RecoverableStub>> get_stub(const std::string& host, int port);
     void cleanup_expired(const butil::EndPoint& endpoint);
+    void shutdown();
 
 private:
     LakeServiceBrpcStubCache();


### PR DESCRIPTION
## Why I'm doing:
This PR fixes a heap-use-after-free triggered at process exit when `LakeServiceStubCache` unschedule cleanup tasks after PipelineTimer has already been destroyed by ExecEnv::destroy(). The fix avoids relying on static destruction order and ensures cleanup happens safely.

## What I'm doing:

**LakeServiceBrpcStubCache**
+ Keep a dedicated shutdown() and delegate the destructor to call shutdown().
In shutdown(), collect tasks under lock, unschedule if the timer exists, and clear _stub_map under lock.
ExecEnv
+ Ensure LakeServiceBrpcStubCache::shutdown() is invoked before deleting PipelineTimer in ExecEnv::destroy().

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
