### PR TITLE
[BugFix] Fix collect paimon table column statistics information report error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
@@ -23,6 +23,7 @@ import com.starrocks.thrift.TIcebergSchemaField;
 import com.starrocks.thrift.TPaimonTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.table.DataTable;
 import org.apache.paimon.types.DataField;
 
@@ -87,7 +88,11 @@ public class PaimonTable extends Table {
 
     @Override
     public String getUUID() {
-        return String.join(".", catalogName, databaseName, tableName, paimonNativeTable.uuid());
+        if (!new Identifier(databaseName, tableName).isSystemTable()) {
+            return String.join(".", catalogName,  paimonNativeTable.uuid());
+        } else {
+            return String.join(".", catalogName, databaseName, tableName, paimonNativeTable.uuid());
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonTableTest.java
@@ -16,9 +16,23 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
 import com.starrocks.connector.ColumnTypeConverter;
+import com.starrocks.connector.ConnectorProperties;
+import com.starrocks.connector.ConnectorType;
+import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.paimon.PaimonMetadata;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.thrift.TTableDescriptor;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
@@ -27,6 +41,7 @@ import org.apache.paimon.types.RowType;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -102,5 +117,43 @@ public class PaimonTableTest {
         org.junit.jupiter.api.Assertions.assertEquals(table, table2);
         org.junit.jupiter.api.Assertions.assertEquals(table, table);
         org.junit.jupiter.api.Assertions.assertNotEquals(table, null);
+    }
+
+    @Test
+    public void testGetUUID() throws Exception {
+        //1.initialize env、db、table
+        java.nio.file.Path tmpDir = Files.createTempDirectory("tmp_");
+        Catalog catalog = CatalogFactory.createCatalog(CatalogContext.create(new Path(tmpDir.toString())));
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+        PaimonMetadata metadata = new PaimonMetadata("paimon_catalog", new HdfsEnvironment(), catalog,
+                new ConnectorProperties(ConnectorType.PAIMON));
+
+        catalog.createDatabase("test_db", true);
+
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("order_id", DataTypes.STRING());
+        schemaBuilder.column("order_date", DataTypes.STRING());
+        Options options = new Options();
+        options.set(CoreOptions.BUCKET, 2);
+        options.set(CoreOptions.BUCKET_KEY, "order_id");
+        schemaBuilder.options(options.toMap());
+        Schema schema = schemaBuilder.build();
+
+        Identifier identifier = Identifier.create("test_db", "test_table");
+        catalog.createTable(identifier, schema, true);
+
+        //2.check
+        //2.1 check not system table
+        PaimonTable paimonNotSystemTable = (PaimonTable) metadata.getTable(connectContext, "test_db", "test_table");
+        org.junit.jupiter.api.Assertions.assertEquals(paimonNotSystemTable.getUUID().split("\\.").length, 4);
+
+        //2.2 check system table
+        PaimonTable paimonSystemTable = (PaimonTable) metadata.getTable(connectContext, "test_db", "test_table$snapshots");
+        org.junit.jupiter.api.Assertions.assertEquals(paimonSystemTable.getUUID().split("\\.").length, 4);
+
+        //3.clean env
+        catalog.dropTable(identifier, true);
+        catalog.dropDatabase("test_db", true, true);
+        Files.delete(tmpDir);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonTableTest.java
@@ -146,10 +146,14 @@ public class PaimonTableTest {
         //2.1 check not system table
         PaimonTable paimonNotSystemTable = (PaimonTable) metadata.getTable(connectContext, "test_db", "test_table");
         org.junit.jupiter.api.Assertions.assertEquals(paimonNotSystemTable.getUUID().split("\\.").length, 4);
+        org.junit.jupiter.api.Assertions.assertTrue(
+                paimonNotSystemTable.getUUID().contains("paimon_catalog.test_db.test_table"));
 
         //2.2 check system table
         PaimonTable paimonSystemTable = (PaimonTable) metadata.getTable(connectContext, "test_db", "test_table$snapshots");
         org.junit.jupiter.api.Assertions.assertEquals(paimonSystemTable.getUUID().split("\\.").length, 4);
+        org.junit.jupiter.api.Assertions.assertTrue(
+                paimonSystemTable.getUUID().contains("paimon_catalog.test_db.test_table$snapshots"));
 
         //3.clean env
         catalog.dropTable(identifier, true);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -220,7 +220,7 @@ public class PaimonMetadataTest {
         assertEquals(ScalarType.DOUBLE, paimonTable.getBaseSchema().get(1).getType());
         org.junit.jupiter.api.Assertions.assertTrue(paimonTable.getBaseSchema().get(1).isAllowNull());
         assertEquals("paimon_catalog", paimonTable.getCatalogName());
-        assertEquals("paimon_catalog.db1.tbl1.null", paimonTable.getUUID());
+        assertEquals("paimon_catalog.null", paimonTable.getUUID());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
when query Non-system paimon table, fe report error log as follows, via print error log, the reason is `PaimonTable::getUUID` return value with duplicate database/table name, cause `Preconditions.checkState(splits.length == 4);` in `StatisticsUtils::getTableByUUID` check failed.
<img width="1511" height="268" alt="0928_1" src="https://github.com/user-attachments/assets/e4bdc86e-ae26-4756-ae4f-2a9072330984" />
<img width="994" height="319" alt="0928_2" src="https://github.com/user-attachments/assets/04729cdb-3a65-4e39-93d5-9f2e4d6b89bc" />

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts UUID generation for Paimon tables to avoid duplicated db/table for non-system tables; adds dedicated UUID tests and updates expectations.
> 
> - **Catalog**:
>   - **`PaimonTable#getUUID`**: Use `Identifier.isSystemTable()` to compose UUIDs; non-system tables now use `catalogName.uuid`, system tables include `databaseName` and `tableName`.
> - **Tests**:
>   - Add `PaimonTableTest#testGetUUID` to validate UUIDs for system vs non-system tables using an in-memory Paimon catalog.
>   - Update `PaimonMetadataTest` UUID expectation to `"paimon_catalog.null"` for mocked non-system tables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52aaf932d78a0a984be5faf1b0418f2c8841b4e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->