### PR TITLE
[BugFix] Fix the thread safety issue caused by concurrent initialization of column evaluator by multiple iceberg partition writers.

### DIFF
--- a/be/src/connector/partition_chunk_writer.cpp
+++ b/be/src/connector/partition_chunk_writer.cpp
@@ -73,10 +73,10 @@ Status BufferPartitionChunkWriter::init() {
 }
 
 Status BufferPartitionChunkWriter::write(Chunk* chunk) {
-    RETURN_IF_ERROR(create_file_writer_if_needed());
-    if (_file_writer->get_written_bytes() >= _max_file_size) {
+    if (_file_writer && _file_writer->get_written_bytes() >= _max_file_size) {
         commit_file();
     }
+    RETURN_IF_ERROR(create_file_writer_if_needed());
     return _file_writer->write(chunk);
 }
 
@@ -120,9 +120,6 @@ Status SpillPartitionChunkWriter::init() {
     RETURN_IF_ERROR(_load_spill_block_mgr->init());
     _load_chunk_spiller = std::make_unique<LoadChunkSpiller>(_load_spill_block_mgr.get(),
                                                              _fragment_context->runtime_state()->runtime_profile());
-    if (_column_evaluators) {
-        RETURN_IF_ERROR(ColumnEvaluator::init(*_column_evaluators));
-    }
     return Status::OK();
 }
 


### PR DESCRIPTION
## Why I'm doing:
Now we initialize the column evaluator in the partition writer, which cause the same evaluator instance may be modified by different threads.

## What I'm doing:
Remove the unnecessary evaluator initialization in the iceberg partition writer because it has been initialized in partition chunk writer factory.

Also, we check the file writer and create it if needed before writing file data, because it may has been reset by the previous commit operation.

Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/10333)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
