### PR TITLE
[BugFix] connect context is missing in deploy scan range threads

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -396,6 +396,11 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     @VisibleForTesting
     public long addPartition(FileScanTask task) throws AnalysisException {
         PartitionSpec spec = task.spec();
+
+        if (!partitionSlotIdsCache.containsKey(spec.specId())) {
+            partitionSlotIdsCache.put(spec.specId(), buildPartitionSlotIds(task.spec()));
+        }
+
         // Make sure the partition data with byte[], decimal value object etc. can get the same hash code.
         StructLike origPartition = task.partition();
         StructLikeWrapper partitionWrapper = StructLikeWrapper.forType(spec.partitionType());
@@ -419,10 +424,6 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
 
         partitionKeyToId.put(partition, partitionId);
         referencedPartitions.put(partitionId, referencedPartitionInfo);
-        if (!partitionSlotIdsCache.containsKey(spec.specId())) {
-            partitionSlotIdsCache.put(spec.specId(), buildPartitionSlotIds(task.spec()));
-        }
-
         return partitionId;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -284,6 +284,10 @@ public class ConnectContext {
         return threadLocalInfo.get();
     }
 
+    public static void set(ConnectContext ctx) {
+        threadLocalInfo.set(ctx);
+    }
+
     public static SessionVariable getSessionVariableOrDefault() {
         ConnectContext ctx = get();
         return (ctx != null) ? ctx.sessionVariable : SessionVariable.DEFAULT_SESSION_VARIABLE;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
@@ -18,6 +18,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.proto.PPlanFragmentCancelReason;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.qe.scheduler.Deployer;
 import com.starrocks.qe.scheduler.slot.DeployState;
@@ -41,11 +42,16 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
 
     class TracerContext implements AutoCloseable {
         Tracers savedTracers;
+        ConnectContext savedConnectContext;
 
-        TracerContext(Tracers currentTracers) {
+        TracerContext(Tracers currentTracers, ConnectContext connectContext) {
             if (currentTracers != null) {
                 savedTracers = Tracers.get();
                 Tracers.set(currentTracers);
+            }
+            if (connectContext != null) {
+                savedConnectContext = ConnectContext.get();
+                ConnectContext.set(connectContext);
             }
         }
 
@@ -54,6 +60,9 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
             if (savedTracers != null) {
                 Tracers.set(savedTracers);
             }
+            if (savedConnectContext != null) {
+                ConnectContext.set(savedConnectContext);
+            }
         }
     }
 
@@ -61,6 +70,7 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
         List<DeployState> states;
         ExecutorService executorService;
         Tracers currentTracers;
+        ConnectContext currentConnectContext;
 
         DeployScanRangesTask(List<DeployState> states) {
             this.states = states;
@@ -71,7 +81,7 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
             if (cancelled || states.isEmpty()) {
                 return;
             }
-            try (TracerContext tracerContext = new TracerContext(currentTracers)) {
+            try (TracerContext tracerContext = new TracerContext(currentTracers, currentConnectContext)) {
                 runOnce();
             }
             // If run in the executor service, we need to start the next turn.
@@ -129,6 +139,7 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
         if (option.useQueryDeployExecutor) {
             deployScanRangesTask.executorService = GlobalStateMgr.getCurrentState().getQueryDeployExecutor();
             deployScanRangesTask.currentTracers = Tracers.get();
+            deployScanRangesTask.currentConnectContext = ConnectContext.get();
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

ConnectContext is null in deploy scan ranges thread, and it will affect iceberg identity partition values.

## What I'm doing:

switch connect context in the deploy scan ranges thread.

Fixes #63290

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
