### PR TITLE
[Refactor] Refactor USE and SHOW CREATE DATABASE and RECOVER DATABASE statements to fe-parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -687,7 +687,7 @@ public class ShowExecutor {
 
         @Override
         public ShowResultSet visitShowCreateDbStatement(ShowCreateDbStmt statement, ConnectContext context) {
-            String catalogName = statement.getCatalogName();
+            String catalogName = context.getCurrentCatalog();
             String dbName = statement.getDb();
             List<List<String>> rows = Lists.newArrayList();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BasicDbStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BasicDbStmtAnalyzer.java
@@ -15,7 +15,6 @@
 package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Strings;
-import com.starrocks.common.util.Util;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.RecoverDbStmt;
@@ -42,32 +41,26 @@ public class BasicDbStmtAnalyzer {
 
         @Override
         public Void visitUseDbStatement(UseDbStmt statement, ConnectContext context) {
-            String catalogName = Util.normalizeName(getCatalogNameIfNotSet(statement.getCatalogName(), context));
-            statement.setCatalogName(catalogName);
+            if (Strings.isNullOrEmpty(context.getCurrentCatalog())) {
+                throw new SemanticException(PARSER_ERROR_MSG.noCatalogSelected());
+            }
             return null;
         }
 
         @Override
         public Void visitRecoverDbStatement(RecoverDbStmt statement, ConnectContext context) {
-            statement.setCatalogName(getCatalogNameIfNotSet(statement.getCatalogName(), context));
+            if (Strings.isNullOrEmpty(context.getCurrentCatalog())) {
+                throw new SemanticException(PARSER_ERROR_MSG.noCatalogSelected());
+            }
             return null;
         }
 
         @Override
         public Void visitShowCreateDbStatement(ShowCreateDbStmt statement, ConnectContext context) {
-            statement.setCatalogName(getCatalogNameIfNotSet(statement.getCatalogName(), context));
-            return null;
-        }
-
-        private String getCatalogNameIfNotSet(String currentCatalogName, ConnectContext context) {
-            String result = currentCatalogName;
-            if (currentCatalogName == null) {
-                if (Strings.isNullOrEmpty(context.getCurrentCatalog())) {
-                    throw new SemanticException(PARSER_ERROR_MSG.noCatalogSelected());
-                }
-                result = context.getCurrentCatalog();
+            if (Strings.isNullOrEmpty(context.getCurrentCatalog())) {
+                throw new SemanticException(PARSER_ERROR_MSG.noCatalogSelected());
             }
-            return result;
+            return null;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
@@ -53,7 +53,6 @@ import com.starrocks.sql.ast.ShowAnalyzeJobStmt;
 import com.starrocks.sql.ast.ShowAnalyzeStatusStmt;
 import com.starrocks.sql.ast.ShowBasicStatsMetaStmt;
 import com.starrocks.sql.ast.ShowColumnStmt;
-import com.starrocks.sql.ast.ShowCreateDbStmt;
 import com.starrocks.sql.ast.ShowCreateExternalCatalogStmt;
 import com.starrocks.sql.ast.ShowCreateRoutineLoadStmt;
 import com.starrocks.sql.ast.ShowCreateTableStmt;
@@ -318,14 +317,6 @@ public class ShowStmtAnalyzer {
                 }
             }
             return db;
-        }
-
-        @Override
-        public Void visitShowCreateDbStatement(ShowCreateDbStmt node, ConnectContext context) {
-            String dbName = node.getDb();
-            dbName = getDatabaseName(dbName, context);
-            node.setDb(dbName);
-            return null;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
@@ -108,17 +108,11 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
         return visitDDLStatement(statement, context);
     }
 
-    default R visitShowCreateDbStatement(ShowCreateDbStmt statement, C context) {
-        return visitShowStatement(statement, context);
-    }
 
     default R visitAlterDatabaseRenameStatement(AlterDatabaseRenameStatement statement, C context) {
         return visitDDLStatement(statement, context);
     }
 
-    default R visitRecoverDbStatement(RecoverDbStmt statement, C context) {
-        return visitDDLStatement(statement, context);
-    }
 
     default R visitShowDataDistributionStatement(ShowDataDistributionStmt statement, C context) {
         return visitShowStatement(statement, context);
@@ -251,20 +245,6 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
     }
 
     default R visitDropMaterializedViewStatement(DropMaterializedViewStmt statement, C context) {
-        return visitDDLStatement(statement, context);
-    }
-
-    // ---------------------------------------- Catalog Statement ------------------------------------------------------
-
-    default R visitCreateCatalogStatement(CreateCatalogStmt statement, C context) {
-        return visitDDLStatement(statement, context);
-    }
-
-    default R visitShowCreateExternalCatalogStatement(ShowCreateExternalCatalogStmt statement, C context) {
-        return visitShowStatement(statement, context);
-    }
-
-    default R visitAlterCatalogStatement(AlterCatalogStmt statement, C context) {
         return visitDDLStatement(statement, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -773,7 +773,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowCreateDbStatement(com.starrocks.sql.parser.StarRocksParser.ShowCreateDbStatementContext context) {
         String dbName = ((Identifier) visit(context.identifier())).getValue();
-        return new ShowCreateDbStmt(dbName, createPos(context));
+        return new ShowCreateDbStmt(normalizeName(dbName), createPos(context));
     }
 
     @Override
@@ -787,7 +787,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitRecoverDbStmt(com.starrocks.sql.parser.StarRocksParser.RecoverDbStmtContext context) {
         String dbName = ((Identifier) visit(context.identifier())).getValue();
-        return new RecoverDbStmt(dbName, createPos(context));
+        return new RecoverDbStmt(normalizeName(dbName), createPos(context));
     }
 
     @Override
@@ -2361,7 +2361,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             com.starrocks.sql.parser.StarRocksParser.CreateExternalCatalogStatementContext context) {
         boolean ifNotExists = context.IF() != null;
         Identifier identifier = (Identifier) visit(context.identifierOrString());
-        String catalogName = identifier.getValue();
+        String catalogName = normalizeName(identifier.getValue());
         String comment = null;
         if (context.comment() != null) {
             comment = ((StringLiteral) visit(context.comment())).getStringValue();
@@ -2390,7 +2390,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     public ParseNode visitShowCreateExternalCatalogStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowCreateExternalCatalogStatementContext context) {
         Identifier identifier = (Identifier) visit(context.catalogName);
-        String catalogName = identifier.getValue();
+        String catalogName = normalizeName(identifier.getValue());
         return new ShowCreateExternalCatalogStmt(catalogName, createPos(context));
     }
 
@@ -2406,7 +2406,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
     @Override
     public ParseNode visitAlterCatalogStatement(com.starrocks.sql.parser.StarRocksParser.AlterCatalogStatementContext context) {
-        String catalogName = ((Identifier) visit(context.catalogName)).getValue();
+        String catalogName = normalizeName(((Identifier) visit(context.catalogName)).getValue());
         AlterClause alterClause = (AlterClause) visit(context.modifyPropertiesClause());
         return new AlterCatalogStmt(catalogName, alterClause, createPos(context));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.analysis;
 
 import com.starrocks.common.DdlException;
@@ -35,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 public class CatalogStmtTest {
     private static StarRocksAssert starRocksAssert;
+
     @BeforeAll
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
@@ -48,7 +48,8 @@ public class CatalogStmtTest {
 
     @Test
     public void testCreateCatalogParserAndAnalyzer() {
-        String sql_1 = "CREATE EXTERNAL CATALOG catalog_1 PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
+        String sql_1 =
+                "CREATE EXTERNAL CATALOG catalog_1 PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
         StatementBase stmt = AnalyzeTestUtil.analyzeSuccess(sql_1);
         Assertions.assertTrue(stmt instanceof CreateCatalogStmt);
         String sql_2 = "CREATE EXTERNAL CATALOG catalog_2";
@@ -57,14 +58,19 @@ public class CatalogStmtTest {
         AnalyzeTestUtil.analyzeFail(sql_3);
         String sql_4 = "CREATE EXTERNAL CATALOG catalog_4 properties(\"aaa\"=\"bbb\")";
         AnalyzeTestUtil.analyzeFail(sql_4);
-        String sql_5 = "CREATE EXTERNAL CATALOG default PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
+        String sql_5 =
+                "CREATE EXTERNAL CATALOG default PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
         AnalyzeTestUtil.analyzeFail(sql_5);
         String sql_6 = "CREATE EXTERNAL CATALOG catalog_5 properties(\"type\"=\"hive\")";
         StatementBase stmt2 = AnalyzeTestUtil.analyzeSuccess(sql_6);
-        Assertions.assertEquals("CREATE EXTERNAL CATALOG 'catalog_5' PROPERTIES(\"type\"  =  \"hive\")", stmt2.toSql());
-        String sql_7 = "CREATE EXTERNAL CATALOG IF NOT EXISTS catalog_6 PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
+        Assertions.assertEquals("CREATE EXTERNAL CATALOG 'catalog_5' PROPERTIES(\"type\"  =  \"hive\")",
+                AstToStringBuilder.toString(stmt2));
+        String sql_7 =
+                "CREATE EXTERNAL CATALOG IF NOT EXISTS catalog_6 PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
         StatementBase stmt3 = AnalyzeTestUtil.analyzeSuccess(sql_7);
-        Assertions.assertEquals("CREATE EXTERNAL CATALOG IF NOT EXISTS 'catalog_6' PROPERTIES(\"hive.metastore.uris\"  =  \"thrift://127.0.0.1:9083\", \"type\"  =  \"hive\")", stmt3.toSql());
+        Assertions.assertEquals(
+                "CREATE EXTERNAL CATALOG 'catalog_6' PROPERTIES(\"hive.metastore.uris\"  =  \"thrift://127.0.0.1:9083\", \"type\"  =  \"hive\")",
+                AstToStringBuilder.toString(stmt3));
         Assertions.assertTrue(stmt3 instanceof CreateCatalogStmt);
     }
 
@@ -96,7 +102,8 @@ public class CatalogStmtTest {
 
     @Test
     public void testCreateCatalog() throws Exception {
-        String sql = "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
+        String sql =
+                "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
         StatementBase stmt = AnalyzeTestUtil.analyzeSuccess(sql);
         Assertions.assertTrue(stmt instanceof CreateCatalogStmt);
         ConnectContext connectCtx = new ConnectContext();
@@ -122,7 +129,8 @@ public class CatalogStmtTest {
 
     @Test
     public void testCreateCatalogWithAccessControl() throws Exception {
-        String sql = "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\", \"catalog.access.control\"=\"allowall\")";
+        String sql =
+                "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\", \"catalog.access.control\"=\"allowall\")";
         StatementBase stmt = AnalyzeTestUtil.analyzeSuccess(sql);
         Assertions.assertTrue(stmt instanceof CreateCatalogStmt);
         ConnectContext connectCtx = new ConnectContext();
@@ -140,8 +148,10 @@ public class CatalogStmtTest {
 
     @Test
     public void testCreateExistedCatalog() throws Exception {
-        String sql = "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
-        String sql_2 = "CREATE EXTERNAL CATALOG IF NOT EXISTS hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
+        String sql =
+                "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
+        String sql_2 =
+                "CREATE EXTERNAL CATALOG IF NOT EXISTS hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
         StatementBase stmt = AnalyzeTestUtil.analyzeSuccess(sql);
         Assertions.assertTrue(stmt instanceof CreateCatalogStmt);
         ConnectContext connectCtx = new ConnectContext();
@@ -168,9 +178,9 @@ public class CatalogStmtTest {
     @Test
     public void testDropCatalog() throws Exception {
         // test drop ddl DROP CATALOG catalog_name
-        String createSql = "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
+        String createSql =
+                "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
         String dropSql = "DROP CATALOG hive_catalog";
-
 
         CatalogMgr catalogMgr = GlobalStateMgr.getCurrentState().getCatalogMgr();
         ConnectorMgr connectorMgr = GlobalStateMgr.getCurrentState().getConnectorMgr();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
@@ -1123,7 +1123,8 @@ public class RedirectStatusTest {
 
     @Test
     public void testCreateCatalogStmt() {
-        CreateCatalogStmt stmt = new CreateCatalogStmt("test_catalog", "hive", java.util.Collections.emptyMap(), false);
+        CreateCatalogStmt stmt =
+                new CreateCatalogStmt("test_catalog", "hive", java.util.Collections.emptyMap(), false, NodePosition.ZERO);
         Assertions.assertEquals(RedirectStatus.FORWARD_WITH_SYNC, RedirectStatus.getRedirectStatus(stmt));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/UseDbTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/UseDbTest.java
@@ -1,0 +1,182 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.authorization.MockedLocalMetaStore;
+import com.starrocks.authorization.RBACMockedMetadataMgr;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.server.CatalogMgr;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.ast.UseDbStmt;
+import com.starrocks.sql.parser.SqlParser;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class UseDbTest {
+    @Test
+    public void testUseDbWithoutCurrentCatalog() throws Exception {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        MockedLocalMetaStore localMetastore = new MockedLocalMetaStore(globalStateMgr, globalStateMgr.getRecycleBin(), null);
+        localMetastore.init();
+        globalStateMgr.setLocalMetastore(localMetastore);
+
+        RBACMockedMetadataMgr metadataMgr =
+                new RBACMockedMetadataMgr(localMetastore, globalStateMgr.getConnectorMgr());
+        globalStateMgr.setMetadataMgr(metadataMgr);
+
+        ConnectContext context = new ConnectContext();
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setCurrentRoleIds(UserIdentity.ROOT);
+        context.setQueryId(UUIDUtil.genUUID());
+
+        String sql = "use db1;";
+        UseDbStmt useDbStmt = (UseDbStmt) SqlParser.parseSingleStatement(sql, context.getSessionVariable().getSqlMode());
+        Analyzer.analyze(useDbStmt, context);
+
+        StmtExecutor stmtExecutor = new StmtExecutor(context, useDbStmt);
+        stmtExecutor.execute();
+
+        Assertions.assertEquals("default_catalog", context.getCurrentCatalog());
+        Assertions.assertEquals("db1", context.getDatabase());
+    }
+
+    @Test
+    public void testUseDbWithCatalog() throws Exception {
+        new MockUp<CatalogMgr>() {
+            @Mock
+            public boolean catalogExists(String catalogName) {
+                if (catalogName.equals("catalog1")) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        };
+
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        MockedLocalMetaStore localMetastore = new MockedLocalMetaStore(globalStateMgr, globalStateMgr.getRecycleBin(), null);
+        localMetastore.init();
+        globalStateMgr.setLocalMetastore(localMetastore);
+
+        RBACMockedMetadataMgr metadataMgr =
+                new RBACMockedMetadataMgr(localMetastore, globalStateMgr.getConnectorMgr());
+        globalStateMgr.setMetadataMgr(metadataMgr);
+
+        ConnectContext context = new ConnectContext();
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setCurrentRoleIds(UserIdentity.ROOT);
+        context.setQueryId(UUIDUtil.genUUID());
+        context.setCurrentCatalog("default_catalog");
+
+        String sql = "use catalog1.db1;";
+        UseDbStmt useDbStmt = (UseDbStmt) SqlParser.parseSingleStatement(sql, context.getSessionVariable().getSqlMode());
+        Analyzer.analyze(useDbStmt, context);
+
+        StmtExecutor stmtExecutor = new StmtExecutor(context, useDbStmt);
+        stmtExecutor.execute();
+
+        Assertions.assertEquals("catalog1", context.getCurrentCatalog());
+        Assertions.assertEquals("db1", context.getDatabase());
+    }
+
+    /**
+     * Test case: Use database with non-existent catalog
+     * Test point: Verify that using a non-existent catalog throws appropriate error
+     */
+    @Test
+    public void testUseDbWithNonExistentCatalog() throws Exception {
+        new MockUp<CatalogMgr>() {
+            @Mock
+            public boolean catalogExists(String catalogName) {
+                return false; // All catalogs are non-existent
+            }
+        };
+
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        MockedLocalMetaStore localMetastore = new MockedLocalMetaStore(globalStateMgr, globalStateMgr.getRecycleBin(), null);
+        localMetastore.init();
+        globalStateMgr.setLocalMetastore(localMetastore);
+
+        RBACMockedMetadataMgr metadataMgr =
+                new RBACMockedMetadataMgr(localMetastore, globalStateMgr.getConnectorMgr());
+        globalStateMgr.setMetadataMgr(metadataMgr);
+
+        ConnectContext context = new ConnectContext();
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setCurrentRoleIds(UserIdentity.ROOT);
+        context.setQueryId(UUIDUtil.genUUID());
+        context.setCurrentCatalog("default_catalog");
+
+        String sql = "use nonexistent_catalog.db1;";
+        UseDbStmt useDbStmt = (UseDbStmt) SqlParser.parseSingleStatement(sql, context.getSessionVariable().getSqlMode());
+        Analyzer.analyze(useDbStmt, context);
+
+        StmtExecutor stmtExecutor = new StmtExecutor(context, useDbStmt);
+        stmtExecutor.execute();
+
+        // Should have error state due to non-existent catalog
+        Assertions.assertTrue(context.getState().isError());
+        Assertions.assertTrue(context.getState().getErrorMessage().contains("Unknown catalog"));
+    }
+
+    /**
+     * Test case: Use database statement execution state
+     * Test point: Verify that execution state is set correctly after successful execution
+     */
+    @Test
+    public void testUseDbExecutionState() throws Exception {
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Database getDb(ConnectContext context, String catalogName, String dbName) {
+                if (dbName.equals("db1")) {
+                    return new Database(1, "db1");
+                }
+                return null;
+            }
+        };
+
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        MockedLocalMetaStore localMetastore = new MockedLocalMetaStore(globalStateMgr, globalStateMgr.getRecycleBin(), null);
+        localMetastore.init();
+        globalStateMgr.setLocalMetastore(localMetastore);
+
+        RBACMockedMetadataMgr metadataMgr =
+                new RBACMockedMetadataMgr(localMetastore, globalStateMgr.getConnectorMgr());
+        globalStateMgr.setMetadataMgr(metadataMgr);
+
+        ConnectContext context = new ConnectContext();
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setCurrentRoleIds(UserIdentity.ROOT);
+        context.setQueryId(UUIDUtil.genUUID());
+        context.setCurrentCatalog("default_catalog");
+
+        String sql = "use db1;";
+        UseDbStmt useDbStmt = (UseDbStmt) SqlParser.parseSingleStatement(sql, context.getSessionVariable().getSqlMode());
+        Analyzer.analyze(useDbStmt, context);
+
+        StmtExecutor stmtExecutor = new StmtExecutor(context, useDbStmt);
+        stmtExecutor.execute();
+
+        // Execution state should be OK after successful execution
+        Assertions.assertEquals(QueryState.MysqlStateType.OK, context.getState().getStateType());
+        Assertions.assertFalse(context.getState().isError());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitorTest.java
@@ -1,0 +1,135 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.RecoverDbStmt;
+import com.starrocks.sql.ast.ShowCreateDbStmt;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class AuthorizerStmtVisitorTest {
+
+    private static ConnectContext connectContext;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        Config.dynamic_partition_enable = false;
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+    }
+
+    @AfterAll
+    public static void afterClass() throws Exception {
+        // Cleanup is handled automatically by the test framework
+    }
+
+    @Test
+    public void testShowCreateDbStatementWithNullCatalog() throws Exception {
+        // Test case to cover line 549 in AuthorizerStmtVisitor.java
+        // This should trigger the noCatalogSelected exception when current catalog is null
+        ShowCreateDbStmt stmt =
+                (ShowCreateDbStmt) SqlParser.parse("SHOW CREATE DATABASE test_db", connectContext.getSessionVariable()).get(0);
+
+        // Create a new context with null catalog to trigger the exception
+        ConnectContext testContext = new ConnectContext();
+        testContext.setCurrentUserIdentity(connectContext.getCurrentUserIdentity());
+        testContext.setCurrentRoleIds(connectContext.getCurrentRoleIds());
+        // Set catalog to null to trigger the exception
+        testContext.setCurrentCatalog(null);
+
+        AuthorizerStmtVisitor visitor = new AuthorizerStmtVisitor();
+
+        try {
+            visitor.visitShowCreateDbStatement(stmt, testContext);
+            Assertions.fail("Expected SemanticException to be thrown");
+        } catch (Exception e) {
+            Assertions.assertTrue(e.getMessage().contains("No catalog selected"));
+        }
+    }
+
+    @Test
+    public void testRecoverDbStatementWithNullCatalog() throws Exception {
+        // Test case to cover line 567 in AuthorizerStmtVisitor.java
+        // This should trigger the noCatalogSelected exception when current catalog is null
+        RecoverDbStmt stmt =
+                (RecoverDbStmt) SqlParser.parse("RECOVER DATABASE test_db", connectContext.getSessionVariable()).get(0);
+
+        // Create a new context with null catalog to trigger the exception
+        ConnectContext testContext = new ConnectContext();
+        testContext.setCurrentUserIdentity(connectContext.getCurrentUserIdentity());
+        testContext.setCurrentRoleIds(connectContext.getCurrentRoleIds());
+        // Set catalog to null to trigger the exception
+        testContext.setCurrentCatalog(null);
+
+        AuthorizerStmtVisitor visitor = new AuthorizerStmtVisitor();
+
+        try {
+            visitor.visitRecoverDbStatement(stmt, testContext);
+            Assertions.fail("Expected SemanticException to be thrown");
+        } catch (Exception e) {
+            Assertions.assertTrue(e.getMessage().contains("No catalog selected"));
+        }
+    }
+
+    @Test
+    public void testShowCreateDbStatementWithValidCatalog() throws Exception {
+        // Test case to ensure normal flow works when catalog is set
+        ShowCreateDbStmt stmt =
+                (ShowCreateDbStmt) SqlParser.parse("SHOW CREATE DATABASE test_db", connectContext.getSessionVariable()).get(0);
+
+        // Use the context with valid catalog
+        connectContext.setCurrentCatalog("default_catalog");
+
+        AuthorizerStmtVisitor visitor = new AuthorizerStmtVisitor();
+
+        try {
+            visitor.visitShowCreateDbStatement(stmt, connectContext);
+            // Should not throw noCatalogSelected exception (may throw other exceptions due to missing database)
+        } catch (Exception e) {
+            // Should not be a noCatalogSelected exception
+            Assertions.assertFalse(e.getMessage().contains("No catalog selected"),
+                    "Should not throw noCatalogSelected exception when catalog is set: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testRecoverDbStatementWithValidCatalog() throws Exception {
+        // Test case to ensure normal flow works when catalog is set
+        RecoverDbStmt stmt =
+                (RecoverDbStmt) SqlParser.parse("RECOVER DATABASE test_db", connectContext.getSessionVariable()).get(0);
+
+        // Use the context with valid catalog
+        connectContext.setCurrentCatalog("default_catalog");
+
+        AuthorizerStmtVisitor visitor = new AuthorizerStmtVisitor();
+
+        try {
+            visitor.visitRecoverDbStatement(stmt, connectContext);
+            // Should not throw noCatalogSelected exception (may throw other exceptions due to missing database)
+        } catch (Exception e) {
+            // Should not be a noCatalogSelected exception
+            Assertions.assertFalse(e.getMessage().contains("No catalog selected"),
+                    "Should not throw noCatalogSelected exception when catalog is set: " + e.getMessage());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/BasicDbStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/BasicDbStmtAnalyzerTest.java
@@ -1,0 +1,161 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.RecoverDbStmt;
+import com.starrocks.sql.ast.ShowCreateDbStmt;
+import com.starrocks.sql.ast.UseDbStmt;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class BasicDbStmtAnalyzerTest {
+
+    private static ConnectContext connectContext;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        Config.dynamic_partition_enable = false;
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+    }
+
+    @AfterAll
+    public static void afterClass() throws Exception {
+        // Cleanup is handled automatically by the test framework
+    }
+
+    @Test
+    public void testUseDbStatementWithNullCatalog() throws Exception {
+        // Test case to cover line 45 in BasicDbStmtAnalyzer.java
+        // This should trigger the noCatalogSelected exception when current catalog is null
+        UseDbStmt stmt = (UseDbStmt) SqlParser.parse("USE test_db", connectContext.getSessionVariable()).get(0);
+
+        // Create a new context with null catalog to trigger the exception
+        ConnectContext testContext = new ConnectContext();
+        testContext.setCurrentUserIdentity(connectContext.getCurrentUserIdentity());
+        testContext.setCurrentRoleIds(connectContext.getCurrentRoleIds());
+        // Set catalog to null to trigger the exception
+        testContext.setCurrentCatalog(null);
+
+        try {
+            BasicDbStmtAnalyzer.analyze(stmt, testContext);
+            Assertions.fail("Expected SemanticException to be thrown");
+        } catch (Exception e) {
+            Assertions.assertTrue(e.getMessage().contains("No catalog selected"));
+        }
+    }
+
+    @Test
+    public void testRecoverDbStatementWithNullCatalog() throws Exception {
+        // Test case to cover line 53 in BasicDbStmtAnalyzer.java
+        // This should trigger the noCatalogSelected exception when current catalog is null
+        RecoverDbStmt stmt =
+                (RecoverDbStmt) SqlParser.parse("RECOVER DATABASE test_db", connectContext.getSessionVariable()).get(0);
+
+        // Create a new context with null catalog to trigger the exception
+        ConnectContext testContext = new ConnectContext();
+        testContext.setCurrentUserIdentity(connectContext.getCurrentUserIdentity());
+        testContext.setCurrentRoleIds(connectContext.getCurrentRoleIds());
+        // Set catalog to null to trigger the exception
+        testContext.setCurrentCatalog(null);
+
+        try {
+            BasicDbStmtAnalyzer.analyze(stmt, testContext);
+            Assertions.fail("Expected SemanticException to be thrown");
+        } catch (Exception e) {
+            Assertions.assertTrue(e.getMessage().contains("No catalog selected"));
+        }
+    }
+
+    @Test
+    public void testShowCreateDbStatementWithNullCatalog() throws Exception {
+        // Test case to cover line 61 in BasicDbStmtAnalyzer.java
+        // This should trigger the noCatalogSelected exception when current catalog is null
+        ShowCreateDbStmt stmt =
+                (ShowCreateDbStmt) SqlParser.parse("SHOW CREATE DATABASE test_db", connectContext.getSessionVariable()).get(0);
+
+        // Create a new context with null catalog to trigger the exception
+        ConnectContext testContext = new ConnectContext();
+        testContext.setCurrentUserIdentity(connectContext.getCurrentUserIdentity());
+        testContext.setCurrentRoleIds(connectContext.getCurrentRoleIds());
+        // Set catalog to null to trigger the exception
+        testContext.setCurrentCatalog(null);
+
+        try {
+            BasicDbStmtAnalyzer.analyze(stmt, testContext);
+            Assertions.fail("Expected SemanticException to be thrown");
+        } catch (Exception e) {
+            Assertions.assertTrue(e.getMessage().contains("No catalog selected"));
+        }
+    }
+
+    @Test
+    public void testUseDbStatementWithValidCatalog() throws Exception {
+        // Test case to ensure normal flow works when catalog is set
+        UseDbStmt stmt = (UseDbStmt) SqlParser.parse("USE test_db", connectContext.getSessionVariable()).get(0);
+
+        // Use the context with valid catalog
+        connectContext.setCurrentCatalog("default_catalog");
+
+        try {
+            BasicDbStmtAnalyzer.analyze(stmt, connectContext);
+            // Should not throw exception
+        } catch (Exception e) {
+            Assertions.fail("Should not throw exception when catalog is set: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testRecoverDbStatementWithValidCatalog() throws Exception {
+        // Test case to ensure normal flow works when catalog is set
+        RecoverDbStmt stmt =
+                (RecoverDbStmt) SqlParser.parse("RECOVER DATABASE test_db", connectContext.getSessionVariable()).get(0);
+
+        // Use the context with valid catalog
+        connectContext.setCurrentCatalog("default_catalog");
+
+        try {
+            BasicDbStmtAnalyzer.analyze(stmt, connectContext);
+            // Should not throw exception
+        } catch (Exception e) {
+            Assertions.fail("Should not throw exception when catalog is set: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testShowCreateDbStatementWithValidCatalog() throws Exception {
+        // Test case to ensure normal flow works when catalog is set
+        ShowCreateDbStmt stmt =
+                (ShowCreateDbStmt) SqlParser.parse("SHOW CREATE DATABASE test_db", connectContext.getSessionVariable()).get(0);
+
+        // Use the context with valid catalog
+        connectContext.setCurrentCatalog("default_catalog");
+
+        try {
+            BasicDbStmtAnalyzer.analyze(stmt, connectContext);
+            // Should not throw exception
+        } catch (Exception e) {
+            Assertions.fail("Should not throw exception when catalog is set: " + e.getMessage());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/TableObjectCaseInsensitiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/TableObjectCaseInsensitiveTest.java
@@ -30,7 +30,9 @@ import com.starrocks.sql.ast.AdminSetConfigStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateViewStmt;
 import com.starrocks.sql.ast.DropDbStmt;
+import com.starrocks.sql.ast.RecoverDbStmt;
 import com.starrocks.sql.ast.SetStmt;
+import com.starrocks.sql.ast.ShowCreateDbStmt;
 import com.starrocks.sql.ast.ShowTableStmt;
 import com.starrocks.sql.ast.UseDbStmt;
 import com.starrocks.sql.parser.SqlParser;
@@ -423,5 +425,27 @@ public class TableObjectCaseInsensitiveTest {
         sql = "DROP DATABASE TEST_DB";
         dropDbStmt = (DropDbStmt) SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
         Assertions.assertEquals("test_db", dropDbStmt.getDbName());
+    }
+
+    @Test
+    public void testRecoverDb() {
+        String sql = "RECOVER DATABASE TEST_db";
+        RecoverDbStmt recoverDbStmt = (RecoverDbStmt) SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+        Assertions.assertEquals("test_db", recoverDbStmt.getDbName());
+
+        sql = "RECOVER DATABASE TEST_DB";
+        recoverDbStmt = (RecoverDbStmt) SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+        Assertions.assertEquals("test_db", recoverDbStmt.getDbName());
+    }
+
+    @Test
+    public void testShowCreateDb() {
+        String sql = "SHOW CREATE DATABASE TEST_db";
+        ShowCreateDbStmt showCreateDbStmt = (ShowCreateDbStmt) SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+        Assertions.assertEquals("test_db", showCreateDbStmt.getDb());
+
+        sql = "SHOW CREATE DATABASE TEST_DB";
+        showCreateDbStmt = (ShowCreateDbStmt) SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+        Assertions.assertEquals("test_db", showCreateDbStmt.getDb());
     }
 }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AlterCatalogStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AlterCatalogStmt.java
@@ -11,11 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
-
-import static com.starrocks.common.util.Util.normalizeName;
 
 public class AlterCatalogStmt extends DdlStmt {
     private final String catalogName;
@@ -23,7 +22,7 @@ public class AlterCatalogStmt extends DdlStmt {
 
     public AlterCatalogStmt(String catalogName, AlterClause alterClause, NodePosition pos) {
         super(pos);
-        this.catalogName = normalizeName(catalogName);
+        this.catalogName = catalogName;
         this.alterClause = alterClause;
     }
 
@@ -37,6 +36,6 @@ public class AlterCatalogStmt extends DdlStmt {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitAlterCatalogStatement(this, context);
+        return visitor.visitAlterCatalogStatement(this, context);
     }
 }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -638,6 +638,14 @@ public interface AstVisitor<R, C> {
         return visitShowStatement(statement, context);
     }
 
+    default R visitShowCreateDbStatement(ShowCreateDbStmt statement, C context) {
+        return visitShowStatement(statement, context);
+    }
+
+    default R visitRecoverDbStatement(RecoverDbStmt statement, C context) {
+        return visitDDLStatement(statement, context);
+    }
+
     default R visitDropCNGroupStatement(DropCnGroupStmt statement, C context) {
         return visitDDLStatement(statement, context);
     }
@@ -660,5 +668,17 @@ public interface AstVisitor<R, C> {
 
     default R visitShowSecurityIntegrationStatement(ShowSecurityIntegrationStatement statement, C context) {
         return visitShowStatement(statement, context);
+    }
+
+    default R visitCreateCatalogStatement(CreateCatalogStmt statement, C context) {
+        return visitDDLStatement(statement, context);
+    }
+
+    default R visitShowCreateExternalCatalogStatement(ShowCreateExternalCatalogStmt statement, C context) {
+        return visitShowStatement(statement, context);
+    }
+
+    default R visitAlterCatalogStatement(AlterCatalogStmt statement, C context) {
+        return visitDDLStatement(statement, context);
     }
 }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/CreateCatalogStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/CreateCatalogStmt.java
@@ -14,12 +14,9 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.common.util.PrintableMap;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Map;
-
-import static com.starrocks.common.util.Util.normalizeName;
 
 public class CreateCatalogStmt extends DdlStmt {
     public static final String TYPE = "type";
@@ -28,17 +25,12 @@ public class CreateCatalogStmt extends DdlStmt {
     private final String comment;
     private final Map<String, String> properties;
     private String catalogType;
-
     private final boolean ifNotExists;
-
-    public CreateCatalogStmt(String catalogName, String comment, Map<String, String> properties, boolean ifNotExists) {
-        this(catalogName, comment, properties, ifNotExists, NodePosition.ZERO);
-    }
 
     public CreateCatalogStmt(String catalogName, String comment, Map<String, String> properties,
                              boolean ifNotExists, NodePosition pos) {
         super(pos);
-        this.catalogName = normalizeName(catalogName);
+        this.catalogName = catalogName;
         this.comment = comment;
         this.properties = properties;
         this.ifNotExists = ifNotExists;
@@ -70,21 +62,6 @@ public class CreateCatalogStmt extends DdlStmt {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitCreateCatalogStatement(this, context);
-    }
-
-    @Override
-    public String toSql() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("CREATE EXTERNAL CATALOG ");
-        if (ifNotExists) {
-            sb.append("IF NOT EXISTS ");
-        }
-        sb.append("'").append(catalogName).append("' ");
-        if (comment != null) {
-            sb.append("COMMENT \"").append(comment).append("\" ");
-        }
-        sb.append("PROPERTIES(").append(new PrintableMap<>(properties, " = ", true, false)).append(")");
-        return sb.toString();
+        return visitor.visitCreateCatalogStatement(this, context);
     }
 }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/RecoverDbStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/RecoverDbStmt.java
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,32 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
 
-import static com.starrocks.common.util.Util.normalizeName;
+public class RecoverDbStmt extends DdlStmt {
+    private final String dbName;
 
-// SHOW CREATE EXTERNAL CATALOG statement.
-public class ShowCreateExternalCatalogStmt extends ShowStmt {
-    private final String catalogName;
-
-    public ShowCreateExternalCatalogStmt(String catalogName) {
-        this(catalogName, NodePosition.ZERO);
+    public RecoverDbStmt(String dbName) {
+        this(dbName, NodePosition.ZERO);
     }
 
-    public ShowCreateExternalCatalogStmt(String catalogName, NodePosition pos) {
+    public RecoverDbStmt(String dbName, NodePosition pos) {
         super(pos);
-        this.catalogName = normalizeName(catalogName);
+        this.dbName = dbName;
     }
 
-    public String getCatalogName() {
-        return catalogName;
+    public String getDbName() {
+        return dbName;
     }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitShowCreateExternalCatalogStatement(this, context);
+        return visitor.visitRecoverDbStatement(this, context);
     }
 }
+

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ShowCreateDbStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ShowCreateDbStmt.java
@@ -16,15 +16,12 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
 
-import static com.starrocks.common.util.Util.normalizeName;
-
 // Show create database statement
 //  Syntax:
 //      SHOW CREATE DATABASE db
 public class ShowCreateDbStmt extends ShowStmt {
 
-    private String catalog;
-    private String db;
+    private final String db;
 
     public ShowCreateDbStmt(String db) {
         this(db, NodePosition.ZERO);
@@ -32,23 +29,11 @@ public class ShowCreateDbStmt extends ShowStmt {
 
     public ShowCreateDbStmt(String db, NodePosition pos) {
         super(pos);
-        this.db = normalizeName(db);
-    }
-
-    public String getCatalogName() {
-        return this.catalog;
-    }
-
-    public void setCatalogName(String catalogName) {
-        this.catalog = normalizeName(catalogName);
+        this.db = db;
     }
 
     public String getDb() {
         return db;
-    }
-
-    public void setDb(String db) {
-        this.db = normalizeName(db);
     }
 
     @Override
@@ -58,6 +43,6 @@ public class ShowCreateDbStmt extends ShowStmt {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitShowCreateDbStatement(this, context);
+        return visitor.visitShowCreateDbStatement(this, context);
     }
 }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ShowCreateExternalCatalogStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ShowCreateExternalCatalogStmt.java
@@ -12,44 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
 
-import static com.starrocks.common.util.Util.normalizeName;
+// SHOW CREATE EXTERNAL CATALOG statement.
+public class ShowCreateExternalCatalogStmt extends ShowStmt {
+    private final String catalogName;
 
-public class RecoverDbStmt extends DdlStmt {
-    private String catalog;
-    private String dbName;
-
-    public RecoverDbStmt(String dbName) {
-        this(dbName, NodePosition.ZERO);
+    public ShowCreateExternalCatalogStmt(String catalogName) {
+        this(catalogName, NodePosition.ZERO);
     }
 
-    public RecoverDbStmt(String dbName, NodePosition pos) {
+    public ShowCreateExternalCatalogStmt(String catalogName, NodePosition pos) {
         super(pos);
-        this.dbName = normalizeName(dbName);
-    }
-
-    public String getDbName() {
-        return dbName;
-    }
-
-    public void setDbName(String dbname) {
-        this.dbName = normalizeName(dbname);
+        this.catalogName = catalogName;
     }
 
     public String getCatalogName() {
-        return this.catalog;
-    }
-
-    public void setCatalogName(String catalogName) {
-        this.catalog = normalizeName(catalogName);
+        return catalogName;
     }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitRecoverDbStatement(this, context);
+        return visitor.visitShowCreateExternalCatalogStatement(this, context);
     }
 }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/UseDbStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/UseDbStmt.java
@@ -22,7 +22,7 @@ import com.starrocks.sql.parser.NodePosition;
  * Queries from JDBC will be handled by COM_QUERY protocol, it will generate UseDbStmt.
  */
 public class UseDbStmt extends StatementBase {
-    private String catalog;
+    private final String catalog;
     private final String database;
 
     public UseDbStmt(String catalog, String database, NodePosition pos) {
@@ -33,10 +33,6 @@ public class UseDbStmt extends StatementBase {
 
     public String getCatalogName() {
         return this.catalog;
-    }
-
-    public void setCatalogName(String catalogName) {
-        this.catalog = catalogName;
     }
 
     public String getDbName() {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request refactors and improves the handling of catalog and database statements, especially around the `USE`, `SHOW CREATE DATABASE`, and `RECOVER DATABASE` statements. The changes ensure stricter validation of catalog presence, improve normalization and case-insensitivity, and enhance test coverage for these behaviors.

**Key improvements and changes:**

**1. Catalog Validation and Error Handling**
- Enforces that a catalog must be selected in the context before executing `USE`, `SHOW CREATE DATABASE`, and `RECOVER DATABASE` statements. Throws a semantic exception with a clear error message if not set. (`BasicDbStmtAnalyzer.java`, `AuthorizerStmtVisitor.java`) [[1]](diffhunk://#diff-f53a5a8ab0169b5d4b0a34f794eb21ac221c439e3a68550980553262b8ef9d13L45-R63) [[2]](diffhunk://#diff-3311511b364c1b9c62bb240801f539d8fdd4f8406e8b97ec241ea95bba3828c7R547-R556) [[3]](diffhunk://#diff-3311511b364c1b9c62bb240801f539d8fdd4f8406e8b97ec241ea95bba3828c7L558-R576)
- Removes logic that implicitly sets or normalizes the catalog name from statements, instead relying on the current context and erroring if unset. (`BasicDbStmtAnalyzer.java`)

**2. Case Normalization and Parsing**
- Ensures that database names are normalized (case-insensitive) during parsing for `SHOW CREATE DATABASE` and `RECOVER DATABASE` statements. (`AstBuilder.java`) [[1]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL776-R776) [[2]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL790-R790)
- Updates tests to verify that database names are handled case-insensitively. (`TableObjectCaseInsensitiveTest.java`)

**3. Authorization and Privilege Checks**
- Updates privilege checks for `SHOW CREATE DATABASE` and `RECOVER DATABASE` to use the catalog from the context and provide accurate error reporting. (`AuthorizerStmtVisitor.java`) [[1]](diffhunk://#diff-3311511b364c1b9c62bb240801f539d8fdd4f8406e8b97ec241ea95bba3828c7R547-R556) [[2]](diffhunk://#diff-3311511b364c1b9c62bb240801f539d8fdd4f8406e8b97ec241ea95bba3828c7L558-R576)

**4. Code Cleanup and Consistency**
- Removes redundant visitor methods and normalizing utilities related to catalog/database name handling. (`ShowStmtAnalyzer.java`, `AstVisitorExtendInterface.java`) [[1]](diffhunk://#diff-117f40e7b3769fd0dc2527ac74c3779b6cca60649feaf601306658f1496f1dcaL323-L330) [[2]](diffhunk://#diff-4bac2722f105b9f28e4b57fafe8c96ba1fd20dfeee1134181cb960cd3d5786ffL148-L158)
- Adds missing imports and improves static import usage. (`AuthorizerStmtVisitor.java`, `BasicDbStmtAnalyzer.java`) [[1]](diffhunk://#diff-3311511b364c1b9c62bb240801f539d8fdd4f8406e8b97ec241ea95bba3828c7R17) [[2]](diffhunk://#diff-f53a5a8ab0169b5d4b0a34f794eb21ac221c439e3a68550980553262b8ef9d13L18)

**5. Test Coverage Enhancements**
- Adds comprehensive tests for `USE` statement behavior, including catalog selection, error handling for non-existent catalogs, and execution state validation. (`UseDbTest.java`)

These changes collectively make catalog/database operations more robust, predictable, and easier to maintain, while improving user feedback and test reliability.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
