### PR TITLE
[BugFix] Lead/Lag with specified default value can not adopt low-cardinality optimization

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -960,6 +960,38 @@ public class LowCardinalityArrayTest extends PlanTestBase {
     }
 
     @Test
+    public void testNotSupportedWindowFunctionLeadLagWithSpecifiedDefaultValue() throws Exception {
+        String sqlFmt = "with cte as(\n" +
+                "  select s1.v1, s1.v2, t.a1 a1\n" +
+                "  from s1,unnest(s1.a1)t(a1) \n" +
+                ")\n" +
+                "select v1, a1, {WINDOW_FUN}(a1, 1, 'ABCD') over(partition by v1)\n" +
+                "from cte;";
+
+        String[] windowFuncs = new String[] {
+                FunctionSet.LEAD,
+                FunctionSet.LAG
+        };
+
+        for (String wf : windowFuncs) {
+            String q = sqlFmt.replace("{WINDOW_FUN}", wf);
+            String plan = getVerboseExplain(q);
+            String[] lines = plan.split("\n");
+            List<Integer> decodeNodeLines = IntStream.range(0, lines.length).boxed()
+                    .filter(lineno -> lines[lineno]
+                            .matches("^\\s*\\d+:Decode\\s*$"))
+                    .collect(Collectors.toList());
+
+            List<Integer> analyticNodeLines = IntStream.range(0, lines.length).boxed()
+                    .filter(lineno -> lines[lineno]
+                            .matches("^\\s*\\d+:ANALYTIC\\s*$"))
+                    .collect(Collectors.toList());
+            Assertions.assertEquals(1, decodeNodeLines.size(), plan);
+            Assertions.assertEquals(1, analyticNodeLines.size(), plan);
+            Assertions.assertTrue(decodeNodeLines.get(0) > analyticNodeLines.get(0), plan);
+        }
+    }
+    @Test
     public void testdWindowFunctionCount() throws Exception {
         String sql1 = "with cte as(\n" +
                 "  select s1.v1, s1.v2, t.a1 a1\n" +


### PR DESCRIPTION
## Why I'm doing:

fixup: https://github.com/StarRocks/StarRocksTest/issues/10363

For window functions lead/lag with specified default value(3rd argument), when adopting low-cardinality optimization, this default value is packed into constant BinaryColumn while WindowFunctions(int type) would treat it as IntColumn when extracting this default value, thus be crashes.

```
** Aborted at 1758779709 (unix time) try "date -d @1758779709" if you are using GNU date ***
PC: @          0x7fbb07f void std::vector<int, starrocks::ColumnAllocator<int> >::_M_assign_aux<__gnu_cxx::__normal_iterator<int const*, std::span<int const, 18446744073709551615ul> > >(__gnu_cxx::__normal_iterator<int const*, std::span<int const, 18446744073709551615ul> >, __gnu_r^A
*** SIGSEGV (@0x7efe247ff000) received by PID 1463157 (TID 0x7efd123f7640) LWP(1463772) from PID 612364288; stack trace: ***
    @     0x7efe2da6eee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xe0cb988 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7efe2da17520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x7fbb07f void std::vector<int, starrocks::ColumnAllocator<int> >::_M_assign_aux<__gnu_cxx::__normal_iterator<int const*, std::span<int const, 18446744073709551615ul> > >(__gnu_cxx::__normal_iterator<int const*, std::span<int const, 18446744073709551615ul> >, __gnu_r^A
    @          0x9172b71 starrocks::LeadLagWindowFunction<(starrocks::LogicalType)5, false, true, int>::reset(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocr^A
    @          0xaaa6f48 starrocks::Analytor::_streaming_process_for_half_unbounded_rows_frame(starrocks::RuntimeState*)
    @          0xaaa3e41 starrocks::Analytor::process(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0xaae50f5 starrocks::pipeline::AnalyticSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0xa281aa3 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0xa2b0b0b starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xd15377a starrocks::ThreadPool::dispatch_thread()
    @          0xd14ceb3 starrocks::Thread::supervise_thread(void*)
    @     0x7efe2da69ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7efe2dafb8c0 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1268bf)
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
