### PR TITLE
[NOT TO BE MERGED, PROTOTYPES] Chunks sorter full sort different prototypes

### DIFF
--- a/be/src/bench/chunks_sorter_bench.cpp
+++ b/be/src/bench/chunks_sorter_bench.cpp
@@ -228,7 +228,6 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Logical
     int64_t data_size = 0;
     int64_t mem_usage = 0;
     const int64_t max_buffered_rows = 1024 * 1024;
-    const int64_t max_buffered_bytes = max_buffered_rows * 256;
     const std::vector<SlotId> early_materialized_slots;
 
     for (auto _ : state) {
@@ -242,8 +241,7 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Logical
         switch (sorter_algo) {
         case FullSort: {
             sorter = std::make_unique<ChunksSorterFullSort>(suite._runtime_state.get(), &sort_exprs, &asc_arr,
-                                                            &null_first, "", max_buffered_rows, max_buffered_bytes,
-                                                            early_materialized_slots);
+                                                            &null_first, "");
             expected_rows = total_rows;
             break;
         }

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -261,7 +261,7 @@ uint32_t MapColumn::serialize(size_t idx, uint8_t* pos) const {
             perm[i].index_in_chunk = offset + i;
         }
         Tie tie(map_size, 1);
-        std::pair<int, int> range{0, map_size};
+        SortRange range{0, map_size};
         auto st = sort_and_tie_column(false, _keys, SortDesc(true, true), perm, tie, range, false);
         DCHECK(st.ok());
     }

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -182,6 +182,7 @@ set(EXEC_FILES
     sorting/merge_column.cpp
     sorting/merge_path.cpp
     sorting/merge_cascade.cpp
+    sorting/new_sort.cpp
     sorting/sort_column.cpp
     sorting/sort_permute.cpp
     connector_scan_node.cpp

--- a/be/src/exec/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/chunks_sorter_full_sort.cpp
@@ -14,6 +14,7 @@
 
 #include "chunks_sorter_full_sort.h"
 
+#include "column/vectorized_fwd.h"
 #include "exec/sorting/merge.h"
 #include "exec/sorting/sort_permute.h"
 #include "exec/sorting/sorting.h"
@@ -26,13 +27,8 @@ namespace starrocks {
 
 ChunksSorterFullSort::ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                                            const std::vector<bool>* is_asc_order,
-                                           const std::vector<bool>* is_null_first, const std::string& sort_keys,
-                                           int64_t max_buffered_rows, int64_t max_buffered_bytes,
-                                           const std::vector<SlotId>& early_materialized_slots)
-        : ChunksSorter(state, sort_exprs, is_asc_order, is_null_first, sort_keys, false),
-          max_buffered_rows(static_cast<size_t>(max_buffered_rows)),
-          max_buffered_bytes(max_buffered_bytes),
-          _early_materialized_slots(early_materialized_slots.begin(), early_materialized_slots.end()) {}
+                                           const std::vector<bool>* is_null_first, const std::string& sort_keys)
+        : ChunksSorter(state, sort_exprs, is_asc_order, is_null_first, sort_keys, false) {}
 
 ChunksSorterFullSort::~ChunksSorterFullSort() = default;
 
@@ -41,22 +37,12 @@ void ChunksSorterFullSort::setup_runtime(RuntimeState* state, RuntimeProfile* pr
     _runtime_profile = profile;
     _parent_mem_tracker = parent_mem_tracker;
     _object_pool = std::make_unique<ObjectPool>();
-    _runtime_profile->add_info_string("MaxBufferedRows", std::to_string(max_buffered_rows));
-    _runtime_profile->add_info_string("MaxBufferedBytes", std::to_string(max_buffered_bytes));
     _profiler = _object_pool->add(new ChunksSorterFullSortProfiler(profile, parent_mem_tracker));
 }
 
 Status ChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr& chunk) {
-    RETURN_IF_ERROR(_merge_unsorted(state, chunk));
-    RETURN_IF_ERROR(_partial_sort(state, false));
-
-    return Status::OK();
-}
-
-// Accumulate unsorted input chunks into a larger chunk
-Status ChunksSorterFullSort::_merge_unsorted(RuntimeState* state, const ChunkPtr& chunk) {
     SCOPED_TIMER(_build_timer);
-    _staging_unsorted_chunks.push_back(std::move(chunk));
+    _staging_unsorted_chunks.push_back(chunk);
     _staging_unsorted_rows += chunk->num_rows();
     _staging_unsorted_bytes += chunk->bytes_usage();
     return Status::OK();
@@ -94,199 +80,88 @@ static void concat_chunks(ChunkPtr& dst_chunk, const std::vector<ChunkPtr>& src_
     }
 }
 // Sort the large chunk
-Status ChunksSorterFullSort::_partial_sort(RuntimeState* state, bool done) {
+Status ChunksSorterFullSort::_partial_sort(RuntimeState* state) {
     if (!_staging_unsorted_rows) {
         return Status::OK();
     }
-    bool reach_limit = _staging_unsorted_rows >= max_buffered_rows || _staging_unsorted_bytes >= max_buffered_bytes;
-    if (done || reach_limit) {
-        _max_num_rows = std::max<int>(_max_num_rows, _staging_unsorted_rows);
-        COUNTER_UPDATE(_profiler->input_required_memory, _staging_unsorted_bytes);
-        concat_chunks(_unsorted_chunk, _staging_unsorted_chunks, _staging_unsorted_rows);
-        _staging_unsorted_chunks.clear();
-        RETURN_IF_ERROR(_unsorted_chunk->upgrade_if_overflow());
 
-        SCOPED_TIMER(_sort_timer);
+    COUNTER_UPDATE(_profiler->input_required_memory, _staging_unsorted_bytes);
+    concat_chunks(_unsorted_chunk, _staging_unsorted_chunks, _staging_unsorted_rows);
+    _staging_unsorted_chunks.clear();
+    RETURN_IF_ERROR(_unsorted_chunk->upgrade_if_overflow());
+
+    SCOPED_TIMER(_sort_timer);
+    auto do_sort = [&state, this]<class Perm>(Perm& permutation) {
         DataSegment segment(_sort_exprs, _unsorted_chunk);
-        SmallPermutation permutation = create_small_permutation(_staging_unsorted_rows);
         RETURN_IF_ERROR(
                 sort_and_tie_columns(state->cancelled_ref(), segment.order_by_columns, _sort_desc, permutation));
-        auto sorted_chunk = _unsorted_chunk->clone_empty_with_slot(_unsorted_chunk->num_rows());
-        materialize_by_permutation_single(sorted_chunk.get(), _unsorted_chunk, permutation);
-        RETURN_IF_ERROR(sorted_chunk->upgrade_if_overflow());
+        const size_t input_size = _unsorted_chunk->num_rows();
+        const size_t output_chunk_size = state->chunk_size();
+        const size_t chunk_count = (input_size + output_chunk_size - 1) / output_chunk_size;
+        _sorted_chunks.resize(chunk_count);
+        for (size_t i = 0; i < chunk_count; ++i) {
+            const size_t range_begin = i * output_chunk_size;
+            const size_t range_size = std::min(input_size, (i + 1) * output_chunk_size) - range_begin;
+            ChunkUniquePtr sorted_chunk = _unsorted_chunk->clone_empty(range_size);
+            materialize_by_permutation_single(sorted_chunk.get(), _unsorted_chunk,
+                                              array_view{permutation.data() + range_begin, range_size});
+            _sorted_chunks.at(chunk_count - 1 - i) = std::move(sorted_chunk);
+        }
 
-        _sorted_chunks.emplace_back(std::move(sorted_chunk));
-        _total_rows += _unsorted_chunk->num_rows();
-        _unsorted_chunk->reset();
-        _staging_unsorted_rows = 0;
-        _staging_unsorted_bytes = 0;
-    }
+        return Status::OK();
+    };
 
-    return Status::OK();
-}
-
-Status ChunksSorterFullSort::_merge_sorted(RuntimeState* state) {
-    SCOPED_TIMER(_merge_timer);
-    COUNTER_SET(_profiler->num_sorted_runs, (int64_t)_sorted_chunks.size());
-    // TODO: introduce an extra merge before cascading merge to handle the case that has a lot of sortruns
-    // In cascading merging phase, the height of merging tree is ceiling(log2(num_sorted_runs)) + 1,
-    // so when num_sorted_runs is 1 or 2, the height merging tree is less than 2, the sorted runs just be processed
-    // in at most one pass. there is no need to enable lazy materialization which eliminates non-order-by output
-    // columns's permutation in multiple passes.
-    if (_early_materialized_slots.empty() || _sorted_chunks.size() < 3) {
-        _early_materialized_slots.clear();
-        _runtime_profile->add_info_string("LateMaterialization", "False");
-        RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _sorted_chunks, &_merged_runs));
+    if (_unsorted_chunk->num_rows() <= std::numeric_limits<uint32_t>::max()) {
+        SmallPermutation permutation = create_small_permutation(_staging_unsorted_rows);
+        RETURN_IF_ERROR(do_sort(permutation));
     } else {
-        _runtime_profile->add_info_string("LateMaterialization", "True");
-        _split_late_and_early_chunks();
-        _assign_ordinals();
-        RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _early_materialized_chunks, &_merged_runs));
+        LargePermutation permutation = create_large_permutation(_staging_unsorted_rows);
+        RETURN_IF_ERROR(do_sort(permutation));
     }
-
-    return Status::OK();
-}
-
-void ChunksSorterFullSort::_assign_ordinals() {
-    _chunk_idx_bits = (int)std::ceil(std::log2(_early_materialized_chunks.size()));
-    _chunk_idx_bits = std::max(1, _chunk_idx_bits);
-    _offset_in_chunk_bits = (int)std::ceil(std::log2(_max_num_rows));
-    _offset_in_chunk_bits = std::max(1, _offset_in_chunk_bits);
-    // 64 bit ordinal only used when data skew is extremely drastic, for an example, a PipelineDriver processes
-    // 4 billion rows, it may happen in product environment extremely rarely, if it really happens,
-    // 64 bit ordinal is adopted.
-    auto use_64bit_ordinal = (_chunk_idx_bits + _offset_in_chunk_bits) > 32;
-    _runtime_profile->add_info_string("LateMaterializationUse64BitOrdinal",
-                                      strings::Substitute("$0", use_64bit_ordinal));
-
-    if (use_64bit_ordinal) {
-        _assign_ordinals_tmpl<uint64_t>();
-    } else {
-        _assign_ordinals_tmpl<uint32_t>();
-    }
-}
-TYPE_GUARD(OrdinalGuard, type_is_ordinal, uint32_t, uint64_t);
-
-template <typename T, typename = OrdinalGuard<T>>
-using OrdinalColumn = FixedLengthColumn<T>;
-
-template <typename T>
-void ChunksSorterFullSort::_assign_ordinals_tmpl() {
-    static_assert(type_is_ordinal<T>, "T must be uint32_t or uint64_t");
-    size_t chunk_idx = 0;
-    for (auto& partial_sort_chunk : _early_materialized_chunks) {
-        if (partial_sort_chunk->is_empty()) {
-            ++chunk_idx;
-            continue;
-        }
-        size_t num_rows = partial_sort_chunk->num_rows();
-        auto ordinal_column = OrdinalColumn<T>::create();
-        auto& ordinal_data = down_cast<OrdinalColumn<T>*>(ordinal_column.get())->get_data();
-        raw::make_room(&ordinal_data, num_rows);
-        for (T offset = 0; offset < num_rows; ++offset) {
-            ordinal_data[offset] = static_cast<T>((chunk_idx << _offset_in_chunk_bits) | offset);
-        }
-        partial_sort_chunk->append_column(std::move(ordinal_column), Chunk::SORT_ORDINAL_COLUMN_SLOT_ID);
-        ++chunk_idx;
-    }
-}
-
-void ChunksSorterFullSort::_split_late_and_early_chunks() {
-    _early_materialized_chunks.reserve(_sorted_chunks.size());
-    _late_materialized_chunks.reserve(_sorted_chunks.size());
-    auto& slot_id_to_column_id = _sorted_chunks[0]->get_slot_id_to_index_map();
-    _column_id_to_slot_id.resize(slot_id_to_column_id.size());
-    for (auto it : _sorted_chunks[0]->get_slot_id_to_index_map()) {
-        _column_id_to_slot_id[it.second] = it.first;
-    }
-    for (auto& chunk : _sorted_chunks) {
-        auto eager_chunk = std::make_unique<Chunk>();
-        auto lazy_chunk = std::make_unique<Chunk>();
-        for (auto column_id = 0; column_id < chunk->num_columns(); ++column_id) {
-            auto slot_id = _column_id_to_slot_id[column_id];
-            auto column = chunk->columns()[column_id];
-            if (_early_materialized_slots.count(slot_id)) {
-                eager_chunk->append_column(column, slot_id);
-            } else {
-                lazy_chunk->append_column(column, slot_id);
-            }
-        }
-        _early_materialized_chunks.push_back(std::move(eager_chunk));
-        _late_materialized_chunks.push_back(std::move(lazy_chunk));
-    }
-    _sorted_chunks.clear();
-}
-
-ChunkPtr ChunksSorterFullSort::_late_materialize(const starrocks::ChunkPtr& chunk) {
-    auto use_64bit_ordinal = (_chunk_idx_bits + _offset_in_chunk_bits) > 32;
-    if (use_64bit_ordinal) {
-        return _late_materialize_tmpl<uint64_t>(chunk);
-    } else {
-        return _late_materialize_tmpl<uint32_t>(chunk);
-    }
-}
-
-template <typename T>
-starrocks::ChunkPtr ChunksSorterFullSort::_late_materialize_tmpl(const starrocks::ChunkPtr& sorted_eager_chunk) {
-    static_assert(type_is_ordinal<T>, "T must be uint32_t or uint64_t");
-    const auto num_rows = sorted_eager_chunk->num_rows();
-    auto sorted_lazy_chunk = _late_materialized_chunks[0]->clone_empty(num_rows);
-    auto ordinal_column = sorted_eager_chunk->get_column_by_slot_id(Chunk::SORT_ORDINAL_COLUMN_SLOT_ID);
-    auto& ordinal_data = down_cast<OrdinalColumn<T>*>(ordinal_column.get())->get_data();
-    T _offset_in_chunk_mask = static_cast<T>((1L << _offset_in_chunk_bits) - 1);
-    for (auto i = 0; i < num_rows; ++i) {
-        T ordinal = ordinal_data[i];
-        T chunk_idx = ordinal >> _offset_in_chunk_bits;
-        T off_in_chunk = ordinal & _offset_in_chunk_mask;
-        sorted_lazy_chunk->append(*_late_materialized_chunks[chunk_idx], off_in_chunk, 1);
-    }
-    auto final_chunk = std::make_shared<Chunk>();
-    for (auto slot_id : _column_id_to_slot_id) {
-        if (_early_materialized_slots.count(slot_id)) {
-            final_chunk->append_column(sorted_eager_chunk->get_column_by_slot_id(slot_id), slot_id);
-        } else {
-            final_chunk->append_column(sorted_lazy_chunk->get_column_by_slot_id(slot_id), slot_id);
-        }
-    }
-    return final_chunk;
-}
-Status ChunksSorterFullSort::do_done(RuntimeState* state) {
-    RETURN_IF_ERROR(_partial_sort(state, true));
+    _total_rows += _unsorted_chunk->num_rows();
     _unsorted_chunk.reset();
-    RETURN_IF_ERROR(_merge_sorted(state));
+    _staging_unsorted_rows = 0;
+    _staging_unsorted_bytes = 0;
+
+    return Status::OK();
+}
+
+Status ChunksSorterFullSort::do_done(RuntimeState* state) {
+    RETURN_IF_ERROR(_partial_sort(state));
+    _unsorted_chunk.reset();
 
     return Status::OK();
 }
 
 Status ChunksSorterFullSort::get_next(ChunkPtr* chunk, bool* eos) {
     SCOPED_TIMER(_output_timer);
-    if (_merged_runs.num_chunks() == 0) {
+    if (_sorted_chunks.empty()) {
         *chunk = nullptr;
         *eos = true;
         return Status::OK();
     }
-    size_t chunk_size = _state->chunk_size();
-    SortedRun& run = _merged_runs.front();
-    *chunk = run.steal_chunk(chunk_size);
-    if (*chunk != nullptr) {
-        if (!_early_materialized_slots.empty()) {
-            *chunk = _late_materialize(*chunk);
-        }
-        RETURN_IF_ERROR((*chunk)->downgrade());
-    }
-    if (run.empty()) {
-        _merged_runs.pop_front();
-    }
+    *chunk = std::move(_sorted_chunks.back());
+    _sorted_chunks.pop_back();
+    DCHECK(*chunk != nullptr);
+    RETURN_IF_ERROR((*chunk)->downgrade());
     *eos = false;
     return Status::OK();
 }
 
 size_t ChunksSorterFullSort::get_output_rows() const {
-    return _merged_runs.num_rows();
+    size_t num_rows = 0;
+    for (size_t i = 0; i < _sorted_chunks.size(); ++i) {
+        num_rows += _sorted_chunks.at(i)->num_rows();
+    }
+    return num_rows;
 }
 
 int64_t ChunksSorterFullSort::mem_usage() const {
-    return _merged_runs.mem_usage();
+    int64_t mem_usage = 0;
+    for (size_t i = 0; i < _sorted_chunks.size(); ++i) {
+        mem_usage += _sorted_chunks.at(i)->memory_usage();
+    }
+    return mem_usage;
 }
 
 } // namespace starrocks

--- a/be/src/exec/chunks_sorter_full_sort.h
+++ b/be/src/exec/chunks_sorter_full_sort.h
@@ -33,11 +33,6 @@ struct ChunksSorterFullSortProfiler {
 };
 class ChunksSorterFullSort : public ChunksSorter {
 public:
-    static constexpr size_t kDefaultMaxBufferRows =
-            1 << 30; // 1 billion rows, the number of rows has little impact on performance
-    static constexpr size_t kDefaultMaxBufferBytes =
-            256 << 20; // 256MB, a larger limit may improve performance but is not memory allocator friendly
-
     /**
      * Constructor.
      * @param sort_exprs     The order-by columns or columns with expression. This sorter will use but not own the object.
@@ -47,8 +42,7 @@ public:
      */
     ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                          const std::vector<bool>* is_asc_order, const std::vector<bool>* is_null_first,
-                         const std::string& sort_keys, int64_t max_buffered_rows, int64_t max_buffered_bytes,
-                         const std::vector<SlotId>& early_materialized_slots);
+                         const std::string& sort_keys);
     ~ChunksSorterFullSort() override;
 
     // Append a Chunk for sort.
@@ -64,49 +58,19 @@ public:
                        MemTracker* parent_mem_tracker) override;
 
 private:
-    // Three stages of sorting procedure:
-    // 1. Accumulate input chunks into a big chunk(but not exceed the kMaxBufferedChunkSize), to reduce the memory copy during merge
-    // 2. Sort the accumulated big chunk partially
-    // 3. Merge all big-chunks into global sorted
-    Status _merge_unsorted(RuntimeState* state, const ChunkPtr& chunk);
-    Status _partial_sort(RuntimeState* state, bool done);
-    Status _merge_sorted(RuntimeState* state);
-    void _split_late_and_early_chunks();
-    void _assign_ordinals();
-    template <typename T>
-    void _assign_ordinals_tmpl();
-    template <typename T>
-    ChunkPtr _late_materialize_tmpl(const ChunkPtr& chunk);
+    Status _partial_sort(RuntimeState* state);
 
 protected:
-    ChunkPtr _late_materialize(const ChunkPtr& chunk);
-
     size_t _total_rows = 0; // Total rows of sorting data
     size_t _staging_unsorted_rows = 0;
     size_t _staging_unsorted_bytes = 0;
     std::vector<ChunkPtr> _staging_unsorted_chunks;
     ChunkPtr _unsorted_chunk;                   // Unsorted chunk, accumulate it to a larger chunk
     std::vector<ChunkUniquePtr> _sorted_chunks; // Partial sorted, but not merged
-    SortedRuns _merged_runs;                    // After merge
     RuntimeProfile* _runtime_profile = nullptr;
     MemTracker* _parent_mem_tracker = nullptr;
     std::unique_ptr<ObjectPool> _object_pool = nullptr;
     ChunksSorterFullSortProfiler* _profiler = nullptr;
-
-    // Parameters to control the Merge-Sort behavior
-    const size_t max_buffered_rows;
-    const size_t max_buffered_bytes;
-
-    // only when order-by columns(_sort_exprs) are all ColumnRefs and the cost of eager-materialization of
-    // other columns is large than ordinal column, then we materialize order-by columns and ordinal columns eagerly,
-    // and other columns are lazy-materialized.
-    std::unordered_set<SlotId> _early_materialized_slots;
-    int _max_num_rows = 0;
-    int _offset_in_chunk_bits = 0;
-    int _chunk_idx_bits = 0;
-    std::vector<SlotId> _column_id_to_slot_id;
-    std::vector<ChunkUniquePtr> _early_materialized_chunks;
-    std::vector<ChunkUniquePtr> _late_materialized_chunks;
 };
 
 } // namespace starrocks

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -127,13 +127,12 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver
             size_t max_buffered_chunks = ChunksSorterTopn::max_buffered_chunks(_limit);
             chunks_sorter = std::make_unique<ChunksSorterTopn>(
                     runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
-                    _sort_keys, 0, _limit + _offset, _topn_type, _max_buffered_rows, _max_buffered_bytes,
-                    max_buffered_chunks);
+                    _sort_keys, 0, _limit + _offset, _topn_type, max_buffered_chunks);
         }
     } else {
-        chunks_sorter = std::make_unique<ChunksSorterFullSort>(
-                runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
-                _sort_keys, _max_buffered_rows, _max_buffered_bytes, _early_materialized_slots);
+        chunks_sorter =
+                std::make_unique<ChunksSorterFullSort>(runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
+                                                       &_is_asc_order, &_is_null_first, _sort_keys);
     }
 
     auto sort_context = _sort_context_factory->create(driver_sequence);

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -101,8 +101,7 @@ public:
             std::string sort_keys, int64_t offset, int64_t limit, const TTopNType::type topn_type,
             const std::vector<OrderByType>& order_by_types, TupleDescriptor* materialized_tuple_desc,
             const RowDescriptor& parent_node_row_desc, const RowDescriptor& parent_node_child_row_desc,
-            std::vector<ExprContext*> analytic_partition_exprs, int64_t max_buffered_rows, int64_t max_buffered_bytes,
-            std::vector<SlotId> early_materialized_slots, SpillProcessChannelFactoryPtr spill_channel_factory,
+            std::vector<ExprContext*> analytic_partition_exprs, SpillProcessChannelFactoryPtr spill_channel_factory,
             const char* name = "local_sort_sink")
             : OperatorFactory(id, name, plan_node_id),
               _sort_context_factory(std::move(std::move(sort_context_factory))),
@@ -118,9 +117,6 @@ public:
               _parent_node_row_desc(parent_node_row_desc),
               _parent_node_child_row_desc(parent_node_child_row_desc),
               _analytic_partition_exprs(std::move(analytic_partition_exprs)),
-              _max_buffered_rows(max_buffered_rows),
-              _max_buffered_bytes(max_buffered_bytes),
-              _early_materialized_slots(std::move(early_materialized_slots)),
               _spill_channel_factory(std::move(spill_channel_factory)) {}
 
     ~PartitionSortSinkOperatorFactory() override = default;
@@ -151,9 +147,6 @@ protected:
     const RowDescriptor& _parent_node_row_desc;
     const RowDescriptor& _parent_node_child_row_desc;
     std::vector<ExprContext*> _analytic_partition_exprs;
-    int64_t _max_buffered_rows;
-    int64_t _max_buffered_bytes;
-    std::vector<SlotId> _early_materialized_slots;
     SpillProcessChannelFactoryPtr _spill_channel_factory;
 };
 

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -111,8 +111,7 @@ OperatorPtr SpillablePartitionSortSinkOperatorFactory::create(int32_t degree_of_
     std::shared_ptr<ChunksSorter> chunks_sorter;
 
     chunks_sorter = std::make_unique<SpillableChunksSorterFullSort>(
-            runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first, _sort_keys,
-            _max_buffered_rows, _max_buffered_bytes, _early_materialized_slots);
+            runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first, _sort_keys);
 
     auto spiller = _spill_factory->create(*_spill_options);
     auto spill_channel = _spill_channel_factory->get_or_create(driver_sequence);

--- a/be/src/exec/sorting/new_sort.cpp
+++ b/be/src/exec/sorting/new_sort.cpp
@@ -1,0 +1,546 @@
+
+#include "exec/sorting/new_sort.h"
+
+#include <openssl/ssl.h>
+
+#include "column/array_column.h"
+#include "column/binary_column.h"
+#include "column/column.h"
+#include "column/column_visitor_adapter.h"
+#include "column/const_column.h"
+#include "column/decimalv3_column.h"
+#include "column/fixed_length_column_base.h"
+#include "column/json_column.h"
+#include "column/map_column.h"
+#include "column/nullable_column.h"
+#include "column/object_column.h"
+#include "column/struct_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/status.h"
+#include "exec/sorting/sort_helper.h"
+#include "exec/sorting/sorting.h"
+#include "gutil/casts.h"
+#include "gutil/strings/fastmem.h"
+#include "util/orlp/pdqsort.h"
+
+namespace starrocks {
+class GetInlineSizes final : public ColumnVisitorAdapter<GetInlineSizes> {
+public:
+    explicit GetInlineSizes() : ColumnVisitorAdapter<GetInlineSizes>(this) {}
+
+    Status do_visit(const NullableColumn& dst) {
+        RETURN_IF_ERROR(dst.null_column()->accept(this));
+        RETURN_IF_ERROR(dst.data_column()->accept(this));
+
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(const DecimalV3Column<T>& dst) {
+
+        return generic_visit(dst);
+    }
+
+    template <typename T>
+    Status do_visit(const FixedLengthColumnBase<T>& dst) {
+        _inline_sizes.push_back(sizeof(T));
+        _alignments.push_back(alignof(T));
+
+        return Status::OK();
+    }
+
+    Status do_visit(const ConstColumn& dst) { return generic_visit(dst); }
+
+    Status do_visit(const ArrayColumn& dst) { return generic_visit(dst); }
+
+    Status do_visit(const MapColumn& dst) { return generic_visit(dst); }
+
+    Status do_visit(const StructColumn& dst) {
+        // TODO(SmithCruise) Not tested.
+        return generic_visit(dst);
+    }
+
+    template <typename T>
+    Status do_visit(const BinaryColumnBase<T>& dst) {
+        _inline_sizes.push_back(sizeof(Slice));
+        _alignments.push_back(alignof(Slice));
+
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(const ObjectColumn<T>& dst) {
+        return generic_visit(dst);
+    }
+
+    Status do_visit(const JsonColumn& dst) { return generic_visit(dst); }
+
+    std::pair<std::vector<size_t>, std::vector<size_t>> get_size_info() && {
+        return std::make_pair(std::move(_inline_sizes), std::move(_alignments));
+    }
+
+private:
+    template <class COL_TYPE>
+    Status generic_visit(const COL_TYPE& dst) {
+        return Status::OK();
+    }
+
+    std::vector<size_t> _inline_sizes{};
+    std::vector<size_t> _alignments{};
+};
+
+class CreateInlinedData final : public ColumnVisitorAdapter<CreateInlinedData> {
+public:
+    explicit CreateInlinedData(InlinedData& inlined_data) : ColumnVisitorAdapter<CreateInlinedData>(this), _inlined_data{inlined_data} {}
+
+    Status do_visit(const NullableColumn& dst) {
+        RETURN_IF_ERROR(dst.null_column()->accept(this));
+        RETURN_IF_ERROR(dst.data_column()->accept(this));
+
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(const DecimalV3Column<T>& dst) {
+
+        return generic_visit(dst);
+    }
+
+    template <typename T>
+    Status do_visit(const FixedLengthColumnBase<T>& dst) {
+        auto& container = dst.get_data();
+        for (size_t i = 0; i < container.size(); ++i) {
+            _inlined_data.set(i, _curr_inlined_idx, container[i]);
+        }
+        ++_curr_inlined_idx;
+
+        return Status::OK();
+    }
+
+    Status do_visit(const ConstColumn& dst) { return generic_visit(dst); }
+
+    Status do_visit(const ArrayColumn& dst) { return generic_visit(dst); }
+
+    Status do_visit(const MapColumn& dst) { return generic_visit(dst); }
+
+    Status do_visit(const StructColumn& dst) {
+        // TODO(SmithCruise) Not tested.
+        return generic_visit(dst);
+    }
+
+    template <typename T>
+    Status do_visit(const BinaryColumnBase<T>& dst) {
+        const size_t col_size = dst.size();
+        for (size_t i = 0; i < col_size; ++i) {
+            _inlined_data.set(i, _curr_inlined_idx, dst.get_slice(i));
+        }
+        ++_curr_inlined_idx;
+
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(const ObjectColumn<T>& dst) {
+        return generic_visit(dst);
+    }
+
+    Status do_visit(const JsonColumn& dst) { return generic_visit(dst); }
+
+    size_t get_curr_inlined_index() const { return _curr_inlined_idx; }
+
+private:
+    template <class COL_TYPE>
+    Status generic_visit(const COL_TYPE& dst) {
+        return Status::OK();
+    }
+
+    size_t _curr_inlined_idx{0};
+
+    InlinedData& _inlined_data;
+};
+
+Status inline_data(const Columns& cols, std::unique_ptr<InlinedData>& out) {
+    GetInlineSizes size_visitor{};
+    for (auto& col : cols) {
+        RETURN_IF_ERROR(col->accept(&size_visitor));
+    }
+    auto [sizes, alignments] = std::move(size_visitor).get_size_info();
+    out = std::make_unique<InlinedData>(std::move(sizes), std::move(alignments), cols.at(0)->size());
+
+    CreateInlinedData bla{*out};
+    for (auto& col : cols) {
+        RETURN_IF_ERROR(col->accept(&bla));
+    }
+    const auto row_idx_inlined_idx = bla.get_curr_inlined_index();
+    const auto size = cols.at(0)->size();
+    for (InlinedData::index_type i = 0; i < size; ++i) {
+        out->set(i, row_idx_inlined_idx, i);
+    }
+    return Status::OK();
+}
+
+// Append permutation to column, implements `materialize_by_permutation` function
+class MaterializeFromInlinedData : public ColumnVisitorMutableAdapter<MaterializeFromInlinedData> {
+public:
+    explicit MaterializeFromInlinedData(const Column* src_column, const InlinedData& inlined_data, const SortRange range,
+                                     std::optional<size_t*> inlined_index)
+            : ColumnVisitorMutableAdapter<MaterializeFromInlinedData>(this),
+              _curr_inlined_index(inlined_index),
+              _src_column(src_column),
+              _inlined_data{inlined_data},
+              _range{range} {}
+
+    Status do_visit(NullableColumn* dst) {
+        const size_t orig_size = dst->size();
+        auto& srcDataColumn = static_cast<const NullableColumn*>(_src_column)->data_column_ref();
+        _src_column = static_cast<const NullableColumn*>(_src_column)->null_column();
+        RETURN_IF_ERROR(dst->null_column_mutable_ptr()->accept_mutable(this));
+        if (!dst->has_null()) {
+            dst->set_has_null(
+                    SIMD::count_nonzero(&dst->null_column()->get_data()[orig_size], _range.second - _range.first));
+        }
+        _src_column = &srcDataColumn;
+        RETURN_IF_ERROR(dst->data_column_mutable_ptr()->accept_mutable(this));
+
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(DecimalV3Column<T>* dst) {
+        return generic_visit(dst);
+    }
+
+    template <typename T>
+    Status do_visit(FixedLengthColumnBase<T>* dst) {
+        using Container = typename FixedLengthColumnBase<T>::Container;
+        using ColumnType = FixedLengthColumnBase<T>;
+
+        auto& data = dst->get_data();
+        size_t output = data.size();
+        data.resize(output + (_range.second - _range.first));
+
+        auto end = _inlined_data.begin() + _range.second;
+
+        if (_curr_inlined_index.has_value()) {
+            auto get_value = _inlined_data.get_value<T>(*_curr_inlined_index.value());
+            for (auto curr = _inlined_data.begin() + _range.first; curr != end; ++curr) {
+                data[output++] = get_value(*curr);
+            }
+            ++(*_curr_inlined_index.value());
+        } else {
+            auto get_idx = _inlined_data.get_idx();
+            auto src_container = static_cast<const ColumnType*>(_src_column)->get_data();
+            for (auto curr = _inlined_data.begin() + _range.first; curr != end; ++curr) {
+                data[output++] = src_container[get_idx(*curr)];
+            }
+        }
+
+        return Status::OK();
+    }
+
+    Status do_visit(ConstColumn* dst) { return generic_visit(dst); }
+
+    Status do_visit(ArrayColumn* dst) { return generic_visit(dst); }
+
+    Status do_visit(MapColumn* dst) { return generic_visit(dst); }
+
+    Status do_visit(StructColumn* dst) {
+        // TODO(SmithCruise) Not tested.
+        return generic_visit(dst);
+    }
+
+    template <typename T>
+    Status do_visit(BinaryColumnBase<T>* dst) {
+        using ColumnType = BinaryColumnBase<T>;
+
+        auto& offsets = dst->get_offset();
+        auto& bytes = dst->get_bytes();
+
+        const auto begin = _inlined_data.begin() + _range.first;
+        const auto end = _inlined_data.begin() + _range.second;
+
+        size_t added_bytes{0};
+        std::vector<Slice> slices{};
+        slices.reserve(_range.second - _range.first);
+        if (_curr_inlined_index.has_value()) {
+            auto get_slice = _inlined_data.get_str(*_curr_inlined_index.value());
+            for (auto curr = begin; curr != end; ++curr) {
+                Slice slice = get_slice(*curr);
+                added_bytes += slice.get_size();
+                slices.push_back(slice);
+            }
+            ++(*_curr_inlined_index.value());
+
+        } else {
+            auto get_idx = _inlined_data.get_idx();
+            for (auto curr = begin; curr != end; ++curr) {
+                Slice slice = static_cast<const ColumnType*>(_src_column)->get_slice(get_idx(*curr));
+                added_bytes += slice.get_size();
+                slices.push_back(slice);
+            }
+        }
+
+        bytes.resize(bytes.size() + added_bytes);
+        offsets.reserve(offsets.size() + slices.size());
+
+        DCHECK(!offsets.empty());
+        auto curr_offset = offsets.back();
+        auto* const byte_ptr = bytes.data();
+
+        for (Slice slice : slices) {
+            strings::memcpy_inlined(byte_ptr + curr_offset, slice.get_data(), slice.get_size());
+            curr_offset += slice.get_size();
+            offsets.push_back(curr_offset);
+        }
+
+        dst->invalidate_slice_cache();
+
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(ObjectColumn<T>* dst) {
+        return generic_visit(dst);
+    }
+
+    Status do_visit(JsonColumn* dst) { return generic_visit(dst); }
+
+private:
+    template <class COL_TYPE>
+    Status generic_visit(COL_TYPE* dst) {
+        auto end = _inlined_data.begin() + _range.second;
+
+        auto get_index = _inlined_data.get_idx();
+        for (auto curr = _inlined_data.begin() + _range.first; curr != end; ++curr) {
+            dst->append(*_src_column, get_index(*curr), 1);
+        }
+
+        return Status::OK();
+    }
+
+    const std::optional<size_t*> _curr_inlined_index;
+    const Column* _src_column;
+    const InlinedData& _inlined_data;
+    const SortRange _range;
+};
+
+Status materialize(ChunkPtr& dst, const ChunkPtr& src, const InlinedData& inlined_data, SortRange range) {
+    const size_t chunk_cols = dst->num_columns();
+    size_t currInlinedIndex{0};
+    for (size_t col_index = 0; col_index < chunk_cols; col_index++) {
+        MaterializeFromInlinedData visitor{src->get_column_by_index(col_index), inlined_data, range, &currInlinedIndex};
+        RETURN_IF_ERROR(dst->get_column_by_index(col_index)->accept_mutable(&visitor));
+    }
+    return Status::OK();
+}
+
+template <class Cmp>
+void update_tie(std::span<uint8_t>& tie, InlinedDataView& data, Cmp& cmp) {
+    DCHECK_EQ(tie.size(), data.size());
+    DCHECK(tie.empty() || tie[0] == 0);
+    for (size_t i = 1; i < tie.size(); ++i) {
+        DCHECK_EQ(1, tie[i]);
+        if (cmp(data[i - 1], data[i]) != 0) {
+            tie[i] = 0;
+        }
+    }
+}
+
+// Returns the range of the non-null entries, so that these can be sorted in the next step
+template <class GetNull>
+void partition_null_column(const SortDesc& sort_desc, InlinedDataView& dataView,
+                           std::optional<std::span<uint8_t>>& opt_tie, GetNull& get_null) {
+    const bool null_first = sort_desc.is_null_first();
+    auto null_first_pred = [get_null](InlinedDataProxy proxy) { return get_null(proxy) == 1; };
+    auto null_last_pred = [get_null](InlinedDataProxy proxy) { return get_null(proxy) != 1; };
+
+    const auto pivot_iter = null_first ? std::partition(dataView.begin(), dataView.end(), null_first_pred)
+                                       : std::partition(dataView.begin(), dataView.end(), null_last_pred);
+
+    // The corresponding data column makes directly uses the returned non-null range instead of the tie.
+    // That means we do not need to update if the data column is the last column to be sorted.
+    if (opt_tie.has_value()) {
+        std::span<uint8_t> tie = opt_tie.value();
+        DCHECK_EQ(0, tie[0]);
+        tie[pivot_iter - dataView.begin()] = 0;
+    }
+
+    const ptrdiff_t pivot_idx = pivot_iter - dataView.begin();
+    if (null_first) {
+        dataView = InlinedDataView{pivot_iter, dataView.end()};
+        if (opt_tie.has_value()) {
+            opt_tie = opt_tie.value().subspan(pivot_idx);
+        }
+    } else {
+        dataView = InlinedDataView{dataView.begin(), pivot_iter};
+        if (opt_tie.has_value()) {
+            opt_tie = opt_tie.value().subspan(0, pivot_idx);
+        }
+    }
+}
+
+struct no_function {};
+
+template <class Cmp, class NullCmp>
+Status sort_column(const std::atomic<bool>& cancel, const SortDesc& sort_desc, InlinedData& inlined_data, Tie& tie,
+                   bool updateTie, Cmp& cmp, NullCmp& getNullValue) {
+    auto lesser = [cmp](InlinedDataProxy lhs, InlinedDataProxy rhs) { return cmp(lhs, rhs) < 0; };
+    auto greater = [cmp](InlinedDataProxy lhs, InlinedDataProxy rhs) { return cmp(lhs, rhs) > 0; };
+
+    TieIterator iterator{tie};
+    while (iterator.next()) {
+        DCHECK_EQ(0, tie[0]);
+        if (UNLIKELY(cancel.load(std::memory_order_acquire))) {
+            return Status::Cancelled("Sort cancelled");
+        }
+        DCHECK(iterator.range_first < iterator.range_last);
+        std::optional<std::span<uint8_t>> tieSpan{};
+        if (updateTie) {
+            tieSpan = std::span<uint8_t>{tie.begin() + iterator.range_first, tie.begin() + iterator.range_last};
+        }
+        InlinedDataView dataView{inlined_data.begin() + iterator.range_first, inlined_data.begin() + iterator.range_last};
+        if constexpr (!std::is_same_v<NullCmp, no_function>) {
+            partition_null_column(sort_desc, dataView, tieSpan, getNullValue);
+        }
+
+        if (sort_desc.asc_order()) {
+            ::pdqsort(dataView.begin(), dataView.end(), lesser);
+        } else {
+            ::pdqsort(dataView.begin(), dataView.end(), greater);
+        }
+
+        if (updateTie) {
+            update_tie(tieSpan.value(), dataView, cmp);
+        }
+    }
+    return Status::OK();
+}
+
+// Sort a column by permtuation
+class InlinedDataColumnSorter final : public ColumnVisitorAdapter<InlinedDataColumnSorter> {
+public:
+    explicit InlinedDataColumnSorter(const std::atomic<bool>& cancel, const SortDesc& desc, InlinedData& inlined_data,
+                                  size_t& inlined_index, Tie& tie, bool updateTie)
+            : ColumnVisitorAdapter<InlinedDataColumnSorter>(this),
+              _cancel{cancel},
+              _sort_desc{desc},
+              _curr_inlined_index(inlined_index),
+              _inlined_data{inlined_data},
+              _tie{tie},
+              _updateTie{updateTie} {}
+
+    Status do_visit(const NullableColumn& column) {
+        _last_column_null_column = true;
+        ++_curr_inlined_index;
+        return column.data_column()->accept(this);
+    }
+
+    Status do_visit(const ConstColumn& column) {
+        // noop
+        return Status::OK();
+    }
+
+    Status do_visit(const ArrayColumn& column) { return generic_visit(column); }
+
+    Status do_visit(const MapColumn& column) { return Status::InternalError("Sort does not support map columns"); }
+
+    Status do_visit(const StructColumn& column) { return generic_visit(column); }
+
+    template <typename T>
+    Status do_visit(const BinaryColumnBase<T>& column) {
+        auto get_str = _inlined_data.get_str(_curr_inlined_index);
+        auto cmp = [get_str](InlinedDataProxy lhs, InlinedDataProxy rhs) { return get_str(lhs).compare(get_str(rhs)); };
+        RETURN_IF_ERROR(sort(cmp));
+
+        ++_curr_inlined_index;
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(const FixedLengthColumnBase<T>& column) {
+        auto get_value = _inlined_data.get_value<T>(_curr_inlined_index);
+        auto cmp = [get_value](InlinedDataProxy lhs, InlinedDataProxy rhs) {
+            return SorterComparator<T>::compare(get_value(lhs), get_value(rhs));
+        };
+        RETURN_IF_ERROR(sort(cmp));
+        ++_curr_inlined_index;
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(const ObjectColumn<T>& column) {
+        DCHECK(false) << "not support object column sort_and_tie";
+
+        return Status::NotSupported("not support object column sort_and_tie");
+    }
+
+    Status do_visit(const JsonColumn& column) {
+        auto get_idx = _inlined_data.get_idx();
+        auto cmp = [get_idx, &column](InlinedDataProxy lhs, InlinedDataProxy rhs) {
+            return column.get_object(get_idx(lhs))->compare(*column.get_object(get_idx(rhs)));
+        };
+        return sort(cmp);
+    }
+
+private:
+    template <class ColumnType>
+    Status generic_visit(const ColumnType& column) {
+        auto get_idx = _inlined_data.get_idx();
+        auto nan_direction = _sort_desc.nan_direction();
+        auto cmp = [nan_direction, get_idx, &column](InlinedDataProxy lhs, InlinedDataProxy rhs) {
+            return column.compare_at(get_idx(lhs), get_idx(rhs), column, nan_direction);
+        };
+        return sort(cmp);
+    }
+
+    template <class Cmp>
+    Status sort(const Cmp& cmp) {
+        if (_last_column_null_column) {
+            auto get_null = _inlined_data.get_value<uint8_t>(_curr_inlined_index - 1);
+            return sort_column(_cancel, _sort_desc, _inlined_data, _tie, _updateTie, cmp, get_null);
+        } else {
+            no_function dummy{};
+            return sort_column(_cancel, _sort_desc, _inlined_data, _tie, _updateTie, cmp, dummy);
+        }
+    }
+
+    const std::atomic<bool>& _cancel;
+    SortDesc _sort_desc;
+    size_t& _curr_inlined_index;
+    InlinedData& _inlined_data;
+    Tie& _tie;
+    bool _updateTie;
+    bool _last_column_null_column{false};
+};
+
+Status materialize(Chunk& target_chunk, const ChunkPtr& src_chunk, const std::vector<size_t>& order_by_indexes,
+                   const InlinedData& inlined_data, SortRange range) {
+    // First restore the order by columns
+    size_t currInlinedIndex{0};
+    for (auto order_by_idx : order_by_indexes) {
+        MaterializeFromInlinedData mat{src_chunk->get_column_by_index(order_by_idx), inlined_data, range, &currInlinedIndex};
+        RETURN_IF_ERROR(target_chunk.get_column_by_index(order_by_idx)->accept_mutable(&mat));
+    }
+    // materialize all other columns
+    for (size_t i = 0; i < src_chunk->columns().size(); ++i) {
+        if (std::find(std::begin(order_by_indexes), std::end(order_by_indexes), i) != std::end(order_by_indexes)) {
+            continue;
+        }
+        MaterializeFromInlinedData mat{src_chunk->get_column_by_index(i), inlined_data, range, std::nullopt};
+        RETURN_IF_ERROR(target_chunk.get_column_by_index(i)->accept_mutable(&mat));
+    }
+    return Status::OK();
+}
+
+Status sort(const std::atomic<bool>& cancel, Columns& columns, InlinedData& inlined_data, const SortDescs& sort_descs) {
+    Tie tie(inlined_data.size(), 1);
+    tie.at(0) = 0;
+    size_t currInlinedIndex{0};
+    for (size_t i = 0; i < columns.size(); ++i) {
+        const bool updateTie = i + 1 != columns.size();
+        InlinedDataColumnSorter sorter{cancel, sort_descs.get_column_desc(i), inlined_data, currInlinedIndex, tie, updateTie};
+        RETURN_IF_ERROR(columns.at(i)->accept(&sorter));
+    }
+    return Status::OK();
+}
+} // namespace starrocks

--- a/be/src/exec/sorting/new_sort.h
+++ b/be/src/exec/sorting/new_sort.h
@@ -1,0 +1,391 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <sys/mman.h>
+
+#include <span>
+#include <vector>
+
+#include "column/column.h"
+#include "common/config.h"
+#include "common/status.h"
+#include "exec/sorting/sort_permute.h"
+#include "exec/sorting/sorting.h"
+#include "util/slice.h"
+
+namespace starrocks {
+
+// An object of this class can only be created when a proxy reference is fully dereferenced. This
+// can happen in sort algorithms that store the pivot on the stack.
+// This class should only be used in assignments to proxy references.
+class InlinedDataStackVar {
+public:
+    InlinedDataStackVar(std::span<const char> data) : _data(std::begin(data), std::end(data)) {}
+
+    std::span<char> data() { return std::span<char>{_data}; }
+    std::span<const char> data() const { return std::span<const char>{_data}; }
+
+private:
+    // TODO Store small data inline (on the stack)
+    std::vector<char> _data;
+};
+
+class InlinedDataProxy {
+public:
+    InlinedDataProxy(std::span<char> data) : data{data} {}
+    InlinedDataProxy(const InlinedDataProxy& other) = default;
+    InlinedDataProxy(InlinedDataProxy&& other) = default;
+    InlinedDataProxy(InlinedDataStackVar& temp) : data{temp.data()} {}
+
+    ~InlinedDataProxy() = default;
+
+    InlinedDataProxy& operator=(InlinedDataProxy&& other) noexcept {
+        DCHECK(data.size() == other.data.size());
+        std::ranges::copy(other.data, data.data());
+        return *this;
+    }
+
+    InlinedDataProxy& operator=(const InlinedDataProxy& other) noexcept {
+        DCHECK(data.size() == other.data.size());
+        std::ranges::copy(other.data, data.data());
+        return *this;
+    }
+
+    InlinedDataProxy& operator=(InlinedDataStackVar&& other) noexcept {
+        DCHECK(data.size() == other.data().size());
+        std::ranges::copy(other.data(), data.data());
+        return *this;
+    }
+
+    InlinedDataProxy& operator=(const InlinedDataStackVar& other) noexcept {
+        DCHECK(data.size() == other.data().size());
+        std::ranges::copy(other.data(), data.data());
+        return *this;
+    }
+
+    // creates a copy of the stored data;
+    operator InlinedDataStackVar() { return InlinedDataStackVar(data); }
+
+    friend void swap(InlinedDataProxy lhs, InlinedDataProxy rhs) {
+        DCHECK(lhs.data.size() == rhs.data.size());
+        std::swap_ranges(std::begin(lhs.data), std::end(lhs.data), std::begin(rhs.data));
+    }
+
+    // The named function are not strictly necessary, but nicely match with the use cases
+    template <class T>
+    const T& as_fixed_size(size_t offset) const {
+        return as_type<T>(offset);
+    }
+
+    const bool& as_bool(size_t offset) const { return as_type<bool>(offset); }
+
+    const Slice& as_slice(size_t offset) const { return as_type<Slice>(offset); }
+
+private:
+    template <class T>
+    const T& as_type(size_t offset) const {
+        DCHECK(offset + sizeof(T) <= data.size());
+        DCHECK( (reinterpret_cast<uintptr_t>(data.data()) + offset) % alignof(T) == 0);
+        return *reinterpret_cast<T*>(data.data() + offset);
+    }
+
+    std::span<char> data;
+};
+
+class ConstInlinedDataProxy {
+public:
+    ConstInlinedDataProxy(std::span<const char> data) : data{data} {}
+
+    ~ConstInlinedDataProxy() = default;
+
+    operator InlinedDataStackVar() { return InlinedDataStackVar(data); }
+    // The named function are not strictly necessary, but nicely match with the use cases
+    template <class T>
+    const T& as_fixed_size(size_t offset) const {
+        return as_type<T>(offset);
+    }
+
+    const bool& as_bool(size_t offset) const { return as_type<bool>(offset); }
+
+    const Slice& as_slice(size_t offset) const { return as_type<Slice>(offset); }
+
+private:
+    template <class T>
+    const T& as_type(size_t offset) const {
+        DCHECK(offset + sizeof(T) <= data.size());
+        DCHECK(offset % alignof(T) == 0);
+        return *reinterpret_cast<const T*>(data.data() + offset);
+    }
+
+    std::span<const char> data;
+};
+
+template <class T>
+class InlinedIteratorBase {
+public:
+    T& operator-=(ptrdiff_t x) { return *static_cast<T*>(this) += -x; }
+    T& operator++() { return *static_cast<T*>(this) += 1; }
+    T operator++(int) {
+        T cpy{*static_cast<T*>(this)};
+        operator++();
+        return cpy;
+    }
+    T& operator--() { return *static_cast<T*>(this) += -1; }
+    T operator--(int) {
+        T cpy{*static_cast<T*>(this)};
+        operator--();
+        return cpy;
+    }
+
+    T operator+(ptrdiff_t diff) const {
+        T cpy{*static_cast<const T*>(this)};
+        cpy += diff;
+        return cpy;
+    }
+
+    T operator-(ptrdiff_t diff) const {
+        T cpy{*static_cast<const T*>(this)};
+        cpy -= diff;
+        return cpy;
+    }
+};
+
+class InlinedDataIterator : public InlinedIteratorBase<InlinedDataIterator> {
+public:
+    using difference_type = ptrdiff_t;
+    using value_type = InlinedDataStackVar;
+    using reference = InlinedDataProxy;
+    using iterator_category = std::random_access_iterator_tag;
+
+    InlinedDataIterator() : _size{0}, _curr_pos{nullptr} {}
+    InlinedDataIterator(size_t size, char* ptr) : _size{static_cast<ptrdiff_t>(size)}, _curr_pos{ptr} {}
+
+    InlinedDataProxy operator*() const {
+        return InlinedDataProxy(std::span<char>(_curr_pos, _size));
+    }
+
+    InlinedDataIterator& operator+=(ptrdiff_t x) {
+        _curr_pos += _size * x;
+        return *this;
+    }
+
+    ptrdiff_t operator-(InlinedDataIterator it) const {
+        DCHECK(_size == it._size);
+        return (_curr_pos - it._curr_pos) / _size;
+    }
+    using InlinedIteratorBase<InlinedDataIterator>::operator-;
+
+    InlinedDataProxy operator[](ptrdiff_t offset) const { return *(*this + offset); }
+
+    std::strong_ordering operator<=>(InlinedDataIterator other) const {
+        DCHECK(_size == other._size);
+        if (other._curr_pos == _curr_pos) {
+            return std::strong_ordering::equal;
+        }
+        if (std::less<>{}(_curr_pos, other._curr_pos)) {
+            return std::strong_ordering::less;
+        }
+        return std::strong_ordering::greater;
+    }
+
+    bool operator==(InlinedDataIterator other) const {
+        DCHECK(_size == other._size);
+        return _curr_pos == other._curr_pos;
+        std::vector<bool> bla;
+    }
+
+private:
+    ptrdiff_t _size;
+    char* _curr_pos;
+};
+
+inline InlinedDataIterator operator+(ptrdiff_t n, const InlinedDataIterator& bla) {
+    return bla + n;
+}
+
+static_assert(std::random_access_iterator<InlinedDataIterator>);
+
+using InlinedDataView = std::ranges::subrange<InlinedDataIterator>;
+
+// Behaves like a reference proxy.
+class ConstInlinedDataIterator : public InlinedIteratorBase<ConstInlinedDataIterator> {
+    // Defenitions needed for an autogeneration of the iterator traits
+public:
+    using difference_type = ptrdiff_t;
+    using value_type = InlinedDataStackVar;
+    using reference = ConstInlinedDataProxy;
+    using iterator_category = std::random_access_iterator_tag;
+
+    ConstInlinedDataIterator(size_t element_size, const char* ptr)
+            : size{static_cast<ptrdiff_t>(element_size)}, curr_pos{ptr} {}
+    ConstInlinedDataIterator() : size{0}, curr_pos{nullptr} {}
+
+    ConstInlinedDataProxy operator*() const { return ConstInlinedDataProxy(std::span<const char>(curr_pos, size)); }
+
+    ConstInlinedDataIterator& operator+=(ptrdiff_t x) {
+        curr_pos += size * x;
+        return *this;
+    }
+    ptrdiff_t operator-(ConstInlinedDataIterator it) const { return (curr_pos - it.curr_pos) / size; }
+    using InlinedIteratorBase<ConstInlinedDataIterator>::operator-;
+
+    ConstInlinedDataProxy operator[](ptrdiff_t offset) const { return *(*this + offset); }
+
+    std::strong_ordering operator<=>(ConstInlinedDataIterator other) const {
+        if (other.curr_pos == curr_pos) {
+            return std::strong_ordering::equal;
+        }
+        if (std::less<>{}(curr_pos, other.curr_pos)) {
+            return std::strong_ordering::less;
+        }
+        return std::strong_ordering::greater;
+    }
+
+    bool operator==(ConstInlinedDataIterator other) const {
+        DCHECK(size == other.size);
+        return curr_pos == other.curr_pos;
+    }
+
+private:
+    ptrdiff_t size;
+    const char* curr_pos;
+};
+
+inline ConstInlinedDataIterator operator+(ptrdiff_t n, const ConstInlinedDataIterator& bla) {
+    return bla + n;
+}
+
+static_assert(std::random_access_iterator<ConstInlinedDataIterator>);
+
+struct InlinedData {
+public:
+    using index_type = uint64_t;
+
+    InlinedData(std::vector<size_t>&& sizes, std::vector<size_t>&& alignments, size_t size)
+            : offsets{init_offsets(std::move(sizes), std::move(alignments))}, data(size * offsets.back()) {}
+
+    ConstInlinedDataIterator begin() const { return ConstInlinedDataIterator(entry_size(), data.data()); }
+
+    ConstInlinedDataIterator end() const { return ConstInlinedDataIterator(entry_size(), data.data() + data.size()); }
+
+    InlinedDataIterator begin() { return InlinedDataIterator(entry_size(), data.data()); }
+
+    InlinedDataIterator end() { return InlinedDataIterator(entry_size(), data.data() + data.size()); }
+
+    size_t entry_size() const { return offsets.back(); }
+
+    size_t size() const { return data.size() / entry_size(); }
+
+    template <class T>
+    void set(size_t row_idx, size_t inlined_col_idx, const T& val) {
+        // We will just deallocate the char vector, so the inserted entries need to be trivially destructible
+        static_assert(std::is_trivially_destructible_v<T>);
+        const ptrdiff_t global_entry_position = row_idx * entry_size() + offsets.at(inlined_col_idx);
+        DCHECK(global_entry_position % alignof(T) == 0);
+        DCHECK_LE(offsets.at(inlined_col_idx) + sizeof(val), offsets.at(inlined_col_idx + 1));
+        T& entry = reinterpret_cast<T&>(data[global_entry_position]);
+        entry = val;
+    }
+
+    template <class T>
+    auto get_value(size_t inlined_col_index) {
+        auto offset = offsets.at(inlined_col_index);
+        return [offset](InlinedDataProxy proxy) -> T { return proxy.as_fixed_size<T>(offset); };
+    }
+
+    auto get_str(size_t inlined_col_index) {
+        auto offset = offsets.at(inlined_col_index);
+        return [offset](InlinedDataProxy proxy) -> Slice { return proxy.as_slice(offset); };
+    }
+
+    auto get_idx() {
+        auto offset = *(offsets.end() - 2);
+        return [offset](InlinedDataProxy proxy) -> index_type { return proxy.as_fixed_size<index_type>(offset); };
+    }
+
+    template <class T>
+    auto get_value(size_t inlined_col_index) const {
+        auto offset = offsets.at(inlined_col_index);
+        return [offset](ConstInlinedDataProxy proxy) -> T { return proxy.as_fixed_size<T>(offset); };
+    }
+
+    auto get_str(size_t inlined_col_index) const {
+        auto offset = offsets.at(inlined_col_index);
+        return [offset](ConstInlinedDataProxy proxy) -> Slice { return proxy.as_slice(offset); };
+    }
+
+    auto get_idx() const {
+        auto offset = *(offsets.end() - 2);
+        return [offset](ConstInlinedDataProxy proxy) -> index_type { return proxy.as_fixed_size<index_type>(offset); };
+    }
+
+private:
+    size_t round_up_to_next_aligned_position(size_t curr_offset, size_t next_alignment) {
+        return (curr_offset / next_alignment + (curr_offset % next_alignment != 0)) * next_alignment;
+    }
+
+    std::vector<size_t> init_offsets(std::vector<size_t>&& sizes, std::vector<size_t>&& alignments) {
+        DCHECK_EQ(sizes.size(), alignments.size());
+
+        // Add size info for the row index
+        sizes.push_back(sizeof(index_type));
+        alignments.push_back(alignof(index_type));
+
+
+        std::vector<size_t> offsets{};
+        offsets.reserve(sizes.size() + 2);
+        offsets.push_back(0);
+        for (size_t i = 0; i + 1 < sizes.size(); ++i) {
+            const auto curr_size = sizes.at(i);
+            const auto next_alignment = alignments.at(i + 1);
+            const auto next_offset = round_up_to_next_aligned_position(offsets.back() + curr_size, next_alignment);
+            offsets.push_back(next_offset);
+        }
+
+        // The start address of every object needs to be aligned to the maximum alignment that appears in the object
+        const size_t max_alignment = *std::max_element(std::begin(alignments), std::end(alignments));
+        const auto curr_size = sizes.back();
+        const auto next_offset = round_up_to_next_aligned_position(curr_size + offsets.back(), max_alignment);
+        // The total size of an entry
+        offsets.push_back(next_offset);
+
+        sizes.clear();
+        alignments.clear();
+
+        return offsets;
+    }
+
+    std::vector<size_t> offsets;
+    std::vector<char> data;
+};
+
+inline std::vector<size_t> get_order_by_indexes(const Columns& all_columns, const Columns& order_by_columns) {
+    std::vector<size_t> indexes{};
+    indexes.reserve(order_by_columns.size());
+    for (size_t i = 0; i < order_by_columns.size(); ++i) {
+        auto it = std::find(std::begin(all_columns), std::end(all_columns), order_by_columns.at(i).get());
+        DCHECK(it != std::end(all_columns));
+        indexes.push_back(it - std::begin(all_columns));
+    }
+    return indexes;
+}
+
+Status inline_data(const Columns& cols, std::unique_ptr<InlinedData>& out);
+Status materialize(Chunk& target_chunk, const ChunkPtr& src_chunk, const std::vector<size_t>& order_by_columns,
+                   const InlinedData& inlined_data, SortRange range);
+Status sort(const std::atomic<bool>& cancel, Columns& columns, InlinedData& inlined_data, const SortDescs& sort_descs);
+
+} // namespace starrocks

--- a/be/src/exec/sorting/sorting.h
+++ b/be/src/exec/sorting/sorting.h
@@ -34,18 +34,21 @@ struct SortDescs;
 // @param permutation input and output permutation
 // @param tie input and output tie
 // @param range sort range, {0, 0} means not build tie but sort data
+template <SingleChunkPermutation Perm>
 Status sort_and_tie_column(const std::atomic<bool>& cancel, ColumnPtr& column, const SortDesc& sort_desc,
-                           SmallPermutation& permutation, Tie& tie, std::pair<int, int> range, const bool build_tie);
+                           Perm& permutation, Tie& tie, SortRange range, const bool build_tie);
+template <SingleChunkPermutation Perm>
 Status sort_and_tie_column(const std::atomic<bool>& cancel, const ColumnPtr& column, const SortDesc& sort_desc,
-                           SmallPermutation& permutation, Tie& tie, std::pair<int, int> range, const bool build_tie);
+                           Perm& permutation, Tie& tie, SortRange range, const bool build_tie);
 
 // Sort multiple columns using column-wise algorithm, the final order is stored in the Permutation argument
 Status sort_and_tie_columns(const std::atomic<bool>& cancel, const Columns& columns, const SortDescs& sort_desc,
                             Permutation* permutation);
 
 // Sort multiple columns using column-wise algorithm, the order changes are reflected in the given SmallPermutation
+template <SingleChunkPermutation Perm>
 Status sort_and_tie_columns(const std::atomic<bool>& cancel, const Columns& columns, const SortDescs& sort_desc,
-                            SmallPermutation& permutation);
+                            Perm& permutation);
 
 /// Usually used to sort array columns.
 ///
@@ -68,7 +71,7 @@ Status stable_sort_and_tie_columns(const std::atomic<bool>& cancel, const Column
 
 // Sort multiple columns in vertical
 Status sort_vertical_columns(const std::atomic<bool>& cancel, const Columns& columns, const SortDesc& sort_desc,
-                             Permutation& permutation, Tie& tie, std::pair<int, int> range, const bool build_tie,
+                             Permutation& permutation, Tie& tie, SortRange range, const bool build_tie,
                              const size_t limit = 0, size_t* limited = nullptr);
 
 // Sort multiple chunks in column-wise style

--- a/be/src/exec/spillable_chunks_sorter_full_sort.cpp
+++ b/be/src/exec/spillable_chunks_sorter_full_sort.cpp
@@ -147,9 +147,6 @@ std::function<StatusOr<ChunkPtr>()> SpillableChunksSorterFullSort::_spill_proces
         if (_process_staging_unsorted_chunk_idx != _staging_unsorted_chunks.size()) {
             return std::move(_staging_unsorted_chunks[_process_staging_unsorted_chunk_idx++]);
         }
-        if (_process_early_materialized_chunks_idx != _early_materialized_chunks.size()) {
-            return _late_materialize(std::move(_early_materialized_chunks[_process_early_materialized_chunks_idx++]));
-        }
         if (_process_sorted_chunk_idx != _sorted_chunks.size()) {
             return std::move(_sorted_chunks[_process_sorted_chunk_idx++]);
         }

--- a/be/src/exec/spillable_chunks_sorter_sort.h
+++ b/be/src/exec/spillable_chunks_sorter_sort.h
@@ -51,7 +51,5 @@ private:
     size_t _process_staging_unsorted_chunk_idx = 0;
     // index for _sorted_chunk_idx
     size_t _process_sorted_chunk_idx = 0;
-    // index for _early_materialized_chunks
-    size_t _process_early_materialized_chunks_idx = 0;
 };
 } // namespace starrocks

--- a/be/test/exec/chunks_sorter_test.cpp
+++ b/be/test/exec/chunks_sorter_test.cpp
@@ -597,8 +597,7 @@ TEST_F(ChunksSorterTest, full_sort_incremental) {
     ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
     auto pool = std::make_unique<ObjectPool>();
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
-                                slots);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
     sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
                          pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
@@ -810,8 +809,7 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_first) {
 
     auto pool = std::make_unique<ObjectPool>();
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
-                                slots);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
     sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
                          pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
@@ -850,8 +848,7 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_last) {
 
     auto pool = std::make_unique<ObjectPool>();
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
-                                slots);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
     sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
                          pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
@@ -893,8 +890,7 @@ TEST_F(ChunksSorterTest, full_sort_by_3_columns) {
 
     auto pool = std::make_unique<ObjectPool>();
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
-                                slots);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
     sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
                          pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
@@ -939,8 +935,7 @@ TEST_F(ChunksSorterTest, full_sort_by_4_columns) {
 
     auto pool = std::make_unique<ObjectPool>();
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
-                                slots);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
     sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
                          pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();

--- a/be/test/exec/sorting_test.cpp
+++ b/be/test/exec/sorting_test.cpp
@@ -305,7 +305,7 @@ TEST(SortingTest, materialize_by_permutation_array) {
 
     ColumnPtr materialized = array_data_col->clone_empty();
     SmallPermutation perm{{0}, {2}, {4}, {1}, {3}, {5}};
-    materialize_column_by_permutation_single(materialized.get(), array_data_col, perm);
+    materialize_column_by_permutation_single(materialized.get(), array_data_col, array_view<SmallPermuteItem>{perm});
 
     auto array_cmp = [](const std::vector<std::optional<int32_t>>& cmp_vec, const DatumArray& arr) {
         ASSERT_EQ(cmp_vec.size(), arr.size());
@@ -346,7 +346,7 @@ TEST(SortingTest, materialize_by_permutation_struct) {
 
     ColumnPtr materialized = column->clone_empty();
     SmallPermutation perm{{2}, {0}, {1}};
-    materialize_column_by_permutation_single(materialized.get(), column, perm);
+    materialize_column_by_permutation_single(materialized.get(), column, array_view<SmallPermuteItem>{perm});
     ASSERT_EQ(3, materialized->size());
     ASSERT_EQ("{id:3,name:'hello'}", materialized->debug_item(0));
     ASSERT_EQ("{id:1,name:'smith'}", materialized->debug_item(1));
@@ -368,7 +368,7 @@ TEST(SortingTest, materialize_by_permutation_json) {
     }
     ColumnPtr materialized = json_column->clone_empty();
     SmallPermutation perm{{1}, {2}, {0}};
-    materialize_column_by_permutation_single(materialized.get(), json_column, perm);
+    materialize_column_by_permutation_single(materialized.get(), json_column, array_view<SmallPermuteItem>{perm});
     ASSERT_EQ(3, materialized->size());
     ASSERT_EQ(jsons.at(1), *materialized->get(0).get_json());
     ASSERT_EQ(jsons.at(2), *materialized->get(1).get_json());


### PR DESCRIPTION
## Why I'm doing:

This is just a "showcase" PR of changes that I tried, but that did not universally let to good results. The first commit removes the merge step from the chunks sorter_full_sort and the second commit first copies everything into a row-wise format and then does the (still column-wise) sort. The benchmark numbers for the baseline and the two commits are appended. As can be seen the comparisons are very heterogeneous, probably to heterogeneous for any one of these PR to be merged upstream. Still I thought the numbers are interesting so I thought I share it here.

As the performance numbers are quite complex, and I did not have a lot of time I do not fully understand what is going on. I also just ran the existing unit tests to check the correctness, which is not enough especially for the second commit. 
Some ideas, I do have in that regard:
1. I think the one big performance issue of the first PR is the random materialization. The advantage of the current pdqsort/merge split, is that the materialization after the pdqsort still works on a small enough working set, while the materialization after the merge is normally not as random (if there are not too many columns).
2. For the second PR, I think a big issue is the runtime size of the inline/row wise data. I tried just hardcoding the size for a certain benchmark and that made quite a big difference.
Apart from that there is a lot more going on, but due to the complexity of the differences between the runtimes I did not have time to look to deeply into all of them.

Even if the changes here are not merged, I think there are two things that one might take away:
1. In the second commit I implemented a strategy that makes it possible to not sort the null values in the sort. In the visitor for the sort I have a variable that I only set when a NullableColumn is visited and then I directly call the accept on the data column of the NullableColumn. The data column then has access to the null data and can use it in its sort. The main reason for doing it this way, is to pull the null information through the tie-ranges. If I would implement this existing algorithm, I think I would just store the null columns in the visitor and then access them in the sort of the data column.
2. I am not sure if there is any use case for it, but the second commit contains a way how to convert the column wise data into a row wise format during runtime. There are a lot of subtleties (getting the proxy refernces right, getting the alignment right) where I am not sure that I got it 100% correct, but all in all I think this is the strategy you would use if you ever need such a change.