### PR TITLE
[BugFix] Fix incompatible bitmap index reuse for fast schema evolution in shared-data 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -914,7 +914,7 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         if (!SchemaChangeTypeCompatibility.canReuseZonemapIndex(oriColumn.getType(), modColumn.getType())) {
-            fastSchemaEvolution = false;
+            return false;
         }
 
         // Check whether manually created indexes support fast schema evolution. The rules are as follows:
@@ -928,8 +928,7 @@ public class SchemaChangeHandler extends AlterHandler {
         for (Index index : existedIndexes) {
             if (index.getColumns().contains(oriColumn.getColumnId())) {
                 if (index.getIndexType() != IndexDef.IndexType.NGRAMBF) {
-                    fastSchemaEvolution = false;
-                    break;
+                    return false;
                 }
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -521,4 +521,36 @@ public class LakeTableAsyncFastSchemaChangeJobTest extends StarRocksTestBase {
         createAggTableForAddKeyColumnTest(tableName);
         testAddKeyColumnWithoutFastSchemaEvolutionBase(tableName);
     }
+
+    @Test
+    public void testModifyColumnTypeWithManuallyCreatedIndex() throws Exception {
+        LakeTable table = createTable(connectContext,
+                """
+                CREATE TABLE t_modify_index_type (
+                    c0 INT,
+                    c1 INT,
+                    c2 INT,
+                    INDEX idx1 (c1) USING BITMAP
+                )
+                DUPLICATE KEY(c0)
+                DISTRIBUTED BY HASH(c0) BUCKETS 1
+                PROPERTIES(
+                    'fast_schema_evolution'='true',
+                    'bloom_filter_columns' = 'c2'
+                )
+                """
+            );
+
+        // bitmap index can not use fast schema evolution
+        {
+            String alterSql = "ALTER TABLE t_modify_index_type MODIFY COLUMN c1 BIGINT";
+            executeAlterAndWaitFinish(table, alterSql, false);
+        }
+
+        // bloomfilter index can use fast schema evolution
+        {
+            String alterSql = "ALTER TABLE t_modify_index_type MODIFY COLUMN c2 BIGINT";
+            executeAlterAndWaitFinish(table, alterSql, true);
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
Fast schema evolution in shared-data modifies a column's type without rewriting data files, and the existing bitmap index is reused for the new type. However, this reuse is not universally applicable because some type conversions alter critical semantics, such as orderliness. For type conversions where the index can be reused, the backend (BE) must perform explicit type casting before querying the index. The current fast schema evolution mechanism does not consider these requirements. This leads to incorrect query results, where data may be erroneously filtered or not filtered. This issue can be reproduced with the following steps:

```
create table t (
    c0 int,
    int_to_bigint int,
    date_to_datetime date,
    int_to_string int,
    index idx1 (int_to_bigint) using bitmap,
    index idx2 (date_to_datetime) using bitmap,
    index idx3 (int_to_string) using bitmap
)
duplicate key(c0)
distributed by hash(c0) buckets 1;

-- disable zonemap index filter to eliminate interference
update information_schema.be_configs set value=false where name='enable_index_page_level_zonemap_filter';
update information_schema.be_configs set value=false where name='enable_index_segment_level_zonemap_filter';

insert into t values (1, -1, '2025-09-12', 5);
insert into t values (2, -2147483648, '2025-09-13', 6);

alter table t modify column int_to_bigint bigint,
    modify column date_to_datetime datetime,
    modify column int_to_string string;

select * from t where int_to_bigint = 21474836479;    -- expect empty. wrong
    - BitmapIndexFilterRows: 1
+------+---------------+---------------------+---------------+
| c0   | int_to_bigint | date_to_datetime    | int_to_string |
+------+---------------+---------------------+---------------+
|    1 |            -1 | 2025-09-12 00:00:00 | 5             |
+------+---------------+---------------------+---------------+


select * from t where date_to_datetime = '2025-09-12 00:00:00';    -- expect one row. wrong
Empty set (0.04 sec)
   - BitmapIndexFilterRows: 2

select * from t where int_to_string = "5";    -- expect one row. wrong
Empty set (0.03 sec)
   - BitmapIndexFilterRows: 2
```

This PR wants to fix the issue.

## What I'm doing:

The issue has existed since version 3.3. Therefore, the fix needs to be backported to earlier versions. To minimize the impact of significant changes on older versions, propose a two-step approach:

1. **Forbid fast schema evolution if a bitmap index is present**: This immediate solution will be applied to older versions. It prevents the incorrect behavior by disabling fast schema evolution in scenarios where bitmap index reuse could lead to errors.
2. **Allow fast schema evolution for specific type conversions**: This step will be implemented in later versions only and will not be backported. It will enable fast schema evolution for certain type conversions once the backend (BE) is fully prepared to handle the associated semantic changes and ensure correct index querying.

This PR implements Step 1, which forbids fast schema evolution when a bitmap index is involved, and will be backported to older versions.

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.0
  - [X] 3.5
  - [X] 3.4
  - [X] 3.3
