### PR TITLE
[BugFix] Fix bug where reserved words in iceberg partitions break toThrift

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -559,28 +559,29 @@ public class IcebergApiConverter {
 
     public static String toPartitionField(PartitionSpec spec, PartitionField field, Boolean withTransfomPrefix) {
         String name = spec.schema().findColumnName(field.sourceId());
+        String escapedName =  "`" + name + "`";
         String transform = field.transform().toString();
         String prefix = withTransfomPrefix ? FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX : "";
 
         switch (transform) {
             case "identity":
-                return name;
+                return escapedName;
             case "year":
             case "month":
             case "day":
             case "hour":
             case "void":
-                return prefix + format("%s(%s)", transform, name);
+                return prefix + format("%s(%s)", transform, escapedName);
         }
 
         Matcher matcher = ICEBERG_BUCKET_PATTERN.matcher(transform);
         if (matcher.matches()) {
-            return prefix + format("bucket(%s, %s)", name, matcher.group(1));
+            return prefix + format("bucket(%s, %s)", escapedName, matcher.group(1));
         }
 
         matcher = ICEBERG_TRUNCATE_PATTERN.matcher(transform);
         if (matcher.matches()) {
-            return prefix + format("truncate(%s, %s)", name, matcher.group(1));
+            return prefix + format("truncate(%s, %s)", escapedName, matcher.group(1));
         }
 
         throw new StarRocksConnectorException("Unsupported partition transform: " + field);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -57,6 +57,7 @@ import com.starrocks.connector.metadata.MetadataCollectJob;
 import com.starrocks.connector.metadata.MetadataTableType;
 import com.starrocks.connector.metadata.iceberg.IcebergMetadataCollectJob;
 import com.starrocks.persist.EditLog;
+import com.starrocks.planner.DescriptorTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
@@ -98,8 +99,10 @@ import com.starrocks.statistic.ExternalAnalyzeJob;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.thrift.TIcebergColumnStats;
 import com.starrocks.thrift.TIcebergDataFile;
+import com.starrocks.thrift.TIcebergTable;
 import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.thrift.TSinkCommitInfo;
+import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -113,6 +116,7 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetricsModes;
 import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SortOrder;
@@ -126,6 +130,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.HiveTableOperations;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -155,6 +160,7 @@ import static com.starrocks.connector.iceberg.IcebergMetadata.COMPRESSION_CODEC;
 import static com.starrocks.connector.iceberg.IcebergMetadata.FILE_FORMAT;
 import static com.starrocks.connector.iceberg.IcebergMetadata.LOCATION_PROPERTY;
 import static com.starrocks.connector.iceberg.IcebergTableOperation.REMOVE_ORPHAN_FILES;
+import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class IcebergMetadataTest extends TableTestBase {
@@ -1490,6 +1496,57 @@ public class IcebergMetadataTest extends TableTestBase {
         List<PartitionInfo> partitions = metadata.getPartitions(icebergTable, ImmutableList.of("k2=2", "k2=3"));
         Assertions.assertEquals(2, partitions.size());
         Assertions.assertTrue(partitions.stream().anyMatch(x -> x.getModifiedTime() == -1));
+    }
+
+
+    @Test
+    public void testPartitionWithReservedName() {
+        // Create a schema with a column named "partition" (which is a reserved word)
+        Schema schemaWithPartitionColumn = new Schema(
+                required(1, "id", Types.IntegerType.get()),
+                required(2, "partition", Types.StringType.get())
+        );
+        
+        PartitionSpec specWithPartitionColumn = PartitionSpec.builderFor(schemaWithPartitionColumn)
+                .identity("partition")
+                .bucket("partition", 32)
+                .truncate("partition", 32)
+                .build();
+        
+        TestTables.TestTable testTable = create(schemaWithPartitionColumn, specWithPartitionColumn, "test_partition_table", 1);
+
+        List<Column> columns = Lists.newArrayList(
+                new Column("id", INT),
+                new Column("partition", STRING)
+        );
+        
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "db_name",
+                "table_name", "", columns, testTable, Maps.newHashMap());
+        
+        List<String> partitionColumnNames = icebergTable.getPartitionColumnNames();
+
+        Assertions.assertNotNull(partitionColumnNames);
+        Assertions.assertEquals(3, partitionColumnNames.size());
+        Assertions.assertEquals("partition", partitionColumnNames.get(0));
+        Assertions.assertEquals("partition", partitionColumnNames.get(1));
+        Assertions.assertEquals("partition", partitionColumnNames.get(2));
+
+        List<String> partitionColumnNamesWithTransform = icebergTable.getPartitionColumnNamesWithTransform();
+        Assertions.assertNotNull(partitionColumnNamesWithTransform);
+        Assertions.assertEquals(3, partitionColumnNamesWithTransform.size());
+        Assertions.assertEquals("`partition`", partitionColumnNamesWithTransform.get(0));
+        Assertions.assertEquals("bucket(`partition`, 32)", partitionColumnNamesWithTransform.get(1));
+        Assertions.assertEquals("truncate(`partition`, 32)", partitionColumnNamesWithTransform.get(2));
+
+        // convert the icebergTable into a thrift value 
+        List<DescriptorTable.ReferencedPartitionInfo> partitions = Lists.newArrayList();
+        TTableDescriptor tableDescriptor = icebergTable.toThrift(partitions);
+        Assertions.assertNotNull(tableDescriptor);
+        TIcebergTable tIcebergTable = tableDescriptor.icebergTable;
+        Assertions.assertEquals(3, tIcebergTable.getPartition_column_names().size());
+        Assertions.assertEquals("partition", tIcebergTable.getPartition_column_names().get(0));
+        Assertions.assertEquals("partition", tIcebergTable.getPartition_column_names().get(1));
+        Assertions.assertEquals("partition", tIcebergTable.getPartition_column_names().get(2));
     }
 
     @Test

--- a/test/sql/test_iceberg/R/test_iceberg_show_stmt
+++ b/test/sql/test_iceberg/R/test_iceberg_show_stmt
@@ -13,7 +13,7 @@ partition_transform_table	CREATE TABLE `partition_transform_table` (
   `p1` varchar(1073741824) DEFAULT NULL,
   `p2` varchar(1073741824) DEFAULT NULL
 )
-PARTITION BY (year(t1), month(t2), day(t3), hour(t4), truncate(p1, 5), bucket(p2, 3))
+PARTITION BY (year(`t1`), month(`t2`), day(`t3`), hour(`t4`), truncate(`p1`, 5), bucket(`p2`, 3))
 PROPERTIES ("owner" = "root", "location" = "oss://starrocks-ci-test/iceberg_ci_db/partition_transform_table");
 -- !result
 drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

In 4.0 if an Iceberg table has a partition column name that collides with a reserved keyword the toThrift method throws an error which breaks querying that table. 


## What I'm doing:

To fix this I am wrapping column names from partitions in IcebergApiConverter with backticks.

Fixes #63241

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
