### PR TITLE
[BugFix] avoid crash when submit apply task fail

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -951,6 +951,7 @@ void TabletUpdates::_check_for_apply() {
         std::lock_guard<std::mutex> lg(_apply_running_lock);
         // reset _apply_running to false, so that next time _check_for_apply can submit task again
         _apply_running = false;
+        _apply_stopped_cond.notify_all();
     }
 }
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -948,6 +948,8 @@ void TabletUpdates::_check_for_apply() {
     if (!st.ok()) {
         LOG(ERROR) << strings::Substitute("submit apply task failed: $0 $1", st.to_string(),
                                           _debug_string(false, false));
+        auto time_point = std::chrono::steady_clock::now() + std::chrono::seconds(config::retry_apply_interval_second);
+        StorageEngine::instance()->add_schedule_apply_task(_tablet.tablet_id(), time_point);
         std::lock_guard<std::mutex> lg(_apply_running_lock);
         // reset _apply_running to false, so that next time _check_for_apply can submit task again
         _apply_running = false;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -394,6 +394,35 @@ TEST_F(TabletUpdatesTest, writeread_with_persistent_index) {
     test_writeread(true);
 }
 
+TEST_F(TabletUpdatesTest, submit_apply_task_fail) {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    _tablet->set_enable_persistent_index(true);
+    // init fail point
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+    // write
+    const int N = 8000;
+    std::vector<int64_t> keys;
+    for (int i = 0; i < N; i++) {
+        keys.push_back(i);
+    }
+    auto rs0 = create_rowset(_tablet, keys);
+    ASSERT_TRUE(_tablet->rowset_commit(2, rs0).ok());
+    ASSERT_EQ(2, _tablet->updates()->max_version());
+
+    auto rs1 = create_rowset(_tablet, keys);
+    ASSERT_TRUE(_tablet->rowset_commit(3, rs1).ok());
+    ASSERT_EQ(3, _tablet->updates()->max_version());
+    auto rs2 = create_rowset(_tablet, keys, nullptr, true);
+    ASSERT_TRUE(_tablet->rowset_commit(4, rs2).ok());
+    ASSERT_EQ(4, _tablet->updates()->max_version());
+}
+
 TEST_F(TabletUpdatesTest, test_pk_index_write_amp_score) {
     srand(GetCurrentTimeMicros());
     _tablet = create_tablet(rand(), rand());


### PR DESCRIPTION
## Why I'm doing:
The failure of submitting an apply task may be expected, and it can be resolved by retrying the submission. There is no need to print a fatal error or crash.

## What I'm doing:
This pull request improves error handling in the `TabletUpdates::_check_for_apply()` method. Instead of terminating the process when submitting an apply task fails, it now logs the error and resets the `_apply_running` flag to allow future retries.

Error handling improvements:

* Changed the log level from `FATAL` to `ERROR` when apply task submission fails, preventing process termination.
* Added logic to reset `_apply_running` to `false` under a lock when submission fails, enabling subsequent attempts to submit the task.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
