### PR TITLE
[Enhancement] Generate 3-stage aggregation by child distribution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -339,6 +339,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     // --------  New planner session variables start --------
     public static final String NEW_PLANER_AGG_STAGE = "new_planner_agg_stage";
+    public static final String ENABLE_COST_BASED_MULTI_STAGE_AGG = "enable_cost_based_multi_stage_agg";
     public static final String BROADCAST_ROW_LIMIT = "broadcast_row_limit";
     public static final String BROADCAST_RIGHT_TABLE_SCALE_FACTOR =
             "broadcast_right_table_scale_factor";
@@ -1574,6 +1575,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // single-column distinct scenarios
     @VariableMgr.VarAttr(name = NEW_PLANER_AGG_STAGE)
     private int newPlannerAggStage = SessionVariableConstants.AggregationStage.AUTO.ordinal();
+
+    @VariableMgr.VarAttr(name = ENABLE_COST_BASED_MULTI_STAGE_AGG)
+    private boolean enableCostBasedMultiStageAgg = true;
 
     @VariableMgr.VarAttr(name = TRANSMISSION_COMPRESSION_TYPE)
     private String transmissionCompressionType = "AUTO";
@@ -3676,6 +3680,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setNewPlanerAggStage(int stage) {
         this.newPlannerAggStage = stage;
+    }
+
+    public boolean isEnableCostBasedMultiStageAgg() {
+        return newPlannerAggStage == SessionVariableConstants.AggregationStage.AUTO.ordinal() &&  enableCostBasedMultiStageAgg;
     }
 
     public void setMaxTransformReorderJoins(int maxReorderNodeUseExhaustive) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
@@ -199,6 +199,7 @@ public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
         return "LogicalAggregation" + " {type=" + node.getType() +
                 " ,aggregations=" + node.getAggregations() +
                 " ,groupKeys=" + node.getGroupingKeys() +
+                ", partitionBys=" + node.getPartitionByColumns() +
                 " ,projection=" + node.getProjection() +
                 " ,predicate=" + node.getPredicate() +
                 "}";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
@@ -110,6 +110,10 @@ public class LogicalAggregationOperator extends LogicalOperator {
         return isSplit;
     }
 
+    public void setSplit(boolean split) {
+        isSplit = split;
+    }
+
     public void setOnlyLocalAggregate() {
         isSplit = false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.operator.physical;
 
 import com.google.common.base.Preconditions;
@@ -53,11 +52,11 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
     // For normal aggregate function, partitionByColumns are same with groupingKeys
     // but for single distinct function, partitionByColumns are not same with groupingKeys
     private final List<ColumnRefOperator> partitionByColumns;
-    private final Map<ColumnRefOperator, CallOperator> aggregations;
+    private Map<ColumnRefOperator, CallOperator> aggregations;
 
     // The flag for this aggregate operator has split to
     // two stage aggregate or three stage aggregate
-    private final boolean isSplit;
+    private boolean isSplit;
 
     // TODO introduce builder mode to change these fields to final fields
     // flag for this aggregate operator's parent had been pruned
@@ -119,6 +118,10 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
         return aggregations;
     }
 
+    public void setAggregations(Map<ColumnRefOperator, CallOperator> aggregations) {
+        this.aggregations = aggregations;
+    }
+
     public AggType getType() {
         return type;
     }
@@ -153,6 +156,10 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
         return isSplit;
     }
 
+    public void setSplit(boolean split) {
+        isSplit = split;
+    }
+
     public boolean canUseStreamingPreAgg() {
         if (type.isGlobal() || type.isDistinctGlobal()) {
             return false;
@@ -162,7 +169,6 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
             return isSplit && CollectionUtils.isNotEmpty(groupBys) && !mergedLocalAgg;
         }
     }
-
 
     public String getNeededPreaggregationMode() {
         String mode = ConnectContext.get().getSessionVariable().getStreamingPreaggregationMode();
@@ -203,6 +209,7 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
     public void setGroupByMinMaxStatistic(List<Pair<ConstantOperator, ConstantOperator>> groupByMinMaxStatistic) {
         this.groupByMinMaxStatistic = groupByMinMaxStatistic;
     }
+
     public List<Pair<ConstantOperator, ConstantOperator>> getGroupByMinMaxStatistic() {
         return this.groupByMinMaxStatistic;
     }
@@ -226,7 +233,7 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), type, groupBys, aggregations.keySet());
+        return Objects.hash(super.hashCode(), type, groupBys, aggregations.keySet(), partitionByColumns);
     }
 
     @Override
@@ -241,7 +248,7 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
 
         PhysicalHashAggregateOperator that = (PhysicalHashAggregateOperator) o;
         return type == that.type && Objects.equals(aggregations, that.aggregations) &&
-                Objects.equals(groupBys, that.groupBys);
+                Objects.equals(groupBys, that.groupBys) && Objects.equals(partitionByColumns, that.partitionByColumns);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitMultiPhaseAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitMultiPhaseAggRule.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Sets;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
-import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
@@ -89,7 +89,6 @@ public class SplitMultiPhaseAggRule extends SplitAggregateRule {
         return agg.getType().isGlobal() && !agg.isSplit() && agg.getDistinctColumnDataSkew() == null;
     }
 
-
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalAggregationOperator aggOp = input.getOp().cast();
@@ -107,7 +106,7 @@ public class SplitMultiPhaseAggRule extends SplitAggregateRule {
             return implementDistinctWithoutGroupByAgg(context.getColumnRefFactory(),
                     input, aggOp, distinctCols.get());
         } else {
-            return implementDistinctWithGroupByAgg(context.getColumnRefFactory(), input, aggOp);
+            return implementDistinctWithGroupByAgg(context.getSessionVariable(), context.getColumnRefFactory(), input, aggOp);
         }
 
     }
@@ -166,9 +165,20 @@ public class SplitMultiPhaseAggRule extends SplitAggregateRule {
         return Lists.newArrayList(globalOptExpression);
     }
 
-    // For SQL: select count(distinct id_bigint) from test_basic group by id_int;
+    private OptExpression connectThreeStageAgg(OptExpression localExpr,
+                                               LogicalAggregationOperator distinctGlobal,
+                                               LogicalAggregationOperator global,
+                                               List<ColumnRefOperator> distinctGlobalPartitionBys,
+                                               boolean globalSplit) {
+        distinctGlobal.setPartitionByColumns(distinctGlobalPartitionBys);
+        global.setSplit(globalSplit);
+        return OptExpression.create(global, OptExpression.create(distinctGlobal, localExpr));
+    }
+
+    // For SQL: select count(distinct k1) from test_basic group by v1;
     // Local Agg -> Distinct global Agg -> Global Agg
     private List<OptExpression> implementDistinctWithGroupByAgg(
+            SessionVariable sv,
             ColumnRefFactory columnRefFactory,
             OptExpression input,
             LogicalAggregationOperator oldAgg) {
@@ -177,38 +187,73 @@ public class SplitMultiPhaseAggRule extends SplitAggregateRule {
                 columnRefFactory,
                 oldAgg.getGroupingKeys(), oldAgg.getAggregations(), AggType.LOCAL);
         local.setPartitionByColumns(oldAgg.getGroupingKeys());
-        OptExpression localOptExpression = OptExpression.create(local, input.getInputs());
+        OptExpression localExpr = OptExpression.create(local, input.getInputs());
 
         LogicalAggregationOperator distinctGlobal = createDistinctAggForFirstPhase(
                 columnRefFactory,
                 oldAgg.getGroupingKeys(), oldAgg.getAggregations(), AggType.DISTINCT_GLOBAL);
-        List<ColumnRefOperator> partitionByCols;
 
-        boolean shouldFurtherSplit = false;
-        if (isThreeStageMoreEfficient(input, distinctGlobal.getGroupingKeys(), local.getPartitionByColumns())
-                || oldAgg.getGroupingKeys().containsAll(distinctGlobal.getGroupingKeys())) {
-            partitionByCols = oldAgg.getGroupingKeys();
-        } else {
-            partitionByCols = distinctGlobal.getGroupingKeys();
-            // use grouping keys and distinct cols to distribute data, we need to continue split the global agg.
-            shouldFurtherSplit = true;
-        }
-
-        distinctGlobal.setPartitionByColumns(partitionByCols);
-        OptExpression distinctGlobalOptExpression = OptExpression.create(distinctGlobal, localOptExpression);
-
-        LogicalAggregationOperator.Builder aggBuilder = new LogicalAggregationOperator.Builder().withOperator(oldAgg)
+        LogicalAggregationOperator global = new LogicalAggregationOperator.Builder()
+                .withOperator(oldAgg)
                 .setType(AggType.GLOBAL)
-                .setAggregations(createDistinctAggForSecondPhase(AggType.GLOBAL, oldAgg.getAggregations()));
-        if (!shouldFurtherSplit) {
-            // set isSplit = true to avoid split the global agg
-            aggBuilder.setSplit();
+                .setAggregations(createDistinctAggForSecondPhase(AggType.GLOBAL, oldAgg.getAggregations()))
+                .build();
+
+        // GB is short for Group By, and PB is short for Partition By.
+        if (oldAgg.getGroupingKeys().containsAll(distinctGlobal.getGroupingKeys())) {
+            // 3-stage: Local(GB k1,v1) -> Distinct Global(GB k1,v1; PB v1) -> Global(GB v1; PB v1)
+            return Lists.newArrayList(
+                    connectThreeStageAgg(localExpr, distinctGlobal, global, oldAgg.getGroupingKeys(), true));
         }
 
-        LogicalAggregationOperator global = aggBuilder.build();
-        OptExpression globalOptExpression = OptExpression.create(global, distinctGlobalOptExpression);
+        if (!isThreeStageMoreEfficient(sv, input, distinctGlobal.getGroupingKeys(), local.getPartitionByColumns())) {
+            // 4-stage: Local(GB k1,v1) -> Distinct Global(GB k1,v1; PB k1,v1) -> Local(GB v1) -> Global(GB v1; PB v1)
+            // Use grouping keys and distinct cols to distribute data, we need to continue split the global agg.
+            return Lists.newArrayList(
+                    connectThreeStageAgg(localExpr, distinctGlobal, global, distinctGlobal.getGroupingKeys(), false));
+        }
 
-        return Lists.newArrayList(globalOptExpression);
+        if (!sv.isEnableCostBasedMultiStageAgg()) {
+            // 3-stage: Local(GB k1,v1) -> Distinct Global(GB k1,v1; PB v1) -> Global(GB v1; PB v1)
+            return Lists.newArrayList(
+                    connectThreeStageAgg(localExpr, distinctGlobal, global, oldAgg.getGroupingKeys(), true));
+        }
+
+        // 3-stage: Local(GB k1,v1) -> Distinct Global(GB k1,v1; PB v1)    -> Local(GB v1) -> Global(GB v1; PB v1)
+        //
+        // The reason why the Global split is set to false is that:
+        // CostModel considers `Local Agg(GB v1)->Global(v1)` to have a lower cost than `Global(GB v1)`, which leads to a situation
+        // where the cost of the 3-stage plan:
+        //     [Local(GB k1,v1) -> Exchange(v1) -> Distinct Global(GB k1,v1) -> Global(GB v1)]
+        // is higher than that of the 4-stage plan:
+        //     [Local(GB k1,v1) -> Exchange(k1,v1) -> Distinct Global(GB k1,v1) -> Local(GB v1) -> Exchange(v1) -> Global(GB v1)].
+        // Therefore, in order to ensure that the 3-stage plan is chosen under normal circumstances, the 3-stage plan is first
+        // transformed into a 4-stage plan, and then the redundant Local node is pruned in the PruneAggregateNodeRule.
+        OptExpression threeStageAgg =
+                connectThreeStageAgg(localExpr, distinctGlobal, global, oldAgg.getGroupingKeys(), false);
+
+        // 4-stage: Local(GB k1,v1) -> Distinct Global(GB k1,v1; PB k1,v1) -> Local(GB v1) -> Global(GB v1; PB v1)
+        //
+        // The timing for choosing the 4-stage plan is when the child of Local(GB k1,v1) satisfies the distribution (k1,v1).
+        // In this case, the actual 4-stage plan is:
+        //     [Local(GB k1, v1) -> Distinct Global(GB k1, v1) -> Local(GB v1) -> Exchange(v1) -> Global(GB v1)],
+        // whose cost is lower than the 3-stage plan:
+        //     [Local(GB k1, v1) -> Exchange(v1) -> Distinct Global(GB k1, v1) -> Local(GB v1) -> Global(GB v1)],
+        // because in the 4-stage plan, the child of Exchange(v1) is Local(GB v1), whereas in the 3-stage plan, the child of Exchange(v1)
+        // is Local(GB k1, v1). The cardinality of Local(GB v1) is always greater than or equal to the output of Local(GB k1, v1).
+        //
+        // Furthermore, after applying the PruneAggregateNodeRule, the 4-stage plan becomes:
+        // [MergedLocal(GB k1, v1) -> Local(GB v1) -> Exchange(v1) -> Global(GB v1; PB v1)]
+        LogicalAggregationOperator global4 = new LogicalAggregationOperator.Builder().withOperator(global).build();
+        LogicalAggregationOperator distinctGlobal4 =
+                new LogicalAggregationOperator.Builder().withOperator(distinctGlobal).build();
+        LogicalAggregationOperator local4 = new LogicalAggregationOperator.Builder().withOperator(local)
+                .setPartitionByColumns(local.getGroupingKeys()).build();
+        OptExpression localExpr4 = OptExpression.create(local4, input.getInputs());
+        OptExpression fourStageAgg =
+                connectThreeStageAgg(localExpr4, distinctGlobal4, global4, distinctGlobal4.getGroupingKeys(), false);
+
+        return Lists.newArrayList(threeStageAgg, fourStageAgg);
     }
 
     private LogicalAggregationOperator createDistinctAggForFirstPhase(
@@ -342,12 +387,12 @@ public class SplitMultiPhaseAggRule extends SplitAggregateRule {
         return elseOperator;
     }
 
-    private boolean isThreeStageMoreEfficient(OptExpression input, List<ColumnRefOperator> groupKeys,
+    private boolean isThreeStageMoreEfficient(SessionVariable sv, OptExpression input, List<ColumnRefOperator> groupKeys,
                                               List<ColumnRefOperator> partitionByColumns) {
-        if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == FOUR_STAGE.ordinal()) {
+        if (sv.getNewPlannerAggStage() == FOUR_STAGE.ordinal()) {
             return false;
         }
-        if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == THREE_STAGE.ordinal()) {
+        if (sv.getNewPlannerAggStage() == THREE_STAGE.ordinal()) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneAggregateNodeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneAggregateNodeRule.java
@@ -107,9 +107,11 @@ public class PruneAggregateNodeRule implements TreeRewriteRule {
             if (ConnectContext.get().getSessionVariable().isEnableCostBasedMultiStageAgg() &&
                     parentAgg.getType().isGlobal() && parentAgg.isSplit() &&
                     childAgg.getType().isLocal() && childAgg.isSplit() && !childAgg.isMergedLocalAgg()) {
-                OptExpression newAgg = mergeTwoPhaseAgg(parentAgg, childAgg, optExpression, optExpression.inputAt(0));
-                if (newAgg != null) {
-                    return newAgg;
+                OptExpression newAggExpr = mergeTwoPhaseAgg(parentAgg, childAgg, optExpression, optExpression.inputAt(0));
+                if (newAggExpr != null) {
+                    // Continue to process child nodes. For example, as for Local->DistinctGlobal->Local->Global, after merging
+                    // Local->Global, we should continue to process DistinctGlobal->Local.
+                    return visit(newAggExpr, context);
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneAggregateNodeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneAggregateNodeRule.java
@@ -19,6 +19,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -122,6 +123,10 @@ public class PruneAggregateNodeRule implements TreeRewriteRule {
                                                PhysicalHashAggregateOperator localAgg,
                                                OptExpression globalExpr,
                                                OptExpression localExpr) {
+            if (Utils.mustGenerateMultiStageAggregate(localAgg, localExpr.inputAt(0).getOp())) {
+                return null;
+            }
+
             Map<ColumnRefOperator, CallOperator> newAggregationMap = Maps.newHashMap();
             for (Map.Entry<ColumnRefOperator, CallOperator> entry : globalAgg.getAggregations().entrySet()) {
                 ColumnRefOperator globalColumn = entry.getKey();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -3140,9 +3140,10 @@ public class AggregateTest extends PlanTestBase {
             sql = "SELECT count(distinct v2), bitmap_union_count(to_bitmap(v2)) from t0 group by v3;";
             plan = getCostExplain(sql);
             assertContains(plan, "  5:AGGREGATE (update finalize)\n" +
-                    "  |  aggregate: " +
-                    "count[([2: v2, BIGINT, true]); args: BIGINT; result: BIGINT; args nullable: true; result nullable: false], " +
-                    "bitmap_union_count[([6: bitmap_union_count, BIGINT, false]); args: BITMAP; result: BIGINT; args nullable: true; " +
+                    "  |  aggregate: count[([2: v2, BIGINT, true]); args: BIGINT; result: BIGINT; " +
+                    "args nullable: true; result nullable: false], " +
+                    "bitmap_union_count[([6: bitmap_union_count, BIGINT, false]); " +
+                    "args: BITMAP; result: BIGINT; args nullable: true; " +
                     "result nullable: false]\n" +
                     "  |  group by: [3: v3, BIGINT, true]\n" +
                     "  |  cardinality: 1\n" +
@@ -3152,7 +3153,8 @@ public class AggregateTest extends PlanTestBase {
                     "  |  * bitmap_union_count-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
                     "  |  \n" +
                     "  4:AGGREGATE (merge serialize)\n" +
-                    "  |  aggregate: bitmap_union_count[([6: bitmap_union_count, BITMAP, false]); args: BITMAP; result: BIGINT; " +
+                    "  |  aggregate: bitmap_union_count[([6: bitmap_union_count, BITMAP, false]); " +
+                    "args: BITMAP; result: BIGINT; " +
                     "args nullable: true; result nullable: false]\n" +
                     "  |  group by: [2: v2, BIGINT, true], [3: v3, BIGINT, true]\n" +
                     "  |  cardinality: 1");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggTest.java
@@ -114,8 +114,8 @@ public class DistinctAggTest extends PlanTestBase {
                         "  |  output: group_concat(4: group_concat, ',')\n" +
                         "  |  group by: "));
         argumentsList.add(Arguments.of("select count(distinct v1, v2) from (select * from t0 limit 2) t group by 1 + 1",
-                "5:AGGREGATE (merge finalize)\n" +
-                        "  |  output: count(5: count)\n" +
+                "  4:AGGREGATE (update finalize)\n" +
+                        "  |  output: count(if(1: v1 IS NULL, NULL, 2: v2))\n" +
                         "  |  group by: 4: expr"));
         argumentsList.add(Arguments.of("select group_concat(distinct v1, v2) from (select * from t0 limit 2) t group by v3",
                 "3:AGGREGATE (update finalize)\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1603,18 +1603,20 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
 
     @Test
     public void testOneTabletDistinctAgg() throws Exception {
-        String sql = "select sum(id), group_concat(distinct name) from skew_table where id = 1 group by id";
-        String plan = getFragmentPlan(sql);
-        assertContains(plan, "2:AGGREGATE (update serialize)\n"
-                + "  |  STREAMING\n"
-                + "  |  output: sum(3: sum), group_concat(2: name, ',')\n"
-                + "  |  group by: 1: id\n"
-                + "  |  \n"
-                + "  1:AGGREGATE (update serialize)\n"
-                + "  |  output: sum(1: id)\n"
-                + "  |  group by: 1: id, 2: name\n"
-                + "  |  \n"
-                + "  0:OlapScanNode");
+        String sql;
+        String plan;
+
+        sql = "select sum(id), group_concat(distinct name) from skew_table where id = 1 group by id";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(3: sum), group_concat(2: name, ',')\n" +
+                "  |  group by: 1: id\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update serialize)\n" +
+                "  |  output: sum(1: id)\n" +
+                "  |  group by: 1: id, 2: name\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
 
         sql = "select n_name,count(distinct n_regionkey,n_name) from nation group by n_name";
         plan = getFragmentPlan(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1049,8 +1049,7 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
     public void testLocalGroupingSet1() throws Exception {
         String sql = "select v1, v2, v3 from t0 group by grouping sets((v1, v2), (v1, v3), (v1))";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:AGGREGATE (update serialize)\n" +
-                "  |  STREAMING\n" +
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
                 "  |  group by: 1: v1, 2: v2, 3: v3, 4: GROUPING_ID\n" +
                 "  |  \n" +
                 "  1:REPEAT_NODE\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -2411,4 +2411,9 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
             connectContext.getSessionVariable().setBroadcastRowCountLimit(originLimit);
         }
     }
+
+    @Test
+    public void testCostBasedMultiStageAgg() {
+        runFileUnitTest("optimized-plan/cost_based_multi_stage_agg", true);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1049,7 +1049,11 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
     public void testLocalGroupingSet1() throws Exception {
         String sql = "select v1, v2, v3 from t0 group by grouping sets((v1, v2), (v1, v3), (v1))";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "  3:AGGREGATE (merge finalize)\n" +
+                "  |  group by: 1: v1, 2: v2, 3: v3, 4: GROUPING_ID\n" +
+                "  |  \n" +
+                "  2:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
                 "  |  group by: 1: v1, 2: v2, 3: v3, 4: GROUPING_ID\n" +
                 "  |  \n" +
                 "  1:REPEAT_NODE\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -2413,6 +2413,6 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
 
     @Test
     public void testCostBasedMultiStageAgg() {
-        runFileUnitTest("optimized-plan/cost_based_multi_stage_agg", true);
+        runFileUnitTest("optimized-plan/cost_based_multi_stage_agg");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -55,6 +55,14 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
     @BeforeEach
     public void before() {
         connectContext.getSessionVariable().setNewPlanerAggStage(0);
+
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
+        setTableStatistics(t0, NUM_TABLE0_ROWS);
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
+        setTableStatistics(t1, 10000);
+        OlapTable t2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
+        setTableStatistics(t2, NUM_TABLE2_ROWS);
     }
 
     private static final String V1 = "v1";

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q11.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q11.sql
@@ -50,15 +50,14 @@ TOP-N (order by [[21: sum DESC NULLS LAST]])
 TOP-N (order by [[21: sum DESC NULLS LAST]])
     TOP-N (order by [[21: sum DESC NULLS LAST]])
         INNER JOIN (join-predicate [21: sum > 43: expr] post-join-predicate [null])
-            AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(21: sum)}] group by [[1: PS_PARTKEY]] having [null]
-                AGGREGATE ([LOCAL] aggregate [{21: sum=sum(20: expr)}] group by [[1: PS_PARTKEY]] having [null]
-                    INNER JOIN (join-predicate [10: S_NATIONKEY = 15: N_NATIONKEY] post-join-predicate [null])
-                        INNER JOIN (join-predicate [2: PS_SUPPKEY = 7: S_SUPPKEY] post-join-predicate [null])
-                            SCAN (columns[1: PS_PARTKEY, 2: PS_SUPPKEY, 3: PS_AVAILQTY, 4: PS_SUPPLYCOST] predicate[null])
-                            EXCHANGE BROADCAST
-                                SCAN (columns[7: S_SUPPKEY, 10: S_NATIONKEY] predicate[null])
+            AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(20: expr)}] group by [[1: PS_PARTKEY]] having [null]
+                INNER JOIN (join-predicate [10: S_NATIONKEY = 15: N_NATIONKEY] post-join-predicate [null])
+                    INNER JOIN (join-predicate [2: PS_SUPPKEY = 7: S_SUPPKEY] post-join-predicate [null])
+                        SCAN (columns[1: PS_PARTKEY, 2: PS_SUPPKEY, 3: PS_AVAILQTY, 4: PS_SUPPLYCOST] predicate[null])
                         EXCHANGE BROADCAST
-                            SCAN (columns[15: N_NATIONKEY, 16: N_NAME] predicate[16: N_NAME = PERU])
+                            SCAN (columns[7: S_SUPPKEY, 10: S_NATIONKEY] predicate[null])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[15: N_NATIONKEY, 16: N_NAME] predicate[16: N_NAME = PERU])
             EXCHANGE BROADCAST
                 AGGREGATE ([GLOBAL] aggregate [{42: sum=sum(41: expr)}] group by [[]] having [null]
                     EXCHANGE GATHER
@@ -74,15 +73,14 @@ TOP-N (order by [[21: sum DESC NULLS LAST]])
 TOP-N (order by [[21: sum DESC NULLS LAST]])
     TOP-N (order by [[21: sum DESC NULLS LAST]])
         INNER JOIN (join-predicate [21: sum > 43: expr] post-join-predicate [null])
-            AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(21: sum)}] group by [[1: PS_PARTKEY]] having [null]
-                AGGREGATE ([LOCAL] aggregate [{21: sum=sum(20: expr)}] group by [[1: PS_PARTKEY]] having [null]
-                    INNER JOIN (join-predicate [2: PS_SUPPKEY = 7: S_SUPPKEY] post-join-predicate [null])
-                        SCAN (columns[1: PS_PARTKEY, 2: PS_SUPPKEY, 3: PS_AVAILQTY, 4: PS_SUPPLYCOST] predicate[null])
-                        EXCHANGE BROADCAST
-                            INNER JOIN (join-predicate [10: S_NATIONKEY = 15: N_NATIONKEY] post-join-predicate [null])
-                                SCAN (columns[7: S_SUPPKEY, 10: S_NATIONKEY] predicate[null])
-                                EXCHANGE BROADCAST
-                                    SCAN (columns[15: N_NATIONKEY, 16: N_NAME] predicate[16: N_NAME = PERU])
+            AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(20: expr)}] group by [[1: PS_PARTKEY]] having [null]
+                INNER JOIN (join-predicate [2: PS_SUPPKEY = 7: S_SUPPKEY] post-join-predicate [null])
+                    SCAN (columns[1: PS_PARTKEY, 2: PS_SUPPKEY, 3: PS_AVAILQTY, 4: PS_SUPPLYCOST] predicate[null])
+                    EXCHANGE BROADCAST
+                        INNER JOIN (join-predicate [10: S_NATIONKEY = 15: N_NATIONKEY] post-join-predicate [null])
+                            SCAN (columns[7: S_SUPPKEY, 10: S_NATIONKEY] predicate[null])
+                            EXCHANGE BROADCAST
+                                SCAN (columns[15: N_NATIONKEY, 16: N_NAME] predicate[16: N_NAME = PERU])
             EXCHANGE BROADCAST
                 AGGREGATE ([GLOBAL] aggregate [{42: sum=sum(41: expr)}] group by [[]] having [null]
                     EXCHANGE GATHER
@@ -144,15 +142,14 @@ TOP-N (order by [[21: sum DESC NULLS LAST]])
 TOP-N (order by [[21: sum DESC NULLS LAST]])
     TOP-N (order by [[21: sum DESC NULLS LAST]])
         INNER JOIN (join-predicate [21: sum > 43: expr] post-join-predicate [null])
-            AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(21: sum)}] group by [[1: PS_PARTKEY]] having [null]
-                AGGREGATE ([LOCAL] aggregate [{21: sum=sum(20: expr)}] group by [[1: PS_PARTKEY]] having [null]
-                    INNER JOIN (join-predicate [10: S_NATIONKEY = 15: N_NATIONKEY] post-join-predicate [null])
-                        INNER JOIN (join-predicate [2: PS_SUPPKEY = 7: S_SUPPKEY] post-join-predicate [null])
-                            SCAN (columns[1: PS_PARTKEY, 2: PS_SUPPKEY, 3: PS_AVAILQTY, 4: PS_SUPPLYCOST] predicate[null])
-                            EXCHANGE BROADCAST
-                                SCAN (columns[7: S_SUPPKEY, 10: S_NATIONKEY] predicate[null])
+            AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(20: expr)}] group by [[1: PS_PARTKEY]] having [null]
+                INNER JOIN (join-predicate [10: S_NATIONKEY = 15: N_NATIONKEY] post-join-predicate [null])
+                    INNER JOIN (join-predicate [2: PS_SUPPKEY = 7: S_SUPPKEY] post-join-predicate [null])
+                        SCAN (columns[1: PS_PARTKEY, 2: PS_SUPPKEY, 3: PS_AVAILQTY, 4: PS_SUPPLYCOST] predicate[null])
                         EXCHANGE BROADCAST
-                            SCAN (columns[15: N_NATIONKEY, 16: N_NAME] predicate[16: N_NAME = PERU])
+                            SCAN (columns[7: S_SUPPKEY, 10: S_NATIONKEY] predicate[null])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[15: N_NATIONKEY, 16: N_NAME] predicate[16: N_NAME = PERU])
             EXCHANGE BROADCAST
                 AGGREGATE ([GLOBAL] aggregate [{42: sum=sum(41: expr)}] group by [[]] having [null]
                     EXCHANGE GATHER
@@ -168,15 +165,14 @@ TOP-N (order by [[21: sum DESC NULLS LAST]])
 TOP-N (order by [[21: sum DESC NULLS LAST]])
     TOP-N (order by [[21: sum DESC NULLS LAST]])
         INNER JOIN (join-predicate [21: sum > 43: expr] post-join-predicate [null])
-            AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(21: sum)}] group by [[1: PS_PARTKEY]] having [null]
-                AGGREGATE ([LOCAL] aggregate [{21: sum=sum(20: expr)}] group by [[1: PS_PARTKEY]] having [null]
-                    INNER JOIN (join-predicate [2: PS_SUPPKEY = 7: S_SUPPKEY] post-join-predicate [null])
-                        SCAN (columns[1: PS_PARTKEY, 2: PS_SUPPKEY, 3: PS_AVAILQTY, 4: PS_SUPPLYCOST] predicate[null])
-                        EXCHANGE BROADCAST
-                            INNER JOIN (join-predicate [10: S_NATIONKEY = 15: N_NATIONKEY] post-join-predicate [null])
-                                SCAN (columns[7: S_SUPPKEY, 10: S_NATIONKEY] predicate[null])
-                                EXCHANGE BROADCAST
-                                    SCAN (columns[15: N_NATIONKEY, 16: N_NAME] predicate[16: N_NAME = PERU])
+            AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(20: expr)}] group by [[1: PS_PARTKEY]] having [null]
+                INNER JOIN (join-predicate [2: PS_SUPPKEY = 7: S_SUPPKEY] post-join-predicate [null])
+                    SCAN (columns[1: PS_PARTKEY, 2: PS_SUPPKEY, 3: PS_AVAILQTY, 4: PS_SUPPLYCOST] predicate[null])
+                    EXCHANGE BROADCAST
+                        INNER JOIN (join-predicate [10: S_NATIONKEY = 15: N_NATIONKEY] post-join-predicate [null])
+                            SCAN (columns[7: S_SUPPKEY, 10: S_NATIONKEY] predicate[null])
+                            EXCHANGE BROADCAST
+                                SCAN (columns[15: N_NATIONKEY, 16: N_NAME] predicate[16: N_NAME = PERU])
             EXCHANGE BROADCAST
                 AGGREGATE ([GLOBAL] aggregate [{42: sum=sum(41: expr)}] group by [[]] having [null]
                     EXCHANGE GATHER

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q16.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q16.sql
@@ -1,5 +1,5 @@
 [planCount]
-2
+6
 [plan-1]
 TOP-N (order by [[26: count DESC NULLS LAST, 10: P_BRAND ASC NULLS FIRST, 11: P_TYPE ASC NULLS FIRST, 12: P_SIZE ASC NULLS FIRST]])
     TOP-N (order by [[26: count DESC NULLS LAST, 10: P_BRAND ASC NULLS FIRST, 11: P_TYPE ASC NULLS FIRST, 12: P_SIZE ASC NULLS FIRST]])
@@ -16,6 +16,53 @@ TOP-N (order by [[26: count DESC NULLS LAST, 10: P_BRAND ASC NULLS FIRST, 11: P_
                                 SCAN (columns[17: S_SUPPKEY, 23: S_COMMENT] predicate[23: S_COMMENT LIKE %Customer%Complaints%])
 [end]
 [plan-2]
+TOP-N (order by [[26: count DESC NULLS LAST, 10: P_BRAND ASC NULLS FIRST, 11: P_TYPE ASC NULLS FIRST, 12: P_SIZE ASC NULLS FIRST]])
+    TOP-N (order by [[26: count DESC NULLS LAST, 10: P_BRAND ASC NULLS FIRST, 11: P_TYPE ASC NULLS FIRST, 12: P_SIZE ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{26: count=count(2: PS_SUPPKEY)}] group by [[10: P_BRAND, 11: P_TYPE, 12: P_SIZE]] having [null]
+            AGGREGATE ([DISTINCT_GLOBAL] aggregate [{}] group by [[2: PS_SUPPKEY, 10: P_BRAND, 11: P_TYPE, 12: P_SIZE]] having [null]
+                EXCHANGE SHUFFLE[10, 11, 12]
+                    AGGREGATE ([LOCAL] aggregate [{}] group by [[2: PS_SUPPKEY, 10: P_BRAND, 11: P_TYPE, 12: P_SIZE]] having [null]
+                        NULL AWARE LEFT ANTI JOIN (join-predicate [2: PS_SUPPKEY = 17: S_SUPPKEY] post-join-predicate [null])
+                            INNER JOIN (join-predicate [1: PS_PARTKEY = 7: P_PARTKEY] post-join-predicate [null])
+                                SCAN (columns[1: PS_PARTKEY, 2: PS_SUPPKEY] predicate[null])
+                                EXCHANGE SHUFFLE[7]
+                                    SCAN (columns[7: P_PARTKEY, 10: P_BRAND, 11: P_TYPE, 12: P_SIZE] predicate[10: P_BRAND != Brand#43 AND NOT 11: P_TYPE LIKE PROMO BURNISHED% AND 12: P_SIZE IN (31, 43, 9, 6, 18, 11, 25, 1)])
+                            EXCHANGE BROADCAST
+                                SCAN (columns[17: S_SUPPKEY, 23: S_COMMENT] predicate[23: S_COMMENT LIKE %Customer%Complaints%])
+[end]
+[plan-4]
+TOP-N (order by [[26: count DESC NULLS LAST, 10: P_BRAND ASC NULLS FIRST, 11: P_TYPE ASC NULLS FIRST, 12: P_SIZE ASC NULLS FIRST]])
+    TOP-N (order by [[26: count DESC NULLS LAST, 10: P_BRAND ASC NULLS FIRST, 11: P_TYPE ASC NULLS FIRST, 12: P_SIZE ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{26: count=count(26: count)}] group by [[10: P_BRAND, 11: P_TYPE, 12: P_SIZE]] having [null]
+            EXCHANGE SHUFFLE[10, 11, 12]
+                AGGREGATE ([LOCAL] aggregate [{26: count=count(2: PS_SUPPKEY)}] group by [[10: P_BRAND, 11: P_TYPE, 12: P_SIZE]] having [null]
+                    AGGREGATE ([DISTINCT_GLOBAL] aggregate [{}] group by [[2: PS_SUPPKEY, 10: P_BRAND, 11: P_TYPE, 12: P_SIZE]] having [null]
+                        EXCHANGE SHUFFLE[2, 10, 11, 12]
+                            AGGREGATE ([LOCAL] aggregate [{}] group by [[2: PS_SUPPKEY, 10: P_BRAND, 11: P_TYPE, 12: P_SIZE]] having [null]
+                                NULL AWARE LEFT ANTI JOIN (join-predicate [2: PS_SUPPKEY = 17: S_SUPPKEY] post-join-predicate [null])
+                                    INNER JOIN (join-predicate [1: PS_PARTKEY = 7: P_PARTKEY] post-join-predicate [null])
+                                        SCAN (columns[1: PS_PARTKEY, 2: PS_SUPPKEY] predicate[null])
+                                        EXCHANGE SHUFFLE[7]
+                                            SCAN (columns[7: P_PARTKEY, 10: P_BRAND, 11: P_TYPE, 12: P_SIZE] predicate[10: P_BRAND != Brand#43 AND NOT 11: P_TYPE LIKE PROMO BURNISHED% AND 12: P_SIZE IN (31, 43, 9, 6, 18, 11, 25, 1)])
+                                    EXCHANGE BROADCAST
+                                        SCAN (columns[17: S_SUPPKEY, 23: S_COMMENT] predicate[23: S_COMMENT LIKE %Customer%Complaints%])
+[end]
+[plan-5]
+TOP-N (order by [[26: count DESC NULLS LAST, 10: P_BRAND ASC NULLS FIRST, 11: P_TYPE ASC NULLS FIRST, 12: P_SIZE ASC NULLS FIRST]])
+    TOP-N (order by [[26: count DESC NULLS LAST, 10: P_BRAND ASC NULLS FIRST, 11: P_TYPE ASC NULLS FIRST, 12: P_SIZE ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{26: count=count(2: PS_SUPPKEY)}] group by [[10: P_BRAND, 11: P_TYPE, 12: P_SIZE]] having [null]
+            AGGREGATE ([DISTINCT_GLOBAL] aggregate [{}] group by [[2: PS_SUPPKEY, 10: P_BRAND, 11: P_TYPE, 12: P_SIZE]] having [null]
+                EXCHANGE SHUFFLE[10, 11, 12]
+                    AGGREGATE ([LOCAL] aggregate [{}] group by [[2: PS_SUPPKEY, 10: P_BRAND, 11: P_TYPE, 12: P_SIZE]] having [null]
+                        NULL AWARE LEFT ANTI JOIN (join-predicate [2: PS_SUPPKEY = 17: S_SUPPKEY] post-join-predicate [null])
+                            INNER JOIN (join-predicate [1: PS_PARTKEY = 7: P_PARTKEY] post-join-predicate [null])
+                                SCAN (columns[1: PS_PARTKEY, 2: PS_SUPPKEY] predicate[null])
+                                EXCHANGE BROADCAST
+                                    SCAN (columns[7: P_PARTKEY, 10: P_BRAND, 11: P_TYPE, 12: P_SIZE] predicate[10: P_BRAND != Brand#43 AND NOT 11: P_TYPE LIKE PROMO BURNISHED% AND 12: P_SIZE IN (31, 43, 9, 6, 18, 11, 25, 1)])
+                            EXCHANGE BROADCAST
+                                SCAN (columns[17: S_SUPPKEY, 23: S_COMMENT] predicate[23: S_COMMENT LIKE %Customer%Complaints%])
+[end]
+[plan-6]
 TOP-N (order by [[26: count DESC NULLS LAST, 10: P_BRAND ASC NULLS FIRST, 11: P_TYPE ASC NULLS FIRST, 12: P_SIZE ASC NULLS FIRST]])
     TOP-N (order by [[26: count DESC NULLS LAST, 10: P_BRAND ASC NULLS FIRST, 11: P_TYPE ASC NULLS FIRST, 12: P_SIZE ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{26: count=count(2: PS_SUPPKEY)}] group by [[10: P_BRAND, 11: P_TYPE, 12: P_SIZE]] having [null]

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q18.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q18.sql
@@ -45,9 +45,8 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                     EXCHANGE BROADCAST
                         SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
                 EXCHANGE BROADCAST
-                    AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(54: sum)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
-                        AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
-                            SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+                    AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
+                        SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
 [end]
 [plan-4]
 TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
@@ -62,9 +61,8 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                             EXCHANGE BROADCAST
                                 SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
                 EXCHANGE BROADCAST
-                    AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(54: sum)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
-                        AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
-                            SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+                    AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
+                        SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
 [end]
 [plan-5]
 TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
@@ -108,9 +106,8 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                             SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 13: O_TOTALPRICE, 14: O_ORDERDATE] predicate[null])
                     EXCHANGE BROADCAST
                         SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
-                AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(54: sum)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
-                    AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
-                        SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+                AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
+                    SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
 [end]
 [plan-8]
 TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
@@ -124,9 +121,8 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                             SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 13: O_TOTALPRICE, 14: O_ORDERDATE] predicate[null])
                             EXCHANGE BROADCAST
                                 SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
-                AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(54: sum)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
-                    AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
-                        SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+                AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
+                    SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
 [end]
 [plan-9]
 TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
@@ -143,6 +139,8 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                 EXCHANGE BROADCAST
                     SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
 [end]
+
+
 [plan-10]
 TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
     TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
@@ -153,9 +151,8 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                         SCAN (columns[20: L_ORDERKEY, 24: L_QUANTITY] predicate[null])
                         EXCHANGE SHUFFLE[10]
                             SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 13: O_TOTALPRICE, 14: O_ORDERDATE] predicate[null])
-                    AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(54: sum)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
-                        AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
-                            SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+                    AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
+                        SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
                 EXCHANGE BROADCAST
                     SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
 [end]
@@ -186,9 +183,8 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                         LEFT SEMI JOIN (join-predicate [10: O_ORDERKEY = 37: L_ORDERKEY] post-join-predicate [null])
                             SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 13: O_TOTALPRICE, 14: O_ORDERDATE] predicate[null])
                             EXCHANGE SHUFFLE[37]
-                                AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(54: sum)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
-                                    AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
-                                        SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+                                AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
+                                    SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
                 EXCHANGE BROADCAST
                     SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
 [end]
@@ -221,9 +217,8 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                             EXCHANGE BROADCAST
                                 SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
                         EXCHANGE SHUFFLE[37]
-                            AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(54: sum)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
-                                AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
-                                    SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+                            AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
+                                SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
 [end]
 [plan-15]
 TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
@@ -252,9 +247,8 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                         LEFT SEMI JOIN (join-predicate [10: O_ORDERKEY = 37: L_ORDERKEY] post-join-predicate [null])
                             SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 13: O_TOTALPRICE, 14: O_ORDERDATE] predicate[null])
                             EXCHANGE SHUFFLE[37]
-                                AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(54: sum)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
-                                    AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
-                                        SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+                                AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [54: sum > 315]
+                                    SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
                         EXCHANGE BROADCAST
                             SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
 [end]

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q3.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q3.sql
@@ -27,26 +27,25 @@ TOP-N (order by [[38: sum DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
 [plan-3]
 TOP-N (order by [[38: sum DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
     TOP-N (order by [[38: sum DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{38: sum=sum(38: sum)}] group by [[20: L_ORDERKEY, 14: O_ORDERDATE, 17: O_SHIPPRIORITY]] having [null]
-            AGGREGATE ([LOCAL] aggregate [{38: sum=sum(37: expr)}] group by [[20: L_ORDERKEY, 14: O_ORDERDATE, 17: O_SHIPPRIORITY]] having [null]
-                INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
-                    INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
-                        SCAN (columns[20: L_ORDERKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT, 30: L_SHIPDATE] predicate[30: L_SHIPDATE > 1995-03-11])
-                        EXCHANGE SHUFFLE[10]
-                            SCAN (columns[17: O_SHIPPRIORITY, 10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE < 1995-03-11])
-                    EXCHANGE BROADCAST
-                        SCAN (columns[1: C_CUSTKEY, 7: C_MKTSEGMENT] predicate[7: C_MKTSEGMENT = HOUSEHOLD])
-[end]
-[plan-4]
-TOP-N (order by [[38: sum DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
-    TOP-N (order by [[38: sum DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{38: sum=sum(38: sum)}] group by [[20: L_ORDERKEY, 14: O_ORDERDATE, 17: O_SHIPPRIORITY]] having [null]
-            AGGREGATE ([LOCAL] aggregate [{38: sum=sum(37: expr)}] group by [[20: L_ORDERKEY, 14: O_ORDERDATE, 17: O_SHIPPRIORITY]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{38: sum=sum(37: expr)}] group by [[20: L_ORDERKEY, 14: O_ORDERDATE, 17: O_SHIPPRIORITY]] having [null]
+            INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
                 INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                     SCAN (columns[20: L_ORDERKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT, 30: L_SHIPDATE] predicate[30: L_SHIPDATE > 1995-03-11])
                     EXCHANGE SHUFFLE[10]
-                        INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
-                            SCAN (columns[17: O_SHIPPRIORITY, 10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE < 1995-03-11])
-                            EXCHANGE BROADCAST
-                                SCAN (columns[1: C_CUSTKEY, 7: C_MKTSEGMENT] predicate[7: C_MKTSEGMENT = HOUSEHOLD])
+                        SCAN (columns[17: O_SHIPPRIORITY, 10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE < 1995-03-11])
+                EXCHANGE BROADCAST
+                    SCAN (columns[1: C_CUSTKEY, 7: C_MKTSEGMENT] predicate[7: C_MKTSEGMENT = HOUSEHOLD])
+[end]
+
+[plan-4]
+TOP-N (order by [[38: sum DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+    TOP-N (order by [[38: sum DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{38: sum=sum(37: expr)}] group by [[20: L_ORDERKEY, 14: O_ORDERDATE, 17: O_SHIPPRIORITY]] having [null]
+            INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
+                SCAN (columns[20: L_ORDERKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT, 30: L_SHIPDATE] predicate[30: L_SHIPDATE > 1995-03-11])
+                EXCHANGE SHUFFLE[10]
+                    INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                        SCAN (columns[17: O_SHIPPRIORITY, 10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE < 1995-03-11])
+                        EXCHANGE BROADCAST
+                            SCAN (columns[1: C_CUSTKEY, 7: C_MKTSEGMENT] predicate[7: C_MKTSEGMENT = HOUSEHOLD])
 [end]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/cost_based_multi_stage_agg.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/cost_based_multi_stage_agg.sql
@@ -1,0 +1,85 @@
+[sql]
+-- pruned 4-stage: MergedLocal(GB v1,v2; PB v1,v2) -> Local(v2) -> Global(v2)
+SELECT count(distinct v1), sum(v3) from t0 join t1 on v3=v6 group by v2;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{7: count=count(7: count), 8: sum=sum(8: sum)}] group by [[2: v2]] having [null]
+    EXCHANGE SHUFFLE[2]
+        AGGREGATE ([LOCAL] aggregate [{7: count=count(1: v1), 8: sum=sum(8: sum)}] group by [[2: v2]] having [null]
+            AGGREGATE ([LOCAL] aggregate [{8: sum=sum(3: v3)}] group by [[1: v1, 2: v2]] having [null]
+                INNER JOIN (join-predicate [3: v3 = 6: v6] post-join-predicate [null])
+                    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 IS NOT NULL])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[6: v6] predicate[6: v6 IS NOT NULL])
+[end]
+
+[sql]
+SELECT count(distinct v1), sum(v3) from t0 join [shuffle] t1 on v1=v6 group by v2;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{7: count=count(7: count), 8: sum=sum(8: sum)}] group by [[2: v2]] having [null]
+    EXCHANGE SHUFFLE[2]
+        AGGREGATE ([LOCAL] aggregate [{7: count=count(1: v1), 8: sum=sum(8: sum)}] group by [[2: v2]] having [null]
+            AGGREGATE ([LOCAL] aggregate [{8: sum=sum(3: v3)}] group by [[1: v1, 2: v2]] having [null]
+                INNER JOIN (join-predicate [1: v1 = 6: v6] post-join-predicate [null])
+                    EXCHANGE SHUFFLE[1]
+                        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
+                    EXCHANGE SHUFFLE[6]
+                        SCAN (columns[6: v6] predicate[6: v6 IS NOT NULL])
+[end]
+
+[sql]
+SELECT /*+SET_VAR(enable_cost_based_multi_stage_agg=false)*/ count(distinct v1), sum(v3) from t0 join t1 on v3=v6 group by v2;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{7: count=count(1: v1), 8: sum=sum(8: sum)}] group by [[2: v2]] having [null]
+    AGGREGATE ([DISTINCT_GLOBAL] aggregate [{8: sum=sum(8: sum)}] group by [[1: v1, 2: v2]] having [null]
+        EXCHANGE SHUFFLE[2]
+            AGGREGATE ([LOCAL] aggregate [{8: sum=sum(3: v3)}] group by [[1: v1, 2: v2]] having [null]
+                INNER JOIN (join-predicate [3: v3 = 6: v6] post-join-predicate [null])
+                    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 IS NOT NULL])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[6: v6] predicate[6: v6 IS NOT NULL])
+[end]
+
+[sql]
+-- 3-stage: Local(GB v1*2,v2)->DistinctGlobal(GB v1*2,v2; PB v2) -> Global(v2)
+SELECT count(distinct v1*2), sum(v3) from t0 join t1 on v3=v6 group by v2;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{8: count=count(7: expr), 9: sum=sum(9: sum)}] group by [[2: v2]] having [null]
+    AGGREGATE ([DISTINCT_GLOBAL] aggregate [{9: sum=sum(9: sum)}] group by [[2: v2, 7: expr]] having [null]
+        EXCHANGE SHUFFLE[2]
+            AGGREGATE ([LOCAL] aggregate [{9: sum=sum(3: v3)}] group by [[2: v2, 7: expr]] having [null]
+                INNER JOIN (join-predicate [3: v3 = 6: v6] post-join-predicate [null])
+                    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 IS NOT NULL])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[6: v6] predicate[6: v6 IS NOT NULL])
+[end]
+
+[sql]
+-- Force 3-stage: Local(GB v1,v2)->DistinctGlobal(GB v1,v2; PB v2) -> Global(v2)
+SELECT /*+SET_VAR(new_planner_agg_stage=3)*/ count(distinct v1), sum(v3) from t0 join t1 on v3=v6 group by v2;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{7: count=count(1: v1), 8: sum=sum(8: sum)}] group by [[2: v2]] having [null]
+    AGGREGATE ([DISTINCT_GLOBAL] aggregate [{8: sum=sum(8: sum)}] group by [[1: v1, 2: v2]] having [null]
+        EXCHANGE SHUFFLE[2]
+            AGGREGATE ([LOCAL] aggregate [{8: sum=sum(3: v3)}] group by [[1: v1, 2: v2]] having [null]
+                INNER JOIN (join-predicate [3: v3 = 6: v6] post-join-predicate [null])
+                    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 IS NOT NULL])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[6: v6] predicate[6: v6 IS NOT NULL])
+[end]
+
+[sql]
+-- Force 4-stage: Local(GB v1*2,v2)->DistinctGlobal(GB v1*2,v2; PB v1,v2) -> Local(v2) -> Global(v2)
+SELECT /*+SET_VAR(new_planner_agg_stage=4)*/ count(distinct v1*2), sum(v3) from t0 join t1 on v3=v6 group by v2;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{8: count=count(8: count), 9: sum=sum(9: sum)}] group by [[2: v2]] having [null]
+    EXCHANGE SHUFFLE[2]
+        AGGREGATE ([LOCAL] aggregate [{8: count=count(7: expr), 9: sum=sum(9: sum)}] group by [[2: v2]] having [null]
+            AGGREGATE ([DISTINCT_GLOBAL] aggregate [{9: sum=sum(9: sum)}] group by [[2: v2, 7: expr]] having [null]
+                EXCHANGE SHUFFLE[2, 7]
+                    AGGREGATE ([LOCAL] aggregate [{9: sum=sum(3: v3)}] group by [[2: v2, 7: expr]] having [null]
+                        INNER JOIN (join-predicate [3: v3 = 6: v6] post-join-predicate [null])
+                            SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 IS NOT NULL])
+                            EXCHANGE BROADCAST
+                                SCAN (columns[6: v6] predicate[6: v6 IS NOT NULL])
+[end]
+


### PR DESCRIPTION
## Why I'm doing:

As shown in the following figure, for `SELECT COUNT(DISTINCT k1) FROM t1 GROUP BY v1`, we currently generate only a 3-stage plan or a 4-stage plan. However, if the child satisfies the `(k1, v1)` distribution, we can produce a better plan—the one on the far right in the figure.

<img width="1624" height="836" alt="QQ_1759141560019" src="https://github.com/user-attachments/assets/5dbd1ca6-b09e-4898-a972-3abb37237c75" />





In essence, this “better” plan is just the 4-stage plan with the redundant `Streaming Agg GB k1,v1 → Shuffle (k1,v1)` removed. Therefore, we can have `SplitMultiPhaseAggRule` return both the 3-stage and 4-stage plans as candidates and let the `CostModel` choose between them.


---

Specifically:



<img width="1554" height="814" alt="QQ_1759141568863" src="https://github.com/user-attachments/assets/165df24c-9432-4d00-a054-59bb0d0a573f" />

**Two candidates as shown in the above figure:**
- **3-stage**:  
  `[Local(GB k1,v1) -> Distinct Global(GB k1,v1; PB v1) -> Local(GB v1) -> Global(GB v1; PB v1)]`  
  - **Physical3**:  
    `[Local(GB k1,v1) -> Exchange(v1) -> Distinct Global(GB k1,v1) -> Local(GB v1) -> Global(GB v1)]`,  
    which will be rewritten by `PruneAggregateNodeRule` to:  
    `[Local(GB k1,v1) -> Exchange(v1) -> Distinct Global(GB k1,v1) -> Global(GB v1)]`.

- **4-stage**:  
  `[Local(GB k1,v1) -> Distinct Global(GB k1,v1; PB k1,v1) -> Local(GB v1) -> Global(GB v1; PB v1)]`  
  - **Physical41** (when the child satisfies the (k1, v1) distribution):  
    `[Local(GB k1,v1) -> Distinct Global(GB k1,v1) -> Local(GB v1) -> Exchange(v1) -> Global(GB v1)]`,  
    which will be rewritten by `PruneAggregateNodeRule` to:  
    `[Distinct Global(GB k1,v1) -> Local(GB v1) -> Exchange(v1) -> Global(GB v1)]`.
  - **Physical42** (when the child does **not** satisfy the (k1, v1) distribution):  
    `[Local(GB k1,v1) -> Exchange(k1,v1) -> Distinct Global(GB k1,v1) -> Local(GB v1) -> Exchange(v1) -> Global(GB v1)]`.

**Cost comparison between 3-stage and 4-stage:**
- If the child satisfies the (k1, v1) distribution, the cost of **4-stage (Physical41)** is lower than that of **3-stage (Physical3)**, because in **Physical41** the child of `Exchange(v1)` is `Local(GB v1)`, whereas in **Physical3** the child of `Exchange(v1)` is `Local(GB k1,v1)`. The cardinality of `Local(GB v1)` is always greater than or equal to the output of `Local(GB k1,v1)`.
- Otherwise, the cost of **3-stage (Physical3)** is lower than that of **4-stage (Physical42)**, because **Physical42** incurs one additional `Exchange(k1,v1)` compared to **Physical3**.

**Why is the 3-stage plan first transformed into a 4-stage plan and then the redundant `Local` node pruned by `PruneAggregateNodeRule`?**  
Because the `CostModel` deems `Local(GB v1) -> Global(v1)` cheaper than `Global(GB v1)`, which leads to a situation where the cost of the 3-stage plan:

[Local(GB k1,v1) -> Exchange(v1) -> Distinct Global(GB k1,v1) -> Global(GB v1)]

is higher than that of the 4-stage plan:

[Local(GB k1,v1) -> Exchange(k1,v1) -> Distinct Global(GB k1,v1) -> Local(GB v1) -> Exchange(v1) -> Global(GB v1)].


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
