### PR TITLE
[BugFix] Forget left join flag of table function when applying array low cardinality optimization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
@@ -149,6 +149,9 @@ public class TableFunction extends Function {
         this.isLeftJoin = isLeftJoin;
     }
 
+    public boolean isLeftJoin() {
+        return this.isLeftJoin;
+    }
 
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/TableFunctionNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/TableFunctionNode.java
@@ -116,4 +116,9 @@ public class TableFunctionNode extends PlanNode {
     public List<Integer> getOuterSlots() {
         return outerSlots;
     }
+
+    @VisibleForTesting
+    public TableFunction getTableFunction() {
+        return tableFunction;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -343,6 +343,7 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
             function = (TableFunction) Expr.getBuiltinFunction(FunctionSet.UNNEST,
                     fnInputs.stream().map(ScalarOperator::getType).toArray(Type[]::new), function.getArgNames(),
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            function.setIsLeftJoin(tableFunc.getFn().isLeftJoin());
         }
 
         ScalarOperator predicate = rewritePredicate(tableFunc.getPredicate(), inputStringRefs);


### PR DESCRIPTION
## Why I'm doing:
when transform TableFunctionOperator in low cardinality optimizing rule, its left join flag is neglected and the number of result rows is incorrect.

prepare data
```
create table t(c0 int, c1 array<string>)properties("replication_num"="1");
insert into t values(1, NULL),(2, []), (3, ["foo","bar"]);
```

query
```
select c0, tmp.c1 from t left join unnest(t.c1) on true;
```

expect result
```
+------+------+
| c0   | c1   |
+------+------+
|    2 | NULL |
|    1 | NULL |
|    3 | foo  |
|    3 | bar  |
+------+------+

```
actual result
```
+------+------+
| c0   | c1   |
+------+------+
|    3 | foo  |
|    3 | bar  |
+------+------+
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
