### PR TITLE
[Enhancement] make the default_unpartitioned_table_bucket_num configurable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Sets;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -428,8 +429,7 @@ public class CatalogUtils {
             bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
             // If table is not partitioned, the bucketNum should be at least DEFAULT_UNPARTITIONED_TABLE_BUCKET_NUM
             if (!olapTable.getPartitionInfo().isPartitioned()) {
-                bucketNum = bucketNum > FeConstants.DEFAULT_UNPARTITIONED_TABLE_BUCKET_NUM ?
-                        bucketNum : FeConstants.DEFAULT_UNPARTITIONED_TABLE_BUCKET_NUM;
+                bucketNum = Math.max(bucketNum, Config.default_unpartitioned_table_bucket_num);
             }
             return bucketNum;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1408,6 +1408,9 @@ public class OlapTable extends Table {
                 info.setBucketNum((int) numBucket);
             } else if (info.getBucketNum() == 0) {
                 numBucket = CatalogUtils.calPhysicalPartitionBucketNum();
+                if (!isPartitionedTable()) {
+                    numBucket = Math.max(numBucket, Config.default_unpartitioned_table_bucket_num);
+                }
                 info.setBucketNum((int) numBucket);
             }
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2384,6 +2384,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long default_automatic_bucket_size = 4 * 1024 * 1024 * 1024L;
 
+    @ConfField(mutable = true, comment = "Minimum number of buckets of unpartitioned table")
+    public static int default_unpartitioned_table_bucket_num = 16;
+
     /**
      * Used to limit num of agent task for one be. currently only for drop task.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -113,8 +113,6 @@ public class FeConstants {
     // Max counter num of TOP K function
     public static final int MAX_COUNTER_NUM_OF_TOP_K = 100000;
 
-    public static final int DEFAULT_UNPARTITIONED_TABLE_BUCKET_NUM = 16;
-
     public static final int MAX_LIST_PARTITION_NAME_LENGTH = 50;
 
     public static final String DOCUMENT_SHOW_ALTER =

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CTASAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CTASAutoTabletTest.java
@@ -18,7 +18,6 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.common.Config;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.pseudocluster.PseudoCluster;
@@ -91,8 +90,8 @@ public class CTASAutoTabletTest {
         } finally {
             locker.unLockDatabase(db.getId(), LockType.READ);
         }
-        Assertions.assertEquals(bucketNum1, FeConstants.DEFAULT_UNPARTITIONED_TABLE_BUCKET_NUM);
+        Assertions.assertEquals(bucketNum1, Config.default_unpartitioned_table_bucket_num);
         Assertions.assertEquals(bucketNum2, 3);
-        Assertions.assertEquals(bucketNum3, FeConstants.DEFAULT_UNPARTITIONED_TABLE_BUCKET_NUM);
+        Assertions.assertEquals(bucketNum3, Config.default_unpartitioned_table_bucket_num);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogUtilsTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.catalog;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,7 +58,7 @@ public class CatalogUtilsTest {
 
         int bucketNum = CatalogUtils.calAvgBucketNumOfRecentPartitions(olapTable, 5, true);
 
-        assertEquals(FeConstants.DEFAULT_UNPARTITIONED_TABLE_BUCKET_NUM, bucketNum);
+        assertEquals(Config.default_unpartitioned_table_bucket_num, bucketNum);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Enable configuration for `default_unpartitioned_table_bucket_num`:
- Definition: Specifies the minimum number of buckets for an unpartitioned table, regardless of whether it uses RANDOM or HASH distribution.
- Default setting: 16

Behavior Change:  
- Previously, only HASH DISTRIBUTION had a lower threshold, while RANDOM DISTRIBUTION did not. The default number of buckets for RANDOM DISTRIBUTION was determined based on the number of backends.  
- Now, both HASH DISTRIBUTION and RANDOM DISTRIBUTION share the same lower threshold, defined by `default_unpartitioned_table_bucket_num`.  



- Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
