### PR TITLE
[BugFix] OptimizeJob: prevent partition replace with non-visible data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
@@ -387,6 +387,29 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
             if (status.getState() == Constants.TaskRunState.FAILED) {
                 LOG.warn("optimize task {} failed", rewriteTask.getName());
                 rewriteTask.setOptimizeTaskState(Constants.TaskRunState.FAILED);
+            } else if (status.getState() == Constants.TaskRunState.SUCCESS) {
+                // Task finished successfully at SQL level. Now gate on visibility for its temp partition.
+                try {
+                    Partition tmpPartition = tbl.getPartition(rewriteTask.getTempPartitionName(), true);
+                    if (tmpPartition == null) {
+                        LOG.warn("temp partition {} not found for task {}", rewriteTask.getTempPartitionName(),
+                                rewriteTask.getName());
+                        rewriteTask.setOptimizeTaskState(Constants.TaskRunState.FAILED);
+                    } else {
+                        boolean hasCommitted = hasCommittedNotVisible(tmpPartition.getId());
+                        if (hasCommitted) {
+                            // Not visible yet, mark this task as FAILED to avoid replacing this partition.
+                            LOG.warn("optimize task {} not visible yet, mark as FAILED (temp partition: {}, pid: {})",
+                                    rewriteTask.getName(), rewriteTask.getTempPartitionName(), tmpPartition.getId());
+                            rewriteTask.setOptimizeTaskState(Constants.TaskRunState.FAILED);
+                        } else {
+                            rewriteTask.setOptimizeTaskState(Constants.TaskRunState.SUCCESS);
+                        }
+                    }
+                } catch (Exception ex) {
+                    LOG.warn("check visibility for task {} failed", rewriteTask.getName(), ex);
+                    rewriteTask.setOptimizeTaskState(Constants.TaskRunState.FAILED);
+                }
             }
             progress += 100 / rewriteTasks.size();
         }
@@ -419,6 +442,13 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
     @Override
     protected void runFinishedRewritingJob() {
         // nothing to do
+    }
+
+    // Visible check wrapper for testability.
+    // Returns true if there exists committed-but-not-visible txn for the given partition.
+    protected boolean hasCommittedNotVisible(long partitionId) {
+        return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                .existCommittedTxns(dbId, tableId, partitionId);
     }
 
     private void onFinished(Database db, OlapTable targetTable) throws AlterCancelException {

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -498,8 +498,18 @@ public class InsertOverwriteJobRunner {
                     }
                 }
             }
-            List<String> tmpPartitionNames = job.getTmpPartitionIds().stream()
-                    .map(partitionId -> targetTable.getPartition(partitionId).getName())
+            List<Long> tmpPartitionIds = job.getTmpPartitionIds();
+            if (tmpPartitionIds == null) {
+                throw new DmlException("tmp partitions are empty for job:%s", job.getJobId());
+            }
+            List<String> tmpPartitionNames = tmpPartitionIds.stream()
+                    .map(partitionId -> {
+                        Partition partition = targetTable.getPartition(partitionId);
+                        if (partition == null) {
+                            throw new DmlException("temp partition id:%s does not exist", partitionId);
+                        }
+                        return partition.getName();
+                    })
                     .collect(Collectors.toList());
             Set<Tablet> sourceTablets = Sets.newHashSet();
             sourcePartitionNames.forEach(name -> {
@@ -528,15 +538,25 @@ public class InsertOverwriteJobRunner {
                         }
                         tmpPartitionNames = txnState.getCreatedPartitionNames(tableId);
                         job.setTmpPartitionIds(tmpPartitionNames.stream()
-                                .map(name -> targetTable.getPartition(name, true).getId())
+                                .map(name -> {
+                                    Partition partition = targetTable.getPartition(name, true);
+                                    if (partition == null) {
+                                        throw new DmlException("temp partition %s does not exist", name);
+                                    }
+                                    return partition.getId();
+                                })
                                 .collect(Collectors.toList()));
+                        tmpPartitionIds = job.getTmpPartitionIds();
                     }
                     LOG.info("dynamic overwrite job {} replace tmpPartitionNames:{}", job.getJobId(), tmpPartitionNames);
+                    ensureTempPartitionsVisible(targetTable, tmpPartitionIds);
                     targetTable.replaceMatchPartitions(dbId, tmpPartitionNames);
                 } else {
+                    ensureTempPartitionsVisible(targetTable, tmpPartitionIds);
                     targetTable.replaceTempPartitions(dbId, sourcePartitionNames, tmpPartitionNames, true, false);
                 }
             } else if (partitionInfo instanceof SinglePartitionInfo) {
+                ensureTempPartitionsVisible(targetTable, tmpPartitionIds);
                 targetTable.replacePartition(dbId, sourcePartitionNames.get(0), tmpPartitionNames.get(0));
             } else {
                 throw new DdlException("partition type " + partitionInfo.getType() + " is not supported");
@@ -634,5 +654,29 @@ public class InsertOverwriteJobRunner {
 
     protected void testDoCommit(boolean isReplay) {
         doCommit(isReplay);
+    }
+
+    protected void ensureTempPartitionsVisible(OlapTable targetTable, List<Long> partitionIds) {
+        if (partitionIds == null) {
+            return;
+        }
+        for (Long partitionId : partitionIds) {
+            if (partitionId == null) {
+                continue;
+            }
+            Partition partition = targetTable.getPartition(partitionId);
+            if (partition == null) {
+                throw new DmlException("temp partition id:%s does not exist", partitionId);
+            }
+            if (hasCommittedNotVisible(partitionId)) {
+                throw new DmlException("temp partition %s still has committed transactions not visible",
+                        partition.getName());
+            }
+        }
+    }
+
+    protected boolean hasCommittedNotVisible(long partitionId) {
+        return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                .existCommittedTxns(dbId, tableId, partitionId);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/MergePartitionJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/MergePartitionJobTest.java
@@ -1,0 +1,87 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.common.collect.Multimap;
+import com.starrocks.alter.AlterCancelException;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.scheduler.Constants;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class MergePartitionJobTest {
+
+    @Test
+    public void testTempPartitionNotVisibleRaisesFailure() throws Exception {
+        String tempPartitionName = "tmp_p1";
+        MergePartitionJob job = new MergePartitionJob(1L, 2L, 3L, "tbl", 1000L) {
+            @Override
+            protected boolean hasCommittedNotVisible(long partitionId) {
+                return partitionId == 100L;
+            }
+        };
+
+        Field nameMappingField = MergePartitionJob.class.getDeclaredField("tempPartitionNameToSourcePartitionNames");
+        nameMappingField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Multimap<String, String> nameMapping = (Multimap<String, String>) nameMappingField.get(job);
+        nameMapping.put(tempPartitionName, "p1");
+
+        OptimizeTask task = new OptimizeTask("task-1");
+        task.setTempPartitionName(tempPartitionName);
+        task.setPartitionName("p1");
+        task.setLastVersion(0L);
+        task.setOptimizeTaskState(Constants.TaskRunState.SUCCESS);
+        job.getOptimizeTasks().add(task);
+
+        Database db = Mockito.mock(Database.class);
+        Mockito.when(db.getId()).thenReturn(2L);
+
+        OlapTable table = Mockito.mock(OlapTable.class);
+        Partition tempPartition = Mockito.mock(Partition.class);
+        Mockito.when(tempPartition.getId()).thenReturn(100L);
+        Mockito.when(tempPartition.getName()).thenReturn(tempPartitionName);
+        Mockito.when(table.getPartition(tempPartitionName, true)).thenReturn(tempPartition);
+        Mockito.doNothing().when(table).dropTempPartition(tempPartitionName, true);
+        Mockito.when(table.getPartition("p1")).thenReturn(null);
+
+        Method onFinished = MergePartitionJob.class.getDeclaredMethod("onFinished", Database.class, OlapTable.class);
+        onFinished.setAccessible(true);
+
+        AlterCancelException ex = Assertions.assertThrows(AlterCancelException.class, () -> {
+            try {
+                onFinished.invoke(job, db, table);
+            } catch (InvocationTargetException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof AlterCancelException) {
+                    throw (AlterCancelException) cause;
+                }
+                throw new RuntimeException(cause);
+            }
+        });
+        Assertions.assertTrue(ex.getMessage().contains("rewrite failed"));
+
+        Mockito.verify(table).dropTempPartition(tempPartitionName, true);
+        Assertions.assertEquals(Constants.TaskRunState.FAILED, task.getOptimizeTaskState());
+        Assertions.assertTrue(nameMapping.isEmpty());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
@@ -192,6 +192,92 @@ public class OptimizeJobV2Test extends DDLTestBase {
     }
 
     @Test
+    public void testTaskSuccessButNotVisibleMarkedFailed() throws Exception {
+        SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
+
+        schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
+        Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
+        Assertions.assertEquals(1, alterJobsV2.size());
+        OptimizeJobV2 realJob = (OptimizeJobV2) alterJobsV2.values().stream().findAny().get();
+
+        OptimizeJobV2 job = Mockito.spy(realJob);
+        Mockito.doReturn(true).when(job).isPreviousLoadFinished();
+        // Force visibility check to return true (has committed-not-visible)
+        Mockito.doReturn(true).when(job).hasCommittedNotVisible(Mockito.anyLong());
+
+        job.runPendingJob();
+        job.runWaitingTxnJob();
+        Assertions.assertEquals(JobState.RUNNING, job.getJobState());
+
+        // Mark all tasks SQL SUCCESS and add history
+        for (OptimizeTask t : job.getOptimizeTasks()) {
+            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
+                .getTaskRunScheduler().removeRunningTask(t.getId());
+            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
+                .getTaskRunScheduler().removePendingTask(t);
+            TaskRunStatus s = new TaskRunStatus();
+            s.setTaskName(t.getName());
+            s.setDbName(db.getFullName());
+            s.setState(Constants.TaskRunState.SUCCESS);
+            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager().getTaskRunHistory().addHistory(s);
+        }
+
+        try {
+            job.runRunningJob();
+        } catch (AlterCancelException e) {
+            job.cancel(e.getMessage());
+        }
+
+        // All tasks should be turned to FAILED due to not visible
+        for (OptimizeTask t : job.getOptimizeTasks()) {
+            Assertions.assertEquals(Constants.TaskRunState.FAILED, t.getOptimizeTaskState());
+        }
+        // All partitions rewrite failed, job should be CANCELLED
+        Assertions.assertEquals(JobState.CANCELLED, job.getJobState());
+    }
+
+    @Test
+    public void testTaskSuccessAndVisibleKeepsSuccess() throws Exception {
+        SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
+
+        schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
+        Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
+        Assertions.assertEquals(1, alterJobsV2.size());
+        OptimizeJobV2 realJob = (OptimizeJobV2) alterJobsV2.values().stream().findAny().get();
+
+        OptimizeJobV2 job = Mockito.spy(realJob);
+        Mockito.doReturn(true).when(job).isPreviousLoadFinished();
+        // Visibility check returns false (no committed-not-visible), so SUCCESS remains SUCCESS
+        Mockito.doReturn(false).when(job).hasCommittedNotVisible(Mockito.anyLong());
+
+        job.runPendingJob();
+        job.runWaitingTxnJob();
+        Assertions.assertEquals(JobState.RUNNING, job.getJobState());
+
+        for (OptimizeTask t : job.getOptimizeTasks()) {
+            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
+                .getTaskRunScheduler().removeRunningTask(t.getId());
+            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
+                .getTaskRunScheduler().removePendingTask(t);
+            TaskRunStatus s = new TaskRunStatus();
+            s.setTaskName(t.getName());
+            s.setDbName(db.getFullName());
+            s.setState(Constants.TaskRunState.SUCCESS);
+            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager().getTaskRunHistory().addHistory(s);
+        }
+
+        // Should proceed to finish
+        job.runRunningJob();
+        Assertions.assertEquals(JobState.FINISHED, job.getJobState());
+    }
+
+    @Test
     public void testOptimizeTableFailed() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);


### PR DESCRIPTION
## Why I'm doing:

This fixes a window where optimize could replace partitions while INSERT data was committed but not yet visible, leading to user data invisibility.


## What I'm doing:

Gate each rewrite task on visibility: after SQL SUCCESS, check temp partition has no committed-but-not-visible txn via GlobalTransactionMgr.existCommittedTxns; if not visible, mark task FAILED

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add committed-not-visible transaction checks before replacing partitions in optimize/merge/insert-overwrite, dropping non-visible temps, failing tasks, and adding tests.
> 
> - **Optimize/Merge (Alter)**:
>   - OptimizeJobV2: after SQL SUCCESS, check temp partition visibility via `hasCommittedNotVisible`; mark task `FAILED` if not visible; helper added.
>   - MergePartitionJob: add `hasCommittedNotVisible`; before replace, validate temp partition existence/visibility, drop non-visible temps, mark tasks `FAILED`, and abort if all failed.
> - **Insert Overwrite (Load)**:
>   - Add `ensureTempPartitionsVisible` to verify temp partitions exist and have no committed-not-visible txns; invoked before `replace*` paths (dynamic/static, single/range/list).
>   - Strengthen tmp partition handling: null checks, explicit errors when temp partitions missing.
> - **Tests**:
>   - New/updated UTs covering visibility gating and error paths for OptimizeJobV2, MergePartitionJob, and InsertOverwriteJobRunner.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c54f21e5cd6159294656cf267b93e4e6c37a16a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->