### PR TITLE
[Enhancement] remove the adaptive zonemap creation

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -333,12 +333,6 @@ CONF_mBool(enable_ordinal_index_memory_page_cache, "true");
 CONF_mBool(enable_string_prefix_zonemap, "true");
 // Prefix length used for string ZoneMap min/max when enabled
 CONF_mInt32(string_prefix_zonemap_prefix_len, "16");
-// Adaptive creation of string zonemap index based on page overlap quality.
-// If the estimated overlap ratio across consecutive pages is greater than this threshold,
-// skip writing the page-level string zonemap index. Range: [0.0, 1.0].
-CONF_mDouble(string_zonemap_overlap_threshold, "0.8");
-// Minimum number of non-empty pages before applying the adaptive check.
-CONF_mInt32(string_zonemap_min_pages_for_adaptive_check, "16");
 
 // ========================== ZONEMAP END ===================================
 

--- a/be/src/storage/rowset/column_writer.h
+++ b/be/src/storage/rowset/column_writer.h
@@ -138,7 +138,6 @@ class OrdinalIndexWriter;
 class PageBuilder;
 class BloomFilterIndexWriter;
 class ZoneMapIndexWriter;
-class ZoneMapIndexQualityJudger;
 
 class ColumnWriter {
 public:
@@ -300,7 +299,6 @@ private:
 
     std::unique_ptr<OrdinalIndexWriter> _ordinal_index_builder;
     std::unique_ptr<ZoneMapIndexWriter> _zone_map_index_builder;
-    std::unique_ptr<ZoneMapIndexQualityJudger> _zone_map_index_quality_judger;
     std::unique_ptr<BitmapIndexWriter> _bitmap_index_builder;
     std::unique_ptr<BloomFilterIndexWriter> _bloom_filter_index_builder;
     std::unique_ptr<InvertedWriter> _inverted_index_builder;

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -2168,23 +2168,6 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: Prefix length used for string ZoneMap min/max when `enable_string_prefix_zonemap` is enabled.
 - Introduced in: -
 
-##### string_zonemap_overlap_threshold
-
-- Default: 0.8
-- Type: Double
-- Unit: -
-- Is mutable: Yes
-- Description: Threshold for adaptive creation of page-level string ZoneMap. If the estimated overlap ratio across consecutive pages is greater than this threshold, StarRocks skips writing the page-level string ZoneMap. Range: [0.0, 1.0].
-- Introduced in: -
-
-##### string_zonemap_min_pages_for_adaptive_check
-
-- Default: 16
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: Minimum number of non-empty pages required before applying the adaptive string ZoneMap quality check.
-- Introduced in: -
 
 ##### enable_ordinal_index_memory_page_cache
 

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -1453,23 +1453,6 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: `enable_string_prefix_zonemap` が有効な場合に、文字列ゾーンマップの最小値/最大値に使用する前置長。
 - 導入バージョン: -
 
-##### string_zonemap_overlap_threshold
-
-- デフォルト: 0.8
-- タイプ: Double
-- 単位: -
-- 可変: はい
-- 説明: 文字列ページレベルのゾーンマップを自動作成するためのしきい値。連続するページ間の推定オーバーラップ率がこの値を超える場合、ページレベルのゾーンマップの書き込みをスキップします。範囲: [0.0, 1.0]。
-- 導入バージョン: -
-
-##### string_zonemap_min_pages_for_adaptive_check
-
-- デフォルト: 16
-- タイプ: Int
-- 単位: -
-- 可変: はい
-- 説明: 自適応チェックを適用する前に必要な非空ページの最小数。
-- 導入バージョン: -
 
 ##### enable_ordinal_index_memory_page_cache
 

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -2115,23 +2115,6 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：启用 `enable_string_prefix_zonemap` 时用于字符串 Zonemap 最小值/最大值的前缀长度。
 - 引入版本：-
 
-##### string_zonemap_overlap_threshold
-
-- 默认值：0.8
-- 类型：Double
-- 单位：-
-- 是否动态：是
-- 描述：字符串页级 Zonemap 自适应创建的阈值。如果连续页之间的估算重叠比例大于该阈值，将跳过写入该页级 Zonemap。取值范围：[0.0, 1.0]。
-- 引入版本：-
-
-##### string_zonemap_min_pages_for_adaptive_check
-
-- 默认值：16
-- 类型：Int
-- 单位：-
-- 是否动态：是
-- 描述：应用自适应检查前所需的非空页的最小数量。
-- 引入版本：-
 
 ##### enable_ordinal_index_memory_page_cache
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Remove the "Adaptive ZoneMap creation" function #61960, due to robustness and predictability.

A corner case like this:
```
[A, A]
[A, A]
[A, A]
[A, A]
[A, A]
[A, A]
[B, B]
```

The current adaptive strategy tends to reject this zonemap due to excessive overlap among pages. However, this zonemap can still prove valuable in certain scenarios:
- For queries like `WHERE value = 'B'`, the zonemap can effectively prune most pages, even if the majority of pages contain `A`.
- While the page-level zonemap might be ineffective, the segment-level zonemap can still assist in pruning pages.

In summary, the overlap ratio based strategy is sufficiently robust to handle such cases, especially when the data distribution is skewed.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3