### PR TITLE
[Enhancement] Iceberg cache revise

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -21,6 +21,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
@@ -46,6 +47,7 @@ import org.apache.iceberg.StarRocksIcebergTableScan;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.view.View;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -63,6 +65,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
+import static com.google.common.cache.CacheLoader.asyncReloading;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class CachingIcebergCatalog implements IcebergCatalog {
@@ -73,13 +76,14 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     private static final int MEMORY_FILE_SAMPLES = 100;
     private final String catalogName;
     private final IcebergCatalog delegate;
-    private final Cache<IcebergTableName, Table> tables;
+    private final LoadingCache<IcebergTableCacheKey, Table> tables;
     private final Cache<String, Database> databases;
     private final ExecutorService backgroundExecutor;
 
     private final IcebergCatalogProperties icebergProperties;
     private final com.github.benmanes.caffeine.cache.Cache<String, Set<DataFile>> dataFileCache;
     private final com.github.benmanes.caffeine.cache.Cache<String, Set<DeleteFile>> deleteFileCache;
+    private final Map<IcebergTableName, Set<String>> metaFileCacheMap = new ConcurrentHashMap<>(); // table -> metadata file paths
     private final Map<IcebergTableName, Long> tableLatestAccessTime = new ConcurrentHashMap<>();
     private final Map<IcebergTableName, Long> tableLatestRefreshTime = new ConcurrentHashMap<>();
 
@@ -91,11 +95,23 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         this.delegate = delegate;
         this.icebergProperties = icebergProperties;
         boolean enableCache = icebergProperties.isEnableIcebergMetadataCache();
-        this.databases = newCacheBuilder(icebergProperties.getIcebergMetaCacheTtlSec(),
+        this.databases = newCacheBuilder(icebergProperties.getIcebergMetaCacheTtlSec(), NEVER_CACHE,
                 enableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE).build();
         this.tables = newCacheBuilder(icebergProperties.getIcebergMetaCacheTtlSec(),
-                enableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE).build();
-        this.partitionCache = newCacheBuilder(icebergProperties.getIcebergMetaCacheTtlSec(),
+                icebergProperties.getIcebergTableCacheRefreshIntervalSec(),
+                enableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE)
+                .removalListener((RemovalNotification<IcebergTableCacheKey, Table> n) -> {
+                    LOG.debug("iceberg table cache removal: {}.{}, cause={}, evicted={}",
+                            n.getKey().icebergTableName.dbName, n.getKey().icebergTableName.tableName,
+                            n.getCause(), n.wasEvicted());
+                })
+                .build(asyncReloading(CacheLoader.from(key -> {
+                    LOG.debug("Loading iceberg table {}.{} from remote catalog",
+                                    key.icebergTableName.dbName, key.icebergTableName.tableName);
+                    return delegate.getTable(key.connectContext, 
+                                    key.icebergTableName.dbName, key.icebergTableName.tableName);
+                }), executorService));  
+        this.partitionCache = newCacheBuilder(icebergProperties.getIcebergMetaCacheTtlSec(), NEVER_CACHE,
                 enableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE).build(
                 CacheLoader.from(key -> {
                     Table nativeTable = getTable(new ConnectContext(), key.dbName, key.tableName);
@@ -192,16 +208,22 @@ public class CachingIcebergCatalog implements IcebergCatalog {
             tableLatestAccessTime.put(icebergTableName, System.currentTimeMillis());
         }
 
-        if (tables.getIfPresent(icebergTableName) != null) {
-            // do not cache if jwt or oauth2 is not used OR if it is not a REST Catalog.
-            if (Strings.isNullOrEmpty(connectContext.getAuthToken()) || !(delegate instanceof IcebergRESTCatalog)) {
-                return tables.getIfPresent(icebergTableName);
-            }
+        // do not cache if jwt or oauth2 is not used OR if it is not a REST Catalog.
+        boolean cacheAllowed = Strings.isNullOrEmpty(connectContext.getAuthToken())
+                       || !(delegate instanceof IcebergRESTCatalog);
+        if (!cacheAllowed) {
+            return delegate.getTable(connectContext, dbName, tableName);
         }
-
-        Table icebergTable = delegate.getTable(connectContext, dbName, tableName);
-        tables.put(icebergTableName, icebergTable);
-        return icebergTable;
+        IcebergTableCacheKey key = new IcebergTableCacheKey(icebergTableName, connectContext);
+        try {
+            return tables.get(key);
+        } catch (Exception e) {
+            Throwable c = e.getCause();
+            if (c instanceof NoSuchTableException) {
+                throw (NoSuchTableException) c;
+            }
+            throw new StarRocksConnectorException("Load table failed: " + dbName + "." + tableName, c);
+        }
     }
 
     @Override
@@ -297,13 +319,14 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     @Override
-    public synchronized void refreshTable(String dbName, String tableName, ExecutorService executorService) {
+    public synchronized void refreshTable(String dbName, String tableName, ConnectContext ctx, ExecutorService executorService) {
         IcebergTableName icebergTableName = new IcebergTableName(dbName, tableName);
-        if (tables.getIfPresent(icebergTableName) == null) {
+        IcebergTableCacheKey key = new IcebergTableCacheKey(icebergTableName, ctx);
+        if (tables.getIfPresent(key) == null) {
             partitionCache.invalidate(icebergTableName);
         } else {
-            BaseTable currentTable = (BaseTable) tables.getIfPresent(icebergTableName);
-            BaseTable updateTable = (BaseTable) delegate.getTable(new ConnectContext(), dbName, tableName);
+            BaseTable currentTable = (BaseTable) tables.getIfPresent(key);
+            BaseTable updateTable = (BaseTable) delegate.getTable(ctx, dbName, tableName);
             if (updateTable == null) {
                 invalidateCache(icebergTableName);
                 return;
@@ -332,25 +355,27 @@ public class CachingIcebergCatalog implements IcebergCatalog {
             if (!currentLocation.equals(updateLocation)) {
                 LOG.info("Refresh iceberg caching catalog table {}.{} from {} to {}",
                         dbName, tableName, currentLocation, updateLocation);
-                refreshTable(currentTable, updateTable, dbName, tableName, executorService);
+                refreshTable(currentTable, updateTable, dbName, tableName, ctx, executorService);
                 LOG.info("Finished to refresh iceberg table {}.{}", dbName, tableName);
             }
         }
     }
 
     private void refreshTable(BaseTable currentTable, BaseTable updatedTable,
-                              String dbName, String tableName, ExecutorService executorService) {
+                              String dbName, String tableName, ConnectContext ctx, ExecutorService executorService) {
         long baseSnapshotId = currentTable.currentSnapshot().snapshotId();
         long updatedSnapshotId = updatedTable.currentSnapshot().snapshotId();
         IcebergTableName baseIcebergTableName = new IcebergTableName(dbName, tableName, baseSnapshotId);
         IcebergTableName updatedIcebergTableName = new IcebergTableName(dbName, tableName, updatedSnapshotId);
+        IcebergTableCacheKey baseKey = new IcebergTableCacheKey(baseIcebergTableName, ctx);
+        IcebergTableCacheKey updateKey = new IcebergTableCacheKey(updatedIcebergTableName, ctx);
         long latestRefreshTime = tableLatestRefreshTime.computeIfAbsent(new IcebergTableName(dbName, tableName), ignore -> -1L);
 
         // update tables before refresh partition cache
         // so when refreshing partition cache, `getTables` can return the latest one.
         // another way to fix is to call `delegate.getTables` when refreshing partition cache.
         synchronized (this) {
-            tables.put(updatedIcebergTableName, updatedTable);
+            tables.put(updateKey, updatedTable);
         }
 
         partitionCache.invalidate(baseIcebergTableName);
@@ -382,19 +407,22 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     public void refreshCatalog() {
-        List<IcebergTableName> identifiers = Lists.newArrayList(tables.asMap().keySet());
-        for (IcebergTableName identifier : identifiers) {
+        List<IcebergTableCacheKey> identifiers = Lists.newArrayList(tables.asMap().keySet());
+        for (IcebergTableCacheKey identifier : identifiers) {
             try {
-                Long latestAccessTime = tableLatestAccessTime.get(identifier);
+                Long latestAccessTime = tableLatestAccessTime.get(identifier.icebergTableName);
                 if (latestAccessTime == null || (System.currentTimeMillis() - latestAccessTime) / 1000 >
                         Config.background_refresh_metadata_time_secs_since_last_access_secs) {
+                    invalidateCache(identifier.icebergTableName);
                     continue;
                 }
 
-                refreshTable(identifier.dbName, identifier.tableName, backgroundExecutor);
+                refreshTable(identifier.icebergTableName.dbName, identifier.icebergTableName.tableName, 
+                        identifier.connectContext, backgroundExecutor);
             } catch (Exception e) {
-                LOG.warn("refresh {}.{} metadata cache failed, msg : ", identifier.dbName, identifier.tableName, e);
-                invalidateCache(identifier);
+                LOG.warn("refresh {}.{} metadata cache failed, msg : ", identifier.icebergTableName.dbName, 
+                        identifier.icebergTableName.tableName, e);
+                invalidateCache(identifier.icebergTableName);
             }
         }
     }
@@ -414,15 +442,22 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     private void invalidateCache(IcebergTableName key) {
-        tables.invalidate(key);
+        tables.invalidate(new IcebergTableCacheKey(key, new ConnectContext()));
         // will invalidate all snapshots of this table
         partitionCache.invalidate(key);
+        Set<String> paths = metaFileCacheMap.get(key);
+        if (paths != null && !paths.isEmpty()) {
+            dataFileCache.invalidateAll(paths);
+            deleteFileCache.invalidateAll(paths);
+            paths.clear();
+        }
     }
 
     @Override
     public StarRocksIcebergTableScan getTableScan(Table table, StarRocksIcebergTableScanContext scanContext) {
         scanContext.setDataFileCache(dataFileCache);
         scanContext.setDeleteFileCache(deleteFileCache);
+        scanContext.setMetaFileCacheMap(metaFileCacheMap);
         scanContext.setDataFileCacheWithMetrics(icebergProperties.isIcebergManifestCacheWithColumnStatistics());
         scanContext.setEnableCacheDataFileIdentifierColumnMetrics(
                 icebergProperties.enableCacheDataFileIdentifierColumnStatistics());
@@ -430,10 +465,14 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         return delegate.getTableScan(table, scanContext);
     }
 
-    private CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long maximumSize) {
+    private CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshInterval, long maximumSize) {
         CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
         if (expiresAfterWriteSec >= 0) {
             cacheBuilder.expireAfterWrite(expiresAfterWriteSec, SECONDS);
+        }
+
+        if (refreshInterval > 0) {
+            cacheBuilder.refreshAfterWrite(refreshInterval, SECONDS);
         }
 
         cacheBuilder.maximumSize(maximumSize);
@@ -485,6 +524,33 @@ public class CachingIcebergCatalog implements IcebergCatalog {
             sb.append(", tableName='").append(tableName).append('\'');
             sb.append('}');
             return sb.toString();
+        }
+    }
+
+    public static class IcebergTableCacheKey {
+        IcebergTableName icebergTableName;
+        ConnectContext connectContext;
+
+        IcebergTableCacheKey(IcebergTableName icebergTableName, ConnectContext connectContext) {
+            this.icebergTableName = icebergTableName;
+            this.connectContext = connectContext;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            IcebergTableCacheKey that = (IcebergTableCacheKey) obj;
+            return icebergTableName.equals(that.icebergTableName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(icebergTableName);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -223,7 +223,7 @@ public interface IcebergCatalog extends MemoryTrackable {
     default void deleteUncommittedDataFiles(List<String> fileLocations) {
     }
 
-    default void refreshTable(String dbName, String tableName, ExecutorService refreshExecutor) {
+    default void refreshTable(String dbName, String tableName, ConnectContext ctx, ExecutorService refreshExecutor) {
     }
 
     default void invalidatePartitionCache(String dbName, String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -365,7 +365,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         synchronized (this) {
             tables.remove(TableIdentifier.of(dbName, tableName));
             try {
-                icebergCatalog.refreshTable(dbName, tableName, jobPlanningExecutor);
+                icebergCatalog.refreshTable(dbName, tableName, context, jobPlanningExecutor);
             } catch (Exception exception) {
                 LOG.error("Failed to refresh caching iceberg table.");
                 icebergCatalog.invalidateCache(dbName, tableName);
@@ -1202,7 +1202,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             String tableName = icebergTable.getCatalogTableName();
             tables.remove(TableIdentifier.of(dbName, tableName));
             try {
-                icebergCatalog.refreshTable(dbName, tableName, jobPlanningExecutor);
+                icebergCatalog.refreshTable(dbName, tableName, new ConnectContext(), jobPlanningExecutor);
             } catch (Exception e) {
                 LOG.error("Failed to refresh table {}.{}.{}. invalidate cache", catalogName, dbName, tableName, e);
                 icebergCatalog.invalidateCache(dbName, tableName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
@@ -16,10 +16,12 @@ package com.starrocks.connector.iceberg;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.starrocks.connector.PlanMode;
+import com.starrocks.connector.iceberg.CachingIcebergCatalog.IcebergTableName;
 import com.starrocks.qe.ConnectContext;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 
+import java.util.Map;
 import java.util.Set;
 
 public class StarRocksIcebergTableScanContext {
@@ -30,6 +32,7 @@ public class StarRocksIcebergTableScanContext {
     private boolean dataFileCacheWithMetrics;
     private Cache<String, Set<DataFile>> dataFileCache;
     private Cache<String, Set<DeleteFile>> deleteFileCache;
+    private Map<IcebergTableName, Set<String>> metaFileCacheMap;
     private boolean onlyReadCache;
     private int localParallelism;
     private long localPlanningMaxSlotSize;
@@ -73,6 +76,10 @@ public class StarRocksIcebergTableScanContext {
         return deleteFileCache;
     }
 
+    public Map<IcebergTableName, Set<String>> getMetaFileCacheMap() {
+        return metaFileCacheMap;
+    }
+
     public void setDataFileCacheWithMetrics(boolean dataFileCacheWithMetrics) {
         this.dataFileCacheWithMetrics = dataFileCacheWithMetrics;
     }
@@ -83,6 +90,10 @@ public class StarRocksIcebergTableScanContext {
 
     public void setDeleteFileCache(Cache<String, Set<DeleteFile>> deleteFileCache) {
         this.deleteFileCache = deleteFileCache;
+    }
+
+    public void setMetaFileCacheMap(Map<IcebergTableName, Set<String>> metaFileCacheMap) {
+        this.metaFileCacheMap = metaFileCacheMap;
     }
 
     public boolean isOnlyReadCache() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.iceberg;
 
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
@@ -110,5 +111,37 @@ public class CachingIcebergCatalogTest {
             List<String> res = cachingIcebergCatalog.listPartitionNames(table, requestContext, null);
             Assertions.assertEquals(res.size(), 0);
         }
+    }
+
+    @Test
+    public void testGetDB(@Mocked IcebergCatalog icebergCatalog, @Mocked Database db) {
+        new Expectations() {
+            {
+                icebergCatalog.getDB(connectContext, "test");
+                result = db;
+                minTimes = 1;
+            }
+        };
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, icebergCatalog,
+                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        Assertions.assertEquals(db, cachingIcebergCatalog.getDB(connectContext, "test"));
+        Assertions.assertEquals(db, cachingIcebergCatalog.getDB(connectContext, "test"));
+    }
+
+    @Test
+    public void testGetTable(@Mocked IcebergCatalog icebergCatalog, @Mocked Table nativeTable) {
+        new Expectations() {
+            {
+                icebergCatalog.getTable(connectContext, "test", "table");
+                result = nativeTable;
+                minTimes = 1;
+            }
+        };
+        //test for cache
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, icebergCatalog,
+                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        Assertions.assertEquals(nativeTable, cachingIcebergCatalog.getTable(connectContext, "test", "table"));
+        Assertions.assertEquals(nativeTable, cachingIcebergCatalog.getTable(connectContext, "test", "table"));
+        cachingIcebergCatalog.invalidateCache("test", "table");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1551,9 +1551,10 @@ public class IcebergMetadataTest extends TableTestBase {
 
     @Test
     public void testRefreshTableException(@Mocked CachingIcebergCatalog icebergCatalog) {
+        ConnectContext ctx = new ConnectContext();
         new Expectations() {
             {
-                icebergCatalog.refreshTable(anyString, anyString, null);
+                icebergCatalog.refreshTable(anyString, anyString, (ConnectContext) any, null);
                 result = new StarRocksConnectorException("refresh failed");
             }
         };


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. Add the refreshAfterWrite for meta cache.
2. invalidate all related cache when auto refresh finished for a table.

Fixes https://github.com/StarRocks/starrocks/issues/63372

### Test on local env:

1. test refreshAfterWrite:

```
mysql> select * from t1;
+------+------+
| c1   | c2   |
+------+------+
|    1 |    2 |
|    1 |    2 |
|    1 |    1 |
|    1 |    2 |
|    1 |    2 |
|    1 |    1 |
+------+------+
6 rows in set (0.11 sec)
2025-09-23 10:56:23.770+08:00 DEBUG (starrocks-mysql-nio-pool-0|159) [CachingIcebergCatalog$2.load():123] Loading iceberg table owen_iceberg_oss.t1 from remote catalog

mysql> select * from t1;
+------+------+
| c1   | c2   |
+------+------+
|    1 |    2 |
|    1 |    2 |
|    1 |    1 |
|    1 |    2 |
|    1 |    2 |
|    1 |    1 |
+------+------+
6 rows in set (0.11 sec)
2025-09-23 11:00:48.932+08:00 DEBUG (starrocks-mysql-nio-pool-1|294) [CachingIcebergCatalog$2.reload():130] Async reloading iceberg table owen_iceberg_oss.t1 from remote catalog
2025-09-23 11:00:48.943+08:00 INFO (iceberg_qa_test-background-iceberg-worker-pool-0|295) [BaseMetastoreTableOperations.refreshFromMetadataLocation():190] Refreshing table metadata from new version: oss://starrocks-qa-test-data/system_data/iceberg_data/owen_iceberg_oss.db/t1/metadata/00005-27ca8bda-b863-4a75-b829-8601e6293445.metadata.json

spark-sql> insert into t1 values(3,3);
spark-sql> select * from t1;
3       3
1       1
1       1
1       2
1       2
1       2
1       2
Time taken: 4.865 seconds, Fetched 7 row(s)

mysql> select * from t1;
+------+------+
| c1   | c2   |
+------+------+
|    1 |    1 |
|    1 |    2 |
|    1 |    2 |
|    1 |    2 |
|    1 |    2 |
|    1 |    1 |
+------+------+
6 rows in set (0.03 sec)
2025-09-23 11:12:28.110+08:00 DEBUG (starrocks-mysql-nio-pool-2|424) [CachingIcebergCatalog$2.reload():130] Async reloading iceberg table owen_iceberg_oss.t1 from remote catalog/
mysql> select * from t1;
+------+------+
| c1   | c2   |
+------+------+
|    3 |    3 |
|    1 |    2 |
|    1 |    2 |
|    1 |    1 |
|    1 |    2 |
|    1 |    1 |
|    1 |    2 |
+------+------+
7 rows in set (0.12 sec)

mysql> 
```

2. test TTL:

```
create external catalog iceberg_qa_test PROPERTIES (
    "type"  =  "iceberg",
    "iceberg.catalog.type"  =  "hive",
    "iceberg.catalog.hive.metastore.uris"="thrift://x:9083",
    "aws.s3.access_key"  =  "x",
    "aws.s3.secret_key"  =  "x",
    "aws.s3.endpoint"  =  "https://x",
    "iceberg_meta_cache_ttl_sec" = "60"
);

mysql> select current_time();
+----------------+
| current_time() |
+----------------+
| 12:48:55       |
+----------------+
1 row in set (0.01 sec)

mysql> select * from t1;
+------+------+
| c1   | c2   |
+------+------+
|    1 |    2 |
|    1 |    1 |
|    4 |    4 |
|    1 |    2 |
|    1 |    2 |
|    1 |    2 |
|    3 |    3 |
|    1 |    1 |
+------+------+
8 rows in set (0.18 sec)

2025-09-23 12:50:34.002+08:00 DEBUG (statistics meta manager|44) [CachingIcebergCatalog.lambda$new$1():128] iceberg table cache removal: owen_iceberg_oss.t1, cause=EXPIRED, evicted=true
2025-09-23 12:50:34.054+08:00 DEBUG (statistics meta manager|44) [CachingIcebergCatalog.lambda$new$0():104] iceberg database cache removal: owen_iceberg_oss, cause=EXPIRED, evicted=true
```

3. test background refresh finish invalidation:

```
set in fe.conf
background_refresh_metadata_interval_millis = 30000
background_refresh_metadata_time_secs_since_last_access_secs = 60
Then query table t1 and wait to watch the log:
2025-09-23 13:30:49.351+08:00 DEBUG (com.starrocks.connector.hive.ConnectorTableMetadataProcessor|53) [CachingIcebergCatalog.lambda$new$1():128] iceberg table cache removal: owen_iceberg_oss.t1, cause=EXPLICIT, evicted=false

2025-09-23 13:30:49.354+08:00 DEBUG (iceberg_qa_test-background-iceberg-worker-pool-1|320) [CachingIcebergCatalog.lambda$new$4():175] Key=oss://starrocks-qa-test-data/system_data/iceberg_data/owen_iceberg_oss.db/t1/metadata/92ec4b08-a01e-419d-bf49-6015c479d088-m0.avro, Value.size=1, Cause=EXPLICIT
.........
2025-09-23 13:30:49.354+08:00 DEBUG (iceberg_qa_test-background-iceberg-worker-pool-2|321) [CachingIcebergCatalog.lambda$new$4():175] Key=oss://starrocks-qa-test-data/system_data/iceberg_data/owen_iceberg_oss.db/t1/metadata/f66d01b5-4611-4a3f-94ef-df8c4a890c0a-m0.avro, Value.size=1, Cause=EXPLICIT
```
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
