### PR TITLE
[Enhancement] add more print info when PersistentIndexMemtable meet duplicate key

### DIFF
--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -61,8 +61,10 @@ Status PersistentIndexMemtable::insert(size_t n, const Slice* keys, const IndexV
             auto old_index_value = old_index_value_ver.second;
             if (old_index_value.get_value() != NullIndexValue) {
                 // shouldn't happen
-                std::string msg = strings::Substitute("PersistentIndexMemtable<$0> insert found duplicate key $1",
-                                                      key.size(), hexdump((const char*)key.data(), key.size()));
+                std::string msg = strings::Substitute(
+                        "PersistentIndexMemtable<$0> insert found duplicate key $1, old_val $2 old_ver $3 new_val $4",
+                        key.size(), hexdump((const char*)key.data(), key.size()), old_index_value.get_value(),
+                        old_index_value_ver.first, value.get_value());
                 LOG(ERROR) << msg;
                 if (!config::experimental_lake_ignore_pk_consistency_check) {
                     return Status::AlreadyExist(msg);


### PR DESCRIPTION
## Why I'm doing:
add more print info when PersistentIndexMemtable meet duplicate key, to further issue debug.

## What I'm doing:
This pull request enhances error logging in the `PersistentIndexMemtable::insert` function to provide more detailed information when a duplicate key is detected. The update adds additional context to the error message, which will help with debugging and root cause analysis.

Error logging improvements:

* Updated the error message in `PersistentIndexMemtable::insert` (in `persistent_index_memtable.cpp`) to include the old value, old version, and new value when a duplicate key is found. This gives more insight into the conflicting data and versioning for easier troubleshooting.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
