### PR TITLE
[BugFix] Fix incompatible bitmap index reuse for fast schema evolution in shared-data (backport #63315)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -906,7 +906,23 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         if (!ColumnType.canReuseZonemapIndex(oriColumn.getType(), modColumn.getType())) {
-            fastSchemaEvolution = false;
+            return false;
+        }
+
+        // Check whether manually created indexes support fast schema evolution. The rules are as follows:
+        // 1. The index can be reused after type conversion, and BE has made necessary changes,
+        //    such as casting new type values to old type values before querying the index.
+        // 2. The index cannot be reused, and BE has made changes to skip it during queries.
+        // Currently, BLOOMFILTER and NGRAMBF indexes use rule 2 to support fast schema evolution. BE-side changes
+        // for other indexes are not yet ready, so fast schema change is temporarily disabled for them. This feature
+        // will be gradually enabled for these indexes once BE support is in place.
+        List<Index> existedIndexes = olapTable.getIndexes();
+        for (Index index : existedIndexes) {
+            if (index.getColumns().contains(oriColumn.getColumnId())) {
+                if (index.getIndexType() != IndexDef.IndexType.NGRAMBF) {
+                    return false;
+                }
+            }
         }
 
         return fastSchemaEvolution;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -318,4 +318,24 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
             Assert.assertEquals(ScalarType.INT, table.getBaseSchema().get(4).getType());
         }
     }
+
+    @Test
+    public void testModifyColumnTypeWithManuallyCreatedIndex() throws Exception {
+        LakeTable table = createTable(connectContext, "CREATE TABLE t_modify_index_type " +
+                "(c0 INT, c1 INT, c2 INT, INDEX idx1 (c1) USING BITMAP) " +
+                "DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES( 'fast_schema_evolution'='true', 'bloom_filter_columns' = 'c2') ");
+
+        // bitmap index can not use fast schema evolution
+        {
+            String alterSql = "ALTER TABLE t_modify_index_type MODIFY COLUMN c1 BIGINT";
+            executeAlterAndWaitFinish(table, alterSql, false);
+        }
+
+        // bloomfilter index can use fast schema evolution
+        {
+            String alterSql = "ALTER TABLE t_modify_index_type MODIFY COLUMN c2 BIGINT";
+            executeAlterAndWaitFinish(table, alterSql, true);
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
backport #63315

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [X] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

