### PR TITLE
[BugFix] explain logical iceberg with eq delete files infinite recursion

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
@@ -46,6 +46,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHudiScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalIcebergEqualityDeleteScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalIntersectOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalJDBCScanOperator;
@@ -244,6 +245,23 @@ public class Explain {
             PhysicalIcebergScanOperator scan = (PhysicalIcebergScanOperator) optExpression.getOp();
 
             StringBuilder sb = new StringBuilder("- ICEBERG-SCAN [")
+                    .append(scan.getTable().getCatalogTableName())
+                    .append("]")
+                    .append(buildOutputColumns(scan,
+                            "[" + scan.getOutputColumns().stream().map(EXPR_PRINTER::print)
+                                    .collect(Collectors.joining(", ")) + "]"))
+                    .append("\n");
+            buildCostEstimate(sb, optExpression, context.step);
+            buildCommonProperty(sb, scan, context.step);
+            return new OperatorStr(sb.toString(), context.step, Collections.emptyList());
+        }
+
+        @Override
+        public OperatorStr visitPhysicalIcebergEqualityDeleteScan(OptExpression optExpression,
+                                                                 OperatorPrinter.ExplainContext context) {
+            PhysicalIcebergEqualityDeleteScanOperator scan = (PhysicalIcebergEqualityDeleteScanOperator) optExpression.getOp();
+
+            StringBuilder sb = new StringBuilder("- ICEBERG-EQUALITY-DELETE-SCAN [")
                     .append(scan.getTable().getCatalogTableName())
                     .append("]")
                     .append(buildOutputColumns(scan,


### PR DESCRIPTION
## Why I'm doing:
explain logical does not work with iceberg with eq deletes
## What I'm doing:
add missing visitPhysicalIcebergEqualityDeleteScan
Fixes #63341
```
mysql> explain logical select count(*) from transactions ;
+---------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                              |
+---------------------------------------------------------------------------------------------------------------------------------------------+
| - Output => [52:count]                                                                                                                      |
|     - AGGREGATE(GLOBAL) []                                                                                                                  |
|             Estimates: {row: 1, cpu: 8.00, memory: 8.00, network: 0.00, cost: 64122472132255.09}                                            |
|             52:count := count(52:count)                                                                                                     |
|         - EXCHANGE(GATHER)                                                                                                                  |
|                 Estimates: {row: 1, cpu: 8.00, memory: 0.00, network: 8.00, cost: 64122472132235.09}                                        |
|             - AGGREGATE(LOCAL) []                                                                                                           |
|                     Estimates: {row: 1, cpu: 84213243.40, memory: 0.80, network: 0.00, cost: 64122472132219.09}                             |
|                     52:count := count()                                                                                                     |
|                 - UNION => [54:auto_fill_col]                                                                                               |
|                         Estimates: {row: 421066217, cpu: 0.00, memory: 0.00, network: 0.00, cost: 64122430025595.80}                        |
|                         54:auto_fill_col := 1                                                                                               |
|                     - EXCHANGE(ROUND_ROBIN)                                                                                                 |
|                             Estimates: {row: 221066217, cpu: 221066217.00, memory: 0.00, network: 221066217.00, cost: 442132434.00}         |
|                         - ICEBERG-SCAN [transactions] => [144:is_instant]                                                                   |
|                                 Estimates: {row: 221066217, cpu: 0.00, memory: 0.00, network: 0.00, cost: 0.00}                             |
|                     - EXCHANGE(ROUND_ROBIN)                                                                                                 |
|                             Estimates: {row: 200000000, cpu: ?, memory: ?, network: ?, cost: 6.41219878931618E13}                           |
|                         - HASH/LEFT ANTI JOIN [55:id = 107:id AND 106:$data_sequence_number < 108:$data_sequence_number] => [90:is_instant] |
|                                 Estimates: {row: 200000000, cpu: ?, memory: ?, network: ?, cost: 6.41215878931618E13}                       |
|                             - ICEBERG-SCAN [transactions] => [90:is_instant, 55:id, 106:$data_sequence_number]                              |
|                                     Estimates: {row: 1000000000, cpu: ?, memory: ?, network: ?, cost: 0.0}                                  |
|                             - EXCHANGE(BROADCAST)                                                                                           |
|                                     Estimates: {row: 1000000000, cpu: ?, memory: ?, network: ?, cost: 6.4E13}                               |
|                                 - ICEBERG-EQUALITY-DELETE-SCAN [transactions] => [107:id, 108:$data_sequence_number]                        |
|                                         Estimates: {row: 1000000000, cpu: ?, memory: ?, network: ?, cost: 0.0}                              |
+---------------------------------------------------------------------------------------------------------------------------------------------+
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3