### PR TITLE
[BugFix] Fix wrong results in binary bitmap functions with NULL inputs

### DIFF
--- a/be/test/exprs/bitmap_functions_test.cpp
+++ b/be/test/exprs/bitmap_functions_test.cpp
@@ -432,13 +432,9 @@ TEST_F(VecBitmapFunctionsTest, bitmapOrTest) {
 
         auto v = BitmapFunctions::bitmap_or(ctx, columns).value();
 
-        ASSERT_TRUE(v->is_nullable());
-        ASSERT_FALSE(v->is_object());
-
-        auto p = ColumnHelper::cast_to<TYPE_OBJECT>(ColumnHelper::as_column<NullableColumn>(v)->data_column());
-
-        ASSERT_EQ(4, p->get_object(0)->cardinality());
-        ASSERT_TRUE(v->is_null(1));
+        ASSERT_FALSE(v->is_nullable());
+        ASSERT_TRUE(v->is_object());
+        ASSERT_FALSE(v->is_null(1));
     }
 }
 

--- a/test/sql/test_bitmap_functions/R/test_bitmap_null_handling
+++ b/test/sql/test_bitmap_functions/R/test_bitmap_null_handling
@@ -1,0 +1,178 @@
+-- name: test_bitmap_null_handling
+-- Test NULL handling for bitmap_or, bitmap_andnot, bitmap_xor functions
+-- This test covers the optimization introduced in commit for bitmap NULL value handling
+
+-- Create test tables
+CREATE TABLE `bitmap_null_test` (
+  `id` int(11) NULL COMMENT "",
+  `bitmap_col` bitmap BITMAP_UNION NULL COMMENT ""
+) ENGINE=OLAP
+AGGREGATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+-- Test bitmap_or NULL handling
+-- bitmap_or(NULL, bitmap) = bitmap
+-- bitmap_or(bitmap, NULL) = bitmap
+-- bitmap_or(NULL, NULL) = NULL
+-- bitmap_or(bitmap, bitmap) = normal OR operation
+
+-- Test data preparation
+insert into bitmap_null_test values (1, NULL);
+insert into bitmap_null_test values (2, bitmap_empty());
+insert into bitmap_null_test values (3, to_bitmap(1));
+insert into bitmap_null_test values (4, to_bitmap('2,3,4'));
+
+-- Test bitmap_or with NULL values
+-- Case 1: bitmap_or(NULL, bitmap) should return bitmap
+SELECT bitmap_to_string(bitmap_or(NULL, to_bitmap('1,2,3'))) as result;
+1,2,3
+SELECT bitmap_to_string(bitmap_or(NULL, bitmap_empty())) as result;
+(empty)
+SELECT bitmap_to_string(bitmap_or(NULL, to_bitmap(5))) as result;
+5
+
+-- Case 2: bitmap_or(bitmap, NULL) should return bitmap
+SELECT bitmap_to_string(bitmap_or(to_bitmap('1,2,3'), NULL)) as result;
+1,2,3
+SELECT bitmap_to_string(bitmap_or(bitmap_empty(), NULL)) as result;
+(empty)
+SELECT bitmap_to_string(bitmap_or(to_bitmap(5), NULL)) as result;
+5
+
+-- Case 3: bitmap_or(NULL, NULL) should return NULL
+SELECT bitmap_to_string(bitmap_or(NULL, NULL)) as result;
+NULL
+SELECT bitmap_or(NULL, NULL) IS NULL as is_null_result;
+1
+
+-- Case 4: bitmap_or(normal, normal) should work as before
+SELECT bitmap_to_string(bitmap_or(to_bitmap('1,2,3'), to_bitmap('3,4,5'))) as result;
+1,2,3,4,5
+SELECT bitmap_to_string(bitmap_or(to_bitmap('1,2'), bitmap_empty())) as result;
+1,2
+
+-- Test bitmap_andnot NULL handling
+-- bitmap_andnot(NULL, bitmap) = NULL
+-- bitmap_andnot(bitmap, NULL) = bitmap
+-- bitmap_andnot(NULL, NULL) = NULL
+-- bitmap_andnot(bitmap, bitmap) = normal ANDNOT operation
+
+-- Case 1: bitmap_andnot(NULL, bitmap) should return NULL
+SELECT bitmap_to_string(bitmap_andnot(NULL, to_bitmap('1,2,3'))) as result;
+NULL
+SELECT bitmap_andnot(NULL, to_bitmap('1,2,3')) IS NULL as is_null_result;
+1
+
+-- Case 2: bitmap_andnot(bitmap, NULL) should return bitmap
+SELECT bitmap_to_string(bitmap_andnot(to_bitmap('1,2,3'), NULL)) as result;
+1,2,3
+SELECT bitmap_to_string(bitmap_andnot(to_bitmap('5,6,7'), NULL)) as result;
+5,6,7
+
+-- Case 3: bitmap_andnot(NULL, NULL) should return NULL
+SELECT bitmap_to_string(bitmap_andnot(NULL, NULL)) as result;
+NULL
+SELECT bitmap_andnot(NULL, NULL) IS NULL as is_null_result;
+1
+
+-- Case 4: bitmap_andnot(normal, normal) should work as before
+SELECT bitmap_to_string(bitmap_andnot(to_bitmap('1,2,3,4,5'), to_bitmap('2,4'))) as result;
+1,3,5
+SELECT bitmap_to_string(bitmap_andnot(to_bitmap('1,2,3'), bitmap_empty())) as result;
+1,2,3
+
+-- Test bitmap_xor NULL handling
+-- bitmap_xor(NULL, bitmap) = bitmap
+-- bitmap_xor(bitmap, NULL) = bitmap
+-- bitmap_xor(NULL, NULL) = NULL
+-- bitmap_xor(bitmap, bitmap) = normal XOR operation
+
+-- Case 1: bitmap_xor(NULL, bitmap) should return bitmap
+SELECT bitmap_to_string(bitmap_xor(NULL, to_bitmap('1,2,3'))) as result;
+1,2,3
+SELECT bitmap_to_string(bitmap_xor(NULL, bitmap_empty())) as result;
+(empty)
+
+-- Case 2: bitmap_xor(bitmap, NULL) should return bitmap
+SELECT bitmap_to_string(bitmap_xor(to_bitmap('1,2,3'), NULL)) as result;
+1,2,3
+SELECT bitmap_to_string(bitmap_xor(to_bitmap('5,6'), NULL)) as result;
+5,6
+
+-- Case 3: bitmap_xor(NULL, NULL) should return NULL
+SELECT bitmap_to_string(bitmap_xor(NULL, NULL)) as result;
+NULL
+SELECT bitmap_xor(NULL, NULL) IS NULL as is_null_result;
+1
+
+-- Case 4: bitmap_xor(normal, normal) should work as before
+SELECT bitmap_to_string(bitmap_xor(to_bitmap('1,2,3'), to_bitmap('2,3,4'))) as result;
+1,4
+SELECT bitmap_to_string(bitmap_xor(to_bitmap('1,2'), bitmap_empty())) as result;
+1,2
+
+-- Test with table data
+-- Insert test data with NULL values
+insert into bitmap_null_test values (5, NULL);
+insert into bitmap_null_test values (6, to_bitmap('10,11,12'));
+
+-- Test bitmap_or with table data
+SELECT id, bitmap_to_string(bitmap_or(bitmap_col, to_bitmap('100'))) as or_result
+FROM bitmap_null_test
+ORDER BY id;
+1,NULL
+2,100
+3,1,100
+4,2,3,4,100
+5,NULL
+6,10,11,12,100
+
+SELECT id, bitmap_to_string(bitmap_or(to_bitmap('200'), bitmap_col)) as or_result
+FROM bitmap_null_test
+ORDER BY id;
+1,200
+2,200
+3,1,200
+4,2,3,4,200
+5,200
+6,10,11,12,200
+
+-- Test bitmap_andnot with table data
+SELECT id, bitmap_to_string(bitmap_andnot(bitmap_col, to_bitmap('10'))) as andnot_result
+FROM bitmap_null_test
+WHERE id >= 5
+ORDER BY id;
+5,NULL
+6,11,12
+
+SELECT id, bitmap_to_string(bitmap_andnot(to_bitmap('10,11,12'), bitmap_col)) as andnot_result
+FROM bitmap_null_test
+WHERE id >= 5
+ORDER BY id;
+5,10,11,12
+6,(empty)
+
+-- Test bitmap_xor with table data
+SELECT id, bitmap_to_string(bitmap_xor(bitmap_col, to_bitmap('100'))) as xor_result
+FROM bitmap_null_test
+ORDER BY id;
+1,NULL
+2,100
+3,1,100
+4,2,3,4,100
+5,NULL
+6,10,11,12,100
+
+SELECT id, bitmap_to_string(bitmap_xor(to_bitmap('200'), bitmap_col)) as xor_result
+FROM bitmap_null_test
+ORDER BY id;
+1,200
+2,200
+3,1,200
+4,2,3,4,200
+5,200
+6,10,11,12,200
+
+-- Clean up
+DROP TABLE bitmap_null_test;

--- a/test/sql/test_bitmap_functions/T/test_bitmap_null_handling
+++ b/test/sql/test_bitmap_functions/T/test_bitmap_null_handling
@@ -1,0 +1,124 @@
+-- name: test_bitmap_null_handling
+-- Test NULL handling for bitmap_or, bitmap_andnot, bitmap_xor functions
+-- This test covers the optimization introduced in commit for bitmap NULL value handling
+
+-- Create test tables
+CREATE TABLE `bitmap_null_test` (
+  `id` int(11) NULL COMMENT "",
+  `bitmap_col` bitmap BITMAP_UNION NULL COMMENT ""
+) ENGINE=OLAP
+AGGREGATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+-- Test bitmap_or NULL handling
+-- bitmap_or(NULL, bitmap) = bitmap
+-- bitmap_or(bitmap, NULL) = bitmap
+-- bitmap_or(NULL, NULL) = NULL
+-- bitmap_or(bitmap, bitmap) = normal OR operation
+
+-- Test data preparation
+insert into bitmap_null_test values (1, NULL);
+insert into bitmap_null_test values (2, bitmap_empty());
+insert into bitmap_null_test values (3, to_bitmap(1));
+insert into bitmap_null_test values (4, to_bitmap('2,3,4'));
+
+-- Test bitmap_or with NULL values
+-- Case 1: bitmap_or(NULL, bitmap) should return bitmap
+SELECT bitmap_to_string(bitmap_or(NULL, to_bitmap('1,2,3'))) as result;
+SELECT bitmap_to_string(bitmap_or(NULL, bitmap_empty())) as result;
+SELECT bitmap_to_string(bitmap_or(NULL, to_bitmap(5))) as result;
+
+-- Case 2: bitmap_or(bitmap, NULL) should return bitmap
+SELECT bitmap_to_string(bitmap_or(to_bitmap('1,2,3'), NULL)) as result;
+SELECT bitmap_to_string(bitmap_or(bitmap_empty(), NULL)) as result;
+SELECT bitmap_to_string(bitmap_or(to_bitmap(5), NULL)) as result;
+
+-- Case 3: bitmap_or(NULL, NULL) should return NULL
+SELECT bitmap_to_string(bitmap_or(NULL, NULL)) as result;
+SELECT bitmap_or(NULL, NULL) IS NULL as is_null_result;
+
+-- Case 4: bitmap_or(normal, normal) should work as before
+SELECT bitmap_to_string(bitmap_or(to_bitmap('1,2,3'), to_bitmap('3,4,5'))) as result;
+SELECT bitmap_to_string(bitmap_or(to_bitmap('1,2'), bitmap_empty())) as result;
+
+-- Test bitmap_andnot NULL handling
+-- bitmap_andnot(NULL, bitmap) = NULL
+-- bitmap_andnot(bitmap, NULL) = bitmap
+-- bitmap_andnot(NULL, NULL) = NULL
+-- bitmap_andnot(bitmap, bitmap) = normal ANDNOT operation
+
+-- Case 1: bitmap_andnot(NULL, bitmap) should return NULL
+SELECT bitmap_to_string(bitmap_andnot(NULL, to_bitmap('1,2,3'))) as result;
+SELECT bitmap_andnot(NULL, to_bitmap('1,2,3')) IS NULL as is_null_result;
+
+-- Case 2: bitmap_andnot(bitmap, NULL) should return bitmap
+SELECT bitmap_to_string(bitmap_andnot(to_bitmap('1,2,3'), NULL)) as result;
+SELECT bitmap_to_string(bitmap_andnot(to_bitmap('5,6,7'), NULL)) as result;
+
+-- Case 3: bitmap_andnot(NULL, NULL) should return NULL
+SELECT bitmap_to_string(bitmap_andnot(NULL, NULL)) as result;
+SELECT bitmap_andnot(NULL, NULL) IS NULL as is_null_result;
+
+-- Case 4: bitmap_andnot(normal, normal) should work as before
+SELECT bitmap_to_string(bitmap_andnot(to_bitmap('1,2,3,4,5'), to_bitmap('2,4'))) as result;
+SELECT bitmap_to_string(bitmap_andnot(to_bitmap('1,2,3'), bitmap_empty())) as result;
+
+-- Test bitmap_xor NULL handling
+-- bitmap_xor(NULL, bitmap) = bitmap
+-- bitmap_xor(bitmap, NULL) = bitmap
+-- bitmap_xor(NULL, NULL) = NULL
+-- bitmap_xor(bitmap, bitmap) = normal XOR operation
+
+-- Case 1: bitmap_xor(NULL, bitmap) should return bitmap
+SELECT bitmap_to_string(bitmap_xor(NULL, to_bitmap('1,2,3'))) as result;
+SELECT bitmap_to_string(bitmap_xor(NULL, bitmap_empty())) as result;
+
+-- Case 2: bitmap_xor(bitmap, NULL) should return bitmap
+SELECT bitmap_to_string(bitmap_xor(to_bitmap('1,2,3'), NULL)) as result;
+SELECT bitmap_to_string(bitmap_xor(to_bitmap('5,6'), NULL)) as result;
+
+-- Case 3: bitmap_xor(NULL, NULL) should return NULL
+SELECT bitmap_to_string(bitmap_xor(NULL, NULL)) as result;
+SELECT bitmap_xor(NULL, NULL) IS NULL as is_null_result;
+
+-- Case 4: bitmap_xor(normal, normal) should work as before
+SELECT bitmap_to_string(bitmap_xor(to_bitmap('1,2,3'), to_bitmap('2,3,4'))) as result;
+SELECT bitmap_to_string(bitmap_xor(to_bitmap('1,2'), bitmap_empty())) as result;
+
+-- Test with table data
+-- Insert test data with NULL values
+insert into bitmap_null_test values (5, NULL);
+insert into bitmap_null_test values (6, to_bitmap('10,11,12'));
+
+-- Test bitmap_or with table data
+SELECT id, bitmap_to_string(bitmap_or(bitmap_col, to_bitmap('100'))) as or_result
+FROM bitmap_null_test
+ORDER BY id;
+
+SELECT id, bitmap_to_string(bitmap_or(to_bitmap('200'), bitmap_col)) as or_result
+FROM bitmap_null_test
+ORDER BY id;
+
+-- Test bitmap_andnot with table data
+SELECT id, bitmap_to_string(bitmap_andnot(bitmap_col, to_bitmap('10'))) as andnot_result
+FROM bitmap_null_test
+WHERE id >= 5
+ORDER BY id;
+
+SELECT id, bitmap_to_string(bitmap_andnot(to_bitmap('10,11,12'), bitmap_col)) as andnot_result
+FROM bitmap_null_test
+WHERE id >= 5
+ORDER BY id;
+
+-- Test bitmap_xor with table data
+SELECT id, bitmap_to_string(bitmap_xor(bitmap_col, to_bitmap('100'))) as xor_result
+FROM bitmap_null_test
+ORDER BY id;
+
+SELECT id, bitmap_to_string(bitmap_xor(to_bitmap('200'), bitmap_col)) as xor_result
+FROM bitmap_null_test
+ORDER BY id;
+
+-- Clean up
+DROP TABLE bitmap_null_test;


### PR DESCRIPTION
## Why I'm doing:

Bitmap functions like `bitmap_or`, `bitmap_xor` and `bitmap_andnot` would return wrong result while encountered NULL inputs.

## What I'm doing:

-- bitmap_or(NULL, bitmap) = bitmap
-- bitmap_or(bitmap, NULL) = bitmap
-- bitmap_or(NULL, NULL) = NULL
-- bitmap_or(bitmap, bitmap) = normal OR operation

-- bitmap_xor(NULL, bitmap) = bitmap
-- bitmap_xor(bitmap, NULL) = bitmap
-- bitmap_xor(NULL, NULL) = NULL
-- bitmap_xor(bitmap, bitmap) = normal XOR operation

-- bitmap_andnot(NULL, bitmap) = NULL
-- bitmap_andnot(bitmap, NULL) = bitmap
-- bitmap_andnot(NULL, NULL) = NULL
-- bitmap_andnot(bitmap, bitmap) = normal ANDNOT operation


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
