### PR TITLE
[BugFix] fix delvec no found issue when drop tablet and queries run concurrently

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -449,11 +449,6 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, TabletDropFlag flag) {
             (void)dropped_tablet->set_tablet_state(TABLET_SHUTDOWN);
         }
 
-        // just try to remove the tablet meta. if failed, it will be removed in sweep_shutdown_tablet
-        if (auto st = _remove_tablet_meta(dropped_tablet); !st.ok()) {
-            LOG(WARNING) << "Fail to remove tablet meta. tablet_id=" << tablet_id << " status=" << st;
-        }
-
         // Remove the tablet directory in background to avoid holding the lock of tablet map shard for long.
         std::unique_lock l(_shutdown_tablets_lock);
         _add_shutdown_tablet_unlocked(tablet_id, std::move(drop_info));


### PR DESCRIPTION
## Why I'm doing:
When a query and a drop tablet operation run concurrently, the following situation may occur:
1. The query, based on the version, obtains the list of rowsets to read and sets references to prevent the files from being deleted.
2. After balance completes, the FE issues a drop tablet task to delete the tablet that is being queried.
3. Once the deletion is completed, the delvec information is removed.
4. During execution, when the query tries to read the segment file, it fails to obtain the corresponding delvec and an error occurs (`no delete vector found`).

When dropping a tablet, the delvec cannot be deleted immediately, because at that point the tablet is still in the `_shutdown_tablets` list. The delvec should only be cleaned up when the background process removes the `_shutdown_tablets`. This approach resolves the concurrency issue described above.

## What I'm doing:
This pull request makes a minor change to the `TabletManager::drop_tablet` method in `tablet_manager.cpp`. The logic that attempted to immediately remove the tablet meta and logged a warning if it failed has been removed. Now, the tablet meta will only be removed later during the sweep process, simplifying the drop workflow.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
