### PR TITLE
[BugFix] Fix profile lost sql statement and planner trace when use prepare statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -601,11 +601,25 @@ public class ConnectProcessor {
             String originStmt = executeStmt.toSql();
             executeStmt.setOrigStmt(new OriginStatement(originStmt, 0));
 
-            executor = new StmtExecutor(ctx, executeStmt);
-            ctx.setExecutor(executor);
-
             boolean isQuery = ctx.isQueryStmt(executeStmt);
             ctx.getState().setIsQuery(isQuery);
+
+            if (isQuery) {
+                // for query stmt, we should register and init tracer.
+                Tracers.register(ctx);
+                Tracers.init(ctx, executeStmt.getTraceMode(), executeStmt.getTraceModule());
+                // set original statement to original query
+                PrepareStmtContext prepareStmtContext = ctx.getPreparedStmt(executeStmt.getStmtName());
+                if (prepareStmtContext != null) {
+                    if (prepareStmtContext.getStmt().getInnerStmt() instanceof QueryStatement) {
+                        originStmt = AstToSQLBuilder.toSQL(prepareStmtContext.getStmt().getInnerStmt());
+                        executeStmt.setOrigStmt(new OriginStatement(originStmt, 0));
+                    }
+                }
+            }
+
+            executor = new StmtExecutor(ctx, executeStmt);
+            ctx.setExecutor(executor);
 
             if (enableAudit && isQuery) {
                 executor.addRunningQueryDetail(executeStmt);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -43,6 +43,7 @@ import com.starrocks.authentication.PlainPasswordAuthenticationProvider;
 import com.starrocks.authorization.PrivilegeBuiltinConstants;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.mysql.MysqlCapability;
 import com.starrocks.mysql.MysqlChannel;
@@ -75,6 +76,9 @@ import org.xnio.StreamConnection;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -738,5 +742,113 @@ public class ConnectProcessorTest extends DDLTestBase {
 
         Assertions.assertEquals(MysqlCommand.COM_STMT_EXECUTE, myContext.getCommand());
         Assertions.assertTrue(ctx.getState().isQuery());
+    }
+
+    /**
+     * Test handleExecute method with tracing for query statements
+     */
+    @Test
+    public void testHandleExecuteTracingForQuery() throws Exception {
+        // Create a prepared statement packet for COM_STMT_EXECUTE
+        ByteBuffer executePacket = createExecutePacket(1, new ArrayList<>());
+        ConnectContext ctx = initMockContext(mockChannel(executePacket), GlobalStateMgr.getCurrentState());
+        
+        // Create a prepared statement context with a query statement
+        PrepareStmt prepareStmt = createMockPrepareStmt("SELECT 1 + 2");
+        PrepareStmtContext prepareCtx = new PrepareStmtContext(prepareStmt, ctx, null);
+        ctx.putPreparedStmt("1", prepareCtx);
+        
+        ConnectProcessor processor = new ConnectProcessor(ctx);
+        
+        // Track method calls
+        AtomicReference<Boolean> tracersRegistered = new AtomicReference<>(false);
+        AtomicReference<Boolean> tracersInitialized = new AtomicReference<>(false);
+        
+        // Mock Tracers
+        new MockUp<Tracers>() {
+            @Mock
+            public void register(ConnectContext context) {
+                tracersRegistered.set(true);
+            }
+            
+            @Mock
+            public void init(ConnectContext context, String traceMode, String traceModule) {
+                tracersInitialized.set(true);
+            }
+        };
+        
+        // Mock StmtExecutor
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute() throws Exception {
+                // Do nothing for test
+            }
+            
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return statistics;
+            }
+            
+            @Mock
+            public StatementBase getParsedStmt() {
+                return prepareStmt;
+            }
+        };
+        
+        processor.processOnce();
+        
+        // Verify that tracers are properly initialized for query statements
+        Assertions.assertTrue(tracersRegistered.get(), "Tracers should be registered for query statements");
+        Assertions.assertTrue(tracersInitialized.get(), "Tracers should be initialized for query statements");
+        Assertions.assertEquals(MysqlCommand.COM_STMT_EXECUTE, myContext.getCommand());
+        Assertions.assertEquals("SELECT 1 + 2 AS `1 + 2`", processor.executor.getOriginStmtInString());
+    }
+    
+    /**
+     * Helper method to create a COM_STMT_EXECUTE packet
+     */
+    private ByteBuffer createExecutePacket(int stmtId, List<Object> params) {
+        MysqlSerializer serializer = MysqlSerializer.newInstance();
+        
+        // Command type COM_STMT_EXECUTE (0x17 = 23)
+        serializer.writeInt1(23);
+        
+        // Statement ID
+        serializer.writeInt4(stmtId);
+        
+        // Flags (0 = CURSOR_TYPE_NO_CURSOR)
+        serializer.writeInt1(0);
+        
+        // Iteration count (always 1)
+        serializer.writeInt4(1);
+        
+        // NULL bitmap (empty for no parameters)
+        int nullBitmapLength = (params.size() + 7) / 8;
+        if (nullBitmapLength > 0) {
+            byte[] nullBitmap = new byte[nullBitmapLength];
+            serializer.writeBytes(nullBitmap);
+        }
+        
+        // new_params_bind_flag (0 = types not included)
+        if (params.size() > 0) {
+            serializer.writeInt1(0);
+        }
+        
+        return serializer.toByteBuffer().order(ByteOrder.LITTLE_ENDIAN);
+    }
+    
+    /**
+     * Helper method to create a mock PrepareStmt
+     */
+    private PrepareStmt createMockPrepareStmt(String sql) {
+        try {
+            // Create a simple statement for testing
+            StatementBase innerStmt = UtFrameUtils.parseStmtWithNewParser(sql,
+                    UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT));
+            return new PrepareStmt("test_stmt", innerStmt, null);
+        } catch (Exception e) {
+            // Return a simple mock for test purposes
+            return new PrepareStmt("test_stmt", null, null);
+        }
     }
 }

--- a/test/sql/test_preparestatement/R/test_preprare_statement
+++ b/test/sql/test_preparestatement/R/test_preprare_statement
@@ -147,7 +147,7 @@ function: assert_prepare_execute('test_prepare_1', "SELECT customer_key, custome
 -- result:
 None
 -- !result
-shell: current_time=$(date +%s); curl -s -X GET "${url}/api/query_detail?event_time=$((current_time - 1))" -u 'root:' | grep -c "EXECUTE" > 0
+shell: current_time=$(date +%s); curl -s -X GET "${url}/api/query_detail?event_time=$((current_time - 1))" -u 'root:' | grep -c "SELECT customer_key" > 0
 -- result:
 0
 -- !result

--- a/test/sql/test_preparestatement/T/test_preprare_statement
+++ b/test/sql/test_preparestatement/T/test_preprare_statement
@@ -80,7 +80,7 @@ admin set frontend config ("enable_collect_query_detail_info" = "true");
 
 
 function: assert_prepare_execute('test_prepare_1', "SELECT customer_key, customer_row_value_0, customer_row_value_1, customer_row_value_2 FROM customer_row WHERE customer_key = ?", ['1'])
-shell: current_time=$(date +%s); curl -s -X GET "${url}/api/query_detail?event_time=$((current_time - 1))" -u 'root:' | grep -c "EXECUTE" > 0
+shell: current_time=$(date +%s); curl -s -X GET "${url}/api/query_detail?event_time=$((current_time - 1))" -u 'root:' | grep -c "SELECT customer_key" > 0
 
 admin set frontend config ("enable_collect_query_detail_info" = "false");
 DROP PREPARE select_customer_stmt;


### PR DESCRIPTION
## Why I'm doing:
![img_v3_02qd_c53d45e5-f5f0-4044-a962-3b8e687de5eg](https://github.com/user-attachments/assets/f106b66c-1eeb-4336-a166-c700bcce7fc3)
user use jdbc connect to starrocks, the mysql connector will use prepare statement, it will lost sql statement and planner trace time in profile
## What I'm doing:

Fixes #issue

## What type of PR is this:
This pull request introduces improvements to the handling and testing of tracing for query statements executed via prepared statements in the `ConnectProcessor` class. The main changes ensure that tracing is properly initialized for query statements, and that the original SQL statement is correctly set for auditing and tracing purposes. Additionally, new unit tests have been added to verify the tracing logic.

**Enhancements to tracing and statement handling:**

* Improved tracing initialization for query statements in `handleExecute()`: Tracing is now registered and initialized only for query statements, and the original statement is set from the prepared statement context if available.
* The original SQL statement is always set for `ExecuteStmt`, regardless of audit settings, ensuring consistency for tracing and auditing.

**Unit test improvements:**

* Added a new test `testHandleExecuteTracingForQuery` to verify that tracing is registered and initialized for query statements executed via prepared statements, and that the original SQL is set correctly.
* Introduced helper methods in the test suite for creating COM_STMT_EXECUTE packets and mock `PrepareStmt` objects to facilitate testing of prepared statement execution and tracing.

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
