### PR TITLE
[Enhancement] New mechanism to improve the robustness of Gson deserialization in the presence of legacy data 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -148,6 +148,7 @@ import com.starrocks.catalog.StructType;
 import com.starrocks.catalog.TableFunction;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.View;
+import com.starrocks.common.Config;
 import com.starrocks.common.tvr.TvrTableDelta;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
@@ -436,7 +437,7 @@ public class GsonUtils {
             RuntimeTypeAdapterFactory.of(ComputeResource.class, "clazz")
                     .registerSubtype(WarehouseComputeResource.class, "WarehouseComputeResource", true);
 
-    public static final RuntimeTypeAdapterFactory<DynamicTablet> DYNAMIC_TABLET_RUNTIME_TYPE_ADAPTER_FACTORY = 
+    public static final RuntimeTypeAdapterFactory<DynamicTablet> DYNAMIC_TABLET_RUNTIME_TYPE_ADAPTER_FACTORY =
             RuntimeTypeAdapterFactory.of(DynamicTablet.class, "clazz")
                     .registerSubtype(SplittingTablet.class, "SplittingTablet")
                     .registerSubtype(MergingTablet.class, "MergingTablet")
@@ -472,53 +473,62 @@ public class GsonUtils {
 
     // the builder of GSON instance.
     // Add any other adapters if necessary.
-    private static final GsonBuilder GSON_BUILDER = new GsonBuilder()
-            .addSerializationExclusionStrategy(new HiddenAnnotationExclusionStrategy())
-            .addDeserializationExclusionStrategy(new HiddenAnnotationExclusionStrategy())
-            .enableComplexMapKeySerialization()
-            .registerTypeHierarchyAdapter(Table.class, new GuavaTableAdapter())
-            .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter())
-            .registerTypeHierarchyAdapter(ColumnId.class, new ColumnIdAdapter())
-            .registerTypeAdapterFactory(new ProcessHookTypeAdapterFactory())
-            // For call constructor with selectedFields
-            .registerTypeAdapter(MapType.class, new MapType.MapTypeDeserializer())
-            .registerTypeAdapter(StructType.class, new StructType.StructTypeDeserializer())
-            .registerTypeAdapterFactory(COLUMN_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(DISTRIBUTION_INFO_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(RESOURCE_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(ALTER_JOB_V2_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(LOAD_JOB_STATE_UPDATE_INFO_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(TABLET_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(HEARTBEAT_RESPONSE_ADAPTER_FACTOR)
-            .registerTypeAdapterFactory(PARTITION_INFO_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(PARTITION_PERSIST_INFO_V_2_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(RECYCLE_PARTITION_INFO_V_2_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(TABLE_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(SNAPSHOT_INFO_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(P_ENTRY_OBJECT_RUNTIME_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(SEC_INTEGRATION_RUNTIME_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(GROUP_PROVIDER_RUNTIME_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(WAREHOUSE_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(LOAD_JOB_TYPE_RUNTIME_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(TXN_COMMIT_ATTACHMENT_TYPE_RUNTIME_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(ROUTINE_LOAD_PROGRESS_TYPE_RUNTIME_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(ROUTINE_LOAD_JOB_TYPE_RUNTIME_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(ABSTRACT_JOB_TYPE_RUNTIME_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(FUNCTION_TYPE_RUNTIME_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(STORAGE_VOLUME_MGR_TYPE_RUNTIME_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(ANALYZE_STATUS_RUNTIME_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(ANALYZE_JOB_RUNTIME_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(COMPUTE_RESOURCE_RUNTIME_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(DYNAMIC_TABLET_RUNTIME_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapterFactory(TVR_DELTA_RUNTIME_TYPE_ADAPTER_FACTORY)
-            .registerTypeAdapter(LocalDateTime.class, LOCAL_DATE_TIME_TYPE_SERIALIZER)
-            .registerTypeAdapter(LocalDateTime.class, LOCAL_DATE_TIME_TYPE_DESERIALIZER)
-            .registerTypeAdapter(QueryDumpInfo.class, DUMP_INFO_SERIALIZER)
-            .registerTypeAdapter(QueryDumpInfo.class, DUMP_INFO_DESERIALIZER)
-            .registerTypeAdapter(EncryptionKeyPB.class, new EncryptionKeyPBAdapter())
-            .registerTypeAdapter(HiveTableDumpInfo.class, HIVE_TABLE_DUMP_INFO_SERIALIZER)
-            .registerTypeAdapter(HiveTableDumpInfo.class, HIVE_TABLE_DUMP_INFO_DESERIALIZER)
-            .registerTypeAdapter(PrimitiveType.class, PRIMITIVE_TYPE_DESERIALIZER);
+    private static final GsonBuilder GSON_BUILDER = createGsonBuilder();
+
+    private static GsonBuilder createGsonBuilder() {
+        GsonBuilder builder = new GsonBuilder()
+                .addSerializationExclusionStrategy(new HiddenAnnotationExclusionStrategy())
+                .addDeserializationExclusionStrategy(new HiddenAnnotationExclusionStrategy())
+                .enableComplexMapKeySerialization()
+                .registerTypeHierarchyAdapter(Table.class, new GuavaTableAdapter())
+                .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter())
+                .registerTypeHierarchyAdapter(ColumnId.class, new ColumnIdAdapter())
+                .registerTypeAdapterFactory(new ProcessHookTypeAdapterFactory())
+                // For call constructor with selectedFields
+                .registerTypeAdapter(MapType.class, new MapType.MapTypeDeserializer())
+                .registerTypeAdapter(StructType.class, new StructType.StructTypeDeserializer())
+                .registerTypeAdapterFactory(COLUMN_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(DISTRIBUTION_INFO_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(RESOURCE_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(ALTER_JOB_V2_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(LOAD_JOB_STATE_UPDATE_INFO_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(TABLET_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(HEARTBEAT_RESPONSE_ADAPTER_FACTOR)
+                .registerTypeAdapterFactory(PARTITION_INFO_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(PARTITION_PERSIST_INFO_V_2_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(RECYCLE_PARTITION_INFO_V_2_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(TABLE_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(SNAPSHOT_INFO_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(P_ENTRY_OBJECT_RUNTIME_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(SEC_INTEGRATION_RUNTIME_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(GROUP_PROVIDER_RUNTIME_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(WAREHOUSE_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(LOAD_JOB_TYPE_RUNTIME_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(TXN_COMMIT_ATTACHMENT_TYPE_RUNTIME_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(ROUTINE_LOAD_PROGRESS_TYPE_RUNTIME_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(ROUTINE_LOAD_JOB_TYPE_RUNTIME_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(ABSTRACT_JOB_TYPE_RUNTIME_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(FUNCTION_TYPE_RUNTIME_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(STORAGE_VOLUME_MGR_TYPE_RUNTIME_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(ANALYZE_STATUS_RUNTIME_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(ANALYZE_JOB_RUNTIME_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(COMPUTE_RESOURCE_RUNTIME_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(DYNAMIC_TABLET_RUNTIME_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(TVR_DELTA_RUNTIME_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapter(LocalDateTime.class, LOCAL_DATE_TIME_TYPE_SERIALIZER)
+                .registerTypeAdapter(LocalDateTime.class, LOCAL_DATE_TIME_TYPE_DESERIALIZER)
+                .registerTypeAdapter(QueryDumpInfo.class, DUMP_INFO_SERIALIZER)
+                .registerTypeAdapter(QueryDumpInfo.class, DUMP_INFO_DESERIALIZER)
+                .registerTypeAdapter(EncryptionKeyPB.class, new EncryptionKeyPBAdapter())
+                .registerTypeAdapter(HiveTableDumpInfo.class, HIVE_TABLE_DUMP_INFO_SERIALIZER)
+                .registerTypeAdapter(HiveTableDumpInfo.class, HIVE_TABLE_DUMP_INFO_DESERIALIZER)
+                .registerTypeAdapter(PrimitiveType.class, PRIMITIVE_TYPE_DESERIALIZER);
+
+        if (Config.metadata_ignore_unknown_subtype) {
+            builder.registerTypeAdapterFactory(new SubtypeSkippingTypeAdapterFactory());
+        }
+        return builder;
+    }
 
     // this instance is thread-safe.
     public static final Gson GSON = GSON_BUILDER.create();

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/SubtypeSkippingTypeAdapterFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/SubtypeSkippingTypeAdapterFactory.java
@@ -1,0 +1,254 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.internal.Streams;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * TypeAdapterFactory that shields deserialization from legacy data containing values encoded
+ * with unregistered subtypes. It wraps Gson's default Map/List adapters and eagerly probes each
+ * element via the existing delegate; any element that triggers {@link SubtypeNotFoundException}
+ * is dropped while legitimate {@code null} values are preserved.
+ */
+public class SubtypeSkippingTypeAdapterFactory implements TypeAdapterFactory {
+    private static final Logger LOG = LogManager.getLogger(SubtypeSkippingTypeAdapterFactory.class);
+
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        if (Map.class.isAssignableFrom(type.getRawType())) {
+            TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
+            TypeAdapter<?> keyAdapter = resolveMapKeyAdapter(gson, type);
+            TypeAdapter<?> valueAdapter = resolveMapValueAdapter(gson, type);
+            if (delegate == null || valueAdapter == null) {
+                return delegate;
+            }
+
+            // Wrap the default Map adapter so we can inspect and drop incompatible values first.
+            return new FilteringMapTypeAdapter<>(delegate, keyAdapter, valueAdapter).nullSafe();
+        }
+
+        if (Collection.class.isAssignableFrom(type.getRawType())) {
+            TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
+            TypeAdapter<?> elementAdapter = resolveCollectionElementAdapter(gson, type);
+            if (delegate == null || elementAdapter == null) {
+                return delegate;
+            }
+
+            // Same idea for Collection/List: probe each element before passing to Gson's adapter.
+            return new FilteringCollectionTypeAdapter<>(delegate, elementAdapter).nullSafe();
+        }
+
+        return null;
+    }
+
+    private static TypeAdapter<?> resolveMapKeyAdapter(Gson gson, TypeToken<?> typeToken) {
+        Type mapType = typeToken.getType();
+        if (!(mapType instanceof ParameterizedType)) {
+            return null;
+        }
+        Type keyType = ((ParameterizedType) mapType).getActualTypeArguments()[0];
+        return gson.getAdapter(TypeToken.get(keyType));
+    }
+
+    private static TypeAdapter<?> resolveMapValueAdapter(Gson gson, TypeToken<?> typeToken) {
+        Type mapType = typeToken.getType();
+        if (!(mapType instanceof ParameterizedType)) {
+            return null;
+        }
+        Type valueType = ((ParameterizedType) mapType).getActualTypeArguments()[1];
+        return gson.getAdapter(TypeToken.get(valueType));
+    }
+
+    private static TypeAdapter<?> resolveCollectionElementAdapter(Gson gson, TypeToken<?> typeToken) {
+        Type collectionType = typeToken.getType();
+        if (!(collectionType instanceof ParameterizedType)) {
+            return null;
+        }
+        Type elementType = ((ParameterizedType) collectionType).getActualTypeArguments()[0];
+        return gson.getAdapter(TypeToken.get(elementType));
+    }
+
+    private static class FilteringMapTypeAdapter<T> extends TypeAdapter<T> {
+        private final TypeAdapter<T> delegate;
+        private final TypeAdapter<?> keyAdapter;
+        private final TypeAdapter<?> valueAdapter;
+
+        FilteringMapTypeAdapter(TypeAdapter<T> delegate, TypeAdapter<?> keyAdapter,
+                                TypeAdapter<?> valueAdapter) {
+            this.delegate = delegate;
+            this.keyAdapter = keyAdapter;
+            this.valueAdapter = valueAdapter;
+        }
+
+        @Override
+        public T read(JsonReader in) throws IOException {
+            JsonElement element = Streams.parse(in);
+            if (element == null || element.isJsonNull()) {
+                return delegate.fromJsonTree(element);
+            }
+
+            JsonElement filtered = filter(element);
+            return delegate.fromJsonTree(filtered);
+        }
+
+        private JsonElement filter(JsonElement element) {
+            if (element.isJsonObject()) {
+                // MapTypeAdapterFactory handles string-keyed maps as JSON objects, so we drop
+                // entries directly by field name when either key or value cannot be materialized.
+                JsonObject object = element.getAsJsonObject();
+                List<String> keysToRemove = new ArrayList<>();
+                for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
+                    if (shouldDrop(new JsonPrimitive(entry.getKey()), keyAdapter)
+                            || shouldDrop(entry.getValue(), valueAdapter)) {
+                        keysToRemove.add(entry.getKey());
+                    }
+                }
+                for (String key : keysToRemove) {
+                    object.remove(key);
+                }
+                return object;
+            }
+
+            if (element.isJsonArray()) {
+                // Complex map keys (enableComplexMapKeySerialization) are encoded as arrays of
+                // [key, value] pairs; we mirror that shape so the delegate still receives valid
+                // tuples while skipping the incompatible values.
+                JsonArray array = element.getAsJsonArray();
+                JsonArray filtered = new JsonArray();
+                for (JsonElement entry : array) {
+                    if (!entry.isJsonArray()) {
+                        filtered.add(entry);
+                        continue;
+                    }
+                    JsonArray pair = entry.getAsJsonArray();
+                    //enableComplexMapKeySerialization() will serialize a Map as a two-element array [keyJson, valueJson];
+                    // according to Gson's normal output, this array will always contain exactly two elements.
+                    if (pair.size() < 2) {
+                        // Legacy dumps may contain truncated [key, value] tuples (for example, only the key
+                        // survives after manual edits). These entries are not necessarily tied to subtype
+                        // registration issues, so we keep them intact and rely on Gson's default adapter to
+                        // decide whether to surface an error.
+                        filtered.add(entry);
+                        continue;
+                    }
+                    boolean dropKey = shouldDrop(pair.get(0), keyAdapter);
+                    boolean dropValue = shouldDrop(pair.get(1), valueAdapter);
+                    if (!dropKey && !dropValue) {
+                        filtered.add(entry);
+                    }
+                }
+                return filtered;
+            }
+
+            return element;
+        }
+
+        private boolean shouldDrop(JsonElement element, TypeAdapter<?> adapter) {
+            if (adapter == null || element == null || element.isJsonNull()) {
+                return false;
+            }
+            try {
+                JsonElement candidate = element.deepCopy();
+                adapter.fromJsonTree(candidate);
+                return false;
+            } catch (SubtypeNotFoundException e) {
+                LOG.warn("Dropping map entry because its subtype is not registered. " +
+                        "Element: {}", element, e);
+                return true;
+            }
+        }
+
+        @Override
+        public void write(JsonWriter out, T value) throws IOException {
+            delegate.write(out, value);
+        }
+    }
+
+    private static class FilteringCollectionTypeAdapter<T> extends TypeAdapter<T> {
+        private final TypeAdapter<T> delegate;
+        private final TypeAdapter<?> elementAdapter;
+
+        FilteringCollectionTypeAdapter(TypeAdapter<T> delegate, TypeAdapter<?> elementAdapter) {
+            this.delegate = delegate;
+            this.elementAdapter = elementAdapter;
+        }
+
+        @Override
+        public T read(JsonReader in) throws IOException {
+            JsonElement element = Streams.parse(in);
+            if (element == null || element.isJsonNull()) {
+                return delegate.fromJsonTree(element);
+            }
+
+            JsonElement filtered = filter(element);
+            return delegate.fromJsonTree(filtered);
+        }
+
+        private JsonElement filter(JsonElement element) {
+            if (!element.isJsonArray()) {
+                return element;
+            }
+            JsonArray array = element.getAsJsonArray();
+            JsonArray filtered = new JsonArray();
+            for (JsonElement item : array) {
+                if (!shouldDrop(item)) {
+                    filtered.add(item);
+                }
+            }
+            return filtered;
+        }
+
+        private boolean shouldDrop(JsonElement valueElement) {
+            if (valueElement == null || valueElement.isJsonNull()) {
+                return false;
+            }
+            try {
+                // Keep explicit nulls while isolating adapters from mutating the original node.
+                JsonElement candidate = valueElement.deepCopy();
+                elementAdapter.fromJsonTree(candidate);
+                return false;
+            } catch (SubtypeNotFoundException e) {
+                LOG.warn("Dropping collection element because its subtype is not registered. " +
+                        "Element: {}", valueElement, e);
+                return true;
+            }
+        }
+
+        @Override
+        public void write(JsonWriter out, T value) throws IOException {
+            delegate.write(out, value);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/persist/gson/DeserializedCompatibleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/gson/DeserializedCompatibleTest.java
@@ -1,0 +1,494 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist.gson;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class DeserializedCompatibleTest {
+
+    static class NotificationPayload {
+        @SerializedName("base")
+        private String baseValue = "base";
+    }
+
+    static class EmailNotificationPayload extends NotificationPayload {
+        @SerializedName("email")
+        private String emailValue = "email";
+    }
+
+    static class LegacyNotificationPayload extends NotificationPayload {
+        @SerializedName("legacy")
+        private String legacyValue = "legacy";
+    }
+
+    static class NotificationMapWrapper {
+        @SerializedName("map")
+        private final Map<String, NotificationPayload> notifications;
+
+        NotificationMapWrapper(Map<String, NotificationPayload> notifications) {
+            this.notifications = notifications;
+        }
+
+        Map<String, NotificationPayload> getNotifications() {
+            return notifications;
+        }
+    }
+
+    static class NotificationListWrapper {
+        @SerializedName("list")
+        private final List<NotificationPayload> notifications;
+
+        NotificationListWrapper(List<NotificationPayload> notifications) {
+            this.notifications = notifications;
+        }
+
+        List<NotificationPayload> getNotifications() {
+            return notifications;
+        }
+    }
+
+    static class NotificationSetWrapper {
+        @SerializedName("set")
+        private final Set<NotificationPayload> notifications;
+
+        NotificationSetWrapper(Set<NotificationPayload> notifications) {
+            this.notifications = notifications;
+        }
+
+        Set<NotificationPayload> getNotifications() {
+            return notifications;
+        }
+    }
+
+    static class NotificationKeyedMapWrapper {
+        @SerializedName("map")
+        private final Map<NotificationPayload, String> notifications;
+
+        NotificationKeyedMapWrapper(Map<NotificationPayload, String> notifications) {
+            this.notifications = notifications;
+        }
+
+        Map<NotificationPayload, String> getNotifications() {
+            return notifications;
+        }
+    }
+
+    static class CoordinateKey {
+        @SerializedName("x")
+        private final int x;
+        @SerializedName("y")
+        private final int y;
+
+        CoordinateKey(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof CoordinateKey that)) {
+                return false;
+            }
+            return this.x == that.x && this.y == that.y;
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * x + y;
+        }
+    }
+
+    static class ComplexKeyNotificationMapWrapper {
+        @SerializedName("map")
+        private final Map<CoordinateKey, NotificationPayload> notifications;
+
+        ComplexKeyNotificationMapWrapper(Map<CoordinateKey, NotificationPayload> notifications) {
+            this.notifications = notifications;
+        }
+
+        Map<CoordinateKey, NotificationPayload> getNotifications() {
+            return notifications;
+        }
+    }
+
+    enum EnumKey {
+        KEY1,
+        KEY2,
+        KEY3
+    }
+
+    static class EnumKeyNotificationMapWrapper {
+        @SerializedName("map")
+        private final Map<EnumKey, NotificationPayload> notifications;
+
+        EnumKeyNotificationMapWrapper(Map<EnumKey, NotificationPayload> notifications) {
+            this.notifications = notifications;
+        }
+
+        Map<EnumKey, NotificationPayload> getNotifications() {
+            return notifications;
+        }
+    }
+
+    static class NestedNotificationWrapper {
+        @SerializedName("nested")
+        private final Map<String, List<NotificationPayload>> nested;
+
+        NestedNotificationWrapper(Map<String, List<NotificationPayload>> nested) {
+            this.nested = nested;
+        }
+
+        Map<String, List<NotificationPayload>> getNested() {
+            return nested;
+        }
+    }
+
+    static class MultiLayerNotificationWrapper {
+        @SerializedName("multi")
+        private final List<Map<String, List<NotificationPayload>>> multiLayer;
+
+        MultiLayerNotificationWrapper(List<Map<String, List<NotificationPayload>>> multiLayer) {
+            this.multiLayer = multiLayer;
+        }
+
+        List<Map<String, List<NotificationPayload>>> getMultiLayer() {
+            return multiLayer;
+        }
+    }
+
+    static class UltraNestedNotificationWrapper {
+        @SerializedName("ultra")
+        private final Map<String, List<Map<String, NotificationPayload>>> ultraNested;
+
+        UltraNestedNotificationWrapper(Map<String, List<Map<String, NotificationPayload>>> ultraNested) {
+            this.ultraNested = ultraNested;
+        }
+
+        Map<String, List<Map<String, NotificationPayload>>> getUltraNested() {
+            return ultraNested;
+        }
+    }
+
+    @Test
+    public void mapSkipsLegacySubtypeButKeepsNullEntry() {
+        Gson writer = gsonWithAdapters(false, runtimeFactoryWithLegacy());
+
+        Map<String, NotificationPayload> original = Maps.newLinkedHashMap();
+        original.put("email", new EmailNotificationPayload());
+        original.put("null", null);
+        original.put("legacy", new LegacyNotificationPayload());
+
+        String json = writer.toJson(new NotificationMapWrapper(original));
+
+        Gson reader = gsonWithSkipping(false, runtimeFactoryWithoutLegacy());
+        Map<String, NotificationPayload> result = reader.fromJson(json, NotificationMapWrapper.class)
+                .getNotifications();
+
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertInstanceOf(EmailNotificationPayload.class, result.get("email"));
+        Assertions.assertTrue(result.containsKey("null"));
+        Assertions.assertNull(result.get("null"));
+        Assertions.assertFalse(result.containsKey("legacy"));
+    }
+
+    @Test
+    public void listSkipsLegacySubtypeButKeepsNullEntry() {
+        Gson writer = gsonWithAdapters(false, runtimeFactoryWithLegacy());
+
+        List<NotificationPayload> original = new ArrayList<>();
+        original.add(new EmailNotificationPayload());
+        original.add(null);
+        original.add(new LegacyNotificationPayload());
+
+        String json = writer.toJson(new NotificationListWrapper(original));
+
+        Gson reader = gsonWithSkipping(false, runtimeFactoryWithoutLegacy());
+        List<NotificationPayload> result = reader.fromJson(json, NotificationListWrapper.class)
+                .getNotifications();
+
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertInstanceOf(EmailNotificationPayload.class, result.get(0));
+        Assertions.assertNull(result.get(1));
+    }
+
+    @Test
+    public void mapKeySkipsLegacySubtype() {
+        Gson writer = gsonWithAdapters(true, runtimeFactoryWithLegacy());
+
+        Map<NotificationPayload, String> original = new LinkedHashMap<>();
+        NotificationPayload emailKey = new EmailNotificationPayload();
+        NotificationPayload legacyKey = new LegacyNotificationPayload();
+        original.put(emailKey, "ok");
+        original.put(legacyKey, "legacy");
+
+        String json = writer.toJson(new NotificationKeyedMapWrapper(original));
+
+        Gson reader = gsonWithSkipping(true, runtimeFactoryWithoutLegacy());
+        Map<NotificationPayload, String> result = reader
+                .fromJson(json, NotificationKeyedMapWrapper.class)
+                .getNotifications();
+
+        Assertions.assertEquals(1, result.size());
+        NotificationPayload onlyKey = result.keySet().iterator().next();
+        Assertions.assertInstanceOf(EmailNotificationPayload.class, onlyKey);
+        Assertions.assertEquals("ok", result.get(onlyKey));
+    }
+
+    @Test
+    public void complexKeyMapSkipsLegacySubtype() {
+        Gson writer = gsonWithAdapters(true, runtimeFactoryWithLegacy());
+
+        Map<CoordinateKey, NotificationPayload> original = new LinkedHashMap<>();
+        CoordinateKey emailKey = new CoordinateKey(1, 1);
+        CoordinateKey nullKey = new CoordinateKey(2, 2);
+        CoordinateKey legacyKey = new CoordinateKey(3, 3);
+        original.put(emailKey, new EmailNotificationPayload());
+        original.put(nullKey, null);
+        original.put(legacyKey, new LegacyNotificationPayload());
+
+        String json = writer.toJson(new ComplexKeyNotificationMapWrapper(original));
+
+        Gson reader = gsonWithSkipping(true, runtimeFactoryWithoutLegacy());
+        Map<CoordinateKey, NotificationPayload> result = reader
+                .fromJson(json, ComplexKeyNotificationMapWrapper.class)
+                .getNotifications();
+
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertInstanceOf(EmailNotificationPayload.class, result.get(emailKey));
+        Assertions.assertTrue(result.containsKey(nullKey));
+        Assertions.assertNull(result.get(nullKey));
+        Assertions.assertFalse(result.containsKey(legacyKey));
+    }
+
+    @Test
+    public void enumKeyMapSkipsLegacySubtype() {
+        Gson writer = gsonWithAdapters(true, runtimeFactoryWithLegacy());
+
+        Map<EnumKey, NotificationPayload> original = new LinkedHashMap<>();
+        original.put(EnumKey.KEY1, new EmailNotificationPayload());
+        original.put(EnumKey.KEY2, null);
+        original.put(EnumKey.KEY3, new LegacyNotificationPayload());
+
+        String json = writer.toJson(new EnumKeyNotificationMapWrapper(original));
+
+        Gson reader = gsonWithSkipping(true, runtimeFactoryWithoutLegacy());
+        Map<EnumKey, NotificationPayload> result = reader
+                .fromJson(json, EnumKeyNotificationMapWrapper.class)
+                .getNotifications();
+
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertInstanceOf(EmailNotificationPayload.class, result.get(EnumKey.KEY1));
+        Assertions.assertTrue(result.containsKey(EnumKey.KEY2));
+        Assertions.assertNull(result.get(EnumKey.KEY2));
+        Assertions.assertFalse(result.containsKey(EnumKey.KEY3));
+    }
+
+    @Test
+    public void nestedStructuresSkipLegacySubtype() {
+        Gson writer = gsonWithAdapters(false, runtimeFactoryWithLegacy());
+
+        Map<String, List<NotificationPayload>> nested = Maps.newLinkedHashMap();
+        List<NotificationPayload> inbox = new ArrayList<>();
+        inbox.add(new EmailNotificationPayload());
+        inbox.add(null);
+        inbox.add(new LegacyNotificationPayload());
+        nested.put("inbox", inbox);
+
+        List<NotificationPayload> archive = new ArrayList<>();
+        archive.add(null);
+        nested.put("archive", archive);
+
+        String json = writer.toJson(new NestedNotificationWrapper(nested));
+
+        Gson reader = gsonWithSkipping(false, runtimeFactoryWithoutLegacy());
+        Map<String, List<NotificationPayload>> result = reader
+                .fromJson(json, NestedNotificationWrapper.class)
+                .getNested();
+
+        Assertions.assertEquals(2, result.get("inbox").size());
+        Assertions.assertInstanceOf(EmailNotificationPayload.class, result.get("inbox").get(0));
+        Assertions.assertNull(result.get("inbox").get(1));
+        Assertions.assertEquals(1, result.get("archive").size());
+        Assertions.assertNull(result.get("archive").get(0));
+    }
+
+    @Test
+    public void setSkipsLegacySubtype() {
+        Gson writer = gsonWithAdapters(false, runtimeFactoryWithLegacy());
+
+        LinkedHashSet<NotificationPayload> original = Sets.newLinkedHashSet();
+        original.add(new EmailNotificationPayload());
+        original.add(null);
+        original.add(new LegacyNotificationPayload());
+
+        String json = writer.toJson(new NotificationSetWrapper(original));
+
+        Gson reader = gsonWithSkipping(false, runtimeFactoryWithoutLegacy());
+        Set<NotificationPayload> result = reader.fromJson(json, NotificationSetWrapper.class)
+                .getNotifications();
+
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertTrue(result.contains(null));
+        Assertions.assertTrue(result.stream().anyMatch(EmailNotificationPayload.class::isInstance));
+        Assertions.assertFalse(result.stream().anyMatch(LegacyNotificationPayload.class::isInstance));
+    }
+
+    @Test
+    public void multiLayerNestedStructureSkipsLegacySubtype() {
+        Gson writer = gsonWithAdapters(false, runtimeFactoryWithLegacy());
+
+        List<Map<String, List<NotificationPayload>>> layers = new ArrayList<>();
+
+        Map<String, List<NotificationPayload>> firstLayer = new LinkedHashMap<>();
+        List<NotificationPayload> firstList = new ArrayList<>();
+        firstList.add(new EmailNotificationPayload());
+        firstList.add(null);
+        firstList.add(new LegacyNotificationPayload());
+        firstLayer.put("first", firstList);
+        layers.add(firstLayer);
+
+        Map<String, List<NotificationPayload>> secondLayer = new LinkedHashMap<>();
+        List<NotificationPayload> secondList = new ArrayList<>();
+        secondList.add(null);
+        secondLayer.put("second", secondList);
+        layers.add(secondLayer);
+
+        String json = writer.toJson(new MultiLayerNotificationWrapper(layers));
+
+        Gson reader = gsonWithSkipping(false, runtimeFactoryWithoutLegacy());
+        List<Map<String, List<NotificationPayload>>> result = reader
+                .fromJson(json, MultiLayerNotificationWrapper.class)
+                .getMultiLayer();
+
+        Assertions.assertEquals(2, result.size());
+
+        List<NotificationPayload> firstResult = result.get(0).get("first");
+        Assertions.assertEquals(2, firstResult.size());
+        Assertions.assertInstanceOf(EmailNotificationPayload.class, firstResult.get(0));
+        Assertions.assertNull(firstResult.get(1));
+
+        List<NotificationPayload> secondResult = result.get(1).get("second");
+        Assertions.assertEquals(1, secondResult.size());
+        Assertions.assertNull(secondResult.get(0));
+    }
+
+    @Test
+    public void ultraNestedStructureSkipsLegacySubtype() {
+        Gson writer = gsonWithAdapters(false, runtimeFactoryWithLegacy());
+
+        Map<String, List<Map<String, NotificationPayload>>> ultra = new LinkedHashMap<>();
+
+        List<Map<String, NotificationPayload>> layerOne = new ArrayList<>();
+        Map<String, NotificationPayload> firstMap = new LinkedHashMap<>();
+        firstMap.put("email", new EmailNotificationPayload());
+        firstMap.put("legacy", new LegacyNotificationPayload());
+        layerOne.add(firstMap);
+
+        Map<String, NotificationPayload> secondMap = new LinkedHashMap<>();
+        secondMap.put("null", null);
+        layerOne.add(secondMap);
+        ultra.put("layer-one", layerOne);
+
+        List<Map<String, NotificationPayload>> layerTwo = new ArrayList<>();
+        Map<String, NotificationPayload> thirdMap = new LinkedHashMap<>();
+        thirdMap.put("legacy-two", new LegacyNotificationPayload());
+        thirdMap.put("email-two", new EmailNotificationPayload());
+        layerTwo.add(thirdMap);
+        ultra.put("layer-two", layerTwo);
+
+        String json = writer.toJson(new UltraNestedNotificationWrapper(ultra));
+
+        Gson reader = gsonWithSkipping(false, runtimeFactoryWithoutLegacy());
+        Map<String, List<Map<String, NotificationPayload>>> result = reader
+                .fromJson(json, UltraNestedNotificationWrapper.class)
+                .getUltraNested();
+
+        Assertions.assertEquals(2, result.get("layer-one").size());
+        Map<String, NotificationPayload> firstResult = result.get("layer-one").get(0);
+        Assertions.assertEquals(1, firstResult.size());
+        Assertions.assertInstanceOf(EmailNotificationPayload.class, firstResult.get("email"));
+        Assertions.assertFalse(firstResult.containsKey("legacy"));
+
+        Map<String, NotificationPayload> secondResult = result.get("layer-one").get(1);
+        Assertions.assertEquals(1, secondResult.size());
+        Assertions.assertTrue(secondResult.containsKey("null"));
+        Assertions.assertNull(secondResult.get("null"));
+
+        Map<String, NotificationPayload> thirdResult = result.get("layer-two").get(0);
+        Assertions.assertEquals(1, thirdResult.size());
+        Assertions.assertInstanceOf(EmailNotificationPayload.class, thirdResult.get("email-two"));
+        Assertions.assertFalse(thirdResult.containsKey("legacy-two"));
+    }
+
+    private RuntimeTypeAdapterFactory<NotificationPayload> runtimeFactoryWithLegacy() {
+        return RuntimeTypeAdapterFactory.of(NotificationPayload.class, "clazz")
+                .registerSubtype(EmailNotificationPayload.class, "email")
+                .registerSubtype(LegacyNotificationPayload.class, "legacy");
+    }
+
+    private RuntimeTypeAdapterFactory<NotificationPayload> runtimeFactoryWithoutLegacy() {
+        return RuntimeTypeAdapterFactory.of(NotificationPayload.class, "clazz")
+                .registerSubtype(EmailNotificationPayload.class, "email");
+    }
+
+    private Gson gsonWithAdapters(boolean enableComplexMapKey,
+                                  RuntimeTypeAdapterFactory<NotificationPayload> runtimeFactory) {
+        GsonBuilder builder = new GsonBuilder()
+                .addSerializationExclusionStrategy(new GsonUtils.HiddenAnnotationExclusionStrategy())
+                .addDeserializationExclusionStrategy(new GsonUtils.HiddenAnnotationExclusionStrategy())
+                // In the current GsonUtils implementation, serializeNulls is disabled by default,
+                // and in practice values are not expected to be null.
+                // However, enable this option to be safe for future code changes.
+                .serializeNulls()
+                .registerTypeAdapterFactory(runtimeFactory);
+        if (enableComplexMapKey) {
+            builder.enableComplexMapKeySerialization();
+        }
+        return builder.create();
+    }
+
+    private Gson gsonWithSkipping(boolean enableComplexMapKey,
+                                  RuntimeTypeAdapterFactory<NotificationPayload> runtimeFactory) {
+        GsonBuilder builder = new GsonBuilder()
+                .addSerializationExclusionStrategy(new GsonUtils.HiddenAnnotationExclusionStrategy())
+                .addDeserializationExclusionStrategy(new GsonUtils.HiddenAnnotationExclusionStrategy())
+                // In the current GsonUtils implementation, serializeNulls is disabled by default,
+                // and in practice values are not expected to be null.
+                // However, enable this option to be safe for future code changes.
+                .serializeNulls()
+                .registerTypeAdapterFactory(new SubtypeSkippingTypeAdapterFactory())
+                .registerTypeAdapterFactory(runtimeFactory);
+        if (enableComplexMapKey) {
+            builder.enableComplexMapKeySerialization();
+        }
+        return builder.create();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/persist/gson/SubtypeSkippingPerformanceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/gson/SubtypeSkippingPerformanceTest.java
@@ -1,0 +1,447 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Performance test suite for SubtypeSkippingTypeAdapterFactory
+ * This test compares deserialization performance with and without SubtypeSkippingTypeAdapterFactory
+ * <p>
+ * Note: These tests are disabled by default as they are performance benchmarks, not functional tests.
+ * To run these tests explicitly, use:
+ * ./gradlew :fe-core:test --tests "com.starrocks.persist.gson.SubtypeSkippingPerformanceTest"
+ */
+@Disabled("Performance tests - run manually when needed")
+public class SubtypeSkippingPerformanceTest {
+
+    static class NotificationPayload {
+        @SerializedName("base")
+        private String baseValue = "base";
+    }
+
+    static class EmailNotificationPayload extends NotificationPayload {
+        @SerializedName("email")
+        private String emailValue = "email";
+    }
+
+    static class LegacyNotificationPayload extends NotificationPayload {
+        @SerializedName("legacy")
+        private String legacyValue = "legacy";
+    }
+
+    static class NotificationMapWrapper {
+        @SerializedName("map")
+        private final Map<String, NotificationPayload> notifications;
+
+        NotificationMapWrapper(Map<String, NotificationPayload> notifications) {
+            this.notifications = notifications;
+        }
+
+        Map<String, NotificationPayload> getNotifications() {
+            return notifications;
+        }
+    }
+
+    enum EnumKey {
+        KEY1,
+        KEY2,
+        KEY3
+    }
+
+    static class EnumNotificationMapWrapper {
+        @SerializedName("map")
+        private final Map<EnumKey, NotificationPayload> notifications;
+
+        EnumNotificationMapWrapper(Map<EnumKey, NotificationPayload> notifications) {
+            this.notifications = notifications;
+        }
+
+        Map<EnumKey, NotificationPayload> getNotifications() {
+            return notifications;
+        }
+    }
+
+    static class NotificationListWrapper {
+        @SerializedName("list")
+        private final List<NotificationPayload> notifications;
+
+        NotificationListWrapper(List<NotificationPayload> notifications) {
+            this.notifications = notifications;
+        }
+
+        List<NotificationPayload> getNotifications() {
+            return notifications;
+        }
+    }
+
+    static class NestedNotificationWrapper {
+        @SerializedName("nested")
+        private final Map<String, List<NotificationPayload>> nested;
+
+        NestedNotificationWrapper(Map<String, List<NotificationPayload>> nested) {
+            this.nested = nested;
+        }
+
+        Map<String, List<NotificationPayload>> getNested() {
+            return nested;
+        }
+    }
+
+    /**
+     * Performance test: Compare simple map deserialization performance
+     * Test point: Measure the performance impact of using SubtypeSkippingTypeAdapterFactory
+     * for filtering legacy subtypes during deserialization
+     */
+    @Test
+    public void testMapPerformanceImpact() {
+        // Create test data with mixed legacy and current subtypes
+        Map<String, NotificationPayload> testData = createLargeTestData(10000);
+        NotificationMapWrapper wrapper = new NotificationMapWrapper(testData);
+
+        // Serialize the data
+        Gson writer = gsonWithAdapters(runtimeFactoryWithLegacy());
+        String json = writer.toJson(wrapper);
+
+        // Test deserialization without SubtypeSkippingTypeAdapterFactory
+        Gson readerWithoutSkipping = gsonWithAdapters(runtimeFactoryWithLegacy());
+        long timeWithoutSkipping = measureDeserializationTime(readerWithoutSkipping, json, 50);
+
+        // Test deserialization with SubtypeSkippingTypeAdapterFactory
+        Gson readerWithSkipping = gsonWithSkipping(runtimeFactoryWithLegacy());
+        long timeWithSkipping = measureDeserializationTime(readerWithSkipping, json, 50);
+
+        // Log performance results
+        System.out.println("=== Map Performance Test Results ===");
+        System.out.println("Test data size: 10,000 entries");
+        System.out.println("Iterations: 50");
+        System.out.println("Without SubtypeSkippingTypeAdapterFactory: " + timeWithoutSkipping + " ms");
+        System.out.println("With SubtypeSkippingTypeAdapterFactory: " + timeWithSkipping + " ms");
+        long timeDiff = timeWithSkipping - timeWithoutSkipping;
+        double percentageChange = (double) timeDiff / timeWithoutSkipping * 100;
+        double speedRatio = (double) timeWithSkipping / timeWithoutSkipping;
+        System.out.println("Time difference: " + (timeDiff >= 0 ? "+" : "") + timeDiff + " ms");
+        System.out.println("Percentage change: " + String.format("%+.2f", percentageChange) + "%");
+        System.out.println("Speed ratio: " + String.format("%.2f", speedRatio) + "x");
+        System.out.println();
+    }
+
+    /**
+     * Performance test: Compare list deserialization performance
+     * Test point: Measure the performance impact of using SubtypeSkippingTypeAdapterFactory
+     * for filtering legacy subtypes in List collections
+     */
+    @Test
+    public void testListPerformanceImpact() {
+        // Create test data with mixed legacy and current subtypes
+        List<NotificationPayload> testData = createLargeListData(50000);
+        NotificationListWrapper wrapper = new NotificationListWrapper(testData);
+
+        // Serialize the data
+        Gson writer = gsonWithAdapters(runtimeFactoryWithLegacy());
+        String json = writer.toJson(wrapper);
+
+        // Test deserialization without SubtypeSkippingTypeAdapterFactory
+        Gson readerWithoutSkipping = gsonWithAdapters(runtimeFactoryWithLegacy());
+        long timeWithoutSkipping = measureDeserializationTimeForList(readerWithoutSkipping, json, 50);
+
+        // Test deserialization with SubtypeSkippingTypeAdapterFactory
+        Gson readerWithSkipping = gsonWithSkipping(runtimeFactoryWithLegacy());
+        long timeWithSkipping = measureDeserializationTimeForList(readerWithSkipping, json, 50);
+
+        // Log performance results
+        System.out.println("=== List Performance Test Results ===");
+        System.out.println("Test data size: 50,000 list entries");
+        System.out.println("Iterations: 50");
+        System.out.println("Without SubtypeSkippingTypeAdapterFactory: " + timeWithoutSkipping + " ms");
+        System.out.println("With SubtypeSkippingTypeAdapterFactory: " + timeWithSkipping + " ms");
+        long timeDiff = timeWithSkipping - timeWithoutSkipping;
+        double percentageChange = (double) timeDiff / timeWithoutSkipping * 100;
+        double speedRatio = (double) timeWithSkipping / timeWithoutSkipping;
+        System.out.println("Time difference: " + (timeDiff >= 0 ? "+" : "") + timeDiff + " ms");
+        System.out.println("Percentage change: " + String.format("%+.2f", percentageChange) + "%");
+        System.out.println("Speed ratio: " + String.format("%.2f", speedRatio) + "x");
+        System.out.println();
+    }
+
+    /**
+     * Performance test: Compare nested structure deserialization performance
+     * Test point: Measure performance impact on complex nested structures with mixed subtypes
+     */
+    @Test
+    public void testNestedStructurePerformanceImpact() {
+        // Create complex nested test data
+        Map<String, List<NotificationPayload>> nestedData = createNestedTestData(10000, 10);
+        NestedNotificationWrapper wrapper = new NestedNotificationWrapper(nestedData);
+
+        // Serialize the data
+        Gson writer = gsonWithAdapters(runtimeFactoryWithLegacy());
+        String json = writer.toJson(wrapper);
+
+        // Test deserialization without SubtypeSkippingTypeAdapterFactory
+        Gson readerWithoutSkipping = gsonWithAdapters(runtimeFactoryWithoutLegacy());
+        long timeWithoutSkipping = measureDeserializationTime(readerWithoutSkipping, json, 50);
+
+        // Test deserialization with SubtypeSkippingTypeAdapterFactory
+        Gson readerWithSkipping = gsonWithSkipping(runtimeFactoryWithoutLegacy());
+        long timeWithSkipping = measureDeserializationTime(readerWithSkipping, json, 50);
+
+        // Log performance results
+        System.out.println("=== Nested Structure Performance Test Results ===");
+        System.out.println("Test data size: 10,000 outer entries x 10 inner entries");
+        System.out.println("Iterations: 50");
+        System.out.println("Without SubtypeSkippingTypeAdapterFactory: " + timeWithoutSkipping + " ms");
+        System.out.println("With SubtypeSkippingTypeAdapterFactory: " + timeWithSkipping + " ms");
+        long timeDiff = timeWithSkipping - timeWithoutSkipping;
+        double percentageChange = (double) timeDiff / timeWithoutSkipping * 100;
+        double speedRatio = (double) timeWithSkipping / timeWithoutSkipping;
+        System.out.println("Time difference: " + (timeDiff >= 0 ? "+" : "") + timeDiff + " ms");
+        System.out.println("Percentage change: " + String.format("%+.2f", percentageChange) + "%");
+        System.out.println("Speed ratio: " + String.format("%.2f", speedRatio) + "x");
+        System.out.println();
+    }
+
+    /**
+     * Performance test: Compare complex map key deserialization performance
+     * Test point: Measure performance impact on maps with complex keys containing mixed subtypes
+     */
+    @Test
+    public void testComplexMapKeyPerformanceImpact() {
+        // Create test data with enum keys
+        Map<EnumKey, NotificationPayload> testData = createEnumKeyTestData(10000);
+        EnumNotificationMapWrapper wrapper = new EnumNotificationMapWrapper(testData);
+
+        // Serialize the data
+        Gson writer = gsonWithAdapters(runtimeFactoryWithLegacy());
+        String json = writer.toJson(wrapper);
+
+        // Test deserialization without SubtypeSkippingTypeAdapterFactory
+        Gson readerWithoutSkipping = gsonWithAdapters(runtimeFactoryWithLegacy());
+        long timeWithoutSkipping = measureDeserializationTime(readerWithoutSkipping, json, 50);
+
+        // Test deserialization with SubtypeSkippingTypeAdapterFactory
+        Gson readerWithSkipping = gsonWithSkipping(runtimeFactoryWithLegacy());
+        long timeWithSkipping = measureDeserializationTime(readerWithSkipping, json, 50);
+
+        // Log performance results
+        System.out.println("=== Complex Map Key Performance Test Results ===");
+        System.out.println("Test data size: 10,000 enum key entries");
+        System.out.println("Iterations: 50");
+        System.out.println("Without SubtypeSkippingTypeAdapterFactory: " + timeWithoutSkipping + " ms");
+        System.out.println("With SubtypeSkippingTypeAdapterFactory: " + timeWithSkipping + " ms");
+        long timeDiff = timeWithSkipping - timeWithoutSkipping;
+        double percentageChange = (double) timeDiff / timeWithoutSkipping * 100;
+        double speedRatio = (double) timeWithSkipping / timeWithoutSkipping;
+        System.out.println("Time difference: " + (timeDiff >= 0 ? "+" : "") + timeDiff + " ms");
+        System.out.println("Percentage change: " + String.format("%+.2f", percentageChange) + "%");
+        System.out.println("Speed ratio: " + String.format("%.2f", speedRatio) + "x");
+        System.out.println();
+    }
+
+    /**
+     * Create large test data with mixed subtypes for performance testing
+     */
+    private Map<String, NotificationPayload> createLargeTestData(int size) {
+        Map<String, NotificationPayload> data = new LinkedHashMap<>();
+        for (int i = 0; i < size; i++) {
+            String key = "item_" + i;
+            NotificationPayload payload;
+            switch (i % 4) {
+                case 0:
+                    payload = new EmailNotificationPayload();
+                    break;
+                case 1:
+                    payload = new LegacyNotificationPayload();
+                    break;
+                case 2:
+                    payload = null;
+                    break;
+                default:
+                    payload = new EmailNotificationPayload();
+                    break;
+            }
+            data.put(key, payload);
+        }
+        return data;
+    }
+
+    /**
+     * Create large list test data with mixed subtypes for performance testing
+     */
+    private List<NotificationPayload> createLargeListData(int size) {
+        List<NotificationPayload> data = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            NotificationPayload payload;
+            switch (i % 4) {
+                case 0:
+                    payload = new EmailNotificationPayload();
+                    break;
+                case 1:
+                    payload = new LegacyNotificationPayload();
+                    break;
+                case 2:
+                    payload = null;
+                    break;
+                default:
+                    payload = new EmailNotificationPayload();
+                    break;
+            }
+            data.add(payload);
+        }
+        return data;
+    }
+
+    /**
+     * Create nested test data for performance testing
+     */
+    private Map<String, List<NotificationPayload>> createNestedTestData(int outerSize, int innerSize) {
+        Map<String, List<NotificationPayload>> data = new LinkedHashMap<>();
+        for (int i = 0; i < outerSize; i++) {
+            String key = "list_" + i;
+            List<NotificationPayload> list = new ArrayList<>();
+            for (int j = 0; j < innerSize; j++) {
+                NotificationPayload payload;
+                switch (j % 4) {
+                    case 0:
+                        payload = new EmailNotificationPayload();
+                        break;
+                    case 1:
+                        payload = new LegacyNotificationPayload();
+                        break;
+                    case 2:
+                        payload = null;
+                        break;
+                    default:
+                        payload = new EmailNotificationPayload();
+                        break;
+                }
+                list.add(payload);
+            }
+            data.put(key, list);
+        }
+        return data;
+    }
+
+    /**
+     * Create enum key test data for performance testing
+     */
+    private Map<EnumKey, NotificationPayload> createEnumKeyTestData(int size) {
+        Map<EnumKey, NotificationPayload> data = new LinkedHashMap<>();
+        for (int i = 0; i < size; i++) {
+            EnumKey key = EnumKey.values()[i % EnumKey.values().length];
+            NotificationPayload payload;
+            switch (i % 4) {
+                case 0:
+                    payload = new EmailNotificationPayload();
+                    break;
+                case 1:
+                    payload = new LegacyNotificationPayload();
+                    break;
+                case 2:
+                    payload = null;
+                    break;
+                default:
+                    payload = new EmailNotificationPayload();
+                    break;
+            }
+            data.put(key, payload);
+        }
+        return data;
+    }
+
+    /**
+     * Measure deserialization time for the given Gson instance and JSON string
+     */
+    private long measureDeserializationTime(Gson gson, String json, int iterations) {
+        long startTime = System.nanoTime();
+
+        for (int i = 0; i < iterations; i++) {
+            try {
+                gson.fromJson(json, NotificationMapWrapper.class);
+            } catch (Exception e) {
+                // Expected for some test cases - ignore exceptions during performance measurement
+            }
+        }
+
+        long endTime = System.nanoTime();
+        return TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
+    }
+
+    /**
+     * Measure deserialization time for List wrapper
+     */
+    private long measureDeserializationTimeForList(Gson gson, String json, int iterations) {
+        long startTime = System.nanoTime();
+
+        for (int i = 0; i < iterations; i++) {
+            try {
+                gson.fromJson(json, NotificationListWrapper.class);
+            } catch (Exception e) {
+                // Expected for some test cases - ignore exceptions during performance measurement
+            }
+        }
+
+        long endTime = System.nanoTime();
+        return TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
+    }
+
+    private RuntimeTypeAdapterFactory<NotificationPayload> runtimeFactoryWithLegacy() {
+        return RuntimeTypeAdapterFactory.of(NotificationPayload.class, "clazz")
+                .registerSubtype(EmailNotificationPayload.class, "email")
+                .registerSubtype(LegacyNotificationPayload.class, "legacy");
+    }
+
+    private RuntimeTypeAdapterFactory<NotificationPayload> runtimeFactoryWithoutLegacy() {
+        return RuntimeTypeAdapterFactory.of(NotificationPayload.class, "clazz")
+                .registerSubtype(EmailNotificationPayload.class, "email");
+    }
+
+    private Gson gsonWithAdapters(RuntimeTypeAdapterFactory<NotificationPayload> runtimeFactory) {
+        return new GsonBuilder()
+                .addSerializationExclusionStrategy(new GsonUtils.HiddenAnnotationExclusionStrategy())
+                .addDeserializationExclusionStrategy(new GsonUtils.HiddenAnnotationExclusionStrategy())
+                // In the current GsonUtils implementation, serializeNulls is disabled by default,
+                // and in practice values are not expected to be null.
+                // However, enable this option to be safe for future code changes.
+                .serializeNulls()
+                .enableComplexMapKeySerialization()
+                .registerTypeAdapterFactory(runtimeFactory)
+                .create();
+    }
+
+    private Gson gsonWithSkipping(RuntimeTypeAdapterFactory<NotificationPayload> runtimeFactory) {
+        return new GsonBuilder()
+                .addSerializationExclusionStrategy(new GsonUtils.HiddenAnnotationExclusionStrategy())
+                .addDeserializationExclusionStrategy(new GsonUtils.HiddenAnnotationExclusionStrategy())
+                // In the current GsonUtils implementation, serializeNulls is disabled by default,
+                // and in practice values are not expected to be null.
+                // However, enable this option to be safe for future code changes.
+                .serializeNulls()
+                .enableComplexMapKeySerialization()
+                .registerTypeAdapterFactory(new SubtypeSkippingTypeAdapterFactory())
+                .registerTypeAdapterFactory(runtimeFactory)
+                .create();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -16,6 +16,7 @@ package com.starrocks.scheduler.history;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.gson.JsonSyntaxException;
 import com.starrocks.common.Config;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.SimpleExecutor;
@@ -333,7 +334,7 @@ public class TaskRunHistoryTest {
             List<TaskRunStatus> ans = TaskRunStatus.TaskRunStatusJSONRecord.fromJson(jsonString).data;
             Preconditions.checkArgument(ans == null);
         } catch (Exception e) {
-            Assertions.assertTrue(e.getMessage().contains("Expected a string but was BEGIN_OBJECT at line 1 column 568"));
+            Assertions.assertInstanceOf(JsonSyntaxException.class, e);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request introduces a new mechanism to improve the robustness of Gson deserialization in the presence of legacy data containing unregistered subtypes. The main change is the addition and registration of a custom `SubtypeSkippingTypeAdapterFactory`, which ensures that problematic elements in collections and maps are skipped rather than causing deserialization failures.

**Enhancements to Gson deserialization:**

* Added a new class `SubtypeSkippingTypeAdapterFactory` that wraps Gson's default adapters for `Map` and `Collection` types, filtering out elements that would trigger a `SubtypeNotFoundException` during deserialization. This helps prevent errors when encountering legacy or unregistered subtypes in persisted data.
* Registered the new `SubtypeSkippingTypeAdapterFactory` in the global Gson configuration within `GsonUtils`, ensuring that all relevant deserialization operations benefit from the improved error handling.

**List Performance Test Results**
Test data size: 50,000 list entries
Iterations: 50
Without SubtypeSkippingTypeAdapterFactory: 1629 ms
With SubtypeSkippingTypeAdapterFactory: 3638 ms
Time difference: +2009 ms
Percentage change: +123.33%
Speed ratio: 2.23x
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
