### PR TITLE
[Enhancement] Optimize database locks into table with intensive db locks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
@@ -240,14 +240,14 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
         if (db == null) {
             throw new AlterCancelException("database id: " + dbId + " does not exist");
         }
+        OlapTable targetTable = checkAndGetTable(db, tableId);
         Locker locker = new Locker();
-        if (!locker.lockDatabaseAndCheckExist(db, LockType.READ)) {
+        if (!locker.lockTableAndCheckDbExist(db, targetTable.getId(), LockType.READ)) {
             throw new AlterCancelException("insert overwrite commit failed because locking db: " + dbId + " failed");
         }
 
         try {
             dbName = db.getFullName();
-            OlapTable targetTable = checkAndGetTable(db, tableId);
             if (getTmpPartitionIds().stream().anyMatch(id -> targetTable.getPartition(id) == null)) {
                 throw new AlterCancelException("partitions changed during insert");
             }
@@ -265,7 +265,7 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
             tableColumnNames = targetTable.getBaseSchema().stream().filter(column -> !column.isGeneratedColumn())
                     .map(col -> ParseUtil.backquote(col.getName())).collect(Collectors.toList());
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), targetTable.getId(), LockType.READ);
         }
 
         // start insert job
@@ -584,31 +584,37 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
     }
 
     private void cancelInternal() {
+        try {
+            doCancelInternal();
+        } catch (Exception e) {
+            LOG.warn("exception when cancel optimize job.", e);
+        }
+    }
+
+    private void doCancelInternal() throws Exception {
         // remove temp partitions, and set state to NORMAL
         Database db = null;
         Locker locker = new Locker();
         try {
             db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
-            if (db == null) {
+            if (db == null || !db.isExist()) {
                 throw new AlterCancelException("database id:" + dbId + " does not exist");
             }
-
-            if (!locker.lockDatabaseAndCheckExist(db, LockType.WRITE)) {
-                throw new AlterCancelException("insert overwrite commit failed because locking db:" + dbId + " failed");
-            }
-
         } catch (Exception e) {
             LOG.warn("get and write lock database failed when cancel job: {}", jobId, e);
             return;
         }
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+        if (table == null) {
+            throw new AlterCancelException("table:" + tableId + " does not exist in database:" + db.getFullName());
+        }
+        Preconditions.checkState(table instanceof OlapTable);
+        OlapTable targetTable = (OlapTable) table;
 
+        if (!locker.lockTableAndCheckDbExist(db, table.getId(), LockType.WRITE)) {
+            throw new AlterCancelException("insert overwrite commit failed because locking db:" + dbId + " failed");
+        }
         try {
-            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
-            if (table == null) {
-                throw new AlterCancelException("table:" + tableId + " does not exist in database:" + db.getFullName());
-            }
-            Preconditions.checkState(table instanceof OlapTable);
-            OlapTable targetTable = (OlapTable) table;
             Set<Tablet> sourceTablets = Sets.newHashSet();
             if (getTmpPartitionIds() != null) {
                 for (long pid : getTmpPartitionIds()) {
@@ -634,7 +640,7 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
         } catch (Exception e) {
             LOG.warn("exception when cancel optimize job.", e);
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.WRITE);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -36,11 +36,11 @@ package com.starrocks.catalog;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
+import com.google.common.collect.Tables;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
@@ -67,7 +67,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -120,14 +119,14 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
 
     public CatalogRecycleBin() {
         super("recycle bin");
-        idToDatabase = Maps.newHashMap();
-        idToTableInfo = HashBasedTable.create();
-        nameToTableInfo = HashBasedTable.create();
-        idToPartition = Maps.newHashMap();
-        idToRecycleTime = Maps.newHashMap();
-        enableEraseLater = new HashSet<>();
-        asyncDeleteForPartitions = Maps.newHashMap();
-        asyncDeleteForTables = Maps.newHashMap();
+        idToDatabase = Maps.newConcurrentMap();
+        idToTableInfo = Tables.newCustomTable(Maps.newConcurrentMap(), () -> Maps.newConcurrentMap());
+        nameToTableInfo = Tables.newCustomTable(Maps.newConcurrentMap(), () -> Maps.newConcurrentMap());
+        idToPartition = Maps.newConcurrentMap();
+        idToRecycleTime = Maps.newConcurrentMap();
+        enableEraseLater = Sets.newConcurrentHashSet();
+        asyncDeleteForPartitions = Maps.newConcurrentMap();
+        asyncDeleteForTables = Maps.newConcurrentMap();
     }
 
     private void removeRecycleMarkers(Long id) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -277,7 +277,7 @@ public class HiveTable extends Table {
             throw new StarRocksConnectorException("Not found database " + dbName);
         }
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.WRITE);
+        locker.lockTableWithIntensiveDbLock(db.getId(), this.id, LockType.WRITE);
         try {
             this.fullSchema.clear();
             this.nameToColumn.clear();
@@ -292,7 +292,7 @@ public class HiveTable extends Table {
                 GlobalStateMgr.getCurrentState().getEditLog().logModifyTableColumn(log);
             }
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), this.id, LockType.WRITE);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -265,11 +265,7 @@ public class TabletChecker extends FrontendDaemon {
         long start = System.nanoTime();
         TabletCheckerStat totStat = new TabletCheckerStat();
 
-        long lockTotalTime = 0;
-        long waitTotalTime = 0;
-        long lockStart;
         List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIdsIncludeRecycleBin();
-        DATABASE:
         for (Long dbId : dbIds) {
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIncludeRecycleBin(dbId);
             if (db == null) {
@@ -280,102 +276,19 @@ public class TabletChecker extends FrontendDaemon {
                 continue;
             }
 
-            // set the config to a local variable to avoid config params changed.
-            int partitionBatchNum = Config.tablet_checker_partition_batch_num;
-            int partitionChecked = 0;
-            Locker locker = new Locker();
-            locker.lockDatabase(db.getId(), LockType.READ);
-            lockStart = System.nanoTime();
-            try {
-                List<Long> aliveBeIdsInCluster =
-                        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds(true);
-                TABLE:
-                for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTablesIncludeRecycleBin(db)) {
-                    if (!table.needSchedule(false)) {
-                        continue;
-                    }
-                    if (table.isCloudNativeTableOrMaterializedView()) {
-                        // replicas are managed by StarOS and cloud storage.
-                        continue;
-                    }
-
-                    if ((isUrgent && !isUrgentTable(dbId, table.getId()))) {
-                        continue;
-                    }
-
-                    OlapTable olapTbl = (OlapTable) table;
-                    for (PhysicalPartition physicalPartition : GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .getAllPhysicalPartitionsIncludeRecycleBin(olapTbl)) {
-                        partitionChecked++;
-
-                        boolean isPartitionUrgent = isPartitionUrgent(dbId, table.getId(), physicalPartition.getId());
-                        totStat.isUrgentPartitionHealthy = true;
-                        if ((isUrgent && !isPartitionUrgent) || (!isUrgent && isPartitionUrgent)) {
-                            continue;
-                        }
-
-                        if (partitionChecked % partitionBatchNum == 0) {
-                            LOG.debug("partition checked reached batch value, release lock");
-                            lockTotalTime += System.nanoTime() - lockStart;
-                            // release lock, so that lock can be acquired by other threads.
-                            locker.unLockDatabase(db.getId(), LockType.READ);
-                            locker.lockDatabase(db.getId(), LockType.READ);
-                            LOG.debug("checker get lock again");
-                            lockStart = System.nanoTime();
-                            if (GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIncludeRecycleBin(dbId) == null) {
-                                continue DATABASE;
-                            }
-                            if (GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                    .getTableIncludeRecycleBin(db, olapTbl.getId()) == null) {
-                                continue TABLE;
-                            }
-                            if (GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                    .getPhysicalPartitionIncludeRecycleBin(olapTbl, physicalPartition.getId()) == null) {
-                                continue;
-                            }
-                        }
-
-                        Partition logicalPartition = olapTbl.getPartition(physicalPartition.getParentId());
-                        if (logicalPartition == null) {
-                            continue;
-                        }
-
-                        if (logicalPartition.getState() != PartitionState.NORMAL) {
-                            // when alter job is in FINISHING state, partition state will be set to NORMAL,
-                            // and we can schedule the tablets in it.
-                            continue;
-                        }
-
-                        short replicaNum = GlobalStateMgr.getCurrentState()
-                                .getLocalMetastore()
-                                .getReplicationNumIncludeRecycleBin(
-                                        olapTbl.getPartitionInfo(), physicalPartition.getParentId());
-                        if (replicaNum == (short) -1) {
-                            continue;
-                        }
-
-                        TabletCheckerStat partitionTabletCheckerStat = doCheckOnePartition(db, olapTbl, physicalPartition,
-                                replicaNum, aliveBeIdsInCluster, isPartitionUrgent);
-                        totStat.accumulateStat(partitionTabletCheckerStat);
-
-                        if (totStat.isUrgentPartitionHealthy && isPartitionUrgent) {
-                            // if all replicas in this partition are healthy, remove this partition from
-                            // priorities.
-                            LOG.debug("partition is healthy, remove from urgent table: {}-{}-{}",
-                                    db.getId(), olapTbl.getId(), physicalPartition.getId());
-                            removeFromUrgentTable(new RepairTabletInfo(db.getId(),
-                                    olapTbl.getId(), Lists.newArrayList(physicalPartition.getId())));
-                        }
-                    } // partitions
-                } // tables
-            } finally {
-                lockTotalTime += System.nanoTime() - lockStart;
-                locker.unLockDatabase(db.getId(), LockType.READ);
-            }
+            List<Long> aliveBeIdsInCluster =
+                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds(true);
+            for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTablesIncludeRecycleBin(db)) {
+                if (GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIncludeRecycleBin(dbId) == null) {
+                    break;
+                }
+                doCheckTable(db, table, aliveBeIdsInCluster, isUrgent, totStat);
+            } // tables
         } // end for dbs
 
         long cost = (System.nanoTime() - start) / 1000000;
-        lockTotalTime = lockTotalTime / 1000000;
+        long waitTotalTime = totStat.waitTotalTime;
+        long lockTotalTime = totStat.lockTotalTime / 1000000;
 
         stat.counterTabletCheckCostMs.addAndGet(cost);
         stat.counterTabletChecked.addAndGet(totStat.totalTabletNum);
@@ -389,6 +302,94 @@ public class TabletChecker extends FrontendDaemon {
                 totStat.tabletInScheduler, totStat.tabletNotReady, cost, lockTotalTime - waitTotalTime, waitTotalTime);
     }
 
+    private void doCheckTable(Database db,
+                              Table table,
+                              List<Long> aliveBeIdsInCluster,
+                              boolean isUrgent,
+                              TabletCheckerStat totStat) {
+        if (!table.needSchedule(false)) {
+            return;
+        }
+        if (table.isCloudNativeTableOrMaterializedView()) {
+            // replicas are managed by StarOS and cloud storage.
+            return;
+        }
+        long dbId = db.getId();
+        if ((isUrgent && !isUrgentTable(dbId, table.getId()))) {
+            return;
+        }
+        OlapTable olapTbl = (OlapTable) table;
+
+        // set the config to a local variable to avoid config params changed.
+        int partitionBatchNum = Config.tablet_checker_partition_batch_num;
+        int partitionChecked = 0;
+
+        Locker locker = new Locker();
+        long lockStart = System.nanoTime();
+        locker.lockTableWithIntensiveDbLock(dbId, table.getId(), LockType.READ);
+        try {
+            for (PhysicalPartition physicalPartition : GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getAllPhysicalPartitionsIncludeRecycleBin(olapTbl)) {
+                partitionChecked++;
+
+                boolean isPartitionUrgent = isPartitionUrgent(dbId, table.getId(), physicalPartition.getId());
+                totStat.isUrgentPartitionHealthy = true;
+                if ((isUrgent && !isPartitionUrgent) || (!isUrgent && isPartitionUrgent)) {
+                    continue;
+                }
+                if (partitionChecked % partitionBatchNum == 0) {
+                    // release lock, so that lock can be acquired by other threads.
+                    if (GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIncludeRecycleBin(dbId) == null) {
+                        return;
+                    }
+                    if (GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTableIncludeRecycleBin(db, olapTbl.getId()) == null) {
+                        return;
+                    }
+                    if (GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getPhysicalPartitionIncludeRecycleBin(olapTbl, physicalPartition.getId()) == null) {
+                        continue;
+                    }
+                }
+
+                Partition logicalPartition = olapTbl.getPartition(physicalPartition.getParentId());
+                if (logicalPartition == null) {
+                    continue;
+                }
+
+                if (logicalPartition.getState() != PartitionState.NORMAL) {
+                    // when alter job is in FINISHING state, partition state will be set to NORMAL,
+                    // and we can schedule the tablets in it.
+                    continue;
+                }
+
+                short replicaNum = GlobalStateMgr.getCurrentState()
+                        .getLocalMetastore()
+                        .getReplicationNumIncludeRecycleBin(
+                                olapTbl.getPartitionInfo(), physicalPartition.getParentId());
+                if (replicaNum == (short) -1) {
+                    continue;
+                }
+
+                TabletCheckerStat partitionTabletCheckerStat = doCheckOnePartition(db, olapTbl, physicalPartition,
+                        replicaNum, aliveBeIdsInCluster, isPartitionUrgent);
+                totStat.accumulateStat(partitionTabletCheckerStat);
+
+                if (totStat.isUrgentPartitionHealthy && isPartitionUrgent) {
+                    // if all replicas in this partition are healthy, remove this partition from
+                    // priorities.
+                    LOG.debug("partition is healthy, remove from urgent table: {}-{}-{}",
+                            db.getId(), olapTbl.getId(), physicalPartition.getId());
+                    removeFromUrgentTable(new RepairTabletInfo(db.getId(),
+                            olapTbl.getId(), Lists.newArrayList(physicalPartition.getId())));
+                }
+            } // partitions
+        } finally {
+            totStat.addLockTime(System.nanoTime() - lockStart);
+            locker.unLockTableWithIntensiveDbLock(dbId, table.getId(), LockType.READ);
+        }
+    }
+
     private static class TabletCheckerStat {
         public long totalTabletNum = 0;
         public long unhealthyTabletNum = 0;
@@ -396,6 +397,7 @@ public class TabletChecker extends FrontendDaemon {
         public long tabletInScheduler = 0;
         public long tabletNotReady = 0;
         public long waitTotalTime = 0;
+        private long lockTotalTime = 0;
         public boolean isUrgentPartitionHealthy = true;
 
         public void accumulateStat(TabletCheckerStat stat) {
@@ -405,7 +407,12 @@ public class TabletChecker extends FrontendDaemon {
             tabletInScheduler += stat.tabletInScheduler;
             tabletNotReady += stat.tabletNotReady;
             waitTotalTime += stat.waitTotalTime;
+            lockTotalTime += stat.lockTotalTime;
             isUrgentPartitionHealthy = stat.isUrgentPartitionHealthy;
+        }
+
+        public void addLockTime(long time) {
+            lockTotalTime += time;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1092,8 +1092,8 @@ public class TabletScheduler extends FrontendDaemon {
             throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
         }
         Locker locker = new Locker();
+        locker.lockDatabase(db.getId(), LockType.WRITE);
         try {
-            locker.lockDatabase(db.getId(), LockType.WRITE);
             checkMetaExist(tabletCtx);
             if (deleteBackendDropped(tabletCtx, force)
                     || deleteBadReplica(tabletCtx, force)
@@ -1333,8 +1333,8 @@ public class TabletScheduler extends FrontendDaemon {
             throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
         }
         Locker locker = new Locker();
+        locker.lockDatabase(db.getId(), LockType.WRITE);
         try {
-            locker.lockDatabase(db.getId(), LockType.WRITE);
             checkMetaExist(tabletCtx);
             List<Replica> replicas = tabletCtx.getReplicas();
             for (Replica replica : replicas) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -566,7 +566,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             return;
         }
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.WRITE);
+        locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.WRITE);
         try {
             // check db and table again
             if (GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(db.getId()) == null) {
@@ -578,7 +578,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             GlobalStateMgr.getCurrentState().getColocateTableIndex().updateLakeTableColocationInfo(table, true /* isJoin */,
                     null /* expectGroupId */);
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.WRITE);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -595,7 +594,7 @@ public class CatalogRecycleBinTest {
         recycleBin.recycleTable(dbId, table2SameName, true);
         recycleBin.recycleTable(dbId, table2, true);
 
-        Assertions.assertEquals(recycleBin.getTables(dbId), Arrays.asList(table1, table2SameName, table2));
+        Assertions.assertEquals(Sets.newHashSet(recycleBin.getTables(dbId)), Sets.newHashSet(table1, table2SameName, table2));
         Assertions.assertSame(recycleBin.getTable(dbId, table1.getId()), table1);
         Assertions.assertSame(recycleBin.getTable(dbId, table2.getId()), table2);
         Assertions.assertTrue(recycleBin.idToRecycleTime.containsKey(table1.getId()));
@@ -924,7 +923,7 @@ public class CatalogRecycleBinTest {
         recycleBin.recycleTable(dbId, table2SameName, true);
         recycleBin.recycleTable(dbId, table2, true);
 
-        Assertions.assertEquals(recycleBin.getTables(dbId), Arrays.asList(table1, table2SameName, table2));
+        Assertions.assertEquals(Sets.newHashSet(recycleBin.getTables(dbId)), Sets.newHashSet(table1, table2SameName, table2));
         Assertions.assertSame(recycleBin.getTable(dbId, table1.getId()), table1);
         Assertions.assertSame(recycleBin.getTable(dbId, table2.getId()), table2);
         Assertions.assertTrue(recycleBin.idToRecycleTime.containsKey(table1.getId()));

--- a/fe/fe-core/src/test/java/com/starrocks/common/lock/TestLockException.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/lock/TestLockException.java
@@ -118,8 +118,6 @@ public class TestLockException {
         Database db = new Database(1, "db");
         Locker locker = new Locker();
         Assertions.assertThrows(ErrorReportException.class, () -> locker.lockDatabase(db.getId(), LockType.READ));
-        Assertions.assertThrows(ErrorReportException.class, () -> locker.tryLockDatabase(db.getId(), LockType.READ,
-                10000, TimeUnit.MILLISECONDS));
 
         Assertions.assertThrows(ErrorReportException.class, () -> locker.lockTablesWithIntensiveDbLock(
                 1L, Lists.newArrayList(2L), LockType.READ));

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/concurrent/lock/TestLockInterface.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/concurrent/lock/TestLockInterface.java
@@ -11,18 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package com.starrocks.common.lock;
+package com.starrocks.common.util.concurrent.lock;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.concurrent.QueryableReentrantReadWriteLock;
-import com.starrocks.common.util.concurrent.lock.LockException;
-import com.starrocks.common.util.concurrent.lock.LockManager;
-import com.starrocks.common.util.concurrent.lock.LockParams;
-import com.starrocks.common.util.concurrent.lock.LockType;
-import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.server.GlobalStateMgr;
 import mockit.Mock;
 import mockit.MockUp;
@@ -45,15 +40,6 @@ public class TestLockInterface {
     public void tearDown() {
         Config.lock_manager_enabled = false;
         Config.lock_manager_enable_resolve_deadlock = false;
-    }
-
-    @Test
-    public void testLockAndCheckExist1() {
-        long rid = 1L;
-        Database database = new Database(rid, "db");
-        database.setExist(false);
-        Locker locker = new Locker();
-        Assertions.assertFalse(locker.lockDatabaseAndCheckExist(database, LockType.READ));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Bug 1: `updateMetaForOlapTable` is slow:
```
      {
         "id":9658056,
         "name":"starrocks-taskrun-pool-26084",
         "type":"INTENTION_EXCLUSIVE",
         "heldFor":6980,
         "waitTime":0,
         "stack":[
            "java.base@11.0.28/java.util.HashMap.hash(HashMap.java:340)",
            "java.base@11.0.28/java.util.HashMap.put(HashMap.java:608)",
            "java.base@11.0.28/java.util.HashSet.add(HashSet.java:220)",
            "java.base@11.0.28/java.util.stream.Collectors$$Lambda$35/0x00000008000fd040.accept(Unknown Source)",
            "java.base@11.0.28/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)",
            "java.base@11.0.28/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)",
            "java.base@11.0.28/java.util.TreeMap$KeySpliterator.forEachRemaining(TreeMap.java:2739)",
            "java.base@11.0.28/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)",
            "java.base@11.0.28/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)",
            "java.base@11.0.28/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)",
            "java.base@11.0.28/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)",
            "java.base@11.0.28/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)",
            "app//com.starrocks.catalog.OlapTable.getVisiblePartitionNames(OlapTable.java:1680)",
            "app//com.starrocks.scheduler.mv.MVVersionManager.lambda$updateMetaForOlapTable$2(MVVersionManager.java:123)",
            "app//com.starrocks.scheduler.mv.MVVersionManager$$Lambda$3757/0x00000008014bd040.test(Unknown Source)",
            "java.base@11.0.28/java.util.Collection.removeIf(Collection.java:544)",
            "app//com.starrocks.scheduler.mv.MVVersionManager.updateMetaForOlapTable(MVVersionManager.java:122)",
            "app//com.starrocks.scheduler.mv.MVVersionManager.updateMVVersionInfo(MVVersionManager.java:73)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.updateMeta(PartitionBasedMvRefreshProcessor.java:831)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:472)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:376)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:335)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:203)",
            "app//com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:313)",
            "app//com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:60)",
            "app//com.starrocks.scheduler.TaskRunExecutor$$Lambda$2841/0x000000080145d840.get(Unknown Source)",
            "java.base@11.0.28/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)",
            "java.base@11.0.28/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)",
            "java.base@11.0.28/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)",
            "java.base@11.0.28/java.lang.Thread.run(Thread.java:829)"
         ]
      }
```
Problem 2: Query's `Lock` time may be too long if it contains related mvs:
```
  Planner:
     - -- Parser[1] 0
     - -- Total[1] 6s883ms
     -     -- Analyzer[1] 6s732ms
     -         -- Lock[1] 6s725ms
     -         -- AnalyzeDatabase[3] 0
     -         -- AnalyzeTemporaryTable[3] 0
     -         -- AnalyzeTable[3] 0
     -     -- Transformer[1] 2ms
     -     -- Optimizer[1] 144ms
     -         -- MVPreprocess[1] 1ms
     -             -- MVChooseCandidates[1] 0
     -         -- MVTextRewrite[1] 0
     -         -- RuleBaseOptimize[1] 92ms
     -         -- CostBaseOptimize[1] 40ms
     -         -- PhysicalRewrite[1] 10ms
     -         -- PlanValidate[1] 0
     -             -- InputDependenciesChecker[1] 0
     -             -- TypeChecker[1] 0
     -             -- CTEUniqueChecker[1] 0
     -             -- ColumnReuseChecker[1] 0
     -     -- ExecPlanBuild[1] 0
     - -- Pending[1] 0
     - -- Prepare[1] 0
     - -- Deploy[1] 7ms
     -     -- DeployLockInternalTime[1] 7ms
     -         -- DeploySerializeConcurrencyTime[3] 0
     -         -- DeployStageByStageTime[9] 0
     -         -- DeployWaitTime[9] 5ms
     -             -- DeployAsyncSendTime[4] 0
     - DeployDataSize: 23604
```
## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/63482

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces widespread database locks with table-scoped intensive locks, adds concurrent data structures, and refactors tablet/alter workflows for safer, faster operations.
> 
> - **Locking Refactor**:
>   - Replace `lockDatabase` usage with `lockTableWithIntensiveDbLock`/`ReadLockedTable`/`WriteLockedTable` across alter jobs, binlog, metastore, lake syncer, HTTP actions, and schedulers.
>   - Consolidate replay/cancel paths to use table-level locks; add safe try/catch in cancel flows.
> - **Concurrency & Data Structures**:
>   - Switch several maps to `ConcurrentHashMap`; use `Tables.newCustomTable`; adopt `Sets.newConcurrentHashSet` in `CatalogRecycleBin`.
>   - Remove unnecessary DB-level locks in fast paths (e.g., TableRowCountAction, checks).
> - **Tablet/Checker/Scheduler**:
>   - Refactor `TabletChecker` to per-table checking (`doCheckTable`), track lock/wait time, and simplify flow.
>   - Adjust `TabletSchedCtx`/`TabletScheduler` to use table locks during clone/finish/update paths.
> - **Metastore/Operations**:
>   - `LocalMetastore`, `Database.dropTable`, partition ops, truncate/replace, recover/replay paths updated to table locks; minor logic fixes.
> - **Lake/MV/Optimize Jobs**:
>   - Lake rollup/schema change/optimize jobs updated to table locks; minor robustness tweaks and logging.
> - **Tests**:
>   - Update lock tests and recycle bin tests for new behavior and unordered collections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6014f7bca4813ae91055e285a618d581772940c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->