### PR TITLE
[BugFix] Fix the crash caused by out-of-order instruction execution in the ARM environment

### DIFF
--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -147,7 +147,7 @@ public:
         auto& src_null_data = src_nullable_column->null_column()->get_data();
         auto& dst_null_data = dst_nullable_column->null_column()->get_data();
 
-        size_t size = src_column->size();
+        size_t size = dst_null_data->size();
         memcpy(dst_null_data.data(), src_null_data.data(), size);
         convert_int_to_int<SourceType, DestType>(src_data.data(), dst_data.data(), size);
         dst_nullable_column->set_has_null(src_nullable_column->has_null());

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -147,7 +147,7 @@ public:
         auto& src_null_data = src_nullable_column->null_column()->get_data();
         auto& dst_null_data = dst_nullable_column->null_column()->get_data();
 
-        size_t size = dst_null_data->size();
+        size_t size = dst_null_data.size();
         memcpy(dst_null_data.data(), src_null_data.data(), size);
         convert_int_to_int<SourceType, DestType>(src_data.data(), dst_data.data(), size);
         dst_nullable_column->set_has_null(src_nullable_column->has_null());


### PR DESCRIPTION
## Why I'm doing:

Fix https://github.com/StarRocks/StarRocksTest/issues/10267

How to reproduce the bug:

Use branch-4.0 or main (726fa67c3f87301d02f2f23183d417d73deef4bf)

```
create external catalog hive_catalog_b061d7d0_8edd_11f0_a012_00163e0e489a PROPERTIES("type" = "hive","hive.metastore.uris" = "thrift://xxxx:9083");
use hive_catalog_b061d7d0_8edd_11f0_a012_00163e0e489a.hive_extbl_test;
select col_varchar,col_char from hive_hdfs_parquet_column_position_1 order by col_tinyint limit 1;
```

```
(gdb) bt
#0  __memcpy_sve () at ../sysdeps/aarch64/multiarch/memcpy_sve.S:77
#1  0x000000000b3aad14 in memcpy (__len=1, __src=<optimized out>, __dest=<optimized out>) at /usr/include/aarch64-linux-gnu/bits/string_fortified.h:29
#2  starrocks::parquet::NumericToNumericConverter<int, signed char>::convert (this=<optimized out>, src=..., dst=0x521d82a09ae0)
    at be/src/formats/parquet/column_converter.cpp:151
#3  0x000000000b3d4d74 in starrocks::parquet::StatisticsHelper::decode_value_into_column (column=...,
    values=std::vector of length 124961465, capacity 2821450090381 = {...}, null_pages=<error reading variable: Cannot access memory at address 0x1>, type=...,
    field=<optimized out>, timezone=...) at be/src/formats/parquet/statistics_helper.cpp:70
```

```
    Status convert(const ColumnPtr& src, Column* dst) override {
        auto* src_nullable_column = ColumnHelper::as_raw_column<NullableColumn>(src);
        // hive only support null column
        // TODO: support not null
        auto* dst_nullable_column = down_cast<NullableColumn*>(dst);
        dst_nullable_column->resize_uninitialized(src_nullable_column->size());

        auto* src_column =
                ColumnHelper::as_raw_column<FixedLengthColumn<SourceType>>(src_nullable_column->data_column());
        auto* dst_column = ColumnHelper::as_raw_column<FixedLengthColumn<DestType>>(dst_nullable_column->data_column());

        auto& src_data = src_column->get_data();
        auto& dst_data = dst_column->get_data();
        auto& src_null_data = src_nullable_column->null_column()->get_data();
        auto& dst_null_data = dst_nullable_column->null_column()->get_data();

        size_t size = src_column->size();
        memcpy(dst_null_data.data(), src_null_data.data(), size);  //dst_null_data.data() is nullptr
        convert_int_to_int<SourceType, DestType>(src_data.data(), dst_data.data(), size);
        dst_nullable_column->set_has_null(src_nullable_column->has_null());
        return Status::OK();
    }
```

memcpy(dst_null_data.data(), src_null_data.data(), size);  //dst_null_data.data() is nullptr

The reason for the null value is that the pointer used is from dst_nullable_column before the resize_uninitialized operation.

The assembly code itself is correct, and memcpy is after resize.

Therefore, it is highly likely caused by the out-of-order execution of CPU instructions.

Therefore, I modified this line of code to create a dependency on size, preventing out-of-order execution. Verification shows that this crash can be avoided.

```
(gdb) disassemble
Dump of assembler code for function _ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_:
   0x000000000b3aac50 <+0>:	stp	x29, x30, [sp, #-112]!
   0x000000000b3aac54 <+4>:	adrp	x0, 0x8394000 <_ZN9starrocks14NullableColumn9replicateERKSt6vectorIjNS_15ColumnAllocatorIjEEE+512>
   0x000000000b3aac58 <+8>:	add	x0, x0, #0x5d0
   0x000000000b3aac5c <+12>:	mov	x29, sp
   0x000000000b3aac60 <+16>:	stp	x21, x22, [sp, #32]
   0x000000000b3aac64 <+20>:	ldr	x21, [x1]
   0x000000000b3aac68 <+24>:	stp	x19, x20, [sp, #16]
   0x000000000b3aac6c <+28>:	mov	x19, x2
   0x000000000b3aac70 <+32>:	ldr	x2, [x2]
   0x000000000b3aac74 <+36>:	stp	x23, x24, [sp, #48]
   0x000000000b3aac78 <+40>:	mov	x20, x8
   0x000000000b3aac7c <+44>:	ldr	x1, [x21]
   0x000000000b3aac80 <+48>:	stp	x25, x26, [sp, #64]
   0x000000000b3aac84 <+52>:	stp	x27, x28, [sp, #80]
   0x000000000b3aac88 <+56>:	ldr	x1, [x1, #240]
   0x000000000b3aac8c <+60>:	ldr	x23, [x2, #328]
   0x000000000b3aac90 <+64>:	cmp	x1, x0
   0x000000000b3aac94 <+68>:	b.ne	0xb3aaeb8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+616>  // b.any
   0x000000000b3aac98 <+72>:	ldr	x0, [x21, #16]
   0x000000000b3aac9c <+76>:	ldr	x1, [x0]
   0x000000000b3aaca0 <+80>:	ldr	x1, [x1, #240]
   0x000000000b3aaca4 <+84>:	blr	x1
   0x000000000b3aaca8 <+88>:	mov	x22, x0
   0x000000000b3aacac <+92>:	adrp	x0, 0x8394000 <_ZN9starrocks14NullableColumn9replicateERKSt6vectorIjNS_15ColumnAllocatorIjEEE+512>
   0x000000000b3aacb0 <+96>:	add	x0, x0, #0xfd0
   0x000000000b3aacb4 <+100>:	cmp	x23, x0
   0x000000000b3aacb8 <+104>:	b.ne	0xb3aaea0 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+592>  // b.any
   0x000000000b3aacbc <+108>:	ldr	x0, [x19, #16]
--Type <RET> for more, q to quit, c to continue without paging--c
   0x000000000b3aacc0 <+112>:	mov	x1, x22
   0x000000000b3aacc4 <+116>:	ldr	x2, [x0]
   0x000000000b3aacc8 <+120>:	ldr	x2, [x2, #328]
   0x000000000b3aaccc <+124>:	blr	x2
   0x000000000b3aacd0 <+128>:	ldr	x24, [x19, #24]
   0x000000000b3aacd4 <+132>:	add	x27, x24, #0x10
   0x000000000b3aacd8 <+136>:	ldr	x25, [x27, #8]
   0x000000000b3aacdc <+140>:	ldr	x23, [x24, #16]
   0x000000000b3aace0 <+144>:	sub	x26, x25, x23
   0x000000000b3aace4 <+148>:	cmp	x22, x26
   0x000000000b3aace8 <+152>:	b.hi	0xb3aaed8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+648>  // b.pmore
   0x000000000b3aacec <+156>:	b.cc	0xb3aae8c <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+572>  // b.lo, b.ul, b.last
   0x000000000b3aacf0 <+160>:	mov	x0, x23
   0x000000000b3aacf4 <+164>:	ldp	x23, x1, [x21, #16]
   0x000000000b3aacf8 <+168>:	ldr	x27, [x19, #16]
   0x000000000b3aacfc <+172>:	ldp	x26, x25, [x23, #16]
   0x000000000b3aad00 <+176>:	ldr	x1, [x1, #16]
   0x000000000b3aad04 <+180>:	sub	x24, x25, x26
   0x000000000b3aad08 <+184>:	asr	x22, x24, #2
   0x000000000b3aad0c <+188>:	mov	x2, x22
   0x000000000b3aad10 <+192>:	bl	0x11a594d0
=> 0x000000000b3aad14 <+196>:	ldr	x5, [x23, #16]
   0x000000000b3aad18 <+200>:	ldr	x0, [x27, #16]
   0x000000000b3aad1c <+204>:	cmp	x26, x25
   0x000000000b3aad20 <+208>:	b.eq	0xb3aae40 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+496>  // b.none
   0x000000000b3aad24 <+212>:	cmp	x24, #0x0
   0x000000000b3aad28 <+216>:	csinc	x6, x22, xzr, ne	// ne = any
   0x000000000b3aad2c <+220>:	cmp	x24, #0x3c
   0x000000000b3aad30 <+224>:	b.ls	0xb3aaef8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+680>  // b.plast
   0x000000000b3aad34 <+228>:	and	x3, x6, #0xfffffffffffffff0
   0x000000000b3aad38 <+232>:	mov	x4, x0
   0x000000000b3aad3c <+236>:	add	x2, x3, x0
   0x000000000b3aad40 <+240>:	mov	x1, x5
   0x000000000b3aad44 <+244>:	nop
   0x000000000b3aad48 <+248>:	ldp	q0, q3, [x1]
   0x000000000b3aad4c <+252>:	ldp	q1, q2, [x1, #32]
   0x000000000b3aad50 <+256>:	add	x1, x1, #0x40
   0x000000000b3aad54 <+260>:	uzp1	v0.8h, v0.8h, v3.8h
   0x000000000b3aad58 <+264>:	uzp1	v1.8h, v1.8h, v2.8h
   0x000000000b3aad5c <+268>:	uzp1	v0.16b, v0.16b, v1.16b
   0x000000000b3aad60 <+272>:	str	q0, [x4], #16
   0x000000000b3aad64 <+276>:	cmp	x2, x4
   0x000000000b3aad68 <+280>:	b.ne	0xb3aad48 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+248>  // b.any
   0x000000000b3aad6c <+284>:	cmp	x6, x3
   0x000000000b3aad70 <+288>:	b.eq	0xb3aae40 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+496>  // b.none
   0x000000000b3aad74 <+292>:	sub	x1, x6, x3
   0x000000000b3aad78 <+296>:	sub	x2, x1, #0x1
   0x000000000b3aad7c <+300>:	cmp	x2, #0x6
   0x000000000b3aad80 <+304>:	b.ls	0xb3aadb8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+360>  // b.plast
   0x000000000b3aad84 <+308>:	lsl	x4, x3, #2
   0x000000000b3aad88 <+312>:	and	x6, x1, #0xfffffffffffffff8
   0x000000000b3aad8c <+316>:	add	x2, x5, x4
   0x000000000b3aad90 <+320>:	ldr	d0, [x5, x4]
   0x000000000b3aad94 <+324>:	ldr	d2, [x2, #8]
   0x000000000b3aad98 <+328>:	ldr	q1, [x2, #16]
   0x000000000b3aad9c <+332>:	mov	v0.d[1], v2.d[0]
   0x000000000b3aada0 <+336>:	uzp1	v0.8h, v0.8h, v1.8h
   0x000000000b3aada4 <+340>:	xtn	v0.8b, v0.8h
   0x000000000b3aada8 <+344>:	str	d0, [x0, x3]
   0x000000000b3aadac <+348>:	add	x3, x3, x6
   0x000000000b3aadb0 <+352>:	tst	x1, #0x7
   0x000000000b3aadb4 <+356>:	b.eq	0xb3aae40 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+496>  // b.none
   0x000000000b3aadb8 <+360>:	ldr	w2, [x5, x3, lsl #2]
   0x000000000b3aadbc <+364>:	add	x1, x3, #0x1
   0x000000000b3aadc0 <+368>:	strb	w2, [x0, x3]
   0x000000000b3aadc4 <+372>:	lsl	x2, x3, #2
   0x000000000b3aadc8 <+376>:	cmp	x22, x1
   0x000000000b3aadcc <+380>:	b.ls	0xb3aae40 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+496>  // b.plast
   0x000000000b3aadd0 <+384>:	add	x5, x5, x2
   0x000000000b3aadd4 <+388>:	add	x2, x3, #0x2
   0x000000000b3aadd8 <+392>:	ldr	w4, [x5, #4]
   0x000000000b3aaddc <+396>:	strb	w4, [x0, x1]
   0x000000000b3aade0 <+400>:	cmp	x22, x2
   0x000000000b3aade4 <+404>:	b.ls	0xb3aae40 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+496>  // b.plast
   0x000000000b3aade8 <+408>:	ldr	w4, [x5, #8]
   0x000000000b3aadec <+412>:	add	x1, x3, #0x3
   0x000000000b3aadf0 <+416>:	strb	w4, [x0, x2]
   0x000000000b3aadf4 <+420>:	cmp	x22, x1
   0x000000000b3aadf8 <+424>:	b.ls	0xb3aae40 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+496>  // b.plast
   0x000000000b3aadfc <+428>:	ldr	w4, [x5, #12]
   0x000000000b3aae00 <+432>:	add	x2, x3, #0x4
   0x000000000b3aae04 <+436>:	strb	w4, [x0, x1]
   0x000000000b3aae08 <+440>:	cmp	x22, x2
   0x000000000b3aae0c <+444>:	b.ls	0xb3aae40 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+496>  // b.plast
   0x000000000b3aae10 <+448>:	ldr	w4, [x5, #16]
   0x000000000b3aae14 <+452>:	add	x1, x3, #0x5
   0x000000000b3aae18 <+456>:	strb	w4, [x0, x2]
   0x000000000b3aae1c <+460>:	cmp	x22, x1
   0x000000000b3aae20 <+464>:	b.ls	0xb3aae40 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+496>  // b.plast
   0x000000000b3aae24 <+468>:	ldr	w2, [x5, #20]
   0x000000000b3aae28 <+472>:	add	x3, x3, #0x6
   0x000000000b3aae2c <+476>:	strb	w2, [x0, x1]
   0x000000000b3aae30 <+480>:	cmp	x22, x3
   0x000000000b3aae34 <+484>:	b.ls	0xb3aae40 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+496>  // b.plast
   0x000000000b3aae38 <+488>:	ldr	w1, [x5, #24]
   0x000000000b3aae3c <+492>:	strb	w1, [x0, x3]
   0x000000000b3aae40 <+496>:	ldr	x1, [x21]
   0x000000000b3aae44 <+500>:	adrp	x0, 0x8394000 <_ZN9starrocks14NullableColumn9replicateERKSt6vectorIjNS_15ColumnAllocatorIjEEE+512>
   0x000000000b3aae48 <+504>:	add	x0, x0, #0x4e0
   0x000000000b3aae4c <+508>:	ldr	x1, [x1, #32]
   0x000000000b3aae50 <+512>:	cmp	x1, x0
   0x000000000b3aae54 <+516>:	b.ne	0xb3aaec8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+632>  // b.any
   0x000000000b3aae58 <+520>:	ldrb	w1, [x21, #32]
   0x000000000b3aae5c <+524>:	ldrb	w2, [x19, #32]
   0x000000000b3aae60 <+528>:	mov	x0, x20
   0x000000000b3aae64 <+532>:	ldp	x21, x22, [sp, #32]
   0x000000000b3aae68 <+536>:	orr	w1, w1, w2
   0x000000000b3aae6c <+540>:	strb	w1, [x19, #32]
   0x000000000b3aae70 <+544>:	ldp	x23, x24, [sp, #48]
   0x000000000b3aae74 <+548>:	ldp	x25, x26, [sp, #64]
   0x000000000b3aae78 <+552>:	ldp	x27, x28, [sp, #80]
   0x000000000b3aae7c <+556>:	str	xzr, [x20]
   0x000000000b3aae80 <+560>:	ldp	x19, x20, [sp, #16]
   0x000000000b3aae84 <+564>:	ldp	x29, x30, [sp], #112
   0x000000000b3aae88 <+568>:	ret
   0x000000000b3aae8c <+572>:	add	x22, x23, x22
   0x000000000b3aae90 <+576>:	cmp	x25, x22
   0x000000000b3aae94 <+580>:	b.eq	0xb3aacf0 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+160>  // b.none
   0x000000000b3aae98 <+584>:	str	x22, [x27, #8]
   0x000000000b3aae9c <+588>:	b	0xb3aacf0 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+160>
   0x000000000b3aaea0 <+592>:	mov	x0, x19
   0x000000000b3aaea4 <+596>:	mov	x1, x22
   0x000000000b3aaea8 <+600>:	blr	x23
   0x000000000b3aaeac <+604>:	ldr	x0, [x19, #24]
   0x000000000b3aaeb0 <+608>:	ldr	x23, [x0, #16]
   0x000000000b3aaeb4 <+612>:	b	0xb3aacf0 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+160>
   0x000000000b3aaeb8 <+616>:	mov	x0, x21
   0x000000000b3aaebc <+620>:	blr	x1
   0x000000000b3aaec0 <+624>:	mov	x22, x0
   0x000000000b3aaec4 <+628>:	b	0xb3aacac <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+92>
   0x000000000b3aaec8 <+632>:	mov	x0, x21
   0x000000000b3aaecc <+636>:	blr	x1
   0x000000000b3aaed0 <+640>:	and	w1, w0, #0xff
   0x000000000b3aaed4 <+644>:	b	0xb3aae5c <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+524>
   0x000000000b3aaed8 <+648>:	ldr	x1, [x27, #16]
   0x000000000b3aaedc <+652>:	sub	x0, x22, x26
   0x000000000b3aaee0 <+656>:	sub	x1, x1, x25
   0x000000000b3aaee4 <+660>:	cmp	x1, x0
   0x000000000b3aaee8 <+664>:	b.cc	0xb3aaf00 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+688>  // b.lo, b.ul, b.last
   0x000000000b3aaeec <+668>:	add	x0, x25, x0
   0x000000000b3aaef0 <+672>:	str	x0, [x27, #8]
   0x000000000b3aaef4 <+676>:	b	0xb3aacf0 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+160>
   0x000000000b3aaef8 <+680>:	mov	x3, #0x0                   	// #0
   0x000000000b3aaefc <+684>:	b	0xb3aad74 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+292>
   0x000000000b3aaf00 <+688>:	mov	x1, #0x7fffffffffffffff    	// #9223372036854775807
   0x000000000b3aaf04 <+692>:	sub	x2, x1, x26
   0x000000000b3aaf08 <+696>:	cmp	x2, x0
   0x000000000b3aaf0c <+700>:	b.cc	0xb3ab0f8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+1192>  // b.lo, b.ul, b.last
   0x000000000b3aaf10 <+704>:	mrs	x3, tpidr_el0
   0x000000000b3aaf14 <+708>:	cmp	x26, x0
   0x000000000b3aaf18 <+712>:	add	x0, x3, #0x0, lsl #12
   0x000000000b3aaf1c <+716>:	add	x0, x0, #0x40
   0x000000000b3aaf20 <+720>:	lsl	x28, x26, #1
   0x000000000b3aaf24 <+724>:	csel	x28, x28, x22, cs	// cs = hs, nlast
   0x000000000b3aaf28 <+728>:	str	x3, [sp, #104]
   0x000000000b3aaf2c <+732>:	cmp	x28, x1
   0x000000000b3aaf30 <+736>:	ldr	x0, [x0]
   0x000000000b3aaf34 <+740>:	csel	x28, x28, x1, ls	// ls = plast
   0x000000000b3aaf38 <+744>:	mov	x1, x28
   0x000000000b3aaf3c <+748>:	ldr	x2, [x0]
   0x000000000b3aaf40 <+752>:	ldr	x2, [x2, #96]
   0x000000000b3aaf44 <+756>:	blr	x2
   0x000000000b3aaf48 <+760>:	mov	x2, x0
   0x000000000b3aaf4c <+764>:	ldr	x3, [sp, #104]
   0x000000000b3aaf50 <+768>:	cmp	x25, x23
   0x000000000b3aaf54 <+772>:	b.eq	0xb3ab0c8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+1144>  // b.none
   0x000000000b3aaf58 <+776>:	sub	x4, x26, #0x1
   0x000000000b3aaf5c <+780>:	mov	x5, x26
   0x000000000b3aaf60 <+784>:	cmp	x4, #0x6
   0x000000000b3aaf64 <+788>:	b.ls	0xb3ab0d0 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+1152>  // b.plast
   0x000000000b3aaf68 <+792>:	add	x0, x23, #0x1
   0x000000000b3aaf6c <+796>:	mov	x1, #0x0                   	// #0
   0x000000000b3aaf70 <+800>:	sub	x0, x2, x0
   0x000000000b3aaf74 <+804>:	cmp	x0, #0xe
   0x000000000b3aaf78 <+808>:	b.hi	0xb3aafe4 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+916>  // b.pmore
   0x000000000b3aaf7c <+812>:	nop
   0x000000000b3aaf80 <+816>:	ldrb	w0, [x23, x1]
   0x000000000b3aaf84 <+820>:	strb	w0, [x2, x1]
   0x000000000b3aaf88 <+824>:	add	x1, x1, #0x1
   0x000000000b3aaf8c <+828>:	cmp	x26, x1
   0x000000000b3aaf90 <+832>:	b.ne	0xb3aaf80 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+816>  // b.any
   0x000000000b3aaf94 <+836>:	add	x3, x3, #0x0, lsl #12
   0x000000000b3aaf98 <+840>:	add	x3, x3, #0x40
   0x000000000b3aaf9c <+844>:	adrp	x1, 0x82df000 <_ZNK9starrocks28AggregateFunctionBatchHelperINS_11BitmapValueENS_28BitmapUnionAggregateFunctionEE27batch_create_with_selectionEPNS_15FunctionContextEmRSt6vectorIPhNS_15ColumnAllocatorIS7_EEEmRKS6_IhNS8_IhEEE>
   0x000000000b3aafa0 <+848>:	add	x1, x1, #0x460
   0x000000000b3aafa4 <+852>:	str	x2, [sp, #104]
   0x000000000b3aafa8 <+856>:	ldr	x0, [x3]
   0x000000000b3aafac <+860>:	ldr	x3, [x0]
   0x000000000b3aafb0 <+864>:	ldr	x3, [x3, #24]
   0x000000000b3aafb4 <+868>:	cmp	x3, x1
   0x000000000b3aafb8 <+872>:	b.ne	0xb3ab0d8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+1160>  // b.any
   0x000000000b3aafbc <+876>:	mov	x0, x23
   0x000000000b3aafc0 <+880>:	bl	0xc3432d4 <my_free(void*)>
   0x000000000b3aafc4 <+884>:	ldr	x2, [sp, #104]
   0x000000000b3aafc8 <+888>:	add	x22, x2, x22
   0x000000000b3aafcc <+892>:	ldr	x0, [x19, #24]
   0x000000000b3aafd0 <+896>:	ldr	x23, [x0, #16]
   0x000000000b3aafd4 <+900>:	str	x2, [x24, #16]
   0x000000000b3aafd8 <+904>:	add	x2, x2, x28
   0x000000000b3aafdc <+908>:	stp	x22, x2, [x27, #8]
   0x000000000b3aafe0 <+912>:	b	0xb3aacf0 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+160>
   0x000000000b3aafe4 <+916>:	cmp	x4, #0xe
   0x000000000b3aafe8 <+920>:	b.ls	0xb3ab0e8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+1176>  // b.plast
   0x000000000b3aafec <+924>:	and	x1, x26, #0xfffffffffffffff0
   0x000000000b3aaff0 <+928>:	mov	x0, #0x0                   	// #0
   0x000000000b3aaff4 <+932>:	nop
   0x000000000b3aaff8 <+936>:	ldr	q0, [x23, x0]
   0x000000000b3aaffc <+940>:	str	q0, [x2, x0]
   0x000000000b3ab000 <+944>:	add	x0, x0, #0x10
   0x000000000b3ab004 <+948>:	cmp	x0, x1
   0x000000000b3ab008 <+952>:	b.ne	0xb3aaff8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+936>  // b.any
   0x000000000b3ab00c <+956>:	add	x0, x23, x1
   0x000000000b3ab010 <+960>:	add	x4, x2, x1
   0x000000000b3ab014 <+964>:	cmp	x26, x1
   0x000000000b3ab018 <+968>:	b.eq	0xb3aaf94 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+836>  // b.none
   0x000000000b3ab01c <+972>:	sub	x5, x26, x1
   0x000000000b3ab020 <+976>:	sub	x6, x5, #0x1
   0x000000000b3ab024 <+980>:	cmp	x6, #0x6
   0x000000000b3ab028 <+984>:	b.ls	0xb3ab048 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+1016>  // b.plast
   0x000000000b3ab02c <+988>:	ldr	d0, [x23, x1]
   0x000000000b3ab030 <+992>:	and	x6, x5, #0xfffffffffffffff8
   0x000000000b3ab034 <+996>:	add	x0, x0, x6
   0x000000000b3ab038 <+1000>:	add	x4, x4, x6
   0x000000000b3ab03c <+1004>:	str	d0, [x2, x1]
   0x000000000b3ab040 <+1008>:	tst	x5, #0x7
   0x000000000b3ab044 <+1012>:	b.eq	0xb3ab0c8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+1144>  // b.none
   0x000000000b3ab048 <+1016>:	mov	x1, x0
   0x000000000b3ab04c <+1020>:	ldrb	w5, [x1], #1
   0x000000000b3ab050 <+1024>:	strb	w5, [x4]
   0x000000000b3ab054 <+1028>:	cmp	x25, x1
   0x000000000b3ab058 <+1032>:	b.eq	0xb3ab0c8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+1144>  // b.none
   0x000000000b3ab05c <+1036>:	ldrb	w5, [x0, #1]
   0x000000000b3ab060 <+1040>:	add	x1, x0, #0x2
   0x000000000b3ab064 <+1044>:	strb	w5, [x4, #1]
   0x000000000b3ab068 <+1048>:	cmp	x25, x1
   0x000000000b3ab06c <+1052>:	b.eq	0xb3ab0c8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+1144>  // b.none
   0x000000000b3ab070 <+1056>:	ldrb	w5, [x0, #2]
   0x000000000b3ab074 <+1060>:	add	x1, x0, #0x3
   0x000000000b3ab078 <+1064>:	strb	w5, [x4, #2]
   0x000000000b3ab07c <+1068>:	cmp	x25, x1
   0x000000000b3ab080 <+1072>:	b.eq	0xb3ab0c8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+1144>  // b.none
   0x000000000b3ab084 <+1076>:	ldrb	w5, [x0, #3]
   0x000000000b3ab088 <+1080>:	add	x1, x0, #0x4
   0x000000000b3ab08c <+1084>:	strb	w5, [x4, #3]
   0x000000000b3ab090 <+1088>:	cmp	x25, x1
   0x000000000b3ab094 <+1092>:	b.eq	0xb3ab0c8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+1144>  // b.none
   0x000000000b3ab098 <+1096>:	ldrb	w5, [x0, #4]
   0x000000000b3ab09c <+1100>:	add	x1, x0, #0x5
   0x000000000b3ab0a0 <+1104>:	strb	w5, [x4, #4]
   0x000000000b3ab0a4 <+1108>:	cmp	x25, x1
   0x000000000b3ab0a8 <+1112>:	b.eq	0xb3ab0c8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+1144>  // b.none
   0x000000000b3ab0ac <+1116>:	ldrb	w5, [x0, #5]
   0x000000000b3ab0b0 <+1120>:	add	x1, x0, #0x6
   0x000000000b3ab0b4 <+1124>:	strb	w5, [x4, #5]
   0x000000000b3ab0b8 <+1128>:	cmp	x25, x1
   0x000000000b3ab0bc <+1132>:	b.eq	0xb3ab0c8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+1144>  // b.none
   0x000000000b3ab0c0 <+1136>:	ldrb	w0, [x0, #6]
   0x000000000b3ab0c4 <+1140>:	strb	w0, [x4, #6]
   0x000000000b3ab0c8 <+1144>:	cbz	x23, 0xb3aafc8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+888>
   0x000000000b3ab0cc <+1148>:	b	0xb3aaf94 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+836>
   0x000000000b3ab0d0 <+1152>:	mov	x1, #0x0                   	// #0
   0x000000000b3ab0d4 <+1156>:	b	0xb3aaf80 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+816>
   0x000000000b3ab0d8 <+1160>:	mov	x1, x23
   0x000000000b3ab0dc <+1164>:	blr	x3
   0x000000000b3ab0e0 <+1168>:	ldr	x2, [sp, #104]
   0x000000000b3ab0e4 <+1172>:	b	0xb3aafc8 <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+888>
   0x000000000b3ab0e8 <+1176>:	mov	x4, x2
   0x000000000b3ab0ec <+1180>:	mov	x0, x23
   0x000000000b3ab0f0 <+1184>:	mov	x1, #0x0                   	// #0
   0x000000000b3ab0f4 <+1188>:	b	0xb3ab02c <_ZN9starrocks7parquet25NumericToNumericConverterIiaE7convertERKNS_3CowINS_6ColumnEE8ImmutPtrIS4_EEPS4_+988>
   0x000000000b3ab0f8 <+1192>:	adrp	x0, 0x3f89000
   0x000000000b3ab0fc <+1196>:	add	x0, x0, #0xc30
   0x000000000b3ab100 <+1200>:	bl	0x119e1cfc <_ZSt20__throw_length_errorPKc>
End of assembler dump.
```


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
