### PR TITLE
[Enhancement] Optimize MaterializedView's inferDistribution policy by using existing tablets

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1835,6 +1835,19 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     @Override
     public void inferDistribution(DistributionInfo info) throws DdlException {
         if (info.getBucketNum() == 0) {
+            // if mv has been already refreshed, deduce bucket num from existing tablets
+            boolean hasRefreshed = getVisiblePartitions().stream().anyMatch(Partition::hasData);
+            if (hasRefreshed) {
+                int numBucket = CatalogUtils.calAvgBucketNumOfRecentPartitions(this,
+                        FeConstants.DEFAULT_INFER_BUCKET_NUM_RECENT_PARTITION_NUM,
+                        Config.enable_auto_tablet_distribution);
+                // use the numBucket only when it's greater than 1, otherwise skip
+                if (numBucket > 1) {
+                    info.setBucketNum(numBucket);
+                    return;
+                }
+            }
+
             int inferredBucketNum = 0;
             for (BaseTableInfo base : getBaseTableInfos()) {
                 Optional<Table> optTable = MvUtils.getTable(base);
@@ -1844,8 +1857,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 Table table = optTable.get();
                 if (table.isNativeTableOrMaterializedView()) {
                     OlapTable olapTable = (OlapTable) table;
-                    DistributionInfo dist = olapTable.getDefaultDistributionInfo();
-                    inferredBucketNum = Math.max(inferredBucketNum, dist.getBucketNum());
+                    // deduce bucket num from base table rather than use its distribution info
+                    int numBucket = CatalogUtils.calAvgBucketNumOfRecentPartitions(olapTable,
+                            FeConstants.DEFAULT_INFER_BUCKET_NUM_RECENT_PARTITION_NUM,
+                            Config.enable_auto_tablet_distribution);
+                    inferredBucketNum = Math.max(inferredBucketNum, numBucket);
                 }
             }
             if (inferredBucketNum == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -69,6 +69,7 @@ import com.starrocks.clone.TabletScheduler;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.InvalidOlapTableStateException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.DeepCopy;
@@ -1390,15 +1391,19 @@ public class OlapTable extends Table {
         return defaultDistributionInfo;
     }
 
-    /*
-     * Infer the distribution info based on partitions and cluster status
+    /**
+     * Infer the distribution info based on partitions and cluster status:
+     * - For hash distribution, if bucket num is not set, we will set it to
+     *  average bucket num of recent partitions.
+     * - For random distribution, if mutable bucket num is not set, we will set it with a deduced value.
      */
     public void inferDistribution(DistributionInfo info) throws DdlException {
         if (info.getType() == DistributionInfo.DistributionInfoType.HASH) {
             // infer bucket num
             if (info.getBucketNum() == 0) {
                 int numBucket = CatalogUtils.calAvgBucketNumOfRecentPartitions(this,
-                        5, Config.enable_auto_tablet_distribution);
+                        FeConstants.DEFAULT_INFER_BUCKET_NUM_RECENT_PARTITION_NUM,
+                        Config.enable_auto_tablet_distribution);
                 info.setBucketNum(numBucket);
             }
         } else if (info.getType() == DistributionInfo.DistributionInfoType.RANDOM) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -114,6 +114,8 @@ public class FeConstants {
     public static final int MAX_COUNTER_NUM_OF_TOP_K = 100000;
 
     public static final int DEFAULT_UNPARTITIONED_TABLE_BUCKET_NUM = 16;
+    // When inferring bucket num from recent partitions, we will check at most 5 recent partitions
+    public static final int DEFAULT_INFER_BUCKET_NUM_RECENT_PARTITION_NUM = 5;
 
     public static final int MAX_LIST_PARTITION_NAME_LENGTH = 50;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
@@ -390,9 +390,7 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                                 PlanTestBase.assertContains(plan, "     TABLE: mv0\n" +
                                         "     PREAGGREGATION: ON\n" +
                                         "     PREDICATES: 9: k1 = 1\n" +
-                                        "     partitions=1/1\n" +
-                                        "     rollup: mv0\n" +
-                                        "     tabletRatio=1/3");
+                                        "     partitions=1/1\n");
                             }
                         }
                         {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteOlapTest.java
@@ -141,20 +141,17 @@ public class MvTransparentUnionRewriteOlapTest extends MVTestBase {
                                 "     PREAGGREGATION: ON\n" +
                                 "     PREDICATES: 5: k1 = 1\n" +
                                 "     partitions=1/1\n" +
-                                "     rollup: mv0\n" +
-                                "     tabletRatio=1/3",
+                                "     rollup: mv0\n",
                         "     TABLE: mv0\n" +
                                 "     PREAGGREGATION: ON\n" +
                                 "     PREDICATES: 5: k1 < 3\n" +
                                 "     partitions=1/1\n" +
-                                "     rollup: mv0\n" +
-                                "     tabletRatio=3/3",
+                                "     rollup: mv0\n",
                         "     TABLE: mv0\n" +
                                 "     PREAGGREGATION: ON\n" +
                                 "     PREDICATES: 5: k1 < 2\n" +
                                 "     partitions=1/1\n" +
-                                "     rollup: mv0\n" +
-                                "     tabletRatio=3/3",
+                                "     rollup: mv0\n"
                 };
                 for (int i = 0; i < sqls.length; i++) {
                     String query = sqls[i];
@@ -216,33 +213,22 @@ public class MvTransparentUnionRewriteOlapTest extends MVTestBase {
                 String[] expectPlans = {
                         "     TABLE: m1\n" +
                                 "     PREAGGREGATION: ON\n" +
-                                "     PREDICATES: 13: k1 < 6, 14: k2 LIKE 'a%'\n" +
-                                "     partitions=1/3",
+                                "     PREDICATES: 13: k1 < 6, 14: k2 LIKE 'a%'\n",
                         "     TABLE: mv0\n" +
                                 "     PREAGGREGATION: ON\n" +
-                                "     PREDICATES: 9: k1 < 6, 10: k2 LIKE 'a%'\n" +
-                                "     partitions=1/1", // case 1
+                                "     PREDICATES: 9: k1 < 6, 10: k2 LIKE 'a%'\n",
                         "     TABLE: m1\n" +
                                 "     PREAGGREGATION: ON\n" +
-                                "     PREDICATES: 13: k1 > 0, 13: k1 < 6, 14: k2 LIKE 'a%'\n" +
-                                "     partitions=1/3",
+                                "     PREDICATES: 13: k1 > 0, 13: k1 < 6, 14: k2 LIKE 'a%'\n",
                         "     TABLE: mv0\n" +
                                 "     PREAGGREGATION: ON\n" +
-                                "     PREDICATES: 9: k1 > 0, 9: k1 < 6, 10: k2 LIKE 'a%'\n" +
-                                "     partitions=1/1\n" +
-                                "     rollup: mv0", // case 2
+                                "     PREDICATES: 9: k1 > 0, 9: k1 < 6, 10: k2 LIKE 'a%'\n",
                         "     TABLE: m1\n" +
                                 "     PREAGGREGATION: ON\n" +
-                                "     PREDICATES: 13: k1 > 1, 13: k1 < 6, 14: k2 LIKE 'a%'\n" +
-                                "     partitions=1/3\n" +
-                                "     rollup: m1\n" +
-                                "     tabletRatio=3/3",
+                                "     PREDICATES: 13: k1 > 1, 13: k1 < 6, 14: k2 LIKE 'a%'\n",
                         "     TABLE: mv0\n" +
                                 "     PREAGGREGATION: ON\n" +
-                                "     PREDICATES: 9: k1 > 1, 9: k1 < 6, 10: k2 LIKE 'a%'\n" +
-                                "     partitions=1/1\n" +
-                                "     rollup: mv0\n" +
-                                "     tabletRatio=3/3", // case 3
+                                "     PREDICATES: 9: k1 > 1, 9: k1 < 6, 10: k2 LIKE 'a%'\n"
                 };
                 for (int i = 0; i < sqls.length; i++) {
                     logSysInfo("start to test " + i);
@@ -270,50 +256,35 @@ public class MvTransparentUnionRewriteOlapTest extends MVTestBase {
                                 "     PREAGGREGATION: ON\n" +
                                 "     PREDICATES: 9: k1 != 3, 10: k2 LIKE 'a%'\n" +
                                 "     partitions=1/1\n" +
-                                "     rollup: mv0\n" +
-                                "     tabletRatio=3/3",
+                                "     rollup: mv0\n",
                         "     TABLE: m1\n" +
                                 "     PREAGGREGATION: ON\n" +
                                 "     PREDICATES: 13: k1 != 3, 14: k2 LIKE 'a%'\n" +
-                                "     partitions=2/3\n" +
-                                "     rollup: m1\n" +
-                                "     tabletRatio=6/6",
+                                "     partitions=2/3\n",
                         "     TABLE: mv0\n" +
                                 "     PREAGGREGATION: ON\n" +
                                 "     PREDICATES: 9: k1 > 0, 10: k2 LIKE 'a%'\n" +
-                                "     partitions=1/1\n" +
-                                "     rollup: mv0\n" +
-                                "     tabletRatio=3/3",
+                                "     partitions=1/1\n",
                         "     TABLE: m1\n" +
                                 "     PREAGGREGATION: ON\n" +
                                 "     PREDICATES: 13: k1 > 0, 14: k2 LIKE 'a%'\n" +
-                                "     partitions=2/3\n" +
-                                "     rollup: m1\n" +
-                                "     tabletRatio=6/6",
+                                "     partitions=2/3\n",
                         "     TABLE: mv0\n" +
                                 "     PREAGGREGATION: ON\n" +
                                 "     PREDICATES: 9: k1 > 1, 10: k2 LIKE 'a%'\n" +
-                                "     partitions=1/1\n" +
-                                "     rollup: mv0\n" +
-                                "     tabletRatio=3/3",
+                                "     partitions=1/1\n",
                         "     TABLE: m1\n" +
                                 "     PREAGGREGATION: ON\n" +
                                 "     PREDICATES: 13: k1 > 1, 14: k2 LIKE 'a%'\n" +
-                                "     partitions=2/3\n" +
-                                "     rollup: m1\n" +
-                                "     tabletRatio=6/6",
+                                "     partitions=2/3\n",
                         "     TABLE: mv0\n" +
                                 "     PREAGGREGATION: ON\n" +
                                 "     PREDICATES: 9: k1 > 0, 10: k2 LIKE 'a%'\n" +
-                                "     partitions=1/1\n" +
-                                "     rollup: mv0\n" +
-                                "     tabletRatio=3/3",
+                                "     partitions=1/1\n",
                         "     TABLE: m1\n" +
                                 "     PREAGGREGATION: ON\n" +
                                 "     PREDICATES: 13: k1 > 0, 14: k2 LIKE 'a%'\n" +
-                                "     partitions=2/3\n" +
-                                "     rollup: m1\n" +
-                                "     tabletRatio=6/6",
+                                "     partitions=2/3\n",
                 };
                 for (int i = 0; i < sqls.length; i++) {
                     String query = sqls[i];


### PR DESCRIPTION
## Why I'm doing:

https://github.com/StarRocks/starrocks/pull/26726 may create mv with many buckets(200/500) if there are many compute nodes(eg: 30) which will cause the culster unstable because of huge metadata in FE.

The current implementation hasn't taken `hash/random` distribution yet and may generate too many tablets:
```
public void inferDistribution(DistributionInfo info) throws DdlException {
    if (info.getBucketNum() == 0) {
        int inferredBucketNum = 0;
        for (BaseTableInfo base : getBaseTableInfos()) {
            Optional<Table> optTable = MvUtils.getTable(base);
            if (optTable.isEmpty()) {
                continue;
            }
            Table table = optTable.get();
            if (table.isNativeTableOrMaterializedView()) {
                OlapTable olapTable = (OlapTable) table;
                DistributionInfo dist = olapTable.getDefaultDistributionInfo();
                inferredBucketNum = Math.max(inferredBucketNum, dist.getBucketNum());
            }
        }
        if (inferredBucketNum == 0) {
            inferredBucketNum = CatalogUtils.calBucketNumAccordingToBackends();
        }
        info.setBucketNum(inferredBucketNum);
    }
}
```
## What I'm doing:

Use OlapTable's implementation (https://github.com/StarRocks/starrocks/pull/38763) to deduce mv's default bucket by default.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
