### PR TITLE
[Enhancement] Primary key consistency test supports PK parallel execution

### DIFF
--- a/be/src/storage/sstable/table_builder.cpp
+++ b/be/src/storage/sstable/table_builder.cpp
@@ -66,7 +66,6 @@ TableBuilder::TableBuilder(const Options& options, WritableFile* file) : rep_(ne
 }
 
 TableBuilder::~TableBuilder() {
-    assert(rep_->closed); // Catch errors where caller forgot to call Finish()
     delete rep_->filter_block;
     delete rep_;
 }

--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -717,8 +717,8 @@ protected:
 };
 
 TEST_P(LakePrimaryKeyConsistencyTest, test_local_pk_consistency) {
-    _seed = 1719499276;   // seed
-    _run_second = 500000; // 50 second
+    _seed = 1719499276; // seed
+    _run_second = 50;   // 50 second
     LOG(INFO) << "LakePrimaryKeyConsistencyTest begin, seed : " << _seed;
     auto st = run_random_tests();
     if (!st.ok()) {
@@ -737,7 +737,8 @@ TEST_P(LakePrimaryKeyConsistencyTest, test_random_seed_pk_consistency) {
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyConsistencyTest, LakePrimaryKeyConsistencyTest,
-                         ::testing::Values(PrimaryKeyParam{
-                                 .persistent_index_type = PersistentIndexTypePB::CLOUD_NATIVE}));
+                         ::testing::Values(PrimaryKeyParam{.persistent_index_type = PersistentIndexTypePB::LOCAL},
+                                           PrimaryKeyParam{
+                                                   .persistent_index_type = PersistentIndexTypePB::CLOUD_NATIVE}));
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -395,12 +395,12 @@ public:
         return force_flush_guard;
     }
 
-    // 50% chance to enable pk parallel execution
+    // 20% chance to enable pk parallel execution
     std::unique_ptr<ConfigResetGuard<bool>> random_pk_parallel_execution() {
         std::unique_ptr<ConfigResetGuard<bool>> pk_parallel_execution_guard;
         uint32_t r = _random_generator->random() % 100;
-        if (r < 50) {
-            // 50% chance to enable pk parallel execution
+        if (r < 20) {
+            // 20% chance to enable pk parallel execution
             pk_parallel_execution_guard =
                     std::make_unique<ConfigResetGuard<bool>>(&config::enable_pk_parallel_execution, true);
         }


### PR DESCRIPTION
## Why I'm doing:
This PR contains two changes:
1. Primary key consistency test supports PK parallel execution
2. Remove `rep_->closed` check in `~TableBuilder`, because it's unnecessary.

## What I'm doing:
This pull request updates the Lake primary key consistency tests to use string (VARCHAR) primary keys instead of integers, and introduces randomized configuration changes to improve test coverage for index flushing and parallel execution. The changes also include internal refactoring to support the new key type and enhance the robustness of the tests.

**Primary Key Type Migration:**

* Changed all primary key columns (`c0`) in the test schema and related logic from integer (`INT`) to string (`VARCHAR`), including schema definitions, slot setup, and column creation. [[1]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116L219-R220) [[2]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116L290-R293) [[3]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116L302-R308) [[4]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116R334-R349) [[5]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116R365-R378)
* Updated all internal maps and key handling in the `Replayer` class and related test logic to use `std::string` instead of `int` for primary key storage and comparisons. [[1]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116L102-R109) [[2]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116L149-R166) [[3]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116L189-R193) [[4]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116L209-R209)

**Test Robustness and Randomization:**

* Added helper methods to randomly force index memtable flushes (5% chance) and enable PK parallel execution (50% chance) during test operations, increasing scenario coverage and stress-testing concurrency.
* Integrated these random configuration changes into all major test operations, such as upsert, delete, partial update, condition update, batch publish, and compaction. [[1]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116R429-R430) [[2]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116R466-R467) [[3]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116R503-R504) [[4]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116R536-R537) [[5]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116R579-R580) [[6]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116R606-R607)

**Configuration Management:**

* Added backup and restoration of the `pk_parallel_execution_threshold_bytes` configuration to ensure test isolation and prevent side effects. [[1]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116R272-R281) [[2]](diffhunk://#diff-468cadd2dd316474b700d7f49d166f15321e1af7ca4270a55afb92a3be861116R716-R721)

**Other Minor Changes:**

* Increased test duration for the local PK consistency test to allow for more extensive randomized testing.
* Limited test instantiation to only the `CLOUD_NATIVE` persistent index type, removing the `LOCAL` type from test parameters.

**Code Quality:**

* Removed an unnecessary assertion in the `TableBuilder` destructor to avoid potential false positives when closing resources.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
