### PR TITLE
[BugFix] remove the annoying warning log of json

### DIFF
--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -74,6 +74,8 @@ public:
 
     bool is_index() const { return _type == TAccessPathType::type::INDEX; }
 
+    bool is_root() const { return _type == TAccessPathType::type::ROOT; }
+
     bool is_from_predicate() const { return _from_predicate; }
 
     bool is_extended() const { return _extended; }

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -409,6 +409,10 @@ Status OlapChunkSource::_init_column_access_paths(Schema* schema) {
             } else {
                 LOG(WARNING) << "failed to convert column access path: " << res.status();
             }
+        } else if (path->is_root() && !path->children().empty()) {
+            // Check if this is a ROOT path for JSON field that has been pruned
+            // For JSON fields, the root column might be pruned but sub-paths are still needed
+            VLOG_ROW << "Skipping pruned JSON root path: " << root;
         } else {
             LOG(WARNING) << "failed to find column in schema: " << root;
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

For a query like `select count(*) from bluesky where get_json_string(data, 'commit.collection') = 'app.bsky.graph.list'`, the only required column access path is `data.commit.collection`, and the `data` would be pruned. so it's a normal case that the `data` is not found in the schema.

Fixes #63225

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
