### PR TITLE
[BugFix] change CHECK to DCHECK in nullablecolumn to prevent the crash

### DIFF
--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -529,11 +529,11 @@ void NullableColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool 
 }
 
 void NullableColumn::check_or_die() const {
-    CHECK_EQ(_null_column->size(), _data_column->size());
+    DCHECK_EQ(_null_column->size(), _data_column->size());
     // when _has_null=true, the column may have no null value, so don't check.
     if (!_has_null) {
         auto null_data = _null_column->immutable_data();
-        CHECK(!SIMD::contain_nonzero(null_data, 0));
+        DCHECK(!SIMD::contain_nonzero(null_data, 0));
     }
     _data_column->check_or_die();
     _null_column->check_or_die();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
F20250923 23:42:04.217981 47716112008960 nullable_column.cpp:426] Check failed: _null_column->size() == _data_column->size() (4096 vs. 0)
    @          0x45e4183 starrocks::failure_function()
    @          0xb64b24a google::LogMessage::Fail()
    @          0xb64cc84 google::LogMessageFatal::~LogMessageFatal()
    @          0x46a0aad starrocks::NullableColumn::check_or_die() const
    @          0x7aa102d starrocks::JsonMergeIterator::next_batch(starrocks::SparseRange<unsigned int> const&, starrocks::Column*)
    @          0x704c3db starrocks::SegmentIterator::_read(starrocks::Chunk*, std::vector<unsigned int, std::allocator<unsigned int> >*, unsigned long)
    @          0x703b539 starrocks::SegmentIterator::_do_get_next(starrocks::Chunk*, std::vector<unsigned int, std::allocator<unsigned int> >*)
    @          0x7047351 starrocks::SegmentIterator::do_get_next(starrocks::Chunk*)
    @          0x70c6865 starrocks::ProjectionIterator::do_get_next(starrocks::Chunk*)

```


In `JsonMergeIterator`, the `Column::check_or_die` function is used to validate data and previously relied on `CHECK` to enforce this. We have now replaced `CHECK` with `DCHECK` to prevent crashes in release builds.

This change is a temporary workaround to address the crash issue but does not resolve the underlying problem.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
