### PR TITLE
[BugFix] lz4 encode/decode

### DIFF
--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -118,11 +118,12 @@ uint8_t* encode_string_lz4(const void* data, size_t size, uint8_t* buff, int enc
         throw std::runtime_error(
                 fmt::format("The input size for compression should be less than {}", LZ4_MAX_INPUT_SIZE));
     }
-    uint64_t encode_size =
+    auto encode_size =
             LZ4_compress_fast(reinterpret_cast<const char*>(data), reinterpret_cast<char*>(buff + sizeof(uint64_t)),
                               size, LZ4_compressBound(size), std::max(1, std::abs(encode_level / 10000) % 100));
     if (encode_size <= 0) {
-        throw std::runtime_error("lz4 compress error.");
+        throw std::runtime_error(
+                fmt::format("lz4 compress failed: raw size = {}, compressed get encode size = {}.", size, encode_size));
     }
     buff = write_little_endian_64(encode_size, buff);
 
@@ -135,10 +136,12 @@ uint8_t* encode_string_lz4(const void* data, size_t size, uint8_t* buff, int enc
 const uint8_t* decode_string_lz4(const uint8_t* buff, void* target, size_t size) {
     uint64_t encode_size = 0;
     buff = read_little_endian_64(buff, &encode_size);
-    uint64_t decode_size = LZ4_decompress_safe(reinterpret_cast<const char*>(buff), reinterpret_cast<char*>(target),
-                                               encode_size, size);
+    auto decode_size = LZ4_decompress_safe(reinterpret_cast<const char*>(buff), reinterpret_cast<char*>(target),
+                                           encode_size, size);
     if (decode_size <= 0) {
-        throw std::runtime_error("lz4 decompress error.");
+        throw std::runtime_error(fmt::format(
+                "lz4 decompress failed: encode size = {}, raw size = {}, decompressed get decode size = {}.",
+                encode_size, size, decode_size));
     }
     if (size != decode_size) {
         throw std::runtime_error(


### PR DESCRIPTION
## Why I'm doing:
Fix #63628 

## What I'm doing:

Fix #63628 

According to https://github.com/lz4/lz4/blob/release/lib/lz4.h.
```
LZ4LIB_API int LZ4_compress_fast (const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
LZ4LIB_API int LZ4_decompress_safe (const char* src, char* dst, int compressedSize, int dstCapacity);
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates LZ4 encode/decode to use inferred size types and adds detailed error messages with sizes in `be/src/serde/column_array_serde.cpp`.
> 
> - **Serde (LZ4 string compression/decompression)** in `be/src/serde/column_array_serde.cpp`:
>   - Use `auto` for `encode_size`/`decode_size` from `LZ4_compress_fast`/`LZ4_decompress_safe`.
>   - Replace generic errors with detailed messages including raw/compressed sizes.
>   - Keep existing bounds and size-equality checks unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d52afbed48fb1e3761e4883b97134e3e15f9320. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->