### PR TITLE
[BugFix] fix exception-safety of json extraction

### DIFF
--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -113,6 +113,11 @@ Status FlatJsonColumnWriter::_flat_column(Columns& json_datas) {
         flattener.flatten(json_data);
         _flat_columns = flattener.mutable_result();
 
+        // IMPORTANT: Check flattener result integrity to prevent  inconsistency
+        for (const auto& flat_col : _flat_columns) {
+            flat_col->check_or_die();
+        }
+
         // recode null column in 1st
         if (_json_meta->is_nullable()) {
             auto nulls = NullColumn::create();
@@ -222,6 +227,12 @@ Status FlatJsonColumnWriter::_init_flat_writers() {
 Status FlatJsonColumnWriter::_write_flat_column() {
     DCHECK(!_flat_columns.empty());
     DCHECK_EQ(_flat_columns.size(), _flat_writers.size());
+
+    // IMPORTANT: Final integrity check before writing to prevent  inconsistency
+    for (const auto& flat_col : _flat_columns) {
+        flat_col->check_or_die();
+    }
+
     // flat datas
     for (size_t i = 0; i < _flat_columns.size(); i++) {
         RETURN_IF_ERROR(_flat_writers[i]->append(*_flat_columns[i]));

--- a/be/src/util/json_converter.h
+++ b/be/src/util/json_converter.h
@@ -183,10 +183,10 @@ static Status cast_vpjson_to(const vpack::Slice& slice, ColumnBuilder<ResultType
             }
         }
     } catch (const vpack::Exception& e) {
-        LOG(WARNING) << "vpack::Exception in cast_vpjson_to: " << e.what();
         if constexpr (AllowThrowException) {
             return Status::JsonFormatError(fmt::format("cast from JSON to {} failed", type_to_string(ResultType)));
         }
+        LOG(INFO) << "vpack::Exception in cast_vpjson_to: " << e.what();
         result.append_null();
     }
     return Status::OK();

--- a/be/src/util/json_converter.h
+++ b/be/src/util/json_converter.h
@@ -96,6 +96,9 @@ static StatusOr<RunTimeCppType<ResultType>> get_number_from_vpjson(const vpack::
     return Status::JsonFormatError("not a number");
 }
 
+// Converts a JSON value to the specified type and appends it to the result column.
+// Performs type conversion as needed to match the target type.
+// TODO(murphy): it's duplicated with extract_number/extract_bool/extract_string in json_flattener.cpp
 template <LogicalType ResultType, bool AllowThrowException>
 static Status cast_vpjson_to(const vpack::Slice& slice, ColumnBuilder<ResultType>& result) {
     if constexpr (!lt_is_arithmetic<ResultType> && !lt_is_string<ResultType> && ResultType != TYPE_JSON) {
@@ -180,6 +183,7 @@ static Status cast_vpjson_to(const vpack::Slice& slice, ColumnBuilder<ResultType
             }
         }
     } catch (const vpack::Exception& e) {
+        LOG(WARNING) << "vpack::Exception in cast_vpjson_to: " << e.what();
         if constexpr (AllowThrowException) {
             return Status::JsonFormatError(fmt::format("cast from JSON to {} failed", type_to_string(ResultType)));
         }

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -157,8 +157,8 @@ void extract_json(const vpack::Slice* json, NullableColumn* result) {
     if (json->isNone()) {
         result->append_nulls(1);
     } else {
-        JsonValue json_value(*json);
-        result->append_datum(Datum(&json_value));
+        down_cast<JsonColumn*>(result->data_column().get())->append(JsonValue(*json));
+        result->null_column()->append(0);
     }
 }
 

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -76,7 +76,7 @@ void extract_number(const vpack::Slice* json, NullableColumn* result) {
             datum.set_null();
         }
     } catch (const vpack::Exception& e) {
-        LOG(WARNING) << "vpack::Exception in extract_number: " << e.what();
+        LOG(INFO) << "vpack::Exception in extract_number: " << e.what();
         datum.set_null();
     }
 
@@ -119,7 +119,7 @@ void extract_bool(const vpack::Slice* json, NullableColumn* result) {
             datum.set_null();
         }
     } catch (const vpack::Exception& e) {
-        LOG(WARNING) << "vpack::Exception in extract_bool: " << e.what();
+        LOG(INFO) << "vpack::Exception in extract_bool: " << e.what();
         datum.set_null();
     }
 
@@ -148,7 +148,7 @@ void extract_string(const vpack::Slice* json, NullableColumn* result) {
             result->append_datum(Datum(Slice(str)));
         }
     } catch (const vpack::Exception& e) {
-        LOG(WARNING) << "vpack::Exception in extract_string: " << e.what();
+        LOG(INFO) << "vpack::Exception in extract_string: " << e.what();
         result->append_nulls(1);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

The `extract_number`, `extract_bool`, and `extract_string` functions are not exception-safe. They modify `data_column` and `null_column` independently, which can lead to an inconsistent state in the `NullableColumn` if an exception occurs midway.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
