### PR TITLE
[Enhancement] Enhance MaterializedView with sql_dialect and sql_mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -304,6 +304,13 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                             ", please add `session.` prefix if you want add session variables for mv(" +
                             "eg, \"session.insert_timeout\"=\"30000000\").");
                 }
+                if (PropertyAnalyzer.PROPERTIES_MV_SESSION_SQL_DIALECT.equalsIgnoreCase(entry.getKey()) ||
+                        PropertyAnalyzer.PROPERTIES_MV_SESSION_SQL_MODE.equalsIgnoreCase(entry.getKey())) {
+                    // refresh mv's cache again
+                    CachingMvPlanContextBuilder.getInstance().cacheMaterializedView(materializedView);
+                    continue;
+                }
+
                 String varKey = entry.getKey().substring(PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX.length());
                 SystemVariable variable = new SystemVariable(varKey, new StringLiteral(entry.getValue()));
                 try {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
@@ -21,6 +21,7 @@ import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.parser.SqlDialect;
 
 import java.util.List;
 
@@ -44,7 +45,7 @@ public class HiveView extends ConnectorView {
     @Override
     public QueryStatement doGetQueryStatement(SessionVariable sessionVariable) throws StarRocksPlannerException {
         if (viewType == HiveView.Type.Trino) {
-            sessionVariable.setSqlDialect("trino");
+            sessionVariable.setSqlDialect(SqlDialect.TRINO_DIALECT);
         }
 
         return super.doGetQueryStatement(sessionVariable);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -73,7 +73,6 @@ import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SelectAnalyzer;
 import com.starrocks.sql.ast.ParseNode;
-import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.TableName;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -82,6 +82,7 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.mv.MVUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import com.starrocks.sql.parser.SqlMode;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.statistic.StatsConstants;
@@ -2408,10 +2409,17 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     public static long getQuerySqlMode(Map<String, String> props) {
         if (props == null) {
-            return 32L;
+            return SqlMode.DEFAULT;
         }
-        String val = props.getOrDefault(PropertyAnalyzer.PROPERTIES_MV_SESSION_SQL_MODE, "");
-        return Long.parseLong(val);
+        try {
+            String val = props.getOrDefault(PropertyAnalyzer.PROPERTIES_MV_SESSION_SQL_MODE, "");
+            if (Strings.isNullOrEmpty(val)) {
+                return SqlMode.DEFAULT;
+            }
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            return SqlMode.DEFAULT;
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -82,6 +82,7 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.mv.MVUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import com.starrocks.sql.parser.SqlDialect;
 import com.starrocks.sql.parser.SqlMode;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
@@ -2402,24 +2403,9 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      */
     public long getQuerySqlMode() {
         if (tableProperty == null || tableProperty.getProperties() == null) {
-            return 32L;
-        }
-        return getQuerySqlMode(tableProperty.getProperties());
-    }
-
-    public static long getQuerySqlMode(Map<String, String> props) {
-        if (props == null) {
             return SqlMode.DEFAULT;
         }
-        try {
-            String val = props.getOrDefault(PropertyAnalyzer.PROPERTIES_MV_SESSION_SQL_MODE, "");
-            if (Strings.isNullOrEmpty(val)) {
-                return SqlMode.DEFAULT;
-            }
-            return Long.parseLong(val);
-        } catch (NumberFormatException e) {
-            return SqlMode.DEFAULT;
-        }
+        return SqlMode.getSqlMode(tableProperty.getProperties());
     }
 
     /**
@@ -2429,13 +2415,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         if (tableProperty == null || tableProperty.getProperties() == null) {
             return "";
         }
-        return getQuerySqlDialect(tableProperty.getProperties());
-    }
-
-    public static String getQuerySqlDialect(Map<String, String> props) {
-        if (props == null) {
-            return "";
-        }
-        return props.getOrDefault(PropertyAnalyzer.PROPERTIES_MV_SESSION_SQL_DIALECT, "");
+        return SqlDialect.getSqlDialect(tableProperty.getProperties());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -70,6 +70,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -216,6 +217,12 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_EXCLUDED_TRIGGER_TABLES = "excluded_trigger_tables";
     public static final String PROPERTIES_EXCLUDED_REFRESH_TABLES = "excluded_refresh_tables";
     public static final String PROPERTIES_MV_REFRESH_MODE = "refresh_mode";
+    // mv sql_dialect
+    public static final String PROPERTIES_MV_SESSION_SQL_DIALECT =
+            PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX + SessionVariable.SQL_DIALECT;
+    // mv sql_mode
+    public static final String PROPERTIES_MV_SESSION_SQL_MODE =
+            PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX + SessionVariable.SQL_MODE;
 
     // 1. `force_external_table_query_rewrite` is used to control whether external table can be rewritten or not
     // 2. external table can be rewritten by default if not specific.
@@ -1930,6 +1937,10 @@ public class PropertyAnalyzer {
                 // analyze properties
                 List<SetListItem> setListItems = Lists.newArrayList();
                 for (Map.Entry<String, String> entry : properties.entrySet()) {
+                    if (PropertyAnalyzer.PROPERTIES_MV_SESSION_SQL_DIALECT.equalsIgnoreCase(entry.getKey()) ||
+                            PropertyAnalyzer.PROPERTIES_MV_SESSION_SQL_MODE.equalsIgnoreCase(entry.getKey())) {
+                        continue;
+                    }
                     SystemVariable variable = getMVSystemVariable(properties, entry);
                     GlobalStateMgr.getCurrentState().getVariableMgr().checkSystemVariableExist(variable);
                     setListItems.add(variable);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -61,6 +61,8 @@ import com.starrocks.server.StorageVolumeMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.common.QueryDebugOptions;
+import com.starrocks.sql.parser.SqlDialect;
+import com.starrocks.sql.parser.SqlMode;
 import com.starrocks.storagevolume.StorageVolume;
 import com.starrocks.system.BackendResourceStat;
 import com.starrocks.thrift.TCloudConfiguration;
@@ -1113,7 +1115,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     // Default sqlMode is ONLY_FULL_GROUP_BY
     @VariableMgr.VarAttr(name = SQL_MODE_STORAGE_NAME, alias = SQL_MODE, show = SQL_MODE)
-    private long sqlMode = 32L;
+    private long sqlMode = SqlMode.DEFAULT;
 
     // The specified resource group of this session
     @VariableMgr.VarAttr(name = RESOURCE_GROUP, flag = VariableMgr.SESSION_ONLY)
@@ -2407,7 +2409,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private long bigQueryLogScanRowsThreshold = 1000000000L;
 
     @VarAttr(name = SQL_DIALECT)
-    private String sqlDialect = "StarRocks";
+    private String sqlDialect = SqlDialect.STARROCKS_DIALECT;
 
     @VarAttr(name = ENABLE_DIALECT_DOWNGRADE)
     private boolean enableDialectDowngrade = true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/TranslateAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/TranslateAnalyzer.java
@@ -18,6 +18,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.translate.TranslateStmt;
+import com.starrocks.sql.parser.SqlDialect;
 
 public class TranslateAnalyzer {
     public static void analyze(StatementBase statement, ConnectContext context) {
@@ -32,7 +33,7 @@ public class TranslateAnalyzer {
         @Override
         public Void visitTranslateStatement(TranslateStmt statement, ConnectContext context) {
             String dialect = statement.getDialect();
-            if (!dialect.equalsIgnoreCase("trino")) {
+            if (!SqlDialect.TRINO_DIALECT.equalsIgnoreCase(dialect)) {
                 throw new SemanticException(String.format("Unsupported dialect: %s, only support trino dialect now", dialect));
             }
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
@@ -73,7 +73,7 @@ public class MaterializedViewOptimizer {
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
         String mvSql = mv.getViewDefineSql();
         // parse mv's defined query
-        StatementBase stmt = MvUtils.parse(mv, mvSql, connectContext);
+        StatementBase stmt = MvUtils.parseDefinedQuery(mv, mvSql, connectContext);
         if (stmt == null) {
             return new MvPlanContext(false, "MV Plan parse failed");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -501,21 +501,23 @@ public class MvUtils {
         String origSqlDialect = connectContext.getSessionVariable().getSqlDialect();
         long origSqlMode = connectContext.getSessionVariable().getSqlMode();
         try {
-            // sql_dialect
-            String sqlDialect = mv.getQuerySqlDialect();
-            if (!Strings.isNullOrEmpty(sqlDialect)) {
-                connectContext.getSessionVariable().setSqlDialect(sqlDialect);
+            if (mv != null) {
+                // sql_dialect
+                String sqlDialect = mv.getQuerySqlDialect();
+                if (!Strings.isNullOrEmpty(sqlDialect)) {
+                    connectContext.getSessionVariable().setSqlDialect(sqlDialect);
+                }
+                // sql_mode
+                long sqlMode = mv.getQuerySqlMode();
+                connectContext.getSessionVariable().setSqlMode(sqlMode);
             }
-            // sql_mode
-            long sqlMode = mv.getQuerySqlMode();
-            connectContext.getSessionVariable().setSqlMode(sqlMode);
 
             List<StatementBase> statementBases =
                     com.starrocks.sql.parser.SqlParser.parse(sql, connectContext.getSessionVariable());
             Preconditions.checkState(statementBases.size() == 1);
             mvStmt = statementBases.get(0);
         } catch (ParsingException parsingException) {
-            LOG.warn("parse mv{}'s sql:{} failed", mv.getName(), sql, parsingException);
+            LOG.warn("parse mv{}'s sql:{} failed", mv != null ? mv.getName() : "", sql, parsingException);
             return null;
         } finally {
             connectContext.getSessionVariable().setSqlDialect(origSqlDialect);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -45,7 +45,6 @@ import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.connector.parser.trino.TrinoParserUtils;
 import com.starrocks.mysql.MysqlPassword;
 import com.starrocks.mysql.privilege.AuthPlugin;
 import com.starrocks.qe.ConnectContext;
@@ -2186,7 +2185,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         // check defined query's sql dialect
         QueryStatement queryStatement;
         String sqlDialect = MaterializedView.getQuerySqlDialect(properties);
-        ConnectContext connectContext = ConnectContext.get() == null ? ConnectContext.build():
+        ConnectContext connectContext = ConnectContext.get() == null ? ConnectContext.build() :
                 ConnectContext.get();
         if (SqlDialect.TRINO_DIALECT.equalsIgnoreCase(sqlDialect)) {
             // Use Trino dialect to generate query statement

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -29,7 +29,6 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MapType;
-import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.StructField;
@@ -2183,10 +2182,10 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         int queryStartIndex = context.queryStatement().start.getStartIndex();
         int queryStopIndex = context.queryStatement().stop.getStopIndex() + 1;
         // check defined query's sql dialect
-        QueryStatement queryStatement;
-        String sqlDialect = MaterializedView.getQuerySqlDialect(properties);
+        String sqlDialect = SqlDialect.getSqlDialect(properties);
         ConnectContext connectContext = ConnectContext.get() == null ? ConnectContext.build() :
                 ConnectContext.get();
+        QueryStatement queryStatement;
         if (SqlDialect.TRINO_DIALECT.equalsIgnoreCase(sqlDialect)) {
             // Use Trino dialect to generate query statement
             String queryText = context.start.getInputStream().getText(new Interval(queryStartIndex, queryStopIndex));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlDialect.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlDialect.java
@@ -1,0 +1,25 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.parser;
+
+/**
+ * SQL Dialect constants
+ */
+public class SqlDialect {
+    // Trino dialect
+    public static final String TRINO_DIALECT = "trino";
+    // StarRocks dialect
+    public static final String STARROCKS_DIALECT = "starrocks";
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlDialect.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlDialect.java
@@ -14,6 +14,10 @@
 
 package com.starrocks.sql.parser;
 
+import com.starrocks.common.util.PropertyAnalyzer;
+
+import java.util.Map;
+
 /**
  * SQL Dialect constants
  */
@@ -22,4 +26,11 @@ public class SqlDialect {
     public static final String TRINO_DIALECT = "trino";
     // StarRocks dialect
     public static final String STARROCKS_DIALECT = "starrocks";
+
+    public static String getSqlDialect(Map<String, String> props) {
+        if (props == null) {
+            return "";
+        }
+        return props.getOrDefault(PropertyAnalyzer.PROPERTIES_MV_SESSION_SQL_DIALECT, "");
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlMode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlMode.java
@@ -1,0 +1,19 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.parser;
+
+public class SqlMode {
+    public static final long DEFAULT = 32;
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlMode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlMode.java
@@ -14,6 +14,26 @@
 
 package com.starrocks.sql.parser;
 
+import com.google.common.base.Strings;
+import com.starrocks.common.util.PropertyAnalyzer;
+
+import java.util.Map;
+
 public class SqlMode {
     public static final long DEFAULT = 32;
+
+    public static long getSqlMode(Map<String, String> props) {
+        if (props == null) {
+            return SqlMode.DEFAULT;
+        }
+        try {
+            String val = props.getOrDefault(PropertyAnalyzer.PROPERTIES_MV_SESSION_SQL_MODE, "");
+            if (Strings.isNullOrEmpty(val)) {
+                return SqlMode.DEFAULT;
+            }
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            return SqlMode.DEFAULT;
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -64,7 +64,7 @@ public class SqlParser {
 
     public static List<StatementBase> parse(String sql, SessionVariable sessionVariable) {
         try {
-            if (sessionVariable.getSqlDialect().equalsIgnoreCase("trino")) {
+            if (SqlDialect.TRINO_DIALECT.equalsIgnoreCase(sessionVariable.getSqlDialect())) {
                 return parseWithTrinoDialect(sql, sessionVariable);
             } else {
                 return parseWithStarRocksDialect(sql, sessionVariable);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -75,7 +75,7 @@ public class SqlParser {
         }
     }
 
-    private static List<StatementBase> parseWithTrinoDialect(String sql, SessionVariable sessionVariable) {
+    public static List<StatementBase> parseWithTrinoDialect(String sql, SessionVariable sessionVariable) {
         List<StatementBase> statements = Lists.newArrayList();
         try {
             StatementSplitter splitter = new StatementSplitter(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateAsyncMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateAsyncMaterializedViewTest.java
@@ -1,0 +1,134 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class CreateAsyncMaterializedViewTest extends MVTestBase {
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        FeConstants.unitTestView = false;
+        MVTestBase.beforeClass();
+    }
+
+    @Test
+    public void testCreateMVWithDialect() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_table1 (\n" +
+                "  stream_time       DATETIME NOT NULL,\n" +
+                "  date_id           INT NOT NULL,\n" +
+                "  hour_local        INT NOT NULL,\n" +
+                "  minute_local      INT NOT NULL,\n" +
+                "  country_id        BIGINT,\n" +
+                "  city_id           BIGINT,\n" +
+                "  drop_off_poi_id   BIGINT,\n" +
+                "  vehicle_type_id   BIGINT,\n" +
+                "  event             VARCHAR(64),\n" +
+                "  originalsurge     DECIMAL(10,2),\n" +
+                "  final_fare        DECIMAL(10,2),\n" +
+                "  distance          DECIMAL(10,2),\n" +
+                "  surge             DECIMAL(10,2),\n" +
+                "  series_id         BIGINT\n" +
+                ") ENGINE=OLAP\n" +
+                "DISTRIBUTED BY HASH(stream_time) BUCKETS 10\n" +
+                "PROPERTIES(\n" +
+                "  \"replication_num\" = \"1\"\n" +
+                ");");
+        starRocksAssert.withRefreshedMaterializedView("CREATE MATERIALIZED VIEW test_mv1 \n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"session.sql_dialect\" = \"trino\"\n" +
+                ") AS\n" +
+                "SELECT\n" +
+                "DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), " +
+                "STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))),\n" +
+                "date_id,\n" +
+                "sum(originalsurge) as sum_originalsurge,\n" +
+                "count(originalsurge) as count_originalsurge\n" +
+                "FROM base_table1\n" +
+                "group by 1,2\n" +
+                ";");
+        connectContext.getSessionVariable().setSqlDialect("trino");
+        String plan = getFragmentPlan("SELECT\n" +
+                "\tCAST(AVG(originalsurge) AS DOUBLE) AS raw_surge_with_poi\n" +
+                "FROM base_table1\n" +
+                "WHERE\n" +
+                "\tDATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), " +
+                "STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))) >= STR_TO_DATE('2025-07-01 00:00:00', '%Y-%m-%d %H:%i:%S');");
+        PlanTestBase.assertContains(plan, "test_mv1");
+    }
+
+    @Test
+    public void testCreateMVWithMode() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_table1 (\n" +
+                "  stream_time       DATETIME NOT NULL,\n" +
+                "  date_id           INT NOT NULL,\n" +
+                "  hour_local        INT NOT NULL,\n" +
+                "  minute_local      INT NOT NULL,\n" +
+                "  country_id        BIGINT,\n" +
+                "  city_id           BIGINT,\n" +
+                "  drop_off_poi_id   BIGINT,\n" +
+                "  vehicle_type_id   BIGINT,\n" +
+                "  event             VARCHAR(64),\n" +
+                "  originalsurge     DECIMAL(10,2),\n" +
+                "  final_fare        DECIMAL(10,2),\n" +
+                "  distance          DECIMAL(10,2),\n" +
+                "  surge             DECIMAL(10,2),\n" +
+                "  series_id         BIGINT\n" +
+                ") ENGINE=OLAP\n" +
+                "DISTRIBUTED BY HASH(stream_time) BUCKETS 10\n" +
+                "PROPERTIES(\n" +
+                "  \"replication_num\" = \"1\"\n" +
+                ");");
+        starRocksAssert.withRefreshedMaterializedView("CREATE MATERIALIZED VIEW test_mv1 \n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"session.sql_dialect\" = \"trino\",\n" +
+                "\"session.sql_mode\" = \"8589934626\"\n" +
+                ") AS\n" +
+                "SELECT\n" +
+                "CASE\n" +
+                "WHEN city_id = 0 THEN 'Control'\n" +
+                "WHEN city_id = 1 THEN 'Treatment'\n" +
+                "ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0')\n" +
+                "END AS treatment_id," +
+                "DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), " +
+                "STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))),\n" +
+                "date_id,\n" +
+                "sum(originalsurge) as sum_originalsurge,\n" +
+                "count(originalsurge) as count_originalsurge\n" +
+                "FROM base_table1\n" +
+                "group by 1,2,3\n" +
+                ";");
+        connectContext.getSessionVariable().setSqlDialect("trino");
+        connectContext.getSessionVariable().setSqlMode(8589934626L);
+        String plan = getFragmentPlan("SELECT\n" +
+                "\tCAST(AVG(originalsurge) AS DOUBLE) AS raw_surge_with_poi\n" +
+                "FROM base_table1\n" +
+                "WHERE\n" +
+                "CASE\n" +
+                "WHEN city_id = 0 THEN 'Control'\n" +
+                "WHEN city_id = 1 THEN 'Treatment'\n" +
+                "ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0')\n" +
+                "END = 'Treatment'");
+        PlanTestBase.assertContains(plan, "test_mv1");
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
@@ -223,9 +223,8 @@ public class MaterializedViewTextBasedRewriteTest extends MaterializedViewTestBa
     public void testMvAstCache() {
         String query = "select user_id, time, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id, time " +
                 "order by user_id, time;";
-        MaterializedView mv = getMv("test", query);
-        ParseNode parseNode1 = MvUtils.getQueryAst(mv, query, connectContext);
-        ParseNode parseNode2 = MvUtils.getQueryAst(mv, query, connectContext);
+        ParseNode parseNode1 = MvUtils.getQueryAst(null, query, connectContext);
+        ParseNode parseNode2 = MvUtils.getQueryAst(null, query, connectContext);
         Assertions.assertFalse(parseNode2.equals(parseNode1));
 
         CachingMvPlanContextBuilder.AstKey astKey1 = new CachingMvPlanContextBuilder.AstKey(parseNode1);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.planner;
 
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.sql.ast.ParseNode;
 import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
@@ -222,8 +223,9 @@ public class MaterializedViewTextBasedRewriteTest extends MaterializedViewTestBa
     public void testMvAstCache() {
         String query = "select user_id, time, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id, time " +
                 "order by user_id, time;";
-        ParseNode parseNode1 = MvUtils.getQueryAst(query, connectContext);
-        ParseNode parseNode2 = MvUtils.getQueryAst(query, connectContext);
+        MaterializedView mv = getMv("test", query);
+        ParseNode parseNode1 = MvUtils.getQueryAst(mv, query, connectContext);
+        ParseNode parseNode2 = MvUtils.getQueryAst(mv, query, connectContext);
         Assertions.assertFalse(parseNode2.equals(parseNode1));
 
         CachingMvPlanContextBuilder.AstKey astKey1 = new CachingMvPlanContextBuilder.AstKey(parseNode1);

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -222,7 +222,7 @@ public class UtFrameUtils {
         StatementBase statementBase;
         try {
             statementBase =
-                        com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode()).get(0);
+                        com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable()).get(0);
             com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, ctx);
         } catch (ParsingException | SemanticException e) {
             System.err.println("parse failed: " + e.getMessage());
@@ -241,7 +241,7 @@ public class UtFrameUtils {
         StatementBase statementBase;
         try {
             statementBase =
-                        com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode()).get(0);
+                        com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable()).get(0);
         } catch (ParsingException e) {
             if (e.getMessage() == null) {
                 throw e;
@@ -488,7 +488,8 @@ public class UtFrameUtils {
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
 
         List<StatementBase> statements =
-                    com.starrocks.sql.parser.SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode());
+                    com.starrocks.sql.parser.SqlParser.parse(sql, connectContext.getSessionVariable());
+
         connectContext.getDumpInfo().setOriginStmt(sql);
         SessionVariable oldSessionVariable = connectContext.getSessionVariable();
         StatementBase statementBase = statements.get(0);
@@ -672,7 +673,7 @@ public class UtFrameUtils {
                 try {
                     StatementBase viewStatement =
                                 SqlParser.parse(createTableStmt.getInlineViewDef(),
-                                            connectContext.getSessionVariable().getSqlMode()).get(0);
+                                            connectContext.getSessionVariable()).get(0);
                     com.starrocks.sql.analyzer.Analyzer.analyze(viewStatement, connectContext);
                 } catch (Exception e) {
                     System.out.println("invalid view def: " + createTableStmt.getInlineViewDef()

--- a/test/sql/test_materialized_view/R/test_create_mv_with_dialect
+++ b/test/sql/test_materialized_view/R/test_create_mv_with_dialect
@@ -1,0 +1,161 @@
+-- name: test_create_mv_with_dialect
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+E: (1064, 'org/apache/thrift/transport/TFramedTransport')
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+E: (1064, 'Failed to connect to Hive Metastore')
+-- !result
+CREATE TABLE base_table1 (
+  stream_time       DATETIME,
+  date_id           INT,
+  hour_local        INT,
+  minute_local      INT,
+  country_id        BIGINT,
+  city_id           BIGINT,
+  drop_off_poi_id   BIGINT,
+  vehicle_type_id   BIGINT,
+  event             VARCHAR(64),
+  originalsurge     DECIMAL(10,2),
+  final_fare        DECIMAL(10,2),
+  distance          DECIMAL(10,2),
+  surge             DECIMAL(10,2),
+  series_id         BIGINT
+);
+-- result:
+E: (1046, 'Getting analyzing error. Detail message: No database selected.')
+-- !result
+insert into base_table1 values 
+  ('2023-12-01 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+  ('2023-12-02 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+  ('2023-12-03 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+-- result:
+E: (1046, 'Getting analyzing error. Detail message: No database selected.')
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1",
+"session.sql_dialect" = "trino"
+) AS
+SELECT
+  date_id,
+  DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))),
+  sum(originalsurge) as sum_originalsurge,
+  count(originalsurge) as count_originalsurge
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1
+  group by 1,2
+;
+-- result:
+E: (1064, 'Failed to connect to Hive Metastore')
+-- !result
+refresh materialized view test_mv1 with sync mode;
+functionselect * from test_mv1 order by 1,2;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 0. Detail message: Unexpected input 'functionselect', the most similar input is {'UNINSTALL', 'USE', 'PAUSE', 'EXECUTE', 'UPDATE', '(', ';'}.")
+-- !result
+set sql_dialect = "trino";
+-- result:
+-- !result
+SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2;
+-- result:
+E: (1064, 'Failed to connect to Hive Metastore')
+-- !result
+functioin: print_hit_materialized_view("SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2;", "test_mv1")
+SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), avg(originalsurge) as avg_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;
+-- result:
+E: (1064, "Trino parser parse sql error: [io.trino.sql.parser.ParsingException: line 1:1: mismatched input 'functioin'. Expecting: 'ALTER', 'ANALYZE', 'CALL', 'COMMENT', 'COMMIT', 'CREATE', 'DEALLOCATE', 'DELETE', 'DENY', 'DESC', 'DESCRIBE', 'DROP', 'EXECUTE', 'EXPLAIN', 'GRANT', 'INSERT', 'MERGE', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'TRUNCATE', 'UPDATE', 'USE', <query>], and StarRocks parser also can not parse: [com.starrocks.sql.parser.ParsingException: Getting syntax error at line 1, column 0. Detail message: Unexpected input 'functioin', the most similar input is {'UNINSTALL', 'UNLOCK', 'STOP', 'SYNC', 'GRANT', '(', ';'}.]")
+-- !result
+function: print_hit_materialized_view("SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), avg(originalsurge) as avg_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;", "test_mv1")
+-- result:
+False
+-- !result
+drop materialized view test_mv1;
+-- result:
+E: (1064, 'Materialized view test_mv1 is not found')
+-- !result
+set sql_dialect = "starrocks";
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1",
+"session.sql_dialect" = "trino",
+"session.sql_mode" = "8589934626"
+) AS
+SELECT
+  CASE
+  WHEN city_id = 0 THEN 'Control'
+  WHEN city_id = 1 THEN 'Treatment'
+  ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0')
+  END AS treatment_id,
+  DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), 
+  STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))),
+  date_id,
+  sum(originalsurge) as sum_originalsurge,
+  count(originalsurge) as count_originalsurge
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1
+  group by 1,2,3
+;
+-- result:
+E: (1064, 'Failed to connect to Hive Metastore')
+-- !result
+refresh materialized view test_mv1 with sync mode;
+select * from test_mv1 order by 1,2,3;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'db_d8a3b82333bd41ad821003c153579330.test_mv1'.")
+-- !result
+set sql_dialect = "trino";
+-- result:
+-- !result
+SELECT CASE WHEN city_id = 0 THEN 'Control' WHEN city_id = 1 THEN 'Treatment' ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0') END AS treatment_id, DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2,3;
+-- result:
+E: (1064, 'Failed to connect to Hive Metastore')
+-- !result
+function: print_hit_materialized_view("SELECT CASE WHEN city_id = 0 THEN 'Control' WHEN city_id = 1 THEN 'Treatment' ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0') END AS treatment_id, DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2,3;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT CASE WHEN city_id = 0 THEN 'Control' WHEN city_id = 1 THEN 'Treatment' ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0') END AS treatment_id, avg(originalsurge) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;
+-- result:
+E: (1064, 'Failed to connect to Hive Metastore')
+-- !result
+function: print_hit_materialized_view("SELECT CASE WHEN city_id = 0 THEN 'Control' WHEN city_id = 1 THEN 'Treatment' ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0') END AS treatment_id, avg(originalsurge) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;", "test_mv1")
+-- result:
+False
+-- !result
+drop materialized view test_mv1;
+-- result:
+E: (1064, 'Materialized view test_mv1 is not found')
+-- !result
+set sql_dialect = "starrocks";
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+REFRESH DEFERRED MANUAL
+-- result:
+E: (1064, "Getting syntax error at line 2, column 23. Detail message: Unexpected input '<EOF>', the most similar input is {'REFRESH', 'ORDER', 'PROPERTIES', 'AS', 'DISTRIBUTED'}.")
+-- !result

--- a/test/sql/test_materialized_view/R/test_create_mv_with_dialect
+++ b/test/sql/test_materialized_view/R/test_create_mv_with_dialect
@@ -13,11 +13,9 @@ set catalog mv_iceberg_${uuid0};
 -- !result
 create database mv_ice_db_${uuid0};
 -- result:
-E: (1064, 'org/apache/thrift/transport/TFramedTransport')
 -- !result
 use mv_ice_db_${uuid0};
 -- result:
-E: (1064, 'Failed to connect to Hive Metastore')
 -- !result
 CREATE TABLE base_table1 (
   stream_time       DATETIME,
@@ -36,14 +34,14 @@ CREATE TABLE base_table1 (
   series_id         BIGINT
 );
 -- result:
-E: (1046, 'Getting analyzing error. Detail message: No database selected.')
 -- !result
-insert into base_table1 values 
-  ('2023-12-01 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
-  ('2023-12-02 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
-  ('2023-12-03 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+insert into base_table1 (
+  stream_time, date_id, hour_local, minute_local, country_id, city_id, drop_off_poi_id, vehicle_type_id, event, originalsurge, final_fare, distance, surge, series_id
+) values
+  ('2023-12-01 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 'event1', 1, 1, 1, 1, 1),
+  ('2023-12-02 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 'event2', 1, 1, 1, 1, 1),
+  ('2023-12-03 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 'event3', 1, 1, 1, 1, 1);
 -- result:
-E: (1046, 'Getting analyzing error. Detail message: No database selected.')
 -- !result
 set catalog default_catalog;
 -- result:
@@ -69,32 +67,33 @@ FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1
   group by 1,2
 ;
 -- result:
-E: (1064, 'Failed to connect to Hive Metastore')
 -- !result
 refresh materialized view test_mv1 with sync mode;
-functionselect * from test_mv1 order by 1,2;
+select * from test_mv1 order by 1,2;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 0. Detail message: Unexpected input 'functionselect', the most similar input is {'UNINSTALL', 'USE', 'PAUSE', 'EXECUTE', 'UPDATE', '(', ';'}.")
+2000	None	3.00	3
 -- !result
 set sql_dialect = "trino";
 -- result:
 -- !result
 SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2;
 -- result:
-E: (1064, 'Failed to connect to Hive Metastore')
+None	2000	3.00	3
 -- !result
-functioin: print_hit_materialized_view("SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2;", "test_mv1")
+function: print_hit_materialized_view("SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2;", "test_mv1")
+-- result:
+True
+-- !result
 SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), avg(originalsurge) as avg_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;
 -- result:
-E: (1064, "Trino parser parse sql error: [io.trino.sql.parser.ParsingException: line 1:1: mismatched input 'functioin'. Expecting: 'ALTER', 'ANALYZE', 'CALL', 'COMMENT', 'COMMIT', 'CREATE', 'DEALLOCATE', 'DELETE', 'DENY', 'DESC', 'DESCRIBE', 'DROP', 'EXECUTE', 'EXPLAIN', 'GRANT', 'INSERT', 'MERGE', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'TRUNCATE', 'UPDATE', 'USE', <query>], and StarRocks parser also can not parse: [com.starrocks.sql.parser.ParsingException: Getting syntax error at line 1, column 0. Detail message: Unexpected input 'functioin', the most similar input is {'UNINSTALL', 'UNLOCK', 'STOP', 'SYNC', 'GRANT', '(', ';'}.]")
+None	1.00000000
 -- !result
 function: print_hit_materialized_view("SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), avg(originalsurge) as avg_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 drop materialized view test_mv1;
 -- result:
-E: (1064, 'Materialized view test_mv1 is not found')
 -- !result
 set sql_dialect = "starrocks";
 -- result:
@@ -121,41 +120,40 @@ FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1
   group by 1,2,3
 ;
 -- result:
-E: (1064, 'Failed to connect to Hive Metastore')
 -- !result
 refresh materialized view test_mv1 with sync mode;
 select * from test_mv1 order by 1,2,3;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'db_d8a3b82333bd41ad821003c153579330.test_mv1'.")
+Treatment	None	2000	3.00	3
 -- !result
 set sql_dialect = "trino";
 -- result:
 -- !result
 SELECT CASE WHEN city_id = 0 THEN 'Control' WHEN city_id = 1 THEN 'Treatment' ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0') END AS treatment_id, DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2,3;
 -- result:
-E: (1064, 'Failed to connect to Hive Metastore')
+Treatment	None	2000	3.00	3
 -- !result
 function: print_hit_materialized_view("SELECT CASE WHEN city_id = 0 THEN 'Control' WHEN city_id = 1 THEN 'Treatment' ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0') END AS treatment_id, DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2,3;", "test_mv1")
 -- result:
-False
+True
 -- !result
 SELECT CASE WHEN city_id = 0 THEN 'Control' WHEN city_id = 1 THEN 'Treatment' ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0') END AS treatment_id, avg(originalsurge) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;
 -- result:
-E: (1064, 'Failed to connect to Hive Metastore')
+Treatment	1.00000000
 -- !result
 function: print_hit_materialized_view("SELECT CASE WHEN city_id = 0 THEN 'Control' WHEN city_id = 1 THEN 'Treatment' ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0') END AS treatment_id, avg(originalsurge) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 drop materialized view test_mv1;
 -- result:
-E: (1064, 'Materialized view test_mv1 is not found')
 -- !result
-set sql_dialect = "starrocks";
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1;
 -- result:
 -- !result
-CREATE MATERIALIZED VIEW test_mv1 
-REFRESH DEFERRED MANUAL
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
 -- result:
-E: (1064, "Getting syntax error at line 2, column 23. Detail message: Unexpected input '<EOF>', the most similar input is {'REFRESH', 'ORDER', 'PROPERTIES', 'AS', 'DISTRIBUTED'}.")
+-- !result
+drop database db_${uuid0} force;
+-- result:
 -- !result

--- a/test/sql/test_materialized_view/T/test_create_mv_with_dialect
+++ b/test/sql/test_materialized_view/T/test_create_mv_with_dialect
@@ -1,0 +1,100 @@
+-- name: test_create_mv_with_dialect
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+CREATE TABLE base_table1 (
+  stream_time       DATETIME,
+  date_id           INT,
+  hour_local        INT,
+  minute_local      INT,
+  country_id        BIGINT,
+  city_id           BIGINT,
+  drop_off_poi_id   BIGINT,
+  vehicle_type_id   BIGINT,
+  event             VARCHAR(64),
+  originalsurge     DECIMAL(10,2),
+  final_fare        DECIMAL(10,2),
+  distance          DECIMAL(10,2),
+  surge             DECIMAL(10,2),
+  series_id         BIGINT
+);
+
+insert into base_table1 values 
+  ('2023-12-01 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+  ('2023-12-02 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+  ('2023-12-03 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+set catalog default_catalog;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- case 1: with specific param
+
+CREATE MATERIALIZED VIEW test_mv1 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1",
+"session.sql_dialect" = "trino"
+) AS
+SELECT
+  date_id,
+  DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))),
+  sum(originalsurge) as sum_originalsurge,
+  count(originalsurge) as count_originalsurge
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1
+  group by 1,2
+;
+refresh materialized view test_mv1 with sync mode;
+functionselect * from test_mv1 order by 1,2;
+
+set sql_dialect = "trino";
+SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2;
+functioin: print_hit_materialized_view("SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2;", "test_mv1")
+SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), avg(originalsurge) as avg_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;
+function: print_hit_materialized_view("SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), avg(originalsurge) as avg_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;", "test_mv1")
+drop materialized view test_mv1;
+
+set sql_dialect = "starrocks";
+CREATE MATERIALIZED VIEW test_mv1 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1",
+"session.sql_dialect" = "trino",
+"session.sql_mode" = "8589934626"
+) AS
+SELECT
+  CASE
+  WHEN city_id = 0 THEN 'Control'
+  WHEN city_id = 1 THEN 'Treatment'
+  ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0')
+  END AS treatment_id,
+  DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), 
+  STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))),
+  date_id,
+  sum(originalsurge) as sum_originalsurge,
+  count(originalsurge) as count_originalsurge
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1
+  group by 1,2,3
+;
+refresh materialized view test_mv1 with sync mode;
+select * from test_mv1 order by 1,2,3;
+
+set sql_dialect = "trino";
+SELECT CASE WHEN city_id = 0 THEN 'Control' WHEN city_id = 1 THEN 'Treatment' ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0') END AS treatment_id, DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2,3;
+function: print_hit_materialized_view("SELECT CASE WHEN city_id = 0 THEN 'Control' WHEN city_id = 1 THEN 'Treatment' ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0') END AS treatment_id, DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2,3;", "test_mv1")
+SELECT CASE WHEN city_id = 0 THEN 'Control' WHEN city_id = 1 THEN 'Treatment' ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0') END AS treatment_id, avg(originalsurge) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;
+function: print_hit_materialized_view("SELECT CASE WHEN city_id = 0 THEN 'Control' WHEN city_id = 1 THEN 'Treatment' ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0') END AS treatment_id, avg(originalsurge) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;", "test_mv1")
+
+drop materialized view test_mv1;
+
+set sql_dialect = "starrocks";
+CREATE MATERIALIZED VIEW test_mv1 
+REFRESH DEFERRED MANUAL

--- a/test/sql/test_materialized_view/T/test_create_mv_with_dialect
+++ b/test/sql/test_materialized_view/T/test_create_mv_with_dialect
@@ -27,10 +27,12 @@ CREATE TABLE base_table1 (
   series_id         BIGINT
 );
 
-insert into base_table1 values 
-  ('2023-12-01 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
-  ('2023-12-02 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
-  ('2023-12-03 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+insert into base_table1 (
+  stream_time, date_id, hour_local, minute_local, country_id, city_id, drop_off_poi_id, vehicle_type_id, event, originalsurge, final_fare, distance, surge, series_id
+) values
+  ('2023-12-01 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 'event1', 1, 1, 1, 1, 1),
+  ('2023-12-02 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 'event2', 1, 1, 1, 1, 1),
+  ('2023-12-03 00:00:00', 2000, 1, 1, 1, 1, 1, 1, 'event3', 1, 1, 1, 1, 1);
 set catalog default_catalog;
 
 create database db_${uuid0};
@@ -53,11 +55,11 @@ FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1
   group by 1,2
 ;
 refresh materialized view test_mv1 with sync mode;
-functionselect * from test_mv1 order by 1,2;
+select * from test_mv1 order by 1,2;
 
 set sql_dialect = "trino";
 SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2;
-functioin: print_hit_materialized_view("SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2;", "test_mv1")
+function: print_hit_materialized_view("SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), date_id, sum(originalsurge) as sum_originalsurge, count(originalsurge) as count_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1,2;", "test_mv1")
 SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), avg(originalsurge) as avg_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;
 function: print_hit_materialized_view("SELECT DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))), avg(originalsurge) as avg_originalsurge FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1 group by 1;", "test_mv1")
 drop materialized view test_mv1;
@@ -95,6 +97,6 @@ function: print_hit_materialized_view("SELECT CASE WHEN city_id = 0 THEN 'Contro
 
 drop materialized view test_mv1;
 
-set sql_dialect = "starrocks";
-CREATE MATERIALIZED VIEW test_mv1 
-REFRESH DEFERRED MANUAL
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:
We cannot create mv with setting `sql_mode` or `sql_dialect` but user can query with setting `sql_mode` or `sql_dialect`, so mv cannot rewrite those cases for queries with setting `sql_mode` or `sql_dialect`.

## What I'm doing:

After this pr, you can set `sql_dialect`/`sql_mode` in mv's defination as below, so this mv will use the setting  `sql_dialect`/`sql_mode` to parse/analyze/rewrite the defined query:
```
CREATE MATERIALIZED VIEW test_mv1 
REFRESH DEFERRED MANUAL
PROPERTIES (
"replication_num" = "1",
"session.sql_dialect" = "trino", -- <<<<
"session.sql_mode" = "8589934626" -- <<<<
) AS
SELECT
  CASE
  WHEN city_id = 0 THEN 'Control'
  WHEN city_id = 1 THEN 'Treatment'
  ELSE 'Treatment-' || lpad(cast(city_id as varchar), 2, '0')
  END AS treatment_id,
  DATE_TRUNC('day', date_add('minute', (hour_local * 60 + minute_local), 
  STR_TO_DATE(CAST(date_id AS VARCHAR), '%Y%m%d'))),
  date_id,
  sum(originalsurge) as sum_originalsurge,
  count(originalsurge) as count_originalsurge
FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.base_table1
  group by 1,2,3
;
```

Fixes https://github.com/StarRocks/starrocks/issues/63184

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
