### PR TITLE
[Enhancement] support paimon option:partition.legacy-name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -192,7 +192,7 @@ public class PaimonMetadata implements ConnectorMetadata {
         for (int i = 0; i < partitionValues.length; i++) {
             String column = partitionColumnNames.get(i);
             String value = partitionValues[i].trim();
-            if (partitionColumnTypes.get(i) instanceof DateType && !partitionLegacyName) {
+            if (partitionColumnTypes.get(i) instanceof DateType && partitionLegacyName) {
                 value = DateTimeUtils.formatDate(Integer.parseInt(value));
             }
             sb.append(column).append("=").append(value);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -155,7 +155,7 @@ public class PaimonMetadata implements ConnectorMetadata {
 
         try {
             List<org.apache.paimon.partition.Partition> partitions = paimonNativeCatalog.listPartitions(identifier);
-            String partitionLegacyName = paimonTable.options().get(CoreOptions.PARTITION_GENERATE_LEGCY_NAME);
+            String partitionLegacyName = paimonTable.options().get(CoreOptions.PARTITION_GENERATE_LEGCY_NAME.key());
             for (org.apache.paimon.partition.Partition partition : partitions) {
                 String partitionPath = PartitionPathUtils.generatePartitionPath(partition.spec(), dataTableRowType);
                 String[] partitionValues = Arrays.stream(partitionPath.split("/"))

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -185,7 +185,7 @@ public class PaimonMetadata implements ConnectorMetadata {
         for (int i = 0; i < partitionValues.length; i++) {
             String column = partitionColumnNames.get(i);
             String value = partitionValues[i].trim();
-            if (partitionColumnTypes.get(i) instanceof DateType && !"false".equals(partitionLegacyName)) {
+            if (partitionColumnTypes.get(i) instanceof DateType && !Boolean.parseBoolean(partitionLegacyName)) {
                 value = DateTimeUtils.formatDate(Integer.parseInt(value));
             }
             sb.append(column).append("=").append(value);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -193,8 +193,8 @@ public class PaimonMetadata implements ConnectorMetadata {
         }
         sb.deleteCharAt(sb.length() - 1);
         String partitionName = sb.toString();
-
-        return new Partition(partitionName, convertToSystemDefaultTime(Timestamp.fromEpochMillis(partition.lastFileCreationTime())),
+        Timestamp lastUpdateTime = Timestamp.fromEpochMillis(partition.lastFileCreationTime());
+        return new Partition(partitionName, convertToSystemDefaultTime(lastUpdateTime),
                 partition.recordCount(), partition.fileSizeInBytes(), partition.fileCount());
     }
 


### PR DESCRIPTION
## Why I'm doing:
```sql
--flinksql
CREATE TABLE `paimon_catalog`.`dm`.`dm_test_dt` (
  `id` BIGINT NOT NULL,
  `name` STRING NOT NULL,
  `dt` DATE NOT NULL,
  PRIMARY KEY (`id`, `dt`) NOT ENFORCED
) PARTITIONED BY (`dt`)
WITH (
  'bucket' = '1',
  'partition.legacy-name' = 'false', -- this option
  'deletion-vectors.enabled' = 'true'
);

insert into dm_test_dt values(1, 'test', cast('2025-09-21' as date));
insert into dm_test_dt values(2, 'test2', cast('2025-09-21' as date));
insert into dm_test_dt values(3, 'test3', cast('2025-09-22' as date));

--starrocks sql
CREATE MATERIALIZED VIEW `dm`.`dm_test_dt_view`
COMMENT ""
PARTITION BY (`dt`)
DISTRIBUTED BY HASH(`id`) BUCKETS 1
PROPERTIES (
"partition_refresh_number" = "2"
)
AS
select id, name, dt from paimon_catalog.dm.dm_test_dt;

```

then
```
Refresh mv dm_test_dt_view failed after 1 times, try lock failed: 0, error-msg : java.lang.NumberFormatException: For input string: "2025-09-22"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.base/java.lang.Integer.parseInt(Integer.java:652)
	at java.base/java.lang.Integer.parseInt(Integer.java:770)
	at com.starrocks.connector.paimon.PaimonMetadata.getPartition(PaimonMetadata.java:184)
	at com.starrocks.connector.paimon.PaimonMetadata.updatePartitionInfo(PaimonMetadata.java:155)
	at com.starrocks.connector.paimon.PaimonMetadata.listPartitionNames(PaimonMetadata.java:204)
	at com.starrocks.connector.CatalogConnectorMetadata.listPartitionNames(CatalogConnectorMetadata.java:120)
	at com.starrocks.server.MetadataMgr.listPartitionNames(MetadataMgr.java:604)
	at com.starrocks.server.MetadataMgr.listPartitionNames(MetadataMgr.java:596)
	at com.starrocks.connector.partitiontraits.DefaultTraits.getPartitionNames(DefaultTraits.java:91)
	at com.starrocks.connector.partitiontraits.DefaultTraits.getPartitionKeyRange(DefaultTraits.java:104)
	at com.starrocks.connector.PartitionUtil.getPartitionKeyRange(PartitionUtil.java:291)
	at com.starrocks.sql.common.RangePartitionDiffer.syncBaseTablePartitionInfos(RangePartitionDiffer.java:238)
	at com.starrocks.sql.common.RangePartitionDiffer.computeRangePartitionDiff(RangePartitionDiffer.java:329)
	at com.starrocks.scheduler.mv.MVPCTRefreshRangePartitioner.syncAddOrDropPartitions(MVPCTRefreshRangePartitioner.java:95)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.syncPartitions(PartitionBasedMvRefreshProcessor.java:940)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:420)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:376)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:335)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:203)
	at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:312)
	at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:60)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
## What I'm doing:
support partition.legacy-name
see :https://paimon.apache.org/docs/1.2/maintenance/configurations/
Fixes #63470

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
