### PR TITLE
[Enhancement] Replace assert_regexp_matches with assert_regex for python 3.12 in test/lib

### DIFF
--- a/test/lib/choose_cases.py
+++ b/test/lib/choose_cases.py
@@ -515,7 +515,7 @@ class ChooseCase(object):
 
                     _t_info_line = f_lines[line_id].rstrip()
                     _t_line = _t_info_line.lstrip()
-                    tools.assert_regexp_matches(_t_line.lstrip(), t_info_regex, f"Missing thread info : {_t_line}")
+                    tools.assert_regex(_t_line.lstrip(), t_info_regex, f"Missing thread info : {_t_line}")
 
                     # get thread name & thread count
                     _t_name, _, _t_count = re.findall(r"-- ([0-9a-zA-Z_\- ]+)(\(([0-9]+)\))?:", _t_line)[0]

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1442,7 +1442,7 @@ class StarrocksSQLApiLib(object):
         else:
             if exp.startswith(REGEX_FLAG):
                 log.info("[check regex]: %s" % exp[len(REGEX_FLAG) :])
-                tools.assert_regexp_matches(
+                tools.assert_regex(
                     r"%s" % str(act),
                     exp[len(REGEX_FLAG) :],
                     "sql result not match regex:\n- [SQL]: %s\n- [exp]: %s\n- [act]: %s\n---"
@@ -3155,7 +3155,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
             act.append(processed_row)
 
         log.info("[check regex]: %s" % exp[len(REGEX_FLAG) :])
-        tools.assert_regexp_matches(
+        tools.assert_regex(
             r"%s" % str(act),
             exp[len(REGEX_FLAG) :],
             "sql result not match regex:\n- [SQL]: %s\n- [exp]: %s\n- [act]: %s\n---"


### PR DESCRIPTION
## Why I'm doing:
nose.tools maps assert_regexp_matches to unittest `AssertRegexpMatches`.
`AssertRegexpMatches` got renamed to `AssertRegex` and  is deprecated since python 3.2. The alias got removed in 3.12 ([changelog](https://github.com/python/cpython/blob/49e83e31bd45e513a3caaa39b5789e95caa78ac1/Doc/whatsnew/3.12.rst#unittest-1)). 
When running with `python >= 3.12` this will result in `AttributeError: module 'nose.tools' has no attribute 'assert_regexp_matches'`.
## What I'm doing:
Replacing occurences of assert_regexp_matches with assert_regex.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
