### PR TITLE
[BugFix] fix jsonpath rewrite with wrong column type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -394,7 +394,9 @@ public class JsonPathRewriteRule extends TransformationRule {
         }
 
         private boolean isSupportedJsonFunction(CallOperator call) {
-            return SUPPORTED_JSON_FUNCTIONS.contains(call.getFnName()) && call.getArguments().size() == 2;
+            return SUPPORTED_JSON_FUNCTIONS.contains(call.getFnName())
+                    && call.getArguments().size() == 2
+                    && call.getChild(0).getType().equals(Type.JSON);
         }
 
         private ScalarOperator rewriteJsonFunction(CallOperator call, ScalarOperatorRewriteContext rewriteContext) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
@@ -28,9 +28,11 @@ public class JsonPathRewriteTest extends PlanTestBase {
 
     @BeforeAll
     public static void beforeAll() throws Exception {
-        starRocksAssert.withTable("create table extend_predicate( c1 int, c2 json ) properties('replication_num'='1')");
+        starRocksAssert.withTable("create table extend_predicate( c1 int, c2 json) properties('replication_num'='1')");
         starRocksAssert.withTable("create table extend_predicate2( c1 int, c2 json ) properties" +
                 "('replication_num'='1')");
+        starRocksAssert.withTable("create table extend_predicate3( c1 int, c2 string) " +
+                "properties('replication_num'='1')");
 
         FeConstants.USE_MOCK_DICT_MANAGER = true;
         connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
@@ -212,6 +214,12 @@ public class JsonPathRewriteTest extends PlanTestBase {
                                 "     Table: extend_predicate\n" +
                                 "     <id 6> : dict_merge_c2.f1\n",
                         "     ExtendedColumnAccessPath: [/c2(varchar)/f1(varchar)]\n"
+                ),
+                // [21] Test parameter type validation - get_json_string(string, string) should not be rewritten
+                Arguments.of(
+                        "select get_json_string(c2, 'f1') from extend_predicate3",
+                        "get_json_string(2: c2, 'f1')",
+                        ""
                 )
         );
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

`get_json_string` can accept `STRING` and `JSON` type, but only `JSON` type can use this optimization. 

Fixes #63677

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
