### PR TITLE
[BugFix] fix infinite balance when enable be label

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1099,11 +1099,11 @@ public class TabletScheduler extends FrontendDaemon {
                     || deleteBadReplica(tabletCtx, force)
                     || deleteBackendUnavailable(tabletCtx, force)
                     || deleteCloneOrDecommissionReplica(tabletCtx, force)
-                    || deleteLocationMismatchReplica(tabletCtx, force)
                     || deleteReplicaWithFailedVersion(tabletCtx, force)
                     || deleteReplicaWithLowerVersion(tabletCtx, force)
                     || deleteReplicaOnSameHost(tabletCtx, force)
                     || deleteReplicaChosenByRebalancer(tabletCtx, force)
+                    || deleteLocationMismatchReplica(tabletCtx, force)
                     || deleteReplicaOnHighLoadBackend(tabletCtx, force)) {
                 // if we delete at least one redundant replica, we still throw a SchedException with status FINISHED
                 // to remove this tablet from the pendingTablets(consider it as finished)


### PR DESCRIPTION
## Why I'm doing:
When be label feature enabled and a table with labels.location property exists, some tablets will always be balanced.

For example:
1. 6 bes for a, b, c, d, e, f
2. 3 labels: label1 for a, b; label2 for c, d; label3 for e, f
3. create a table use all of labels
4. write some data to the table
5. some replicas will be balanced from a to b since partition skew, but when repair after balance, the replica on b will be deleted rather than a. So the balance will always be genarated

## What I'm doing:
Put deleteReplicaChosenByRebalancer priority before deleteLocationMismatchReplica to make deleteReplicaChosenByRebalancer to delete a's replica

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
