### PR TITLE
[BugFix]Fixed the behavior of the regexp_extract_all function when pos equals null and added support for pos equal to 0.

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -3468,6 +3468,76 @@ StatusOr<ColumnPtr> StringFunctions::regexp_extract(FunctionContext* context, co
     return regexp_extract_general(context, options, columns);
 }
 
+// Helper function to extract whole match (group 0) using RE2::Match
+// This is shared by both overloaded extract_regex_matches functions
+template <typename IndexType>
+static void extract_whole_matches(const re2::StringPiece& str_sp, const re2::RE2& regex, BinaryColumn* str_col,
+                                  IndexType& index, int max_matches) {
+    re2::StringPiece input = str_sp;
+    std::vector<re2::StringPiece> matches(max_matches);
+    size_t pos = 0;
+
+    while (pos <= input.size()) {
+        re2::StringPiece remaining = input.substr(pos);
+        if (regex.Match(remaining, 0, remaining.size(), RE2::UNANCHORED, &matches[0], max_matches)) {
+            // matches[0] contains the whole match (group 0)
+            str_col->append(Slice(matches[0].data(), matches[0].size()));
+            index += 1;
+            // Move past this match
+            pos = matches[0].data() - input.data() + matches[0].size();
+            if (matches[0].size() == 0) {
+                pos++; // Avoid infinite loop on zero-length matches
+            }
+        } else {
+            break;
+        }
+    }
+}
+
+// Helper function to extract regex matches and append to column
+// This reduces code duplication across regexp_extract_all_* functions
+static void extract_regex_matches(const Slice& str_value, const re2::RE2& regex, int group, BinaryColumn* str_col,
+                                  uint32_t& index, int max_matches) {
+    re2::StringPiece str_sp(str_value.get_data(), str_value.get_size());
+
+    if (group == 0) {
+        // Extract the whole match (group 0)
+        extract_whole_matches(str_sp, regex, str_col, index, max_matches);
+    } else {
+        // Extract specific capture group
+        re2::StringPiece find[group];
+        const RE2::Arg* args[group];
+        RE2::Arg argv[group];
+
+        for (size_t i = 0; i < group; i++) {
+            argv[i] = &find[i];
+            args[i] = &argv[i];
+        }
+        while (re2::RE2::FindAndConsumeN(&str_sp, regex, args, group)) {
+            str_col->append(Slice(find[group - 1].data(), find[group - 1].size()));
+            index += 1;
+        }
+    }
+}
+
+// Overloaded version for pre-allocated arrays (used by regexp_extract_all_const)
+static void extract_regex_matches(const Slice& str_value, const re2::RE2& regex, int group, BinaryColumn* str_col,
+                                  uint64_t& index, const std::unique_ptr<re2::StringPiece[]>& find,
+                                  const std::unique_ptr<const RE2::Arg*[]>& args, int max_matches) {
+    re2::StringPiece str_sp(str_value.get_data(), str_value.get_size());
+
+    if (group == 0) {
+        // Extract the whole match (group 0) - reuse common logic
+        extract_whole_matches(str_sp, regex, str_col, index, max_matches);
+    } else {
+        // Extract specific capture group using pre-allocated arrays
+        while (re2::RE2::FindAndConsumeN(&str_sp, regex, args.get(), group)) {
+            str_col->append(Slice(find[group - 1].data(), find[group - 1].size()));
+            index += 1;
+        }
+    }
+}
+
 static ColumnPtr regexp_extract_all_general(FunctionContext* context, re2::RE2::Options* options,
                                             const Columns& columns) {
     auto content_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
@@ -3483,7 +3553,7 @@ static ColumnPtr regexp_extract_all_general(FunctionContext* context, re2::RE2::
     uint32_t index = 0;
 
     for (int row = 0; row < size; ++row) {
-        if (content_viewer.is_null(row) || ptn_viewer.is_null(row)) {
+        if (content_viewer.is_null(row) || ptn_viewer.is_null(row) || group_viewer.is_null(row)) {
             offset_col->append(index);
             nl_col->append(1);
             continue;
@@ -3500,7 +3570,7 @@ static ColumnPtr regexp_extract_all_general(FunctionContext* context, re2::RE2::
 
         nl_col->append(0);
         auto group = group_viewer.value(row);
-        if (group <= 0) {
+        if (group < 0) {
             offset_col->append(index);
             continue;
         }
@@ -3511,27 +3581,13 @@ static ColumnPtr regexp_extract_all_general(FunctionContext* context, re2::RE2::
             continue;
         }
 
-        auto str_value = content_viewer.value(row);
-        re2::StringPiece str_sp(str_value.get_data(), str_value.get_size());
-
-        re2::StringPiece find[group];
-        const RE2::Arg* args[group];
-        RE2::Arg argv[group];
-
-        for (size_t i = 0; i < group; i++) {
-            argv[i] = &find[i];
-            args[i] = &argv[i];
-        }
-        while (re2::RE2::FindAndConsumeN(&str_sp, local_re, args, group)) {
-            str_col->append(Slice(find[group - 1].data(), find[group - 1].size()));
-            index += 1;
-        }
+        extract_regex_matches(content_viewer.value(row), local_re, group, str_col.get(), index, max_matches);
         offset_col->append(index);
     }
 
-    auto array = ArrayColumn::create(NullableColumn::create(std::move(str_col), NullColumn::create(str_col->size(), 0)),
-                                     std::move(offset_col));
-    return NullableColumn::create(std::move(array), std::move(nl_col));
+    auto array =
+            ArrayColumn::create(NullableColumn::create(str_col, NullColumn::create(str_col->size(), 0)), offset_col);
+    return NullableColumn::create(array, nl_col);
 }
 
 static ColumnPtr regexp_extract_all_const_pattern(re2::RE2* const_re, const Columns& columns) {
@@ -3547,7 +3603,7 @@ static ColumnPtr regexp_extract_all_const_pattern(re2::RE2* const_re, const Colu
     uint32_t index = 0;
 
     for (int row = 0; row < size; ++row) {
-        if (content_viewer.is_null(row)) {
+        if (content_viewer.is_null(row) || group_viewer.is_null(row)) {
             offset_col->append(index);
             nl_col->append(1);
             continue;
@@ -3555,7 +3611,7 @@ static ColumnPtr regexp_extract_all_const_pattern(re2::RE2* const_re, const Colu
 
         nl_col->append(0);
         auto group = group_viewer.value(row);
-        if (group <= 0) {
+        if (group < 0) {
             offset_col->append(index);
             continue;
         }
@@ -3566,30 +3622,16 @@ static ColumnPtr regexp_extract_all_const_pattern(re2::RE2* const_re, const Colu
             continue;
         }
 
-        auto str_value = content_viewer.value(row);
-        re2::StringPiece str_sp(str_value.get_data(), str_value.get_size());
-
-        re2::StringPiece find[group];
-        const RE2::Arg* args[group];
-        RE2::Arg argv[group];
-
-        for (size_t i = 0; i < group; i++) {
-            argv[i] = &find[i];
-            args[i] = &argv[i];
-        }
-        while (re2::RE2::FindAndConsumeN(&str_sp, *const_re, args, group)) {
-            str_col->append(Slice(find[group - 1].data(), find[group - 1].size()));
-            index += 1;
-        }
+        extract_regex_matches(content_viewer.value(row), *const_re, group, str_col.get(), index, max_matches);
         offset_col->append(index);
     }
 
-    auto array = ArrayColumn::create(NullableColumn::create(std::move(str_col), NullColumn::create(str_col->size(), 0)),
-                                     std::move(offset_col));
+    auto array =
+            ArrayColumn::create(NullableColumn::create(str_col, NullColumn::create(str_col->size(), 0)), offset_col);
     if (ColumnHelper::is_all_const(columns)) {
-        return ConstColumn::create(std::move(array), columns[0]->size());
+        return ConstColumn::create(array, columns[0]->size());
     }
-    return NullableColumn::create(std::move(array), std::move(nl_col));
+    return NullableColumn::create(array, nl_col);
 }
 
 static ColumnPtr regexp_extract_all_const(re2::RE2* const_re, const Columns& columns) {
@@ -3602,58 +3644,58 @@ static ColumnPtr regexp_extract_all_const(re2::RE2* const_re, const Columns& col
     auto offset_col = UInt32Column::create();
     offset_col->append(0);
 
-    NullColumn::MutablePtr nl_col;
+    NullColumnPtr nl_col;
     if (columns[0]->is_nullable()) {
-        auto x = down_cast<const NullableColumn*>(columns[0].get())->null_column();
-        nl_col = NullColumn::static_pointer_cast(x->clone());
+        auto x = down_cast<NullableColumn*>(columns[0].get())->null_column();
+        nl_col = ColumnHelper::as_column<NullColumn>(x->clone_shared());
     } else {
         nl_col = NullColumn::create(size, 0);
     }
 
     uint64_t index = 0;
     int max_matches = 1 + const_re->NumberOfCapturingGroups();
-    if (group <= 0 || group >= max_matches) {
+    if (group < 0 || group >= max_matches) {
         offset_col->append_value_multiple_times(&index, size);
-        auto array = ArrayColumn::create(NullableColumn::create(std::move(str_col), NullColumn::create(0, 0)),
-                                         std::move(offset_col));
+        auto array = ArrayColumn::create(NullableColumn::create(str_col, NullColumn::create(0, 0)), offset_col);
 
         if (ColumnHelper::is_all_const(columns)) {
-            return ConstColumn::create(std::move(array), columns[0]->size());
+            return ConstColumn::create(array, columns[0]->size());
         }
-        return NullableColumn::create(std::move(array), std::move(nl_col));
+        return NullableColumn::create(array, nl_col);
     }
 
-    re2::StringPiece find[group];
-    const RE2::Arg* args[group];
-    RE2::Arg argv[group];
+    // Prepare arguments for FindAndConsumeN (only needed when group > 0)
+    std::unique_ptr<re2::StringPiece[]> find;
+    std::unique_ptr<const RE2::Arg*[]> args;
+    std::unique_ptr<RE2::Arg[]> argv;
 
-    for (size_t i = 0; i < group; i++) {
-        argv[i] = &find[i];
-        args[i] = &argv[i];
+    if (group > 0) {
+        find = std::make_unique<re2::StringPiece[]>(group);
+        args = std::make_unique<const RE2::Arg*[]>(group);
+        argv = std::make_unique<RE2::Arg[]>(group);
+
+        for (size_t i = 0; i < group; i++) {
+            argv[i] = &find[i];
+            args[i] = &argv[i];
+        }
     }
+
+    // focuses only on iteration and offset management
     for (int row = 0; row < size; ++row) {
-        if (content_viewer.is_null(row)) {
-            offset_col->append(index);
-            continue;
-        }
-
-        auto str_value = content_viewer.value(row);
-        re2::StringPiece str_sp(str_value.get_data(), str_value.get_size());
-        while (re2::RE2::FindAndConsumeN(&str_sp, *const_re, args, group)) {
-            str_col->append(Slice(find[group - 1].data(), find[group - 1].size()));
-
-            index += 1;
+        if (!content_viewer.is_null(row)) {
+            extract_regex_matches(content_viewer.value(row), *const_re, group, str_col.get(), index, find, args,
+                                  max_matches);
         }
         offset_col->append(index);
     }
 
-    auto array = ArrayColumn::create(NullableColumn::create(std::move(str_col), NullColumn::create(str_col->size(), 0)),
-                                     std::move(offset_col));
+    auto array =
+            ArrayColumn::create(NullableColumn::create(str_col, NullColumn::create(str_col->size(), 0)), offset_col);
 
     if (ColumnHelper::is_all_const(columns)) {
-        return ConstColumn::create(std::move(array), columns[0]->size());
+        return ConstColumn::create(array, columns[0]->size());
     }
-    return NullableColumn::create(std::move(array), std::move(nl_col));
+    return NullableColumn::create(array, nl_col);
 }
 
 StatusOr<ColumnPtr> StringFunctions::regexp_extract_all(FunctionContext* context, const Columns& columns) {

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -3646,8 +3646,8 @@ static ColumnPtr regexp_extract_all_const(re2::RE2* const_re, const Columns& col
 
     NullColumnPtr nl_col;
     if (columns[0]->is_nullable()) {
-        auto x = down_cast<NullableColumn*>(columns[0].get())->null_column();
-        nl_col = ColumnHelper::as_column<NullColumn>(x->clone_shared());
+        auto x = down_cast<const NullableColumn*>(columns[0].get())->null_column();
+        nl_col = ColumnHelper::as_column<NullColumn>(x->clone());
     } else {
         nl_col = NullColumn::create(size, 0);
     }


### PR DESCRIPTION
## Why I'm doing:
1 regexp_extract_all don't support pos equal to 0.
2 fixed the behavior of the regexp_extract_all function when pos equals null.
## What I'm doing:


> mysql> select * from t5;
+------+-----------+-------------------------------+-------+
| id   | str       | pattern                       | group |
+------+-----------+-------------------------------+-------+
|    1 | AbCdExCeF | ([[:lower:]]+)C([[:lower:]]+) |  NULL |
|    1 | AbCdExCeF | ([[:lower:]]+)C([[:lower:]]+) |  NULL |
+------+-----------+-------------------------------+-------+
2 rows in set (0.01 sec)

> mysql> SELECT id, regexp_extract_all(str, pattern, `group`) from t5;
+------+-----------------------------------------+
| id   | regexp_extract_all(str, pattern, group) |
+------+-----------------------------------------+
|    1 | NULL                                    |
|    1 | NULL                                    |
+------+-----------------------------------------+
2 rows in set (0.00 sec)


**Error behavior**

> mysql> select * from t5;
+------+-----------+-------------------------------+-------+
| id   | str       | pattern                       | group |
+------+-----------+-------------------------------+-------+
|    1 | AbCdExCeF | ([[:lower:]]+)C([[:lower:]]+) |  NULL |
|    1 | AbCdExCeF | ([[:lower:]]+)C([[:lower:]]+) |  NULL |
|    1 | AbCdExCeF | ([[:lower:]]+)C([[:lower:]]+) |     2 |
+------+-----------+-------------------------------+-------+
3 rows in set (0.00 sec)

> mysql> SELECT id, regexp_extract_all(str, pattern, `group`) from t5;
+------+-----------------------------------------+
| id   | regexp_extract_all(str, pattern, group) |
+------+-----------------------------------------+
|    1 | ["b","x"]                               |
|    1 | ["b","x"]                               |
|    1 | ["d","e"]                               |
+------+-----------------------------------------+

**Correct behavior**
> mysql> SELECT id, regexp_extract_all(str, pattern, group) from t5;
+------+-----------------------------------------+
| id   | regexp_extract_all(str, pattern, group) |
+------+-----------------------------------------+
|    1 | NULL                                    |
|    1 | NULL                                    |
|    1 | ["d","e"]                               |
+------+-----------------------------------------+

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
