### PR TITLE
[Enhancement] Add enable_optimizer_rule_debug session variable for rule failure diagnosis

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -782,6 +782,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_PLAN_VALIDATION = "enable_plan_validation";
 
+    public static final String ENABLE_OPTIMIZER_RULE_DEBUG = "enable_optimizer_rule_debug";
+
     public static final String ENABLE_STRICT_TYPE = "enable_strict_type";
 
     public static final String PARTIAL_UPDATE_MODE = "partial_update_mode";
@@ -2462,6 +2464,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_PLAN_VALIDATION, flag = VariableMgr.INVISIBLE)
     private boolean enablePlanValidation = true;
+
+    @VarAttr(name = ENABLE_OPTIMIZER_RULE_DEBUG)
+    private boolean enableOptimizerRuleDebug = false;
 
     @VarAttr(name = SCAN_OR_TO_UNION_LIMIT, flag = VariableMgr.INVISIBLE)
     private int scanOrToUnionLimit = 4;
@@ -4729,6 +4734,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnablePlanValidation(boolean val) {
         this.enablePlanValidation = val;
+    }
+
+    public boolean enableOptimizerRuleDebug() {
+        return this.enableOptimizerRuleDebug;
+    }
+
+    public void setEnableOptimizerRuleDebug(boolean enableOptimizerRuleDebug) {
+        this.enableOptimizerRuleDebug = enableOptimizerRuleDebug;
     }
 
     public boolean isCboPruneSubfield() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -131,7 +131,6 @@ import com.starrocks.sql.optimizer.task.TaskContext;
 import com.starrocks.sql.optimizer.task.TaskScheduler;
 import com.starrocks.sql.optimizer.validate.MVRewriteValidator;
 import com.starrocks.sql.optimizer.validate.OptExpressionValidator;
-import com.starrocks.sql.optimizer.validate.PlanValidator;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -309,8 +308,9 @@ public class QueryOptimizer extends Optimizer {
         mvScan.stream().map(scan -> ((MaterializedView) scan.getTable()).getDbId()).forEach(currentSqlDbIds::add);
 
         try (Timer ignored = Tracers.watchScope("PlanValidate")) {
+            rootTaskContext.getPlanValidator().enableAllCheckers();
             // valid the final plan
-            PlanValidator.getInstance().validatePlan(finalPlan, rootTaskContext);
+            rootTaskContext.getPlanValidator().validatePlan(finalPlan, rootTaskContext);
             // validate mv and log tracer if needed
             MVRewriteValidator mvRewriteValidator = new MVRewriteValidator(allLogicalOlapScanOperators);
             mvRewriteValidator.validateMV(connectContext, finalPlan, rootTaskContext);
@@ -589,6 +589,9 @@ public class QueryOptimizer extends Optimizer {
         rootTaskContext.setRequiredColumns(requiredColumns.clone());
         scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PRUNE_COLUMNS_RULES);
 
+        // Enable input dependencies checker after column pruning for rule transformation validation
+        rootTaskContext.getPlanValidator().enableInputDependenciesChecker();
+
         pruneTables(tree, rootTaskContext, requiredColumns);
 
         scheduler.rewriteIterative(tree, rootTaskContext, new PruneEmptyWindowRule());
@@ -663,7 +666,6 @@ public class QueryOptimizer extends Optimizer {
 
         scheduler.rewriteDownTop(tree, rootTaskContext, OnPredicateMoveAroundRule.INSTANCE);
         scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PUSH_DOWN_PREDICATE_RULES);
-
         scheduler.rewriteIterative(tree, rootTaskContext, new PartitionColumnMinMaxRewriteRule());
         scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PARTITION_PRUNE_RULES);
         scheduler.rewriteIterative(tree, rootTaskContext, new RewriteMultiDistinctRule());
@@ -699,10 +701,8 @@ public class QueryOptimizer extends Optimizer {
         scheduler.rewriteOnce(tree, rootTaskContext, new PartitionColumnValueOnlyOnScanRule());
         // before MergeProjectWithChildRule, after INLINE_CTE and MergeApplyWithTableFunction
         scheduler.rewriteIterative(tree, rootTaskContext, RewriteUnnestBitmapRule.getInstance());
-
         // After this rule, we shouldn't generate logical project operator
         scheduler.rewriteIterative(tree, rootTaskContext, new MergeProjectWithChildRule());
-
         scheduler.rewriteOnce(tree, rootTaskContext, new EliminateSortColumnWithEqualityPredicateRule());
         scheduler.rewriteOnce(tree, rootTaskContext, new PushDownTopNBelowOuterJoinRule());
         // intersect rewrite depend on statistics
@@ -720,7 +720,6 @@ public class QueryOptimizer extends Optimizer {
         scheduler.rewriteOnce(tree, rootTaskContext, JsonPathRewriteRule.createForOlapScan());
         scheduler.rewriteIterative(tree, rootTaskContext, new RewriteMinMaxByMonotonicFunctionRule());
         scheduler.rewriteOnce(tree, rootTaskContext, RewriteSimpleAggToHDFSScanRule.SCAN_NO_PROJECT);
-
         // NOTE: This rule should be after MV Rewrite because MV Rewrite cannot handle
         // select count(distinct c) from t group by a, b
         // if this rule has applied before MV.
@@ -975,7 +974,6 @@ public class QueryOptimizer extends Optimizer {
     private OptExpression physicalRuleRewrite(ConnectContext connectContext, TaskContext rootTaskContext,
                                               OptExpression result) {
         Preconditions.checkState(result.getOp().isPhysical());
-
         int planCount = result.getPlanCount();
 
         // Since there may be many different plans in the logic phase, it's possible

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RowOutputInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RowOutputInfo.java
@@ -137,7 +137,7 @@ public class RowOutputInfo {
     }
 
     public List<ColumnRefOperator> getOutputColRefs() {
-        return chooseOutputMap().values().stream().map(e -> e.getColumnRef()).collect(Collectors.toList());
+        return chooseOutputMap().values().stream().map(ColumnOutputInfo::getColumnRef).collect(Collectors.toList());
     }
 
     public Map<ColumnRefOperator, ScalarOperator> getColumnRefMap() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefSet.java
@@ -47,7 +47,7 @@ public class ColumnRefSet implements Cloneable {
 
     public static ColumnRefSet createByIds(Collection<Integer> colIds) {
         ColumnRefSet columnRefSet = new ColumnRefSet();
-        colIds.stream().forEach(columnRefSet::union);
+        colIds.forEach(columnRefSet::union);
         return columnRefSet;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
@@ -247,7 +247,7 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
     /*
      * select a, b, c, d, null, sum(x) x from t group by rollup(a, b, c, d)
      */
-    private OptExpression buildSubRepeatConsume(ColumnRefFactory factory,
+    public OptExpression buildSubRepeatConsume(ColumnRefFactory factory,
                                                 Map<ColumnRefOperator, ColumnRefOperator> outputs,
                                                 LogicalAggregationOperator aggregate, LogicalRepeatOperator repeat,
                                                 int cteId) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/ApplyRuleTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/ApplyRuleTask.java
@@ -89,6 +89,7 @@ public class ApplyRuleTask extends OptimizerTask {
             }
             List<OptExpression> targetExpressions;
             OptimizerTraceUtil.logApplyRuleBefore(context.getOptimizerContext(), rule, extractExpr);
+            
             try (Timer ignore = Tracers.watchScope(Tracers.Module.OPTIMIZER, rule.getClass().getSimpleName())) {
                 targetExpressions = rule.transform(extractExpr, context.getOptimizerContext());
             } catch (StarRocksPlannerException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/TaskContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/TaskContext.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.optimizer.task;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.validate.PlanValidator;
 
 // The context for optimizer task
 public class TaskContext {
@@ -25,6 +26,7 @@ public class TaskContext {
     private final PhysicalPropertySet requiredProperty;
     private ColumnRefSet requiredColumns;
     private double upperBoundCost;
+    private final PlanValidator planValidator;
 
     public TaskContext(OptimizerContext context,
                        PhysicalPropertySet physicalPropertySet,
@@ -34,6 +36,11 @@ public class TaskContext {
         this.requiredProperty = physicalPropertySet;
         this.requiredColumns = requiredColumns;
         this.upperBoundCost = cost;
+        this.planValidator = new PlanValidator();
+    }
+
+    public PlanValidator getPlanValidator() {
+        return planValidator;
     }
 
     public OptimizerContext getOptimizerContext() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/CTEUniqueChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/CTEUniqueChecker.java
@@ -43,7 +43,6 @@ public class CTEUniqueChecker implements PlanValidator.Checker {
         return INSTANCE;
     }
 
-
     @Override
     public void validate(OptExpression physicalPlan, TaskContext taskContext) {
         CTEUniqueChecker.Visitor visitor = new CTEUniqueChecker.Visitor();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -202,7 +202,7 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
             ColumnRefSet missedCols = usedCols.clone();
             missedCols.except(inputCols);
             if (!missedCols.isEmpty()) {
-                String message = String.format("Invalid plan:%s%s%s The required cols %s cannot obtain from input cols %s.",
+                String message = String.format("Invalid plan:%s%s\n%s \nThe required cols %s cannot obtain from input cols %s.",
                         System.lineSeparator(), optExpr.debugString(), PREFIX, missedCols, inputCols);
                 throw new StarRocksPlannerException(message, ErrorType.INTERNAL_ERROR);
             }
@@ -210,7 +210,7 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
 
         private void checkInputType(ColumnRefOperator inputCol, ColumnRefOperator outputCol, OptExpression optExpression) {
             if (!outputCol.getType().isFullyCompatible(inputCol.getType())) {
-                String message = String.format("Invalid plan:%s%s%s Type of output col %s is not fully compatible with " +
+                String message = String.format("Invalid plan:%s%s\n%s \nType of output col %s is not fully compatible with " +
                                 "type of input col %s.",
                         System.lineSeparator(), optExpression.debugString(), PREFIX, outputCol, inputCol);
                 throw new StarRocksPlannerException(message, ErrorType.INTERNAL_ERROR);
@@ -219,7 +219,7 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
 
         private void checkChildNumberOfSet(int inputSize, int requiredSize, OptExpression optExpression) {
             if (inputSize != requiredSize) {
-                String message = String.format("Invalid plan:%s%s%s. The required number of children is %d but found %d.",
+                String message = String.format("Invalid plan:%s%s\n%s. \nThe required number of children is %d but found %d.",
                         System.lineSeparator(), optExpression.debugString(), PREFIX, requiredSize, inputSize);
                 throw new StarRocksPlannerException(message, ErrorType.INTERNAL_ERROR);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -13,14 +13,43 @@
 // limitations under the License.package com.starrocks.sql.plan;
 package com.starrocks.sql.plan;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.ibm.icu.impl.Assert;
+import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.AggType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalRepeatOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
+import com.starrocks.sql.optimizer.rule.transformation.PushDownAggregateGroupingSetsRule;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class GroupingSetsTest extends PlanTestBase {
     private static final int NUM_TABLE0_ROWS = 10000;
@@ -409,6 +438,138 @@ public class GroupingSetsTest extends PlanTestBase {
             assertContains(plan, "PREDICATES: 14: t1b IS NULL");
         } finally {
             connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
+        }
+    }
+
+    @Test
+    public void testPushDownGroupingSetHavingWithPlanValidate() {
+        new MockUp<PushDownAggregateGroupingSetsRule>() {
+            @Mock
+            public OptExpression buildSubRepeatConsume(ColumnRefFactory factory,
+                                                       Map<ColumnRefOperator, ColumnRefOperator> outputs,
+                                                       LogicalAggregationOperator aggregate, LogicalRepeatOperator repeat,
+                                                       int cteId) {
+                int subGroups = repeat.getRepeatColumnRef().size() - 1;
+                List<ColumnRefOperator> nullRefs = Lists.newArrayList(repeat.getRepeatColumnRef().get(subGroups));
+                repeat.getRepeatColumnRef().stream().limit(subGroups).forEach(nullRefs::removeAll);
+
+                // consume
+                Map<ColumnRefOperator, ColumnRefOperator> cteColumnRefs = Maps.newHashMap();
+                for (ColumnRefOperator input : aggregate.getAggregations().keySet()) {
+                    ColumnRefOperator cteOutput = factory.create(input, input.getType(), input.isNullable());
+                    cteColumnRefs.put(cteOutput, input);
+                    outputs.put(input, cteOutput);
+                }
+                for (ColumnRefOperator input : aggregate.getGroupingKeys()) {
+                    if (!repeat.getOutputGrouping().contains(input) && !nullRefs.contains(input)) {
+                        ColumnRefOperator cteOutput = factory.create(input, input.getType(), input.isNullable());
+                        cteColumnRefs.put(cteOutput, input);
+                        outputs.put(input, cteOutput);
+                    }
+                }
+
+                LogicalCTEConsumeOperator consume = new LogicalCTEConsumeOperator(cteId, cteColumnRefs);
+
+                // repeat
+                List<ColumnRefOperator> outputGrouping = Lists.newArrayList();
+                repeat.getOutputGrouping().forEach(k -> {
+                    ColumnRefOperator x = factory.create(k, k.getType(), k.isNullable());
+                    outputs.put(k, x);
+                    outputGrouping.add(x);
+                });
+
+                List<List<ColumnRefOperator>> repeatRefs = repeat.getRepeatColumnRef().stream().limit(subGroups)
+                        .map(l -> l.stream().map(outputs::get).filter(Objects::nonNull).collect(Collectors.toList()))
+                        .collect(Collectors.toList());
+
+                List<List<Long>> groupingIds = repeat.getGroupingIds().stream()
+                        .map(s -> s.subList(0, subGroups)).collect(Collectors.toList());
+
+                ScalarOperator predicate = null;
+                if (null != repeat.getPredicate()) {
+                    ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(outputs);
+                    predicate = rewriter.rewrite(repeat.getPredicate());
+                }
+
+                LogicalRepeatOperator newRepeat = LogicalRepeatOperator.builder()
+                        .setOutputGrouping(outputGrouping)
+                        .setRepeatColumnRefList(repeatRefs)
+                        .setGroupingIds(groupingIds)
+                        .setHasPushDown(true)
+                        .setPredicate(predicate)
+                        .build();
+
+                // aggregate
+                Map<ColumnRefOperator, CallOperator> aggregations = Maps.newHashMap();
+                aggregate.getAggregations().forEach((k, v) -> {
+                    ColumnRefOperator x = factory.create(k, k.getType(), k.isNullable());
+                    Function aggFunc = Expr.getBuiltinFunction(v.getFnName(), new Type[] {k.getType()},
+                            Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+
+                    Preconditions.checkState(aggFunc instanceof AggregateFunction);
+                    if (k.getType().isDecimalOfAnyVersion()) {
+                        aggFunc = DecimalV3FunctionAnalyzer.rectifyAggregationFunction((AggregateFunction) aggFunc, k.getType(),
+                                v.getType());
+                    }
+
+                    aggregations.put(x,
+                            new CallOperator(v.getFnName(), k.getType(), Lists.newArrayList(outputs.get(k)), aggFunc));
+                    outputs.put(k, x);
+                });
+
+                List<ColumnRefOperator> groupings = aggregate.getGroupingKeys().stream()
+                        .filter(c -> !nullRefs.contains(c)).map(outputs::get).collect(Collectors.toList());
+
+                if (null != aggregate.getPredicate()) {
+                    Map<ColumnRefOperator, ScalarOperator> replaceMap = Maps.newHashMap(outputs);
+                    nullRefs.forEach(c -> replaceMap.put(c, ConstantOperator.createNull(c.getType())));
+                    ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(replaceMap);
+                    predicate = rewriter.rewrite(aggregate.getPredicate());
+                }
+                LogicalAggregationOperator newAggregate = LogicalAggregationOperator.builder()
+                        .setAggregations(aggregations)
+                        .setGroupingKeys(groupings)
+                        .setType(AggType.GLOBAL)
+                        .setPredicate(predicate)
+                        .setPartitionByColumns(groupings)
+                        .build();
+
+                // project
+                Map<ColumnRefOperator, ScalarOperator> projection = Maps.newHashMap();
+                aggregations.keySet().forEach(k -> projection.put(k, k));
+                groupings.forEach(k -> projection.put(k, k));
+
+                for (ColumnRefOperator nullRef : nullRefs) {
+                    ColumnRefOperator m = factory.create(nullRef, nullRef.getType(), true);
+                    projection.put(m, ConstantOperator.createNull(nullRef.getType()));
+                    outputs.put(nullRef, m);
+                }
+                LogicalProjectOperator projectOperator = new LogicalProjectOperator(projection);
+
+                return OptExpression.create(projectOperator,
+                        OptExpression.create(newAggregate, OptExpression.create(newRepeat, OptExpression.create(consume))));
+            }
+        };
+
+        connectContext.getSessionVariable().setCboPushDownGroupingSet(true);
+        connectContext.getSessionVariable().setEnableOptimizerRuleDebug(true);
+        try {
+            String sql = "select t1b, t1c, t1d, sum(t1g) " +
+                    "   from test_all_type group by rollup(t1b, t1c, t1d) " +
+                    "   having t1b is null and (t1c is null or t1d is null)";
+            try {
+                getFragmentPlan(sql);
+                Assert.fail("should throw exception");
+            } catch (Exception e) {
+                String errMsg = e.getMessage();
+                assertContains(errMsg, "Optimizer rule debug: Plan validation failed after applying rule " +
+                        "[TF_PUSHDOWN_AGG_GROUPING_SET].");
+                assertContains(errMsg, "The required cols {4} cannot obtain from input cols {13,14,15}");
+                assertContains(errMsg, "Input dependency cols check failed");
+            }
+        } finally {
+            connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
+            connectContext.getSessionVariable().setEnableOptimizerRuleDebug(false);
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Currently, when optimizer rules encounter bugs, users often see cryptic error messages like `Error 1064 (HY000): only found column statistics: {353: sum, 3}` without knowing which specific rule caused the problem. This makes troubleshooting extremely difficult in production environments, as users cannot identify the problematic rule to apply workarounds.

When optimizer rules fail, especially during complex query optimization phases, the error messages lack context about which transformation or validation rule triggered the failure. This creates significant challenges for both users and developers in diagnosing and resolving optimizer-related issues.

## What I'm doing:

This PR introduces a new session variable `enable_optimizer_rule_debug` to provide detailed debugging information when optimizer rules fail. The enhancement includes:

**New Session Variable: `enable_optimizer_rule_debug`**
- When enabled, provides detailed error context including the specific rule that caused the failure
- Shows before/after query plans when rule validation fails
- Helps identify problematic optimizer rules for troubleshooting
- Works in conjunction with the `cbo_disabled_rules` feature from [PR #64269](https://github.com/StarRocks/starrocks/pull/64269) to provide users with immediate workarounds


**Usage Example:**
```sql
-- Enable optimizer rule debugging
SET enable_optimizer_rule_debug = true;
```

--Rerun the failed query.  When a rule fails, you'll see detailed output like:
```
Optimizer rule debug: Plan validation failed after applying rule [TF_PUSHDOWN_AGG_GROUPING_SET].
Validation error: Invalid plan:
LOGICAL_REPEAT
->  LogicalCTEConsumeOperator{cteId='1', limit=-1, predicate=null}
Input dependency cols check failed. 
The required cols {4} cannot obtain from input cols {13,14,15}.
Hint: This error was caught by enable_optimizer_rule_debug=true
Before:xxx
After:xxx
```

-- Combined with cbo_disabled_rules for workarounds:
```
SET cbo_disabled_rules = 'TF_PUSHDOWN_AGG_GROUPING_SET';  -- Disable the problematic rule
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
