### PR TITLE
[BugFix] Fix shutdown tablet can not gc

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -447,6 +447,7 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, TabletDropFlag flag) {
             // to 'RUNNING' from 'SHUTDOWN'.
             std::unique_lock l(dropped_tablet->get_header_lock());
             (void)dropped_tablet->set_tablet_state(TABLET_SHUTDOWN);
+            dropped_tablet->save_meta();
         }
 
         // just try to remove the tablet meta. if failed, it will be removed in sweep_shutdown_tablet


### PR DESCRIPTION
## Why I'm doing:
When dropping a tablet with kDeleteFiles flag, the tablet state was set to TABLET_SHUTDOWN in memory but not persisted to RocksDB storage. This caused a critical issue during garbage collection:
1. Memory vs Storage State Mismatch: The tablet state was only updated in memory (set_tablet_state(TABLET_SHUTDOWN)) but not saved to persistent storage
2. GC Failure: During sweep_shutdown_tablet(), the GC process reads the tablet state from RocksDB storage via TabletMetaManager::get_tablet_meta()
3. State Check Failure: The GC found the tablet state as TABLET_RUNNING in storage (not TABLET_SHUTDOWN), causing the GC to skip tablet removal with the error: "Cannot remove normal state tablet"

## What I'm doing:
Added `dropped_tablet->save_meta()` call immediately after setting the tablet state to TABLET_SHUTDOWN to ensure the state change is persisted to RocksDB storage.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
