### PR TITLE
[BugFix] fix clang-tidy errors on arm

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -670,7 +670,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         # ignore warning from apache-orc
         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-switch-default")
     endif ()
-    # Add -rtlib=compiler-rt for ARM architecture to fix LLVM bug 16404
+    # Add -rtlib=compiler-rt for ARM architecture to fix LLVM bug: https://bugs.llvm.org/show_bug.cgi?id=16404
     if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "aarch64")
         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -rtlib=compiler-rt")
     endif()

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -670,6 +670,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         # ignore warning from apache-orc
         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-switch-default")
     endif ()
+    # Add -rtlib=compiler-rt for ARM architecture to fix LLVM bug 16404
+    if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "aarch64")
+        set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -rtlib=compiler-rt")
+    endif()
 else ()
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0.0")
         # ignore error from apache-orc

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -650,6 +650,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror")
     endif()
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unused-parameter -Wno-documentation -Wno-weak-vtables")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unknown-warning-option")
     # Turn on following warning as error explicitly
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror=string-plus-int")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror=pessimizing-move")

--- a/be/src/exprs/arithmetic_expr.cpp
+++ b/be/src/exprs/arithmetic_expr.cpp
@@ -44,7 +44,7 @@ namespace starrocks {
                                                       \
     virtual Expr* clone(ObjectPool* pool) const override { return pool->add(new CLASS_NAME(*this)); }
 
-static std::optional<LogicalType> eliminate_trivial_cast_for_decimal_mul(const Expr* e) {
+[[maybe_unused]] static std::optional<LogicalType> eliminate_trivial_cast_for_decimal_mul(const Expr* e) {
     DIAGNOSTIC_PUSH
 #if defined(__GNUC__) && !defined(__clang__)
     DIAGNOSTIC_IGNORE("-Wmaybe-uninitialized")

--- a/be/src/storage/rowset/binary_plain_page.cpp
+++ b/be/src/storage/rowset/binary_plain_page.cpp
@@ -168,7 +168,7 @@ template <LogicalType Type>
 void BinaryPlainPageDecoder<Type>::batch_string_at_index(Slice* dst, const int32_t* idx, size_t size) const {
     if (_parsed_datas.has_value()) {
         const std::vector<Slice>& parsed_data = *_parsed_datas;
-        const Slice* parsed_data_ptr = parsed_data.data();
+        [[maybe_unused]] const Slice* parsed_data_ptr = parsed_data.data();
         static_assert(sizeof(Slice) == sizeof(__int128));
 #ifdef __SSE4_2__
 #pragma GCC unroll 2

--- a/be/src/storage/rowset/binary_plain_page.cpp
+++ b/be/src/storage/rowset/binary_plain_page.cpp
@@ -168,9 +168,9 @@ template <LogicalType Type>
 void BinaryPlainPageDecoder<Type>::batch_string_at_index(Slice* dst, const int32_t* idx, size_t size) const {
     if (_parsed_datas.has_value()) {
         const std::vector<Slice>& parsed_data = *_parsed_datas;
-        [[maybe_unused]] const Slice* parsed_data_ptr = parsed_data.data();
         static_assert(sizeof(Slice) == sizeof(__int128));
 #ifdef __SSE4_2__
+        const Slice* parsed_data_ptr = parsed_data.data();
 #pragma GCC unroll 2
         for (int i = 0; i < size; ++i) {
             DCHECK_LT(idx[i], parsed_data.size());


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust build flags for Clang/ARM and minor code tweaks to silence unused variables and fix SIMD path.
> 
> - **Build/CMake**:
>   - Add `-Wno-unknown-warning-option` under Clang.
>   - On `aarch64`, add `-rtlib=compiler-rt` to workaround an LLVM issue.
> - **Exprs**:
>   - Mark `eliminate_trivial_cast_for_decimal_mul` as `[[maybe_unused]]` to avoid unused warnings.
> - **Storage**:
>   - In `BinaryPlainPageDecoder::batch_string_at_index`, scope `parsed_data_ptr` to the `__SSE4_2__` path to avoid unused-variable issues when SIMD is off.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcacec527c0d1b268087783f52bbe1e71d7bb6e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->