### PR TITLE
[BugFix] Fix pk index cumulative compaction strategy when max_rss_rowid is same

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -454,7 +454,13 @@ void LakePersistentIndex::pick_sstables_for_merge(const PersistentIndexSstableMe
         // we should force to do base merge.
         // That's because in `LakePersistentIndex::apply_opcompaction`, we will sort sstable
         // by max_rss_rowid, and if they are same, the base sstable will be after cumulative sstable,
-        // which is not what we want.
+        // which is not what we want. E.g.
+        //  t1 : (base sst: max_rss_rowid = 4, cumulative sst: max_rss_rowid = 4, cumulative sst: max_rss_rowid = 4)
+        //  t2 : do cumulative compaction, merge these two cumulative sst, and get new (cumulative sst: max_rss_rowid = 4).
+        //  t3 : apply new cumulative sst, now the order is:
+        //       (cumulative sst: max_rss_rowid = 4, base sst: max_rss_rowid = 4)
+        //       which is wrong, because base sst should be before cumulative sst.
+        // so we force to do base merge here.
         *merge_base_level = true;
         sstables->insert(sstables->begin(), sstable_meta.sstables(0));
     }

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -449,7 +449,7 @@ void LakePersistentIndex::pick_sstables_for_merge(const PersistentIndexSstableMe
         sstables->resize(max_limit);
     }
     if (!*merge_base_level && sstables->size() > 0 &&
-        sstable_meta.sstables(0).max_rss_rowid() == sstables->back()->max_rss_rowid()) {
+        sstable_meta.sstables(0).max_rss_rowid() == sstables->back().max_rss_rowid()) {
         // If base sstable's max_rss_rowid is same as cumulative sstable's max_rss_rowid,
         // we should force to do base merge.
         // That's because in `LakePersistentIndex::apply_opcompaction`, we will sort sstable

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -394,15 +394,15 @@ TEST_F(LakePersistentIndexTest, test_compaction_strategy_same_max_rss_rowid) {
 
     // Add base sstable (index 0) with large size
     auto* base_sstable = sstable_meta.add_sstables();
-    base_sstable->set_filesize(1000000);  // 1MB
+    base_sstable->set_filesize(1000000); // 1MB
     base_sstable->set_filename("base.sst");
-    base_sstable->set_max_rss_rowid(100);  // Same max_rss_rowid
+    base_sstable->set_max_rss_rowid(100); // Same max_rss_rowid
 
     // Add cumulative sstables with small total size (would trigger cumulative merge normally)
     auto* cumulative_sstable = sstable_meta.add_sstables();
-    cumulative_sstable->set_filesize(50000);  // 50KB - much smaller than base
+    cumulative_sstable->set_filesize(50000); // 50KB - much smaller than base
     cumulative_sstable->set_filename("cumulative1.sst");
-    cumulative_sstable->set_max_rss_rowid(100);  // Same max_rss_rowid as base
+    cumulative_sstable->set_max_rss_rowid(100); // Same max_rss_rowid as base
 
     // Without the fix, this would choose cumulative merge because:
     // base_level_bytes * ratio (1000000 * 0.1 = 100000) > cumulative_level_bytes (50000)
@@ -423,12 +423,12 @@ TEST_F(LakePersistentIndexTest, test_compaction_strategy_same_max_rss_rowid) {
     base_sstable = sstable_meta.add_sstables();
     base_sstable->set_filesize(1000000);
     base_sstable->set_filename("base2.sst");
-    base_sstable->set_max_rss_rowid(100);  // Different max_rss_rowid
+    base_sstable->set_max_rss_rowid(100); // Different max_rss_rowid
 
     cumulative_sstable = sstable_meta.add_sstables();
     cumulative_sstable->set_filesize(50000);
     cumulative_sstable->set_filename("cumulative2.sst");
-    cumulative_sstable->set_max_rss_rowid(200);  // Different max_rss_rowid
+    cumulative_sstable->set_max_rss_rowid(200); // Different max_rss_rowid
 
     LakePersistentIndex::pick_sstables_for_merge(sstable_meta, &sstables, &merge_base_level);
 

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -262,10 +262,11 @@ TEST_F(LakePersistentIndexTest, test_compaction_strategy) {
         auto* sstable_pb = sstable_meta.add_sstables();
         sstable_pb->set_filesize(1000000);
         sstable_pb->set_filename("aaa.sst");
+        sstable_pb->set_max_rss_rowid(0);
         for (int i = 0; i < N; i++) {
             sstable_pb = sstable_meta.add_sstables();
             sstable_pb->set_filesize(sub_size);
-            sstable_pb->set_max_rss_rowid(i);
+            sstable_pb->set_max_rss_rowid(i + 1);
         }
         LakePersistentIndex::pick_sstables_for_merge(sstable_meta, &sstables, &merge_base_level);
         if (is_base) {

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -265,6 +265,7 @@ TEST_F(LakePersistentIndexTest, test_compaction_strategy) {
         for (int i = 0; i < N; i++) {
             sstable_pb = sstable_meta.add_sstables();
             sstable_pb->set_filesize(sub_size);
+            sstable_pb->set_max_rssid(i);
         }
         LakePersistentIndex::pick_sstables_for_merge(sstable_meta, &sstables, &merge_base_level);
         if (is_base) {
@@ -451,9 +452,8 @@ TEST_F(LakePersistentIndexTest, test_compaction_strategy_same_max_rss_rowid) {
     LakePersistentIndex::pick_sstables_for_merge(sstable_meta, &sstables, &merge_base_level);
 
     // Should choose base merge since there are no cumulative sstables
-    ASSERT_TRUE(merge_base_level) << "Should choose base merge when no cumulative sstables exist";
-    ASSERT_EQ(1, sstables.size()) << "Should only include base sstable";
-    ASSERT_EQ("base3.sst", sstables[0].filename()) << "Only base sstable should be included";
+    ASSERT_TRUE(!merge_base_level) << "Should choose cumulative merge when no cumulative sstables exist";
+    ASSERT_EQ(0, sstables.size()) << "Should be empty since no cumulative sstables exist";
 }
 
 TEST_F(LakePersistentIndexTest, test_major_compaction_with_predicate) {

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -265,7 +265,7 @@ TEST_F(LakePersistentIndexTest, test_compaction_strategy) {
         for (int i = 0; i < N; i++) {
             sstable_pb = sstable_meta.add_sstables();
             sstable_pb->set_filesize(sub_size);
-            sstable_pb->set_max_rssid(i);
+            sstable_pb->set_max_rss_rowid(i);
         }
         LakePersistentIndex::pick_sstables_for_merge(sstable_meta, &sstables, &merge_base_level);
         if (is_base) {


### PR DESCRIPTION
## Why I'm doing:

### Summary

This PR fixes a critical bug in the Lake Persistent Index compaction strategy that occurs when the base sstable and cumulative sstable(generated by compaction) have identical `max_rss_rowid` values (In scenarios with mixed upsert and delete imports, issues may occur because the rowid of a delete is treated as UINT32_MAX). The issue causes incorrect sstable ordering during compaction, which will lead to delete operation lost in pk index.

**Root Cause**

In `LakePersistentIndex::apply_opcompaction`, sstables are sorted by `max_rss_rowid`. When the base sstable and cumulative sstable(generated by compaction) have the same `max_rss_rowid`, the base sstable ends up being placed **after** the cumulative sstable(generated by compaction) in the sorted order, which violates the expected compaction semantics.
More detail : https://github.com/StarRocks/starrocks/blob/2981ce997a296c8447e503bd532b7e1b662b1c0b/be/src/storage/lake/lake_persistent_index.cpp#L604.

**Before Fix (Incorrect Behavior):**
```
Scenario: base.max_rss_rowid == cumulative.max_rss_rowid == 100

Original Order:                   After sort_by(max_rss_rowid): (WRONG)        Expected Order: (CORRECT)
┌──────────────────────┐          ┌────────────────────────────┐            ┌──────────────────────┐
│   Base SSTable       │          │ Cumulative SST (compacted) │            │   Base SSTable       │
│ max_rss_rowid = 100  │   ==>    │ max_rss_rowid = 100        │   ==>      │ max_rss_rowid = 100  │
└──────────────────────┘          └────────────────────────────┘            └──────────────────────┘

┌────────────────────────────┐     ┌──────────────────────┐                 ┌────────────────────────────┐
│ Cumulative SST (compacted) │     │   Base SSTable       │                 │ Cumulative SST (compacted) │
│ max_rss_rowid = 100        │     │ max_rss_rowid = 100  │                 │ max_rss_rowid = 100        │
└────────────────────────────┘     └──────────────────────┘                 └────────────────────────────┘
     WRONG! ─────────────────────────────────────────────────────────────────────► CORRECT!
```

**After Fix (Correct Behavior):**
```
Detection Logic:
if (!merge_base_level && base.max_rss_rowid == cumulative.max_rss_rowid) {
    merge_base_level = true;  // Force base merge
    sstables.insert(sstables.begin(), base_sstable);  // Ensure base comes first
}

Result:
┌─────────────────┐
│   Base SSTable (compacted)  │  ◄── Always placed first
│ max_rss_rowid=100│
└─────────────────┘
```

## What I'm doing:
 
This pull request updates the compaction strategy in `LakePersistentIndex::pick_sstables_for_merge` to handle cases where the base and cumulative SSTables have the same `max_rss_rowid`. It ensures that a base merge is forced in such cases to avoid ordering issues during compaction. Additionally, comprehensive unit tests have been added to verify the new logic and edge cases.

### Compaction strategy improvements

* Updated `LakePersistentIndex::pick_sstables_for_merge` to force a base merge when the base SSTable's `max_rss_rowid` matches the cumulative SSTable's `max_rss_rowid`, preventing incorrect ordering during compaction.

### Testing enhancements

* Added a new test case `test_compaction_strategy_same_max_rss_rowid` in `lake_persistent_index_test.cpp` to validate the revised merge logic for scenarios with matching `max_rss_rowid`, differing `max_rss_rowid`, and empty cumulative SSTables.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
