### PR TITLE
[BugFix] Fix mv refresh peformance issue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.ConnectorTableInfo;
@@ -34,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class MVMetaVersionRepairer {
     private static final Logger LOG = LogManager.getLogger(MVMetaVersionRepairer.class);
@@ -69,7 +71,8 @@ public class MVMetaVersionRepairer {
 
             // acquire mvDb + mv write lock to modify meta of mv
             Locker locker = new Locker();
-            if (!locker.lockDatabaseAndCheckExist(mvDb, mv, LockType.WRITE)) {
+            if (!locker.tryLockTableWithIntensiveDbLock(mvDb.getId(), mv.getId(), LockType.WRITE,
+                    Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
                 continue;
             }
             try {
@@ -99,8 +102,7 @@ public class MVMetaVersionRepairer {
         LOG.info("repair base table {} version changes for mv {}, changed versions:{}",
                 table.getName(), mv.getName(), changedVersions);
         // update edit log
-        long maxChangedTableRefreshTime =
-                MvUtils.getMaxTablePartitionInfoRefreshTime(Lists.newArrayList(changedVersions));
+        long maxChangedTableRefreshTime = MvUtils.getMaxTablePartitionInfoRefreshTime(changedVersions);
         MVVersionManager.updateEditLogAfterVersionMetaChanged(mv, maxChangedTableRefreshTime);
         LOG.info("Update edit log after version changed for mv {}, maxChangedTableRefreshTime:{}",
                 mv.getName(), maxChangedTableRefreshTime);

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
@@ -71,7 +71,7 @@ public class MVMetaVersionRepairer {
 
             // acquire mvDb + mv write lock to modify meta of mv
             Locker locker = new Locker();
-            if (!locker.tryLockTableWithIntensiveDbLock(mvDb.getId(), mv.getId(), LockType.WRITE,
+            if (!locker.tryLockTableWithIntensiveDbLock(mvDb, mv.getId(), LockType.WRITE,
                     Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -80,7 +80,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
     public boolean syncAddOrDropPartitions() throws LockTimeoutException {
         // collect mv partition items with lock
         Locker locker = new Locker();
-        if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), mv.getId(),
+        if (!locker.tryLockTableWithIntensiveDbLock(db, mv.getId(),
                 LockType.READ, Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
             throw new LockTimeoutException("Failed to lock database: " + db.getFullName() + " in syncPartitionsForList");
         }
@@ -93,7 +93,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
                 return false;
             }
         } finally {
-            locker.unLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db, mv.getId(), LockType.READ);
         }
 
         {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -80,7 +80,8 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
     public boolean syncAddOrDropPartitions() throws LockTimeoutException {
         // collect mv partition items with lock
         Locker locker = new Locker();
-        if (!locker.tryLockDatabase(db, LockType.READ, Config.mv_refresh_try_lock_timeout_ms)) {
+        if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), mv.getId(),
+                LockType.READ, Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
             throw new LockTimeoutException("Failed to lock database: " + db.getFullName() + " in syncPartitionsForList");
         }
 
@@ -92,7 +93,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
                 return false;
             }
         } finally {
-            locker.unLockDatabase(db, LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.READ);
         }
 
         {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -259,7 +259,7 @@ public abstract class MVPCTRefreshPartitioner {
     protected void dropPartition(Database db, MaterializedView materializedView, String mvPartitionName) {
         String dropPartitionName = materializedView.getPartition(mvPartitionName).getName();
         Locker locker = new Locker();
-        if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), materializedView.getId(), LockType.WRITE,
+        if (!locker.tryLockTableWithIntensiveDbLock(db, materializedView.getId(), LockType.WRITE,
                 Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
             logger.warn("Fail to lock database {} in drop partition for mv refresh {}", db.getFullName(),
                     materializedView.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -42,6 +43,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static com.starrocks.catalog.MvRefreshArbiter.getMvBaseTableUpdateInfo;
 import static com.starrocks.catalog.MvRefreshArbiter.needsToRefreshTable;
@@ -257,7 +259,8 @@ public abstract class MVPCTRefreshPartitioner {
     protected void dropPartition(Database db, MaterializedView materializedView, String mvPartitionName) {
         String dropPartitionName = materializedView.getPartition(mvPartitionName).getName();
         Locker locker = new Locker();
-        if (!locker.lockDatabaseAndCheckExist(db, materializedView, LockType.WRITE)) {
+        if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), materializedView.getId(), LockType.WRITE,
+                Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
             logger.warn("Fail to lock database {} in drop partition for mv refresh {}", db.getFullName(),
                     materializedView.getName());
             throw new DmlException("drop partition failed. database:" + db.getFullName() + " not exist");

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
@@ -27,6 +27,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
@@ -27,7 +27,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -107,9 +107,8 @@ public class MVVersionManager {
                 continue;
             }
             Long tableId = snapshotTable.getId();
-            currentVersionMap.computeIfAbsent(tableId, (v) -> Maps.newConcurrentMap());
             Map<String, MaterializedView.BasePartitionInfo> currentTablePartitionInfo =
-                    currentVersionMap.get(tableId);
+                    currentVersionMap.computeIfAbsent(tableId, (v) -> Maps.newConcurrentMap());
             Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = snapshotInfo.getRefreshedPartitionInfos();
             logger.info("Update materialized view {} meta for base table {} with partitions info: {}, old partition infos:{}",
                     mv.getName(), snapshotTable.getName(), partitionInfoMap, currentTablePartitionInfo);
@@ -119,8 +118,15 @@ public class MVVersionManager {
             // remove partition info of not-exist partition for snapshot table from version map
             if (snapshotTable.isOlapOrCloudNativeTable()) {
                 OlapTable snapshotOlapTable = (OlapTable) snapshotTable;
-                currentTablePartitionInfo.keySet().removeIf(partitionName ->
-                        !snapshotOlapTable.getVisiblePartitionNames().contains(partitionName));
+                Set<String> visiblePartitionNames = snapshotOlapTable.getVisiblePartitionNames();
+                // Use iterator to avoid creating intermediate collections and for better performance
+                Iterator<String> keyIter = currentTablePartitionInfo.keySet().iterator();
+                while (keyIter.hasNext()) {
+                    String partitionName = keyIter.next();
+                    if (!visiblePartitionNames.contains(partitionName)) {
+                        keyIter.remove();
+                    }
+                }
             }
         }
         if (!changedTablePartitionInfos.isEmpty()) {
@@ -168,8 +174,9 @@ public class MVVersionManager {
                         snapshotTable.getName(), snapshotInfo.getRefreshedPartitionInfos(), mv.getName());
                 continue;
             }
-            currentVersionMap.computeIfAbsent(baseTableInfo, (v) -> Maps.newConcurrentMap());
-            Map<String, MaterializedView.BasePartitionInfo> currentTablePartitionInfo = currentVersionMap.get(baseTableInfo);
+            // Use computeIfAbsent to avoid unnecessary map creation
+            Map<String, MaterializedView.BasePartitionInfo> currentTablePartitionInfo =
+                    currentVersionMap.computeIfAbsent(baseTableInfo, v -> Maps.newConcurrentMap());
             Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = snapshotInfo.getRefreshedPartitionInfos();
             logger.info("Update materialized view {} meta for external base table {} with partitions info: {}, " +
                             "old partition infos:{}", mv.getName(), snapshotTable.getName(),
@@ -177,10 +184,23 @@ public class MVVersionManager {
             // overwrite old partition names
             currentTablePartitionInfo.putAll(partitionInfoMap);
 
-            // FIXME: If base table's partition has been dropped, should drop the according version partition too?
-            // remove partition info of not-exist partition for snapshot table from version map
-            Set<String> partitionNames = Sets.newHashSet(PartitionUtil.getPartitionNames(snapshotTable));
-            currentTablePartitionInfo.keySet().removeIf(partitionName -> !partitionNames.contains(partitionName));
+            // Remove partition info for partitions that no longer exist in the snapshot table
+            List<String> partitionNamesList = PartitionUtil.getPartitionNames(snapshotTable);
+            if (!partitionNamesList.isEmpty()) {
+                Set<String> partitionNames = Sets.newHashSetWithExpectedSize(partitionNamesList.size());
+                partitionNames.addAll(partitionNamesList);
+                // Remove using iterator for better performance on concurrent maps
+                Iterator<String> iter = currentTablePartitionInfo.keySet().iterator();
+                while (iter.hasNext()) {
+                    String partitionName = iter.next();
+                    if (!partitionNames.contains(partitionName)) {
+                        iter.remove();
+                    }
+                }
+            } else {
+                // If no partitions exist, clear all
+                currentTablePartitionInfo.clear();
+            }
         }
         if (!changedTablePartitionInfos.isEmpty()) {
             Collection<Map<String, MaterializedView.BasePartitionInfo>> allChangedPartitionInfos =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -823,9 +823,21 @@ public class MvRewritePreprocessor {
         // If query tables are set which means use related mv for non lock optimization,
         // copy mv's metadata into a ready-only object.
         MaterializedView copiedMV = (context.getQueryTables() != null) ? copyOnlyMaterializedView(mv) : mv;
+        return buildMaterializationContext(context, copiedMV, mvPlanContext, mvUpdateInfo,
+                baseTables, intersectingTables, mvPlan, level);
+    }
+
+    private static MaterializationContext buildMaterializationContext(OptimizerContext context,
+                                                                      MaterializedView mv,
+                                                                      MvPlanContext mvPlanContext,
+                                                                      MvUpdateInfo mvUpdateInfo,
+                                                                      List<Table> baseTables,
+                                                                      List<Table> intersectingTables,
+                                                                      OptExpression mvPlan,
+                                                                      int level) {
         List<ColumnRefOperator> mvOutputColumns = mvPlanContext.getOutputColumns();
         MaterializationContext materializationContext =
-                new MaterializationContext(context, copiedMV, mvPlan, context.getColumnRefFactory(),
+                new MaterializationContext(context, mv, mvPlan, context.getColumnRefFactory(),
                         mvPlanContext.getRefFactory(), baseTables, intersectingTables,
                         mvPartialPartitionPredicates, mvUpdateInfo, mvOutputColumns, level);
         // generate scan mv plan here to reuse it in rule applications
@@ -834,7 +846,7 @@ public class MvRewritePreprocessor {
         materializationContext.setScanMvOperator(scanMvOp);
         // should keep the sequence of schema
         List<ColumnRefOperator> scanMvOutputColumns = Lists.newArrayList();
-        for (Column column : copiedMV.getOrderedOutputColumns()) {
+        for (Column column : mv.getOrderedOutputColumns()) {
             scanMvOutputColumns.add(scanMvOp.getColumnReference(column));
         }
         Preconditions.checkState(mvOutputColumns.size() == scanMvOutputColumns.size());
@@ -850,7 +862,6 @@ public class MvRewritePreprocessor {
             outputMapping.put(mvOutputColumns.get(i), scanMvOutputColumns.get(i));
         }
         materializationContext.setOutputMapping(outputMapping);
-
         return materializationContext;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -823,13 +823,14 @@ public class MvRewritePreprocessor {
         // If query tables are set which means use related mv for non lock optimization,
         // copy mv's metadata into a ready-only object.
         MaterializedView copiedMV = (context.getQueryTables() != null) ? copyOnlyMaterializedView(mv) : mv;
-        return buildMaterializationContext(context, copiedMV, mvPlanContext, mvUpdateInfo,
+        return buildMaterializationContext(context, copiedMV, mvPlanContext, mvPartialPartitionPredicates, mvUpdateInfo,
                 baseTables, intersectingTables, mvPlan, level);
     }
 
     private static MaterializationContext buildMaterializationContext(OptimizerContext context,
                                                                       MaterializedView mv,
                                                                       MvPlanContext mvPlanContext,
+                                                                     ScalarOperator mvPartialPartitionPredicates,
                                                                       MvUpdateInfo mvUpdateInfo,
                                                                       List<Table> baseTables,
                                                                       List<Table> intersectingTables,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1081,16 +1081,27 @@ public class MvUtils {
 
 
     /**
-     * Return the max refresh timestamp of all partition infos.
+     * Returns the maximum refresh timestamp among all partition infos.
+     * If no valid refresh time is found, returns the current system time.
      */
     public static long getMaxTablePartitionInfoRefreshTime(
             Collection<Map<String, MaterializedView.BasePartitionInfo>> partitionInfos) {
         return partitionInfos.stream()
-                .flatMap(x -> x.values().stream())
-                .map(x -> x.getLastRefreshTime())
+                .map(MvUtils::getMaxTablePartitionInfoRefreshTime)
                 .max(Long::compareTo)
+                .orElseGet(System::currentTimeMillis);
+    }
+
+    /**
+     * Returns the maximum refresh timestamp from a single partition info map.
+     * If no valid refresh time is found, returns the current system time.
+     */
+    public static long getMaxTablePartitionInfoRefreshTime(Map<String, MaterializedView.BasePartitionInfo> partitionInfos) {
+        return partitionInfos.values().stream()
+                .map(MaterializedView.BasePartitionInfo::getLastRefreshTime)
                 .filter(Objects::nonNull)
-                .orElse(System.currentTimeMillis());
+                .max(Long::compareTo)
+                .orElseGet(System::currentTimeMillis);
     }
 
     public static List<ScalarOperator> collectOnPredicate(OptExpression optExpression) {


### PR DESCRIPTION
## Why I'm doing:
This is a part bugfix from https://github.com/StarRocks/starrocks/pull/63481
```
Bug 1: updateMetaForOlapTable is slow:

      {
         "id":9658056,
         "name":"starrocks-taskrun-pool-26084",
         "type":"INTENTION_EXCLUSIVE",
         "heldFor":6980,
         "waitTime":0,
         "stack":[
            "java.base@11.0.28/java.util.HashMap.hash(HashMap.java:340)",
            "java.base@11.0.28/java.util.HashMap.put(HashMap.java:608)",
            "java.base@11.0.28/java.util.HashSet.add(HashSet.java:220)",
            "java.base@11.0.28/java.util.stream.Collectors$$Lambda$35/0x00000008000fd040.accept(Unknown Source)",
            "java.base@11.0.28/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)",
            "java.base@11.0.28/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)",
            "java.base@11.0.28/java.util.TreeMap$KeySpliterator.forEachRemaining(TreeMap.java:2739)",
            "java.base@11.0.28/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)",
            "java.base@11.0.28/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)",
            "java.base@11.0.28/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)",
            "java.base@11.0.28/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)",
            "java.base@11.0.28/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)",
            "app//com.starrocks.catalog.OlapTable.getVisiblePartitionNames(OlapTable.java:1680)",
            "app//com.starrocks.scheduler.mv.MVVersionManager.lambda$updateMetaForOlapTable$2(MVVersionManager.java:123)",
            "app//com.starrocks.scheduler.mv.MVVersionManager$$Lambda$3757/0x00000008014bd040.test(Unknown Source)",
            "java.base@11.0.28/java.util.Collection.removeIf(Collection.java:544)",
            "app//com.starrocks.scheduler.mv.MVVersionManager.updateMetaForOlapTable(MVVersionManager.java:122)",
            "app//com.starrocks.scheduler.mv.MVVersionManager.updateMVVersionInfo(MVVersionManager.java:73)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.updateMeta(PartitionBasedMvRefreshProcessor.java:831)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:472)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:376)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:335)",
            "app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:203)",
            "app//com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:313)",
            "app//com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:60)",
            "app//com.starrocks.scheduler.TaskRunExecutor$$Lambda$2841/0x000000080145d840.get(Unknown Source)",
            "java.base@11.0.28/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)",
            "java.base@11.0.28/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)",
            "java.base@11.0.28/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)",
            "java.base@11.0.28/java.lang.Thread.run(Thread.java:829)"
         ]
      }
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

