### PR TITLE
[Enhancement] Cache parquet column batch for delta lake metadata

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeCatalogProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeCatalogProperties.java
@@ -50,11 +50,11 @@ public class DeltaLakeCatalogProperties {
         this.enableDeltaLakeCheckpointMetaCache =
                 PropertyUtil.propertyAsBoolean(properties, ENABLE_DELTA_LAKE_CHECKPOINT_META_CACHE, true);
         this.deltaLakeJsonMetaCacheTtlSec =
-                PropertyUtil.propertyAsLong(properties, DELTA_LAKE_JSON_META_CACHE_TTL, 48 * 60 * 60);
+                PropertyUtil.propertyAsLong(properties, DELTA_LAKE_JSON_META_CACHE_TTL, 24 * 60 * 60);
         this.deltaLakeJsonMetaCacheMemoryUsageRatio =
                 PropertyUtil.propertyAsDouble(properties, DELTA_LAKE_JSON_META_CACHE_MEMORY_USAGE_RATIO, 0.1);
         this.deltaLakeCheckpointMetaCacheTtlSec =
-                PropertyUtil.propertyAsLong(properties, DELTA_LAKE_CHECKPOINT_META_CACHE_TTL, 48 * 60 * 60);
+                PropertyUtil.propertyAsLong(properties, DELTA_LAKE_CHECKPOINT_META_CACHE_TTL, 24 * 60 * 60);
         this.deltaLakeCheckpointMetaCacheMemoryUsageRatio =
                 PropertyUtil.propertyAsDouble(properties, DELTA_LAKE_CHECKPOINT_META_CACHE_MEMORY_USAGE_RATIO, 0.1);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeParquetHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeParquetHandler.java
@@ -125,11 +125,7 @@ public class DeltaLakeParquetHandler extends DefaultParquetHandler {
                     currentFile = deltaLakeFileStatus.getPath();
                     if (LogReplay.containsAddOrRemoveFileActions(physicalSchema)) {
                         Pair<DeltaLakeFileStatus, StructType> key = Pair.create(deltaLakeFileStatus, physicalSchema);
-                        if (checkpointCache.getIfPresent(key) != null || predicate.isEmpty()) {
-                            currentColumnarBatchList = checkpointCache.get(key);
-                        } else {
-                            currentColumnarBatchList = readParquetFile(currentFile, physicalSchema, hadoopConf);
-                        }
+                        currentColumnarBatchList = checkpointCache.get(key);
                     } else {
                         currentColumnarBatchList = readParquetFile(currentFile, physicalSchema, hadoopConf);
                     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request makes adjustments to Delta Lake catalog properties and improves logic in the Delta Lake Parquet handler. The main changes involve reducing the default cache TTL values and simplifying the logic for reading Parquet files when using the checkpoint cache.

**Delta Lake catalog property changes:**

* Reduced the default TTL for both `DELTA_LAKE_JSON_META_CACHE_TTL` and `DELTA_LAKE_CHECKPOINT_META_CACHE_TTL` from 48 hours to 24 hours in `DeltaLakeCatalogProperties.java`.

**Delta Lake Parquet handler Use checkpoint cache :**

* Simplified the logic. DeltaLakeParquetHandler will read the checkpoint cache directly,  Regardless of whether there is a partition predicate or not.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
