### PR TITLE
[BugFix] fix delete predicate edge case

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -936,6 +936,9 @@ CONF_mInt64(tablet_internal_parallel_min_scan_dop, "4");
 // Only the num rows of lake tablet less than lake_tablet_rows_splitted_ratio * splitted_scan_rows, than the lake tablet can be splitted.
 CONF_mDouble(lake_tablet_rows_splitted_ratio, "1.5");
 
+// Allow skipping invalid delete_predicate in order to get the segment data back, and do manual correction.
+CONF_mBool(lake_tablet_ignore_invalid_delete_predicate, "false");
+
 // The bitmap serialize version.
 CONF_Int16(bitmap_serialize_version, "1");
 // The max hdfs file handle.

--- a/be/src/storage/conjunctive_predicates.cpp
+++ b/be/src/storage/conjunctive_predicates.cpp
@@ -34,6 +34,9 @@ Status ConjunctivePredicates::evaluate_or(const Chunk* chunk, uint8_t* selection
 
 Status ConjunctivePredicates::evaluate(const Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) const {
     FAIL_POINT_TRIGGER_RETURN_ERROR(random_error);
+    if (empty()) {
+        return Status::OK();
+    }
     DCHECK_LE(to, chunk->num_rows());
     if (!_vec_preds.empty()) {
         const ColumnPredicate* pred = _vec_preds[0];
@@ -50,6 +53,9 @@ Status ConjunctivePredicates::evaluate(const Chunk* chunk, uint8_t* selection, u
 
 Status ConjunctivePredicates::evaluate_or(const Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) const {
     DCHECK_LE(to, chunk->num_rows());
+    if (empty()) {
+        return Status::OK();
+    }
     std::unique_ptr<uint8_t[]> buff(new uint8_t[chunk->num_rows()]);
     RETURN_IF_ERROR(evaluate(chunk, buff.get(), from, to));
     const uint8_t* p = buff.get();

--- a/be/src/storage/delete_predicates.cpp
+++ b/be/src/storage/delete_predicates.cpp
@@ -22,6 +22,9 @@ namespace starrocks {
 
 void DeletePredicates::add(int32_t version, ConjunctivePredicates preds) {
     // fast path.
+    if (preds.empty()) {
+        return;
+    }
     if (_version_predicates.empty() || version > _version_predicates.back()._version) {
         _version_predicates.emplace_back(version, std::move(preds));
         return;

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -455,13 +455,24 @@ Status TabletReader::init_delete_predicates(const TabletReaderParams& params, De
 
         ConjunctivePredicates conjunctions;
         for (const auto& cond : conds) {
-            ASSIGN_OR_RETURN(ColumnPredicate * pred, pred_parser.parse_thrift_cond(cond));
-            conjunctions.add(pred);
+            auto pred_or = pred_parser.parse_thrift_cond(cond);
+            if (!pred_or.ok()) {
+                if (LIKELY(!config::lake_tablet_ignore_invalid_delete_predicate)) {
+                    return pred_or.status();
+                } else {
+                    LOG(WARNING) << "failed to parse delete condition.column_name[" << cond.column_name
+                                 << "], condition_op[" << cond.condition_op << "], condition_values["
+                                 << (cond.condition_values.empty() ? "<empty>" : cond.condition_values[0]) << "].";
+                    continue;
+                }
+            }
+            conjunctions.add(pred_or.value());
             // save for memory release.
-            _predicate_free_list.emplace_back(pred);
+            _predicate_free_list.emplace_back(pred_or.value());
         }
-
-        dels->add(index, conjunctions);
+        if (!conjunctions.empty()) {
+            dels->add(index, conjunctions);
+        }
     }
 
     return Status::OK();

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1612,6 +1612,8 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
     if (chunk_size > 0 && chunk->delete_state() != DEL_NOT_SATISFIED && !_opts.delete_predicates.empty()) {
         SCOPED_RAW_TIMER(&_opts.stats->del_filter_ns);
         size_t old_sz = chunk->num_rows();
+        // NOTE: risk of using _selection.data() without initialization
+        // if the delete_predicates do nothing to the selection.
         RETURN_IF_ERROR(_opts.delete_predicates.evaluate(chunk, _selection.data()));
         size_t deletes = SIMD::count_nonzero(_selection.data(), old_sz);
         if (deletes == old_sz) {

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -457,6 +457,7 @@ SET(DW_TEST_FILES
     ./storage/decimal12_test.cpp
     ./storage/default_compaction_policy_test.cpp
     ./storage/delete_handler_test.cpp
+    ./storage/delete_predicates_test.cpp
     ./storage/delta_column_group_test.cpp
     ./storage/delta_writer_test.cpp
     ./storage/del_vector_test.cpp

--- a/be/test/storage/conjunctive_predicates_test.cpp
+++ b/be/test/storage/conjunctive_predicates_test.cpp
@@ -171,6 +171,42 @@ TEST(ConjunctivePredicatesTest, test_evaluate) {
     }
 }
 
+TEST(ConjunctivePredicatesTest, test_empty_predicates) {
+    SchemaPtr schema(new Schema());
+    auto c0_field = std::make_shared<Field>(0, "c0", TYPE_INT, true);
+    schema->append(c0_field);
+    auto c0 = ChunkHelper::column_from_field(*c0_field);
+
+    // +------+
+    // | c0   |
+    // +------+
+    // | NULL |
+    // |    1 |
+    // |    2 |
+    // |    3 |
+    // +------+
+    c0->append_datum(Datum());
+    c0->append_datum(Datum(1));
+    c0->append_datum(Datum(2));
+    c0->append_datum(Datum(3));
+
+    ChunkPtr chunk = std::make_shared<Chunk>(Columns{std::move(c0)}, schema);
+
+    std::vector<uint8_t> selection = {1, 0, 1, 0};
+    EXPECT_EQ("1,0,1,0", to_string(selection));
+
+    ConjunctivePredicates conjuncts;
+
+    conjuncts.evaluate(chunk.get(), selection.data());
+    EXPECT_EQ("1,0,1,0", to_string(selection));
+
+    conjuncts.evaluate_or(chunk.get(), selection.data());
+    EXPECT_EQ("1,0,1,0", to_string(selection));
+
+    conjuncts.evaluate_and(chunk.get(), selection.data());
+    EXPECT_EQ("1,0,1,0", to_string(selection));
+}
+
 // NOLINTNEXTLINE
 TEST(ConjunctivePredicatesTest, test_evaluate_and) {
     SchemaPtr schema(new Schema());

--- a/be/test/storage/delete_predicates_test.cpp
+++ b/be/test/storage/delete_predicates_test.cpp
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/delete_predicates.h"
+
+#include <gtest/gtest.h>
+
+#include "storage/column_predicate.h"
+#include "storage/conjunctive_predicates.h"
+
+namespace starrocks {
+
+using PredicatePtr = std::unique_ptr<ColumnPredicate>;
+
+TEST(DeletePredicatesTest, test_add_empty_preds) {
+    DeletePredicates delete_predicates;
+    EXPECT_TRUE(delete_predicates.get_predicates(0).empty());
+
+    {
+        ConjunctivePredicates conjuncts;
+        delete_predicates.add(1, conjuncts);
+        // Nothing added
+        EXPECT_TRUE(delete_predicates.get_predicates(0).empty());
+    }
+    {
+        PredicatePtr p0(new_column_null_predicate(get_type_info(TYPE_INT), 0, false));
+        ConjunctivePredicates conjuncts;
+
+        conjuncts.add(p0.get());
+        delete_predicates.add(1, conjuncts);
+
+        auto dis_delete_predicates = delete_predicates.get_predicates(0);
+        auto& conjuncts_arr = dis_delete_predicates.predicate_list();
+        EXPECT_EQ(1U, conjuncts_arr.size());
+        EXPECT_EQ(1U, conjuncts_arr[0].vec_preds().size());
+        EXPECT_EQ(p0.get(), conjuncts_arr[0].vec_preds()[0]);
+    }
+}
+
+} // namespace starrocks

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -2656,6 +2656,15 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Introduced in: -
 -->
 
+##### lake_tablet_ignore_invalid_delete_predicate
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: A boolean value to control whether ignore invalid delete predicates in tablet rowset metadata which may be introduced by logic deletion to a duplicate key table after the column name renamed.
+- Introduced in: v4.0
+
 <!--
 ##### bitmap_serialize_version
 


### PR DESCRIPTION
* Skip adding empty delete predicates to the DeletePredicates collection
* Add early return in ConjunctivePredicates evaluation when no predicates exist
* Introduce configuration option to ignore invalid delete predicates for recovery scenarios

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3