### PR TITLE
[BugFix] Fix date_trunc partition pruning with combined predicates causing EMPTYSET

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -484,27 +484,30 @@ public class SyncPartitionUtils {
                 }
                 break;
             case MONTH:
-                if (upperDateTime.with(TemporalAdjusters.firstDayOfMonth()).equals(upperDateTime)) {
+                LocalDateTime monthStart = upperDateTime.with(TemporalAdjusters.firstDayOfMonth()).with(LocalTime.MIDNIGHT);
+                if (monthStart.equals(upperDateTime)) {
                     truncUpperDateTime = upperDateTime;
                 } else {
-                    truncUpperDateTime = upperDateTime.plusMonths(1).with(TemporalAdjusters.firstDayOfMonth());
+                    truncUpperDateTime = monthStart.plusMonths(1);
                 }
                 break;
             case QUARTER:
-                if (upperDateTime.with(upperDateTime.getMonth().firstMonthOfQuarter())
-                        .with(TemporalAdjusters.firstDayOfMonth()).equals(upperDateTime)) {
+                LocalDateTime quarterStart = upperDateTime
+                        .with(upperDateTime.getMonth().firstMonthOfQuarter())
+                        .with(TemporalAdjusters.firstDayOfMonth())
+                        .with(LocalTime.MIDNIGHT);
+                if (quarterStart.equals(upperDateTime)) {
                     truncUpperDateTime = upperDateTime;
                 } else {
-                    LocalDateTime nextDateTime = upperDateTime.plusMonths(3);
-                    truncUpperDateTime = nextDateTime.with(nextDateTime.getMonth().firstMonthOfQuarter())
-                            .with(TemporalAdjusters.firstDayOfMonth());
+                    truncUpperDateTime = quarterStart.plusMonths(3);
                 }
                 break;
             case YEAR:
-                if (upperDateTime.with(TemporalAdjusters.firstDayOfYear()).equals(upperDateTime)) {
+                LocalDateTime yearStart = upperDateTime.with(TemporalAdjusters.firstDayOfYear()).with(LocalTime.MIDNIGHT);
+                if (yearStart.equals(upperDateTime)) {
                     truncUpperDateTime = upperDateTime;
                 } else {
-                    truncUpperDateTime = upperDateTime.plusYears(1).with(TemporalAdjusters.firstDayOfYear());
+                    truncUpperDateTime = yearStart.plusYears(1);
                 }
                 break;
             default:
@@ -534,15 +537,17 @@ public class SyncPartitionUtils {
                 truncUpperDateTime = upperDateTime.plusWeeks(1).with(LocalTime.MIN);
                 break;
             case MONTH:
-                truncUpperDateTime = upperDateTime.plusMonths(1).with(TemporalAdjusters.firstDayOfMonth());
+                truncUpperDateTime = upperDateTime.plusMonths(1).with(TemporalAdjusters.firstDayOfMonth())
+                        .with(LocalTime.MIDNIGHT);
                 break;
             case QUARTER:
                 LocalDateTime nextDateTime = upperDateTime.plusMonths(3);
                 truncUpperDateTime = nextDateTime.with(nextDateTime.getMonth().firstMonthOfQuarter())
-                        .with(TemporalAdjusters.firstDayOfMonth());
+                        .with(TemporalAdjusters.firstDayOfMonth()).with(LocalTime.MIDNIGHT);
                 break;
             case YEAR:
-                truncUpperDateTime = upperDateTime.plusYears(1).with(TemporalAdjusters.firstDayOfYear());
+                truncUpperDateTime = upperDateTime.plusYears(1).with(TemporalAdjusters.firstDayOfYear())
+                        .with(LocalTime.MIDNIGHT);
                 break;
             default:
                 throw new SemanticException("Do not support date_trunc format string:{}", granularity);
@@ -570,14 +575,15 @@ public class SyncPartitionUtils {
                 truncLowerDateTime = lowerDateTime.with(DayOfWeek.MONDAY).truncatedTo(ChronoUnit.DAYS);
                 break;
             case MONTH:
-                truncLowerDateTime = lowerDateTime.with(TemporalAdjusters.firstDayOfMonth());
+                truncLowerDateTime = lowerDateTime.with(TemporalAdjusters.firstDayOfMonth()).with(LocalTime.MIDNIGHT);
                 break;
             case QUARTER:
                 truncLowerDateTime = lowerDateTime.with(lowerDateTime.getMonth().firstMonthOfQuarter())
-                        .with(TemporalAdjusters.firstDayOfMonth());
+                        .with(TemporalAdjusters.firstDayOfMonth())
+                        .with(LocalTime.MIDNIGHT);
                 break;
             case YEAR:
-                truncLowerDateTime = lowerDateTime.with(TemporalAdjusters.firstDayOfYear());
+                truncLowerDateTime = lowerDateTime.with(TemporalAdjusters.firstDayOfYear()).with(LocalTime.MIDNIGHT);
                 break;
             default:
                 throw new SemanticException("Do not support in date_trunc format string:" + granularity);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -71,6 +71,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.starrocks.sql.common.SyncPartitionUtils.getLowerDateTime;
+import static com.starrocks.sql.common.SyncPartitionUtils.nextUpperDateTime;
 import static com.starrocks.sql.common.TimeUnitUtils.TIME_MAP;
 
 /**
@@ -110,8 +112,7 @@ public class ColumnFilterConverter {
             if (FunctionSet.SUBSTRING.equalsIgnoreCase(functionName) ||
                     FunctionSet.SUBSTR.equalsIgnoreCase(functionName)) {
                 Expr firstExpr = node.getChild(0);
-                if (firstExpr instanceof SlotRef) {
-                    SlotRef slotRef = (SlotRef) firstExpr;
+                if (firstExpr instanceof SlotRef slotRef) {
                     if (columnRef.getName().equals(slotRef.getColumnName())) {
                         node.setChild(0, new StringLiteral(constant.getVarchar()));
                         return true;
@@ -120,8 +121,7 @@ public class ColumnFilterConverter {
             } else if (FunctionSet.FROM_UNIXTIME.equalsIgnoreCase(functionName) ||
                     FunctionSet.FROM_UNIXTIME_MS.equalsIgnoreCase(functionName)) {
                 Expr firstExpr = node.getChild(0);
-                if (firstExpr instanceof SlotRef) {
-                    SlotRef slotRef = (SlotRef) firstExpr;
+                if (firstExpr instanceof SlotRef slotRef) {
                     if (columnRef.getName().equals(slotRef.getColumnName())) {
                         node.setChild(0, new IntLiteral(constant.getBigint()));
                         return true;
@@ -218,7 +218,94 @@ public class ColumnFilterConverter {
             return;
         }
 
+        // Fast path: build range for date_trunc(...) on expression-partitioned tables; if handled, return.
+        if (predicate instanceof BinaryPredicateOperator
+                && predicate.getChild(0) instanceof CallOperator
+                && buildDateTruncRange((BinaryPredicateOperator) predicate, result, table)) {
+            return;
+        }
+
         predicate.accept(COLUMN_FILTER_VISITOR, result);
+    }
+
+    // Build a PartitionColumnFilter range for date_trunc predicates. Returns true if handled.
+    private static boolean buildDateTruncRange(BinaryPredicateOperator predicate,
+                                               Map<String, PartitionColumnFilter> result,
+                                               Table table) {
+        if (!(table instanceof OlapTable)) {
+            return false;
+        }
+        if (!(predicate.getChild(0) instanceof CallOperator call) ||
+                !(predicate.getChild(1) instanceof ConstantOperator rhsConst)) {
+            return false;
+        }
+        if (!FunctionSet.DATE_TRUNC.equals(call.getFnName())) {
+            return false;
+        }
+        PartitionInfo pinfo = ((OlapTable) table).getPartitionInfo();
+        if (!(pinfo instanceof ExpressionRangePartitionInfo)) {
+            return false;
+        }
+        ExpressionRangePartitionInfo exprInfo = (ExpressionRangePartitionInfo) pinfo;
+        if (!checkPartitionExprsContainsOperator(exprInfo.getPartitionExprs(table.getIdToColumn()), call)) {
+            return false;
+        }
+
+        try {
+            // Partition column and RHS constant as literal
+            ColumnRefOperator columnRef = Utils.extractColumnRef(predicate.getChild(0)).get(0);
+            LiteralExpr rhsLiteral = convertLiteral(columnRef.getType(), rhsConst);
+            if (!(rhsLiteral instanceof DateLiteral) || !(call.getChild(0) instanceof ConstantOperator)) {
+                return false;
+            }
+            // Time unit and normalized endpoints
+            String granularity = ((ConstantOperator) call.getChild(0)).getVarchar().toLowerCase();
+            LocalDateTime rhsDateTime = ((DateLiteral) rhsLiteral).toLocalDateTime();
+            LocalDateTime periodStart = getLowerDateTime(rhsDateTime, granularity);
+            LocalDateTime nextPeriodStart = nextUpperDateTime(periodStart, granularity);
+
+            DateLiteral startLit = new DateLiteral(periodStart, rhsLiteral.getType());
+            DateLiteral nextStartLit = new DateLiteral(nextPeriodStart, rhsLiteral.getType());
+
+            PartitionColumnFilter filter = result.getOrDefault(columnRef.getName(), new PartitionColumnFilter());
+            boolean isAligned = rhsDateTime.equals(periodStart);
+            switch (predicate.getBinaryType()) {
+                case EQ: {
+                    // If RHS constant is not aligned to the granularity, equality can never be true.
+                    // Build an empty interval: [L, L)
+                    if (!isAligned) {
+                        filter.setLowerBound(startLit, true);
+                        filter.setUpperBound(startLit, false);
+                    } else {
+                        filter.setLowerBound(startLit, true);
+                        filter.setUpperBound(nextStartLit, false);
+                    }
+                    break;
+                }
+                case GE:
+                    // If not aligned, minimal satisfying dt starts from next period start [U, +inf)
+                    filter.setLowerBound(isAligned ? startLit : nextStartLit, true);
+                    break;
+                case GT:
+                    filter.setLowerBound(nextStartLit, true);
+                    break;
+                case LE:
+                    filter.setUpperBound(nextStartLit, false);
+                    break;
+                case LT:
+                    // If not aligned, T(dt) < C allows dt < U; if aligned, dt < L
+                    filter.setUpperBound(isAligned ? startLit : nextStartLit, false);
+                    break;
+                default:
+                    return false;
+            }
+            filter.setFromFunctionCall();
+            result.put(columnRef.getName(), filter);
+            return true;
+        } catch (Exception e) {
+            LOG.warn("build date_trunc column filter failed", e);
+            return false;
+        }
     }
 
     // Replace the predicate of the query with the predicate of the partition expression and evaluate.
@@ -250,14 +337,13 @@ public class ColumnFilterConverter {
                 return predicate;
             }
             ScalarOperator evaluation = ScalarOperatorEvaluator.INSTANCE.evaluation(callOperator);
-            if (!(evaluation instanceof ConstantOperator)) {
+            if (!(evaluation instanceof ConstantOperator result)) {
                 return predicate;
             }
             predicate = predicate.clone();
-            ConstantOperator result = (ConstantOperator) evaluation;
             Optional<ConstantOperator> castResult = result.castTo(predicateExpr.getType());
 
-            if (!castResult.isPresent()) {
+            if (castResult.isEmpty()) {
                 return predicate;
             }
             result = castResult.get();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
@@ -828,20 +828,20 @@ public class SyncPartitionUtilsTest {
         {
             // MONTH
             Pair<String, String> result = getDateTruncFuncTransform(baseRange, "MONTH");
-            Assertions.assertEquals("2020-01-01 12:34:56", result.first);
-            Assertions.assertEquals("2020-02-01 12:34:56", result.second);
+            Assertions.assertEquals("2020-01-01 00:00:00", result.first);
+            Assertions.assertEquals("2020-02-01 00:00:00", result.second);
         }
         {
             // QUARTER
             Pair<String, String> result = getDateTruncFuncTransform(baseRange, "QUARTER");
-            Assertions.assertEquals("2020-01-01 12:34:56", result.first);
-            Assertions.assertEquals("2020-04-01 12:34:56", result.second);
+            Assertions.assertEquals("2020-01-01 00:00:00", result.first);
+            Assertions.assertEquals("2020-04-01 00:00:00", result.second);
         }
         {
             // YEAR
             Pair<String, String> result = getDateTruncFuncTransform(baseRange, "YEAR");
-            Assertions.assertEquals("2020-01-01 12:34:56", result.first);
-            Assertions.assertEquals("2021-01-01 12:34:56", result.second);
+            Assertions.assertEquals("2020-01-01 00:00:00", result.first);
+            Assertions.assertEquals("2021-01-01 00:00:00", result.second);
         }
     }
 

--- a/test/sql/test_partition_by_expr/R/test_date_trunc_partition_prune.sql
+++ b/test/sql/test_partition_by_expr/R/test_date_trunc_partition_prune.sql
@@ -1,0 +1,256 @@
+-- name: test_date_trunc_partition_prune
+DROP DATABASE IF EXISTS test_date_trunc_partition_prune;
+-- result:
+-- !result
+CREATE DATABASE test_date_trunc_partition_prune;
+-- result:
+-- !result
+use test_date_trunc_partition_prune;
+-- result:
+-- !result
+CREATE TABLE `date_trunc_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('month', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO date_trunc_test VALUES 
+(1, '2020-01-15 10:30:00', 'jan'),
+(2, '2020-01-25 14:20:00', 'jan'),
+(3, '2020-02-10 09:15:00', 'feb'),
+(4, '2020-02-28 16:45:00', 'feb'),
+(5, '2020-03-05 11:00:00', 'mar'),
+(6, '2020-03-20 13:30:00', 'mar'),
+(7, '2020-04-12 08:20:00', 'apr'),
+(8, '2020-04-28 17:10:00', 'apr'),
+(9, '2020-06-15 12:40:00', 'jun'),
+(10, '2020-07-08 15:25:00', 'jul');
+-- result:
+-- !result
+select pk, dt from date_trunc_test where date_trunc('month', dt) = '2020-01-01' and dt < '2020-01-20' order by pk;
+-- result:
+1	2020-01-15 10:30:00
+-- !result
+select pk, dt from date_trunc_test where date_trunc('month', dt) = '2020-01-15 12:00:00' and dt >= '2020-01-01' order by pk;
+-- result:
+-- !result
+select pk, dt from date_trunc_test where date_trunc('month', dt) >= '2020-02-01' and dt < '2020-03-15' order by pk;
+-- result:
+3	2020-02-10 09:15:00
+4	2020-02-28 16:45:00
+5	2020-03-05 11:00:00
+-- !result
+select pk, dt from date_trunc_test where date_trunc('month', dt) >= '2020-02-15' and dt < '2020-04-01' order by pk;
+-- result:
+5	2020-03-05 11:00:00
+6	2020-03-20 13:30:00
+-- !result
+select pk, dt from date_trunc_test where date_trunc('month', dt) > '2020-01-01' and dt < '2020-03-01' order by pk;
+-- result:
+3	2020-02-10 09:15:00
+4	2020-02-28 16:45:00
+-- !result
+select pk, dt from date_trunc_test where date_trunc('month', dt) <= '2020-03-01' and dt >= '2020-02-15' order by pk;
+-- result:
+4	2020-02-28 16:45:00
+5	2020-03-05 11:00:00
+6	2020-03-20 13:30:00
+-- !result
+select pk, dt from date_trunc_test where date_trunc('month', dt) <= '2020-03-15' and dt >= '2020-03-01' order by pk;
+-- result:
+5	2020-03-05 11:00:00
+6	2020-03-20 13:30:00
+-- !result
+select pk, dt from date_trunc_test where date_trunc('month', dt) < '2020-04-01' and dt >= '2020-03-01' order by pk;
+-- result:
+5	2020-03-05 11:00:00
+6	2020-03-20 13:30:00
+-- !result
+select pk, dt from date_trunc_test where date_trunc('month', dt) < '2020-04-15' and dt >= '2020-04-01' order by pk;
+-- result:
+7	2020-04-12 08:20:00
+8	2020-04-28 17:10:00
+-- !result
+CREATE TABLE `date_trunc_day_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO date_trunc_day_test VALUES 
+(1, '2020-01-15 10:30:00', 'day1'),
+(2, '2020-01-15 14:20:00', 'day1'),
+(3, '2020-01-16 09:15:00', 'day2'),
+(4, '2020-01-17 16:45:00', 'day3');
+-- result:
+-- !result
+select pk, dt from date_trunc_day_test where date_trunc('day', dt) = '2020-01-15' and dt >= '2020-01-15 12:00:00' order by pk;
+-- result:
+2	2020-01-15 14:20:00
+-- !result
+select pk, dt from date_trunc_day_test where date_trunc('day', dt) = '2020-01-15 10:30:00' and dt >= '2020-01-15' order by pk;
+-- result:
+-- !result
+CREATE TABLE `date_trunc_year_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('year', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO date_trunc_year_test VALUES 
+(1, '2020-03-15 10:30:00', 'year2020'),
+(2, '2020-08-25 14:20:00', 'year2020'),
+(3, '2021-02-10 09:15:00', 'year2021'),
+(4, '2021-11-28 16:45:00', 'year2021');
+-- result:
+-- !result
+select pk, dt from date_trunc_year_test where date_trunc('year', dt) = '2020-01-01' and dt < '2020-06-01' order by pk;
+-- result:
+1	2020-03-15 10:30:00
+-- !result
+select pk, dt from date_trunc_year_test where date_trunc('year', dt) = '2020-01-01 01:00:00' and dt >= '2020-01-01' order by pk;
+-- result:
+-- !result
+CREATE TABLE `date_trunc_quarter_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('quarter', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO date_trunc_quarter_test VALUES 
+(1, '2020-01-15 10:30:00', 'q1'),
+(2, '2020-02-25 14:20:00', 'q1'),
+(3, '2020-04-10 09:15:00', 'q2'),
+(4, '2020-05-28 16:45:00', 'q2'),
+(5, '2020-07-15 11:00:00', 'q3'),
+(6, '2020-08-20 13:30:00', 'q3'),
+(7, '2020-10-12 08:20:00', 'q4'),
+(8, '2020-11-28 17:10:00', 'q4');
+-- result:
+-- !result
+select pk, dt from date_trunc_quarter_test where date_trunc('quarter', dt) >= '2020-05-15' and dt < '2020-10-01' order by pk;
+-- result:
+5	2020-07-15 11:00:00
+6	2020-08-20 13:30:00
+-- !result
+select pk, dt from date_trunc_quarter_test where date_trunc('quarter', dt) <= '2020-04-01' and dt >= '2020-04-01' order by pk;
+-- result:
+3	2020-04-10 09:15:00
+4	2020-05-28 16:45:00
+-- !result
+select pk, dt from date_trunc_test where date_trunc('month', dt) >= '2020-02-01' and date_trunc('month', dt) < '2020-04-01' and dt >= '2020-02-15' order by pk;
+-- result:
+4	2020-02-28 16:45:00
+5	2020-03-05 11:00:00
+6	2020-03-20 13:30:00
+-- !result
+CREATE TABLE `date_trunc_minute_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('minute', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO date_trunc_minute_test VALUES 
+(1, '2020-01-15 10:30:15', 'min30'),
+(2, '2020-01-15 10:30:45', 'min30'),
+(3, '2020-01-15 10:31:20', 'min31'),
+(4, '2020-01-15 10:32:50', 'min32');
+-- result:
+-- !result
+select pk, dt from date_trunc_minute_test where date_trunc('minute', dt) = '2020-01-15 10:30:00' and dt >= '2020-01-15 10:30:30' order by pk;
+-- result:
+2	2020-01-15 10:30:45
+-- !result
+select pk, dt from date_trunc_minute_test where date_trunc('minute', dt) = '2020-01-15 10:30:15' and dt >= '2020-01-15 10:30:00' order by pk;
+-- result:
+-- !result
+CREATE TABLE `date_trunc_second_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('second', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO date_trunc_second_test VALUES 
+(1, '2020-01-15 10:30:15', 'sec15'),
+(2, '2020-01-15 10:30:16', 'sec16'),
+(3, '2020-01-15 10:30:17', 'sec17');
+-- result:
+-- !result
+select pk, dt from date_trunc_second_test where date_trunc('second', dt) = '2020-01-15 10:30:15' and dt = '2020-01-15 10:30:15' order by pk;
+-- result:
+1	2020-01-15 10:30:15
+-- !result
+select pk, dt from date_trunc_second_test where date_trunc('second', dt) >= '2020-01-15 10:30:16' and dt <= '2020-01-15 10:30:17' order by pk;
+-- result:
+2	2020-01-15 10:30:16
+3	2020-01-15 10:30:17
+-- !result
+CREATE TABLE `date_trunc_hour_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('hour', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO date_trunc_hour_test VALUES 
+(1, '2020-01-15 10:15:30', 'hour10'),
+(2, '2020-01-15 10:45:20', 'hour10'),
+(3, '2020-01-15 11:20:15', 'hour11'),
+(4, '2020-01-15 11:50:45', 'hour11');
+-- result:
+-- !result
+select pk, dt from date_trunc_hour_test where date_trunc('hour', dt) = '2020-01-15 10:00:00' and dt >= '2020-01-15 10:30:00' order by pk;
+-- result:
+2	2020-01-15 10:45:20
+-- !result
+select pk, dt from date_trunc_hour_test where date_trunc('hour', dt) = '2020-01-15 10:15:00' and dt >= '2020-01-15 10:00:00' order by pk;
+-- result:
+-- !result

--- a/test/sql/test_partition_by_expr/T/test_date_trunc_partition_prune.sql
+++ b/test/sql/test_partition_by_expr/T/test_date_trunc_partition_prune.sql
@@ -1,0 +1,215 @@
+-- name: test_date_trunc_partition_prune
+DROP DATABASE IF EXISTS test_date_trunc_partition_prune;
+CREATE DATABASE test_date_trunc_partition_prune;
+use test_date_trunc_partition_prune;
+
+CREATE TABLE `date_trunc_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('month', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+-- Insert test data covering multiple months
+INSERT INTO date_trunc_test VALUES 
+(1, '2020-01-15 10:30:00', 'jan'),
+(2, '2020-01-25 14:20:00', 'jan'),
+(3, '2020-02-10 09:15:00', 'feb'),
+(4, '2020-02-28 16:45:00', 'feb'),
+(5, '2020-03-05 11:00:00', 'mar'),
+(6, '2020-03-20 13:30:00', 'mar'),
+(7, '2020-04-12 08:20:00', 'apr'),
+(8, '2020-04-28 17:10:00', 'apr'),
+(9, '2020-06-15 12:40:00', 'jun'),
+(10, '2020-07-08 15:25:00', 'jul');
+
+-- Test EQ aligned with month start + column predicate
+select pk, dt from date_trunc_test where date_trunc('month', dt) = '2020-01-01' and dt < '2020-01-20' order by pk;
+
+-- Test EQ unaligned (should be empty due to unaligned constant)
+select pk, dt from date_trunc_test where date_trunc('month', dt) = '2020-01-15 12:00:00' and dt >= '2020-01-01' order by pk;
+
+-- Test GE aligned: >= Feb 1st and before Mar 15th
+select pk, dt from date_trunc_test where date_trunc('month', dt) >= '2020-02-01' and dt < '2020-03-15' order by pk;
+
+-- Test GE unaligned: >= Feb 15th means from Mar 1st, combined with dt < Apr 1st
+select pk, dt from date_trunc_test where date_trunc('month', dt) >= '2020-02-15' and dt < '2020-04-01' order by pk;
+
+-- Test GT: > Jan means from Feb 1st, combined with dt < Mar 1st
+select pk, dt from date_trunc_test where date_trunc('month', dt) > '2020-01-01' and dt < '2020-03-01' order by pk;
+
+-- Test LE aligned: <= Mar means up to Apr 1st (exclusive), combined with dt >= Feb 15th
+select pk, dt from date_trunc_test where date_trunc('month', dt) <= '2020-03-01' and dt >= '2020-02-15' order by pk;
+
+-- Test LE unaligned: <= Mar 15th means up to Apr 1st (exclusive), combined with dt >= Mar 1st
+select pk, dt from date_trunc_test where date_trunc('month', dt) <= '2020-03-15' and dt >= '2020-03-01' order by pk;
+
+-- Test LT aligned: < Apr means before Apr 1st, combined with dt >= Mar 1st
+select pk, dt from date_trunc_test where date_trunc('month', dt) < '2020-04-01' and dt >= '2020-03-01' order by pk;
+
+-- Test LT unaligned: < Apr 15th means before May 1st, combined with dt >= Apr 1st
+select pk, dt from date_trunc_test where date_trunc('month', dt) < '2020-04-15' and dt >= '2020-04-01' order by pk;
+
+-- Test different granularities
+
+-- Day granularity table
+CREATE TABLE `date_trunc_day_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO date_trunc_day_test VALUES 
+(1, '2020-01-15 10:30:00', 'day1'),
+(2, '2020-01-15 14:20:00', 'day1'),
+(3, '2020-01-16 09:15:00', 'day2'),
+(4, '2020-01-17 16:45:00', 'day3');
+
+-- Test day granularity EQ aligned
+select pk, dt from date_trunc_day_test where date_trunc('day', dt) = '2020-01-15' and dt >= '2020-01-15 12:00:00' order by pk;
+
+-- Test day granularity EQ unaligned (should be empty)
+select pk, dt from date_trunc_day_test where date_trunc('day', dt) = '2020-01-15 10:30:00' and dt >= '2020-01-15' order by pk;
+
+-- Year granularity table
+CREATE TABLE `date_trunc_year_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('year', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO date_trunc_year_test VALUES 
+(1, '2020-03-15 10:30:00', 'year2020'),
+(2, '2020-08-25 14:20:00', 'year2020'),
+(3, '2021-02-10 09:15:00', 'year2021'),
+(4, '2021-11-28 16:45:00', 'year2021');
+
+-- Test year granularity EQ aligned
+select pk, dt from date_trunc_year_test where date_trunc('year', dt) = '2020-01-01' and dt < '2020-06-01' order by pk;
+
+-- Test year granularity EQ unaligned (should be empty)
+select pk, dt from date_trunc_year_test where date_trunc('year', dt) = '2020-01-01 01:00:00' and dt >= '2020-01-01' order by pk;
+
+-- Quarter granularity table
+CREATE TABLE `date_trunc_quarter_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('quarter', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO date_trunc_quarter_test VALUES 
+(1, '2020-01-15 10:30:00', 'q1'),
+(2, '2020-02-25 14:20:00', 'q1'),
+(3, '2020-04-10 09:15:00', 'q2'),
+(4, '2020-05-28 16:45:00', 'q2'),
+(5, '2020-07-15 11:00:00', 'q3'),
+(6, '2020-08-20 13:30:00', 'q3'),
+(7, '2020-10-12 08:20:00', 'q4'),
+(8, '2020-11-28 17:10:00', 'q4');
+
+-- Test quarter granularity GE unaligned: >= Q2 15th means from Q3 start (July 1st)
+select pk, dt from date_trunc_quarter_test where date_trunc('quarter', dt) >= '2020-05-15' and dt < '2020-10-01' order by pk;
+
+-- Test quarter granularity LE aligned: <= Q2 start means before Q3 start (July 1st)
+select pk, dt from date_trunc_quarter_test where date_trunc('quarter', dt) <= '2020-04-01' and dt >= '2020-04-01' order by pk;
+
+-- Edge cases: test with multiple date_trunc predicates (should still work correctly)
+select pk, dt from date_trunc_test where date_trunc('month', dt) >= '2020-02-01' and date_trunc('month', dt) < '2020-04-01' and dt >= '2020-02-15' order by pk;
+
+-- Test minute granularity
+CREATE TABLE `date_trunc_minute_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('minute', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO date_trunc_minute_test VALUES 
+(1, '2020-01-15 10:30:15', 'min30'),
+(2, '2020-01-15 10:30:45', 'min30'),
+(3, '2020-01-15 10:31:20', 'min31'),
+(4, '2020-01-15 10:32:50', 'min32');
+
+-- Test minute granularity EQ aligned
+select pk, dt from date_trunc_minute_test where date_trunc('minute', dt) = '2020-01-15 10:30:00' and dt >= '2020-01-15 10:30:30' order by pk;
+
+-- Test minute granularity EQ unaligned (should be empty)
+select pk, dt from date_trunc_minute_test where date_trunc('minute', dt) = '2020-01-15 10:30:15' and dt >= '2020-01-15 10:30:00' order by pk;
+
+-- Test second granularity
+CREATE TABLE `date_trunc_second_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('second', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO date_trunc_second_test VALUES 
+(1, '2020-01-15 10:30:15', 'sec15'),
+(2, '2020-01-15 10:30:16', 'sec16'),
+(3, '2020-01-15 10:30:17', 'sec17');
+
+-- Test second granularity EQ aligned
+select pk, dt from date_trunc_second_test where date_trunc('second', dt) = '2020-01-15 10:30:15' and dt = '2020-01-15 10:30:15' order by pk;
+
+-- Test second granularity GE
+select pk, dt from date_trunc_second_test where date_trunc('second', dt) >= '2020-01-15 10:30:16' and dt <= '2020-01-15 10:30:17' order by pk;
+
+-- Test hour granularity
+CREATE TABLE `date_trunc_hour_test` (
+  `pk` int(11) NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `col1` varchar(100) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`pk`, `dt`)
+PARTITION BY date_trunc('hour', dt)
+DISTRIBUTED BY HASH(`pk`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO date_trunc_hour_test VALUES 
+(1, '2020-01-15 10:15:30', 'hour10'),
+(2, '2020-01-15 10:45:20', 'hour10'),
+(3, '2020-01-15 11:20:15', 'hour11'),
+(4, '2020-01-15 11:50:45', 'hour11');
+
+-- Test hour granularity EQ aligned
+select pk, dt from date_trunc_hour_test where date_trunc('hour', dt) = '2020-01-15 10:00:00' and dt >= '2020-01-15 10:30:00' order by pk;
+
+-- Test hour granularity EQ unaligned (should be empty)
+select pk, dt from date_trunc_hour_test where date_trunc('hour', dt) = '2020-01-15 10:15:00' and dt >= '2020-01-15 10:00:00' order by pk;
+


### PR DESCRIPTION
## Why I'm doing:
Currently, date_trunc partitioned tables can construct filters for partition pruning based on partition conditions. However, queries like `where date_trunc('month', dt) = '2025-09-01 00:00:00' and dt > '2025-09-23 00:00:00'` return incorrect results.

**Root Cause Analysis:**

1. **Incorrect date_trunc equality handling:** The condition `date_trunc('month', dt) = '2025-09-01 00:00:00'` is incorrectly converted to a point filter `dt = '2025-09-01 00:00:00'`, which creates a PartitionColumnFilter with identical lower and upper bounds: `[2025-09-01 00:00:00, 2025-09-01 00:00:00]` (a closed interval containing only the single point `2025-09-01 00:00:00`). However, this is semantically wrong because `date_trunc('month', dt) = '2025-09-01'` should actually represent all datetime values in September 2025, i.e., the range `[2025-09-01 00:00:00, 2025-10-01 00:00:00)`.

2. **Filter merging conflict:** The second condition `dt > '2025-09-23 00:00:00'` constructs a filter range `(2025-09-23 00:00:00, +∞)`. When these two filters are merged in PartitionColumnFilter:
   - First filter: `[2025-09-01 00:00:00, 2025-09-01 00:00:00]` (point range)
   - Second filter: `(2025-09-23 00:00:00, +∞)`
   - Combined lower bound: `max(2025-09-01 00:00:00, 2025-09-23 00:00:00) = 2025-09-23 00:00:00`
   - Combined upper bound: `min(2025-09-01 00:00:00, +∞) = 2025-09-01 00:00:00`
   - Result: Invalid range `[2025-09-23 00:00:00, 2025-09-01 00:00:00]` where lower > upper

3. **Partition pruning failure:** The invalid range causes `RangePartitionPruner.getRange()` to throw `IllegalArgumentException: Invalid range`, leading to no partitions being selected and the optimizer returning `EMPTYSET`.

**Core Issue:** `date_trunc` equality predicates are not properly expanded into ranges. `date_trunc('month', dt) = '2025-09-01'` should be expanded to `dt >= '2025-09-01 00:00:00' AND dt < '2025-10-01 00:00:00'`.

**Expected Behavior:** 
The query should return rows where `dt` is in September 2025 AND `dt > '2025-09-23 00:00:00'`, which should result in the effective range `(2025-09-23 00:00:00, 2025-10-01 00:00:00)` and return rows from Sept 24-30, 2025.

## What I'm doing:

**1. Implement date_trunc predicate range expansion logic**
- Add `buildDateTruncRange` method in `ColumnFilterConverter.java`
- Properly handle EQ/GE/GT/LE/LT operators for `date_trunc` functions, converting them to correct time ranges
- Support both aligned and unaligned constants:
  - Aligned: `date_trunc('month', dt) = '2025-09-01'` → `dt >= '2025-09-01' AND dt < '2025-10-01'`
  - Unaligned: `date_trunc('month', dt) = '2025-09-15'` → empty range (equality condition can never be satisfied)

**2. Fix SyncPartitionUtils time handling methods**
- Fix `getLowerDateTime`: ensure month/quarter/year granularities return 00:00:00 time
- Fix `nextUpperDateTime`: ensure correct calculation of next period start time for all granularities
- Fix `getUpperDateTime`: ensure proper boundary alignment checking and time advancement logic

**3. Support all time granularities and comparison operators**
- Supported granularities: second, minute, hour, day, month, quarter, year
- Supported operators: EQ (=), GE (>=), GT (>), LE (<=), LT (<)
- Properly handle boundary conditions for unaligned constants


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

