### PR TITLE
[Tool] meta_tool: dump_zonemap

### DIFF
--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -604,14 +604,14 @@ StatusOr<std::vector<ZoneMapDetail>> ColumnReader::get_raw_zone_map(const IndexR
 
     LogicalType type = _encoding_info->type();
     int32_t num_pages = _zonemap_index->num_pages();
-    std::vector<ZoneMapDetail> result(num_pages);
+    std::vector<ZoneMapDetail> result;
+    result.reserve(num_pages);
 
-    for (auto& zm : _zonemap_index->page_zone_maps()) {
+    for (const auto& zm : _zonemap_index->page_zone_maps()) {
         ZoneMapDetail detail;
         RETURN_IF_ERROR(_parse_zone_map(type, zm, &detail));
-        result.emplace_back(detail);
+        result.emplace_back(std::move(detail));
     }
-
     return result;
 }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


Add a function to dump the zonemap of columns: `bin/meta_tool.sh --operation=dump_zonemap --file xxxxx`

```

ZoneMap Format: [min, max, has_null, has_not_null]

=== Column 0 () ===
Type: BIGINT
Number of rows: 196608
Datapages footprint: 534335
Total memory footprint: 1572864
Number of datapages: 24
Number of zonemaps: 24
Segment: [247000001, 247573440, false, true]
Page 0: [247000033, 247573437, false, true]
Page 1: [247000001, 247573439, false, true]
Page 2: [247000024, 247573434, false, true]
Page 3: [247000012, 247573429, false, true]
Page 4: [247000048, 247573430, false, true]
Page 5: [247000015, 247573404, false, true]
Page 6: [247000014, 247573425, false, true]
Page 7: [247000020, 247573440, false, true]
Page 8: [247000002, 247573424, false, true]
Page 9: [247000032, 247573410, false, true]
Page 10: [247000022, 247573438, false, true]
Page 11: [247000018, 247573403, false, true]
Page 12: [247000008, 247573435, false, true]
Page 13: [247000016, 247573371, false, true]
Page 14: [247000028, 247573409, false, true]
Page 15: [247000006, 247573423, false, true]
Page 16: [247000027, 247573421, false, true]
Page 17: [247000011, 247573431, false, true]
Page 18: [247000067, 247573379, false, true]
Page 19: [247000038, 247573362, false, true]
Page 20: [247000019, 247573433, false, true]
Page 21: [247000004, 247573414, false, true]
Page 22: [247000005, 247573374, false, true]
Page 23: [247000003, 247573417, false, true]
```


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
