### PR TITLE
[Enhancement] Improved the logic for determining when to enable PK parallel execution

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -217,6 +217,7 @@ set(STORAGE_FILES
     lake/lake_primary_key_recover.cpp
     lake/spill_mem_table_sink.cpp
     lake/tablet_retain_info.cpp
+    lake/tablet_writer.cpp
     load_spill_block_manager.cpp
     load_chunk_spiller.cpp
     sstable/block_builder.cpp

--- a/be/src/storage/lake/compaction_task.h
+++ b/be/src/storage/lake/compaction_task.h
@@ -53,6 +53,8 @@ public:
 
     Status fill_compaction_segment_info(TxnLogPB_OpCompaction* op_compaction, TabletWriter* writer);
 
+    bool should_enable_pk_parallel_execution(int64_t input_bytes);
+
 protected:
     int64_t _txn_id;
     VersionedTablet _tablet;

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -65,7 +65,7 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     RETURN_IF_ERROR(writer->open());
     DeferOp defer([&]() { writer->close(); });
 
-    if (input_bytes >= config::pk_parallel_execution_threshold_bytes) {
+    if (should_enable_pk_parallel_execution(input_bytes)) {
         writer->try_enable_pk_parallel_execution();
     }
 

--- a/be/src/storage/lake/tablet_writer.cpp
+++ b/be/src/storage/lake/tablet_writer.cpp
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/tablet_writer.h"
+
+#include "storage/lake/tablet_manager.h"
+
+namespace starrocks::lake {
+
+void TabletWriter::try_enable_pk_parallel_execution() {
+    if (!config::enable_pk_parallel_execution || _schema->keys_type() != KeysType::PRIMARY_KEYS ||
+        _schema->has_separate_sort_key()) {
+        return;
+    }
+    auto metadata = _tablet_mgr->get_latest_cached_tablet_metadata(_tablet_id);
+    if (metadata != nullptr) {
+        // Pk parallel execution only support cloud native pk index.
+        if (!metadata->enable_persistent_index() ||
+            metadata->persistent_index_type() != PersistentIndexTypePB::CLOUD_NATIVE) {
+            return;
+        }
+    }
+    // For primary key table with single key column and the type is not VARCHAR/CHAR,
+    // we can't enable pk parrallel execution. The reason is that, in the current implementation,
+    // when encoding a single-key column of a non-binary type, big-endian encoding is not used,
+    // which may result in incorrect ordering between sst and segment files.
+    // This is a legacy bug, but for compatibility reasons, it will not be supported in the first phase.
+    // Will fix it later.
+    if (_schema->num_key_columns() > 1 || _schema->column(0).type() == LogicalType::TYPE_VARCHAR ||
+        _schema->column(0).type() == LogicalType::TYPE_CHAR) {
+        _enable_pk_parallel_execution = true;
+    }
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -148,22 +148,7 @@ public:
     // When the system determines that pk parallel execution can be enabled
     // (for example, during large imports or major compaction tasks), it will invoke this function.
     // However, whether pk parallel execution is actually enabled still depends on the schema.
-    void try_enable_pk_parallel_execution() {
-        if (!config::enable_pk_parallel_execution || _schema->keys_type() != KeysType::PRIMARY_KEYS ||
-            _schema->has_separate_sort_key()) {
-            return;
-        }
-        // For primary key table with single key column and the type is not VARCHAR/CHAR,
-        // we can't enable pk parrallel execution. The reason is that, in the current implementation,
-        // when encoding a single-key column of a non-binary type, big-endian encoding is not used,
-        // which may result in incorrect ordering between sst and segment files.
-        // This is a legacy bug, but for compatibility reasons, it will not be supported in the first phase.
-        // Will fix it later.
-        if (_schema->num_key_columns() > 1 || _schema->column(0).type() == LogicalType::TYPE_VARCHAR ||
-            _schema->column(0).type() == LogicalType::TYPE_CHAR) {
-            _enable_pk_parallel_execution = true;
-        }
-    }
+    void try_enable_pk_parallel_execution();
 
     bool enable_pk_parallel_execution() const { return _enable_pk_parallel_execution; }
 

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -58,7 +58,7 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     RETURN_IF_ERROR(writer->open());
     DeferOp defer([&]() { writer->close(); });
 
-    if (input_bytes >= config::pk_parallel_execution_threshold_bytes) {
+    if (should_enable_pk_parallel_execution(input_bytes)) {
         writer->try_enable_pk_parallel_execution();
     }
 

--- a/be/test/storage/lake/spill_mem_table_sink_test.cpp
+++ b/be/test/storage/lake/spill_mem_table_sink_test.cpp
@@ -268,7 +268,7 @@ TEST_F(SpillMemTableSinkTest, test_out_of_disk_space) {
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
             _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile, true);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
     auto chunk = gen_data(kChunkSize, 0);
     starrocks::SegmentPB segment0;
     ASSERT_OK(sink.flush_chunk(*chunk, &segment0, false));

--- a/be/test/storage/lake/spill_mem_table_sink_test.cpp
+++ b/be/test/storage/lake/spill_mem_table_sink_test.cpp
@@ -268,7 +268,7 @@ TEST_F(SpillMemTableSinkTest, test_out_of_disk_space) {
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
             _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile, true);
     auto chunk = gen_data(kChunkSize, 0);
     starrocks::SegmentPB segment0;
     ASSERT_OK(sink.flush_chunk(*chunk, &segment0, false));


### PR DESCRIPTION
## Why I'm doing:
For import tasks, enabling PK parallel execution requires using the cloud-native index and meeting the data size threshold. For compaction tasks, in addition to using the cloud-native index and meeting the data size threshold, the light compaction publish strategy must also be in effect.

## What I'm doing:
This pull request introduces improvements to how primary key (PK) parallel execution is enabled and managed for compaction tasks in the Lake storage engine. The changes add stricter checks to ensure PK parallel execution is only activated under the correct conditions, refactor related logic for clarity and consistency, and enhance test coverage for these scenarios.

**Enhancements to PK Parallel Execution Logic:**

* Added a new method `CompactionTask::should_enable_pk_parallel_execution` to centralize and clarify the conditions under which PK parallel execution can be enabled, including checks for cloud native index, light compaction publish, and input size threshold. (`be/src/storage/lake/compaction_task.cpp`, `be/src/storage/lake/compaction_task.h`) [[1]](diffhunk://#diff-1e439ad0c5ae3d3e0348c25088f3a55097dbfa2a1f5932a330ee7ba947e67164R93-R109) [[2]](diffhunk://#diff-cc856a55ebfe8f58240a0ade91f55da5fc431a312425ad7249700b2780c25b96R56-R57)
* Updated compaction task execution logic to use the new `should_enable_pk_parallel_execution` method instead of a simple input size check, ensuring stricter and more accurate activation of PK parallel execution. (`be/src/storage/lake/horizontal_compaction_task.cpp`, `be/src/storage/lake/vertical_compaction_task.cpp`) [[1]](diffhunk://#diff-f7fd3e76508b60fb1199994d6d4d507b253a851a7a0083b296176481905d0ef6L68-R68) [[2]](diffhunk://#diff-a1ab8c006c1ef5ff09f84e1efb5bc6a947967bc096730c0be13884068a8071dfL61-R61)

**Tablet Writer Refactoring:**

* Refactored `TabletWriter::try_enable_pk_parallel_execution` into a separate implementation file for better maintainability, and added additional checks for schema and index type before enabling PK parallel execution. (`be/src/storage/lake/tablet_writer.cpp`, `be/src/storage/lake/tablet_writer.h`) [[1]](diffhunk://#diff-83aef32ce1a8ab9fae6291a9219b535da001a1956183015054e270af609b57abR1-R46) [[2]](diffhunk://#diff-22e40a71efd1ffa705f77ad85728eaa3ec3673afb8d06bbdd9b4d76bd2e74550L151-R151)

**Update Manager and SST Ingestion Logic:**

* Introduced a utility function to check for cloud native PK index and updated SST ingestion and index update logic to only operate when the cloud native PK index is in use, improving correctness and efficiency. (`be/src/storage/lake/update_manager.cpp`) [[1]](diffhunk://#diff-ce8ef103b70e198d350635a74a2ce6449e3c2b612231c6de6493359af140ab66R50-R54) [[2]](diffhunk://#diff-ce8ef103b70e198d350635a74a2ce6449e3c2b612231c6de6493359af140ab66L282-R290) [[3]](diffhunk://#diff-ce8ef103b70e198d350635a74a2ce6449e3c2b612231c6de6493359af140ab66L296-R303) [[4]](diffhunk://#diff-ce8ef103b70e198d350635a74a2ce6449e3c2b612231c6de6493359af140ab66L1195-R1202) [[5]](diffhunk://#diff-ce8ef103b70e198d350635a74a2ce6449e3c2b612231c6de6493359af140ab66L1207-R1214)

**Testing Improvements:**

* Added comprehensive tests to verify the correct behavior of `should_enable_pk_parallel_execution` under various configurations, ensuring reliability and correctness of the new logic. (`be/test/storage/lake/primary_key_compaction_task_test.cpp`)
* Minor adjustment to test setup for `SpillMemTableSink` to support new constructor signature. (`be/test/storage/lake/spill_mem_table_sink_test.cpp`)

Fix #62740

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
