### PR TITLE
[Enhancement] pushdown scan_range to zonemap filter

### DIFF
--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -137,16 +137,8 @@ public:
     /// |pred_relation| is the relation among |predicates|, it can be AND or OR.
     virtual Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                               const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                              CompoundNodeType pred_relation) {
-        return get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation, SparseRange<>());
-    }
-
-    /// Store the row ranges that satisfy the given predicates into |row_ranges|.
-    /// |pred_relation| is the relation among |predicates|, it can be AND or OR.
-    // Optimized version, which can pass |scan_range| to reduce filtering overhead.
-    virtual Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
-                                              const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                              CompoundNodeType pred_relation, const SparseRange<>& scan_range) {
+                                              CompoundNodeType pred_relation,
+                                              const SparseRange<>& scan_range = SparseRange<>()) {
         row_ranges->add({0, static_cast<rowid_t>(num_rows())});
         return Status::OK();
     }

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -138,6 +138,15 @@ public:
     virtual Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                               const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
                                               CompoundNodeType pred_relation) {
+        return get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation, SparseRange<>());
+    }
+
+    /// Store the row ranges that satisfy the given predicates into |row_ranges|.
+    /// |pred_relation| is the relation among |predicates|, it can be AND or OR.
+    // Optimized version, which can pass |scan_range| to reduce filtering overhead.
+    virtual Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
+                                              const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
+                                              CompoundNodeType pred_relation, const SparseRange<>& scan_range) {
         row_ranges->add({0, static_cast<rowid_t>(num_rows())});
         return Status::OK();
     }

--- a/be/src/storage/rowset/column_iterator_decorator.h
+++ b/be/src/storage/rowset/column_iterator_decorator.h
@@ -47,8 +47,8 @@ public:
 
     Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                       const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                      CompoundNodeType pred_relation) override {
-        return _parent->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation);
+                                      CompoundNodeType pred_relation, const SparseRange<>& scan_range) override {
+        return _parent->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation, scan_range);
     }
 
     bool has_original_bloom_filter_index() const override { return _parent->has_original_bloom_filter_index(); }

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -669,12 +669,12 @@ Status ColumnReader::_zone_map_filter(const std::vector<const ColumnPredicate*>&
     int32_t page_size = _zonemap_index->num_pages();
 
     // Skip pages that are completely outside the scan range to reduce overhead
-    if (!scan_range.empty()) {
+    if (!scan_range.empty() && scan_range.is_sorted()) {
         auto ordinal_iter = _ordinal_index->seek_at_or_before(scan_range.begin());
         for (; ordinal_iter.valid(); ordinal_iter.next()) {
             int32_t page_index = ordinal_iter.page_index();
             ordinal_t last = ordinal_iter.last_ordinal();
-            if (last > scan_range.end()) {
+            if (last >= scan_range.end()) {
                 break;
             }
 

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -607,16 +607,16 @@ Status ColumnReader::zone_map_filter(const std::vector<const ColumnPredicate*>& 
                                      const ColumnPredicate* del_predicate,
                                      std::unordered_set<uint32_t>* del_partial_filtered_pages,
                                      SparseRange<>* row_ranges, const IndexReadOptions& opts,
-                                     CompoundNodeType pred_relation) {
+                                     CompoundNodeType pred_relation, const SparseRange<>& scan_range) {
     RETURN_IF_ERROR(_load_zonemap_index(opts));
 
     std::vector<uint32_t> page_indexes;
     if (pred_relation == CompoundNodeType::AND) {
         RETURN_IF_ERROR(_zone_map_filter<CompoundNodeType::AND>(predicates, del_predicate, del_partial_filtered_pages,
-                                                                &page_indexes));
+                                                                &page_indexes, scan_range));
     } else {
         RETURN_IF_ERROR(_zone_map_filter<CompoundNodeType::OR>(predicates, del_predicate, del_partial_filtered_pages,
-                                                               &page_indexes));
+                                                               &page_indexes, scan_range));
     }
 
     RETURN_IF_ERROR(_calculate_row_ranges(page_indexes, row_ranges));
@@ -645,7 +645,7 @@ template <CompoundNodeType PredRelation>
 Status ColumnReader::_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
                                       const ColumnPredicate* del_predicate,
                                       std::unordered_set<uint32_t>* del_partial_filtered_pages,
-                                      std::vector<uint32_t>* pages) {
+                                      std::vector<uint32_t>* pages, const SparseRange<>& scan_range) {
     const ColumnPredicate* predicate;
     if (!predicates.empty()) {
         predicate = predicates[0];
@@ -667,18 +667,46 @@ Status ColumnReader::_zone_map_filter(const std::vector<const ColumnPredicate*>&
 
     const std::vector<ZoneMapPB>& zone_maps = _zonemap_index->page_zone_maps();
     int32_t page_size = _zonemap_index->num_pages();
-    for (int32_t i = 0; i < page_size; ++i) {
-        const ZoneMapPB& zm = zone_maps[i];
-        ZoneMapDetail detail;
-        RETURN_IF_ERROR(_parse_zone_map(lt, zm, &detail));
 
-        if (!page_satisfies_zone_map_filter(detail)) {
-            continue;
+    // Skip pages that are completely outside the scan range to reduce overhead
+    if (!scan_range.empty()) {
+        auto ordinal_iter = _ordinal_index->seek_at_or_before(scan_range.begin());
+        for (; ordinal_iter.valid(); ordinal_iter.next()) {
+            int32_t page_index = ordinal_iter.page_index();
+            ordinal_t last = ordinal_iter.last_ordinal();
+            if (last > scan_range.end()) {
+                break;
+            }
+
+            // parse and check the zonemap
+            const ZoneMapPB& zm = zone_maps[page_index];
+            ZoneMapDetail detail;
+            RETURN_IF_ERROR(_parse_zone_map(lt, zm, &detail));
+
+            if (!page_satisfies_zone_map_filter(detail)) {
+                continue;
+            }
+            pages->emplace_back(page_index);
+
+            if (del_predicate && del_predicate->zone_map_filter(detail)) {
+                del_partial_filtered_pages->emplace(page_index);
+            }
         }
-        pages->emplace_back(i);
+    } else {
+        // fallback to iterate all zonemaps
+        for (int32_t i = 0; i < page_size; ++i) {
+            const ZoneMapPB& zm = zone_maps[i];
+            ZoneMapDetail detail;
+            RETURN_IF_ERROR(_parse_zone_map(lt, zm, &detail));
 
-        if (del_predicate && del_predicate->zone_map_filter(detail)) {
-            del_partial_filtered_pages->emplace(i);
+            if (!page_satisfies_zone_map_filter(detail)) {
+                continue;
+            }
+            pages->emplace_back(i);
+
+            if (del_predicate && del_predicate->zone_map_filter(detail)) {
+                del_partial_filtered_pages->emplace(i);
+            }
         }
     }
     return Status::OK();

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -159,7 +159,8 @@ public:
     Status zone_map_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p,
                            const ::starrocks::ColumnPredicate* del_predicate,
                            std::unordered_set<uint32_t>* del_partial_filtered_pages, SparseRange<>* row_ranges,
-                           const IndexReadOptions& opts, CompoundNodeType pred_relation);
+                           const IndexReadOptions& opts, CompoundNodeType pred_relation,
+                           const SparseRange<>& scan_range = SparseRange<>());
 
     // NOTE: RAW interface should be used carefully
     // Return all page-level zonemap
@@ -236,7 +237,8 @@ private:
 
     template <CompoundNodeType PredRelation>
     Status _zone_map_filter(const std::vector<const ColumnPredicate*>& predicates, const ColumnPredicate* del_predicate,
-                            std::unordered_set<uint32_t>* del_partial_filtered_pages, std::vector<uint32_t>* pages);
+                            std::unordered_set<uint32_t>* del_partial_filtered_pages, std::vector<uint32_t>* pages,
+                            const SparseRange<>& scan_range);
 
     Status _load_inverted_index(const std::shared_ptr<TabletIndex>& index_meta, const SegmentReadOptions& opts);
 

--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -160,8 +160,8 @@ Status DefaultValueColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, 
 
 Status DefaultValueColumnIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                               const ColumnPredicate* del_predicate,
-                                                              SparseRange<>* row_ranges,
-                                                              CompoundNodeType pred_relation) {
+                                                              SparseRange<>* row_ranges, CompoundNodeType pred_relation,
+                                                              const SparseRange<>& scan_range) {
     DCHECK(row_ranges->empty());
     // TODO
     row_ranges->add({0, static_cast<rowid_t>(_num_rows)});

--- a/be/src/storage/rowset/default_value_column_iterator.h
+++ b/be/src/storage/rowset/default_value_column_iterator.h
@@ -78,7 +78,7 @@ public:
 
     Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                       const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                      CompoundNodeType pred_relation) override;
+                                      CompoundNodeType pred_relation, const SparseRange<>& scan_range) override;
 
     bool all_page_dict_encoded() const override { return false; }
 

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -434,7 +434,8 @@ Status JsonDynamicFlatIterator::seek_to_ordinal(ordinal_t ord) {
 Status JsonDynamicFlatIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                            const ColumnPredicate* del_predicate,
                                                            SparseRange<>* row_ranges, CompoundNodeType pred_relation) {
-    return _json_iter->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation);
+    return _json_iter->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation,
+                                                  SparseRange<>());
 }
 
 class JsonMergeIterator final : public ColumnIterator {

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -83,7 +83,7 @@ public:
 
     Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                       const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                      CompoundNodeType pred_relation) override;
+                                      CompoundNodeType pred_relation, const SparseRange<>& scan_range) override;
 
     std::string name() const override { return "JsonFlatColumnIterator"; }
 
@@ -297,7 +297,8 @@ Status JsonFlatColumnIterator::seek_to_ordinal(ordinal_t ord) {
 
 Status JsonFlatColumnIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                           const ColumnPredicate* del_predicate,
-                                                          SparseRange<>* row_ranges, CompoundNodeType pred_relation) {
+                                                          SparseRange<>* row_ranges, CompoundNodeType pred_relation,
+                                                          const SparseRange<>& scan_range) {
     row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
     return Status::OK();
 }
@@ -332,7 +333,7 @@ public:
     /// for vectorized engine
     Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                       const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                      CompoundNodeType pred_relation) override;
+                                      CompoundNodeType pred_relation, const SparseRange<>& scan_range) override;
 
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
@@ -433,9 +434,9 @@ Status JsonDynamicFlatIterator::seek_to_ordinal(ordinal_t ord) {
 
 Status JsonDynamicFlatIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                            const ColumnPredicate* del_predicate,
-                                                           SparseRange<>* row_ranges, CompoundNodeType pred_relation) {
-    return _json_iter->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation,
-                                                  SparseRange<>());
+                                                           SparseRange<>* row_ranges, CompoundNodeType pred_relation,
+                                                           const SparseRange<>& scan_range) {
+    return _json_iter->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation, scan_range);
 }
 
 class JsonMergeIterator final : public ColumnIterator {
@@ -468,7 +469,8 @@ public:
     /// for vectorized engine
     [[nodiscard]] Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                     const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                                    CompoundNodeType pred_relation) override;
+                                                    CompoundNodeType pred_relation,
+                                                    const SparseRange<>& scan_range) override;
 
     [[nodiscard]] Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
@@ -639,7 +641,7 @@ Status JsonMergeIterator::seek_to_ordinal(ordinal_t ord) {
 
 Status JsonMergeIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                      const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                                     CompoundNodeType pred_relation) {
+                                                     CompoundNodeType pred_relation, const SparseRange<>& scan_range) {
     row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
     return Status::OK();
 }

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -36,6 +36,7 @@
 
 #include "common/status.h"
 #include "storage/column_predicate.h"
+#include "storage/range.h"
 #include "storage/rowset/binary_dict_page.h"
 #include "storage/rowset/bitshuffle_page.h"
 #include "storage/rowset/column_reader.h"
@@ -413,7 +414,8 @@ Status ScalarColumnIterator::_read_data_page(const OrdinalPageIndexIterator& ite
 
 Status ScalarColumnIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                         const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                                        CompoundNodeType pred_relation) {
+                                                        CompoundNodeType pred_relation,
+                                                        const SparseRange<>& scan_range) {
     DCHECK(row_ranges->empty());
     if (_reader->has_zone_map()) {
         if (!_delete_partial_satisfied_pages.has_value()) {
@@ -427,7 +429,7 @@ Status ScalarColumnIterator::get_row_ranges_by_zone_map(const std::vector<const 
         opts.read_file = _opts.read_file;
         opts.stats = _opts.stats;
         RETURN_IF_ERROR(_reader->zone_map_filter(predicates, del_predicate, &_delete_partial_satisfied_pages.value(),
-                                                 row_ranges, opts, pred_relation));
+                                                 row_ranges, opts, pred_relation, scan_range));
     } else {
         row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
     }

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -67,9 +67,9 @@ public:
 
     bool has_zone_map() const override { return _reader->has_zone_map(); }
 
-    Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicate,
-                                      const ColumnPredicate* del_predicate, SparseRange<>* range,
-                                      CompoundNodeType pred_relationn) override;
+    Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
+                                      const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
+                                      CompoundNodeType pred_relation, const SparseRange<>& scan_range) override;
 
     bool has_original_bloom_filter_index() const override;
     bool has_ngram_bloom_filter_index() const override;

--- a/be/test/storage/rowset/default_value_column_iterator_test.cpp
+++ b/be/test/storage/rowset/default_value_column_iterator_test.cpp
@@ -39,7 +39,7 @@ TEST_F(DefaultValueColumnIteratorTest, delete_after_column) {
     std::vector<const ColumnPredicate*> preds;
     std::unique_ptr<ColumnPredicate> del_pred(new_column_null_predicate(type_info, 1, true));
     SparseRange<> row_ranges;
-    st = iter.get_row_ranges_by_zone_map(preds, del_pred.get(), &row_ranges, CompoundNodeType::AND);
+    st = iter.get_row_ranges_by_zone_map(preds, del_pred.get(), &row_ranges, CompoundNodeType::AND, SparseRange<>());
     ASSERT_TRUE(st.ok());
 
     TypeDescriptor type_desc(LogicalType::TYPE_INT);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


When applying the zonemap index filter, the existing scan_range is not taken into account, leading to additional overhead. To enhance performance, we propose integrating scan_range pushdown into the zonemap filtering process.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pushes `scan_range` through zone-map APIs and SegmentIterator to skip non-overlapping pages during filtering, reducing page checks and overhead.
> 
> - **Zone Map filtering**:
>   - Pushes `scan_range` into `get_row_ranges_by_zone_map` across `ColumnIterator` and implementations (`ScalarColumnIterator`, `DefaultValueColumnIterator`, JSON iterators, decorator).
>   - Extends `ColumnReader::zone_map_filter` and internal `_zone_map_filter` to accept `scan_range` and restrict evaluated pages via `_ordinal_index` (compute `page_start/page_end`).
>   - `SegmentIterator`: passes `_scan_range` to zone-map evaluation via `ZoneMapFilterEvaluator` to prune pages within current scan window.
> - **Plumbing/API**:
>   - Updates method signatures to include optional `scan_range` default param; adds necessary include of `storage/range.h`.
> - **Tests**:
>   - Adjusts `DefaultValueColumnIterator` test to use new `scan_range` parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a07cb62190eced861b6dd34d9015105a4bb300d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->