### PR TITLE
[Enhancement] Optimize mv relatd locks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -232,26 +232,24 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
         // check db
         final TableName mvName = stmt.getMvName();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvName.getDb());
-        if (db == null) {
+        if (db == null || !db.isExist()) {
             throw new SemanticException("Database %s is not found", mvName.getCatalogAndDb());
         }
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(mvName.getDb(), mvName.getTbl());
+        if (table == null) {
+            throw new SemanticException("Table %s is not found", mvName);
+        }
+        if (!table.isMaterializedView()) {
+            throw new SemanticException("The specified table [" + mvName + "] is not a view");
+        }
+        this.db = db;
+        this.table = table;
 
         Locker locker = new Locker();
-        if (!locker.lockDatabaseAndCheckExist(db, LockType.WRITE)) {
+        if (!locker.lockTableAndCheckDbExist(db, table.getId(), LockType.WRITE)) {
             throw new AlterJobException("alter materialized failed. database:" + db.getFullName() + " not exist");
         }
-
         try {
-            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(mvName.getDb(), mvName.getTbl());
-            if (table == null) {
-                throw new SemanticException("Table %s is not found", mvName);
-            }
-            if (!table.isMaterializedView()) {
-                throw new SemanticException("The specified table [" + mvName + "] is not a view");
-            }
-            this.db = db;
-            this.table = table;
-
             MaterializedView materializedView = (MaterializedView) table;
             // check materialized view state
             if (materializedView.getState() != OlapTable.OlapTableState.NORMAL) {
@@ -264,7 +262,7 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
             GlobalStateMgr.getCurrentState().getMaterializedViewMgr().rebuildMaintainMV(materializedView);
             return null;
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.WRITE);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -146,13 +146,11 @@ public class AlterJobMgr {
         // check db
         String dbName = stmt.getDbName();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
-        if (db == null) {
+        if (db == null || !db.isExist()) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
-        Locker locker = new Locker();
-        if (!locker.lockDatabaseAndCheckExist(db, LockType.WRITE)) {
-            throw new DdlException("drop materialized failed. database:" + db.getFullName() + " not exist");
-        }
+
+        OlapTable targetTable = null;
         try {
             Table table = null;
             boolean hasfindTable = false;
@@ -185,21 +183,30 @@ public class AlterJobMgr {
                         "Do not support non-OLAP table [" + table.getName() + "] when drop materialized view");
             }
             // check table state
-            OlapTable olapTable = (OlapTable) table;
-            if (olapTable.getState() != OlapTableState.NORMAL) {
-                throw InvalidOlapTableStateException.of(olapTable.getState(), olapTable.getName());
+            targetTable = (OlapTable) table;
+            if (targetTable.getState() != OlapTableState.NORMAL) {
+                throw InvalidOlapTableStateException.of(targetTable.getState(), targetTable.getName());
             }
-            // drop materialized view
-            materializedViewHandler.processDropMaterializedView(stmt, db, olapTable);
-
         } catch (MetaNotFoundException e) {
             if (stmt.isSetIfExists()) {
                 LOG.info(e.getMessage());
             } else {
                 throw e;
             }
+        }
+        if (targetTable == null) {
+            return;
+        }
+
+        Locker locker = new Locker();
+        if (!locker.lockTableAndCheckDbExist(db, targetTable.getId(), LockType.WRITE)) {
+            throw new AlterJobException("alter materialized failed. database:" + db.getFullName() + " not exist");
+        }
+        try {
+            // drop materialized view
+            materializedViewHandler.processDropMaterializedView(stmt, db, targetTable);
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), targetTable.getId(), LockType.WRITE);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -493,7 +493,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
 
             final MaterializedView.MvRefreshScheme refreshScheme = materializedView.getRefreshScheme();
             Locker locker = new Locker();
-            if (!locker.lockDatabaseAndCheckExist(db, LockType.WRITE)) {
+            if (!locker.lockTableAndCheckDbExist(db, materializedView.getId(), LockType.WRITE)) {
                 throw new DmlException("update meta failed. database:" + db.getFullName() + " not exist");
             }
             try {
@@ -529,7 +529,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                 final ChangeMaterializedViewRefreshSchemeLog log = new ChangeMaterializedViewRefreshSchemeLog(materializedView);
                 GlobalStateMgr.getCurrentState().getEditLog().logMvChangeRefreshScheme(log);
             } finally {
-                locker.unLockDatabase(db.getId(), LockType.WRITE);
+                locker.unLockTableWithIntensiveDbLock(db.getId(), materializedView.getId(), LockType.WRITE);
             }
             LOG.info("change materialized view refresh type {} to {}, id: {}", oldRefreshType,
                     newRefreshType, materializedView.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -421,7 +421,7 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
 
         Locker locker = new Locker();
         for (DropPartitionClause dropPartitionClause : dropPartitionClauses) {
-            if (!locker.lockDatabaseAndCheckExist(db, LockType.WRITE)) {
+            if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.WRITE)) {
                 LOG.warn("db: {}({}) has been dropped, skip", db.getFullName(), db.getId());
                 return false;
             }
@@ -434,7 +434,7 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
             } catch (DdlException e) {
                 runtimeInfoCollector.recordDropPartitionFailedMsg(db.getOriginName(), tableName, e.getMessage());
             } finally {
-                locker.unLockDatabase(db.getId(), LockType.WRITE);
+                locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -229,7 +229,7 @@ public class InsertOverwriteJobRunner {
             throw new DmlException("database id:%s does not exist", dbId);
         }
         Locker locker = new Locker();
-        if (!locker.lockDatabaseAndCheckExist(db, tableId, LockType.WRITE)) {
+        if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.WRITE)) {
             throw new DmlException("insert overwrite commit failed because locking db:%s failed", dbId);
         }
 
@@ -357,19 +357,13 @@ public class InsertOverwriteJobRunner {
         }
         long createPartitionStartTimestamp = System.currentTimeMillis();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
-        if (db == null) {
+        if (db == null || !db.isExist()) {
             throw new DmlException("database id:%s does not exist", dbId);
         }
-        Locker locker = new Locker();
-        if (!locker.lockDatabaseAndCheckExist(db, tableId, LockType.READ)) {
+        if (!db.isExist()) {
             throw new DmlException("insert overwrite commit failed because locking db:%s failed", dbId);
         }
-        OlapTable targetTable;
-        try {
-            targetTable = checkAndGetTable(db, tableId);
-        } finally {
-            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
-        }
+        OlapTable targetTable = checkAndGetTable(db, tableId);
         // acquire compute resource
         ComputeResource computeResource = context.getCurrentComputeResource();
         if (computeResource == null) {
@@ -385,21 +379,21 @@ public class InsertOverwriteJobRunner {
         LOG.info("insert overwrite job {} start to garbage collect", job.getJobId());
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
-        if (db == null) {
+        if (db == null || !db.isExist()) {
             throw new DmlException("database id:%s does not exist", dbId);
         }
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+        if (table == null) {
+            throw new DmlException("table:%d does not exist in database:%s", tableId, db.getFullName());
+        }
+        Preconditions.checkState(table instanceof OlapTable);
+        OlapTable targetTable = (OlapTable) table;
+
         Locker locker = new Locker();
-        if (!locker.lockDatabaseAndCheckExist(db, tableId, LockType.WRITE)) {
+        if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.WRITE)) {
             throw new DmlException("insert overwrite commit failed because locking db:%s failed", dbId);
         }
-
         try {
-            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
-            if (table == null) {
-                throw new DmlException("table:%d does not exist in database:%s", tableId, db.getFullName());
-            }
-            Preconditions.checkState(table instanceof OlapTable);
-            OlapTable targetTable = (OlapTable) table;
             Set<Tablet> sourceTablets = Sets.newHashSet();
             if (job.getTmpPartitionIds() != null) {
                 for (long pid : job.getTmpPartitionIds()) {
@@ -475,7 +469,7 @@ public class InsertOverwriteJobRunner {
             throw new DmlException("database id:%s does not exist", dbId);
         }
         Locker locker = new Locker();
-        if (!locker.lockDatabaseAndCheckExist(db, tableId, LockType.WRITE)) {
+        if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.WRITE)) {
             throw new DmlException("insert overwrite commit failed because locking db:%s failed", dbId);
         }
         OlapTable tmpTargetTable = null;
@@ -591,7 +585,7 @@ public class InsertOverwriteJobRunner {
             throw new DmlException("database id:%s does not exist", dbId);
         }
         Locker locker = new Locker();
-        if (!locker.lockDatabaseAndCheckExist(db, tableId, LockType.READ)) {
+        if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.READ)) {
             throw new DmlException("insert overwrite commit failed because locking db:%s failed", dbId);
         }
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/load/PartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/PartitionUtils.java
@@ -65,7 +65,7 @@ public class PartitionUtils {
                 .createTempPartitionsFromPartitions(db, targetTable, postfix, sourcePartitionIds,
                         tmpPartitionIds, distributionDesc, computeResource);
         Locker locker = new Locker();
-        if (!locker.lockDatabaseAndCheckExist(db, LockType.WRITE)) {
+        if (!locker.lockTableAndCheckDbExist(db, targetTable.getId(), LockType.WRITE)) {
             throw new DdlException("create and add partition failed. database:{}" + db.getFullName() + " not exist");
         }
         boolean success = false;
@@ -151,7 +151,7 @@ public class PartitionUtils {
                     LOG.warn("clear tablets from inverted index failed", t);
                 }
             }
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), targetTable.getId(), LockType.WRITE);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.ConnectorTableInfo;
@@ -34,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class MVMetaVersionRepairer {
     private static final Logger LOG = LogManager.getLogger(MVMetaVersionRepairer.class);
@@ -70,7 +72,8 @@ public class MVMetaVersionRepairer {
 
             // acquire mvDb + mv write lock to modify meta of mv
             Locker locker = new Locker();
-            if (!locker.lockDatabaseAndCheckExist(mvDb, mv, LockType.WRITE)) {
+            if (!locker.tryLockTableWithIntensiveDbLock(mvDb.getId(), mv.getId(), LockType.WRITE,
+                    Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
                 continue;
             }
             try {
@@ -100,8 +103,7 @@ public class MVMetaVersionRepairer {
         LOG.info("repair base table {} version changes for mv {}, changed versions:{}",
                 table.getName(), mv.getName(), changedVersions);
         // update edit log
-        long maxChangedTableRefreshTime =
-                MvUtils.getMaxTablePartitionInfoRefreshTime(Lists.newArrayList(changedVersions));
+        long maxChangedTableRefreshTime = MvUtils.getMaxTablePartitionInfoRefreshTime(changedVersions);
         MVVersionManager.updateEditLogAfterVersionMetaChanged(mv, maxChangedTableRefreshTime);
         LOG.info("Update edit log after version changed for mv {}, maxChangedTableRefreshTime:{}",
                 mv.getName(), maxChangedTableRefreshTime);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -2443,7 +2443,7 @@ public class StmtExecutor {
         InsertOverwriteJob job = new InsertOverwriteJob(GlobalStateMgr.getCurrentState().getNextId(),
                 insertStmt, db.getId(), olapTable.getId(), context.getCurrentWarehouseId(),
                 insertStmt.isDynamicOverwrite());
-        if (!locker.lockDatabaseAndCheckExist(db, LockType.WRITE)) {
+        if (!locker.lockTableAndCheckDbExist(db, olapTable.getId(), LockType.WRITE)) {
             throw new DmlException("database:%s does not exist.", db.getFullName());
         }
         try {
@@ -2453,7 +2453,7 @@ public class StmtExecutor {
                     job.isDynamicOverwrite());
             GlobalStateMgr.getCurrentState().getEditLog().logCreateInsertOverwrite(info);
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), olapTable.getId(), LockType.WRITE);
         }
         insertStmt.setOverwriteJobId(job.getJobId());
         InsertOverwriteJobMgr manager = GlobalStateMgr.getCurrentState().getInsertOverwriteJobMgr();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -343,7 +343,8 @@ public abstract class BaseMVRefreshProcessor {
 
                 // first lock and drop partitions from a visible map
                 Locker locker = new Locker();
-                if (!locker.lockDatabaseAndCheckExist(db, this.mv, LockType.WRITE)) {
+                if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.WRITE,
+                        Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
                     logger.warn("failed to lock database: {} in syncPartitions for force refresh", db.getFullName());
                     throw new DmlException("Force refresh failed, database:" + db.getFullName() + " not exist");
                 }
@@ -818,7 +819,8 @@ public abstract class BaseMVRefreshProcessor {
 
         Locker locker = new Locker();
         // update the meta if succeed
-        if (!locker.lockDatabaseAndCheckExist(db, this.mv, LockType.WRITE)) {
+        if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.WRITE,
+                Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
             logger.warn("failed to lock database: {} in updateMeta for mv refresh", db.getFullName());
             throw new DmlException("update meta failed. database:" + db.getFullName() + " not exist");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
@@ -196,7 +196,7 @@ public class MVPCTMetaRepairer {
         }
         // acquire db write lock to modify meta of mv
         Locker locker = new Locker();
-        if (!locker.lockDatabaseAndCheckExist(db, mv, LockType.WRITE)) {
+        if (!locker.lockTableAndCheckDbExist(db, mv.getId(), LockType.WRITE)) {
             throw new DmlException("repair mv meta failed. database:" + db.getFullName() + " not exist");
         }
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -114,7 +114,8 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
     public boolean syncAddOrDropPartitions() throws LockTimeoutException {
         // collect mv partition items with lock
         Locker locker = new Locker();
-        if (!locker.tryLockDatabase(db.getId(), LockType.READ, Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
+        if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), mv.getId(),
+                LockType.READ, Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
             throw new LockTimeoutException("Failed to lock database: " + db.getFullName() + " in syncPartitionsForList");
         }
 
@@ -126,7 +127,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
                 return false;
             }
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.READ);
         }
 
         // drop old partitions and add new partitions

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -547,7 +547,8 @@ public abstract class MVPCTRefreshPartitioner {
     protected void dropPartition(Database db, MaterializedView materializedView, String mvPartitionName) {
         String dropPartitionName = materializedView.getPartition(mvPartitionName).getName();
         Locker locker = new Locker();
-        if (!locker.lockDatabaseAndCheckExist(db, materializedView, LockType.WRITE)) {
+        if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), materializedView.getId(), LockType.WRITE,
+                Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
             logger.warn("Fail to lock database {} in drop partition for mv refresh {}", db.getFullName(),
                     materializedView.getName());
             throw new DmlException("drop partition failed. database:" + db.getFullName() + " not exist");

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
@@ -27,7 +27,7 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -80,14 +80,18 @@ public class MVVersionManager {
             return;
         }
 
-        Collection<Map<String, MaterializedView.BasePartitionInfo>> allChangedPartitionInfos =
-                snapshotBaseTables.values()
-                        .stream()
-                        .filter(snapshot -> snapshot instanceof PCTTableSnapshotInfo)
-                        .map(snapshot -> ((PCTTableSnapshotInfo) snapshot).getRefreshedPartitionInfos())
-                        .collect(Collectors.toList());
-        long maxChangedTableRefreshTime = MvUtils.getMaxTablePartitionInfoRefreshTime(allChangedPartitionInfos);
-        mv.getRefreshScheme().setLastRefreshTime(maxChangedTableRefreshTime);
+        long maxChangedTableRefreshTime = 0L;
+        for (BaseTableSnapshotInfo snapshot : snapshotBaseTables.values()) {
+            if (snapshot instanceof PCTTableSnapshotInfo) {
+                Map<String, MaterializedView.BasePartitionInfo> partitionInfos =
+                        ((PCTTableSnapshotInfo) snapshot).getRefreshedPartitionInfos();
+                long refreshTime = MvUtils.getMaxTablePartitionInfoRefreshTime(partitionInfos);
+                if (refreshTime > maxChangedTableRefreshTime) {
+                    maxChangedTableRefreshTime = refreshTime;
+                }
+            }
+        }
+        mvRefreshScheme.setLastRefreshTime(maxChangedTableRefreshTime);
         updateEditLogAfterVersionMetaChanged(mv, maxChangedTableRefreshTime);
 
         // trigger timeless info event since mv version changed
@@ -135,9 +139,8 @@ public class MVVersionManager {
                 continue;
             }
             Long tableId = snapshotTable.getId();
-            currentVersionMap.computeIfAbsent(tableId, (v) -> Maps.newConcurrentMap());
             Map<String, MaterializedView.BasePartitionInfo> currentTablePartitionInfo =
-                    currentVersionMap.get(tableId);
+                    currentVersionMap.computeIfAbsent(tableId, (v) -> Maps.newConcurrentMap());
             Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = pctTableSnapshotInfo.getRefreshedPartitionInfos();
             logger.debug("Update materialized view {} meta for base table {} with partitions info: {}, old partition infos:{}",
                     mv.getName(), snapshotTable.getName(), partitionInfoMap, currentTablePartitionInfo);
@@ -147,8 +150,15 @@ public class MVVersionManager {
             // remove partition info of not-exist partition for snapshot table from version map
             if (snapshotTable.isOlapOrCloudNativeTable()) {
                 OlapTable snapshotOlapTable = (OlapTable) snapshotTable;
-                currentTablePartitionInfo.keySet().removeIf(partitionName ->
-                        !snapshotOlapTable.getVisiblePartitionNames().contains(partitionName));
+                Set<String> visiblePartitionNames = snapshotOlapTable.getVisiblePartitionNames();
+                // Use iterator to avoid creating intermediate collections and for better performance
+                Iterator<String> keyIter = currentTablePartitionInfo.keySet().iterator();
+                while (keyIter.hasNext()) {
+                    String partitionName = keyIter.next();
+                    if (!visiblePartitionNames.contains(partitionName)) {
+                        keyIter.remove();
+                    }
+                }
             }
             isOlapTableRefreshed = true;
         }
@@ -194,8 +204,10 @@ public class MVVersionManager {
                         snapshotTable.getName(), pctTableSnapshotInfo.getRefreshedPartitionInfos(), mv.getName());
                 continue;
             }
-            currentVersionMap.computeIfAbsent(baseTableInfo, (v) -> Maps.newConcurrentMap());
-            Map<String, MaterializedView.BasePartitionInfo> currentTablePartitionInfo = currentVersionMap.get(baseTableInfo);
+
+            // Use computeIfAbsent to avoid unnecessary map creation
+            Map<String, MaterializedView.BasePartitionInfo> currentTablePartitionInfo =
+                    currentVersionMap.computeIfAbsent(baseTableInfo, v -> Maps.newConcurrentMap());
             Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = pctTableSnapshotInfo.getRefreshedPartitionInfos();
             logger.debug("Update materialized view {} meta for external base table {} with partitions info: {}, " +
                             "old partition infos:{}", mv.getName(), snapshotTable.getName(),
@@ -203,10 +215,23 @@ public class MVVersionManager {
             // overwrite old partition names
             currentTablePartitionInfo.putAll(partitionInfoMap);
 
-            // FIXME: If base table's partition has been dropped, should drop the according version partition too?
-            // remove partition info of not-exist partition for snapshot table from version map
-            Set<String> partitionNames = Sets.newHashSet(PartitionUtil.getPartitionNames(snapshotTable));
-            currentTablePartitionInfo.keySet().removeIf(partitionName -> !partitionNames.contains(partitionName));
+            // Remove partition info for partitions that no longer exist in the snapshot table
+            List<String> partitionNamesList = PartitionUtil.getPartitionNames(snapshotTable);
+            if (!partitionNamesList.isEmpty()) {
+                Set<String> partitionNames = Sets.newHashSetWithExpectedSize(partitionNamesList.size());
+                partitionNames.addAll(partitionNamesList);
+                // Remove using iterator for better performance on concurrent maps
+                Iterator<String> iter = currentTablePartitionInfo.keySet().iterator();
+                while (iter.hasNext()) {
+                    String partitionName = iter.next();
+                    if (!partitionNames.contains(partitionName)) {
+                        iter.remove();
+                    }
+                }
+            } else {
+                // If no partitions exist, clear all
+                currentTablePartitionInfo.clear();
+            }
         }
         return true;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1164,16 +1164,27 @@ public class MvUtils {
     }
 
     /**
-     * Return the max refresh timestamp of all partition infos.
+     * Returns the maximum refresh timestamp among all partition infos.
+     * If no valid refresh time is found, returns the current system time.
      */
     public static long getMaxTablePartitionInfoRefreshTime(
             Collection<Map<String, MaterializedView.BasePartitionInfo>> partitionInfos) {
         return partitionInfos.stream()
-                .flatMap(x -> x.values().stream())
-                .map(x -> x.getLastRefreshTime())
+                .map(MvUtils::getMaxTablePartitionInfoRefreshTime)
                 .max(Long::compareTo)
+                .orElseGet(System::currentTimeMillis);
+    }
+
+    /**
+     * Returns the maximum refresh timestamp from a single partition info map.
+     * If no valid refresh time is found, returns the current system time.
+     */
+    public static long getMaxTablePartitionInfoRefreshTime(Map<String, MaterializedView.BasePartitionInfo> partitionInfos) {
+        return partitionInfos.values().stream()
+                .map(MaterializedView.BasePartitionInfo::getLastRefreshTime)
                 .filter(Objects::nonNull)
-                .orElse(System.currentTimeMillis());
+                .max(Long::compareTo)
+                .orElseGet(System::currentTimeMillis);
     }
 
     public static List<ScalarOperator> collectOnPredicate(OptExpression optExpression) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/lock/TestLockInterface.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/lock/TestLockInterface.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class TestLockInterface {
@@ -64,7 +63,7 @@ public class TestLockInterface {
         Database database = new Database(rid, "db");
         database.setExist(false);
         Locker locker = new Locker();
-        Assertions.assertFalse(locker.lockDatabaseAndCheckExist(database, rid2, LockType.READ));
+        Assertions.assertFalse(locker.lockTableAndCheckDbExist(database, rid2, LockType.READ));
     }
 
     @Test
@@ -197,46 +196,6 @@ public class TestLockInterface {
         };
 
         Assertions.assertTrue(locker.tryLockDatabase(database.getId(), LockType.READ, 10, TimeUnit.MILLISECONDS));
-
-        Config.lock_manager_enabled = true;
-    }
-
-    @Test
-    public void testReentrantReadWriteTryLock() {
-        List<Database> dbs = Lists.newArrayList();
-        for (int i = 0; i < 10; i++) {
-            dbs.add(new Database(i, "db" + i));
-        }
-        Locker locker = new Locker();
-        Config.lock_manager_enabled = false;
-
-        {
-            Assertions.assertTrue(locker.tryLockDatabases(dbs, LockType.WRITE, 10, TimeUnit.MILLISECONDS));
-            Assertions.assertTrue(locker.tryLockDatabases(dbs, LockType.WRITE, 10, TimeUnit.MILLISECONDS));
-            locker.unlockDatabases(dbs, LockType.WRITE);
-            locker.unlockDatabases(dbs, LockType.WRITE);
-        }
-
-        {
-            new MockUp<Locker>() {
-                @Mock
-                public boolean tryLockDatabase(Long dbId, LockType lockType, long timeout, TimeUnit unit) {
-                    if (dbId == 5) {
-                        return false;
-                    }
-
-                    QueryableReentrantReadWriteLock rwLock = dbs.get(dbId.intValue()).getRwLock();
-                    rwLock.exclusiveLock();
-                    return true;
-                }
-
-                @Mock
-                public void unLockDatabase(Long dbId, LockType lockType) {
-
-                }
-            };
-            Assertions.assertFalse(locker.tryLockDatabases(dbs, LockType.WRITE, 10, TimeUnit.MILLISECONDS));
-        }
 
         Config.lock_manager_enabled = true;
     }


### PR DESCRIPTION
## Why I'm doing:
This is part of https://github.com/StarRocks/starrocks/pull/63446.

Bug 1: `updateMetaForOlapTable` is slow:
```
      {
         "id":9658056,
         "name":"starrocks-taskrun-pool-26084",
         "type":"INTENTION_EXCLUSIVE",
         "heldFor":6980,
         "waitTime":0,
         "stack":[
            "java.base@11.0.28/java.util.HashMap.hash(HashMap.java:340)",
            "java.base@11.0.28/java.util.HashMap.put(HashMap.java:608)",
            "java.base@11.0.28/java.util.HashSet.add(HashSet.java:220)",
            "java.base@11.0.28/java.util.stream.Collectors$$Lambda$35/0x00000008000fd040.accept(Unknown Source)",
            "java.base@11.0.28/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)",
            "java.base@11.0.28/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)",
            "java.base@11.0.28/java.util.TreeMap$KeySpliterator.forEachRemaining(TreeMap.java:2739)",
            "java.base@11.0.28/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)",
            "java.base@11.0.28/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)",
            "java.base@11.0.28/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)",
            "java.base@11.0.28/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)",
            "java.base@11.0.28/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)",
            "app//com.starrocks.catalog.OlapTable.getVisiblePartitionNames(OlapTable.java:1680)",
            "app//com.starrocks.scheduler.mv.MVVersionManager.lambda$updateMetaForOlapTable$2(MVVersionManager.java:123)",
            "app//com.starrocks.scheduler.mv.MVVersionManager$$Lambda$3757/0x00000008014bd040.test(Unknown Source)",
            "java.base@11.0.28/java.util.Collection.removeIf(Collection.java:544)",
            "app//com.starrocks.scheduler.mv.MVVersionManager.updateMetaForOlapTable(MVVersionManager.java:122)",
            "app//com.starrocks.scheduler.mv.MVVersionManager.updateMVVersionInfo(MVVersionManager.java:73)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.updateMeta(PartitionBasedMvRefreshProcessor.java:831)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:472)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:376)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:335)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:203)",
            "app//com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:313)",
            "app//com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:60)",
            "app//com.starrocks.scheduler.TaskRunExecutor$$Lambda$2841/0x000000080145d840.get(Unknown Source)",
            "java.base@11.0.28/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)",
            "java.base@11.0.28/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)",
            "java.base@11.0.28/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)",
            "java.base@11.0.28/java.lang.Thread.run(Thread.java:829)"
         ]
      }
```
Problem 2: Query's `Lock` time may be too long if it contains related mvs:
```
  Planner:
     - -- Parser[1] 0
     - -- Total[1] 6s883ms
     -     -- Analyzer[1] 6s732ms
     -         -- Lock[1] 6s725ms
     -         -- AnalyzeDatabase[3] 0
     -         -- AnalyzeTemporaryTable[3] 0
     -         -- AnalyzeTable[3] 0
     -     -- Transformer[1] 2ms
     -     -- Optimizer[1] 144ms
     -         -- MVPreprocess[1] 1ms
     -             -- MVChooseCandidates[1] 0
     -         -- MVTextRewrite[1] 0
     -         -- RuleBaseOptimize[1] 92ms
     -         -- CostBaseOptimize[1] 40ms
     -         -- PhysicalRewrite[1] 10ms
     -         -- PlanValidate[1] 0
     -             -- InputDependenciesChecker[1] 0
     -             -- TypeChecker[1] 0
     -             -- CTEUniqueChecker[1] 0
     -             -- ColumnReuseChecker[1] 0
     -     -- ExecPlanBuild[1] 0
     - -- Pending[1] 0
     - -- Prepare[1] 0
     - -- Deploy[1] 7ms
     -     -- DeployLockInternalTime[1] 7ms
     -         -- DeploySerializeConcurrencyTime[3] 0
     -         -- DeployStageByStageTime[9] 0
     -         -- DeployWaitTime[9] 5ms
     -             -- DeployAsyncSendTime[4] 0
     - DeployDataSize: 23604
```
## What I'm doing:
- Ensure mv refresh should own `database` level write lock to avoid affecting queries;
- Optimize `updateMetaForOlapTable` for better performance.

Fixes https://github.com/StarRocks/starrocks/issues/63482

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
