### PR TITLE
[Enhancement] Change default_mv_partition_refresh_strategy to adaptive by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -209,15 +209,15 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     // This property only applies to materialized views
     // It represents the maximum number of partitions that will be refreshed by a TaskRun refresh
-    private int partitionRefreshNumber = Config.default_mv_partition_refresh_number;
+    private int partitionRefreshNumber = INVALID;
 
     // This property only applies to materialized views
     // It represents the mode selected to determine the number of partitions to refresh
-    private String partitionRefreshStrategy = Config.default_mv_partition_refresh_strategy;
+    private String partitionRefreshStrategy = "";
 
     // This property only applies to materialized views/
     // It represents the mode selected to determine how to refresh the materialized view
-    private String mvRefreshMode = Config.default_mv_refresh_mode;
+    private String mvRefreshMode = "";
 
     // This property only applies to materialized views
     // When using the system to automatically refresh, the maximum range of the most recent partitions will be refreshed.
@@ -994,12 +994,21 @@ public class TableProperty implements Writable, GsonPostProcessable {
         this.autoRefreshPartitionsLimit = autoRefreshPartitionsLimit;
     }
 
+    public boolean isSetPartitionRefreshNumber() {
+        return partitionRefreshNumber != INVALID;
+    }
+
     public int getPartitionRefreshNumber() {
-        return partitionRefreshNumber;
+        return partitionRefreshNumber == INVALID ? Config.default_mv_partition_refresh_number : partitionRefreshNumber;
+    }
+
+    public boolean isSetPartitionRefreshStrategy() {
+        return !Strings.isNullOrEmpty(partitionRefreshStrategy);
     }
 
     public String getPartitionRefreshStrategy() {
-        return partitionRefreshStrategy;
+        return Strings.isNullOrEmpty(partitionRefreshStrategy) ? Config.default_mv_partition_refresh_strategy
+                : partitionRefreshStrategy;
     }
 
     public void setPartitionRefreshNumber(int partitionRefreshNumber) {
@@ -1015,7 +1024,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
     }
 
     public String getMvRefreshMode() {
-        return mvRefreshMode;
+        return Strings.isNullOrEmpty(mvRefreshMode) ? Config.default_mv_refresh_mode : mvRefreshMode;
     }
 
     public void setResourceGroup(String resourceGroup) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3396,8 +3396,8 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "The default try lock timeout for mv refresh to try base table/mv dbs' lock")
     public static int mv_refresh_try_lock_timeout_ms = 30 * 1000;
 
-    @ConfField(mutable = true, comment = "materialized view can refresh at most 10 partition at a time")
-    public static int mv_max_partitions_num_per_refresh = 10;
+    @ConfField(mutable = true, comment = "materialized view can refresh at most 64 partition at a time")
+    public static int mv_max_partitions_num_per_refresh = 64;
 
     @ConfField(mutable = true, comment = "materialized view can refresh at most 100_000_000 rows of data at a time")
     public static long mv_max_rows_per_refresh = 100_000_000L;
@@ -3428,8 +3428,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int default_mv_partition_refresh_number = 1;
 
-    @ConfField(mutable = true)
-    public static String default_mv_partition_refresh_strategy = "strict";
+    @ConfField(mutable = true, comment = "The default refresh strategy for materialized view partition refresh, " +
+            "adaptive by default")
+    public static String default_mv_partition_refresh_strategy = "adaptive";
 
     @ConfField(mutable = true)
     public static String default_mv_refresh_mode = "pct";

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -222,6 +222,11 @@ public class TaskRun implements Comparable<TaskRun> {
         return Math.min(Math.min(defaultTimeoutS, Config.task_runs_ttl_second), Config.task_ttl_second);
     }
 
+    @VisibleForTesting
+    public void setStatus(TaskRunStatus status) {
+        this.status = status;
+    }
+
     public Map<String, String> refreshTaskProperties(ConnectContext ctx) {
         Map<String, String> newProperties = Maps.newHashMap();
         if (task.getSource() != Constants.TaskSource.MV) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -28,6 +28,7 @@ import com.starrocks.scheduler.history.TaskRunHistory;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.server.GlobalStateMgr;
+import org.apache.arrow.util.VisibleForTesting;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -58,6 +59,11 @@ public class TaskRunManager implements MemoryTrackable {
         this.taskRunScheduler = taskRunScheduler;
     }
 
+    public SubmitResult submitTaskRun(TaskRun taskRun) {
+        return submitTaskRun(taskRun, taskRun.getExecuteOption());
+    }
+
+    @VisibleForTesting
     public SubmitResult submitTaskRun(TaskRun taskRun, ExecuteOption option) {
         LOG.info("submit task run:{}", taskRun);
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -423,40 +423,40 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
     }
 
     @Override
-    public void filterPartitionByRefreshNumber(PCellSortedSet mvPartitionsToRefresh) {
-        filterPartitionByRefreshNumberInternal(mvPartitionsToRefresh, MaterializedView.PartitionRefreshStrategy.STRICT);
-    }
-
-    @Override
-    public void filterPartitionByAdaptiveRefreshNumber(PCellSortedSet mvPartitionsToRefresh) {
-        filterPartitionByRefreshNumberInternal(mvPartitionsToRefresh, MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
-    }
-
-    public void filterPartitionByRefreshNumberInternal(PCellSortedSet toRefreshPartitions,
-                                                       MaterializedView.PartitionRefreshStrategy refreshStrategy) {
-
+    public void filterPartitionByRefreshNumber(PCellSortedSet toRefreshPartitions,
+                                               MaterializedView.PartitionRefreshStrategy refreshStrategy) {
         // filter by partition ttl
         filterPartitionsByTTL(toRefreshPartitions, false);
         if (toRefreshPartitions == null || toRefreshPartitions.isEmpty()) {
             return;
         }
-
-        Iterator<PCellWithName> iterator = toRefreshPartitions.iterator();
+        // filter invalid cells from input
+        toRefreshPartitions.stream()
+                .filter(cell -> !mv.getListPartitionItems().containsKey(cell.name()))
+                .forEach(toRefreshPartitions::remove);
         // dynamically get the number of partitions to be refreshed this time
-        int refreshNumber = getRefreshNumberByMode(iterator, refreshStrategy);
-        if (toRefreshPartitions.size() <= refreshNumber) {
+        int partitionRefreshNumber = getPartitionRefreshNumberAdaptive(toRefreshPartitions, refreshStrategy);
+        if (partitionRefreshNumber <= 0 || partitionRefreshNumber >= toRefreshPartitions.size()) {
             return;
         }
-        // iterate refreshNumber times
-        Set<PListCell> nextPartitionValues = Sets.newHashSet();
         int i = 0;
-        while (iterator.hasNext() && i++ < refreshNumber) {
+        // refresh the recent partitions first
+        Iterator<PCellWithName> iterator = getToRefreshPartitionsIterator(toRefreshPartitions, false);
+        while (i++ < partitionRefreshNumber && iterator.hasNext()) {
+            PCellWithName pCell = iterator.next();
+            logger.debug("Materialized view [{}] to refresh partition name {}, value {}",
+                    mv.getName(), pCell.name(), pCell.cell());
+        }
+
+        // get next partition values for next refresh
+        Set<PListCell> nextPartitionValues = Sets.newHashSet();
+        while (iterator.hasNext()) {
             PCellWithName pCell = iterator.next();
             nextPartitionValues.add((PListCell) pCell.cell());
-            toRefreshPartitions.remove(pCell);
+            iterator.remove();
         }
         logger.info("Filter partitions by refresh number, ttl_number:{}, result:{}, remains:{}",
-                refreshNumber, toRefreshPartitions, nextPartitionValues);
+                partitionRefreshNumber, toRefreshPartitions, nextPartitionValues);
         if (CollectionUtils.isEmpty(nextPartitionValues)) {
             return;
         }
@@ -465,26 +465,6 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
             // will cause endPartitionName == null
             mvContext.setNextPartitionValues(PListCell.batchSerialize(nextPartitionValues));
         }
-    }
-
-    public int getAdaptivePartitionRefreshNumber(Iterator<PCellWithName> iterator) throws MVAdaptiveRefreshException {
-        Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
-        MVRefreshPartitionSelector mvRefreshPartitionSelector =
-                new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh,
-                        Config.mv_max_partitions_num_per_refresh, mvContext.getExternalRefBaseTableMVPartitionMap());
-        int adaptiveRefreshNumber = 0;
-        while (iterator.hasNext()) {
-            PCellWithName cellWithName = iterator.next();
-            String partitionName = cellWithName.name();
-            Map<Table, Set<String>> refPartitionInfos = mvToBaseNameRefs.get(partitionName);
-            if (mvRefreshPartitionSelector.canAddPartition(refPartitionInfos)) {
-                mvRefreshPartitionSelector.addPartition(refPartitionInfos);
-                adaptiveRefreshNumber++;
-            } else {
-                break;
-            }
-        }
-        return adaptiveRefreshNumber;
     }
 
     private void addListPartitions(Database database, MaterializedView materializedView,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
@@ -27,7 +27,6 @@ import com.starrocks.sql.common.PCellNone;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellWithName;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -94,18 +93,9 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     }
 
     @Override
-    public void filterPartitionByRefreshNumber(PCellSortedSet mvPartitionsToRefresh) {
+    public void filterPartitionByRefreshNumber(PCellSortedSet mvPartitionsToRefresh,
+                                               MaterializedView.PartitionRefreshStrategy partitionRefreshStrategy) {
         // do nothing
-    }
-
-    @Override
-    public void filterPartitionByAdaptiveRefreshNumber(PCellSortedSet mvPartitionsToRefresh) {
-        // do nothing
-    }
-
-    @Override
-    protected int getAdaptivePartitionRefreshNumber(Iterator<PCellWithName> partitionNameIter) throws MVAdaptiveRefreshException {
-        return 0;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -173,17 +173,13 @@ public abstract class MVPCTRefreshPartitioner {
     public abstract PCellSortedSet getMVPartitionNamesWithTTL(boolean isAutoRefresh) throws AnalysisException;
 
     /**
-     * Filter to refresh partitions by adaptive refresh number.
-     * @param mvPartitionsToRefresh: mv partitions to refresh.
-     */
-    public abstract void filterPartitionByAdaptiveRefreshNumber(PCellSortedSet mvPartitionsToRefresh);
-
-    /**
      * Filter to refresh partitions by partition refresh number.
      * @param partitionsToRefresh: partitions to refresh.
      */
     @VisibleForTesting
-    public abstract void filterPartitionByRefreshNumber(PCellSortedSet partitionsToRefresh);
+    public abstract void filterPartitionByRefreshNumber(
+            PCellSortedSet partitionsToRefresh,
+            MaterializedView.PartitionRefreshStrategy refreshStrategy);
 
     /**
      * Check whether to calculate the potential partitions to refresh or not. When the base table changed partitions
@@ -308,63 +304,27 @@ public abstract class MVPCTRefreshPartitioner {
         if (mvToRefreshedPartitions.isEmpty() || mvToRefreshedPartitions.size() <= 1) {
             return;
         }
+        // refresh all partition when it's a sync refresh, otherwise updated partitions may be lost.
+        ExecuteOption executeOption = mvContext.getExecuteOption();
+        if (executeOption != null && executeOption.getIsSync()) {
+            return;
+        }
+        // ignore if mv is not partitioned.
+        if (!mv.isPartitionedTable()) {
+            return;
+        }
 
         // filter partitions by partition refresh strategy
-        final MaterializedView.PartitionRefreshStrategy partitionRefreshStrategy = mv.getPartitionRefreshStrategy();
         boolean hasUnsupportedTableType = mv.getBaseTableTypes().stream()
                 .anyMatch(type -> !SUPPORTED_TABLE_TYPES_FOR_ADAPTIVE_MV_REFRESH.contains(type));
         if (hasUnsupportedTableType) {
-            logger.warn("Materialized view {} contains unsupported external tables. Using default refresh strategy.",
-                    mv.getId());
-            filterPartitionWithStrict(mvToRefreshedPartitions);
+            filterPartitionByRefreshNumber(mvToRefreshedPartitions, MaterializedView.PartitionRefreshStrategy.STRICT);
         } else {
-            switch (partitionRefreshStrategy) {
-                case ADAPTIVE:
-                    filterPartitionWithAdaptive(mvToRefreshedPartitions);
-                    break;
-                case STRICT:
-                default:
-                    // Only refresh the first partition refresh number partitions, other partitions will generate new tasks
-                    filterPartitionWithStrict(mvToRefreshedPartitions);
-            }
+            MaterializedView.PartitionRefreshStrategy partitionRefreshStrategy = mv.getPartitionRefreshStrategy();
+            filterPartitionByRefreshNumber(mvToRefreshedPartitions, partitionRefreshStrategy);
         }
         logger.info("after filterPartitionByAdaptive, partitionsToRefresh: {}",
                 mvToRefreshedPartitions);
-    }
-
-    public void filterPartitionWithStrict(PCellSortedSet partitionsToRefresh) {
-        // refresh all partition when it's a sync refresh, otherwise updated partitions may be lost.
-        ExecuteOption executeOption = mvContext.getExecuteOption();
-        if (executeOption != null && executeOption.getIsSync()) {
-            return;
-        }
-        // ignore if mv is not partitioned.
-        if (!mv.isPartitionedTable()) {
-            return;
-        }
-        // ignore if partition_fresh_limit is not set
-        int partitionRefreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
-        if (partitionRefreshNumber <= 0) {
-            return;
-        }
-
-        // do filter actions
-        filterPartitionByRefreshNumber(partitionsToRefresh);
-    }
-
-    public void filterPartitionWithAdaptive(PCellSortedSet partitionsToRefresh) {
-        // refresh all partition when it's a sync refresh, otherwise updated partitions may be lost.
-        ExecuteOption executeOption = mvContext.getExecuteOption();
-        if (executeOption != null && executeOption.getIsSync()) {
-            return;
-        }
-        // ignore if mv is not partitioned.
-        if (!mv.isPartitionedTable()) {
-            return;
-        }
-
-        // do filter actions
-        filterPartitionByAdaptiveRefreshNumber(partitionsToRefresh);
     }
 
     /**
@@ -386,29 +346,86 @@ public abstract class MVPCTRefreshPartitioner {
      * may fail due to missing or invalid metadata. In such cases, the method automatically
      * falls back to the STRICT strategy to ensure the MV can still be refreshed correctly.
      *
-     * @param sortedPartitionIterator Iterator over sorted partition names to be refreshed.
-     * @param refreshStrategy         The refresh strategy: either ADAPTIVE or STRICT.
+     * @param toRefreshPartitions sorted partition names to be refreshed.
+     * @param refreshStrategy     The refresh strategy: either ADAPTIVE or STRICT.
      * @return The number of partitions to refresh.
      */
-    public int getRefreshNumberByMode(Iterator<PCellWithName> sortedPartitionIterator,
-                                      MaterializedView.PartitionRefreshStrategy refreshStrategy) {
+    public int getPartitionRefreshNumberAdaptive(PCellSortedSet toRefreshPartitions,
+                                                 MaterializedView.PartitionRefreshStrategy refreshStrategy) {
         try {
             switch (refreshStrategy) {
                 case ADAPTIVE:
-                    return getAdaptivePartitionRefreshNumber(sortedPartitionIterator);
+                    return getAdaptivePartitionRefreshNumber(toRefreshPartitions);
                 case STRICT:
                 default:
-                    return mv.getTableProperty().getPartitionRefreshNumber();
+                    return getRefreshNumberByDefaultMode(toRefreshPartitions);
             }
-        } catch (MVAdaptiveRefreshException e) {
+        } catch (Exception e) {
             logger.warn("Adaptive refresh failed for mode '{}', falling back to STRICT mode. Reason: {}",
                     refreshStrategy, e.getMessage(), e);
-            return mv.getTableProperty().getPartitionRefreshNumber();
+            return getRefreshNumberByDefaultMode(toRefreshPartitions);
         }
     }
 
-    protected abstract int getAdaptivePartitionRefreshNumber(Iterator<PCellWithName> partitionNameIter)
-            throws MVAdaptiveRefreshException;
+    /**
+     * Get partition refresh number by default mode, which is used to be compatible with old versions and the following
+     * conditions are met:
+     * - partition_refresh_strategy is not set strict by user
+     * - partition_refresh_number is not set by user
+     */
+    private int getRefreshNumberByDefaultMode(PCellSortedSet torRefreshPartitions) {
+        int defaultPartitionRefreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
+        TableProperty tableProperty = mv.getTableProperty();
+        // if user has set partition_refresh_number, use it directly
+        if (tableProperty == null || tableProperty.isSetPartitionRefreshNumber()
+                || defaultPartitionRefreshNumber != Config.default_mv_partition_refresh_number) {
+            return defaultPartitionRefreshNumber;
+        }
+        MaterializedView.PartitionRefreshStrategy partitionRefreshStrategy =
+                MaterializedView.PartitionRefreshStrategy.of(tableProperty.getPartitionRefreshStrategy());
+        // if partition_refresh_strategy is strict, use partition_refresh_number directly
+        if (tableProperty.isSetPartitionRefreshStrategy()
+                && MaterializedView.PartitionRefreshStrategy.STRICT.equals(partitionRefreshStrategy)) {
+            return defaultPartitionRefreshNumber;
+        }
+        // if the number of partitions to refresh is not too many, use it directly
+        int toRefreshPartitionNum = torRefreshPartitions.size();
+        if (toRefreshPartitionNum <= Config.mv_max_partitions_num_per_refresh) {
+            return defaultPartitionRefreshNumber;
+        }
+        // to be compatible with old version, use adaptive mode if partition_refresh_strategy is not set
+        int toRefreshPartitionNumPerTaskRun =
+                (int) Math.ceil((double) toRefreshPartitionNum / Math.max(1, Config.task_runs_concurrency));
+
+        // if there are too many partitions to refresh, limit the number of partitions to refresh per task run
+        int finalToRefreshPartitionNumPerTaskRun = Math.min(toRefreshPartitionNumPerTaskRun,
+                Config.mv_max_partitions_num_per_refresh);
+        return finalToRefreshPartitionNumPerTaskRun;
+    }
+
+    public int getAdaptivePartitionRefreshNumber(PCellSortedSet toRefreshPartitions)
+            throws MVAdaptiveRefreshException {
+        if (!mv.isPartitionedTable()) {
+            return toRefreshPartitions.size();
+        }
+
+        Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
+        MVRefreshPartitionSelector mvRefreshPartitionSelector =
+                new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh,
+                        Config.mv_max_partitions_num_per_refresh, mvContext.getExternalRefBaseTableMVPartitionMap());
+        int adaptiveRefreshNumber = 0;
+        for (PCellWithName pCellWithName : toRefreshPartitions.partitions()) {
+            String mvRefreshPartition = pCellWithName.name();
+            Map<Table, Set<String>> refBaseTablesPartitions = mvToBaseNameRefs.get(mvRefreshPartition);
+            if (mvRefreshPartitionSelector.canAddPartition(refBaseTablesPartitions)) {
+                mvRefreshPartitionSelector.addPartition(refBaseTablesPartitions);
+                adaptiveRefreshNumber++;
+            } else {
+                break;
+            }
+        }
+        return adaptiveRefreshNumber;
+    }
 
     /**
      * Check whether the base table is supported partition refresh or not.
@@ -657,7 +674,9 @@ public abstract class MVPCTRefreshPartitioner {
                 getExpiredPartitionsWithRetention(ttlCondition, toRefreshPartitionMap, isMockPartitionIds);
         if (CollectionUtils.isNotEmpty(toRemovePartitions)) {
             toRemovePartitions.stream()
-                    .forEach(p -> toRefreshPartitions.remove(PCellWithName.of(p, toRefreshPartitionMap.get(p))));
+                    .filter(p -> toRefreshPartitionMap.containsKey(p))
+                    .map(p -> PCellWithName.of(p, toRefreshPartitionMap.get(p)))
+                    .forEach(toRefreshPartitions::remove);
         }
     }
 
@@ -722,4 +741,15 @@ public abstract class MVPCTRefreshPartitioner {
         return result;
     }
 
+    /**
+     * Get the iterator of to refresh partitions according to config.
+     */
+    public Iterator<PCellWithName> getToRefreshPartitionsIterator(PCellSortedSet toRefreshPartitions,
+                                                                  boolean isAscending) {
+        if (isAscending) {
+            return toRefreshPartitions.iterator();
+        } else {
+            return toRefreshPartitions.descendingIterator();
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -64,7 +64,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -413,51 +412,33 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
     }
 
     @Override
-    public void filterPartitionByRefreshNumber(PCellSortedSet mvPartitionsToRefresh) {
-        filterPartitionByRefreshNumberInternal(mvPartitionsToRefresh,
-                MaterializedView.PartitionRefreshStrategy.STRICT);
-    }
-
-    @Override
-    public void filterPartitionByAdaptiveRefreshNumber(PCellSortedSet mvPartitionsToRefresh) {
-        filterPartitionByRefreshNumberInternal(mvPartitionsToRefresh, MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
-    }
-
-    public void filterPartitionByRefreshNumberInternal(PCellSortedSet mvPartitionsToRefresh,
-                                                       MaterializedView.PartitionRefreshStrategy refreshStrategy) {
+    public void filterPartitionByRefreshNumber(PCellSortedSet mvPartitionsToRefresh,
+                                               MaterializedView.PartitionRefreshStrategy refreshStrategy) {
         int partitionRefreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
         Map<String, Range<PartitionKey>> mvRangePartitionMap = mv.getRangePartitionMap();
         if (partitionRefreshNumber <= 0 || partitionRefreshNumber >= mvRangePartitionMap.size()) {
             return;
         }
 
-        Iterator<PCellWithName> inputIter = mvPartitionsToRefresh.iterator();
-        while (inputIter.hasNext()) {
-            PCellWithName pCellWithName = inputIter.next();
-            String mvPartitionName = pCellWithName.name();
-            // skip if partition is not in the mv's partition range map
-            if (!mvRangePartitionMap.containsKey(mvPartitionName)) {
-                logger.warn("Partition {} is not in the materialized view's partition range map, " +
-                        "remove it from refresh list", mvPartitionName);
-                mvPartitionsToRefresh.remove(pCellWithName);
-            }
+        // remove invalid cells from the input to-refresh partitions
+        mvPartitionsToRefresh
+                .stream()
+                .filter(pCell -> !mvRangePartitionMap.containsKey(pCell.name()))
+                .forEach(mvPartitionsToRefresh::remove);
+
+        Iterator<PCellWithName> iterator = getToRefreshPartitionsIterator(mvPartitionsToRefresh,
+                Config.materialized_view_refresh_ascending);
+        // dynamically get the number of partitions to be refreshed this time
+        partitionRefreshNumber = getPartitionRefreshNumberAdaptive(mvPartitionsToRefresh, refreshStrategy);
+        if (partitionRefreshNumber <= 0 || mvPartitionsToRefresh.size() <= partitionRefreshNumber) {
+            return;
         }
 
-        LinkedList<PCellWithName> sortedPartition = mvPartitionsToRefresh
-                .stream()
-                .collect(Collectors.toCollection(LinkedList::new));
-        Iterator<PCellWithName> sortedIterator = Config.materialized_view_refresh_ascending
-                ? sortedPartition.iterator() : sortedPartition.descendingIterator();
-        // dynamically get the number of partitions to be refreshed this time
-        partitionRefreshNumber = getRefreshNumberByMode(sortedIterator, refreshStrategy);
-
-        PCellWithName tmpPCellWithName = null;
-        for (int i = 0; i < partitionRefreshNumber; i++) {
-            if (sortedIterator.hasNext()) {
-                tmpPCellWithName = sortedIterator.next();
-                sortedIterator.remove();
-            }
-
+        int i = 0;
+        while (i++ < partitionRefreshNumber && iterator.hasNext()) {
+            PCellWithName pCell = iterator.next();
+            logger.debug("Materialized view [{}] to refresh partition name {}, value {}",
+                    mv.getName(), pCell.name(), pCell.cell());
             // NOTE: if mv's need to refresh partitions in the many-to-many mappings, no need to filter to
             // avoid data lose.
             // eg:
@@ -477,41 +458,11 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
             // BTW, since the refresh has already scanned the needed base tables' data, it's better to update
             // more mv's partitions as more as possible.
             // TODO: But it may cause much memory to refresh many partitions, support fine-grained partition refresh later.
-            if (!mvToRefreshPotentialPartitions.isEmpty() && mvToRefreshPotentialPartitions.contains(tmpPCellWithName.name())) {
+            if (!mvToRefreshPotentialPartitions.isEmpty() && mvToRefreshPotentialPartitions.contains(pCell.name())) {
                 return;
             }
         }
-        if (!Config.materialized_view_refresh_ascending) {
-            sortedIterator = sortedPartition.iterator();
-        }
-        setNextPartitionStartAndEnd(mvPartitionsToRefresh, sortedIterator);
-    }
 
-    public int getAdaptivePartitionRefreshNumber(
-            Iterator<PCellWithName> iterator) throws MVAdaptiveRefreshException {
-        Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
-        MVRefreshPartitionSelector mvRefreshPartitionSelector =
-                new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh,
-                        Config.mv_max_partitions_num_per_refresh, mvContext.getExternalRefBaseTableMVPartitionMap());
-
-        int adaptiveRefreshNumber = 0;
-        while (iterator.hasNext()) {
-            PCellWithName pCellWithName = iterator.next();
-            String mvRefreshPartition = pCellWithName.name();
-            Map<Table, Set<String>> refBaseTablesPartitions = mvToBaseNameRefs.get(mvRefreshPartition);
-            if (mvRefreshPartitionSelector.canAddPartition(refBaseTablesPartitions)) {
-                mvRefreshPartitionSelector.addPartition(refBaseTablesPartitions);
-                iterator.remove();
-                adaptiveRefreshNumber++;
-            } else {
-                break;
-            }
-        }
-        return adaptiveRefreshNumber;
-    }
-
-    private void setNextPartitionStartAndEnd(PCellSortedSet partitionsToRefresh,
-                                             Iterator<PCellWithName> iterator) {
         String nextPartitionStart = null;
         PCellWithName end = null;
         if (iterator.hasNext()) {
@@ -520,12 +471,11 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
             Range<PartitionKey> partitionKeyRange = pRangeCell.getRange();
             nextPartitionStart = AnalyzerUtils.parseLiteralExprToDateString(partitionKeyRange.lowerEndpoint(), 0);
             end = start;
-            partitionsToRefresh.remove(end);
+            iterator.remove();
         }
         while (iterator.hasNext()) {
             end = iterator.next();
             iterator.remove();
-            partitionsToRefresh.remove(end);
         }
 
         if (!mvRefreshParams.isTentative()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellSortedSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellSortedSet.java
@@ -19,6 +19,7 @@ import com.starrocks.common.Config;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
@@ -90,6 +91,10 @@ public record PCellSortedSet(SortedSet<PCellWithName> partitions) {
 
     public void forEach(Consumer<? super PCellWithName> action) {
         partitions.forEach(action);
+    }
+
+    public Iterator<PCellWithName> descendingIterator() {
+        return ((NavigableSet<PCellWithName>) partitions).descendingIterator();
     }
 
     public Iterator<PCellWithName> iterator() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PRangeCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PRangeCell.java
@@ -117,9 +117,14 @@ public final class PRangeCell extends PCell {
 
     @Override
     public String toString() {
-        return "PRangeCell{" +
-                "range=" + range +
-                '}';
+        return "[%s-%s]".formatted(toString(range.lowerEndpoint()), toString(range.upperEndpoint()));
+    }
+
+    private String toString(PartitionKey partitionKey) {
+        if (partitionKey == null) {
+            return "null";
+        }
+        return partitionKey.toSql();
     }
 
     public static Map<String, Range<PartitionKey>> toRangeMap(Map<String, PCell> input) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -1221,8 +1221,6 @@ public class MaterializedViewTest extends StarRocksTestBase {
 
     @Test
     public void testPartitionRefreshStrategy() {
-        Assertions.assertEquals(MaterializedView.PartitionRefreshStrategy.defaultValue(),
-                MaterializedView.PartitionRefreshStrategy.valueOf("STRICT"));
         String sql = "create materialized view test_mv1 " +
                 "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
                 "REFRESH MANUAL\n" +
@@ -1236,7 +1234,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
             MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
                     .getTable(db.getFullName(), "test_mv1"));
-            Assertions.assertEquals(mv.getPartitionRefreshStrategy(), MaterializedView.PartitionRefreshStrategy.STRICT);
+            Assertions.assertEquals(mv.getPartitionRefreshStrategy(), MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
         });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheAndMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheAndMVTest.java
@@ -177,8 +177,7 @@ public class QueryCacheAndMVTest extends MVTestBase {
                         "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
                         "REFRESH DEFERRED MANUAL\n" +
                         "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"storage_medium\" = \"HDD\"\n" +
+                        "\"replication_num\" = \"1\"" +
                         ")\n" +
                         "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_year` as a;");
         Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -988,7 +988,8 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
         PCellSortedSet mvToRefreshPartitionNames = getMVPCellWithNames(mv, mv.getPartitionNames());
-        partitioner.filterPartitionByAdaptiveRefreshNumber(mvToRefreshPartitionNames);
+        partitioner.filterPartitionByRefreshNumber(mvToRefreshPartitionNames,
+                MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
         MvTaskRunContext mvContext = processor.getMvContext();
         Assertions.assertNull(mvContext.getNextPartitionStart());
         Assertions.assertNull(mvContext.getNextPartitionEnd());
@@ -1018,7 +1019,8 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
         MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
-        partitioner.filterPartitionByAdaptiveRefreshNumber(getMVPCellWithNames(mv, mv.getPartitionNames()));
+        partitioner.filterPartitionByRefreshNumber(getMVPCellWithNames(mv, mv.getPartitionNames()),
+                MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
         MvTaskRunContext mvContext = processor.getMvContext();
         Assertions.assertNull(mvContext.getNextPartitionStart());
         Assertions.assertNull(mvContext.getNextPartitionEnd());
@@ -1061,7 +1063,8 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
         MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
-        partitioner.filterPartitionByAdaptiveRefreshNumber(getMVPCellWithNames(mv, mv.getPartitionNames()));
+        partitioner.filterPartitionByRefreshNumber(getMVPCellWithNames(mv, mv.getPartitionNames()),
+                MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
         MvTaskRunContext mvContext = processor.getMvContext();
         Assertions.assertNull(mvContext.getNextPartitionStart());
         Assertions.assertNull(mvContext.getNextPartitionEnd());
@@ -1120,19 +1123,22 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
             // round 1
             PCellSortedSet toRefresh = getMVPCellWithNames(mv, allPartitions);
-            partitioner.filterPartitionByRefreshNumber(toRefresh);
+            partitioner.filterPartitionByRefreshNumber(toRefresh,
+                    MaterializedView.PartitionRefreshStrategy.STRICT);
             assertPCellNameEquals("p0", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
 
             // round 2
             toRefresh = getMVPCellWithNames(mv, SetUtils.disjunction(allPartitions, refreshedPartitions));
-            partitioner.filterPartitionByRefreshNumber(toRefresh);
+            partitioner.filterPartitionByRefreshNumber(toRefresh,
+                    MaterializedView.PartitionRefreshStrategy.STRICT);
             assertPCellNameEquals("p1", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
 
             // round 3
             toRefresh = getMVPCellWithNames(mv, SetUtils.disjunction(allPartitions, refreshedPartitions));
-            partitioner.filterPartitionByRefreshNumber(toRefresh);
+            partitioner.filterPartitionByRefreshNumber(toRefresh,
+                    MaterializedView.PartitionRefreshStrategy.STRICT);
             assertPCellNameEquals("p2", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
         }
@@ -1144,31 +1150,36 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
             // round 1
             PCellSortedSet toRefresh = getMVPCellWithNames(mv, allPartitions);
-            partitioner.filterPartitionByRefreshNumber(toRefresh);
+            partitioner.filterPartitionByRefreshNumber(toRefresh,
+                    MaterializedView.PartitionRefreshStrategy.STRICT);
             assertPCellNameEquals("p4", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
 
             // round 2
             toRefresh = getMVPCellWithNames(mv, SetUtils.disjunction(allPartitions, refreshedPartitions));
-            partitioner.filterPartitionByRefreshNumber(toRefresh);
+            partitioner.filterPartitionByRefreshNumber(toRefresh,
+                    MaterializedView.PartitionRefreshStrategy.STRICT);
             assertPCellNameEquals("p3", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
 
             // round 3
             toRefresh = getMVPCellWithNames(mv, SetUtils.disjunction(allPartitions, refreshedPartitions));
-            partitioner.filterPartitionByRefreshNumber(toRefresh);
+            partitioner.filterPartitionByRefreshNumber(toRefresh,
+                    MaterializedView.PartitionRefreshStrategy.STRICT);
             assertPCellNameEquals("p2", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
 
             // round 4
             toRefresh = getMVPCellWithNames(mv, SetUtils.disjunction(allPartitions, refreshedPartitions));
-            partitioner.filterPartitionByRefreshNumber(toRefresh);
+            partitioner.filterPartitionByRefreshNumber(toRefresh,
+                    MaterializedView.PartitionRefreshStrategy.STRICT);
             assertPCellNameEquals("p1", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
 
             // round 5
             toRefresh = getMVPCellWithNames(mv, SetUtils.disjunction(allPartitions, refreshedPartitions));
-            partitioner.filterPartitionByRefreshNumber(toRefresh);
+            partitioner.filterPartitionByRefreshNumber(toRefresh,
+                    MaterializedView.PartitionRefreshStrategy.STRICT);
             assertPCellNameEquals("p0", toRefresh);
             refreshedPartitions.addAll(getPartitionNames(toRefresh));
             Config.materialized_view_refresh_ascending = true;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitionerTest.java
@@ -18,13 +18,10 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRunContext;
-import com.starrocks.sql.common.PCellWithName;
+import com.starrocks.sql.common.PCellSortedSet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
-import java.util.Collections;
-import java.util.Iterator;
 
 public class MVPCTRefreshNonPartitionerTest {
 
@@ -37,8 +34,7 @@ public class MVPCTRefreshNonPartitionerTest {
         MVRefreshParams mvRefreshParams = Mockito.mock(MVRefreshParams.class);
         MVPCTRefreshNonPartitioner job = new MVPCTRefreshNonPartitioner(mvTaskRunContext, taskRunContext,
                 database, mv, mvRefreshParams);
-        Iterator<PCellWithName> dummyIter = Collections.emptyIterator();
-        int result = job.getAdaptivePartitionRefreshNumber(dummyIter);
+        int result = job.getAdaptivePartitionRefreshNumber(PCellSortedSet.of());
         Assertions.assertEquals(0, result);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
@@ -31,7 +31,6 @@ import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -47,6 +46,7 @@ public class MVPCTRefreshRangePartitionerTest {
         MaterializedView mv = mock(MaterializedView.class);
         when(mv.getTableProperty()).thenReturn(mock(TableProperty.class));
         when(mv.getPartitionInfo()).thenReturn(mock(PartitionInfo.class));
+        when(mv.isPartitionedTable()).thenReturn(true);
 
         OlapTable refTable1 = Mockito.mock(OlapTable.class);
         Set<String> refTablePartition1 = Set.of("partition1", "partition2");
@@ -67,12 +67,11 @@ public class MVPCTRefreshRangePartitionerTest {
         // TODO: make range cells
         List<PCellWithName> partitions = Arrays.asList(PCellWithName.of("mv_p1", new PCellNone()),
                 PCellWithName.of("mv_p2", new PCellNone()));
-        Iterator<PCellWithName> iter = partitions.iterator();
         MVRefreshParams mvRefreshParams = new MVRefreshParams(mv, new HashMap<>());
         MVPCTRefreshRangePartitioner partitioner = new MVPCTRefreshRangePartitioner(mvContext, null,
                 null, mv, mvRefreshParams);
         MVAdaptiveRefreshException exception = Assertions.assertThrows(MVAdaptiveRefreshException.class,
-                () -> partitioner.getAdaptivePartitionRefreshNumber(iter));
+                () -> partitioner.getAdaptivePartitionRefreshNumber(PCellSortedSet.of(partitions)));
         Assertions.assertTrue(exception.getMessage().contains("Missing too many partition stats"));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -38,14 +38,17 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.MVTaskRunProcessor;
 import com.starrocks.scheduler.MvTaskRunContext;
+import com.starrocks.scheduler.SubmitResult;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.TaskRunBuilder;
+import com.starrocks.scheduler.TaskRunManager;
 import com.starrocks.scheduler.TaskRunProcessor;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.scheduler.mv.MVPCTBasedRefreshProcessor;
@@ -101,6 +104,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -453,6 +457,17 @@ public abstract class MVTestBase extends StarRocksTestBase {
         MvTaskRunContext mvTaskRunContext = mvTaskRunProcessor.getMvTaskRunContext();
         ExecPlan result = mvTaskRunContext.getExecPlan();
         return result;
+    }
+
+    protected static void executeTaskRun(TaskRun taskRun) throws Exception {
+        // ensure taskRun is initialized
+        taskRun.setStatus(null);
+        TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
+        TaskRunManager taskRunManager = taskManager.getTaskRunManager();
+        SubmitResult result = taskRunManager.submitTaskRun(taskRun);
+        Assertions.assertTrue(result.getStatus().equals(SubmitResult.SubmitStatus.SUBMITTED));
+        Constants.TaskRunState state = result.getFuture().get(300000, TimeUnit.MILLISECONDS);
+        Assertions.assertTrue(state.isFinishState());
     }
 
     protected static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {


### PR DESCRIPTION
## Why I'm doing:

Currently If there are too many partitions to refresh once it will generate huge task runs which each task run means triggering one `insert` DML queries since `default_mv_partition_refresh_number` is 1, this can cause unstable load for the cluster.


## What I'm doing:
This pull request updates the materialized view (MV) partition refresh logic to make the refresh strategy more adaptive by default and refactors how partition refresh properties are handled. The changes improve configuration flexibility, simplify the refresh strategy selection, and streamline related code paths.

**Materialized View Partition Refresh Strategy and Property Handling**

* The default partition refresh strategy for materialized views is changed from `STRICT` to `ADAPTIVE`, and the code now uses a new method (`of`) to parse and select the strategy, falling back to the default if parsing fails. [[1]](diffhunk://#diff-30af13c1a1cdd2dcedc3200a0a9a3497645f60a2a173ec4b2ca17217af93afb0L162-R171) [[2]](diffhunk://#diff-c4dd949472990c944bb229f17a8fda3b329551819852735b5a7d7ae75aab1e18L3428-R3430)
* The logic in `MaterializedView#getPartitionRefreshStrategy` is refactored to better prioritize property settings: if the `partition_refresh_strategy` is set and not `STRICT`, it is used; otherwise, if `partition_refresh_number` is set and not equal to 1, `STRICT` is used for compatibility; if neither is set, the default strategy is used.
* Table property fields (`partitionRefreshNumber`, `partitionRefreshStrategy`, `mvRefreshMode`) are now initialized to invalid/empty values instead of config defaults, and new helper methods (`isSetPartitionRefreshNumber`, `isSetPartitionRefreshStrategy`) are added to check if these properties are explicitly set. Getter methods now return config defaults if unset. [[1]](diffhunk://#diff-52d5477d33c44a0027256c5ecb673a76d7ee203626a4d2ae0126530827fe8389L212-R220) [[2]](diffhunk://#diff-52d5477d33c44a0027256c5ecb673a76d7ee203626a4d2ae0126530827fe8389R997-R1011) [[3]](diffhunk://#diff-52d5477d33c44a0027256c5ecb673a76d7ee203626a4d2ae0126530827fe8389L1018-R1027)

**Partition Refresh Filtering Refactor**

* The partition filtering logic in MV refresh partitioners is refactored: filtering is now always done through a single method that takes the refresh strategy as a parameter, removing redundant methods and simplifying the interface. [[1]](diffhunk://#diff-67454435c6e6bc9eb09da43d9cbff7e13b5a2ccb16c668fcaa794346e936904eL426-R459) [[2]](diffhunk://#diff-24e54326260fccb6af7224a54dcf37303e568085ddf62b1a5e0007d7f1db7468L97-L110) [[3]](diffhunk://#diff-27a9cc3819ae1dd6c244e4fe868ffb12d179c6ac8cb77ce96ea93ad7ad06b3bcL175-R182)
* The strict/adaptive filtering logic is consolidated, and the code now checks for unsupported table types and applies the `STRICT` strategy as needed; otherwise, it uses the configured or default strategy. [[1]](diffhunk://#diff-27a9cc3819ae1dd6c244e4fe868ffb12d179c6ac8cb77ce96ea93ad7ad06b3bcL311-L335) [[2]](diffhunk://#diff-27a9cc3819ae1dd6c244e4fe868ffb12d179c6ac8cb77ce96ea93ad7ad06b3bcL345-R327)

**Configuration Changes**

* The maximum number of partitions that can be refreshed at once is increased from 10 to 64, and the default refresh strategy in the config is updated to `"adaptive"`. [[1]](diffhunk://#diff-c4dd949472990c944bb229f17a8fda3b329551819852735b5a7d7ae75aab1e18L3396-R3397) [[2]](diffhunk://#diff-c4dd949472990c944bb229f17a8fda3b329551819852735b5a7d7ae75aab1e18L3428-R3430)


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
