### PR TITLE
[Feature]  insert into files csv compression support

### DIFF
--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(Formats STATIC
         csv/array_converter.cpp
         csv/array_reader.cpp
         csv/boolean_converter.cpp
+        csv/compressed_output_stream_file.cpp
         csv/converter.cpp
         csv/csv_reader.cpp
         csv/csv_file_writer.cpp

--- a/be/src/formats/csv/compressed_output_stream_file.cpp
+++ b/be/src/formats/csv/compressed_output_stream_file.cpp
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "compressed_output_stream_file.h"
+
+#include <zlib.h>
+
+#include "gutil/strings/substitute.h"
+
+namespace starrocks::csv {
+
+CompressedAsyncOutputStreamFile::CompressedAsyncOutputStreamFile(io::AsyncFlushOutputStream* stream,
+                                                                 TCompressionType::type compression_type,
+                                                                 size_t buff_size)
+        : OutputStream(buff_size), _stream(stream), _compression_type(compression_type) {}
+
+Status CompressedAsyncOutputStreamFile::finalize() {
+    RETURN_IF_ERROR(OutputStream::finalize());
+    return _stream->close();
+}
+
+Status CompressedAsyncOutputStreamFile::_sync(const char* data, size_t size) {
+    if (_compression_type == TCompressionType::NO_COMPRESSION) {
+        auto p = reinterpret_cast<const uint8_t*>(data);
+        return _stream->write(p, size);
+    }
+
+    switch (_compression_type) {
+    case TCompressionType::GZIP:
+        return _compress_gzip(data, size);
+    default:
+        return Status::NotSupported(strings::Substitute("Compression type $0 is not supported for CSV format",
+                                                       static_cast<int>(_compression_type)));
+    }
+}
+
+Status CompressedAsyncOutputStreamFile::_compress_gzip(const char* data, size_t size) {
+    z_stream zstrm = {};
+    zstrm.zalloc = Z_NULL;
+    zstrm.zfree = Z_NULL;
+    zstrm.opaque = Z_NULL;
+
+    // Use gzip format (MAX_WBITS + 16) for standard compatibility
+    int ret = deflateInit2(&zstrm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
+    if (ret != Z_OK) {
+        return Status::InternalError(strings::Substitute("deflateInit2 failed: $0", zError(ret)));
+    }
+
+    // Estimate compressed size and reserve buffer
+    size_t max_size = deflateBound(&zstrm, size) + 32; // Extra space for gzip header/trailer
+    _compressed_buffer.resize(max_size);
+
+    zstrm.next_in = reinterpret_cast<Bytef*>(const_cast<char*>(data));
+    zstrm.avail_in = size;
+    zstrm.next_out = reinterpret_cast<Bytef*>(_compressed_buffer.data());
+    zstrm.avail_out = max_size;
+
+    // Compress entire block at once
+    ret = deflate(&zstrm, Z_FINISH);
+    if (ret != Z_STREAM_END) {
+        deflateEnd(&zstrm);
+        return Status::InternalError(strings::Substitute("deflate failed: $0", zError(ret)));
+    }
+
+    size_t compressed_size = max_size - zstrm.avail_out;
+    deflateEnd(&zstrm);
+
+    // Write compressed block to stream
+    return _stream->write(_compressed_buffer.data(), compressed_size);
+}
+
+} // namespace starrocks::csv

--- a/be/src/formats/csv/compressed_output_stream_file.cpp
+++ b/be/src/formats/csv/compressed_output_stream_file.cpp
@@ -41,7 +41,7 @@ Status CompressedAsyncOutputStreamFile::_sync(const char* data, size_t size) {
         return _compress_gzip(data, size);
     default:
         return Status::NotSupported(strings::Substitute("Compression type $0 is not supported for CSV format",
-                                                       static_cast<int>(_compression_type)));
+                                                        static_cast<int>(_compression_type)));
     }
 }
 

--- a/be/src/formats/csv/compressed_output_stream_file.cpp
+++ b/be/src/formats/csv/compressed_output_stream_file.cpp
@@ -23,12 +23,7 @@ namespace starrocks::csv {
 CompressedAsyncOutputStreamFile::CompressedAsyncOutputStreamFile(io::AsyncFlushOutputStream* stream,
                                                                  TCompressionType::type compression_type,
                                                                  size_t buff_size)
-        : OutputStream(buff_size), _stream(stream), _compression_type(compression_type) {}
-
-Status CompressedAsyncOutputStreamFile::finalize() {
-    RETURN_IF_ERROR(OutputStream::finalize());
-    return _stream->close();
-}
+        : AsyncOutputStreamFile(stream, buff_size), _compression_type(compression_type) {}
 
 Status CompressedAsyncOutputStreamFile::_sync(const char* data, size_t size) {
     if (_compression_type == TCompressionType::NO_COMPRESSION) {

--- a/be/src/formats/csv/compressed_output_stream_file.h
+++ b/be/src/formats/csv/compressed_output_stream_file.h
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "common/status.h"
+#include "formats/csv/output_stream.h"
+#include "gen_cpp/Types_types.h"
+#include "io/async_flush_output_stream.h"
+#include "util/raw_container.h"
+
+namespace starrocks::csv {
+
+class CompressedAsyncOutputStreamFile final : public OutputStream {
+public:
+    CompressedAsyncOutputStreamFile(io::AsyncFlushOutputStream* stream, TCompressionType::type compression_type,
+                                    size_t buff_size);
+
+    ~CompressedAsyncOutputStreamFile() override = default;
+
+    Status finalize() override;
+
+    std::size_t size() override { return _stream->tell(); }
+
+protected:
+    Status _sync(const char* data, size_t size) override;
+
+private:
+    Status _compress_gzip(const char* data, size_t size);
+
+    io::AsyncFlushOutputStream* _stream;
+    TCompressionType::type _compression_type;
+    raw::RawVector<uint8_t> _compressed_buffer;
+};
+
+} // namespace starrocks::csv

--- a/be/src/formats/csv/compressed_output_stream_file.h
+++ b/be/src/formats/csv/compressed_output_stream_file.h
@@ -17,23 +17,18 @@
 #include <memory>
 
 #include "common/status.h"
-#include "formats/csv/output_stream.h"
+#include "formats/csv/output_stream_file.h"
 #include "gen_cpp/Types_types.h"
-#include "io/async_flush_output_stream.h"
 #include "util/raw_container.h"
 
 namespace starrocks::csv {
 
-class CompressedAsyncOutputStreamFile final : public OutputStream {
+class CompressedAsyncOutputStreamFile final : public AsyncOutputStreamFile {
 public:
     CompressedAsyncOutputStreamFile(io::AsyncFlushOutputStream* stream, TCompressionType::type compression_type,
                                     size_t buff_size);
 
     ~CompressedAsyncOutputStreamFile() override = default;
-
-    Status finalize() override;
-
-    std::size_t size() override { return _stream->tell(); }
 
 protected:
     Status _sync(const char* data, size_t size) override;
@@ -41,7 +36,6 @@ protected:
 private:
     Status _compress_gzip(const char* data, size_t size);
 
-    io::AsyncFlushOutputStream* _stream;
     TCompressionType::type _compression_type;
     raw::RawVector<uint8_t> _compressed_buffer;
 };

--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -41,7 +41,6 @@ CSVFileWriter::CSVFileWriter(std::string location, std::shared_ptr<csv::OutputSt
 CSVFileWriter::~CSVFileWriter() = default;
 
 Status CSVFileWriter::init() {
-
     RETURN_IF_ERROR(ColumnEvaluator::init(_column_evaluators));
     _column_converters.reserve(_types.size());
     for (auto& type : _types) {
@@ -162,18 +161,18 @@ StatusOr<WriterAndStream> CSVFileWriterFactory::create(const std::string& path) 
     // Create appropriate output stream based on compression type
     std::shared_ptr<csv::OutputStream> csv_output_stream;
     if (_compression_type == TCompressionType::GZIP) {
-        csv_output_stream = std::make_shared<csv::CompressedAsyncOutputStreamFile>(
-                async_output_stream.get(), _compression_type, 1024 * 1024);
+        csv_output_stream = std::make_shared<csv::CompressedAsyncOutputStreamFile>(async_output_stream.get(),
+                                                                                   _compression_type, 1024 * 1024);
     } else if (_compression_type == TCompressionType::NO_COMPRESSION) {
         csv_output_stream = std::make_shared<csv::AsyncOutputStreamFile>(async_output_stream.get(), 1024 * 1024);
     } else {
         return Status::NotSupported(fmt::format("Compression type {} is not supported for CSV format",
-                                               static_cast<int>(_compression_type)));
+                                                static_cast<int>(_compression_type)));
     }
 
-    auto writer =
-            std::make_unique<CSVFileWriter>(final_path, csv_output_stream, _column_names, types, std::move(column_evaluators),
-                                            _compression_type, _parsed_options, rollback_action);
+    auto writer = std::make_unique<CSVFileWriter>(final_path, csv_output_stream, _column_names, types,
+                                                  std::move(column_evaluators), _compression_type, _parsed_options,
+                                                  rollback_action);
     return WriterAndStream{
             .writer = std::move(writer),
             .stream = std::move(async_output_stream),

--- a/be/src/formats/csv/output_stream_file.h
+++ b/be/src/formats/csv/output_stream_file.h
@@ -41,7 +41,7 @@ private:
     std::unique_ptr<WritableFile> _file;
 };
 
-class AsyncOutputStreamFile final : public OutputStream {
+class AsyncOutputStreamFile : public OutputStream {
 public:
     AsyncOutputStreamFile(io::AsyncFlushOutputStream* stream, size_t buff_size)
             : OutputStream(buff_size), _stream(stream) {}
@@ -59,7 +59,6 @@ protected:
         return _stream->write(p, size);
     }
 
-private:
     io::AsyncFlushOutputStream* _stream;
 };
 


### PR DESCRIPTION
## Why I'm doing:
Insert into files in csv format does not support compression

## What I'm doing:
Add CompressedAsyncOutputStreamFile for gzip

export with query execution
Uncompressed 10265078 rows 20.84 sec sec 901_720_235 bytes
Gzip 10265078 rows  33.32 sec 136_100_022 bytes

create table as select and then export
uncompressed 15.42 sec
gzip 24.93 sec file size 88_157_848 perhaps due to sorted input improvements

Fixes #63328

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add gzip compression support for CSV file export with a compressed async output stream and automatic .gz filenames.
> 
> - **CSV export compression**
>   - Implement `csv/CompressedAsyncOutputStreamFile` using zlib to write GZIP-compressed output; inherits from `csv::AsyncOutputStreamFile`.
>   - Allow compression in `CSVFileWriter` (remove prohibition) and route writes through the appropriate stream based on `TCompressionType`.
>   - In `CSVFileWriterFactory::create`:
>     - Append `.gz` to output `path` for `GZIP`.
>     - Select `CompressedAsyncOutputStreamFile` for `GZIP` or `AsyncOutputStreamFile` for `NO_COMPRESSION`; return `NotSupported` for others.
>     - Adjust rollback to delete the final `path`.
> - **Infrastructure**
>   - Make `csv::AsyncOutputStreamFile` non-final and accessible for subclassing; add new source to `formats/CMakeLists.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab296a60e947214338dabd7d5e66c7501b160475. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->