### PR TITLE
Fix starrocks github issue 62686

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
@@ -91,8 +91,11 @@ public class AnalyzeJoinTest {
         analyzeFail("select * from (t0 join tnotnull using(v1)) t , t1",
                 "Getting syntax error at line 1, column 43. Detail message: Unexpected input 't', " +
                         "the most similar input is {<EOF>, ';'}.");
-        // After aligning USING semantics with SQL standard/MySQL, USING columns are coalesced
-        // and unqualified reference is not ambiguous in this case
+        // Using columns should be coalesced and appear only once in output names
+        QueryRelation query1 = ((QueryStatement) analyzeSuccess(
+                "select * from t0 a join t0 b using(v1)")).getQueryRelation();
+        Assertions.assertEquals("v1,v2,v3,v2,v3", String.join(",", query1.getColumnOutputNames()));
+        // Unqualified reference of using column should be unambiguous
         analyzeSuccess("select v1 from (t0 join tnotnull using(v1)), t1");
         analyzeSuccess("select a.v1 from (t0 a join tnotnull b using(v1)), t1");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
@@ -91,7 +91,9 @@ public class AnalyzeJoinTest {
         analyzeFail("select * from (t0 join tnotnull using(v1)) t , t1",
                 "Getting syntax error at line 1, column 43. Detail message: Unexpected input 't', " +
                         "the most similar input is {<EOF>, ';'}.");
-        analyzeFail("select v1 from (t0 join tnotnull using(v1)), t1", "Column 'v1' is ambiguous");
+        // After aligning USING semantics with SQL standard/MySQL, USING columns are coalesced
+        // and unqualified reference is not ambiguous in this case
+        analyzeSuccess("select v1 from (t0 join tnotnull using(v1)), t1");
         analyzeSuccess("select a.v1 from (t0 a join tnotnull b using(v1)), t1");
     }
 


### PR DESCRIPTION
## Why I'm doing:

Fixes #62686. The current implementation of `JOIN ... USING` exposes duplicate columns for `USING` names, leading to ambiguous column references in `SELECT` statements (e.g., `SELECT c1 FROM t1 JOIN t2 USING(c1)` fails). This change aligns the output schema with SQL standard and MySQL behavior, where `USING` columns are deduplicated and appear only once.

## What I'm doing:

Modified `QueryAnalyzer.java` to deduplicate columns specified in the `USING` clause of a `JOIN`. After the initial join `Scope` is formed, if `USING` columns are present, only the first occurrence of each `USING` column (from the left side of the join) is retained in the output `Scope`. This resolves ambiguity for unqualified references to these columns.

Fixes #62686

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-feb0fa4b-5153-4f25-86ec-f09274fb7b55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-feb0fa4b-5153-4f25-86ec-f09274fb7b55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

