### PR TITLE
[UT] Add FE UT timeout to avoid dead loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ fe/fe-core/gen
 fe/fe-common/.classpath
 fe/fe-core/src/main/java/com/starrocks/builtins
 fe/fe-core/src/main/java/com/starrocks/common/Version.java
+fe/fe-core/*.log
 fe/fe-core/src/main/java/com/starrocks/proto
 fe/fe-core/src/main/java/com/starrocks/thrift
 fs_brokers/apache_hdfs_broker/src/main/resources/

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -967,6 +967,10 @@ under the License.
                             </includes>
                             <excludes>
                                 <exclude>com/starrocks/proto/**</exclude>
+                                <exclude>com/starrocks/rpc/**</exclude>
+                                <exclude>com/starrocks/server/**</exclude>
+                                <exclude>**/*$$JProtoBufClass</exclude>
+                                <exclude>**/*$$JProtoBuf*</exclude>
                             </excludes>
                             <append>true</append>
                         </configuration>
@@ -1045,6 +1049,7 @@ under the License.
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                     <!-->not reuse forked jvm, so that each unit test will run in separate jvm. to avoid singleton confict<-->
                     <reuseForks>false</reuseForks>
+
                     <argLine>
                         -javaagent:${settings.localRepository}/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar
                         ${async.profiler.arg}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 
 public class OnlineOptimizeJobV2Test extends DDLTestBase {
-    private static final String TEST_FILE_NAME = OnlineOptimizeJobV2Test.class.getCanonicalName();
     private AlterTableStmt alterTableStmt;
 
     private static final Logger LOG = LogManager.getLogger(OnlineOptimizeJobV2Test.class);
@@ -55,7 +54,7 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
     }
 
     @AfterEach
-    public void clear() {
+    public void clear() throws Exception {
         GlobalStateMgr.getCurrentState().getSchemaChangeHandler().clearJobs();
         Config.enable_online_optimize_table = false;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
@@ -226,10 +226,10 @@ public class RollupJobV2Test extends DDLTestBase {
         int maxRetry = 5;
         while (retryCount < maxRetry) {
             ThreadUtil.sleepAtLeastIgnoreInterrupts(2000L);
-            rollupJob.runRunningJob();
             if (rollupJob.getJobState() == AlterJobV2.JobState.FINISHED) {
                 break;
             }
+            rollupJob.runRunningJob();
             retryCount++;
             LOG.info("rollupJob is waiting for JobState retryCount:" + retryCount);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -77,6 +77,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
                 "\"enable_persistent_index\" = \"true\"\n" +
                 ");");
         FeConstants.enablePruneEmptyOutputScan = false;
+        FeConstants.runningUnitTest = false;
     }
 
     private static String removeSlotIds(String s) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteTestBase.java
@@ -19,6 +19,8 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;
@@ -84,6 +86,8 @@ public abstract class BatchWriteTestBase {
         allNodes = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAvailableBackends()
                 .stream().map(node -> (ComputeNode) node).collect(Collectors.toList());
         Collections.shuffle(allNodes);
+        FeConstants.runningUnitTest = false;
+        Config.enable_new_publish_mechanism = false;
     }
 
     protected List<TTabletCommitInfo> buildCommitInfos() {

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
@@ -16,6 +16,7 @@ package com.starrocks.load.batchwrite;
 
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.LoadException;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.DebugUtil;
@@ -89,6 +90,8 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
                 .withTable(new MTable(TABLE_NAME_1_1, Arrays.asList("c0 INT", "c1 STRING")));
         DATABASE_1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME_1);
         TABLE_1_1 = (OlapTable) DATABASE_1.getTable(TABLE_NAME_1_1);
+        FeConstants.runningUnitTest = false;
+        Config.enable_new_publish_mechanism = false;
     }
 
     @BeforeEach

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
+import com.starrocks.common.FeConstants;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
@@ -71,6 +72,7 @@ public class MaterializedViewTestBase extends PlanTestBase {
 
     @BeforeAll
     public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
         PlanTestBase.beforeClass();
 
         // set default config for async mvs

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/LocationMismatchRepairTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/LocationMismatchRepairTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.clone.TabletScheduler;
 import com.starrocks.clone.TabletSchedulerStat;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.server.GlobalStateMgr;
@@ -44,6 +45,7 @@ import java.util.Set;
 public class LocationMismatchRepairTest {
     @BeforeAll
     public static void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
         Config.tablet_sched_checker_interval_seconds = 1;
         Config.tablet_sched_repair_delay_factor_second = 1;
         Config.tablet_checker_partition_batch_num = 1;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorExecuteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorExecuteTest.java
@@ -1,0 +1,356 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectProcessorTest.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.authentication.AccessControlContext;
+import com.starrocks.authentication.PlainPasswordAuthenticationProvider;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.mysql.MysqlCapability;
+import com.starrocks.mysql.MysqlChannel;
+import com.starrocks.mysql.MysqlCommand;
+import com.starrocks.mysql.MysqlPassword;
+import com.starrocks.mysql.MysqlSerializer;
+import com.starrocks.plugin.AuditEvent.AuditEventBuilder;
+import com.starrocks.proto.PQueryStatistics;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.DDLTestBase;
+import com.starrocks.sql.ast.PrepareStmt;
+import com.starrocks.thrift.TUniqueId;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xnio.StreamConnection;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class ConnectProcessorExecuteTest extends DDLTestBase {
+    private static ByteBuffer initDbPacket;
+    private static ByteBuffer initWarehousePacket;
+    private static ByteBuffer changeUserPacket;
+    private static ByteBuffer resetConnectionPacket;
+    private static ByteBuffer pingPacket;
+    private static ByteBuffer quitPacket;
+    private static ByteBuffer queryPacket;
+    private static ByteBuffer fieldListPacket;
+    private static AuditEventBuilder auditBuilder = new AuditEventBuilder();
+    private static ConnectContext myContext;
+
+    @Mocked
+    private static StreamConnection connection;
+
+    private static PQueryStatistics statistics = new PQueryStatistics();
+
+
+    @BeforeAll
+    public static void setUpClass() {
+        FeConstants.runningUnitTest = false;
+        // Init Database packet
+        {
+            MysqlSerializer serializer = MysqlSerializer.newInstance();
+            serializer.writeInt1(2);
+            serializer.writeEofString("testDb1");
+            initDbPacket = serializer.toByteBuffer();
+        }
+
+        // Init Warehouse packet
+        {
+            MysqlSerializer serializer = MysqlSerializer.newInstance();
+            serializer.writeInt1(2);
+            serializer.writeEofString("'warehouse aaa'");
+            initWarehousePacket = serializer.toByteBuffer();
+        }
+
+        // Change user packet
+        {
+            MysqlSerializer serializer = MysqlSerializer.newInstance();
+            serializer.writeInt1(17);
+            // code
+            serializer.writeInt1(17);
+            // user name
+            serializer.writeNulTerminateString("starrocks-user");
+            // plugin data
+            serializer.writeInt1(20);
+            byte[] buf = new byte[20];
+            for (int i = 0; i < 20; ++i) {
+                buf[i] = (byte) ('a' + i);
+            }
+            serializer.writeBytes(buf);
+            // database
+            serializer.writeNulTerminateString("testDb");
+            // character set
+            serializer.writeInt2(33);
+            changeUserPacket = serializer.toByteBuffer();
+        }
+
+        // Reset connection packet
+        {
+            MysqlSerializer serializer = MysqlSerializer.newInstance();
+            serializer.writeInt1(31);
+            resetConnectionPacket = serializer.toByteBuffer();
+        }
+
+        // Ping packet
+        {
+            MysqlSerializer serializer = MysqlSerializer.newInstance();
+            serializer.writeInt1(14);
+            pingPacket = serializer.toByteBuffer();
+        }
+
+        // Quit packet
+        {
+            MysqlSerializer serializer = MysqlSerializer.newInstance();
+            serializer.writeInt1(1);
+            quitPacket = serializer.toByteBuffer();
+        }
+
+        // Query packet
+        {
+            MysqlSerializer serializer = MysqlSerializer.newInstance();
+            serializer.writeInt1(3);
+            serializer.writeEofString("select * from a");
+            queryPacket = serializer.toByteBuffer();
+        }
+
+        // Field list packet
+        {
+            MysqlSerializer serializer = MysqlSerializer.newInstance();
+            serializer.writeInt1(4);
+            serializer.writeNulTerminateString("testTable1");
+            serializer.writeEofString("");
+            fieldListPacket = serializer.toByteBuffer();
+        }
+
+        statistics.scanBytes = 0L;
+        statistics.scanRows = 0L;
+        DDLTestBase.beforeAll();
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        initDbPacket.clear();
+        initWarehousePacket.clear();
+        pingPacket.clear();
+        quitPacket.clear();
+        queryPacket.clear();
+        fieldListPacket.clear();
+        changeUserPacket.clear();
+        resetConnectionPacket.clear();
+        // Mock
+        MysqlChannel channel = new MysqlChannel(connection);
+        new Expectations(channel) {
+            {
+                channel.getRemoteHostPortString();
+                minTimes = 0;
+                result = "127.0.0.1:12345";
+            }
+        };
+        myContext = new ConnectContext(connection);
+        Deencapsulation.setField(myContext, "mysqlChannel", channel);
+        super.setUp();
+    }
+
+    private static MysqlChannel mockChannel(ByteBuffer packet) {
+        try {
+            MysqlChannel channel = new MysqlChannel(connection);
+            new Expectations(channel) {
+                {
+                    // Mock receive
+                    channel.fetchOnePacket();
+                    minTimes = 0;
+                    result = packet;
+
+                    // Mock reset
+                    channel.setSequenceId(0);
+                    times = 1;
+
+                    // Mock send
+                    channel.sendAndFlush((ByteBuffer) any);
+                    minTimes = 0;
+
+                    channel.getRemoteHostPortString();
+                    minTimes = 0;
+                    result = "127.0.0.1:12345";
+                }
+            };
+            return channel;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static ConnectContext initMockContext(MysqlChannel channel, GlobalStateMgr globalStateMgr) {
+        ConnectContext context = new ConnectContext(connection) {
+            private boolean firstTimeToSetCommand = true;
+
+            @Override
+            public void setKilled() {
+                myContext.setKilled();
+            }
+
+            @Override
+            public MysqlSerializer getSerializer() {
+                return myContext.getSerializer();
+            }
+
+            @Override
+            public QueryState getState() {
+                return myContext.getState();
+            }
+
+            @Override
+            public void setStartTime() {
+                myContext.setStartTime();
+            }
+
+            @Override
+            public String getDatabase() {
+                return myContext.getDatabase();
+            }
+
+            @Override
+            public void setCommand(MysqlCommand command) {
+                if (firstTimeToSetCommand) {
+                    myContext.setCommand(command);
+                    firstTimeToSetCommand = false;
+                } else {
+                    super.setCommand(command);
+                }
+            }
+        };
+
+        new Expectations(context) {
+            {
+                context.getMysqlChannel();
+                minTimes = 0;
+                result = channel;
+
+                context.isKilled();
+                minTimes = 0;
+                maxTimes = 3;
+                returns(false, true, false);
+
+                context.getGlobalStateMgr();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                context.getAuditEventBuilder();
+                minTimes = 0;
+                result = auditBuilder;
+
+                context.getQualifiedUser();
+                minTimes = 0;
+                result = "testCluster:user";
+
+                context.getCurrentUserIdentity();
+                minTimes = 0;
+                result = UserIdentity.ROOT;
+
+                context.getStartTime();
+                minTimes = 0;
+                result = 0L;
+
+                context.getReturnRows();
+                minTimes = 0;
+                result = 1L;
+
+                context.setStmtId(anyLong);
+                minTimes = 0;
+
+                context.getStmtId();
+                minTimes = 0;
+                result = 1L;
+
+                context.getExecutionId();
+                minTimes = 0;
+                result = new TUniqueId();
+
+                context.getCapability();
+                minTimes = 0;
+                result = MysqlCapability.DEFAULT_CAPABILITY;
+
+                context.getAccessControlContext();
+                minTimes = 0;
+                result = new AccessControlContext();
+
+                context.getAuthenticationProvider();
+                minTimes = 0;
+                result = new PlainPasswordAuthenticationProvider(MysqlPassword.EMPTY_PASSWORD);
+            }
+        };
+
+        return context;
+    }
+
+    @Test
+    public void testStmtExecute() throws Exception {
+        int stmtId = 1;
+        MysqlSerializer serializer = MysqlSerializer.newInstance();
+        serializer.writeInt1(MysqlCommand.COM_STMT_EXECUTE.getCommandCode());
+        serializer.writeInt4(stmtId);
+        serializer.writeInt1(0); // flags
+        serializer.writeInt4(0); // flags
+        ByteBuffer packet = serializer.toByteBuffer();
+
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+
+        String sql = "PREPARE stmt1 FROM select * from testDb1.testTable1";
+        PrepareStmt stmt = (PrepareStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        ctx.putPreparedStmt(String.valueOf(stmtId), new PrepareStmtContext(stmt, ctx, null));
+
+        ConnectProcessor processor = new ConnectProcessor(ctx);
+        // Mock statement executor
+        // Create mock for StmtExecutor using MockUp instead of @Mocked parameter
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return statistics;
+            }
+        };
+
+        processor.processOnce();
+
+        Assertions.assertEquals(MysqlCommand.COM_STMT_EXECUTE, myContext.getCommand());
+        Assertions.assertTrue(ctx.getState().isQuery());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -42,6 +42,7 @@ import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.authentication.PlainPasswordAuthenticationProvider;
 import com.starrocks.authorization.PrivilegeBuiltinConstants;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.UUIDUtil;
@@ -102,6 +103,7 @@ public class ConnectProcessorTest extends DDLTestBase {
 
     @BeforeAll
     public static void setUpClass() {
+        FeConstants.runningUnitTest = false;
         // Init Database packet
         {
             MysqlSerializer serializer = MysqlSerializer.newInstance();
@@ -180,11 +182,11 @@ public class ConnectProcessorTest extends DDLTestBase {
 
         statistics.scanBytes = 0L;
         statistics.scanRows = 0L;
+        DDLTestBase.beforeAll();
     }
 
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         initDbPacket.clear();
         initWarehousePacket.clear();
         pingPacket.clear();
@@ -204,6 +206,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         };
         myContext = new ConnectContext(connection);
         Deencapsulation.setField(myContext, "mysqlChannel", channel);
+        super.setUp();
     }
 
     private static MysqlChannel mockChannel(ByteBuffer packet) {
@@ -710,38 +713,6 @@ public class ConnectProcessorTest extends DDLTestBase {
         TMasterOpResult result = processor.proxyExecute(request);
         Assertions.assertNotNull(result);
         Assertions.assertTrue(context.getState().isError());
-    }
-
-    @Test
-    public void testStmtExecute() throws Exception {
-        int stmtId = 1;
-        MysqlSerializer serializer = MysqlSerializer.newInstance();
-        serializer.writeInt1(MysqlCommand.COM_STMT_EXECUTE.getCommandCode());
-        serializer.writeInt4(stmtId);
-        serializer.writeInt1(0); // flags
-        serializer.writeInt4(0); // flags
-        ByteBuffer packet = serializer.toByteBuffer();
-
-        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
-
-        String sql = "PREPARE stmt1 FROM select * from testDb1.testTable1";
-        PrepareStmt stmt = (PrepareStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        ctx.putPreparedStmt(String.valueOf(stmtId), new PrepareStmtContext(stmt, ctx, null));
-
-        ConnectProcessor processor = new ConnectProcessor(ctx);
-        // Mock statement executor
-        // Create mock for StmtExecutor using MockUp instead of @Mocked parameter
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return statistics;
-            }
-        };
-
-        processor.processOnce();
-
-        Assertions.assertEquals(MysqlCommand.COM_STMT_EXECUTE, myContext.getCommand());
-        Assertions.assertTrue(ctx.getState().isQuery());
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
@@ -72,7 +72,6 @@ public class ReplicationMgrTest {
     @BeforeAll
     public static void beforeClass() throws Exception {
         FeConstants.runningUnitTest = true;
-        // UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
         AnalyzeTestUtil.initWithoutTableAndDb(RunMode.SHARED_DATA);
         starRocksAssert = AnalyzeTestUtil.starRocksAssert;
 

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.proc.ReplicationsProcNode;
@@ -27,7 +28,6 @@ import com.starrocks.leader.LeaderImpl;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
-import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.system.Backend;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
@@ -46,7 +46,6 @@ import com.starrocks.thrift.TTableReplicationRequest;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.thrift.TTabletReplicationInfo;
 import com.starrocks.utframe.StarRocksAssert;
-import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
@@ -72,19 +71,17 @@ public class ReplicationMgrTest {
 
     @BeforeAll
     public static void beforeClass() throws Exception {
-        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
-        AnalyzeTestUtil.init();
-        starRocksAssert = new StarRocksAssert(AnalyzeTestUtil.getConnectContext());
-        starRocksAssert.withDatabase("test").useDatabase("test");
+        FeConstants.runningUnitTest = true;
+        // UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        AnalyzeTestUtil.initWithoutTableAndDb(RunMode.SHARED_DATA);
+        starRocksAssert = AnalyzeTestUtil.starRocksAssert;
 
         db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String sql = "create table single_partition_duplicate_key (key1 int, key2 varchar(10))\n" +
                 "distributed by hash(key1) buckets 1\n" +
                 "properties('replication_num' = '1'); ";
-        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql,
-                AnalyzeTestUtil.getConnectContext());
-        StarRocksAssert.utCreateTableWithRetry(createTableStmt);
+        starRocksAssert.withTable(sql);
 
         table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .getTable(db.getFullName(), "single_partition_duplicate_key");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.gson.JsonSyntaxException;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.Constants;
@@ -55,6 +56,7 @@ public class TaskRunHistoryTest {
     @BeforeAll
     public static void beforeAll() {
         UtFrameUtils.createMinStarRocksCluster();
+        FeConstants.runningUnitTest = false;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AlterTableClauseVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AlterTableClauseVisitorTest.java
@@ -22,19 +22,12 @@ import com.starrocks.sql.ast.OrderByElement;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.parser.NodePosition;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class AlterTableClauseVisitorTest extends DDLTestBase {
-
-    @BeforeEach
-    public void beforeClass() throws Exception {
-        super.setUp();
-    }
-
     @Test
     public void testVisitOptimizeClause() {
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
@@ -30,8 +30,8 @@ import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 
 public class AnalyzeTestUtil {
-    protected static ConnectContext connectContext;
-    protected static StarRocksAssert starRocksAssert;
+    public static ConnectContext connectContext;
+    public static StarRocksAssert starRocksAssert;
     protected static String DB_NAME = "test";
 
     public static void initWithoutTableAndDb(RunMode runMode) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DDLTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DDLTestBase.java
@@ -16,10 +16,12 @@
 package com.starrocks.sql.analyzer;
 
 import com.starrocks.catalog.GlobalStateMgrTestUtil;
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
 public class DDLTestBase {
@@ -27,16 +29,23 @@ public class DDLTestBase {
     protected static ConnectContext ctx;
     protected static StarRocksAssert starRocksAssert;
 
-    @BeforeEach
-    public void setUp() throws Exception {
+    @BeforeAll
+    public static void beforeAll() {
         UtFrameUtils.createMinStarRocksCluster();
         ctx = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(ctx);
 
         FeConstants.runningUnitTest = true;
-        starRocksAssert = new StarRocksAssert(ctx);
+        Config.enable_new_publish_mechanism = false;
+        Config.tablet_sched_checker_interval_seconds = 10;
+        Config.tablet_sched_repair_delay_factor_second = 10;
+        Config.alter_scheduler_interval_millisecond = 1000;
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
         starRocksAssert.withDatabase(GlobalStateMgrTestUtil.testDb1)
                 .useDatabase(GlobalStateMgrTestUtil.testDb1);
-
         starRocksAssert.withTable("CREATE TABLE `testTable1` (\n" +
                 "  `v1` bigint NULL COMMENT \"\",\n" +
                 "  `v2` bigint NULL COMMENT \"\",\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -19,10 +19,7 @@ import com.starrocks.alter.AlterJobMgr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.PaimonTable;
 import com.starrocks.catalog.PartitionInfo;
-import com.starrocks.catalog.PrimitiveType;
-import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
@@ -34,12 +31,9 @@ import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.ShowStmt;
-import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.hadoop.util.Lists;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -93,78 +87,6 @@ public class MaterializedViewAnalyzerTest {
     @AfterAll
     public static void afterClass() {
         ConnectorPlanTestBase.dropAllCatalogs();
-    }
-
-    @Test
-    public void testMaterializedAnalyPaimonTable(@Mocked SlotRef slotRef, @Mocked PaimonTable table) {
-        MaterializedViewAnalyzer.MaterializedViewAnalyzerVisitor materializedViewAnalyzerVisitor =
-                new MaterializedViewAnalyzer.MaterializedViewAnalyzerVisitor();
-
-        {
-            // test check partition column can not be found
-            boolean checkSuccess = false;
-            new Expectations() {
-                {
-                    table.isUnPartitioned();
-                    result = false;
-                }
-            };
-            try {
-                materializedViewAnalyzerVisitor.checkPartitionColumnWithBasePaimonTable(slotRef, table);
-                checkSuccess = true;
-            } catch (Exception e) {
-                Assertions.assertTrue(e.getMessage().contains("Materialized view partition column in partition exp " +
-                                "must be base table partition column"),
-                        e.getMessage());
-            }
-            Assertions.assertFalse(checkSuccess);
-        }
-
-        {
-            // test check successfully
-            boolean checkSuccess = false;
-            new Expectations() {
-                {
-                    table.isUnPartitioned();
-                    result = false;
-
-                    table.getPartitionColumnNames();
-                    result = Lists.newArrayList("dt");
-
-                    slotRef.getColumnName();
-                    result = "dt";
-
-                    table.getColumn("dt");
-                    result = new Column("dt", ScalarType.createType(PrimitiveType.DATE));
-                }
-            };
-            try {
-                materializedViewAnalyzerVisitor.checkPartitionColumnWithBasePaimonTable(slotRef, table);
-                checkSuccess = true;
-            } catch (Exception e) {
-            }
-            Assertions.assertTrue(checkSuccess);
-        }
-
-        {
-            //test paimon table is unparitioned
-            new Expectations() {
-                {
-                    table.isUnPartitioned();
-                    result = true;
-                }
-            };
-
-            boolean checkSuccess = false;
-            try {
-                materializedViewAnalyzerVisitor.checkPartitionColumnWithBasePaimonTable(slotRef, table);
-            } catch (Exception e) {
-                Assertions.assertTrue(e.getMessage().contains("Materialized view partition column in partition exp " +
-                                "must be base table partition column"),
-                        e.getMessage());
-            }
-            Assertions.assertFalse(checkSuccess);
-        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerWithPaimonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerWithPaimonTest.java
@@ -1,0 +1,143 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvPlanContext;
+import com.starrocks.catalog.PaimonTable;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.optimizer.MaterializedViewOptimizer;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.apache.hadoop.util.Lists;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+public class MaterializedViewAnalyzerWithPaimonTest {
+    static StarRocksAssert starRocksAssert;
+    @TempDir
+    public static File temp;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        AnalyzeTestUtil.init();
+        starRocksAssert = AnalyzeTestUtil.getStarRocksAssert();
+        ConnectorPlanTestBase.mockAllCatalogs(starRocksAssert.getCtx(), temp.toURI().toString());
+
+        // set default config for async mvs
+        UtFrameUtils.setDefaultConfigForAsyncMVTest(starRocksAssert.getCtx());
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        ConnectorPlanTestBase.dropAllCatalogs();
+    }
+
+    @Test
+    public void testMaterializedAnalyPaimonTable(@Mocked SlotRef slotRef, @Mocked PaimonTable table) {
+        MaterializedViewAnalyzer.MaterializedViewAnalyzerVisitor materializedViewAnalyzerVisitor =
+                new MaterializedViewAnalyzer.MaterializedViewAnalyzerVisitor();
+
+        new MockUp<MaterializedViewOptimizer>() {
+            @Mock
+            public MvPlanContext optimize(MaterializedView mv,
+                                          ConnectContext connectContext,
+                                          boolean inlineView,
+                                          boolean isCheckNonDeterministicFunction) {
+                return new MvPlanContext(false, "");
+            }
+        };
+
+        {
+            // test check partition column can not be found
+            boolean checkSuccess = false;
+            new Expectations() {
+                {
+                    table.isUnPartitioned();
+                    result = false;
+                }
+            };
+            try {
+                materializedViewAnalyzerVisitor.checkPartitionColumnWithBasePaimonTable(slotRef, table);
+                checkSuccess = true;
+            } catch (Exception e) {
+                Assertions.assertTrue(e.getMessage().contains("Materialized view partition column in partition exp " +
+                                "must be base table partition column"),
+                        e.getMessage());
+            }
+            Assertions.assertFalse(checkSuccess);
+        }
+
+        {
+            // test check successfully
+            boolean checkSuccess = false;
+            new Expectations() {
+                {
+                    table.isUnPartitioned();
+                    result = false;
+
+                    table.getPartitionColumnNames();
+                    result = Lists.newArrayList("dt");
+
+                    slotRef.getColumnName();
+                    result = "dt";
+
+                    table.getColumn("dt");
+                    result = new Column("dt", ScalarType.createType(PrimitiveType.DATE));
+                }
+            };
+            try {
+                materializedViewAnalyzerVisitor.checkPartitionColumnWithBasePaimonTable(slotRef, table);
+                checkSuccess = true;
+            } catch (Exception e) {
+            }
+            Assertions.assertTrue(checkSuccess);
+        }
+
+        {
+            //test paimon table is unparitioned
+            new Expectations() {
+                {
+                    table.isUnPartitioned();
+                    result = true;
+                }
+            };
+
+            boolean checkSuccess = false;
+            try {
+                materializedViewAnalyzerVisitor.checkPartitionColumnWithBasePaimonTable(slotRef, table);
+            } catch (Exception e) {
+                Assertions.assertTrue(e.getMessage().contains("Materialized view partition column in partition exp " +
+                                "must be base table partition column"),
+                        e.getMessage());
+            }
+            Assertions.assertFalse(checkSuccess);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -31,6 +31,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.View;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
@@ -140,6 +141,8 @@ public abstract class MVTestBase extends StarRocksTestBase {
 
     @BeforeAll
     public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+
         CachingMvPlanContextBuilder.getInstance().rebuildCache();
         PseudoCluster.getOrCreateWithRandomPort(true, 1);
         GlobalStateMgr.getCurrentState().getTabletChecker().setInterval(100);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -95,6 +95,7 @@ public class StatisticsCalculatorTest {
 
         String dbName = "statistics_test";
         starRocksAssert.withDatabase(dbName).useDatabase(dbName);
+        FeConstants.runningUnitTest = false;
     }
 
     @BeforeEach

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -113,6 +114,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\"\n" +
                 ");");
+        FeConstants.runningUnitTest = false;
     }
 
     @BeforeEach

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.information.AnalyzeStatusSystemTable;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.persist.OperationType;
@@ -58,6 +59,7 @@ public class AnalyzeMgrTest {
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
         ConnectorPlanTestBase.mockHiveCatalog(connectContext);
+        FeConstants.runningUnitTest = false;
     }
 
     @AfterAll

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -310,6 +310,14 @@ public class UtFrameUtils {
         if (CREATED_MIN_CLUSTER.get()) {
             return;
         }
+
+        // set some parameters to speedup test
+        FeConstants.runningUnitTest = true;
+        Config.tablet_sched_checker_interval_seconds = 1;
+        Config.tablet_sched_repair_delay_factor_second = 1;
+        Config.enable_new_publish_mechanism = true;
+        Config.alter_scheduler_interval_millisecond = 100;
+
         try {
             ThriftConnectionPool.beHeartbeatPool = new MockGenericPool.HeatBeatPool("heartbeat");
             ThriftConnectionPool.backendPool = new MockGenericPool.BackendThriftPool("backend");

--- a/fe/fe-core/src/test/java/com/starrocks/warehouse/WarehouseTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/warehouse/WarehouseTestBase.java
@@ -20,20 +20,18 @@ import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 
 public abstract class WarehouseTestBase extends StarRocksTestBase {
-    @BeforeEach
-    public void before() throws Exception {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
         new MockUp<RunMode>() {
             @Mock
             public RunMode getCurrentRunMode() {
                 return RunMode.SHARED_DATA;
             }
         };
-
         UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
         GlobalStateMgr.getCurrentState().getWarehouseMgr().initDefaultWarehouse();
-        super.before();
     }
 }

--- a/fe/fe-core/src/test/resources/junit-platform.properties
+++ b/fe/fe-core/src/test/resources/junit-platform.properties
@@ -1,0 +1,13 @@
+# Global timeout for all test methods (5 minutes = 300 seconds)
+junit.jupiter.execution.timeout.default = 300
+junit.jupiter.execution.timeout.mode = enabled
+
+# Timeout for @Test methods specifically
+junit.jupiter.execution.timeout.testable.method.default = 300
+
+# Timeout for lifecycle methods (@BeforeAll, @AfterAll, @BeforeEach, @AfterEach) - 5 minutes
+junit.jupiter.execution.timeout.lifecycle.method.default = 300
+
+# Timeout mode - use ENABLED to enforce timeouts
+junit.jupiter.execution.timeout.thread.mode.default = separate_thread
+

--- a/fe/fe-parser/src/test/resources/junit-platform.properties
+++ b/fe/fe-parser/src/test/resources/junit-platform.properties
@@ -1,0 +1,13 @@
+# Global timeout for all test methods (5 minutes = 300 seconds)
+junit.jupiter.execution.timeout.default = 300
+junit.jupiter.execution.timeout.mode = enabled
+
+# Timeout for @Test methods specifically
+junit.jupiter.execution.timeout.testable.method.default = 300
+
+# Timeout for lifecycle methods (@BeforeAll, @AfterAll, @BeforeEach, @AfterEach) - 5 minutes
+junit.jupiter.execution.timeout.lifecycle.method.default = 300
+
+# Timeout mode - use ENABLED to enforce timeouts
+junit.jupiter.execution.timeout.thread.mode.default = separate_thread
+

--- a/fe/fe-utils/src/test/resources/junit-platform.properties
+++ b/fe/fe-utils/src/test/resources/junit-platform.properties
@@ -1,0 +1,13 @@
+# Global timeout for all test methods (5 minutes = 300 seconds)
+junit.jupiter.execution.timeout.default = 300
+junit.jupiter.execution.timeout.mode = enabled
+
+# Timeout for @Test methods specifically
+junit.jupiter.execution.timeout.testable.method.default = 300
+
+# Timeout for lifecycle methods (@BeforeAll, @AfterAll, @BeforeEach, @AfterEach) - 5 minutes
+junit.jupiter.execution.timeout.lifecycle.method.default = 300
+
+# Timeout mode - use ENABLED to enforce timeouts
+junit.jupiter.execution.timeout.thread.mode.default = separate_thread
+

--- a/fe/plugin/spark-dpp/src/test/resources/junit-platform.properties
+++ b/fe/plugin/spark-dpp/src/test/resources/junit-platform.properties
@@ -1,0 +1,13 @@
+# Global timeout for all test methods (5 minutes = 300 seconds)
+junit.jupiter.execution.timeout.default = 300
+junit.jupiter.execution.timeout.mode = enabled
+
+# Timeout for @Test methods specifically
+junit.jupiter.execution.timeout.testable.method.default = 300
+
+# Timeout for lifecycle methods (@BeforeAll, @AfterAll, @BeforeEach, @AfterEach) - 5 minutes
+junit.jupiter.execution.timeout.lifecycle.method.default = 300
+
+# Timeout mode - use ENABLED to enforce timeouts
+junit.jupiter.execution.timeout.thread.mode.default = separate_thread
+


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Add `junit-platform.properties` to limit FE UT's execution time （5 min by default, which we can deduce it later).
- Optimize some FE UT's test time in `createMinStarRocksCluster` to speed up tests:
```
        // set some parameters to speedup test
        FeConstants.runningUnitTest = true;
        Config.tablet_sched_checker_interval_seconds = 1;
        Config.tablet_sched_repair_delay_factor_second = 1;
        Config.enable_new_publish_mechanism = true;
        Config.alter_scheduler_interval_millisecond = 100;
```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds global JUnit timeouts to FE modules, improves MV rewrite preprocessor robustness and logging, and adjusts tests/config to stabilize UT execution.
> 
> - **Tests/CI**:
>   - Add `junit-platform.properties` across modules to enforce global 300s timeouts and separate thread execution.
>   - Tweak UT configs (e.g., `FeConstants.runningUnitTest`, `enable_new_publish_mechanism`, scheduler intervals) to speed up/stabilize tests; convert some lifecycle hooks and minor test logic fixes; extract Paimon MV analyzer cases into new `MaterializedViewAnalyzerWithPaimonTest`.
> - **Optimizer (MV)**:
>   - `MvRewritePreprocessor`: replace hard `Preconditions` with null checks and trace logging; include stack traces in logs; refine timeout handling and summary; change `prepareMV` to `void`; factor out outdated MV tracing; add safety checks for output columns.
> - **Build**:
>   - Update JaCoCo excludes (add `com/starrocks/rpc/**`, `com/starrocks/server/**`, `**/*$$JProtoBuf*`).
>   - Ignore `fe/fe-core/*.log` in `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a99c4ef13d7fc79677e59885df0105aadd90db2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->