### PR TITLE
[Doc] Add tip about TPC-DS benchmark query example

### DIFF
--- a/docs/en/best_practices/query_tuning/query_planning.md
+++ b/docs/en/best_practices/query_tuning/query_planning.md
@@ -103,6 +103,10 @@ You can control this merging behavior through the session variable `pipeline_pro
 
 ### Example Query Plan
 
+:::tip
+This is query 96 from the TPC-DS benchmark.
+:::
+
 ```sql
 EXPLAIN select  count(*)
 from store_sales

--- a/docs/ja/best_practices/query_tuning/query_planning.md
+++ b/docs/ja/best_practices/query_tuning/query_planning.md
@@ -101,6 +101,10 @@ StarRocks のプランは階層的です。
 
 ### クエリプランの例
 
+:::tip
+これは、TPC-DS ベンチマークからのクエリ 96 です。
+:::
+
 ```sql
 EXPLAIN select  count(*)
 from store_sales

--- a/docs/zh/best_practices/query_tuning/query_planning.md
+++ b/docs/zh/best_practices/query_tuning/query_planning.md
@@ -101,6 +101,10 @@ StarRocks计划是分层的：
 
 ### 示例查询计划
 
+:::tip
+这是 TPC-DS 基准测试中的第 96 个查询。
+:::
+
 ```sql
 EXPLAIN select  count(*)
 from store_sales


### PR DESCRIPTION
Added a tip regarding the source of the example query.

@murphyatwork , a reader left a comment saying:

> The example query plan and the corresponding explanation of the plan are not in sync, so it's difficult to understand

I am guessing that this is because the plan is a simplified version, but I do not know. Can you have a look please?

While I was reading through the page I noticed that you mentioned "query 96," so I added a tip that the query is from the TPC-DS benchmark.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
