### PR TITLE
[Refactor] Refactor USE CATALOG, SET CATALOG, and DROP CATALOG statements to sql-parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
@@ -36,10 +36,6 @@ import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.isResourceM
 import static com.starrocks.sql.ast.CreateCatalogStmt.TYPE;
 
 public class CatalogAnalyzer {
-    private static final String CATALOG = "CATALOG";
-
-    private static final String WHITESPACE = "\\s+";
-
     private static final Set<String> NOT_SUPPORT_ALTER_PROPERTIES = Sets.newHashSet(
             "type"
     );
@@ -99,18 +95,7 @@ public class CatalogAnalyzer {
 
         @Override
         public Void visitUseCatalogStatement(UseCatalogStmt statement, ConnectContext context) {
-            if (Strings.isNullOrEmpty(statement.getCatalogParts())) {
-                throw new SemanticException("You have an error in your SQL. The correct syntax is: USE 'CATALOG catalog_name'.");
-            }
-
-            String[] splitParts = statement.getCatalogParts().split(WHITESPACE);
-            if (!splitParts[0].equalsIgnoreCase(CATALOG) || splitParts.length != 2) {
-                throw new SemanticException("You have an error in your SQL. The correct syntax is: USE 'CATALOG catalog_name'.");
-            }
-
-            FeNameFormat.checkCatalogName(splitParts[1]);
-            statement.setCatalogName(splitParts[1]);
-
+            FeNameFormat.checkCatalogName(statement.getCatalogName());
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
@@ -303,21 +303,8 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
         return visitDDLStatement(statement, context);
     }
 
-    default R visitDropCatalogStatement(DropCatalogStmt statement, C context) {
-        return visitDDLStatement(statement, context);
-    }
-
-
     default R visitShowCreateExternalCatalogStatement(ShowCreateExternalCatalogStmt statement, C context) {
         return visitShowStatement(statement, context);
-    }
-
-    default R visitUseCatalogStatement(UseCatalogStmt statement, C context) {
-        return visitStatement(statement, context);
-    }
-
-    default R visitSetCatalogStatement(SetCatalogStmt statement, C context) {
-        return visitStatement(statement, context);
     }
 
     default R visitAlterCatalogStatement(AlterCatalogStmt statement, C context) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/UseCatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/UseCatalogStmtTest.java
@@ -90,14 +90,12 @@ public class UseCatalogStmtTest {
 
         Assertions.assertEquals("default_catalog", ctx.getCurrentCatalog());
 
-        executor = new StmtExecutor(ctx, SqlParser.parseSingleStatement(
-                "use 'xxx default_catalog'", ctx.getSessionVariable().getSqlMode()));
-        executor.execute();
-        Assertions.assertSame(ctx.getState().getStateType(), QueryState.MysqlStateType.ERR);
+        Assertions.assertThrows(com.starrocks.sql.parser.ParsingException.class, () ->
+                SqlParser.parseSingleStatement(
+                        "use 'xxx default_catalog'", ctx.getSessionVariable().getSqlMode()));
 
-        executor = new StmtExecutor(ctx, SqlParser.parseSingleStatement(
-                "use 'catalog default_catalog xxx'", ctx.getSessionVariable().getSqlMode()));
-        executor.execute();
-        Assertions.assertSame(ctx.getState().getStateType(), QueryState.MysqlStateType.ERR);
+        Assertions.assertThrows(com.starrocks.sql.parser.ParsingException.class, () ->
+                SqlParser.parseSingleStatement(
+                        "use 'catalog default_catalog xxx'", ctx.getSessionVariable().getSqlMode()));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
@@ -315,7 +315,7 @@ public class RedirectStatusTest {
 
     @Test
     public void testUseCatalogStmt() {
-        UseCatalogStmt stmt = new UseCatalogStmt("test_catalog");
+        UseCatalogStmt stmt = new UseCatalogStmt("test_catalog", NodePosition.ZERO);
         Assertions.assertEquals(RedirectStatus.NO_FORWARD, RedirectStatus.getRedirectStatus(stmt));
     }
 

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -440,6 +440,18 @@ public interface AstVisitor<R, C> {
         return visitStatement(statement, context);
     }
 
+    default R visitUseCatalogStatement(UseCatalogStmt statement, C context) {
+        return visitStatement(statement, context);
+    }
+
+    default R visitSetCatalogStatement(SetCatalogStmt statement, C context) {
+        return visitStatement(statement, context);
+    }
+
+    default R visitDropCatalogStatement(DropCatalogStmt statement, C context) {
+        return visitDDLStatement(statement, context);
+    }
+
     default R visitCreateDbStatement(CreateDbStmt statement, C context) {
         return visitDDLStatement(statement, context);
     }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/DropCatalogStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/DropCatalogStmt.java
@@ -17,7 +17,6 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
 
-import static com.starrocks.common.util.Util.normalizeName;
 
 // ToDo(zhuodong): to support internal catalog in the future
 public class DropCatalogStmt extends DdlStmt {
@@ -36,7 +35,7 @@ public class DropCatalogStmt extends DdlStmt {
 
     public DropCatalogStmt(String name, boolean ifExists, NodePosition pos) {
         super(pos);
-        this.name = normalizeName(name);
+        this.name = name;
         this.ifExists = ifExists;
     }
 
@@ -50,7 +49,7 @@ public class DropCatalogStmt extends DdlStmt {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitDropCatalogStatement(this, context);
+        return visitor.visitDropCatalogStatement(this, context);
     }
 
     @Override

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/SetCatalogStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/SetCatalogStmt.java
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
-
-import static com.starrocks.common.util.Util.normalizeName;
 
 /*
   Set catalog specified by catalog name
@@ -30,16 +27,15 @@ public class SetCatalogStmt extends StatementBase {
 
     public SetCatalogStmt(String catalogName, NodePosition pos) {
         super(pos);
-        this.catalogName = normalizeName(catalogName);
+        this.catalogName = catalogName;
     }
 
     public String getCatalogName() {
         return catalogName;
     }
 
-
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitSetCatalogStatement(this, context);
+        return visitor.visitSetCatalogStatement(this, context);
     }
 }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
-
-import static com.starrocks.common.util.Util.normalizeName;
 
 /*
   Use catalog specified by catalog name
@@ -36,34 +33,19 @@ import static com.starrocks.common.util.Util.normalizeName;
         use "CATALOG hive_metastore_catalog"
  */
 public class UseCatalogStmt extends StatementBase {
-    private final String catalogParts;
+    private final String catalogName;
 
-    private String catalogName;
-
-    public UseCatalogStmt(String catalogParts) {
-        this(catalogParts, NodePosition.ZERO);
-    }
-
-    public UseCatalogStmt(String catalogParts, NodePosition pos) {
+    public UseCatalogStmt(String catalogName, NodePosition pos) {
         super(pos);
-        this.catalogParts = normalizeName(catalogParts);
-        this.catalogName = normalizeName(catalogParts);
-    }
-
-    public String getCatalogParts() {
-        return catalogParts;
+        this.catalogName = catalogName;
     }
 
     public String getCatalogName() {
         return catalogName;
     }
 
-    public void setCatalogName(String catalogName) {
-        this.catalogName = normalizeName(catalogName);
-    }
-
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitUseCatalogStatement(this, context);
+        return visitor.visitUseCatalogStatement(this, context);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request refactors and improves the parsing and analysis of `USE CATALOG`, `SET CATALOG`, and `DROP CATALOG` statements in the StarRocks SQL engine. The main focus is on moving normalization and validation logic from AST node constructors to the parser layer, simplifying AST classes, and improving error handling and test coverage. It also removes redundant code and updates visitor interfaces for better consistency.

**Parser and AST refactoring:**

* Moved normalization and validation of catalog names for `UseCatalogStmt`, `SetCatalogStmt`, and `DropCatalogStmt` from their constructors to the parser (`AstBuilder`). Now, AST nodes simply store the catalog name as provided by the parser, and all normalization is done before node creation. [[1]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL679-R701) [[2]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL2371-R2386) [[3]](diffhunk://#diff-89fb280eec516f4286fe3dee6eacd71f1dab785d6d8ffe9597d2d592b6cb4755L39-R49) [[4]](diffhunk://#diff-cbce9dff151d37b737b3920488c50ede226eb6e1ba12c98462324d154c456ed6L33-R39) [[5]](diffhunk://#diff-1f63909fc42c8b65acb036238aa74c4221f4780cb3c27cc180fa30fdbaeeef50L39-R38)

* Simplified `UseCatalogStmt`, `SetCatalogStmt`, and `DropCatalogStmt` classes by removing unnecessary fields and methods, such as `catalogParts` and `setCatalogName`. Their constructors now directly accept the normalized catalog name. [[1]](diffhunk://#diff-89fb280eec516f4286fe3dee6eacd71f1dab785d6d8ffe9597d2d592b6cb4755L39-R49) [[2]](diffhunk://#diff-cbce9dff151d37b737b3920488c50ede226eb6e1ba12c98462324d154c456ed6L33-R39) [[3]](diffhunk://#diff-1f63909fc42c8b65acb036238aa74c4221f4780cb3c27cc180fa30fdbaeeef50L39-R38)

**Parser and analyzer improvements:**

* Enhanced error handling in the parser: Invalid `USE CATALOG` syntax is now caught at parse time with clear error messages, and corresponding tests were updated to expect parsing exceptions. [[1]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL679-R701) [[2]](diffhunk://#diff-4b2b79a09b3ef9a6d02f0a39d340f744cea115bd91b08889f1752803b7ea818bL93-L101)

* Updated the analyzer logic in `CatalogAnalyzer` to assume that the catalog name is already validated and normalized, removing redundant checks and string splitting.

**Visitor interface and test updates:**

* Updated visitor interfaces to remove redundant or now-unnecessary methods in `AstVisitorExtendInterface`, and added or moved methods to the correct base interface for better maintainability and consistency. [[1]](diffhunk://#diff-4bac2722f105b9f28e4b57fafe8c96ba1fd20dfeee1134181cb960cd3d5786ffL306-L322) [[2]](diffhunk://#diff-70887d8e096b6271d042fca4caaa78682f8686dc6d8ca6137245a444f9155d00R443-R454)

* Adjusted tests to match the new constructor signatures and error handling, ensuring correctness and coverage. [[1]](diffhunk://#diff-2de5601cd26d92472edb7b7cb431cf20b267d30bc75230145fd821df1c450c36L318-R318) [[2]](diffhunk://#diff-4b2b79a09b3ef9a6d02f0a39d340f744cea115bd91b08889f1752803b7ea818bL93-L101)

**Code cleanup and consistency:**

* Removed unused constants and imports, and standardized the use of fully qualified class names in the parser for clarity. [[1]](diffhunk://#diff-981ad2986ef324a1f0699ddbfc07f56e482a3badff321f56bc9ff0424e873fe8L39-L42) [[2]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL6758-R6775) [[3]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL6793-R6810)

* Moved AST classes for catalog statements to the `fe-parser` module for better modularity and separation of concerns. [[1]](diffhunk://#diff-1f63909fc42c8b65acb036238aa74c4221f4780cb3c27cc180fa30fdbaeeef50L20) [[2]](diffhunk://#diff-cbce9dff151d37b737b3920488c50ede226eb6e1ba12c98462324d154c456ed6L15-L21) [[3]](diffhunk://#diff-89fb280eec516f4286fe3dee6eacd71f1dab785d6d8ffe9597d2d592b6cb4755L15-L21)

These changes collectively improve maintainability, clarity, and robustness of catalog statement handling in the StarRocks SQL engine.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
