### PR TITLE
[Enhancement] Preserve SQL comments in audit logs when encryption is required

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -302,7 +302,9 @@ public class ConnectProcessor {
                 return "this is a desensitized invalid sql";
             }
             return SqlCredentialRedactor.redact(origStmt);
-        } else if (AuditEncryptionChecker.needEncrypt(parsedStmt) || Config.enable_sql_desensitize_in_log) {
+        } else if (AuditEncryptionChecker.needEncrypt(parsedStmt)) {
+            return SqlCredentialRedactor.redact(origStmt);
+        } else if (Config.enable_sql_desensitize_in_log) {
             // Some information like username, password in the stmt should not be printed.
             return AstToSQLBuilder.toSQL(parsedStmt, FormatOptions.allEnable()
                             .setColumnSimplifyTableName(false)

--- a/test/sql/test_routine_load/R/test_show_create_routine_load
+++ b/test/sql/test_routine_load/R/test_show_create_routine_load
@@ -47,7 +47,7 @@ testherbavro	CREATE ROUTINE LOAD test_show_create_routine_load.testherbavro on h
  COLUMNS TERMINATED BY '\t',
 COLUMNS (advertiser_id, advertiser_ad_type, advertiser_ad_width, advertiser_currency_type),
 PARTITIONS (p1, p2, p3),
-WHERE `advertiser_id` > -10
+WHERE advertiser_id > -10
 PROPERTIES
 (
 "desired_concurrent_number"="1",


### PR DESCRIPTION
## Why I'm doing:
Preserve SQL comments in audit logs when encryption is required

## What I'm doing:
This PR separates the handling of SQL statements that require encryption from those that need desensitization, ensuring that SQL comments are preserved in audit logs when encryption is required.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
