### PR TITLE
[BugFix] iceberg eq deletes union estimates

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1384,13 +1384,17 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                     estimateColumnStatistic = StatisticsEstimateUtils.unionColumnStatistic(
                             estimateColumnStatistics.get(outputIdx), estimateRowCount,
                             childStatistics.getColumnStatistic(childOutputColumn), childStatistics.getOutputRowCount());
+                    // set new estimate column statistic
+                    estimateColumnStatistics.set(outputIdx, estimateColumnStatistic);
+                    estimateRowCount += childStatistics.getOutputRowCount();
                 } else {
+                    // For Iceberg equality delete rewrite, use only the first child's statistics
+                    // The first child represents the whole table's cardinality (with predicates applied)
+                    // The division between branches is runtime-dependent and doesn't affect overall estimates
                     estimateColumnStatistic = estimateColumnStatistics.get(outputIdx);
+                    estimateColumnStatistics.set(outputIdx, estimateColumnStatistic);
+                    // Don't add child row counts - keep the first child's row count as the union result
                 }
-
-                // set new estimate column statistic
-                estimateColumnStatistics.set(outputIdx, estimateColumnStatistic);
-                estimateRowCount += childStatistics.getOutputRowCount();
             }
             builder.addColumnStatistic(outputColumnRef.get(outputIdx), estimateColumnStatistics.get(outputIdx));
             builder.setOutputRowCount(estimateRowCount);


### PR DESCRIPTION
## Why I'm doing:
Iceberg scan with eq deletes estimate stats are bonkers

## What I'm doing:
Set scan union stats to correct estimate

Fixes #63343
```
explain logical select count(*) from table where credit_id = '01996c8c-4e94-7000-8781-385684fd234d'
|                 - UNION => [34:auto_fill_col]                                                                                                    |
|                         Estimates: {row: 3, cpu: 0.00, memory: 0.00, network: 0.00, cost: 96257006807698.11}                                     |
|                         34:auto_fill_col := 1                                                                                                    |
|                     - EXCHANGE(ROUND_ROBIN)                                                                                                      |
|                             Estimates: {row: 3, cpu: 129.29, memory: 0.00, network: 129.29, cost: 258.58}                                        |
|                         - ICEBERG-SCAN [table] => [70:credit_id]                                                     |
|                                 Estimates: {row: 3, cpu: 0.00, memory: 0.00, network: 0.00, cost: 0.00}                                          |
|                                 predicate: 70:credit_id = '01996c8c-4e94-7000-8781-385684fd234d'                                        |
|                     - EXCHANGE(ROUND_ROBIN)                                                                                                      |
|                             Estimates: {row: 200000000, cpu: ?, memory: ?, network: ?, cost: 9.625700680743953E13}                               |
|                         - HASH/LEFT ANTI JOIN [35:id = 67:id AND 66:$data_sequence_number < 68:$data_sequence_number] => [36:credit_id] |
|                                 Estimates: {row: 200000000, cpu: ?, memory: ?, network: ?, cost: 9.625060680743953E13}                           |
|                             - ICEBERG-SCAN [table] => [36:credit_id, 35:id, 66:$data_sequence_number]                |
|                                     Estimates: {row: 1000000000, cpu: ?, memory: ?, network: ?, cost: 0.0}                                       |
|                                     predicate: 36:credit_id = '01996c8c-4e94-7000-8781-385684fd234d'                                    |
|                             - EXCHANGE(BROADCAST)                                                                                                |
|                                     Estimates: {row: 1000000000, cpu: ?, memory: ?, network: ?, cost: 9.6E13}                                    |
|                                 - ICEBERG-EQUALITY-DELETE-SCAN [table] => [67:id, 68:$data_sequence_number]                   |
|                                         Estimates: {row: 1000000000, cpu: ?, memory: ?, network: ?, cost: 0.0}                                   |
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
