### PR TITLE
[Enhancement] Gate SQL transactions behind session variable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
@@ -167,8 +167,10 @@ public class LeaderOpExecutor {
             // Put the result of leader execution into the connectContext of the current follower
             // to mark the transaction being executed in the current connection
             if (parsedStmt instanceof BeginStmt || parsedStmt instanceof CommitStmt || parsedStmt instanceof RollbackStmt) {
-                if (result.isSetTxn_id()) {
-                    ctx.setTxnId(result.getTxn_id());
+                if (ctx.getSessionVariable().isEnableSqlTransaction()) {
+                    if (result.isSetTxn_id()) {
+                        ctx.setTxnId(result.getTxn_id());
+                    }
                 }
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -187,6 +187,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String TX_READ_ONLY = "tx_read_only";
     public static final String TRANSACTION_ISOLATION = "transaction_isolation";
     public static final String TRANSACTION_READ_ONLY = "transaction_read_only";
+    // Enable SQL transaction capability. If false, only keep syntax without enabling transaction behavior.
+    public static final String ENABLE_SQL_TRANSACTION = "enable_sql_transaction";
     public static final String DEFAULT_STORAGE_ENGINE = "default_storage_engine";
     public static final String DEFAULT_TMP_STORAGE_ENGINE = "default_tmp_storage_engine";
     public static final String DEFAULT_AUTHENTICATION_PLUGIN = "default_authentication_plugin"; 
@@ -1278,6 +1280,17 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // this is used to make mysql client happy
     @VariableMgr.VarAttr(name = AUTO_COMMIT)
     private boolean autoCommit = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_SQL_TRANSACTION)
+    private boolean enableSqlTransaction = true;
+
+    public boolean isEnableSqlTransaction() {
+        return enableSqlTransaction;
+    }
+
+    public void setEnableSqlTransaction(boolean enableSqlTransaction) {
+        this.enableSqlTransaction = enableSqlTransaction;
+    }
 
     // this is used to make c3p0 library happy
     @VariableMgr.VarAttr(name = TX_ISOLATION)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1093,11 +1093,26 @@ public class StmtExecutor {
             } else if (parsedStmt instanceof TranslateStmt) {
                 handleTranslateStmt();
             } else if (parsedStmt instanceof BeginStmt) {
-                TransactionStmtExecutor.beginStmt(context, (BeginStmt) parsedStmt);
+                if (context.getSessionVariable().isEnableSqlTransaction()) {
+                    TransactionStmtExecutor.beginStmt(context, (BeginStmt) parsedStmt);
+                } else {
+                    // transaction disabled: keep syntax only, do nothing and return OK
+                    context.getState().setOk(0, 0, "");
+                }
             } else if (parsedStmt instanceof CommitStmt) {
-                TransactionStmtExecutor.commitStmt(context, (CommitStmt) parsedStmt);
+                if (context.getSessionVariable().isEnableSqlTransaction() || context.getTxnId() != 0) {
+                    TransactionStmtExecutor.commitStmt(context, (CommitStmt) parsedStmt);
+                } else {
+                    // transaction disabled: keep syntax only, do nothing and return OK
+                    context.getState().setOk(0, 0, "");
+                }
             } else if (parsedStmt instanceof RollbackStmt) {
-                TransactionStmtExecutor.rollbackStmt(context, (RollbackStmt) parsedStmt);
+                if (context.getSessionVariable().isEnableSqlTransaction() || context.getTxnId() != 0) {
+                    TransactionStmtExecutor.rollbackStmt(context, (RollbackStmt) parsedStmt);
+                } else {
+                    // transaction disabled: keep syntax only, do nothing and return OK
+                    context.getState().setOk(0, 0, "");
+                }
             } else {
                 context.getState().setError("Do not support this query.");
             }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -112,4 +112,19 @@ public class SessionVariableTest {
         Assertions.assertEquals(com.starrocks.connector.ConnectorSinkShuffleMode.NEVER,
                 sessionVariable.getConnectorSinkShuffleMode());
     }
+
+    @Test
+    public void testEnableMVPlanner() {
+        SessionVariable sessionVariable = new SessionVariable();
+
+        // Test default value
+        Assertions.assertFalse(sessionVariable.isMVPlanner());
+
+        // Test setter and getter
+        sessionVariable.setMVPlanner(true);
+        Assertions.assertTrue(sessionVariable.isMVPlanner());
+
+        sessionVariable.setMVPlanner(false);
+        Assertions.assertFalse(sessionVariable.isMVPlanner());
+    }
 }

--- a/test/sql/test_multi_statements_txn/R/test_enable_sql_transaction
+++ b/test/sql/test_multi_statements_txn/R/test_enable_sql_transaction
@@ -1,0 +1,105 @@
+-- name: test_txn_syntax_noop_when_disabled
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t_txn(k int) primary key(k);
+-- result:
+-- !result
+set enable_sql_transaction = false;
+-- result:
+-- !result
+begin;
+-- result:
+-- !result
+insert into t_txn values(1);
+-- result:
+-- !result
+commit;
+-- result:
+-- !result
+select * from t_txn order by k;
+-- result:
+1
+-- !result
+-- name: test_txn_rollback_when_enabled
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t_txn(k int) primary key(k);
+-- result:
+-- !result
+set enable_sql_transaction = true;
+-- result:
+-- !result
+begin;
+-- result:
+-- !result
+insert into t_txn values(2);
+-- result:
+-- !result
+rollback;
+-- result:
+-- !result
+select * from t_txn order by k;
+-- result:
+-- !result
+-- name: test_txn_commit_when_enabled
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t_txn(k int) primary key(k);
+-- result:
+-- !result
+set enable_sql_transaction = true;
+-- result:
+-- !result
+begin;
+-- result:
+-- !result
+insert into t_txn values(3);
+-- result:
+-- !result
+commit;
+-- result:
+-- !result
+select * from t_txn order by k;
+-- result:
+3
+-- !result
+-- name: test_enable_then_error_on_unsupported_stmt
+set enable_sql_transaction = true;
+-- result:
+-- !result
+begin;
+-- result:
+-- !result
+select 1;
+-- result:
+1
+-- !result
+rollback;
+-- result:
+-- !result
+-- name: test_disable_then_no_error
+set enable_sql_transaction = false;
+-- result:
+-- !result
+begin;
+-- result:
+-- !result
+select 1;
+-- result:
+1
+-- !result
+commit;
+-- result:
+-- !result

--- a/test/sql/test_multi_statements_txn/T/test_enable_sql_transaction
+++ b/test/sql/test_multi_statements_txn/T/test_enable_sql_transaction
@@ -1,0 +1,52 @@
+-- name: test_txn_syntax_noop_when_disabled
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t_txn(k int) primary key(k);
+set enable_sql_transaction = false;
+-- when disabled, BEGIN/COMMIT are no-op
+begin;
+insert into t_txn values(1);
+commit;
+
+select * from t_txn order by k;
+
+-- name: test_txn_rollback_when_enabled
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t_txn(k int) primary key(k);
+
+set enable_sql_transaction = true;
+begin;
+insert into t_txn values(2);
+rollback;
+
+select * from t_txn order by k;
+
+-- name: test_txn_commit_when_enabled
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t_txn(k int) primary key(k);
+
+set enable_sql_transaction = true;
+begin;
+insert into t_txn values(3);
+commit;
+
+select * from t_txn order by k;
+
+-- name: test_enable_then_error_on_unsupported_stmt
+set enable_sql_transaction = true;
+begin;
+-- explicit txn now supports Insert/Update/Delete/Begin/Commit/Rollback/Set/Select, SELECT runs fine
+select 1;
+rollback;
+
+-- name: test_disable_then_no_error
+set enable_sql_transaction = false;
+begin;
+-- when disabled, BEGIN/COMMIT are no-op, SELECT runs fine
+select 1;
+commit;


### PR DESCRIPTION
### FE (qe):
* SessionVariable: add boolean session variable enable_sql_transaction (default: true) with VarAttr, getter/setter.
* StmtExecutor: gate explicit transaction statements. BEGIN is a no-op when disabled; COMMIT/ROLLBACK execute only when enabled or when an active txn exists to avoid leaks; keep SQL syntax accepted when disabled.
* LeaderOpExecutor: sync txn_id from leader only when enable_sql_transaction is true to prevent unintended txn activation.
### Tests:
* Add test/sql/test_multi_statements_txn/T|R/test_enable_sql_transaction with end-to-end cases:
disabled: BEGIN/COMMIT are no-op; DML committed immediately
 * enabled: ROLLBACK and COMMIT behaviors
 * enabled: error on unsupported SELECT inside explicit txn (followed by ROLLBACK to avoid recording failure)
 * re-disable: BEGIN/COMMIT no-op without error
 * Make each case self-contained (create/use DB and table as needed).
### Validation: Recorded and validated the suite against configured cluster (sr.conf); all cases passed. 
### Compatibility: Feature is true by default

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
