### PR TITLE
Remove non-pipeline execution engine code

### DIFF
--- a/be/src/runtime/external_scan_context_mgr.cpp
+++ b/be/src/runtime/external_scan_context_mgr.cpp
@@ -113,7 +113,7 @@ Status ExternalScanContextMgr::clear_scan_context(const std::string& context_id)
         }
     }
     if (context != nullptr) {
-        // cancel pipeline
+        // cancel pipeline fragment
         const auto& fragment_instance_id = context->fragment_instance_id;
         if (auto query_ctx = _exec_env->query_context_mgr()->get(context->query_id); query_ctx != nullptr) {
             if (auto fragment_ctx = query_ctx->fragment_mgr()->get(fragment_instance_id); fragment_ctx != nullptr) {
@@ -165,10 +165,16 @@ void ExternalScanContextMgr::gc_expired_context() {
             }
         }
         for (const auto& expired_context : expired_contexts) {
-            // must cancel the fragment instance, otherwise return thrift transport TTransportException
-            WARN_IF_ERROR(
-                    _exec_env->fragment_mgr()->cancel(expired_context->fragment_instance_id),
-                    strings::Substitute("Fail to cancel fragment $0", print_id(expired_context->fragment_instance_id)));
+            // must cancel the fragment instance (pipeline)
+            if (auto query_ctx = _exec_env->query_context_mgr()->get(expired_context->query_id); query_ctx != nullptr) {
+                if (auto fragment_ctx = query_ctx->fragment_mgr()->get(expired_context->fragment_instance_id);
+                    fragment_ctx != nullptr) {
+                    std::stringstream msg;
+                    msg << "FragmentContext(id=" << print_id(expired_context->fragment_instance_id)
+                        << ") cancelled by gc_expired_context";
+                    fragment_ctx->cancel(Status::Cancelled(msg.str()));
+                }
+            }
             WARN_IF_ERROR(_exec_env->result_queue_mgr()->cancel(expired_context->fragment_instance_id),
                           strings::Substitute("Fail to cancel fragment $0 in result queue mgr",
                                               print_id(expired_context->fragment_instance_id)));


### PR DESCRIPTION
## Why I'm doing:

This PR removes the deprecated and unmaintained non-pipeline execution engine from the BE. The pipeline engine is now the sole execution path, simplifying the codebase and reducing maintenance overhead.

## What I'm doing:

-   Switched `BackendServiceBase` to exclusively use the pipeline `FragmentExecutor`.
-   Enforced pipeline-only execution in `InternalService`, removing the non-pipeline fallback, including for `SCHEMA_TABLE_SINK`.
-   Refactored `StreamLoadExecutor` to schedule and wait on the pipeline executor for fragment completion.
-   Updated `ExternalScanContextMgr` cancellation logic to use pipeline fragment contexts.

## What type of PR is this:

-   [ ] BugFix
-   [ ] Feature
-   [x] Enhancement
-   [x] Refactor
-   [ ] UT
-   [ ] Doc
-   [ ] Tool

Does this PR entail a change in behavior?

-   [x] Yes, this PR will result in a change in behavior.
-   [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

-   [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
-   [ ] Parameter changes: default values, similar parameters but with different default values
-   [x] Policy changes: use new policy to replace old one, functionality automatically enabled
-   [ ] Feature removed
-   [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

-   [ ] I have added test cases for my bug fix or my new feature
-   [ ] This pr needs user documentation (for new or modified features or behaviors)
    -   [ ] I have added documentation for my new feature or new function
-   [ ] This is a backport pr

## Bugfix cherry-pick branch check:
-   [ ] I have checked the version labels which the pr will be auto-backported to the target branch
    -   [ ] 4.0
    -   [ ] 3.5
    -   [ ] 3.4
    -   [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-47e6f158-9c35-4360-93ad-e03c73d24efc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-47e6f158-9c35-4360-93ad-e03c73d24efc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

