### PR TITLE
[Enhancement] Bump Iceberg version to 1.10.0

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -75,7 +75,7 @@ under the License.
         <protobuf-java.version>3.25.5</protobuf-java.version>
         <paimon.version>1.0.1</paimon.version>
         <delta-kernel.version>4.0.0rc1</delta-kernel.version>
-        <iceberg.version>1.9.0</iceberg.version>
+        <iceberg.version>1.10.0</iceberg.version>
         <staros.version>3.5-rc4</staros.version>
         <!-- hadoop-azure requires no more than jetty10+ -->
         <!-- https://stackoverflow.com/questions/66713254/spark-wasb-and-jetty-11 -->

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -34,7 +34,7 @@
         <java-extensions.home>${basedir}</java-extensions.home>
         <aws-v2-sdk.version>2.29.52</aws-v2-sdk.version>
         <hadoop.version>3.4.1</hadoop.version>
-        <iceberg.version>1.9.0</iceberg.version>
+        <iceberg.version>1.10.0</iceberg.version>
         <log4j2.version>2.23.1</log4j2.version>
         <junit.version>5.10.3</junit.version>
         <hive-apache.version>3.1.2-22</hive-apache.version>


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
 Bump Iceberg version to 1.10.0
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade Iceberg to 1.10.0 and sync `ManifestReader` with upstream 1.10.0, simplifying filter/evaluator logic.
> 
> - **Dependencies**:
>   - Bump `iceberg.version` from `1.9.0` to `1.10.0` in `fe/pom.xml` and `java-extensions/pom.xml`.
> - **Iceberg integration**:
>   - Update `fe/fe-core/src/main/java/org/apache/iceberg/ManifestReader.java` to align with Iceberg 1.10.0:
>     - Use `alwaysTrue` static import and remove explicit null checks in `hasRowFilter`/`hasPartitionFilter`.
>     - Simplify `evaluator()` and `metricsEvaluator()` to construct evaluators directly with combined filters.
>     - Adjust `requireStatsProjection` to use `alwaysTrue` comparison.
>     - Update upstream reference comment from 1.9.0 to 1.10.0.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7bcf7f39f3a1da5830022401a1b7982af4c01ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->