### PR TITLE
[Enhancement] add querySource in the QueryDetail & AuditEvent

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -162,6 +162,9 @@ public class AuditEvent {
     @AuditField(value = "TransmittedBytes")
     public long transmittedBytes = -1;
 
+    @AuditField(value = "QuerySource")
+    public String querySource = "";
+
     public static class AuditEventBuilder {
 
         private AuditEvent auditEvent = new AuditEvent();
@@ -421,6 +424,11 @@ public class AuditEvent {
             } else {
                 auditEvent.transmittedBytes += transmittedBytes;
             }
+            return this;
+        }
+
+        public AuditEventBuilder setQuerySource(String querySource) {
+            auditEvent.querySource = querySource;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -64,6 +64,7 @@ import com.starrocks.mysql.ssl.SSLChannel;
 import com.starrocks.mysql.ssl.SSLChannelImp;
 import com.starrocks.mysql.ssl.SSLContextLoader;
 import com.starrocks.plugin.AuditEvent.AuditEventBuilder;
+import com.starrocks.qe.QueryDetail.QuerySource;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
@@ -242,6 +243,9 @@ public class ConnectContext {
     // QueryMaterializationContext is different from MaterializationContext that it keeps the context during the query
     // lifecycle instead of per materialized view.
     private QueryMaterializationContext queryMVContext;
+
+    // Query source to distinguish different types of queries
+    private QuerySource querySource = QuerySource.EXTERNAL;
 
     // In order to ensure the correctness of imported data, in some cases, we don't use connector metadata cache for
     // `insert into table select external table`. Currently, this feature only supports hive table.
@@ -1103,6 +1107,14 @@ public class ConnectContext {
 
     public void setQueryMVContext(QueryMaterializationContext queryMVContext) {
         this.queryMVContext = queryMVContext;
+    }
+
+    public QuerySource getQuerySource() {
+        return querySource;
+    }
+
+    public void setQuerySource(QuerySource querySource) {
+        this.querySource = querySource;
     }
 
     public void startAcceptQuery(ConnectProcessor connectProcessor) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -234,7 +234,8 @@ public class ConnectProcessor {
                 .setIsForwardToLeader(isForwardToLeader)
                 .setQueryId(ctx.getQueryId() == null ? "NaN" : ctx.getQueryId().toString())
                 .setSessionId(ctx.getSessionId().toString())
-                .setCNGroup(ctx.getCurrentComputeResourceName());
+                .setCNGroup(ctx.getCurrentComputeResourceName())
+                .setQuerySource(ctx.getQuerySource().toString());
 
         if (ctx.getState().isQuery()) {
             MetricRepo.COUNTER_QUERY_ALL.increase(1L);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
@@ -46,6 +46,18 @@ public class QueryDetail implements Serializable {
         CANCELLED
     }
 
+    /**
+     * QuerySource distinguishes the origin of a query.
+     */
+    public enum QuerySource {
+        EXTERNAL,  // User-initiated queries
+        INTERNAL,  // System/internal queries
+        MV,        // Materialized view refresh
+        TASK       // Task-submitted queries
+    }
+
+    private QuerySource querySource = QuerySource.EXTERNAL;
+
     // When query received, FE will construct a QueryDetail
     // object. This object will set queryId, startTime, sql
     // fields. As well state is be set as RUNNING.
@@ -119,9 +131,9 @@ public class QueryDetail implements Serializable {
     }
 
     public QueryDetail(String queryId, boolean isQuery, int connId, String remoteIP,
-                        long startTime, long endTime, long latency, QueryMemState state,
-                        String database, String sql, String user, String resourceGroupName,
-                        String warehouse, String catalog) {
+                       long startTime, long endTime, long latency, QueryMemState state,
+                       String database, String sql, String user, String resourceGroupName,
+                       String warehouse, String catalog) {
         this(queryId, isQuery, connId, remoteIP, startTime, endTime, latency,
                 state, database, sql, user, resourceGroupName, catalog);
         this.warehouse = warehouse;
@@ -155,6 +167,7 @@ public class QueryDetail implements Serializable {
         queryDetail.resourceGroupName = this.resourceGroupName;
         queryDetail.catalog = this.catalog;
         queryDetail.queryFeMemory = this.queryFeMemory;
+        queryDetail.querySource = this.querySource;
         return queryDetail;
     }
 
@@ -376,5 +389,13 @@ public class QueryDetail implements Serializable {
 
     public long getQueryFeMemory() {
         return queryFeMemory;
+    }
+
+    public QuerySource getQuerySource() {
+        return querySource;
+    }
+
+    public void setQuerySource(QuerySource querySource) {
+        this.querySource = querySource;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -328,7 +328,9 @@ public class StmtExecutor {
 
     public static StmtExecutor newInternalExecutor(ConnectContext ctx, StatementBase parsedStmt) {
         // Set query source to INTERNAL for system/internal queries only if not already set
-        ctx.setQuerySource(QueryDetail.QuerySource.INTERNAL);
+        if (ctx.getQuerySource().equals(QueryDetail.QuerySource.EXTERNAL)) {
+            ctx.setQuerySource(QueryDetail.QuerySource.INTERNAL);
+        }
         return new StmtExecutor(ctx, parsedStmt, true);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -327,6 +327,8 @@ public class StmtExecutor {
     }
 
     public static StmtExecutor newInternalExecutor(ConnectContext ctx, StatementBase parsedStmt) {
+        // Set query source to INTERNAL for system/internal queries only if not already set
+        ctx.setQuerySource(QueryDetail.QuerySource.INTERNAL);
         return new StmtExecutor(ctx, parsedStmt, true);
     }
 
@@ -3156,8 +3158,8 @@ public class StmtExecutor {
         }
 
         boolean isQuery = context.isQueryStmt(parsedStmt);
-        QueryDetail queryDetail = new QueryDetail(
 
+        QueryDetail queryDetail = new QueryDetail(
                 DebugUtil.printId(context.getQueryId()),
                 isQuery,
                 context.connectionId,
@@ -3170,6 +3172,8 @@ public class StmtExecutor {
                 Optional.ofNullable(context.getResourceGroup()).map(TWorkGroup::getName).orElse(""),
                 context.getCurrentWarehouseName(),
                 context.getCurrentCatalog());
+        // Set query source from context
+        queryDetail.setQuerySource(context.getQuerySource());
         context.setQueryDetail(queryDetail);
         // copy queryDetail, cause some properties can be changed in future
         QueryDetailQueue.addQueryDetail(queryDetail.copy());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -31,6 +31,7 @@ import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.metric.IMaterializedViewMetricsEntity;
 import com.starrocks.metric.MaterializedViewMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.mv.BaseMVRefreshProcessor;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
@@ -175,6 +176,8 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         Tracers.init(mvRefreshTraceMode, mvRefreshTraceModule, true, false);
 
         final ConnectContext connectContext = context.getCtx();
+        // Set query source to MV for materialized view refresh
+        connectContext.setQuerySource(com.starrocks.qe.QueryDetail.QuerySource.MV);
         final QueryMaterializationContext queryMVContext = new QueryMaterializationContext();
         connectContext.setQueryMVContext(queryMVContext);
         try {
@@ -285,6 +288,9 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
             parentStmtExecutor.registerSubStmtExecutor(executor);
         }
         ctx.setStmtId(STMT_ID_GENERATOR.incrementAndGet());
+        // Add running query detail for MV refresh
+        ctx.setQuerySource(QueryDetail.QuerySource.MV);
+        executor.addRunningQueryDetail(insertStmt);
 
         logger.info("[QueryId:{}] start to refresh mv in DML", ctx.getQueryId());
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
@@ -35,6 +35,8 @@ public class SqlTaskRunProcessor extends BaseTaskRunProcessor {
         StmtExecutor executor = null;
         try {
             ConnectContext ctx = context.getCtx();
+            // Set query source to TASK for task-submitted queries
+            ctx.setQuerySource(com.starrocks.qe.QueryDetail.QuerySource.TASK);
             ctx.getAuditEventBuilder().reset();
             ctx.getAuditEventBuilder()
                     .setTimestamp(System.currentTimeMillis())

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTBasedRefreshProcessor.java
@@ -32,6 +32,7 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.metric.IMaterializedViewMetricsEntity;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryDetail;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.MvTaskRunContext;
@@ -180,6 +181,7 @@ public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
                 .setUser(ctx.getQualifiedUser())
                 .setDb(ctx.getDatabase())
                 .setWarehouse(ctx.getCurrentWarehouseName())
+                .setQuerySource(QueryDetail.QuerySource.MV.name())
                 .setCNGroup(ctx.getCurrentComputeResourceName());
 
         // Prepare refresh variables

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedMVRefreshProcessor.java
@@ -37,6 +37,7 @@ import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.metric.IMaterializedViewMetricsEntity;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryDetail;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.MvTaskRunContext;
@@ -390,6 +391,7 @@ public class MVIVMBasedMVRefreshProcessor extends BaseMVRefreshProcessor {
                 .setUser(ctx.getQualifiedUser())
                 .setDb(ctx.getDatabase())
                 .setWarehouse(ctx.getCurrentWarehouseName())
+                .setQuerySource(QueryDetail.QuerySource.MV.name())
                 .setCNGroup(ctx.getCurrentComputeResourceName());
 
         // set tvr target mvid

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
@@ -63,7 +63,8 @@ public class QueryDetailQueueTest extends PlanTestBase {
 
         Gson gson = new Gson();
         String jsonString = gson.toJson(queryDetails);
-        String queryDetailString = "[{\"eventTime\":" + startQueryDetail.getEventTime() + "," +
+        String queryDetailString = "[{\"querySource\":\"EXTERNAL\"," +
+                "\"eventTime\":" + startQueryDetail.getEventTime() + "," +
                 "\"queryId\":\"219a2d5443c542d4-8fc938db37c892e3\"," +
                 "\"isQuery\":false," +
                 "\"remoteIP\":\"127.0.0.1\"," +
@@ -87,7 +88,7 @@ public class QueryDetailQueueTest extends PlanTestBase {
                 "\"warehouse\":\"default_warehouse\"," +
                 "\"catalog\":\"default_catalog\"," +
                 "\"queryFeMemory\":0}]";
-        Assertions.assertEquals(jsonString, queryDetailString);
+        Assertions.assertEquals(queryDetailString, jsonString);
 
         queryDetails = QueryDetailQueue.getQueryDetailsAfterTime(startQueryDetail.getEventTime());
         Assertions.assertEquals(0, queryDetails.size());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailTest.java
@@ -15,8 +15,17 @@
 package com.starrocks.qe;
 
 import com.google.gson.Gson;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 public class QueryDetailTest {
     @Test
@@ -34,5 +43,111 @@ public class QueryDetailTest {
 
         queryDetail.setLatency(10);
         Assertions.assertEquals(-1, copyOfQueryDetail.getLatency());
+    }
+
+    private static ConnectContext connectContext;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        Config.enable_collect_query_detail_info = true;
+    }
+
+    @Test
+    public void testExternalQuerySource() throws Exception {
+        // Test external query (user-initiated)
+        String sql = "SELECT 1";
+        List<StatementBase> statements = SqlParser.parse(sql, connectContext.getSessionVariable());
+        StatementBase statement = statements.get(0);
+
+        // Create a new context for this test
+        ConnectContext testContext = new ConnectContext();
+        testContext.setGlobalStateMgr(connectContext.getGlobalStateMgr());
+        testContext.setQueryId(UUIDUtil.genUUID());
+        testContext.setStartTime();
+
+        // Execute using normal StmtExecutor (external query)
+        StmtExecutor executor = new StmtExecutor(testContext, statement);
+        testContext.setExecutor(executor);
+        testContext.setThreadLocalInfo();
+
+        // Add running query detail
+        executor.addRunningQueryDetail(statement);
+
+        // Verify query source is EXTERNAL
+        QueryDetail queryDetail = testContext.getQueryDetail();
+        Assertions.assertNotNull(queryDetail);
+        Assertions.assertEquals(QueryDetail.QuerySource.EXTERNAL, queryDetail.getQuerySource());
+    }
+
+    @Test
+    public void testInternalQuerySource() throws Exception {
+        // Test internal query (system query)
+        String sql = "SELECT 1";
+        List<StatementBase> statements = SqlParser.parse(sql, connectContext.getSessionVariable());
+        StatementBase statement = statements.get(0);
+
+        // Create a new context for this test
+        ConnectContext testContext = new ConnectContext();
+        testContext.setGlobalStateMgr(connectContext.getGlobalStateMgr());
+        testContext.setQueryId(UUIDUtil.genUUID());
+        testContext.setStartTime();
+
+        // Execute using internal StmtExecutor
+        StmtExecutor executor = StmtExecutor.newInternalExecutor(testContext, statement);
+        testContext.setExecutor(executor);
+        testContext.setThreadLocalInfo();
+
+        // Add running query detail
+        executor.addRunningQueryDetail(statement);
+
+        // Verify query source is INTERNAL
+        QueryDetail queryDetail = testContext.getQueryDetail();
+        Assertions.assertNotNull(queryDetail);
+        Assertions.assertEquals(QueryDetail.QuerySource.INTERNAL, queryDetail.getQuerySource());
+    }
+
+    @Test
+    public void testTaskQuerySource() throws Exception {
+        // Test task query using SqlTaskRunProcessor
+        String sql = "SELECT 1";
+
+        // Create a mock TaskRunContext
+        com.starrocks.scheduler.TaskRunContext taskRunContext = new com.starrocks.scheduler.TaskRunContext();
+
+        // Create a new context for this test
+        ConnectContext testContext = new ConnectContext();
+        testContext.setGlobalStateMgr(connectContext.getGlobalStateMgr());
+        testContext.setQueryId(UUIDUtil.genUUID());
+        testContext.setStartTime();
+        testContext.setDatabase("testDb");
+        testContext.setQualifiedUser("root");
+        testContext.setCurrentCatalog("default_catalog");
+
+        // Set the context in TaskRunContext
+        taskRunContext.setCtx(testContext);
+        taskRunContext.setDefinition(sql);
+        taskRunContext.setRemoteIp("127.0.0.1");
+
+        // Create and execute SqlTaskRunProcessor
+        com.starrocks.scheduler.SqlTaskRunProcessor processor = new com.starrocks.scheduler.SqlTaskRunProcessor();
+
+        // Mock the execution to avoid actual SQL execution
+        try {
+            processor.processTaskRun(taskRunContext);
+        } catch (Exception e) {
+            // Expected to fail due to mock setup, but querySource should be set
+        }
+
+        // Verify query source is TASK
+        QueryDetail queryDetail = testContext.getQueryDetail();
+        Assertions.assertNotNull(queryDetail);
+        Assertions.assertEquals(QueryDetail.QuerySource.TASK, queryDetail.getQuerySource());
+    }
+
+    @Test
+    public void testMVQuerySource() throws Exception {
+        // TODO
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Add a field `querySource` in query_detail and audit_event to distinguish different sources of query:
- EXTERNAL: User-initiated queries
- INTERNAL: System/internal queries
- MV: Materialized view refresh
- TASK: Task-submitted queries


Example of query_detail:
```
  {
    "querySource": "TASK",
    "eventTime": 1758783023554000000,
    "queryId": "01997fa3-29c1-76ee-8ebb-8fb73c49655e",
    "isQuery": false,
    "remoteIP": "",
    "connId": 0,
    "startTime": 1758783023553,
    "endTime": -1,
    "latency": -1,
    "pendingTime": -1,
    "netTime": -1,
    "netComputeTime": -1,
    "state": "RUNNING",
    "database": "d_iceberg",
    "sql": "cache select * from `glue_ice`.`iceberg_test`.`ice_test3`",
    "user": "root",
    "scanRows": -1,
    "scanBytes": -1,
    "returnRows": -1,
    "cpuCostNs": -1,
    "memCostBytes": -1,
    "spillBytes": -1,
    "warehouse": "default_warehouse",
    "catalog": "default_catalog",
    "queryFeMemory": 0
  },
```




Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
