### PR TITLE
[Refactor] Add ColumnBuilder to encapsulate the construction of `Column` objects from `ColumnDef`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -980,26 +980,4 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return this.aggStateDesc;
     }
 
-    public static Column fromColumnDef(Table table, ColumnDef columnDef) {
-        Column col = new Column(columnDef.getName(),
-                columnDef.getTypeDef().getType(),
-                columnDef.isKey(),
-                columnDef.getAggregateType(),
-                columnDef.getAggStateDesc(),
-                columnDef.isAllowNull(),
-                columnDef.getDefaultValueDef(),
-                columnDef.getComment(),
-                Column.COLUMN_UNIQUE_ID_INIT_VALUE);
-        col.setIsAutoIncrement(columnDef.isAutoIncrement());
-
-        Expr generatedColumnExpr = columnDef.getGeneratedColumnExpr();
-        if (generatedColumnExpr != null) {
-            if (table != null) {
-                col.setGeneratedColumnExpr(ColumnIdExpr.create(table.getNameToColumn(), generatedColumnExpr));
-            } else {
-                col.setGeneratedColumnExpr(ColumnIdExpr.create(generatedColumnExpr));
-            }
-        }
-        return col;
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnBuilder.java
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.persist.ColumnIdExpr;
+import com.starrocks.sql.ast.ColumnDef;
+import com.starrocks.sql.ast.expression.Expr;
+
+public class ColumnBuilder {
+    public static Column buildColumn(ColumnDef columnDef) {
+        // Decide final default value here instead of mutating ColumnDef
+        ColumnDef.DefaultValueDef effectiveDefault = getDefaultValueDef(columnDef);
+
+        Column col = new Column(columnDef.getName(),
+                columnDef.getTypeDef().getType(),
+                columnDef.isKey(),
+                columnDef.getAggregateType(),
+                columnDef.getAggStateDesc(),
+                columnDef.isAllowNull(),
+                effectiveDefault,
+                columnDef.getComment(),
+                Column.COLUMN_UNIQUE_ID_INIT_VALUE);
+        col.setIsAutoIncrement(columnDef.isAutoIncrement());
+        return col;
+    }
+
+    public static Column buildGeneratedColumn(Table table, ColumnDef columnDef) {
+        // Decide final default value here instead of mutating ColumnDef
+        ColumnDef.DefaultValueDef effectiveDefault = getDefaultValueDef(columnDef);
+
+        Column col = new Column(columnDef.getName(),
+                columnDef.getTypeDef().getType(),
+                columnDef.isKey(),
+                columnDef.getAggregateType(),
+                columnDef.getAggStateDesc(),
+                columnDef.isAllowNull(),
+                effectiveDefault,
+                columnDef.getComment(),
+                Column.COLUMN_UNIQUE_ID_INIT_VALUE);
+        col.setIsAutoIncrement(columnDef.isAutoIncrement());
+
+        Expr generatedColumnExpr = columnDef.getGeneratedColumnExpr();
+        if (generatedColumnExpr != null) {
+            if (table != null) {
+                col.setGeneratedColumnExpr(ColumnIdExpr.create(table.getNameToColumn(), generatedColumnExpr));
+            } else {
+                col.setGeneratedColumnExpr(ColumnIdExpr.create(generatedColumnExpr));
+            }
+        }
+        return col;
+    }
+
+    private static ColumnDef.DefaultValueDef getDefaultValueDef(ColumnDef columnDef) {
+        ColumnDef.DefaultValueDef effectiveDefault = columnDef.getDefaultValueDef();
+        Type type = columnDef.getTypeDef().getType();
+        AggregateType aggregateType = columnDef.getAggregateType();
+        if (type.isHllType() || type.isBitmapType()) {
+            effectiveDefault = ColumnDef.DefaultValueDef.EMPTY_VALUE;
+        }
+        if (aggregateType == AggregateType.REPLACE_IF_NOT_NULL && !effectiveDefault.isSet) {
+            effectiveDefault = ColumnDef.DefaultValueDef.NULL_DEFAULT_VALUE;
+        }
+        return effectiveDefault;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 package com.starrocks.connector.iceberg;
-
-import com.starrocks.catalog.Column;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.ConnectorAlterTableExecutor;
 import com.starrocks.connector.HdfsEnvironment;
@@ -29,6 +27,7 @@ import com.starrocks.sql.ast.AlterTableCommentClause;
 import com.starrocks.sql.ast.AlterTableOperationClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.BranchOptions;
+import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.ColumnPosition;
 import com.starrocks.sql.ast.ColumnRenameClause;
 import com.starrocks.sql.ast.CreateOrReplaceBranchClause;
@@ -59,7 +58,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static com.starrocks.connector.iceberg.IcebergApiConverter.toIcebergColumnType;
 import static com.starrocks.connector.iceberg.IcebergMetadata.COMMENT;
@@ -101,23 +99,23 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
         actions.add(() -> {
             UpdateSchema updateSchema = this.transaction.updateSchema();
             ColumnPosition pos = clause.getColPos();
-            Column column = Column.fromColumnDef(null, clause.getColumnDef());
+            ColumnDef columnDef = clause.getColumnDef();
 
             // All non-partition columns must use NULL as the default value.
-            if (!column.isAllowNull()) {
+            if (!columnDef.isAllowNull()) {
                 throw new StarRocksConnectorException("column in iceberg table must be nullable.");
             }
             updateSchema.addColumn(
-                    column.getName(),
-                    toIcebergColumnType(column.getType()),
-                    column.getComment());
+                    columnDef.getName(),
+                    toIcebergColumnType(columnDef.getType()),
+                    columnDef.getComment());
 
             // AFTER column / FIRST
             if (pos != null) {
                 if (pos.isFirst()) {
-                    updateSchema.moveFirst(column.getName());
+                    updateSchema.moveFirst(columnDef.getName());
                 } else if (pos.getLastCol() != null) {
-                    updateSchema.moveAfter(column.getName(), pos.getLastCol());
+                    updateSchema.moveAfter(columnDef.getName(), pos.getLastCol());
                 } else {
                     throw new StarRocksConnectorException("Unsupported position: " + pos);
                 }
@@ -132,20 +130,16 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
     public Void visitAddColumnsClause(AddColumnsClause clause, ConnectContext context) {
         actions.add(() -> {
             UpdateSchema updateSchema = this.transaction.updateSchema();
-            List<Column> columns = clause
-                    .getColumnDefs()
-                    .stream()
-                    .map(columnDef -> Column.fromColumnDef(null, columnDef))
-                    .collect(Collectors.toList());
+            List<ColumnDef> columns = clause.getColumnDefs();
 
-            for (Column column : columns) {
-                if (!column.isAllowNull()) {
+            for (ColumnDef columnDef : columns) {
+                if (!columnDef.isAllowNull()) {
                     throw new StarRocksConnectorException("column in iceberg table must be nullable.");
                 }
                 updateSchema.addColumn(
-                        column.getName(),
-                        toIcebergColumnType(column.getType()),
-                        column.getComment());
+                        columnDef.getName(),
+                        toIcebergColumnType(columnDef.getType()),
+                        columnDef.getComment());
             }
             updateSchema.commit();
         });
@@ -177,24 +171,24 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
         actions.add(() -> {
             UpdateSchema updateSchema = this.transaction.updateSchema();
             ColumnPosition colPos = clause.getColPos();
-            Column column = Column.fromColumnDef(null, clause.getColumnDef());
-            org.apache.iceberg.types.Type colType = toIcebergColumnType(column.getType());
+            ColumnDef columnDef = clause.getColumnDef();
+            org.apache.iceberg.types.Type colType = toIcebergColumnType(columnDef.getType());
 
             // UPDATE column type
             if (!colType.isPrimitiveType()) {
                 throw new StarRocksConnectorException(
-                        "Cannot modify " + column.getName() + ", not a primitive type");
+                        "Cannot modify " + columnDef.getName() + ", not a primitive type");
             }
-            updateSchema.updateColumn(column.getName(), colType.asPrimitiveType());
+            updateSchema.updateColumn(columnDef.getName(), colType.asPrimitiveType());
 
             // UPDATE comment
-            if (column.getComment() != null) {
-                updateSchema.updateColumnDoc(column.getName(), column.getComment());
+            if (columnDef.getComment() != null) {
+                updateSchema.updateColumnDoc(columnDef.getName(), columnDef.getComment());
             }
 
             // NOT NULL / NULL
-            if (column.isAllowNull()) {
-                updateSchema.makeColumnOptional(column.getName());
+            if (columnDef.isAllowNull()) {
+                updateSchema.makeColumnOptional(columnDef.getName());
             } else {
                 throw new StarRocksConnectorException(
                         "column in iceberg table must be nullable.");
@@ -203,9 +197,9 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
             // AFTER column / FIRST
             if (colPos != null) {
                 if (colPos.isFirst()) {
-                    updateSchema.moveFirst(column.getName());
+                    updateSchema.moveFirst(columnDef.getName());
                 } else if (colPos.getLastCol() != null) {
-                    updateSchema.moveAfter(column.getName(), colPos.getLastCol());
+                    updateSchema.moveAfter(columnDef.getName(), colPos.getLastCol());
                 } else {
                     throw new StarRocksConnectorException("Unsupported position: " + colPos);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/IMTCreator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/IMTCreator.java
@@ -201,9 +201,13 @@ class IMTCreator {
                 }
 
                 TypeDef typeDef = TypeDef.create(refOp.getType().getPrimitiveType());
-                ColumnDef columnDef = new ColumnDef(refOp.getName(), typeDef);
-                columnDef.setIsKey(isKey);
-                columnDef.setAllowNull(!isKey);
+                ColumnDef columnDef = new ColumnDef(refOp.getName(), typeDef,
+                        /* isKey */ isKey,
+                        /* aggregateType */ null,
+                        /* aggStateDesc */ null,
+                        /* isAllowNull */ !isKey,
+                        /* defaultValueDef */ ColumnDef.DefaultValueDef.NOT_SET,
+                        /* comment */ "");
                 columnDefs.add(columnDef);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
@@ -161,22 +161,16 @@ public class ColumnDefAnalyzer {
             if (defaultValueDef.isSet) {
                 throw new AnalysisException(String.format("Invalid default value for '%s'", name));
             }
-
-            columnDef.setDefaultValueDef(ColumnDef.DefaultValueDef.EMPTY_VALUE);
         }
         if (type.isBitmapType()) {
             if (defaultValueDef.isSet) {
                 throw new AnalysisException(String.format("Invalid default value for '%s'", name));
             }
-            columnDef.setDefaultValueDef(ColumnDef.DefaultValueDef.EMPTY_VALUE);
         }
         if (aggregateType == AggregateType.REPLACE_IF_NOT_NULL) {
             // If aggregate type is REPLACE_IF_NOT_NULL, we set it nullable.
             // If default value is not set, we set it NULL
             columnDef.setAllowNull(true);
-            if (!defaultValueDef.isSet) {
-                columnDef.setDefaultValueDef(ColumnDef.DefaultValueDef.NULL_DEFAULT_VALUE);
-            }
         }
 
         if (!isAllowNull && defaultValueDef == ColumnDef.DefaultValueDef.NULL_DEFAULT_VALUE) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnBuilder;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Index;
@@ -275,7 +276,12 @@ public class CreateTableAnalyzer {
                 throw new SemanticException("BITMAP_UNION must be used in AGG_KEYS", keysDesc.getPos());
             }
 
-            Column col = Column.fromColumnDef(null, columnDef);
+            Column col;
+            if (columnDef.getGeneratedColumnExpr() != null) {
+                col = ColumnBuilder.buildGeneratedColumn(null, columnDef);
+            } else {
+                col = ColumnBuilder.buildColumn(columnDef);
+            }
             if (keysDesc != null && (keysDesc.getKeysType() == KeysType.UNIQUE_KEYS
                     || keysDesc.getKeysType() == KeysType.PRIMARY_KEYS ||
                     keysDesc.getKeysType() == KeysType.DUP_KEYS)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -29,6 +29,7 @@ import com.starrocks.alter.AlterJobMgr;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnBuilder;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExpressionRangePartitionInfoV2;
@@ -1841,7 +1842,7 @@ public class MaterializedViewAnalyzer {
         ColumnDef generatedPartitionColumn = new ColumnDef(
                 columnName, typeDef, null, false, aggregateType, null, true,
                 ColumnDef.DefaultValueDef.NOT_SET, null, adjustedPartitionByExpr, "");
-        return Column.fromColumnDef(null, generatedPartitionColumn);
+        return ColumnBuilder.buildGeneratedColumn(null, generatedPartitionColumn);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnDef.java
@@ -225,10 +225,6 @@ public class ColumnDef implements ParseNode {
         return defaultValueDef;
     }
 
-    public void setDefaultValueDef(DefaultValueDef defaultValueDef) {
-        this.defaultValueDef = defaultValueDef;
-    }
-
     public String getName() {
         return name;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreOperationsTest.java
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.hive;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnBuilder;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.PartitionKey;
@@ -371,7 +371,7 @@ public class HiveMetastoreOperationsTest {
                 "my table comment");
         List<Column> columns = stmt.getColumnDefs()
                 .stream()
-                .map(columnDef -> Column.fromColumnDef(null, columnDef))
+                .map(columnDef -> ColumnBuilder.buildGeneratedColumn(null, columnDef))
                 .collect(Collectors.toList());
         stmt.setColumns(columns);
 
@@ -421,7 +421,8 @@ public class HiveMetastoreOperationsTest {
                 new HashMap<>(),
                 "my table comment");
         List<Column> columns =
-                stmt.getColumnDefs().stream().map(def -> Column.fromColumnDef(null, def)).collect(Collectors.toList());
+                stmt.getColumnDefs().stream().map(def -> ColumnBuilder.buildGeneratedColumn(null, def))
+                        .collect(Collectors.toList());
         stmt.setColumns(columns);
 
         Assertions.assertTrue(mockedHmsOps.createTable(stmt));
@@ -460,7 +461,8 @@ public class HiveMetastoreOperationsTest {
                 new HashMap<>(),
                 "my table comment");
         List<Column> columns =
-                stmt.getColumnDefs().stream().map(def -> Column.fromColumnDef(null, def)).collect(Collectors.toList());
+                stmt.getColumnDefs().stream().map(def -> ColumnBuilder.buildGeneratedColumn(null, def))
+                        .collect(Collectors.toList());
         stmt.setColumns(columns);
 
         Assertions.assertTrue(mockedHmsOps.createTable(stmt));
@@ -498,7 +500,8 @@ public class HiveMetastoreOperationsTest {
                 new HashMap<>(),
                 "my table comment");
         List<Column> columns =
-                stmt.getColumnDefs().stream().map(def -> Column.fromColumnDef(null, def)).collect(Collectors.toList());
+                stmt.getColumnDefs().stream().map(def -> ColumnBuilder.buildGeneratedColumn(null, def))
+                        .collect(Collectors.toList());
         stmt.setColumns(columns);
 
         Assertions.assertTrue(mockedHmsOps.createTable(stmt));
@@ -537,7 +540,7 @@ public class HiveMetastoreOperationsTest {
                 "my table comment");
         List<Column> columns = stmt.getColumnDefs()
                 .stream()
-                .map(columnDef -> Column.fromColumnDef(null, columnDef))
+                .map(columnDef -> ColumnBuilder.buildGeneratedColumn(null, columnDef))
                 .collect(Collectors.toList());
         stmt.setColumns(columns);
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request introduces a new `ColumnBuilder` utility to encapsulate the construction of `Column` objects from `ColumnDef`, and refactors the codebase to use this new builder. It also moves logic for determining effective default values out of the analyzer and into the builder, simplifying the analyzer code and making default value handling more consistent. The changes improve code maintainability and clarity, especially around column creation and default value logic.

**Refactoring and code organization:**

* Introduced a new `ColumnBuilder` class with a static `fromColumnDef` method, moving the construction logic for `Column` objects out of the `Column` class and centralizing it in the builder. This includes logic for handling default values and generated columns. (`fe/fe-core/src/main/java/com/starrocks/catalog/ColumnBuilder.java`)
* Removed the now-redundant `Column.fromColumnDef` method from the `Column` class. (`fe/fe-core/src/main/java/com/starrocks/catalog/Column.java`)

**Default value handling improvements:**

* Moved logic for determining the effective default value for columns (including handling of HLL, Bitmap, and `REPLACE_IF_NOT_NULL` aggregate types) into the `ColumnBuilder`, removing mutation of `ColumnDef` in the analyzer. (`fe/fe-core/src/main/java/com/starrocks/catalog/ColumnBuilder.java`, `fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java`) [[1]](diffhunk://#diff-06dec7b8ff641d31a2104e9af941634fa9a691766c32de6dcb5893a9da471ce9R1-R60) [[2]](diffhunk://#diff-feed1982b0a8e76a1b72111e1c08dddd52d2b7e4538c2291978347b01e66e97bL164-L179)

**Refactoring usages across the codebase:**

* Updated all usages of `Column.fromColumnDef` to use `ColumnBuilder.fromColumnDef` instead, affecting analyzers and executors for table and column operations. (`fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java`, `fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java`, `fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java`, `fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java`, `fe/fe-core/src/main/java/com/starrocks/scheduler/mv/IMTCreator.java`) [[1]](diffhunk://#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cL730-R731) [[2]](diffhunk://#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cL767-R768) [[3]](diffhunk://#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cL862-R863) [[4]](diffhunk://#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cL995-R996) [[5]](diffhunk://#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cL1016-R1017) [[6]](diffhunk://#diff-851f1ba3bb24be960efb43ccef2589567a6b557714c82cbd09ce85da3eb0d773L278-R279) [[7]](diffhunk://#diff-2ef2ec3eb099ffc05bbc17579709e4f9645eefca73b3ce70ae56277894aba3c0L1768-R1769) [[8]](diffhunk://#diff-945d1a4febbf25e17e64b4ef578025f77f2b22e50dda50629debe989719fd137L104-R118) [[9]](diffhunk://#diff-945d1a4febbf25e17e64b4ef578025f77f2b22e50dda50629debe989719fd137L135-R142) [[10]](diffhunk://#diff-945d1a4febbf25e17e64b4ef578025f77f2b22e50dda50629debe989719fd137L180-R191) [[11]](diffhunk://#diff-945d1a4febbf25e17e64b4ef578025f77f2b22e50dda50629debe989719fd137L206-R202) [[12]](diffhunk://#diff-92ca829e128fc4423b028e924d74f0dc10c685d0fedb1aa7d1a4ed82f9dc60ffL204-R210)

**Minor cleanup:**

* Removed unnecessary imports and minor whitespace adjustments for improved code clarity. (`fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java`, `fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java`) [[1]](diffhunk://#diff-945d1a4febbf25e17e64b4ef578025f77f2b22e50dda50629debe989719fd137L16-L17) [[2]](diffhunk://#diff-945d1a4febbf25e17e64b4ef578025f77f2b22e50dda50629debe989719fd137R30) [[3]](diffhunk://#diff-945d1a4febbf25e17e64b4ef578025f77f2b22e50dda50629debe989719fd137L62) [[4]](diffhunk://#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cL1110) [[5]](diffhunk://#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cL1454)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce ColumnBuilder to build Columns (including generated columns) and move default-value resolution out of analyzers; refactor codebase to use it and remove Column.fromColumnDef.
> 
> - **Catalog**:
>   - Add `ColumnBuilder` with `buildColumn` and `buildGeneratedColumn`, centralizing `Column` creation and effective default handling (e.g., HLL/Bitmap empty, `REPLACE_IF_NOT_NULL` -> nullable with NULL default).
>   - Remove `Column.fromColumnDef` from `Column`.
> - **Analyzers**:
>   - Update `CreateTableAnalyzer`, `AlterTableClauseAnalyzer`, `MaterializedViewAnalyzer` to use `ColumnBuilder`; avoid mutating `ColumnDef` for defaults and add post-build NOT NULL default checks.
>   - Simplify `ColumnDefAnalyzer` by removing default-setting side effects (keep validation only).
> - **Connectors/Executors**:
>   - Refactor `IcebergAlterTableExecutor` to operate on `ColumnDef` directly or use `ColumnBuilder` as needed.
> - **Server/Factories**:
>   - Use `ColumnBuilder` in `ElasticSearchTableFactory` for schema creation.
> - **Scheduler/MV**:
>   - Adjust `IMTCreator` to construct `ColumnDef` with full args.
> - **Tests**:
>   - Update tests to use `ColumnBuilder`; add UT validating bitmap default behavior on ALTER ADD COLUMN.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32122d07db09581620ff8093cb06ceb10c1a9779. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->