### PR TITLE
[BugFix] Fix ranger hive service alter privilege not work

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/hive/RangerHiveAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/hive/RangerHiveAccessController.java
@@ -131,6 +131,8 @@ public class RangerHiveAccessController extends RangerAccessController {
             hiveAccessType = HiveAccessType.DROP;
         } else if (privilegeType == PrivilegeType.REFRESH) {
             hiveAccessType = HiveAccessType.REFRESH;
+        } else if (privilegeType == PrivilegeType.ALTER) {
+            hiveAccessType = HiveAccessType.ALTER;
         } else {
             hiveAccessType = HiveAccessType.NONE;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/ranger/RangerInterfaceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/ranger/RangerInterfaceTest.java
@@ -270,5 +270,6 @@ public class RangerInterfaceTest {
         Assertions.assertEquals("create", controller.convertToAccessType(PrivilegeType.CREATE_DATABASE));
         Assertions.assertEquals("refresh", controller.convertToAccessType(PrivilegeType.REFRESH));
         Assertions.assertEquals("drop", controller.convertToAccessType(PrivilegeType.DROP));
+        Assertions.assertEquals("alter", controller.convertToAccessType(PrivilegeType.ALTER));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Fix https://github.com/StarRocks/StarRocksTest/issues/10273
## What I'm doing:
add alter privilege convert to hive service HiveAccessType 
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
