### PR TITLE
[Enhancement] Pass stream load label directly to TransactionStmtExecutor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
@@ -156,8 +156,18 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
     }
 
     public void beginTxn(TransactionResult resp) {
+        // Ensure a non-empty label is generated in TransactionStmtExecutor.beginStmt
+        // by providing a valid executionId. Use the pre-generated loadId as executionId.
+        if (context.getExecutionId() == null) {
+            context.setExecutionId(loadId);
+        }
+        // Also propagate compute resource so the txn carries the same resource context.
+        if (context.getCurrentComputeResource() == null) {
+            context.setCurrentComputeResource(computeResource);
+        }
+
         TransactionStmtExecutor.beginStmt(context, new BeginStmt(NodePosition.ZERO),
-                TransactionState.LoadJobSourceType.MULTI_STATEMENT_STREAMING);
+                TransactionState.LoadJobSourceType.MULTI_STATEMENT_STREAMING, label);
         this.txnId = context.getTxnId();
         LOG.info("start transaction id {}", txnId);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -84,28 +84,44 @@ public class TransactionStmtExecutor {
         beginStmt(context, stmt, TransactionState.LoadJobSourceType.INSERT_STREAMING);
     }
 
-    public static void beginStmt(ConnectContext context, BeginStmt stmt, TransactionState.LoadJobSourceType sourceType) {
+    public static void beginStmt(ConnectContext context, BeginStmt stmt,
+                                 TransactionState.LoadJobSourceType sourceType) {
+        beginStmt(context, stmt, sourceType, null);
+    }
+
+    // Overload allowing explicit label override for creating the transaction state.
+    // If labelOverride is null or empty, it falls back to the default label built from executionId.
+    public static void beginStmt(ConnectContext context, BeginStmt stmt,
+                                 TransactionState.LoadJobSourceType sourceType,
+                                 String labelOverride) {
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
         if (context.getTxnId() != 0) {
-            //Repeated begin does not create a new transaction
+            // Repeated begin does not create a new transaction
             ExplicitTxnState explicitTxnState = globalTransactionMgr.getExplicitTxnState(context.getTxnId());
             String label = explicitTxnState.getTransactionState().getLabel();
             long transactionId = explicitTxnState.getTransactionState().getTransactionId();
-            context.getState().setOk(0, 0, buildMessage(label, TransactionStatus.PREPARE, transactionId, -1));
+            context.getState().setOk(0, 0,
+                    buildMessage(label, TransactionStatus.PREPARE, transactionId, -1));
             return;
         }
 
         long transactionId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
                 .getTransactionIDGenerator().getNextTransactionId();
-        String label = DebugUtil.printId(context.getExecutionId());
-        TransactionState transactionState = new TransactionState(transactionId, label, null,
+        String label = (labelOverride != null && !labelOverride.isEmpty())
+                ? labelOverride
+                : DebugUtil.printId(context.getExecutionId());
+        TransactionState transactionState = new TransactionState(
+                transactionId,
+                label,
+                null,
                 sourceType,
-                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, FrontendOptions.getLocalHostAddress()),
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE,
+                        FrontendOptions.getLocalHostAddress()),
                 context.getExecTimeout() * 1000L);
 
         transactionState.setPrepareTime(System.currentTimeMillis());
         transactionState.setComputeResource(context.getCurrentComputeResource());
-        boolean combinedTxnLog = LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.INSERT_STREAMING);
+        boolean combinedTxnLog = LakeTableHelper.supportCombinedTxnLog(sourceType);
         transactionState.setUseCombinedTxnLog(combinedTxnLog);
 
         ExplicitTxnState explicitTxnState = new ExplicitTxnState();
@@ -113,7 +129,8 @@ public class TransactionStmtExecutor {
         globalTransactionMgr.addTransactionState(transactionId, explicitTxnState);
 
         context.setTxnId(transactionId);
-        context.getState().setOk(0, 0, buildMessage(label, TransactionStatus.PREPARE, transactionId, -1));
+        context.getState().setOk(0, 0,
+                buildMessage(label, TransactionStatus.PREPARE, transactionId, -1));
     }
 
     public static void loadData(Database database,


### PR DESCRIPTION
This commit refactors the stream load process to improve clarity and robustness.

Previously, the transaction label for a multi-statement stream load was indirectly derived from the executionId set in the ConnectContext. This required the TransactionStmtExecutor to have implicit knowledge of how the executionId was constructed.

This change introduces a more direct approach:
1. An overloaded  method is added to that accepts an explicit  string.
2.  now calls this new method, passing its own label directly.
3. The unit test is updated to verify that this explicit label is correctly received and used.

This makes the code easier to understand and maintain by removing the dependency on the executionId for label generation.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
