### PR TITLE
[BugFix] fix cpu time calculation in olap scan and cloud native scan

### DIFF
--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -113,6 +113,8 @@ private:
     int64_t _bytes_read = 0;
     int64_t _cpu_time_spent_ns = 0;
 
+    int64_t _total_time = 0;
+
     RuntimeProfile::Counter* _bytes_read_counter = nullptr;
     RuntimeProfile::Counter* _rows_read_counter = nullptr;
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -658,37 +658,40 @@ Status OlapChunkSource::_read_chunk_from_storage(RuntimeState* state, Chunk* chu
         return Status::Cancelled("canceled state");
     }
 
-    do {
-        RETURN_IF_ERROR(state->check_mem_limit("read chunk from storage"));
-        RETURN_IF_ERROR(_prj_iter->get_next(chunk));
+    {
+        SCOPED_RAW_TIMER(&_total_time);
+        do {
+            RETURN_IF_ERROR(state->check_mem_limit("read chunk from storage"));
+            RETURN_IF_ERROR(_prj_iter->get_next(chunk));
 
-        TRY_CATCH_ALLOC_SCOPE_START()
+            TRY_CATCH_ALLOC_SCOPE_START()
 
-        for (auto slot : _query_slots) {
-            size_t column_index = chunk->schema()->get_field_index_by_name(slot->col_name());
-            chunk->set_slot_id_to_index(slot->id(), column_index);
-        }
+            for (auto slot : _query_slots) {
+                size_t column_index = chunk->schema()->get_field_index_by_name(slot->col_name());
+                chunk->set_slot_id_to_index(slot->id(), column_index);
+            }
 
-        if (!_non_pushdown_pred_tree.empty()) {
-            SCOPED_TIMER(_expr_filter_timer);
-            size_t nrows = chunk->num_rows();
-            _selection.resize(nrows);
-            RETURN_IF_ERROR(_non_pushdown_pred_tree.evaluate(chunk, _selection.data(), 0, nrows));
-            size_t after_rows = chunk->filter(_selection);
-            DCHECK_CHUNK(chunk);
-            COUNTER_UPDATE(_expr_filter_counter, nrows - after_rows);
-        }
-        if (!_scan_ctx->not_push_down_conjuncts().empty()) {
-            SCOPED_TIMER(_expr_filter_timer);
-            size_t before_rows = chunk->num_rows();
-            RETURN_IF_ERROR(ExecNode::eval_conjuncts(_scan_ctx->not_push_down_conjuncts(), chunk));
-            size_t after_rows = chunk->num_rows();
-            COUNTER_UPDATE(_expr_filter_counter, before_rows - after_rows);
-            DCHECK_CHUNK(chunk);
-        }
-        TRY_CATCH_ALLOC_SCOPE_END()
+            if (!_non_pushdown_pred_tree.empty()) {
+                SCOPED_TIMER(_expr_filter_timer);
+                size_t nrows = chunk->num_rows();
+                _selection.resize(nrows);
+                RETURN_IF_ERROR(_non_pushdown_pred_tree.evaluate(chunk, _selection.data(), 0, nrows));
+                size_t after_rows = chunk->filter(_selection);
+                DCHECK_CHUNK(chunk);
+                COUNTER_UPDATE(_expr_filter_counter, nrows - after_rows);
+            }
+            if (!_scan_ctx->not_push_down_conjuncts().empty()) {
+                SCOPED_TIMER(_expr_filter_timer);
+                size_t before_rows = chunk->num_rows();
+                RETURN_IF_ERROR(ExecNode::eval_conjuncts(_scan_ctx->not_push_down_conjuncts(), chunk));
+                size_t after_rows = chunk->num_rows();
+                COUNTER_UPDATE(_expr_filter_counter, before_rows - after_rows);
+                DCHECK_CHUNK(chunk);
+            }
+            TRY_CATCH_ALLOC_SCOPE_END()
 
-    } while (chunk->num_rows() == 0);
+        } while (chunk->num_rows() == 0);
+    }
     _update_realtime_counter(chunk);
     // Improve for select * from table limit x, x is small
     if (_limit != -1 && _num_rows_read >= _limit) {
@@ -703,7 +706,9 @@ void OlapChunkSource::_update_realtime_counter(Chunk* chunk) {
     _num_rows_read += num_rows;
     _scan_rows_num = stats.raw_rows_read;
     _scan_bytes = stats.bytes_read;
-    _cpu_time_spent_ns = stats.decompress_ns + stats.vec_cond_ns + stats.del_filter_ns;
+
+    // cpu time = total time - io time
+    _cpu_time_spent_ns = _total_time - stats.io_ns;
 
     const TQueryOptions& query_options = _runtime_state->query_options();
     if (query_options.__isset.load_job_type && query_options.load_job_type == TLoadJobType::INSERT_QUERY) {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -116,6 +116,8 @@ private:
     // The following are profile meatures
     int64_t _num_rows_read = 0;
 
+    int64_t _total_time = 0;
+
     RuntimeProfile::Counter* _bytes_read_counter = nullptr;
     RuntimeProfile::Counter* _rows_read_counter = nullptr;
 

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3376,7 +3376,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
 
         return True
 
-    def query_detail_check(self, sql=None, expected_scan_rows=None, expected_return_rows=None):
+    def query_detail_check(self, sql=None, expected_scan_rows=None, expected_return_rows=None, expected_cpu_cost_ns=None):
         """
         Comprehensive function to test query detail API using assertions to validate results
         
@@ -3462,7 +3462,16 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
             actual_cpu_cost_ns > 0,
             f"cpuCostNs is negative: {actual_cpu_cost_ns}"
         )
-        # print(f"✓ cpuCostNs validation passed: {actual_cpu_cost_ns}")
+
+        if expected_cpu_cost_ns is not None:
+            tools.assert_true(
+                actual_cpu_cost_ns >= expected_cpu_cost_ns,
+                f"cpuCostNs mismatch: expected {expected_cpu_cost_ns}, got {actual_cpu_cost_ns}"
+            )
+            # print(f"✓ cpuCostNs validation passed: {actual_cpu_cost_ns}")
+        else:
+            # print(f"cpuCostNs: {query_detail.get('cpuCostNs')}")
+            pass
 
         # Validate scanBytes
         actual_scan_bytes = query_detail.get("scanBytes")

--- a/test/sql/test_files/R/test_query_detail_api
+++ b/test/sql/test_files/R/test_query_detail_api
@@ -26,3 +26,13 @@ function: query_detail_check("insert into test_table select * from test_table", 
 -- result:
 {'success': True}
 -- !result
+set pipeline_dop=1;
+-- result:
+-- !result
+set io_tasks_per_scan_operator=1;
+-- result:
+-- !result
+function: query_detail_check("select * from test_table where sleep(1)", 6, 6, 2)
+-- result:
+{'success': True}
+-- !result

--- a/test/sql/test_files/T/test_query_detail_api
+++ b/test/sql/test_files/T/test_query_detail_api
@@ -20,6 +20,11 @@ function: query_detail_check("select * from test_table", 3, 3)
 
 function: query_detail_check("insert into test_table select * from test_table", 3, 0)
 
+set pipeline_dop=1;
+set io_tasks_per_scan_operator=1;
+function: query_detail_check("select * from test_table where sleep(1)", 6, 6, 2)
+
+
 -- admin set frontend config ("enable_collect_query_detail_info" = "false");
 
 


### PR DESCRIPTION
## Why I'm doing:
right now olap scan and cloud native scan's cpu cost calculation only count "stats.decompress_ns + stats.vec_cond_ns + stats.del_filter_ns;" , which is not accurate

## What I'm doing:
calcaute total time and io time, cpu_cost = total_time - io_time, this is the same as DLA' scan

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compute scan CPU time as total minus IO in OLAP and Lake scans, instrument total time, and add query_detail-based tests to validate cpuCostNs.
> 
> - **Backend (Scan CPU metrics)**:
>   - Wrap read loops in `OlapChunkSource::_read_chunk_from_storage` and `LakeDataSource::get_next` with `SCOPED_RAW_TIMER(&_total_time)` and add `int64_t _total_time` members.
>   - Recompute CPU time: in `OlapChunkSource::_update_realtime_counter` set `_cpu_time_spent_ns = _total_time - stats.io_ns`; in `LakeDataSource::update_realtime_counter` set `_cpu_time_spent_ns = _total_time - stats.io_ns - stats.io_ns_read_local_disk - stats.io_ns_write_local_disk - stats.io_ns_remote`.
> - **Tests/Utils**:
>   - Extend `query_detail_check` in `sr_sql_lib.py` to accept `expected_cpu_cost_ns` and assert `cpuCostNs >= expected`.
>   - Add SQL test steps to set `pipeline_dop=1`, `io_tasks_per_scan_operator=1` and validate `cpuCostNs` via `sleep(1)` predicate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15fa009195ff08be4eaf4229f9eb51b1bb5beb99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->