### PR TITLE
[BugFix] Fix get max compaction score NullPointerException bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
@@ -206,8 +206,8 @@ public class CompactionMgr implements MemoryTrackable {
     }
 
     public double getMaxCompactionScore() {
-        return partitionStatisticsHashMap.values().stream().mapToDouble(stat -> stat.getCompactionScore().getMax())
-                .max().orElse(0);
+        return partitionStatisticsHashMap.values().stream().filter(stat -> stat.getCompactionScore() != null)
+                .mapToDouble(stat -> stat.getCompactionScore().getMax()).max().orElse(0);
     }
 
     void enableCompactionAfter(PartitionIdentifier partition, long delayMs) {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
@@ -166,6 +166,7 @@ public class CompactionMgrTest {
         PartitionIdentifier partition2 = new PartitionIdentifier(1, 2, 4);
         Assertions.assertEquals(0, compactionMgr.getMaxCompactionScore(), delta);
 
+        // load and compact partition 1
         compactionMgr.handleLoadingFinished(partition1, 2, System.currentTimeMillis(),
                 Quantiles.compute(Lists.newArrayList(1d)));
         Assertions.assertEquals(1, compactionMgr.getMaxCompactionScore(), delta);
@@ -173,10 +174,17 @@ public class CompactionMgrTest {
                 Quantiles.compute(Lists.newArrayList(2d)), 1234, false);
         Assertions.assertEquals(2, compactionMgr.getMaxCompactionScore(), delta);
 
+        // load partition 2
         compactionMgr.handleLoadingFinished(partition2, 2, System.currentTimeMillis(),
                 Quantiles.compute(Lists.newArrayList(3d)));
         Assertions.assertEquals(3, compactionMgr.getMaxCompactionScore(), delta);
 
+        // set partition 2 compaction score to null
+        PartitionStatistics statistics2 = compactionMgr.getStatistics(partition2);
+        statistics2.setCompactionScore(null);
+        Assertions.assertEquals(2, compactionMgr.getMaxCompactionScore(), delta);
+
+        // remove partition 2
         compactionMgr.removePartition(partition2);
         Assertions.assertEquals(2, compactionMgr.getMaxCompactionScore(), delta);
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
java.lang.NullPointerException: Cannot invoke "com.starrocks.lake.compaction.Quantiles.getMax()" because the return value of "com.starrocks.lake.compaction.PartitionStatistics.getCompactionScor
e()" is null                                                                                                                                                                                     
        at com.starrocks.lake.compaction.CompactionMgr.lambda$getMaxCompactionScore$5(CompactionMgr.java:209)                                                                                    
        at com.starrocks.lake.compaction.CompactionMgr.getMaxCompactionScore(CompactionMgr.java:210) 
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
