### PR TITLE
[BugFix] Forget left join flag of table function when applying array low cardinality optimization (backport #63419)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
@@ -164,6 +164,10 @@ public class TableFunction extends Function {
         Text.writeString(output, GsonUtils.GSON.toJson(this));
     }
 
+    public boolean isLeftJoin() {
+        return this.isLeftJoin;
+    }
+
     public void readFields(DataInput input) throws IOException {
         super.readFields(input);
         final TableFunction tableFunction = GsonUtils.GSON.fromJson(Text.readString(input), TableFunction.class);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/TableFunctionNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/TableFunctionNode.java
@@ -118,4 +118,9 @@ public class TableFunctionNode extends PlanNode {
     public List<Integer> getOuterSlots() {
         return outerSlots;
     }
+
+    @VisibleForTesting
+    public TableFunction getTableFunction() {
+        return tableFunction;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -343,6 +343,7 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
             function = (TableFunction) Expr.getBuiltinFunction(FunctionSet.UNNEST,
                     fnInputs.stream().map(ScalarOperator::getType).toArray(Type[]::new), function.getArgNames(),
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            function.setIsLeftJoin(tableFunc.getFn().isLeftJoin());
         }
 
         ScalarOperator predicate = rewritePredicate(tableFunc.getPredicate(), inputStringRefs);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -14,12 +14,16 @@
 
 package com.starrocks.sql.plan;
 
+import com.google.common.collect.Lists;
 import com.starrocks.common.FeConstants;
+import com.starrocks.planner.TableFunctionNode;
 import com.starrocks.utframe.StarRocksAssert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 public class LowCardinalityArrayTest extends PlanTestBase {
 
@@ -759,5 +763,26 @@ public class LowCardinalityArrayTest extends PlanTestBase {
         Assertions.assertTrue(plan.contains("Global Dict Exprs:\n"
                 + "    14: DictDefine(13: a1, [<place-holder>])\n"
                 + "    15: DictDefine(13: a1, [concat(<place-holder>, 'xxx')])"), plan);
+    }
+
+    @Test
+    public void testArrayLowCardinalityOptimizationOnLateralLeftJoin() throws Exception {
+        String sql = "  select s1.v1, s1.v2, t.a1 a1, t.a2 a2\n" +
+                "  from s1 left join unnest(s1.a1, s1.a2)t(a1,a2) on true";
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("  2:Decode\n" +
+                "  |  <dict id 9> : <string id 5>\n" +
+                "  |  <dict id 10> : <string id 6>\n" +
+                "  |  \n" +
+                "  1:TableValueFunction\n" +
+                "  |  tableFunctionName: unnest\n" +
+                "  |  columns: [unnest]\n" +
+                "  |  returnTypes: [INT, INT]"), plan);
+        ExecPlan execPlan = getExecPlan(sql);
+        List<TableFunctionNode> tfNodes = Lists.newArrayList();
+        execPlan.getTopFragment().getPlanRoot().collect(TableFunctionNode.class, tfNodes);
+        Assertions.assertEquals(1, tfNodes.size());
+        TableFunctionNode tableFunctionNode = tfNodes.get(0);
+        Assertions.assertTrue(tableFunctionNode.getTableFunction().isLeftJoin());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

cp #63419

when transform TableFunctionOperator in low cardinality optimizing rule, its left join flag is neglected and the number of result rows is incorrect.

prepare data
```
create table t(c0 int, c1 array<string>)properties("replication_num"="1");
insert into t values(1, NULL),(2, []), (3, ["foo","bar"]);
```

query
```
select c0, tmp.c1 from t left join unnest(t.c1) on true;
```

expect result
```
+------+------+
| c0   | c1   |
+------+------+
|    2 | NULL |
|    1 | NULL |
|    3 | foo  |
|    3 | bar  |
+------+------+

```
actual result
```
+------+------+
| c0   | c1   |
+------+------+
|    3 | foo  |
|    3 | bar  |
+------+------+
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


