### PR TITLE
[BugFix] Fix dcg meta inconsistency when partial update with auto increment column in column upsert mode.

### DIFF
--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -701,7 +701,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
     */
     for (ColumnId cid : txn_meta.partial_update_column_ids()) {
         if (txn_meta.has_auto_increment_partial_update_column_id() &&
-            cid == txn_meta.auto_increment_partial_update_column_id()) {
+            tschema->column(cid).is_auto_increment()) {
             // skip auto increment column if it is being used for partial update
             continue;
         }

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -700,8 +700,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
       * used and we need to discard the column for the keys which have already existed in the tablet.
     */
     for (ColumnId cid : txn_meta.partial_update_column_ids()) {
-        if (txn_meta.has_auto_increment_partial_update_column_id() &&
-            tschema->column(cid).is_auto_increment()) {
+        if (txn_meta.has_auto_increment_partial_update_column_id() && tschema->column(cid).is_auto_increment()) {
             // skip auto increment column if it is being used for partial update
             continue;
         }

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -700,7 +700,8 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
       * used and we need to discard the column for the keys which have already existed in the tablet.
     */
     for (ColumnId cid : txn_meta.partial_update_column_ids()) {
-        if (txn_meta.has_auto_increment_partial_update_column_id() && tschema->column(cid).is_auto_increment()) {
+        if (txn_meta.has_auto_increment_partial_update_column_id() && cid < tschema->columns().size() &&
+            tschema->column(cid).is_auto_increment()) {
             // skip auto increment column if it is being used for partial update
             continue;
         }

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -700,8 +700,8 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
       * used and we need to discard the column for the keys which have already existed in the tablet.
     */
     for (ColumnId cid : txn_meta.partial_update_column_ids()) {
-        if (txn_meta.has_auto_increment_partial_update_column_id() && cid < tschema->columns().size() &&
-            tschema->column(cid).is_auto_increment()) {
+        DCHECK(cid < tschema->columns().size());
+        if (txn_meta.has_auto_increment_partial_update_column_id() && tschema->column(cid).is_auto_increment()) {
             // skip auto increment column if it is being used for partial update
             continue;
         }

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -877,7 +877,7 @@ sync;
 -- !result
 SELECT * FROM t_auto_increment_partial_update_column_upsert_2;
 -- result:
-1	1	20	1	4
+1	2	20	1	4
 2	None	40	2	None
 -- !result
 INSERT INTO t_auto_increment_partial_update_column_upsert_2 VALUES (1, 300, 20, DEFAULT, 30), (2, 301, 40, DEFAULT, 50);

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -862,7 +862,7 @@ INSERT INTO t_auto_increment_partial_update_column_upsert_2 VALUES (1, 2, 3, DEF
 -- !result
 SELECT * FROM t_auto_increment_partial_update_column_upsert_2;
 -- result:
-1	2 3	1	4
+1	2	3	1	4
 -- !result
 shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_auto_increment_partial_update_only.csv -XPUT -H partial_update:true  -H partial_update_mode:column -H label:test_auto_increment_partial_update_column_upsert_12345 -H column_separator:, -H columns:k,v2,xx ${url}/api/test_auto_increment_partial_update_column_upsert_2/t_auto_increment_partial_update_column_upsert_2/_stream_load
 -- result:
@@ -877,16 +877,16 @@ sync;
 -- !result
 SELECT * FROM t_auto_increment_partial_update_column_upsert_2;
 -- result:
-1	1	20	1 4
-2	None	40	2 None
+1	1	20	1	4
+2	None	40	2	None
 -- !result
 INSERT INTO t_auto_increment_partial_update_column_upsert_2 VALUES (1, 300, 20, DEFAULT, 30), (2, 301, 40, DEFAULT, 50);
 -- result:
 -- !result
 SELECT * FROM t_auto_increment_partial_update_column_upsert_2;
 -- result:
-1	300	20	3 30
-2	301	40	4 50
+1	300	20	3	30
+2	301	40	4	50
 -- !result
 DROP TABLE t_auto_increment_partial_update_column_upsert_2;
 -- result:

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -834,3 +834,63 @@ SELECT * FROM t_alter_auto_increment_counter ORDER BY k;
 DROP TABLE t_alter_auto_increment_counter;
 -- result:
 -- !result
+-- name: test_auto_increment_partial_update_column_upsert_2 @sequential
+CREATE DATABASE test_auto_increment_partial_update_column_upsert_2;
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
+USE test_auto_increment_partial_update_column_upsert_2;
+-- result:
+-- !result
+CREATE TABLE `t_auto_increment_partial_update_column_upsert_2` (
+  `k`  BIGINT NOT NULL COMMENT "",
+  `v1` BIGINT,
+  `v2` BIGINT,
+  `v3` BIGINT AUTO_INCREMENT,
+  `v4` BIGINT
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t_auto_increment_partial_update_column_upsert_2 VALUES (1, 2, 3, DEFAULT, 4);
+-- result:
+-- !result
+SELECT * FROM t_auto_increment_partial_update_column_upsert_2;
+-- result:
+1	2 3	1	4
+-- !result
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_auto_increment_partial_update_only.csv -XPUT -H partial_update:true  -H partial_update_mode:column -H label:test_auto_increment_partial_update_column_upsert_12345 -H column_separator:, -H columns:k,v2,xx ${url}/api/test_auto_increment_partial_update_column_upsert_2/t_auto_increment_partial_update_column_upsert_2/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+SELECT * FROM t_auto_increment_partial_update_column_upsert_2;
+-- result:
+1	1	20	1 4
+2	None	40	2 None
+-- !result
+INSERT INTO t_auto_increment_partial_update_column_upsert_2 VALUES (1, 300, 20, DEFAULT, 30), (2, 301, 40, DEFAULT, 50);
+-- result:
+-- !result
+SELECT * FROM t_auto_increment_partial_update_column_upsert_2;
+-- result:
+1	300	20	3 30
+2	301	40	4 50
+-- !result
+DROP TABLE t_auto_increment_partial_update_column_upsert_2;
+-- result:
+-- !result
+DROP DATABASE test_auto_increment_partial_update_column_upsert_2;
+-- result:
+-- !result

--- a/test/sql/test_auto_increment/T/test_auto_increment
+++ b/test/sql/test_auto_increment/T/test_auto_increment
@@ -373,3 +373,34 @@ ALTER TABLE t_alter_auto_increment_counter AUTO_INCREMENT = 300;
 INSERT INTO t_alter_auto_increment_counter VALUES (3, DEFAULT);
 SELECT * FROM t_alter_auto_increment_counter ORDER BY k;
 DROP TABLE t_alter_auto_increment_counter;
+
+-- name: test_auto_increment_partial_update_column_upsert_2 @sequential
+CREATE DATABASE test_auto_increment_partial_update_column_upsert_2;
+ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
+USE test_auto_increment_partial_update_column_upsert_2;
+CREATE TABLE `t_auto_increment_partial_update_column_upsert_2` (
+  `k`  BIGINT NOT NULL COMMENT "",
+  `v1` BIGINT,
+  `v2` BIGINT,
+  `v3` BIGINT AUTO_INCREMENT,
+  `v4` BIGINT
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+INSERT INTO t_auto_increment_partial_update_column_upsert_2 VALUES (1, 2, 3, DEFAULT, 4);
+SELECT * FROM t_auto_increment_partial_update_column_upsert_2;
+
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_auto_increment_partial_update_only.csv -XPUT -H partial_update:true  -H partial_update_mode:column -H label:test_auto_increment_partial_update_column_upsert_12345 -H column_separator:, -H columns:k,v2,xx ${url}/api/test_auto_increment_partial_update_column_upsert_2/t_auto_increment_partial_update_column_upsert_2/_stream_load
+sync;
+
+SELECT * FROM t_auto_increment_partial_update_column_upsert_2;
+INSERT INTO t_auto_increment_partial_update_column_upsert_2 VALUES (1, 300, 20, DEFAULT, 30), (2, 301, 40, DEFAULT, 50);
+SELECT * FROM t_auto_increment_partial_update_column_upsert_2;
+
+DROP TABLE t_auto_increment_partial_update_column_upsert_2;
+DROP DATABASE test_auto_increment_partial_update_column_upsert_2;


### PR DESCRIPTION
## Why I'm doing:
This bug was introduced by the pr #61341 which is fix 0 value of auto increment column in column upsert mode. But it handle the cid incorrectly when it used to filter out auto increment column just before generate the cols file. In pr #61341 it use txn_meta.auto_increment_partial_update_column_id() to check if the column is auto increment column. But it is incorrect because the txn_meta.auto_increment_partial_update_column_id() means the column offset in partial segment schema but txn_meta.partial_update_column_ids() means the column offset in full tablet schema.

## What I'm doing:
Use TabletColumn::is_auto_increment() to check if the column is auto increment column instead.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
