### PR TITLE
[Enhancement] Make BE reject multi-statement transaction stream load

### DIFF
--- a/be/src/http/http_common.h
+++ b/be/src/http/http_common.h
@@ -78,6 +78,7 @@ static const std::string HTTP_ENABLE_REPLICATED_STORAGE = "enable_replicated_sto
 static const std::string HTTP_MERGE_CONDITION = "merge_condition";
 static const std::string HTTP_LOG_REJECTED_RECORD_NUM = "log_rejected_record_num";
 static const std::string HTTP_PARTIAL_UPDATE_MODE = "partial_update_mode";
+static const std::string HTTP_TRANSACTION_TYPE = "transaction_type";
 
 static const std::string HTTP_100_CONTINUE = "100-continue";
 static const std::string HTTP_CHANNEL_ID = "channel_id";

--- a/test/sql/test_stream_load/R/test_be_reject_transaction_type
+++ b/test/sql/test_stream_load/R/test_be_reject_transaction_type
@@ -1,0 +1,18 @@
+-- name: test_be_reject_transaction_type_header
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table dummy_table (id int) distributed by hash(id) buckets 1 properties("replication_num" = "1");
+-- result:
+-- !result
+shell: curl --location-trusted -u root: -H "label:test_multi_${uuid0}" -H "db:db_${uuid0}" -H "table:dummy_table" -H "transaction_type:multi" -XPOST "http://$(${mysql_cmd} -e "show backends;" | tail -n +2 | head -n 1 | cut -f2):$(${mysql_cmd} -e "show backends;" | tail -n +2 | head -n 1 | cut -f5)/api/transaction/begin"
+-- result:
+0
+{
+    "Status": "INVALID_ARGUMENT",
+    "Message": "Multi-statement transaction requests can only be sent to FE nodes, not BE nodes"
+}
+-- !result

--- a/test/sql/test_stream_load/T/test_be_reject_transaction_type
+++ b/test/sql/test_stream_load/T/test_be_reject_transaction_type
@@ -1,0 +1,7 @@
+-- name: test_be_reject_transaction_type_header
+
+create database db_${uuid0};
+use db_${uuid0};
+create table dummy_table (id int) distributed by hash(id) buckets 1 properties("replication_num" = "1");
+
+shell: curl --location-trusted -u root: -H "label:test_multi_${uuid0}" -H "db:db_${uuid0}" -H "table:dummy_table" -H "transaction_type:multi" -XPOST "http://$(${mysql_cmd} -e "show backends;" | tail -n +2 | head -n 1 | cut -f2):$(${mysql_cmd} -e "show backends;" | tail -n +2 | head -n 1 | cut -f5)/api/transaction/begin"


### PR DESCRIPTION
This commit enhances the robustness of stream loading by making the BE (Backend) node explicitly reject requests intended for multi-statement transactions.

Previously, a stream load request with the `transaction_type` HTTP header could be sent to a BE. Since multi-statement transactions are managed exclusively by the FE (Frontend), this could lead to undefined behavior or errors on the BE.

This change introduces a validation check in the BE's transaction manager action. If a request contains the `transaction_type` header, the BE will now immediately reject it with an `INVALID_ARGUMENT` error and a clear message indicating that such requests must be sent to an FE.

Additionally, a new SQL test case has been added to verify this behavior, ensuring that

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
