### PR TITLE
[BugFix] Fix data cache bugs with invalid compute resources

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
@@ -52,6 +52,7 @@ public class DataCacheSelectExecutor {
         final List<ComputeResource> computeResources = computeResourceProvider.getComputeResources(wh);
 
         List<StmtExecutor> subStmtExecutors = Lists.newArrayList();
+        boolean isFirstSubContext = true;
         for (ComputeResource computeResource : computeResources) {
             if (!computeResourceProvider.isResourceAvailable(computeResource)) {
                 // skip if this compute resource is not available
@@ -59,10 +60,10 @@ public class DataCacheSelectExecutor {
                 continue;
             }
 
-            long workerGroupIdx = computeResource.getWorkerGroupId();
-            ConnectContext subContext = buildCacheSelectConnectContext(statement, connectContext, workerGroupIdx == 0);
+            ConnectContext subContext = buildCacheSelectConnectContext(statement, connectContext, isFirstSubContext);
             subContext.setCurrentComputeResource(computeResource);
             StmtExecutor subStmtExecutor = StmtExecutor.newInternalExecutor(subContext, insertStmt);
+            isFirstSubContext = false;
             // Register new StmtExecutor into current ConnectContext's StmtExecutor, so we can handle ctrl+c command
             // If DataCacheSelect is forward to leader, connectContext's Executor is null
             if (connectContext.getExecutor() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
@@ -32,6 +32,7 @@ import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.ComputeResourceProvider;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -42,17 +43,24 @@ public class DataCacheSelectExecutor {
     private static final Logger LOG = LogManager.getLogger(DataCacheSelectExecutor.class);
 
     public static DataCacheSelectMetrics cacheSelect(DataCacheSelectStatement statement,
-                                                             ConnectContext connectContext) throws Exception {
+                                                     ConnectContext connectContext) throws Exception {
         InsertStmt insertStmt = statement.getInsertStmt();
 
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         final Warehouse wh = warehouseManager.getWarehouse(connectContext.getCurrentWarehouseName());
+        final ComputeResourceProvider computeResourceProvider = warehouseManager.getComputeResourceProvider();
+        final List<ComputeResource> computeResources = computeResourceProvider.getComputeResources(wh);
+
         List<StmtExecutor> subStmtExecutors = Lists.newArrayList();
-        for (int workerGroupIdx = 0; workerGroupIdx < wh.getWorkerGroupIds().size(); workerGroupIdx++) {
-            long workerGroupId = wh.getWorkerGroupIds().get(workerGroupIdx);
+        for (ComputeResource computeResource : computeResources) {
+            if (!computeResourceProvider.isResourceAvailable(computeResource)) {
+                // skip if this compute resource is not available
+                LOG.warn("skip cache select for compute resource {} because it is not available", computeResource);
+                continue;
+            }
+
+            long workerGroupIdx = computeResource.getWorkerGroupId();
             ConnectContext subContext = buildCacheSelectConnectContext(statement, connectContext, workerGroupIdx == 0);
-            ComputeResource computeResource = warehouseManager.getComputeResourceProvider().ofComputeResource(
-                    wh.getId(), workerGroupId);
             subContext.setCurrentComputeResource(computeResource);
             StmtExecutor subStmtExecutor = StmtExecutor.newInternalExecutor(subContext, insertStmt);
             // Register new StmtExecutor into current ConnectContext's StmtExecutor, so we can handle ctrl+c command

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/cngroup/ComputeResourceProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/cngroup/ComputeResourceProvider.java
@@ -34,6 +34,13 @@ public interface ComputeResourceProvider {
     ComputeResource ofComputeResource(long warehouseId, long workGroupId);
 
     /**
+     * Get all ComputeResources by warehouse.
+     * @param warehouse the warehouse to get the ComputeResources from
+     * @return a list of ComputeResources that can be used for compute
+     */
+    List<ComputeResource> getComputeResources(Warehouse warehouse);
+
+    /**
      * NOTE: prefer to call this infrequently, as it can come to dominate the execution time of a query in the
      *  frontend if there are many calls per request (e.g. one per partition when there are many partitions).
      *

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/cngroup/WarehouseComputeResourceProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/cngroup/WarehouseComputeResourceProvider.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.warehouse.cngroup;
 
-import com.google.api.client.util.Lists;
+import com.google.common.collect.Lists;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.StarRocksException;
@@ -45,6 +45,14 @@ public final class WarehouseComputeResourceProvider implements ComputeResourcePr
     @Override
     public ComputeResource ofComputeResource(long warehouseId, long workerGroupId) {
         return WarehouseComputeResource.of(warehouseId);
+    }
+
+    @Override
+    public List<ComputeResource> getComputeResources(Warehouse warehouse) {
+        if (warehouse == null) {
+            throw ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, "warehouse is null");
+        }
+        return Lists.newArrayList(WarehouseComputeResource.of(warehouse.getId()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/cngroup/WarehouseComputeResourceProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/cngroup/WarehouseComputeResourceProvider.java
@@ -19,6 +19,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.warehouse.Warehouse;
@@ -75,6 +76,9 @@ public final class WarehouseComputeResourceProvider implements ComputeResourcePr
      */
     @Override
     public boolean isResourceAvailable(ComputeResource computeResource) {
+        if (!RunMode.isSharedDataMode()) {
+            return true;
+        }
         try {
             final long availableWorkerGroupIdSize =
                     Optional.ofNullable(getAliveComputeNodes(computeResource)).map(List::size).orElse(0);

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -43,6 +43,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -64,6 +65,16 @@ public class WarehouseManagerTest {
 
     @Mocked
     StarOSAgent starOSAgent;
+
+    @BeforeAll
+    public static void setUp() {
+        new MockUp<RunMode>() {
+            @Mock
+            boolean isSharedDataMode() {
+                return true;
+            }
+        };
+    }
 
     @Test
     public void testWarehouseNotExist() {
@@ -399,6 +410,12 @@ public class WarehouseManagerTest {
 
     @Test
     public void testBackgroundWarehouse() {
+        new MockUp<WarehouseComputeResourceProvider>() {
+            @Mock
+            public boolean isResourceAvailable(ComputeResource computeResource) {
+                return true;
+            }
+        };
         WarehouseManager mgr = new WarehouseManager();
         mgr.initDefaultWarehouse();
         Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, mgr.getBackgroundWarehouse(123).getId());

--- a/fe/fe-core/src/test/java/com/starrocks/system/HistoricalNodeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/HistoricalNodeMgrTest.java
@@ -20,6 +20,7 @@ import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import mockit.Mock;
 import mockit.MockUp;
@@ -43,6 +44,12 @@ public class HistoricalNodeMgrTest {
 
     @BeforeEach
     public void setUp() throws IOException {
+        new MockUp<RunMode>() {
+            @Mock
+            boolean isSharedDataMode() {
+                return true;
+            }
+        };
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         warehouseManager.initDefaultWarehouse();
     }


### PR DESCRIPTION
## Why I'm doing:

When `cache select` meets invalid compute resources, it will fail as below:
```
mysql> cache select * from t1;
ERROR 1064 (HY000): Current connection's compute resource(daily_warehouse) is not available:{warehouseId=10346, cnGroupId=6371, createdTime=1758765927725}, please try again.
mysql> set warehouse daily_warehouse;
Query OK, 0 rows affected (0.00 sec)


```
## What I'm doing:
- skip invalid compute resources in `cache select`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cache select now iterates provider-listed compute resources and skips unavailable ones; adds `getComputeResources(Warehouse)` and implements it with adjusted availability checks, plus related test updates.
> 
> - **Datacache**:
>   - `DataCacheSelectExecutor`: fetches compute resources via `ComputeResourceProvider.getComputeResources(warehouse)` and skips those where `isResourceAvailable` is false; uses `isFirstSubContext` to set execution IDs consistently.
> - **Compute Resource Provider**:
>   - `ComputeResourceProvider`: adds `getComputeResources(Warehouse)`.
>   - `WarehouseComputeResourceProvider`: implements `getComputeResources`; `isResourceAvailable` short-circuits to true when not in shared-data mode; minor import adjustments.
> - **Tests**:
>   - `WarehouseManagerTest`, `HistoricalNodeMgrTest`: mock `RunMode` and resource availability where needed; add/setup hooks to ensure tests run with shared-data assumptions and background warehouse checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc463ebda92a1a4d19c8b7a9abc33fbfe59a9fd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->