### PR TITLE
[BugFix] Fix mv rewrite bugs with char/varchar implicit cast

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -35,7 +35,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
@@ -650,26 +649,6 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         OptExpression rewriteOp = OptExpression.create(newAggOp, mvOptExpr);
         deriveLogicalProperty(rewriteOp);
         return rewriteOp;
-    }
-
-    /**
-     * Add columnRefOperator and scalarOperator into newProjection and ensure their type is the same.
-     */
-    private void addIntoProjection(Map<ColumnRefOperator, ScalarOperator> newProjection,
-                                   ColumnRefOperator columnRefOperator,
-                                   ScalarOperator scalarOperator) {
-        // Ensure columnRefOperator's type is exactly the same as scalarOperator's type,
-        // This can happen when mv and the query's type are different but they are the same columns, such as:
-        // query: char(4)
-        // mv   : varchar(-1)
-        if (!columnRefOperator.getType().equals(scalarOperator.getType())) {
-            // add cast if type is not the same
-            // TODO: may it's safe to remove the cast if the type is compatible
-            ScalarOperator newScalarOperator = new CastOperator(columnRefOperator.getType(), scalarOperator, true);
-            newProjection.put(columnRefOperator, newScalarOperator);
-        } else {
-            newProjection.put(columnRefOperator, scalarOperator);
-        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -68,6 +68,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
@@ -3051,5 +3052,25 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
             projection = mvOp.getProjection();
         }
         return projection;
+    }
+
+    /**
+     * Add columnRefOperator and scalarOperator into newProjection and ensure their type is the same.
+     */
+    protected void addIntoProjection(Map<ColumnRefOperator, ScalarOperator> newProjection,
+                                     ColumnRefOperator columnRefOperator,
+                                     ScalarOperator scalarOperator) {
+        // Ensure columnRefOperator's type is exactly the same as scalarOperator's type,
+        // This can happen when mv and the query's type are different but they are the same columns, such as:
+        // query: char(4)
+        // mv   : varchar(-1)
+        // TODO: may it's safe to remove the cast if the type is compatible
+        if (!columnRefOperator.getType().getPrimitiveType().equals(scalarOperator.getType().getPrimitiveType())) {
+            // add cast if type is not the same
+            ScalarOperator newScalarOperator = new CastOperator(columnRefOperator.getType(), scalarOperator, true);
+            newProjection.put(columnRefOperator, newScalarOperator);
+        } else {
+            newProjection.put(columnRefOperator, scalarOperator);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -43,6 +43,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.thrift.TExplainLevel;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
@@ -980,6 +981,36 @@ public class MvRewriteTest extends MVTestBase {
             dropMv("test", "emp_lowcard_sum");
             FeConstants.USE_MOCK_DICT_MANAGER = false;
         }
+    }
+
+    @Test
+    public void testDictWithMVRewrite() throws Exception {
+        FeConstants.USE_MOCK_DICT_MANAGER = true;
+        starRocksAssert.withTable("CREATE TABLE supplier_char(" +
+                " s_suppkey     INTEGER NOT NULL,\n" +
+                " s_name        CHAR(25) NOT NULL,\n" +
+                " s_address     CHAR(40), \n" +
+                " s_nationkey   INTEGER NOT NULL,\n" +
+                " s_phone       CHAR(15) NOT NULL,\n" +
+                " s_acctbal     double NOT NULL,\n" +
+                " s_comment     CHAR(101) NOT NULL,\n" +
+                " pad char(1) NOT NULL)\n" +
+                "DUPLICATE KEY(`s_suppkey`)\n" +
+                "DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ");");
+        starRocksAssert.withMaterializedView(" CREATE MATERIALIZED VIEW test_mv1\n" +
+                "DISTRIBUTED BY RANDOM\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS select s_nationkey, s_name, bitmap_agg(s_suppkey), sum(s_nationkey) from supplier_char group by " +
+                "s_nationkey, s_name;");
+        String query = "select s_name, count(distinct s_suppkey), sum(s_nationkey) from supplier_char group by s_name;";
+        String plan = getFragmentPlan(query, TExplainLevel.COSTS);
+        PlanTestBase.assertContains(plan, "dict_col=s_name");
+        FeConstants.USE_MOCK_DICT_MANAGER = false;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -1000,7 +1000,7 @@ public class MvRewriteTest extends MVTestBase {
                 "PROPERTIES (\n" +
                 "\"replication_num\" = \"1\"" +
                 ");");
-        starRocksAssert.withMaterializedView(" CREATE MATERIALIZED VIEW test_mv1\n" +
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test_mv1\n" +
                 "DISTRIBUTED BY RANDOM\n" +
                 "PROPERTIES (\n" +
                 "\"replication_num\" = \"1\"\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -284,6 +284,10 @@ public class PlanTestNoneDBBase extends StarRocksTestBase {
     }
 
     public String getFragmentPlan(String sql, String traceModule) throws Exception {
+        return getFragmentPlan(sql, TExplainLevel.NORMAL, traceModule);
+    }
+
+    public String getFragmentPlan(String sql, TExplainLevel tExplainLevel, String traceModule) throws Exception {
         Pair<String, Pair<ExecPlan, String>> result =
                 UtFrameUtils.getFragmentPlanWithTrace(connectContext, sql, traceModule);
         Pair<ExecPlan, String> execPlanWithQuery = result.second;
@@ -291,7 +295,7 @@ public class PlanTestNoneDBBase extends StarRocksTestBase {
         if (!Strings.isNullOrEmpty(traceLog)) {
             logSysInfo(traceLog);
         }
-        return execPlanWithQuery.first.getExplainString(TExplainLevel.NORMAL);
+        return execPlanWithQuery.first.getExplainString(tExplainLevel);
     }
 
     public String getLogicalFragmentPlan(String sql) throws Exception {

--- a/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_bugfix3
+++ b/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_bugfix3
@@ -1,0 +1,108 @@
+-- name: test_mv_rewrite_bugfix3
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE supplier_char(
+ s_suppkey     INTEGER NOT NULL,
+ s_name        CHAR(25) NOT NULL,
+ s_address     CHAR(40), 
+ s_nationkey   INTEGER NOT NULL,
+ s_phone       CHAR(15) NOT NULL,
+ s_acctbal     double NOT NULL,
+ s_comment     CHAR(101) NOT NULL,
+ pad char(1) NOT NULL)
+DUPLICATE KEY(`s_suppkey`)
+DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO supplier_char VALUES (1, 'name1', 'address1', 1, 'phone1', 1.0, 'comment1', 'p'),
+(2, 'name2', 'address2', 2, 'phone2', 2.0, 'comment2', 'p'),
+(3, 'name3', 'address3', 3, 'phone3', 3.0, 'comment3', 'p'),
+(4, 'name4', 'address4', 4, 'phone4', 4.0, 'comment4', 'p'),
+(5, 'name5', 'address5', 5, 'phone5', 5.0, 'comment5', 'p'),
+(6, 'name6', 'address6', 6, 'phone6', 6.0, 'comment6', 'p'),
+(7, 'name7', 'address7', 7, 'phone7', 7.0, 'comment7', 'p'),
+(8, 'name8', 'address8', 8, 'phone8', 8.0, 'comment8', 'p'),
+(9, 'name9', 'address9', 9, 'phone9', 9.0, 'comment9', 'p'),
+(10, 'name10', 'address10', 10, 'phone10', 10.0, 'comment10', 'p');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+DISTRIBUTED BY RANDOM
+PROPERTIES (
+"replication_num" = "1"
+)
+AS select s_nationkey, s_name, bitmap_agg(s_suppkey), sum(s_nationkey) from supplier_char group by 
+s_nationkey, s_name;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC] analyze full table supplier_char;
+-- result:
+db_611c78b427b640e2b3e00e6241768903.supplier_char	analyze	status	OK
+-- !result
+[UC] analyze full table test_mv1;
+-- result:
+db_611c78b427b640e2b3e00e6241768903.test_mv1	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('s_name', 'supplier_char')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('s_name', 'test_mv1')
+-- result:
+
+-- !result
+select s_nationkey, s_name, count(distinct s_suppkey), sum(s_nationkey) from supplier_char group by s_nationkey, s_name order by 1,2;
+-- result:
+1	name1	1	1
+2	name2	1	2
+3	name3	1	3
+4	name4	1	4
+5	name5	1	5
+6	name6	1	6
+7	name7	1	7
+8	name8	1	8
+9	name9	1	9
+10	name10	1	10
+-- !result
+select s_name, count(distinct s_suppkey), sum(s_nationkey) from supplier_char group by s_name order by 1,2;
+-- result:
+name1	1	1
+name10	1	10
+name2	1	2
+name3	1	3
+name4	1	4
+name5	1	5
+name6	1	6
+name7	1	7
+name8	1	8
+name9	1	9
+-- !result
+select s_name, count(distinct s_suppkey), sum(s_nationkey) from supplier_char group by s_name having sum(s_nationkey) > 10 order by 1,2;
+-- result:
+-- !result
+function: print_hit_materialized_views("select s_nationkey, s_name, count(distinct s_suppkey), sum(s_nationkey) from supplier_char group by s_nationkey, s_name order by 1,2;")
+-- result:
+test_mv1
+-- !result
+function: print_hit_materialized_views("select s_name, count(distinct s_suppkey), sum(s_nationkey) from supplier_char group by s_name order by 1,2;")
+-- result:
+test_mv1
+-- !result
+function: print_hit_materialized_views("select s_name, count(distinct s_suppkey), sum(s_nationkey) from supplier_char group by s_name having sum(s_nationkey) > 10 order by 1,2;")
+-- result:
+test_mv1
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_bugfix3
+++ b/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_bugfix3
@@ -1,0 +1,55 @@
+-- name: test_mv_rewrite_bugfix3
+
+create database db_${uuid0};
+use db_${uuid0};
+CREATE TABLE supplier_char(
+ s_suppkey     INTEGER NOT NULL,
+ s_name        CHAR(25) NOT NULL,
+ s_address     CHAR(40), 
+ s_nationkey   INTEGER NOT NULL,
+ s_phone       CHAR(15) NOT NULL,
+ s_acctbal     double NOT NULL,
+ s_comment     CHAR(101) NOT NULL,
+ pad char(1) NOT NULL)
+DUPLICATE KEY(`s_suppkey`)
+DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+INSERT INTO supplier_char VALUES (1, 'name1', 'address1', 1, 'phone1', 1.0, 'comment1', 'p'),
+(2, 'name2', 'address2', 2, 'phone2', 2.0, 'comment2', 'p'),
+(3, 'name3', 'address3', 3, 'phone3', 3.0, 'comment3', 'p'),
+(4, 'name4', 'address4', 4, 'phone4', 4.0, 'comment4', 'p'),
+(5, 'name5', 'address5', 5, 'phone5', 5.0, 'comment5', 'p'),
+(6, 'name6', 'address6', 6, 'phone6', 6.0, 'comment6', 'p'),
+(7, 'name7', 'address7', 7, 'phone7', 7.0, 'comment7', 'p'),
+(8, 'name8', 'address8', 8, 'phone8', 8.0, 'comment8', 'p'),
+(9, 'name9', 'address9', 9, 'phone9', 9.0, 'comment9', 'p'),
+(10, 'name10', 'address10', 10, 'phone10', 10.0, 'comment10', 'p');
+
+
+CREATE MATERIALIZED VIEW test_mv1
+DISTRIBUTED BY RANDOM
+PROPERTIES (
+"replication_num" = "1"
+)
+AS select s_nationkey, s_name, bitmap_agg(s_suppkey), sum(s_nationkey) from supplier_char group by 
+s_nationkey, s_name;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+[UC] analyze full table supplier_char;
+[UC] analyze full table test_mv1;
+function: wait_global_dict_ready('s_name', 'supplier_char')
+function: wait_global_dict_ready('s_name', 'test_mv1')
+
+select s_nationkey, s_name, count(distinct s_suppkey), sum(s_nationkey) from supplier_char group by s_nationkey, s_name order by 1,2;
+select s_name, count(distinct s_suppkey), sum(s_nationkey) from supplier_char group by s_name order by 1,2;
+select s_name, count(distinct s_suppkey), sum(s_nationkey) from supplier_char group by s_name having sum(s_nationkey) > 10 order by 1,2;
+
+function: print_hit_materialized_views("select s_nationkey, s_name, count(distinct s_suppkey), sum(s_nationkey) from supplier_char group by s_nationkey, s_name order by 1,2;")
+function: print_hit_materialized_views("select s_name, count(distinct s_suppkey), sum(s_nationkey) from supplier_char group by s_name order by 1,2;")
+function: print_hit_materialized_views("select s_name, count(distinct s_suppkey), sum(s_nationkey) from supplier_char group by s_name having sum(s_nationkey) > 10 order by 1,2;")
+
+drop materialized view test_mv1;
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
```
ava.lang.IllegalStateException
        at com.google.common.base.Preconditions.checkState(Preconditions.java:496)
        at com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeContext$DictExprRewrite.decode(DecodeContext.java:218)
        at com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeContext.rewriteStringRefToDictRef(DecodeContext.java:120)
        at com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeContext.initRewriteExpressions(DecodeContext.java:104)
        at com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeRewriter.rewrite(DecodeRewriter.java:80)
        at com.starrocks.sql.optimizer.rule.tree.lowcardinality.LowCardinalityRewriteRule.rewrite(LowCardinalityRewriteRule.java:43)
        at com.starrocks.sql.optimizer.QueryOptimizer.physicalRuleRewrite(QueryOptimizer.java:941)
        at com.starrocks.sql.optimizer.QueryOptimizer.optimizeByCost(QueryOptimizer.java:291)
        at com.starrocks.sql.optimizer.QueryOptimizer.optimize(QueryOptimizer.java:200)
        at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:384)
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:150)
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:107)
        at com.starrocks.qe.StmtExecutor.generateExecPlan(StmtExecutor.java:579)
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:657)
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:434)
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:645)
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:997)
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:71)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
````

## What I'm doing:
- Add an implicit cast when mv's type and query's type are not the same.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
