### PR TITLE
[BugFix] Fix BE crash in tracer when jaeger_endpoint is invalid

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1094,6 +1094,8 @@ CONF_Int64(rpc_connect_timeout_ms, "30000");
 CONF_Int32(max_batch_publish_latency_ms, "100");
 
 // Config for opentelemetry tracing.
+// Valid example: jaeger_endpoint = localhost:14268
+// Invalid example: jaeger_endpoint = http://localhost:14268
 CONF_String(jaeger_endpoint, "");
 
 // Config for query debug trace


### PR DESCRIPTION
## Why I'm doing:
When BE config jaeger_endpoint is invalid, BE will crash in tracer:
```
*** Aborted at 1757906071 (unix time) try "date -d @1757906071" if you are using GNU date ***
PC: @          0xbe8d0af starrocks::Tracer::start_trace_or_add_span(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
*** SIGSEGV (@0x0) received by PID 3328297 (TID 0x7f30f7d2c640) LWP(3328810) from PID 0; stack trace: ***
    @     0x7f31e6d41ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x109a4ae8 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f31e6cea520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0xbe8d0af starrocks::Tracer::start_trace_or_add_span(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    @          0xcc1383c starrocks::OlapTableSink::init(starrocks::TDataSink const&, starrocks::RuntimeState*)
    @          0xcc09965 starrocks::DataSink::create_data_sink(starrocks::RuntimeState*, starrocks::TDataSink const&, std::vector<starrocks::TExpr, std::allocator<starrocks::TExpr> > const&, starrocks::TPlanFragmentExecParams const&, int, starrocks::RowDescriptor const&, std::uniq@^A
    @          0xcc5475f starrocks::pipeline::FragmentExecutor::_prepare_pipeline_driver(starrocks::ExecEnv*, starrocks::pipeline::UnifiedExecPlanFragmentParams const&)
    @          0xcc55a96 starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
    @          0xcdea3f5 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
    @          0xcde9873 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*)
    @          0xcde9403 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)
    @          0xcb1e547 starrocks::PriorityThreadPool::work_thread(int)
    @         0x1095100b thread_proxy
    @     0x7f31e6d3cac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7f31e6dce850 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x12684f)
```

Invalid jaeger_endpoint example: 
`jaeger_endpoint = http://localhost:14268`

Valid jaeger_endpoint example:
`jaeger_endpoint = localhost:14268 `

## What I'm doing:
Create a no-op tracer to protect BE from crash when jaeger_endpoint is invalid.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
