### PR TITLE
[Enhancement]Optimize performance for the alter publish version in the lake table fast schema change.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -45,7 +45,6 @@ import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
-import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.TraceManager;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -69,8 +68,6 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadPoolExecutor;
-import javax.validation.constraints.NotNull;
 
 /*
  * Version 2 of AlterJob, for replacing the old version of AlterJob.
@@ -128,10 +125,6 @@ public abstract class AlterJobV2 implements Writable {
     protected Span span;
 
     protected Future<Boolean> publishVersionJobFuture = null;
-
-    private ThreadPoolExecutor publishVersionTaskExecutor = null;
-
-    private static final int LAKE_PUBLISH_TASK_MAX_QUEUE_SIZE = 4096;
 
     public AlterJobV2(long jobId, JobType jobType, long dbId, long tableId, String tableName, long timeoutMs) {
         this.jobId = jobId;
@@ -378,14 +371,6 @@ public abstract class AlterJobV2 implements Writable {
                 return false;
             }
         }
-    }
-
-    public @NotNull ThreadPoolExecutor getPublishVersionTaskExecutor() {
-        if (publishVersionTaskExecutor == null) {
-            publishVersionTaskExecutor = ThreadPoolManager.newDaemonFixedThreadPool(Config.lake_publish_version_max_threads,
-                    LAKE_PUBLISH_TASK_MAX_QUEUE_SIZE, "alter-publish-task", false);
-        }
-        return publishVersionTaskExecutor;
     }
 
     private void finishHook() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -315,8 +315,14 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                 CompletableFuture<Boolean> publishFuture = CompletableFuture.allOf(
                                 futureList.toArray(new CompletableFuture[0])).
                         thenApply(v -> futureList.stream().allMatch(CompletableFuture::join));
-                if (!publishFuture.get()) {
-                    LOG.error("Fail to alter publish txn batch");
+                try {
+                    if (!publishFuture.get()) {
+                        LOG.error("Fail to alter publish txn batch");
+                        return false;
+                    }
+                } catch (InterruptedException e) {
+                    LOG.warn("InterruptedException during publish version: ", e);
+                    Thread.currentThread().interrupt();
                     return false;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import javax.validation.constraints.NotNull;
 
@@ -273,6 +274,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             // 2. the table is enable `file_bundling` and this task is not change `file_bundling`
             //    to false.
             boolean useAggregatePublish = enableFileBundling() || (isFileBundling && !disableFileBundling());
+            List<CompletableFuture<Boolean>> futureList = new ArrayList<>();
             for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
                 long commitVersion = commitVersionMap.get(partitionId);
                 Map<Long, MaterializedIndex> dirtyIndexMap = physicalPartitionIndexMap.row(partitionId);
@@ -281,13 +283,41 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                     if (!useAggregatePublish) {
                         Utils.publishVersion(index.getTablets(), txnInfo, commitVersion - 1, commitVersion,
                                 computeResource, false);
+                        CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
+                            try {
+                                Utils.publishVersion(index.getTablets(), txnInfo, commitVersion - 1, commitVersion,
+                                        computeResource, false);
+                            } catch (Exception e) {
+                                LOG.error("Failed to publish version for index {} in " +
+                                                "partition {} during lake table alter job {}, txnId={}, commitVersion={}", 
+                                        index.getId(), partitionId, jobId, watershedTxnId, commitVersion, e);
+                                return false;
+                            }
+                            return true;
+                        }, getPublishVersionTaskExecutor()).exceptionally(ex -> {
+                            LOG.error("Failed to publish version batch for lake table alter job {}, txnId={}, " +
+                                    "partitionId={}, indexId={}", jobId, watershedTxnId, partitionId, index.getId(), ex);
+                            return false;
+                        });
+                        futureList.add(future);
                     } else {
                         tablets.addAll(index.getTablets());
                     }
                 }
+
                 if (useAggregatePublish) {
                     Utils.aggregatePublishVersion(tablets, Lists.newArrayList(txnInfo), commitVersion - 1, commitVersion, 
                                 null, null, computeResource, null);
+                }
+            }
+
+            if (!useAggregatePublish) {
+                CompletableFuture<Boolean> publishFuture = CompletableFuture.allOf(
+                                futureList.toArray(new CompletableFuture[0])).
+                        thenApply(v -> futureList.stream().allMatch(CompletableFuture::join));
+                if (!publishFuture.get()) {
+                    LOG.error("Fail to alter publish txn batch");
+                    return false;
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -294,7 +294,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                                 return false;
                             }
                             return true;
-                        }, getPublishVersionTaskExecutor()).exceptionally(ex -> {
+                        }, GlobalStateMgr.getCurrentState().getPublishVersionDaemon().getLakeTaskExecutor()).exceptionally(ex -> {
                             LOG.error("Failed to publish version batch for lake table alter job {}, txnId={}, " +
                                     "partitionId={}, indexId={}", jobId, watershedTxnId, partitionId, index.getId(), ex);
                             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -305,7 +305,7 @@ public class GlobalStateMgr {
      * Alter Job Manager
      */
     private final AlterJobMgr alterJobMgr;
-    private final ThreadPoolExecutor lakeAlterPublishExecutor;
+    private final ThreadPoolExecutor lakeAlterJobPublishExecutor;
 
     private final PortConnectivityChecker portConnectivityChecker;
 
@@ -664,8 +664,8 @@ public class GlobalStateMgr {
                 new SchemaChangeHandler(),
                 new MaterializedViewHandler(),
                 new SystemHandler());
-        this.lakeAlterPublishExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
-                Config.lake_publish_version_max_threads, "alter-publish", false);
+        this.lakeAlterJobPublishExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
+                Config.lake_publish_version_max_threads, "alter-publish-job", false);
 
         this.load = new Load();
         this.streamLoadMgr = new StreamLoadMgr();
@@ -2219,8 +2219,8 @@ public class GlobalStateMgr {
         return alterJobMgr;
     }
 
-    public ThreadPoolExecutor getLakeAlterPublishExecutor() {
-        return lakeAlterPublishExecutor;
+    public ThreadPoolExecutor getLakeAlterJobPublishExecutor() {
+        return lakeAlterJobPublishExecutor;
     }
 
     public SchemaChangeHandler getSchemaChangeHandler() {


### PR DESCRIPTION
## Why I'm doing:
Currently, lakePublishVersion executes the publishVersion serially by partition, which can be extremely time-consuming if there are many partitions.

## What I'm doing:
Serial actions are optimized for parallel execution
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3