### PR TITLE
[Enhancement] PhysicalSplitMorselQueue V2 

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -928,6 +928,8 @@ CONF_mInt64(tablet_internal_parallel_min_splitted_scan_rows, "16384");
 CONF_mInt64(tablet_internal_parallel_max_splitted_scan_rows, "1048576");
 // Default is 512MB.
 CONF_mInt64(tablet_internal_parallel_max_splitted_scan_bytes, "536870912");
+// V1 or V2
+CONF_mBool(tabelt_internal_parallel_v2, "true");
 //
 // Only when scan_dop is not less than min_scan_dop, this table can use tablet internal parallel,
 // where scan_dop = estimated_scan_rows / splitted_scan_rows.

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -459,7 +459,11 @@ StatusOr<pipeline::MorselQueuePtr> OlapScanNode::convert_scan_range_to_morsel_qu
     // Split tablet physically.
     ASSIGN_OR_RETURN(bool ok, _could_split_tablet_physically(scan_ranges));
     if (ok) {
-        return std::make_unique<pipeline::PhysicalSplitMorselQueueV2>(std::move(morsels), scan_dop, splitted_scan_rows);
+        if (config::tabelt_internal_parallel_v2) {
+            return std::make_unique<pipeline::PhysicalSplitMorselQueueV2>(std::move(morsels), scan_dop, splitted_scan_rows);
+        } else {
+            return std::make_unique<pipeline::PhysicalSplitMorselQueue>(std::move(morsels), scan_dop, splitted_scan_rows);
+        }
     }
 
     return std::make_unique<pipeline::LogicalSplitMorselQueue>(std::move(morsels), scan_dop, splitted_scan_rows);

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -460,9 +460,11 @@ StatusOr<pipeline::MorselQueuePtr> OlapScanNode::convert_scan_range_to_morsel_qu
     ASSIGN_OR_RETURN(bool ok, _could_split_tablet_physically(scan_ranges));
     if (ok) {
         if (config::tabelt_internal_parallel_v2) {
-            return std::make_unique<pipeline::PhysicalSplitMorselQueueV2>(std::move(morsels), scan_dop, splitted_scan_rows);
+            return std::make_unique<pipeline::PhysicalSplitMorselQueueV2>(std::move(morsels), scan_dop,
+                                                                          splitted_scan_rows);
         } else {
-            return std::make_unique<pipeline::PhysicalSplitMorselQueue>(std::move(morsels), scan_dop, splitted_scan_rows);
+            return std::make_unique<pipeline::PhysicalSplitMorselQueue>(std::move(morsels), scan_dop,
+                                                                        splitted_scan_rows);
         }
     }
 

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -459,7 +459,7 @@ StatusOr<pipeline::MorselQueuePtr> OlapScanNode::convert_scan_range_to_morsel_qu
     // Split tablet physically.
     ASSIGN_OR_RETURN(bool ok, _could_split_tablet_physically(scan_ranges));
     if (ok) {
-        return std::make_unique<pipeline::PhysicalSplitMorselQueue>(std::move(morsels), scan_dop, splitted_scan_rows);
+        return std::make_unique<pipeline::PhysicalSplitMorselQueueV2>(std::move(morsels), scan_dop, splitted_scan_rows);
     }
 
     return std::make_unique<pipeline::LogicalSplitMorselQueue>(std::move(morsels), scan_dop, splitted_scan_rows);

--- a/be/src/exec/pipeline/scan/chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/chunk_source.cpp
@@ -18,6 +18,7 @@
 
 #include "common/statusor.h"
 #include "exec/pipeline/scan/balanced_chunk_buffer.h"
+#include "exec/pipeline/scan/morsel.h"
 #include "exec/pipeline/scan/scan_operator.h"
 #include "exec/workgroup/scan_task_queue.h"
 #include "exec/workgroup/work_group.h"

--- a/be/src/exec/pipeline/scan/chunk_source.h
+++ b/be/src/exec/pipeline/scan/chunk_source.h
@@ -62,6 +62,8 @@ public:
     Status buffer_next_batch_chunks_blocking(RuntimeState* state, size_t batch_size,
                                              const workgroup::WorkGroup* running_wg);
 
+    Morsel* get_morsel() { return _morsel.get(); }
+
     // Counters of scan
     int64_t get_cpu_time_spent() const { return _cpu_time_spent_ns; }
     int64_t get_io_time_spent() const { return _io_time_spent_ns; }

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -1312,8 +1312,8 @@ void PhysicalSplitMorselQueueV2::refine_scan_ranges(const RowidRangeOptionPtr& r
                 size_t rowid = segment->range_iter.begin();
                 size_t prev_remain = segment->range_iter.remaining_rows();
 
-                // Apply the rowid range filter
-                segment->scan_range &= *split.row_id_range;
+                // Remove the specified range from scan_range
+                segment->scan_range -= *split.row_id_range;
                 segment->range_iter = segment->scan_range.new_iterator();
                 segment->range_iter.seek(rowid);
 

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -548,7 +548,7 @@ private:
     SparseRangeIterator<> _segment_range_iter;
 
     // The number of unprocessed rows of the current segment.
-    // size_t _num_segment_rest_rows = 0;
+    size_t _num_segment_rest_rows = 0;
 
     MemPool _mempool;
 };
@@ -687,9 +687,7 @@ public:
                         const std::vector<OlapTuple>& range_end_key) override;
 
     // Queue operations
-    bool empty() const override {
-        return _unget_morsel == nullptr && _init_segments.empty() && _refined_segments.empty();
-    }
+    bool empty() const override;
     StatusOr<MorselPtr> try_get() override;
 
     void refine_scan_ranges(const RowidRangeOptionPtr& rowid_range);
@@ -754,7 +752,7 @@ private:
         }
         void set_finished() { state = Finished; }
 
-        std::string id_string() const { return rowset_id.to_string() + "/" + std::to_string(segment_id); }
+        std::string id_string() const { return fmt::format("{}/{}/{}", tablet_idx, rowset_idx, segment_idx); }
     };
 
     rowid_t _lower_bound_ordinal(Segment* segment, const SeekTuple& key, bool lower) const;
@@ -777,7 +775,7 @@ private:
     void _remove_from_init_segments(const RefineSegmentPtr& segment);
 
 private:
-    std::mutex _mutex;
+    mutable std::mutex _mutex;
 
     /// Key ranges passed to the storage layer.
     TabletReaderParams::RangeStartOperation _range_start_op = TabletReaderParams::RangeStartOperation::GT;

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -339,6 +339,7 @@ public:
         SPLIT,
         LOGICAL_SPLIT,
         PHYSICAL_SPLIT,
+        PHYSICAL_SPLIT_V2,
         BUCKET_SEQUENCE,
     };
     MorselQueue() = default;
@@ -690,7 +691,7 @@ public:
     void refine_scan_ranges(const RowidRangeOptionPtr& rowid_range);
 
     std::string name() const override { return "physical_split_morsel_queue_v2"; }
-    Type type() const override { return PHYSICAL_SPLIT; }
+    Type type() const override { return PHYSICAL_SPLIT_V2; }
 
 private:
     struct RefineSegment;
@@ -748,6 +749,8 @@ private:
             state = Refined;
         }
         void set_finished() { state = Finished; }
+
+        std::string id_string() const { return rowset_id.to_string() + "/" + std::to_string(segment_id); }
     };
 
     rowid_t _lower_bound_ordinal(Segment* segment, const SeekTuple& key, bool lower) const;

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -16,6 +16,7 @@
 
 #include <mutex>
 #include <optional>
+#include <utility>
 
 #include "exec/query_cache/ticket_checker.h"
 #include "gen_cpp/InternalService_types.h"
@@ -212,11 +213,14 @@ public:
     }
 
     RowidRangeOptionPtr get_rowid_range_option() { return _rowid_range_option; }
+    void set_filtered_scan_range(RowidRangeOptionPtr filtered_scan_range) {
+        _filtered_scan_range = std::move(filtered_scan_range);
+    }
     RowidRangeOptionPtr get_filtered_scan_range() { return _filtered_scan_range; }
 
 private:
     RowidRangeOptionPtr _rowid_range_option;
-    RowidRangeOptionPtr _filtered_scan_range;
+    RowidRangeOptionPtr _filtered_scan_range = nullptr;
 };
 
 class LogicalSplitScanMorsel final : public ScanMorsel {
@@ -759,6 +763,8 @@ private:
     // Load the meta of the new rowset and the index of the new segment,
     // and find the rowid range of each key range in this segment.
     Status _init_segment(const RefineSegmentPtr& segment);
+    Segment* get_raw_segment(const RefineSegmentPtr& segment);
+    SegmentSharedPtr get_segment_ptr(const RefineSegmentPtr& segment);
 
     void _inc_split(const RefineSegmentPtr& segment, bool is_last_split);
     StatusOr<RowidRangeOptionPtr> _split_morsel_from_segment(const RefineSegmentPtr& segment, bool* is_last);

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -492,12 +492,10 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
 
             int64_t delta_cpu_time = chunk_source->get_cpu_time_spent() - prev_cpu_time;
 
-            // Refine the MorselQueue based on executed morsel
-            Morsel* morsel = chunk_source->get_morsel();
-            if (morsel && dynamic_cast<PhysicalSplitScanMorsel*>(morsel) != nullptr) {
-                PhysicalSplitScanMorsel* physical_split_morsel = dynamic_cast<PhysicalSplitScanMorsel*>(morsel);
-                PhysicalSplitMorselQueueV2* queue = dynamic_cast<PhysicalSplitMorselQueueV2*>(_morsel_queue);
-                auto rowid_range = physical_split_morsel->get_filtered_scan_range();
+            // Refine the MorselQueue based on the executed morsel, if applicable.
+            if (auto* queue = dynamic_cast<PhysicalSplitMorselQueueV2*>(_morsel_queue)) {
+                auto* morsel = down_cast<PhysicalSplitScanMorsel*>(chunk_source->get_morsel());
+                const auto rowid_range = morsel->get_filtered_scan_range();
                 queue->refine_scan_ranges(rowid_range);
             }
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -492,10 +492,11 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
 
             int64_t delta_cpu_time = chunk_source->get_cpu_time_spent() - prev_cpu_time;
 
+            // Refine the MorselQueue based on executed morsel
             Morsel* morsel = chunk_source->get_morsel();
             if (morsel && dynamic_cast<PhysicalSplitScanMorsel*>(morsel) != nullptr) {
                 PhysicalSplitScanMorsel* physical_split_morsel = dynamic_cast<PhysicalSplitScanMorsel*>(morsel);
-                PhysicalSplitMorselQueue* queue = dynamic_cast<PhysicalSplitMorselQueue*>(_morsel_queue);
+                PhysicalSplitMorselQueueV2* queue = dynamic_cast<PhysicalSplitMorselQueueV2*>(_morsel_queue);
                 auto rowid_range = physical_split_morsel->get_filtered_scan_range();
                 queue->refine_scan_ranges(rowid_range);
             }

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -493,11 +493,11 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             int64_t delta_cpu_time = chunk_source->get_cpu_time_spent() - prev_cpu_time;
 
             // Refine the MorselQueue based on the executed morsel, if applicable.
-            if (auto* queue = dynamic_cast<PhysicalSplitMorselQueueV2*>(_morsel_queue)) {
-                auto* morsel = down_cast<PhysicalSplitScanMorsel*>(chunk_source->get_morsel());
-                const auto rowid_range = morsel->get_filtered_scan_range();
-                queue->refine_scan_ranges(rowid_range);
-            }
+            // if (auto* queue = dynamic_cast<PhysicalSplitMorselQueueV2*>(_morsel_queue)) {
+            //     auto* morsel = down_cast<PhysicalSplitScanMorsel*>(chunk_source->get_morsel());
+            //     const auto rowid_range = morsel->get_filtered_scan_range();
+            //     queue->refine_scan_ranges(rowid_range);
+            // }
 
             // It might destory the chunk source
             _finish_chunk_source_task(state, chunk_source_index, delta_cpu_time,

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -493,11 +493,11 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             int64_t delta_cpu_time = chunk_source->get_cpu_time_spent() - prev_cpu_time;
 
             // Refine the MorselQueue based on the executed morsel, if applicable.
-            // if (auto* queue = dynamic_cast<PhysicalSplitMorselQueueV2*>(_morsel_queue)) {
-            //     auto* morsel = down_cast<PhysicalSplitScanMorsel*>(chunk_source->get_morsel());
-            //     const auto rowid_range = morsel->get_filtered_scan_range();
-            //     queue->refine_scan_ranges(rowid_range);
-            // }
+            if (auto* queue = dynamic_cast<PhysicalSplitMorselQueueV2*>(_morsel_queue)) {
+                auto* morsel = down_cast<PhysicalSplitScanMorsel*>(chunk_source->get_morsel());
+                const auto rowid_range = morsel->get_filtered_scan_range();
+                queue->refine_scan_ranges(rowid_range);
+            }
 
             // It might destory the chunk source
             _finish_chunk_source_task(state, chunk_source_index, delta_cpu_time,

--- a/be/src/storage/range.h
+++ b/be/src/storage/range.h
@@ -159,6 +159,7 @@ public:
 
     size_t covered_ranges(size_t size) const;
 
+    void seek(T next);
     void skip(T size);
 
     size_t remaining_rows() const;
@@ -484,6 +485,19 @@ inline size_t SparseRangeIterator<T>::covered_ranges(size_t size) const {
     }
     i += (end > ranges[i].begin());
     return i - _index;
+}
+
+template <typename T>
+inline void SparseRangeIterator<T>::seek(T next) {
+    _next_rowid = next;
+    const std::vector<Range<T>>& ranges = _range->_ranges;
+    _index = 0;
+    while (_index < ranges.size() && ranges[_index].end() <= _next_rowid) {
+        _index++;
+    }
+    if (_index < ranges.size()) {
+        _next_rowid = std::max(_next_rowid, ranges[_index].begin());
+    }
 }
 
 template <typename T>

--- a/be/src/storage/rowset/rowid_range_option.cpp
+++ b/be/src/storage/rowset/rowid_range_option.cpp
@@ -92,4 +92,16 @@ RowidRangeOptionPtr RowidRangeOption::clone() {
     return std::make_shared<RowidRangeOption>(*this);
 }
 
+std::string RowidRangeOption::to_string() const {
+    std::stringstream ss;
+    ss << "RowidRangeOption: ";
+    for (const auto& [rowset_id, segment_map] : rowid_range_per_segment_per_rowset) {
+        ss << "rowset_id: " << rowset_id.to_string() << " ";
+        for (const auto& [segment_id, segment_split] : segment_map) {
+            ss << "segment_id: " << segment_id << " " << segment_split.row_id_range->to_string() << " ";
+        }
+    }
+    return ss.str();
+}
+
 } // namespace starrocks

--- a/be/src/storage/rowset/rowid_range_option.cpp
+++ b/be/src/storage/rowset/rowid_range_option.cpp
@@ -47,6 +47,16 @@ bool RowidRangeOption::contains_rowset(const BaseRowset* rowset) const {
     return rowid_range_per_segment_per_rowset.find(rowset->rowset_id()) != rowid_range_per_segment_per_rowset.end();
 }
 
+bool RowidRangeOption::empty() const {
+    if (rowid_range_per_segment_per_rowset.empty()) {
+        return true;
+    } else if (rowid_range_per_segment_per_rowset.size() == 1) {
+        return rowid_range_per_segment_per_rowset.begin()->second.empty();
+    } else {
+        return false;
+    }
+}
+
 std::optional<std::tuple<RowsetId, SegmentId, RowidRangeOption::SegmentSplit>> RowidRangeOption::get_single_segment()
         const {
     if (rowid_range_per_segment_per_rowset.size() != 1) {

--- a/be/src/storage/rowset/rowid_range_option.cpp
+++ b/be/src/storage/rowset/rowid_range_option.cpp
@@ -51,4 +51,8 @@ RowidRangeOption::SegmentSplit RowidRangeOption::get_segment_rowid_range(const B
     return segment_it->second;
 }
 
+RowidRangeOptionPtr RowidRangeOption::clone() {
+    return std::make_shared<RowidRangeOption>(*this);
+}
+
 } // namespace starrocks

--- a/be/src/storage/rowset/rowid_range_option.h
+++ b/be/src/storage/rowset/rowid_range_option.h
@@ -24,6 +24,9 @@ namespace starrocks {
 class BaseRowset;
 class Segment;
 
+struct RowidRangeOption;
+using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
+
 // It represents a specific rowid range on the segment with `segment_id` of the rowset with `rowset_id`.
 struct RowidRangeOption {
 public:
@@ -39,6 +42,8 @@ public:
 
     bool contains_rowset(const BaseRowset* rowset) const;
     SegmentSplit get_segment_rowid_range(const BaseRowset* rowset, const Segment* segment);
+
+    RowidRangeOptionPtr clone();
 
 public:
     using SetgmentRowidRangeMap = std::unordered_map<uint64_t, SegmentSplit>;

--- a/be/src/storage/rowset/rowid_range_option.h
+++ b/be/src/storage/rowset/rowid_range_option.h
@@ -26,6 +26,7 @@ class Segment;
 
 struct RowidRangeOption;
 using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
+using SegmentId = uint64_t;
 
 // It represents a specific rowid range on the segment with `segment_id` of the rowset with `rowset_id`.
 struct RowidRangeOption {
@@ -37,16 +38,20 @@ public:
 
     RowidRangeOption() = default;
 
+    void add(RowsetId rowset_id, SegmentId segment_id, SparseRangePtr rowid_range, bool is_first_split_of_segment);
     void add(const BaseRowset* rowset, const Segment* segment, SparseRangePtr rowid_range,
              bool is_first_split_of_segment);
 
     bool contains_rowset(const BaseRowset* rowset) const;
     SegmentSplit get_segment_rowid_range(const BaseRowset* rowset, const Segment* segment);
 
+    // Return the segment split if it contains a single split
+    std::optional<std::tuple<RowsetId, SegmentId, SegmentSplit>> get_single_segment() const;
+
     RowidRangeOptionPtr clone();
 
 public:
-    using SetgmentRowidRangeMap = std::unordered_map<uint64_t, SegmentSplit>;
+    using SetgmentRowidRangeMap = std::unordered_map<SegmentId, SegmentSplit>;
     using RowsetRowidRangeMap = std::map<RowsetId, SetgmentRowidRangeMap>;
 
     RowsetRowidRangeMap rowid_range_per_segment_per_rowset;

--- a/be/src/storage/rowset/rowid_range_option.h
+++ b/be/src/storage/rowset/rowid_range_option.h
@@ -44,6 +44,7 @@ public:
 
     bool contains_rowset(const BaseRowset* rowset) const;
     SegmentSplit get_segment_rowid_range(const BaseRowset* rowset, const Segment* segment);
+    bool empty() const;
 
     // Return the segment split if it contains a single split
     std::optional<std::tuple<RowsetId, SegmentId, SegmentSplit>> get_single_segment() const;

--- a/be/src/storage/rowset/rowid_range_option.h
+++ b/be/src/storage/rowset/rowid_range_option.h
@@ -51,6 +51,8 @@ public:
 
     RowidRangeOptionPtr clone();
 
+    std::string to_string() const;
+
 public:
     using SetgmentRowidRangeMap = std::unordered_map<SegmentId, SegmentSplit>;
     using RowsetRowidRangeMap = std::map<RowsetId, SetgmentRowidRangeMap>;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -826,13 +826,16 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
             if (rowid_range == nullptr) {
                 continue;
             }
-            auto [filtered_scan_range, ignore] =
-                    options.filtered_scan_range->get_segment_rowid_range(this, seg_ptr.get());
-            if (filtered_scan_range) {
-                seg_options.filtered_scan_range = filtered_scan_range;
-            }
             seg_options.rowid_range_option = rowid_range;
             seg_options.is_first_split_of_segment = is_first_split_of_segment;
+
+            if (options.filtered_scan_range != nullptr) {
+                auto [filtered_scan_range, ignore] =
+                        options.filtered_scan_range->get_segment_rowid_range(this, seg_ptr.get());
+                if (filtered_scan_range) {
+                    seg_options.filtered_scan_range = filtered_scan_range;
+                }
+            }
         } else if (options.short_key_ranges_option != nullptr) { // logical split.
             seg_options.is_first_split_of_segment = options.short_key_ranges_option->is_first_split_of_tablet;
         } else {

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -826,7 +826,12 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
             if (rowid_range == nullptr) {
                 continue;
             }
-            seg_options.rowid_range_option = std::move(rowid_range);
+            auto [filtered_scan_range, ignore] =
+                    options.filtered_scan_range->get_segment_rowid_range(this, seg_ptr.get());
+            if (filtered_scan_range) {
+                seg_options.filtered_scan_range = filtered_scan_range;
+            }
+            seg_options.rowid_range_option = rowid_range;
             seg_options.is_first_split_of_segment = is_first_split_of_segment;
         } else if (options.short_key_ranges_option != nullptr) { // logical split.
             seg_options.is_first_split_of_segment = options.short_key_ranges_option->is_first_split_of_tablet;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -826,7 +826,7 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
             if (rowid_range == nullptr) {
                 continue;
             }
-            seg_options.rowid_range_option = rowid_range;
+            seg_options.rowid_range_option = std::move(rowid_range);
             seg_options.is_first_split_of_segment = is_first_split_of_segment;
 
             if (options.filtered_scan_range != nullptr) {

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -437,11 +437,12 @@ private:
                                                      const FooterPointerPB* partial_rowset_footer,
                                                      size_t* foot_size_hint);
 
-    std::vector<SegmentSharedPtr> _segments;
-
     std::atomic<bool> is_compacting{false};
 
     KeysType _keys_type;
+
+protected:
+    std::vector<SegmentSharedPtr> _segments;
 };
 
 struct adopt_acquire_t {

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -81,6 +81,7 @@ public:
     const std::unordered_set<uint32_t>* unused_output_column_ids = nullptr;
 
     RowidRangeOptionPtr rowid_range_option = nullptr;
+    RowidRangeOptionPtr filtered_scan_range = nullptr;
     ShortKeyRangesOptionPtr short_key_ranges_option = nullptr;
 
     RuntimeScanRangePruner runtime_range_pruner;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-present StarRocks, Inc. All rights reserved.
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -576,8 +576,6 @@ Status SegmentIterator::_init() {
     bool need_refine = _opts.filtered_scan_range && _opts.is_first_split_of_segment;
     if (need_refine) {
         _scan_range.add(Range<>(0, num_rows()));
-        _opts.filtered_scan_range->clear();
-        _opts.filtered_scan_range->add(Range<>(0, num_rows()));
     } else {
         RETURN_IF_ERROR(_get_row_ranges_by_rowid_range());
     }
@@ -613,7 +611,6 @@ Status SegmentIterator::_init() {
     // in subsequent scan tasks. This ensures that the filtered scan range is reused efficiently.
     if (need_refine) {
         *_opts.filtered_scan_range = _scan_range;
-        VLOG(2) << fmt::format("refine segemnt {} to {} rows", _segment->id(), _scan_range.span_size());
         if (_opts.rowid_range_option != nullptr) {
             _scan_range &= (*_opts.rowid_range_option);
         }

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -95,6 +95,7 @@ public:
     /// A segment may be divided into multiple split to scan concurrently.
     bool is_first_split_of_segment = true;
     SparseRangePtr rowid_range_option = nullptr;
+    SparseRangePtr filtered_scan_range = nullptr;
     std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
 
     RuntimeScanRangePruner runtime_range_pruner;

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -374,6 +374,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     }
     rs_opts.meta = _tablet->data_dir()->get_meta();
     rs_opts.rowid_range_option = params.rowid_range_option;
+    rs_opts.filtered_scan_range = params.filtered_scan_ranges;
     rs_opts.short_key_ranges_option = params.short_key_ranges_option;
     if (keys_type == PRIMARY_KEYS || keys_type == DUP_KEYS) {
         rs_opts.asc_hint = _is_asc_hint;

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -84,8 +84,10 @@ struct TabletReaderParams {
     ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
     const std::unordered_set<uint32_t>* unused_output_column_ids = &EMPTY_FILTERED_COLUMN_IDS;
 
+    // NOTE: PhysicalSplitMorsel would pass the raneg of morsel to here
     RowidRangeOptionPtr rowid_range_option = nullptr;
     ShortKeyRangesOptionPtr short_key_ranges_option = nullptr;
+    RowidRangeOptionPtr filtered_scan_ranges = nullptr;
 
     bool sorted_by_keys_per_tablet = false;
     RuntimeScanRangePruner runtime_range_pruner;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -68,6 +68,7 @@ set(EXEC_FILES
         ./exec/pipeline/pipeline_test_base.cpp
         ./exec/pipeline/query_context_manger_test.cpp
         ./exec/pipeline/multi_cast_local_exchange_test.cpp
+        ./exec/pipeline/morsel_queue_test.cpp
         ./exec/pipeline/table_function_operator_test.cpp
         ./exec/pipeline/sink/export_sink_operator_test.cpp
         ./exec/pipeline/sink/table_function_table_sink_operator_test.cpp

--- a/be/test/exec/pipeline/morsel_queue_test.cpp
+++ b/be/test/exec/pipeline/morsel_queue_test.cpp
@@ -18,9 +18,11 @@
 #include "fs/fs_memory.h"
 #include "gtest/gtest.h"
 #include "storage/chunk_helper.h"
+#include "storage/range.h"
 #include "storage/rowset/rowid_range_option.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_meta.h"
+#include "storage/rowset/unique_rowset_id_generator.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"
 #include "storage/tablet_meta.h"
@@ -33,11 +35,6 @@ namespace starrocks::pipeline {
 class PhysicalSplitMorselQueueV2Test : public ::testing::Test {
 public:
     void SetUp() override {
-        // Initialize test data
-        _plan_node_id = 1;
-        _degree_of_parallelism = 4;
-        _splitted_scan_rows = 1000;
-
         _fs = std::make_shared<MemoryFileSystem>();
         ASSERT_TRUE(_fs->create_dir(std::string(TEST_DIR)).ok());
 
@@ -98,8 +95,9 @@ protected:
     private:
     };
 
-    SegmentSharedPtr create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        auto res = std::make_shared<Segment>(fs, FileInfo{fname}, 1, _dummy_segment_schema, nullptr);
+    SegmentSharedPtr create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname,
+                                          uint64_t segment_id) {
+        auto res = std::make_shared<Segment>(fs, FileInfo{fname}, segment_id, _dummy_segment_schema, nullptr);
         res->set_num_rows(_segment_rows);
         return res;
     }
@@ -108,36 +106,38 @@ protected:
         std::vector<BaseRowsetSharedPtr> rowsets;
 
         for (int i = 0; i < num_rowsets; ++i) {
-            const int num_segments = 3;
-            RowsetId rowset_id;
-            rowset_id.init(10000 + i);
+            RowsetId rowset_id = _rowset_id_generator.next_id();
             Version version(i + 1, i + 1);
 
-            auto rowset = MockRowset::create(rowset_id, version, num_segments, tablet->tablet_schema());
+            auto rowset = MockRowset::create(rowset_id, version, _num_segments_per_rowset, tablet->tablet_schema());
             auto st = tablet->add_rowset(rowset, false);
             CHECK(st.ok()) << st.to_string();
 
-            for (int i = 0; i < num_segments; i++) {
-                auto segment = create_dummy_segment(_fs, _fname);
+            for (int i = 0; i < _num_segments_per_rowset; i++) {
+                auto segment = create_dummy_segment(_fs, _fname, i);
                 rowset->segments().push_back(segment);
             }
-
             rowsets.push_back(rowset);
         }
 
         return rowsets;
     }
 
-    int32_t _plan_node_id;
-    int64_t _degree_of_parallelism;
-    int64_t _splitted_scan_rows;
+    static constexpr int32_t _plan_node_id = 1;
+    static constexpr int64_t _degree_of_parallelism = 4;
+    static constexpr int64_t _splitted_scan_rows = 1000;
+    static constexpr int _segment_rows = 102400;
+    static constexpr size_t _num_tablets = 3;
+    static constexpr size_t _num_rowsets_per_tablet = 4;
+    static constexpr size_t _num_segments_per_rowset = 5;
+
     std::vector<TabletSharedPtr> _tablets;
 
     static constexpr const char* TEST_DIR = "/morsel_queue_test";
     std::shared_ptr<FileSystem> _fs;
     std::string _fname;
     std::shared_ptr<TabletSchema> _dummy_segment_schema;
-    static const int _segment_rows = 102400;
+    UniqueRowsetIdGenerator _rowset_id_generator{UniqueId(0, 1)};
 };
 
 // Integration test: Test the complete workflow of PhysicalSplitMorselQueueV2
@@ -154,45 +154,91 @@ TEST_F(PhysicalSplitMorselQueueV2Test, IntegratedWorkflowTest) {
     // 2. Create real tablets and rowsets
     std::vector<BaseTabletSharedPtr> tablets;
     std::vector<std::vector<BaseRowsetSharedPtr>> tablet_rowsets;
-
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < _num_tablets; ++i) {
         auto tablet = create_real_tablet(i + 1);
         tablets.push_back(tablet);
 
-        auto rowsets = create_real_rowsets(tablet, 2);
+        auto rowsets = create_real_rowsets(tablet, _num_rowsets_per_tablet);
         tablet_rowsets.push_back(rowsets);
     }
-
     queue.set_tablets(tablets);
     queue.set_tablet_rowsets(tablet_rowsets);
-
-    // 3. Set key ranges using TabletReaderParams
-    // std::vector<OlapTuple> range_start_key;
-    // std::vector<OlapTuple> range_end_key;
-    // queue.set_key_ranges(TabletReaderParams::RangeStartOperation::GT, TabletReaderParams::RangeEndOperation::LT,
-    //                      range_start_key, range_end_key);
-
-    // 4. Test queue operations
     EXPECT_FALSE(queue.empty());
-    auto result = queue.try_get();
-    EXPECT_TRUE(result.ok());
-    EXPECT_TRUE(result.value() != nullptr);
-    MorselPtr morsel = std::move(result.value());
-    PhysicalSplitScanMorsel* physical_morsel = dynamic_cast<PhysicalSplitScanMorsel*>(morsel.get());
-    EXPECT_TRUE(physical_morsel != nullptr);
-    RowidRangeOptionPtr range = physical_morsel->get_rowid_range_option();
-    auto [range_rowset, range_segment, range_split] = range->get_single_segment().value();
 
-    // 6. Test refine_scan_ranges method
-    auto rowid_range = std::make_shared<RowidRangeOption>();
-    rowid_range->add(range_rowset, range_segment, std::make_shared<SparseRange<>>(0, 1000), true);
-    queue.refine_scan_ranges(rowid_range);
+    // Test1: get all morsels without refinement
+    std::set<uint64_t> segments;
+    std::vector<std::tuple<RowsetId, uint64_t, bool>> rowid_ranges;
+    for (int i = 0; i < _num_tablets * _num_rowsets_per_tablet * _num_segments_per_rowset; i++) {
+        auto result = queue.try_get();
+        EXPECT_TRUE(result.ok());
+        EXPECT_TRUE(result.value() != nullptr);
+        MorselPtr morsel = std::move(result.value());
+        PhysicalSplitScanMorsel* physical_morsel = dynamic_cast<PhysicalSplitScanMorsel*>(morsel.get());
+        EXPECT_TRUE(physical_morsel != nullptr);
+        RowidRangeOptionPtr range = physical_morsel->get_rowid_range_option();
+        auto [range_rowset, range_segment, range_split] = range->get_single_segment().value();
 
-    // 7. Test multiple try_get calls
-    for (int i = 0; i < 5; ++i) {
-        auto morsel_result = queue.try_get();
-        EXPECT_TRUE(morsel_result.ok());
-        EXPECT_TRUE(morsel_result.value() != nullptr);
+        rowid_ranges.emplace_back(range_rowset, range_segment, range_split.is_first_split_of_segment);
+
+        segments.emplace(range_segment);
+        EXPECT_TRUE(range_split.is_first_split_of_segment);
+        EXPECT_EQ(range_split.row_id_range->span_size(), _splitted_scan_rows);
+    }
+    for (uint64_t i = 0; i < _num_segments_per_rowset; i++) {
+        EXPECT_TRUE(segments.contains(i));
+    }
+
+    // Test2: refine the morsel
+    for (int i = 0; i < rowid_ranges.size(); i++) {
+        SparseRange<> sum_range;
+        sum_range.add(Range<>{0, _segment_rows});
+
+        // Filter the first half of rows in a segment
+        auto rowid_range = std::make_shared<RowidRangeOption>();
+        auto [rowset, segment, split] = rowid_ranges[i];
+        size_t refined_rows = _segment_rows / 2;
+        auto range = std::make_shared<SparseRange<>>(0, refined_rows);
+        rowid_range->add(rowset, segment, range, split);
+        queue.refine_scan_ranges(rowid_range);
+        sum_range -= *range;
+
+        // after refinement, we should be able to get the refined morsel
+        auto refined_segment = queue.try_get();
+        ASSERT_TRUE(refined_segment.ok());
+        ASSERT_TRUE(refined_segment.value() != nullptr);
+        PhysicalSplitScanMorsel* refined_physical_morsel =
+                dynamic_cast<PhysicalSplitScanMorsel*>(refined_segment.value().get());
+        ASSERT_TRUE(refined_physical_morsel != nullptr);
+        RowidRangeOptionPtr refined_range = refined_physical_morsel->get_rowid_range_option();
+        auto [rowset1, segment1, refined_split] = refined_range->get_single_segment().value();
+        ASSERT_FALSE(refined_split.is_first_split_of_segment);
+        ASSERT_EQ(refined_split.row_id_range->span_size(), _splitted_scan_rows);
+        ASSERT_EQ(refined_rows, refined_split.row_id_range->begin());
+
+        int64_t remain_rows = _segment_rows - _splitted_scan_rows - refined_rows;
+        for (int j = 0; j < remain_rows / _splitted_scan_rows; j++) {
+            auto refined_segment2 = queue.try_get();
+            ASSERT_TRUE(refined_segment2.ok());
+            ASSERT_TRUE(refined_segment2.value() != nullptr);
+            PhysicalSplitScanMorsel* refined_physical_morsel =
+                    dynamic_cast<PhysicalSplitScanMorsel*>(refined_segment2.value().get());
+            ASSERT_TRUE(refined_physical_morsel != nullptr);
+            RowidRangeOptionPtr refined_range = refined_physical_morsel->get_rowid_range_option();
+            auto [rowset2, segment2, refined_split] = refined_range->get_single_segment().value();
+            ASSERT_EQ(rowset1, rowset2);
+            ASSERT_EQ(segment1, segment2);
+            ASSERT_FALSE(refined_split.is_first_split_of_segment);
+            ASSERT_GE(refined_split.row_id_range->span_size(), _splitted_scan_rows);
+            ASSERT_EQ(refined_split.row_id_range->begin(), refined_rows + (j + 1) * _splitted_scan_rows);
+            sum_range |= *refined_split.row_id_range;
+        }
+
+        ASSERT_EQ(_segment_rows - refined_rows, sum_range.span_size());
+    }
+
+    while (!queue.empty()) {
+        auto x = queue.try_get();
+        EXPECT_OK(x.status());
     }
 }
 

--- a/be/test/exec/pipeline/morsel_queue_test.cpp
+++ b/be/test/exec/pipeline/morsel_queue_test.cpp
@@ -1,0 +1,199 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <utility>
+
+#include "exec/pipeline/scan/morsel.h"
+#include "fs/fs_memory.h"
+#include "gtest/gtest.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/rowid_range_option.h"
+#include "storage/rowset/rowset.h"
+#include "storage/rowset/rowset_meta.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet.h"
+#include "storage/tablet_meta.h"
+#include "storage/tablet_reader_params.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+
+namespace starrocks::pipeline {
+
+class PhysicalSplitMorselQueueV2Test : public ::testing::Test {
+public:
+    void SetUp() override {
+        // Initialize test data
+        _plan_node_id = 1;
+        _degree_of_parallelism = 4;
+        _splitted_scan_rows = 1000;
+
+        _fs = std::make_shared<MemoryFileSystem>();
+        ASSERT_TRUE(_fs->create_dir(std::string(TEST_DIR)).ok());
+
+        _fname = std::string(TEST_DIR) + "/test_flat_json_compact1.data";
+    }
+
+    void TearDown() override {}
+
+protected:
+    Morsels create_mock_morsels(int count) {
+        Morsels morsels;
+        for (int i = 0; i < count; ++i) {
+            TScanRange scan_range;
+            scan_range.__isset.internal_scan_range = true;
+            scan_range.internal_scan_range.tablet_id = i + 1;
+            scan_range.internal_scan_range.version = "1";
+            scan_range.internal_scan_range.partition_id = i + 1;
+
+            auto morsel = std::make_unique<ScanMorsel>(_plan_node_id, scan_range);
+            morsels.push_back(std::move(morsel));
+        }
+        return morsels;
+    }
+
+    // Create real tablet objects with minimal required fields
+    TabletSharedPtr create_real_tablet(int64_t tablet_id) {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(::starrocks::KeysType::DUP_KEYS);
+        schema_pb.add_column()->set_unique_id(1);
+
+        auto schema = TabletSchema::create(schema_pb);
+        auto meta = TabletMeta::create();
+        meta->set_tablet_id(tablet_id);
+        meta->set_tablet_schema(schema);
+        return Tablet::create_tablet_from_meta(meta);
+    }
+
+    class MockRowset : public Rowset {
+    public:
+        MockRowset(RowsetId rowset_id, Version version, const TabletSchemaCSPtr& tablet_schema,
+                   RowsetMetaSharedPtr meta)
+                : Rowset(tablet_schema, "", std::move(meta)) {}
+
+        static RowsetSharedPtr create(RowsetId rowset_id, Version version, int num_segments,
+                                      const TabletSchemaCSPtr& tablet_schema) {
+            RowsetMetaPB meta;
+            meta.set_rowset_id(rowset_id.to_string());
+            meta.set_start_version(version.first);
+            meta.set_end_version(version.second);
+            meta.set_num_segments(num_segments);
+            auto rowset =
+                    std::make_shared<MockRowset>(rowset_id, version, tablet_schema, std::make_shared<RowsetMeta>(meta));
+            return rowset;
+        }
+
+        Status load() override { return {}; }
+
+    private:
+    };
+
+    SegmentSharedPtr create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
+        auto res = std::make_shared<Segment>(fs, FileInfo{fname}, 1, _dummy_segment_schema, nullptr);
+        res->set_num_rows(_segment_rows);
+        return res;
+    }
+
+    std::vector<BaseRowsetSharedPtr> create_real_rowsets(const TabletSharedPtr& tablet, int num_rowsets) {
+        std::vector<BaseRowsetSharedPtr> rowsets;
+
+        for (int i = 0; i < num_rowsets; ++i) {
+            const int num_segments = 3;
+            RowsetId rowset_id;
+            rowset_id.init(10000 + i);
+            Version version(i + 1, i + 1);
+
+            auto rowset = MockRowset::create(rowset_id, version, num_segments, tablet->tablet_schema());
+            auto st = tablet->add_rowset(rowset, false);
+            CHECK(st.ok()) << st.to_string();
+
+            for (int i = 0; i < num_segments; i++) {
+                auto segment = create_dummy_segment(_fs, _fname);
+                rowset->segments().push_back(segment);
+            }
+
+            rowsets.push_back(rowset);
+        }
+
+        return rowsets;
+    }
+
+    int32_t _plan_node_id;
+    int64_t _degree_of_parallelism;
+    int64_t _splitted_scan_rows;
+    std::vector<TabletSharedPtr> _tablets;
+
+    static constexpr const char* TEST_DIR = "/morsel_queue_test";
+    std::shared_ptr<FileSystem> _fs;
+    std::string _fname;
+    std::shared_ptr<TabletSchema> _dummy_segment_schema;
+    static const int _segment_rows = 102400;
+};
+
+// Integration test: Test the complete workflow of PhysicalSplitMorselQueueV2
+TEST_F(PhysicalSplitMorselQueueV2Test, IntegratedWorkflowTest) {
+    // 1. Create queue
+    auto morsels = create_mock_morsels(3);
+    PhysicalSplitMorselQueueV2 queue(std::move(morsels), _degree_of_parallelism, _splitted_scan_rows);
+
+    // Verify initial state
+    EXPECT_EQ(queue.max_degree_of_parallelism(), _degree_of_parallelism);
+    EXPECT_EQ(queue.type(), MorselQueue::PHYSICAL_SPLIT);
+    EXPECT_EQ(queue.name(), "physical_split_morsel_queue_v2");
+
+    // 2. Create real tablets and rowsets
+    std::vector<BaseTabletSharedPtr> tablets;
+    std::vector<std::vector<BaseRowsetSharedPtr>> tablet_rowsets;
+
+    for (int i = 0; i < 3; ++i) {
+        auto tablet = create_real_tablet(i + 1);
+        tablets.push_back(tablet);
+
+        auto rowsets = create_real_rowsets(tablet, 2);
+        tablet_rowsets.push_back(rowsets);
+    }
+
+    queue.set_tablets(tablets);
+    queue.set_tablet_rowsets(tablet_rowsets);
+
+    // 3. Set key ranges using TabletReaderParams
+    // std::vector<OlapTuple> range_start_key;
+    // std::vector<OlapTuple> range_end_key;
+    // queue.set_key_ranges(TabletReaderParams::RangeStartOperation::GT, TabletReaderParams::RangeEndOperation::LT,
+    //                      range_start_key, range_end_key);
+
+    // 4. Test queue operations
+    EXPECT_FALSE(queue.empty());
+    auto result = queue.try_get();
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(result.value() != nullptr);
+    MorselPtr morsel = std::move(result.value());
+    PhysicalSplitScanMorsel* physical_morsel = dynamic_cast<PhysicalSplitScanMorsel*>(morsel.get());
+    EXPECT_TRUE(physical_morsel != nullptr);
+    RowidRangeOptionPtr range = physical_morsel->get_rowid_range_option();
+    auto [range_rowset, range_segment, range_split] = range->get_single_segment().value();
+
+    // 6. Test refine_scan_ranges method
+    auto rowid_range = std::make_shared<RowidRangeOption>();
+    rowid_range->add(range_rowset, range_segment, std::make_shared<SparseRange<>>(0, 1000), true);
+    queue.refine_scan_ranges(rowid_range);
+
+    // 7. Test multiple try_get calls
+    for (int i = 0; i < 5; ++i) {
+        auto morsel_result = queue.try_get();
+        EXPECT_TRUE(morsel_result.ok());
+        EXPECT_TRUE(morsel_result.value() != nullptr);
+    }
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/storage/range_test.cpp
+++ b/be/test/storage/range_test.cpp
@@ -204,4 +204,48 @@ TEST(SparseRangeIteratorTest, intersect_test) {
     }
 }
 
+TEST(SparseRangeTest, range_subtraction) {
+    // Basic subtraction: [0, 10) - [3, 7) = [0, 3) + [7, 10)
+    SparseRange<> range1(0, 10);
+    SparseRange<> range2(3, 7);
+    SparseRange<> result = range1 - range2;
+    EXPECT_EQ(result.span_size(), 6);
+    EXPECT_EQ(result.to_string(), "([0,3), [7,10))");
+
+    // No intersection: [0, 5) - [10, 15) = [0, 5)
+    SparseRange<> range3(0, 5);
+    SparseRange<> range4(10, 15);
+    SparseRange<> result2 = range3 - range4;
+    EXPECT_EQ(result2.to_string(), "([0,5))");
+
+    // Complete overlap: [0, 10) - [0, 10) = empty
+    SparseRange<> range5(0, 10);
+    SparseRange<> range6(0, 10);
+    SparseRange<> result3 = range5 - range6;
+    EXPECT_TRUE(result3.empty());
+
+    // Operator -=
+    SparseRange<> range7(0, 10);
+    range7 -= SparseRange<>(3, 7);
+    EXPECT_EQ(range7.to_string(), "([0,3), [7,10))");
+}
+
+TEST(SparseRangeTest, range_complement) {
+    // Complement within bounds
+    SparseRange<> range(5, 15);
+    SparseRange<> complement = range.complement(0, 20);
+    EXPECT_EQ(complement.to_string(), "([0,5), [15,20))");
+
+    SparseRange<> range2(5, 15);
+    range2 -= SparseRange<>(3, 7);
+    EXPECT_EQ(range2.to_string(), "([7,15))");
+    SparseRange<> complement2 = range2.complement(0, 20);
+    EXPECT_EQ(complement2.to_string(), "([0,7), [15,20))");
+
+    // Empty range complement
+    SparseRange<> empty;
+    SparseRange<> empty_complement = empty.complement(0, 10);
+    EXPECT_EQ(empty_complement.to_string(), "([0,10))");
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `PhysicalSplitMorselQueueV2` with segment-level refinement wired into OLAP scan, adding rowid/range utilities and tests.
> 
> - **Execution/Pipeline**:
>   - Add `PHYSICAL_SPLIT_V2` via new `pipeline::PhysicalSplitMorselQueueV2` with Init/Refined segment queues, per-segment splitting, and dynamic refinement (`refine_scan_ranges`).
>   - Integrate into `OlapScanNode` to select V2 when `config::tabelt_internal_parallel_v2` is true; fall back to existing queues otherwise.
>   - `ScanOperator` triggers queue refinement after a morsel completes; `ChunkSource` exposes `get_morsel()`.
>   - Extend `PhysicalSplitScanMorsel` to carry `filtered_scan_range`.
> - **Storage/Reader**:
>   - `RowidRangeOption`: new overloads (`add(rowset_id,segment_id,...)`), `empty()`, `get_single_segment()`, `clone()`, `to_string()`.
>   - Plumb `filtered_scan_range` through `TabletReaderParams` → `RowsetReadOptions` → `SegmentReadOptions`; `SegmentIterator` supports initial refine path and updates filtered ranges.
>   - `SparseRange`: add `complement`, subtraction operators, and iterator `seek`.
> - **Misc**:
>   - New config `tabelt_internal_parallel_v2` (V1/V2 switch).
>   - Minor includes and access adjustments (`Rowset` fields protection).
> - **Tests**:
>   - Add `exec/pipeline/morsel_queue_test.cpp` for V2 flow.
>   - Extend `storage/range_test.cpp` for subtraction/complement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f0ef28e6ab1e229e5e1a61439bd83463ad7d887. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->