### PR TITLE
[Enhancement] Enhance iceberg incremental scan read

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/tvr/TvrTableSnapshot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/tvr/TvrTableSnapshot.java
@@ -30,6 +30,10 @@ public final class TvrTableSnapshot extends TvrVersionRange {
         return new TvrTableSnapshot(end);
     }
 
+    public static TvrTableSnapshot of(Long end) {
+        return new TvrTableSnapshot(Optional.of(end));
+    }
+
     public static TvrTableSnapshot of(TvrVersion end) {
         return new TvrTableSnapshot(end);
     }
@@ -40,6 +44,11 @@ public final class TvrTableSnapshot extends TvrVersionRange {
 
     public TvrTableSnapshot(TvrVersion to) {
         super(TvrVersion.MIN, to);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return to.isMinOrMax();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -36,6 +36,7 @@ import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.planner.DescriptorTable;
+import com.starrocks.planner.PartitionIdGenerator;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
 import com.starrocks.planner.TupleDescriptor;
@@ -78,7 +79,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.IcebergTable.DATA_SEQUENCE_NUMBER;
@@ -92,7 +92,6 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     private final IcebergMORParams morParams;
     private final Optional<List<BucketProperty>> bucketProperties;
     private final RemoteFileInfoSource remoteFileInfoSource;
-    private final AtomicLong partitionIdGen = new AtomicLong(0L);
 
     private final Map<Long, DescriptorTable.ReferencedPartitionInfo> referencedPartitions = new HashMap<>();
     private final Map<StructLikeWrapper, Long> partitionKeyToId = Maps.newHashMap();
@@ -114,12 +113,14 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     private final Set<DeleteFile> appliedPosDeleteFiles;
     private final Set<DeleteFile> appliedEqualDeleteFiles;
     private final boolean recordScanFiles;
+    private final PartitionIdGenerator partitionIdGenerator;
 
     public IcebergConnectorScanRangeSource(IcebergTable table,
                                            RemoteFileInfoSource remoteFileInfoSource,
                                            IcebergMORParams morParams,
                                            TupleDescriptor desc,
                                            Optional<List<BucketProperty>> bucketProperties,
+                                           PartitionIdGenerator partitionIdGenerator,
                                            boolean recordScanFiles) {
         this.table = table;
         this.remoteFileInfoSource = remoteFileInfoSource;
@@ -131,23 +132,16 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         this.scannedDataFiles = new HashSet<>();
         this.appliedPosDeleteFiles = new HashSet<>();
         this.appliedEqualDeleteFiles = new HashSet<>();
+        this.partitionIdGenerator = partitionIdGenerator;
     }
 
     public IcebergConnectorScanRangeSource(IcebergTable table,
                                            RemoteFileInfoSource remoteFileInfoSource,
                                            IcebergMORParams morParams,
                                            TupleDescriptor desc,
-                                           Optional<List<BucketProperty>> bucketProperties) {
-        this.table = table;
-        this.remoteFileInfoSource = remoteFileInfoSource;
-        this.morParams = morParams;
-        this.desc = desc;
-        this.bucketProperties = bucketProperties;
-        initBucketInfo();
-        this.recordScanFiles = false;
-        this.scannedDataFiles = new HashSet<>();
-        this.appliedPosDeleteFiles = new HashSet<>();
-        this.appliedEqualDeleteFiles = new HashSet<>();
+                                           Optional<List<BucketProperty>> bucketProperties,
+                                           PartitionIdGenerator partitionIdGenerator) {
+        this(table, remoteFileInfoSource, morParams, desc, bucketProperties, partitionIdGenerator, false);
     }
 
     public void clearScannedFiles() {
@@ -311,11 +305,13 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
             isFirstSplit |= (file.splitOffsets().get(0) == hdfsScanRange.getOffset());
         }
 
-        if (!partitionSlotIdsCache.containsKey(file.specId())) {
-            hdfsScanRange.setPartition_id(-1);
-        } else {
+        ConnectContext context = ConnectContext.get();
+        if (context != null && context.getSessionVariable().getEnableIcebergIdentityColumnOptimize() &&
+                partitionSlotIdsCache.containsKey(file.specId())) {
             hdfsScanRange.setPartition_id(partitionId);
             hdfsScanRange.setIdentity_partition_slot_ids(partitionSlotIdsCache.get(file.specId()));
+        } else {
+            hdfsScanRange.setPartition_id(-1);
         }
 
         hdfsScanRange.setFile_length(file.fileSizeInBytes());
@@ -397,9 +393,10 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         return scanRangeLocations;
     }
 
-    private long addPartition(FileScanTask task) throws AnalysisException {
+    @VisibleForTesting
+    public long addPartition(FileScanTask task) throws AnalysisException {
         PartitionSpec spec = task.spec();
-        //Make sure the parttion data with byte[], decimal value object and etc. can get the same hash code.
+        // Make sure the partition data with byte[], decimal value object etc. can get the same hash code.
         StructLike origPartition = task.partition();
         StructLikeWrapper partitionWrapper = StructLikeWrapper.forType(spec.partitionType());
         StructLikeWrapper partition = partitionWrapper.copyFor(task.file().partition());
@@ -413,7 +410,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         List<Integer> partitionFieldIndexes = indexesCache.computeIfAbsent(spec.specId(),
                 ignore -> getPartitionFieldIndexes(spec, indexToPartitionField));
         PartitionKey partitionKey = getPartitionKey(origPartition, task.spec(), partitionFieldIndexes, indexToPartitionField);
-        long partitionId = partitionIdGen.getAndIncrement();
+        long partitionId = partitionIdGenerator.getOrGenerate(partitionKey);
 
         Path filePath = new Path(URLDecoder.decode(task.file().path().toString(), StandardCharsets.UTF_8));
         DescriptorTable.ReferencedPartitionInfo referencedPartitionInfo =
@@ -448,9 +445,6 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     public BiMap<Integer, PartitionField> getIdentityPartitions(PartitionSpec partitionSpec) {
         // TODO: expose transform information in Iceberg library
         BiMap<Integer, PartitionField> columns = HashBiMap.create();
-        if (!ConnectContext.get().getSessionVariable().getEnableIcebergIdentityColumnOptimize()) {
-            return columns;
-        }
         for (int i = 0; i < partitionSpec.fields().size(); i++) {
             PartitionField field = partitionSpec.fields().get(i);
             if (field.transform().isIdentity()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -985,8 +985,8 @@ public class IcebergMetadata implements ConnectorMetadata {
         final long snapshotId = tvrVersionRange.end().orElseThrow(() -> new StarRocksConnectorException(
                 "Snapshot ID is not present in tvrVersionRange: " + tvrVersionRange));
         Scan scan;
-        if (tvrVersionRange instanceof  TvrTableDelta &&
-                tvrVersionRange.start().isPresent() && tvrVersionRange.start().isPresent()) {
+        if (tvrVersionRange instanceof TvrTableDelta &&
+                tvrVersionRange.start() != null && tvrVersionRange.start().isPresent()) {
             IncrementalAppendScan incrementalAppendScan = nativeTbl.newIncrementalAppendScan();
             incrementalAppendScan =
                     incrementalAppendScan.fromSnapshotExclusive(tvrVersionRange.from.getVersion());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRemoteFileInfoSourceKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRemoteFileInfoSourceKey.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.iceberg;
 
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.PredicateSearchKey;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -26,23 +27,23 @@ public class IcebergRemoteFileInfoSourceKey extends PredicateSearchKey {
 
     private IcebergRemoteFileInfoSourceKey(String databaseName,
                                            String tableName,
-                                           long snapshotId,
+                                           TvrVersionRange tvrVersionRange,
                                            ScalarOperator predicate,
                                            long morId,
                                            IcebergMORParams icebergMORParams) {
-        super(databaseName, tableName, snapshotId, predicate);
+        super(databaseName, tableName, tvrVersionRange, predicate);
         this.morId = morId;
         this.icebergMORParams = icebergMORParams;
     }
 
     public static IcebergRemoteFileInfoSourceKey of(String databaseName,
                                                     String tableName,
-                                                    long snapshotId,
+                                                    TvrVersionRange tvrVersionRange,
                                                     ScalarOperator predicate,
                                                     long morId,
                                                     IcebergMORParams icebergMORParams) {
         predicate = predicate == null ? ConstantOperator.TRUE : predicate;
-        return new IcebergRemoteFileInfoSourceKey(databaseName, tableName, snapshotId, predicate, morId, icebergMORParams);
+        return new IcebergRemoteFileInfoSourceKey(databaseName, tableName, tvrVersionRange, predicate, morId, icebergMORParams);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergMetricsReporter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergMetricsReporter.java
@@ -42,7 +42,7 @@ public class IcebergMetricsReporter implements MetricsReporter {
     }
 
     public Optional<ScanReport> getReporter(String catalogName, String dbName, String tableName,
-                                                              long snapshotId, Expression icebergPredicate, Table table) {
+                                            long snapshotId, Expression icebergPredicate, Table table) {
         if (reports.isEmpty()) {
             return Optional.empty();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -107,7 +107,9 @@ public class DeltaLakeScanNode extends ScanNode {
         reachLimit = true;
     }
 
-    public void setupScanRangeSource(ScalarOperator predicate, List<String> fieldNames, boolean enableIncrementalScanRanges)
+    public void setupScanRangeSource(ScalarOperator predicate, List<String> fieldNames,
+                                     PartitionIdGenerator partitionIdGenerator,
+                                     boolean enableIncrementalScanRanges)
             throws StarRocksException {
         SnapshotImpl snapshot = (SnapshotImpl) deltaLakeTable.getDeltaSnapshot();
         DeltaUtils.checkProtocolAndMetadata(snapshot.getProtocol(), snapshot.getMetadata());
@@ -124,7 +126,7 @@ public class DeltaLakeScanNode extends ScanNode {
             remoteFileInfoSource = new RemoteFileInfoDefaultSource(
                     GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFiles(deltaLakeTable, params));
         }
-        scanRangeSource = new DeltaConnectorScanRangeSource(deltaLakeTable, remoteFileInfoSource);
+        scanRangeSource = new DeltaConnectorScanRangeSource(deltaLakeTable, remoteFileInfoSource, partitionIdGenerator);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DescriptorTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DescriptorTable.java
@@ -63,6 +63,7 @@ public class DescriptorTable {
     private final IdGenerator<TupleId> tupleIdGenerator_ = TupleId.createGenerator();
     private final IdGenerator<SlotId> slotIdGenerator_ = SlotId.createGenerator();
     private final HashMap<SlotId, SlotDescriptor> slotDescs = Maps.newHashMap();
+    private final Map<Table, PartitionIdGenerator> tableToPartitionIdGen = Maps.newHashMap();
 
     public DescriptorTable() {
     }
@@ -176,6 +177,10 @@ public class DescriptorTable {
                     tbl.toThrift(referencedPartitionsPerTable.getOrDefault(tbl, Lists.newArrayList())));
         }
         return result;
+    }
+
+    public PartitionIdGenerator getTablePartitionIdGenerator(Table table) {
+        return tableToPartitionIdGen.computeIfAbsent(table, k -> new PartitionIdGenerator());
     }
 
     public static class ReferencedPartitionInfo {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -73,13 +73,16 @@ public class IcebergScanNode extends ScanNode {
     private volatile boolean reachLimit = false;
     private int selectedPartitionCount = -1;
     private Optional<List<BucketProperty>> bucketProperties = Optional.empty();
+    private PartitionIdGenerator partitionIdGenerator = null;
 
     public IcebergScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName,
-                           IcebergTableMORParams tableFullMORParams, IcebergMORParams morParams) {
+                           IcebergTableMORParams tableFullMORParams, IcebergMORParams morParams,
+                           PartitionIdGenerator partitionIdGenerator) {
         super(id, desc, planNodeName);
         this.icebergTable = (IcebergTable) desc.getTable();
         this.tableFullMORParams = tableFullMORParams;
         this.morParams = morParams;
+        this.partitionIdGenerator = partitionIdGenerator;
         setupCloudCredential();
     }
 
@@ -140,7 +143,7 @@ public class IcebergScanNode extends ScanNode {
         }
 
         scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
-                remoteFileInfoSource, morParams, desc, bucketProperties, true);
+                remoteFileInfoSource, morParams, desc, bucketProperties, partitionIdGenerator, true);
     }
 
     public void setupScanRangeLocations(boolean enableIncrementalScanRanges) throws StarRocksException {
@@ -180,7 +183,7 @@ public class IcebergScanNode extends ScanNode {
         }
 
         scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
-                remoteFileInfoSource, morParams, desc, bucketProperties);
+                remoteFileInfoSource, morParams, desc, bucketProperties, partitionIdGenerator);
     }
 
     private void setupCloudCredential() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PartitionIdGenerator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PartitionIdGenerator.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+package com.starrocks.planner;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.PartitionKey;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * PartitionIdGenerator is used to ensure each PartitionKey get a unique and consistent partitionId in the lifetime of a query.
+ */
+public class PartitionIdGenerator {
+    private final Map<PartitionKey, Long> tablePartitionKeyToId = Maps.newHashMap();
+    private final AtomicLong partitionIdGen = new AtomicLong(0L);
+
+    public PartitionIdGenerator() {
+    }
+
+    public static PartitionIdGenerator of() {
+        return new PartitionIdGenerator();
+    }
+
+    public long getOrGenerate(PartitionKey partitionKey) {
+        return tablePartitionKeyToId.computeIfAbsent(partitionKey, k -> partitionIdGen.getAndIncrement());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -4930,6 +4930,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableIcebergIdentityColumnOptimize;
     }
 
+    public void setEnableIcebergIdentityColumnOptimize(boolean enableIcebergIdentityColumnOptimize) {
+        this.enableIcebergIdentityColumnOptimize = enableIcebergIdentityColumnOptimize;
+    }
+
     public boolean getEnablePlanSerializeConcurrently() {
         return enablePlanSerializeConcurrently;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -613,7 +613,6 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
                     new ExpressionMapping(node.getScope(), outputVariables), columnRefFactory);
         }
 
-        // TODO: merge with tableVersionRange
         TvrVersionRange tableVersionRange;
         if (node.getTvrVersionRange() != null) {
             tableVersionRange = node.getTvrVersionRange();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -51,7 +51,6 @@ import com.starrocks.common.IdGenerator;
 import com.starrocks.common.LocalExchangerType;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.BucketProperty;
 import com.starrocks.connector.metadata.MetadataTable;
 import com.starrocks.load.BrokerFileGroup;
@@ -92,6 +91,7 @@ import com.starrocks.planner.OdpsScanNode;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PaimonScanNode;
+import com.starrocks.planner.PartitionIdGenerator;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanNode;
 import com.starrocks.planner.ProjectNode;
@@ -1275,6 +1275,7 @@ public class PlanFragmentBuilder {
 
             prepareContextSlots(node, context, tupleDescriptor);
 
+            PartitionIdGenerator partitionIdGenerator = context.getDescTbl().getTablePartitionIdGenerator(referenceTable);
             DeltaLakeScanNode deltaLakeScanNode =
                     new DeltaLakeScanNode(context.getNextNodeId(), tupleDescriptor, "DeltaLakeScanNode");
             deltaLakeScanNode.computeStatistics(optExpression.getStatistics());
@@ -1293,7 +1294,7 @@ public class PlanFragmentBuilder {
                 List<String> fieldNames = node.getColRefToColumnMetaMap().keySet().stream()
                         .map(ColumnRefOperator::getName)
                         .collect(Collectors.toList());
-                deltaLakeScanNode.setupScanRangeSource(node.getPredicate(), fieldNames,
+                deltaLakeScanNode.setupScanRangeSource(node.getPredicate(), fieldNames, partitionIdGenerator,
                         context.getConnectContext().getSessionVariable().isEnableConnectorIncrementalScanRanges());
 
                 HDFSScanNodePredicates scanNodePredicates = deltaLakeScanNode.getScanNodePredicates();
@@ -1479,26 +1480,28 @@ public class PlanFragmentBuilder {
             // set slot
             prepareContextSlots(node, context, tupleDescriptor);
 
+            // partition id generator
+            PartitionIdGenerator partitionIdGenerator = context.getDescTbl().getTablePartitionIdGenerator(referenceTable);
+
             boolean isEqDeleteScan = node.getOpType() != OperatorType.PHYSICAL_ICEBERG_SCAN;
             IcebergScanNode icebergScanNode;
             String planNodeName = isEqDeleteScan ? "IcebergEqualityDeleteScanNode" : "IcebergScanNode";
             if (!isEqDeleteScan) {
                 PhysicalIcebergScanOperator op = node.cast();
                 icebergScanNode = new IcebergScanNode(context.getNextNodeId(), tupleDescriptor, planNodeName,
-                        op.getTableFullMORParams(), op.getMORParams());
+                        op.getTableFullMORParams(), op.getMORParams(), partitionIdGenerator);
                 icebergScanNode.updateAppliedDictStringColumns(
                         ((PhysicalIcebergScanOperator) node).getGlobalDicts().stream()
                                 .map(entry -> entry.first).collect(Collectors.toSet()));
             } else {
                 PhysicalIcebergEqualityDeleteScanOperator op = node.cast();
                 icebergScanNode = new IcebergScanNode(context.getNextNodeId(), tupleDescriptor, planNodeName,
-                        op.getTableFullMORParams(), op.getMORParams());
+                        op.getTableFullMORParams(), op.getMORParams(), partitionIdGenerator);
             }
 
             icebergScanNode.setScanOptimizeOption(node.getScanOptimizeOption());
             icebergScanNode.computeStatistics(expression.getStatistics());
             currentExecGroup.add(icebergScanNode, true);
-            TvrVersionRange tvrVersionRange = node.getTvrVersionRange();
             try {
                 // set predicate
                 ScalarOperatorToExpr.FormatterContext formatterContext =

--- a/fe/fe-core/src/test/java/com/starrocks/common/tvr/TvrTableDeltaTraitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/tvr/TvrTableDeltaTraitTest.java
@@ -100,7 +100,7 @@ public class TvrTableDeltaTraitTest {
             String result = empty.toString();
             Assertions.assertTrue(result.contains("Delta@[MIN,MIN]"));
             Assertions.assertTrue(result.contains("MONOTONIC"));
-            Assertions.assertTrue(result.contains("{addedRows=0}"));
+            Assertions.assertTrue(result.contains("addedRows=0"));
         }
         // Test regular versions
         TvrVersion version100 = TvrVersion.of(100L);
@@ -111,7 +111,7 @@ public class TvrTableDeltaTraitTest {
             String result = trait.toString();
             Assertions.assertTrue(result.contains("Delta@[100,200]"));
             Assertions.assertTrue(result.contains("MONOTONIC"));
-            Assertions.assertTrue(result.contains("{addedRows=0}"));
+            Assertions.assertTrue(result.contains("addedRows=0"));
         }
 
         // Test with MIN and MAX versions
@@ -121,7 +121,7 @@ public class TvrTableDeltaTraitTest {
             String result = minMaxTrait.toString();
             Assertions.assertTrue(result.contains("Delta@[MIN,MAX]"));
             Assertions.assertTrue(result.contains("MONOTONIC"));
-            Assertions.assertTrue(result.contains("{addedRows=0}"));
+            Assertions.assertTrue(result.contains("addedRows=0"));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.BucketProperty;
 import com.starrocks.connector.RemoteFileInfoDefaultSource;
+import com.starrocks.planner.PartitionIdGenerator;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
 import com.starrocks.planner.TupleDescriptor;
@@ -73,7 +74,8 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         List<BucketProperty> bucketProperties = icebergTable.getBucketProperties();
 
         IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
-                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor, Optional.of(bucketProperties));
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor, Optional.of(bucketProperties),
+                PartitionIdGenerator.of());
 
         List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTable2Bucket.newScan().planFiles());
         Assertions.assertEquals(2, fileScanTasks.size());
@@ -103,7 +105,8 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         List<BucketProperty> oneBucketProperties = List.of(bucketProperties.get(0));
 
         IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
-                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor, Optional.of(oneBucketProperties));
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor, Optional.of(oneBucketProperties),
+                PartitionIdGenerator.of());
 
         List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTable2Bucket.newScan().planFiles());
         Assertions.assertEquals(2, fileScanTasks.size());
@@ -117,6 +120,38 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
                 // 2 data-j2
                 Assertions.assertEquals(2, mappingId);
             }
+        }
+    }
+
+    @Test
+    public void testSamePartitionIdForSamePartitionKeysAcrossDifferentSources() throws Exception {
+        List<Column> schema = new ArrayList<>();
+        schema.add(new Column("id", INT));
+        schema.add(new Column("k1", INT));
+        schema.add(new Column("k2", VARCHAR));
+        mockedNativeTable2Bucket.newFastAppend().appendFile(FILE_J_1).appendFile(FILE_J_2).commit();
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table", "iceberg_catalog",
+                "resource", "db", "table", "", schema,
+                mockedNativeTable2Bucket, Maps.newHashMap());
+        Assertions.assertTrue(icebergTable.hasBucketProperties());
+        List<BucketProperty> bucketProperties = icebergTable.getBucketProperties();
+        List<BucketProperty> oneBucketProperties = List.of(bucketProperties.get(0));
+        // Use the same partition key values for both
+        PartitionIdGenerator partitionIdGenerator = PartitionIdGenerator.of();
+        IcebergConnectorScanRangeSource scanRangeSource1 = new IcebergConnectorScanRangeSource(
+                icebergTable, RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor,
+                Optional.of(oneBucketProperties), partitionIdGenerator);
+        IcebergConnectorScanRangeSource scanRangeSource2 = new IcebergConnectorScanRangeSource(
+                icebergTable, RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor,
+                Optional.of(oneBucketProperties), partitionIdGenerator);
+        List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTable2Bucket.newScan().planFiles());
+        Assertions.assertFalse(fileScanTasks.isEmpty());
+        for (FileScanTask fileScanTask : fileScanTasks) {
+            // Simulate partition id generation for the same partition key values
+            long partitionId1 = scanRangeSource1.addPartition(fileScanTask);
+            long partitionId2 = scanRangeSource2.addPartition(fileScanTask);
+            Assertions.assertEquals(partitionId1, partitionId2, "Partition IDs should " +
+                    "be the same for the same partition keys and values");
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1106,7 +1106,7 @@ public class IcebergMetadataTest extends TableTestBase {
         Assertions.assertEquals(3, ((IcebergRemoteFileInfo) res.get(0)).getFileScanTask().file().recordCount());
 
         PredicateSearchKey filter = PredicateSearchKey.of("db", "table", 1, null);
-        Assertions.assertEquals("Filter{databaseName='db', tableName='table', snapshotId=1, predicate=true}",
+        Assertions.assertEquals("Filter{databaseName='db', tableName='table', version=Snapshot@(1), predicate=true}",
                 filter.toString());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -151,7 +151,7 @@ public class IcebergScanNodeTest {
 
         IcebergScanNode scanNode = new IcebergScanNode(
                 new PlanNodeId(0), desc, catalog,
-                tableMORParams, IcebergMORParams.DATA_FILE_WITHOUT_EQ_DELETE);
+                tableMORParams, IcebergMORParams.DATA_FILE_WITHOUT_EQ_DELETE, null);
         scanNode.setTvrVersionRange(TvrTableSnapshot.of(Optional.of(12345L)));
 
         IcebergRemoteFileInfo remoteFileInfo = new IcebergRemoteFileInfo(fileScanTask);
@@ -202,7 +202,8 @@ public class IcebergScanNodeTest {
         }};
 
         IcebergConnectorScanRangeSource scanSource = new IcebergConnectorScanRangeSource(
-                null, mockSource, null, null, Optional.empty(), true  // recordScanFiles = true
+                null, mockSource, null, null, Optional.empty(),
+                PartitionIdGenerator.of(), true  // recordScanFiles = true
         ) {
             private int callCount = 0;
 
@@ -611,8 +612,9 @@ public class IcebergScanNodeTest {
                 remoteFileInfoSource,
                 morParams,
                 tupleDesc,
-                Optional.empty()
-        );
+                Optional.empty(),
+                PartitionIdGenerator.of()
+                );
 
         List<FileScanTask> result = source.getSourceFileScanOutputs(
                 10, // maxSize
@@ -752,8 +754,9 @@ public class IcebergScanNodeTest {
                 remoteFileInfoSource,
                 morParams,
                 tupleDesc,
-                Optional.empty()
-        );
+                Optional.empty(),
+                PartitionIdGenerator.of()
+                );
         Mockito.when(scanNode.getSourceRange()).thenReturn(fakeSourceRange);
         StmtExecutor executor = Mockito.mock(StmtExecutor.class);
         new MockUp<StmtExecutor>() {
@@ -872,7 +875,7 @@ public class IcebergScanNodeTest {
 
         IcebergScanNode scanNode = new IcebergScanNode(
                 new PlanNodeId(0), desc, "IcebergScanNode",
-                IcebergTableMORParams.EMPTY, IcebergMORParams.DATA_FILE_WITHOUT_EQ_DELETE);
+                IcebergTableMORParams.EMPTY, IcebergMORParams.DATA_FILE_WITHOUT_EQ_DELETE, null);
 
         // Create three bucket properties
         List<BucketProperty> bucketProperties = new ArrayList<>();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -93,15 +93,16 @@ public class IcebergScanNodeTest {
     class TestableIcebergConnectorScanRangeSource extends IcebergConnectorScanRangeSource {
         public TestableIcebergConnectorScanRangeSource(IcebergConnectorScanRangeSource original) {
             super(
-                Deencapsulation.getField(original, "table"),
-                Deencapsulation.getField(original, "remoteFileInfoSource"),
-                Deencapsulation.getField(original, "morParams"),
-                Deencapsulation.getField(original, "desc"),
-                Deencapsulation.getField(original, "bucketProperties"),
-                Deencapsulation.getField(original, "recordScanFiles")
+                    Deencapsulation.getField(original, "table"),
+                    Deencapsulation.getField(original, "remoteFileInfoSource"),
+                    Deencapsulation.getField(original, "morParams"),
+                    Deencapsulation.getField(original, "desc"),
+                    Deencapsulation.getField(original, "bucketProperties"),
+                    Deencapsulation.getField(original, "partitionIdGenerator"),
+                    Deencapsulation.getField(original, "recordScanFiles")
             );
         }
-    
+
         @Override
         public List<TScanRangeLocations> toScanRanges(FileScanTask fileScanTask) {
             return Collections.singletonList(new TScanRangeLocations());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMTestBase.java
@@ -92,7 +92,7 @@ public abstract class MVIVMTestBase extends MVTestBase {
         }
         // test mv rewrite
         {
-            String plan = getFragmentPlan(mvQuery, "MV");
+            String plan = getFragmentPlan(mvQuery);
             if (isCheckRewrite) {
                 Assertions.assertTrue(plan.contains("test_mv1"));
             }


### PR DESCRIPTION
## Why I'm doing:
In testing pr(https://github.com/StarRocks/starrocks/pull/62699), I found some tests are not stable.

The root cause is , there are some conflicts between  the new Incremental Scan and https://github.com/StarRocks/starrocks/pull/32592 optimization.


## What I'm doing:
Before pr(https://github.com/StarRocks/starrocks/pull/62699),  I do some optimizations below:

- Ensure Iceberg/Delta's virtual partition are unique for the same partition value.
- Use `Iceberg`'s SnapshotSummary to collect snapshot's stats.
- In Icebergmetadata, use `TvrVersionRange` rather than `snapshotId` for better representation of IcebergIncrementalScan.

Fixes https://github.com/StarRocks/starrocks/issues/61789

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
