### PR TITLE
[DSR-BugFix-242] try to adapt field delimiter for text hive table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3922,4 +3922,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "The threshold to flatten compound predicate from deep tree to a balanced tree to " +
             "avoid stack over flow")
     public static int compound_predicate_flatten_threshold = 512;
+
+    @ConfField(mutable = true, comment = "Enable text column cutting symbol enhancement for hive table")
+    public static boolean enable_hive_table_text_field_delimiter_enhancement = false;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
@@ -53,6 +53,8 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Verify.verify;
 import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 import static com.starrocks.connector.PartitionUtil.toPartitionValues;
+import static com.starrocks.connector.hive.HiveMetadata.FIELD_DELIMITOR;
+import static com.starrocks.connector.hive.HiveMetadata.SERIALIZATION_FORMAT;
 import static com.starrocks.connector.hive.HiveMetadata.STARROCKS_QUERY_ID;
 import static com.starrocks.connector.hive.HivePartitionStats.ReduceOperator.SUBTRACT;
 import static com.starrocks.connector.hive.HivePartitionStats.fromCommonStats;
@@ -456,6 +458,8 @@ public class HiveCommitter {
                 .setParameters(ImmutableMap.<String, String>builder()
                         .put("starrocks_version", Version.STARROCKS_VERSION + "-" + Version.STARROCKS_COMMIT_HASH)
                         .put(STARROCKS_QUERY_ID, ConnectContext.get().getQueryId().toString())
+                        .put(FIELD_DELIMITOR, partitionUpdate.getFieldDelimiter())
+                        .put(SERIALIZATION_FORMAT, partitionUpdate.getSerializationFormat())
                         .buildOrThrow())
                 .setStorageFormat(table.getStorageFormat())
                 .setLocation(partitionUpdate.getTargetPath().toString())

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveFieldDelimiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveFieldDelimiter.java
@@ -1,0 +1,379 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive;
+
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.StringWriter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HiveFieldDelimiter {
+    private static final Logger LOG = LogManager.getLogger(HiveFieldDelimiter.class);
+
+    /**
+     * Convert the delimiter string configured by Hive to the actual HDFS file delimiter
+     * @param originStr String
+     * @return String
+     */
+    public static String convert(String originStr) {
+        if (originStr == null || originStr.isEmpty()) {
+            throw new StarRocksConnectorException("Delimiter cannot be empty or null");
+        }
+
+        // 1. Handle hexadecimal representations (\x, 0x, \X, 0X)
+        if (originStr.toUpperCase().startsWith("\\X") || originStr.toUpperCase().startsWith("0X")) {
+            LOG.info("origin value [{}] is use hexadecimal to format", originStr);
+            return convertHexDelimiter(originStr);
+        }
+
+        // 2. Handle octal representations (\ digit, \0 digit)
+        if (originStr.startsWith("\\") && originStr.length() > 1 &&
+                Pattern.matches("^\\\\0?[0-7]{1,3}", originStr)) {
+            LOG.info("origin value [{}] is use octal to format", originStr);
+            return convertOctalDelimiter(originStr);
+        }
+
+        // 3. Handle Unicode representations (\\u, \\U)
+        if (originStr.toUpperCase().startsWith("\\U")) {
+            LOG.info("origin value [{}] is use unicode to format", originStr);
+            return convertUnicodeDelimiter(originStr);
+        }
+
+        // 4. Handle special escape characters
+        if (originStr.startsWith("\\") && originStr.length() == 2) {
+            LOG.info("origin value [{}] is use special escape to format", originStr);
+            return convertSpecialEscape(originStr);
+        }
+
+        // 5. Handle numeric strings (such as "1", "9", etc. representing ASCII codes)
+        if (Pattern.matches("^[0-9]+$", originStr)) {
+            LOG.info("origin value [{}] is use ascii code to format", originStr);
+            return convertNumericDelimiter(originStr);
+        }
+
+        // 6. Default: Handle mixed escape characters
+        LOG.info("origin value [{}] is use mixed escape to format", originStr);
+        return convertMixedEscapedCharacters(originStr);
+    }
+
+    /**
+     * Handle hexadecimal delimiters
+     * @param originStr
+     * @return
+     */
+    private static String convertHexDelimiter(String originStr) {
+        String hexStr = originStr.substring(2);
+
+        if (hexStr.isEmpty()) {
+            throw new StarRocksConnectorException("Invalid delimiter '" + originStr + "': empty hex string");
+        }
+
+        // Check the hexadecimal format
+        if (!Pattern.matches("^[0-9A-Fa-f]+$", hexStr)) {
+            throw new StarRocksConnectorException("Invalid delimiter '" + originStr + "': invalid hex format");
+        }
+
+        // Convert hexadecimal to characters
+        StringWriter writer = new StringWriter();
+        try {
+            // Every two characters represent one byte
+            for (int i = 0; i < hexStr.length(); i += 2) {
+                String byteStr = hexStr.substring(i, Math.min(i + 2, hexStr.length()));
+                // If the length is odd, add zeros
+                if (byteStr.length() == 1) {
+                    byteStr = byteStr + "0";
+                }
+                int byteValue = Integer.parseInt(byteStr, 16);
+                writer.append((char) byteValue);
+            }
+            return writer.toString();
+        } catch (NumberFormatException e) {
+            throw new StarRocksConnectorException("Invalid delimiter '" + originStr + "': hex conversion failed");
+        }
+    }
+
+    /**
+     * Handle octal delimiters
+     * @param originStr
+     * @return
+     */
+    private static String convertOctalDelimiter(String originStr) {
+        // Remove the \ at the beginning
+        String octalStr = originStr.substring(1);
+
+        // Extract octal digits
+        Matcher matcher = Pattern.compile("^0?([0-7]{1,3})").matcher(octalStr);
+        if (matcher.find()) {
+            String octalDigits = matcher.group(1);
+            try {
+                int octalValue = Integer.parseInt(octalDigits, 8);
+                if (octalValue > 255) {
+                    throw new StarRocksConnectorException("Invalid delimiter '" + originStr + "': octal value too large");
+                }
+                return String.valueOf((char) octalValue);
+            } catch (NumberFormatException e) {
+                throw new StarRocksConnectorException("Invalid delimiter '" + originStr + "': invalid octal format");
+            }
+        }
+
+        throw new StarRocksConnectorException("Invalid delimiter '" + originStr + "': invalid octal format");
+    }
+
+    /**
+     * Handle Unicode delimiters
+     * @param originStr
+     * @return
+     */
+    private static String convertUnicodeDelimiter(String originStr) {
+        String unicodeStr = originStr.substring(2);
+
+        if (unicodeStr.isEmpty()) {
+            throw new StarRocksConnectorException("Invalid delimiter '" + originStr + "': empty unicode string");
+        }
+
+        if (!Pattern.matches("^[0-9A-Fa-f]{4,8}$", unicodeStr)) {
+            throw new StarRocksConnectorException("Invalid delimiter '" + originStr + "': invalid unicode format");
+        }
+
+        try {
+            int codePoint = Integer.parseInt(unicodeStr, 16);
+
+            // Check valid Unicode code points
+            if (!Character.isValidCodePoint(codePoint)) {
+                throw new StarRocksConnectorException("Invalid delimiter '" + originStr + "': invalid unicode code point");
+            }
+
+            // Convert code points to strings
+            return new String(Character.toChars(codePoint));
+        } catch (NumberFormatException e) {
+            throw new StarRocksConnectorException("Invalid delimiter '" + originStr + "': unicode conversion failed");
+        }
+    }
+
+    /**
+     * Handle special escape characters
+     * @param originStr
+     * @return
+     */
+    private static String convertSpecialEscape(String originStr) {
+        char escapeChar = originStr.charAt(1);
+
+        switch (escapeChar) {
+            case 'a': return "\u0007";  // alert/bell
+            case 'b': return "\b";      // backspace
+            case 'f': return "\f";      // form feed
+            case 'n': return "\n";      // newline
+            case 'r': return "\r";      // carriage return
+            case 't': return "\t";      // tab
+            case 'v': return "\u000B";  // vertical tab
+            case '\\': return "\\";     // Backslash
+            case '\'': return "'";      // Single quotation marks
+            case '\"': return "\"";     // Double quotation marks
+            case '?': return "?";       // Question mark (used for escaping three-character groups)
+            case '0': return "\0";      // Null character
+            default:
+                // If it's not a special escape, it might be octal or a regular character
+                if (Character.isDigit(escapeChar)) {
+                    // Single-digit octal numbers, such as \1, \2, etc
+                    try {
+                        int octalValue = Integer.parseInt(String.valueOf(escapeChar), 8);
+                        return String.valueOf((char) octalValue);
+                    } catch (NumberFormatException e) {
+                        return String.valueOf(escapeChar);
+                    }
+                } else {
+                    // Ordinary escape characters, such as \A, \B, etc., directly return the character
+                    return String.valueOf(escapeChar);
+                }
+        }
+    }
+
+    /**
+     * Handle numeric strings (such as "1" representing ASCII code 1)
+     * @param originStr
+     * @return
+     */
+    private static String convertNumericDelimiter(String originStr) {
+        try {
+            int asciiCode = Integer.parseInt(originStr);
+            if (asciiCode < 0 || asciiCode > 255) {
+                throw new StarRocksConnectorException("Invalid delimiter '" + originStr + "': ASCII code out of range");
+            }
+            return String.valueOf((char) asciiCode);
+        } catch (NumberFormatException e) {
+            throw new StarRocksConnectorException("Invalid delimiter '" + originStr + "': invalid numeric format");
+        }
+    }
+
+    /**
+     * Handle mixed escape characters (including multiple escape sequences)
+     * @param input
+     * @return
+     */
+    private static String convertMixedEscapedCharacters(String input) {
+        // Use StringBuilder for more precise replacement
+        StringBuilder result = new StringBuilder();
+        int i = 0;
+
+        while (i < input.length()) {
+            if (input.charAt(i) == '\\' && i + 1 < input.length()) {
+                // Handle escape sequences
+                char nextChar = input.charAt(i + 1);
+
+                switch (nextChar) {
+                    case 'a':
+                        result.append('\u0007');
+                        i += 2;
+                        break;
+                    case 'b':
+                        result.append('\b');
+                        i += 2;
+                        break;
+                    case 'f':
+                        result.append('\f');
+                        i += 2;
+                        break;
+                    case 'n':
+                        result.append('\n');
+                        i += 2;
+                        break;
+                    case 'r':
+                        result.append('\r');
+                        i += 2;
+                        break;
+                    case 't':
+                        result.append('\t');
+                        i += 2;
+                        break;
+                    case 'v':
+                        result.append('\u000B');
+                        i += 2;
+                        break;
+                    case '\\':
+                        result.append('\\');
+                        i += 2;
+                        break;
+                    case '\'':
+                        result.append('\'');
+                        i += 2;
+                        break;
+                    case '\"':
+                        result.append('\"');
+                        i += 2;
+                        break;
+                    case '0':
+                        // Check if it is an octal number
+                        if (i + 2 < input.length() &&
+                                Pattern.matches("[0-7]", String.valueOf(input.charAt(i + 2)))) {
+                            // Handle octal escape
+                            String octalStr = input.substring(i + 1, i + 4);
+                            try {
+                                int octalValue = Integer.parseInt(octalStr, 8);
+                                result.append((char) octalValue);
+                                i += 4;
+                            } catch (NumberFormatException e) {
+                                result.append('\0');
+                                i += 2;
+                            }
+                        } else {
+                            result.append('\0');
+                            i += 2;
+                        }
+                        break;
+                    case 'x':
+                    case 'X':
+                        // Handle hexadecimal escape
+                        if (i + 3 < input.length()) {
+                            String hexStr = input.substring(i + 2, i + 4);
+                            if (Pattern.matches("[0-9A-Fa-f]{2}", hexStr)) {
+                                try {
+                                    int hexValue = Integer.parseInt(hexStr, 16);
+                                    result.append((char) hexValue);
+                                    i += 4;
+                                } catch (NumberFormatException e) {
+                                    result.append('\\').append(nextChar);
+                                    i += 2;
+                                }
+                            } else {
+                                result.append('\\').append(nextChar);
+                                i += 2;
+                            }
+                        } else {
+                            result.append('\\').append(nextChar);
+                            i += 2;
+                        }
+                        break;
+                    case 'u':
+                    case 'U':
+                        // Handle Unicode escape
+                        if (i + 5 < input.length()) {
+                            String unicodeStr = input.substring(i + 2, i + 6);
+                            if (Pattern.matches("[0-9A-Fa-f]{4}", unicodeStr)) {
+                                try {
+                                    int codePoint = Integer.parseInt(unicodeStr, 16);
+                                    result.append(new String(Character.toChars(codePoint)));
+                                    i += 6;
+                                } catch (NumberFormatException e) {
+                                    result.append('\\').append(nextChar);
+                                    i += 2;
+                                }
+                            } else {
+                                result.append('\\').append(nextChar);
+                                i += 2;
+                            }
+                        } else {
+                            result.append('\\').append(nextChar);
+                            i += 2;
+                        }
+                        break;
+                    default:
+                        // If it is a number, it might be octal
+                        if (Character.isDigit(nextChar)) {
+                            // Try to parse octal
+                            int j = i + 1;
+                            while (j < input.length() && j < i + 4 &&
+                                    Character.isDigit(input.charAt(j)) &&
+                                    input.charAt(j) >= '0' && input.charAt(j) <= '7') {
+                                j++;
+                            }
+                            String octalStr = input.substring(i + 1, j);
+                            try {
+                                int octalValue = Integer.parseInt(octalStr, 8);
+                                result.append((char) octalValue);
+                                i = j;
+                            } catch (NumberFormatException e) {
+                                result.append('\\').append(nextChar);
+                                i += 2;
+                            }
+                        } else {
+                            // Ordinary escape character
+                            result.append(nextChar);
+                            i += 2;
+                        }
+                }
+            } else {
+                // Ordinary characters
+                result.append(input.charAt(i));
+                i++;
+            }
+        }
+
+        return result.toString();
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveFieldDelimiterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveFieldDelimiterTest.java
@@ -1,0 +1,221 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class HiveFieldDelimiterTest {
+    private static final Logger LOG = LogManager.getLogger(HiveFieldDelimiterTest.class);
+
+    @Test
+    public void testConvert_NullOrEmpty() {
+        // Test null input
+        try {
+            HiveFieldDelimiter.convert(null);
+            fail("Expected exception for null input");
+        } catch (StarRocksConnectorException e) {
+            assertEquals("Delimiter cannot be empty or null", e.getMessage());
+        }
+
+        // Test empty input
+        try {
+            HiveFieldDelimiter.convert("");
+            fail("Expected exception for empty input");
+        } catch (StarRocksConnectorException e) {
+            assertEquals("Delimiter cannot be empty or null", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testConvertHexDelimiter() {
+        // Test valid hex formats
+        assertEquals("\u0001", HiveFieldDelimiter.convert("\\x01"));
+        assertEquals("\u0001", HiveFieldDelimiter.convert("\\X01"));
+        assertEquals("\u0001", HiveFieldDelimiter.convert("0x01"));
+        assertEquals("\u0001", HiveFieldDelimiter.convert("0X01"));
+
+        // Test multiple bytes
+        assertEquals("A", HiveFieldDelimiter.convert("\\x41"));
+        assertEquals("AB", HiveFieldDelimiter.convert("\\x4142"));
+
+        // Test odd length hex (should pad with zero)
+        assertEquals("\n", HiveFieldDelimiter.convert("\\xA"));
+        assertEquals("\n", HiveFieldDelimiter.convert("\\xa"));
+
+        // Test invalid hex formats
+        assertThrows(StarRocksConnectorException.class, () -> HiveFieldDelimiter.convert("\\x"));
+        assertThrows(StarRocksConnectorException.class, () -> HiveFieldDelimiter.convert("\\xGG"));
+        assertThrows(StarRocksConnectorException.class, () -> HiveFieldDelimiter.convert("0x"));
+    }
+
+    @Test
+    public void testConvertOctalDelimiter() {
+        // Test valid octal formats
+        assertEquals("\u0001", HiveFieldDelimiter.convert("\\1"));
+        assertEquals("\u0001", HiveFieldDelimiter.convert("\\01"));
+        assertEquals("\u0001", HiveFieldDelimiter.convert("\\001"));
+        assertEquals("\t", HiveFieldDelimiter.convert("\\11"));
+        assertEquals("A", HiveFieldDelimiter.convert("\\101"));
+
+        // Test invalid octal formats
+        assertThrows(StarRocksConnectorException.class, () -> HiveFieldDelimiter.convert("\\"));
+        assertThrows(StarRocksConnectorException.class, () -> HiveFieldDelimiter.convert("\\8"));
+        assertThrows(StarRocksConnectorException.class, () -> HiveFieldDelimiter.convert("\\400")); // > 255
+    }
+
+    @Test
+    public void testConvertUnicodeDelimiter() {
+        // Test valid unicode formats
+        assertEquals("A", HiveFieldDelimiter.convert("\\u0041"));
+        assertEquals("A", HiveFieldDelimiter.convert("\\U0041"));
+        assertEquals("€", HiveFieldDelimiter.convert("\\u20AC"));
+        assertEquals("😀", HiveFieldDelimiter.convert("\\U0001F600"));
+
+        // Test invalid unicode formats
+        assertThrows(StarRocksConnectorException.class, () -> HiveFieldDelimiter.convert("\\u"));
+        assertThrows(StarRocksConnectorException.class, () -> HiveFieldDelimiter.convert("\\u004"));
+        assertThrows(StarRocksConnectorException.class, () -> HiveFieldDelimiter.convert("\\uGGGG"));
+    }
+
+    @Test
+    public void testConvertSpecialEscape() {
+        // Test special escape sequences
+        assertEquals("\u0007", HiveFieldDelimiter.convert("\\a")); // alert/bell
+        assertEquals("\b", HiveFieldDelimiter.convert("\\b"));     // backspace
+        assertEquals("\f", HiveFieldDelimiter.convert("\\f"));     // form feed
+        assertEquals("\n", HiveFieldDelimiter.convert("\\n"));     // newline
+        assertEquals("\r", HiveFieldDelimiter.convert("\\r"));     // carriage return
+        assertEquals("\t", HiveFieldDelimiter.convert("\\t"));     // tab
+        assertEquals("\u000B", HiveFieldDelimiter.convert("\\v")); // vertical tab
+        assertEquals("\\", HiveFieldDelimiter.convert("\\\\"));    // backslash
+        assertEquals("'", HiveFieldDelimiter.convert("\\'"));      // single quote
+        assertEquals("\"", HiveFieldDelimiter.convert("\\\""));    // double quote
+        assertEquals("?", HiveFieldDelimiter.convert("\\?"));      // question mark
+        assertEquals("\0", HiveFieldDelimiter.convert("\\0"));     // null
+
+        // Test single-digit octal in special escape
+        assertEquals("\u0001", HiveFieldDelimiter.convert("\\1"));
+        assertEquals("\u0002", HiveFieldDelimiter.convert("\\2"));
+        assertEquals("\u0007", HiveFieldDelimiter.convert("\\7"));
+
+        // Test regular character escape
+        assertEquals("A", HiveFieldDelimiter.convert("\\A"));
+        assertEquals("B", HiveFieldDelimiter.convert("\\B"));
+    }
+
+    @Test
+    public void testConvertNumericDelimiter() {
+        // Test valid numeric formats
+        assertEquals("\u0000", HiveFieldDelimiter.convert("0"));
+        assertEquals("\u0001", HiveFieldDelimiter.convert("1"));
+        assertEquals("\t", HiveFieldDelimiter.convert("9"));
+        assertEquals("A", HiveFieldDelimiter.convert("65"));
+
+        // Test invalid numeric formats
+        assertThrows(StarRocksConnectorException.class, () -> HiveFieldDelimiter.convert("-1"));
+        assertThrows(StarRocksConnectorException.class, () -> HiveFieldDelimiter.convert("256"));
+        assertThrows(StarRocksConnectorException.class, () -> HiveFieldDelimiter.convert("999"));
+    }
+
+    @Test
+    public void testConvertMixedEscapedCharacters() {
+        // Test mixed escape sequences
+        assertEquals("\t\n\r", HiveFieldDelimiter.convert("\\t\\n\\r"));
+        assertEquals("A\tB\nC", HiveFieldDelimiter.convert("A\\tB\\nC"));
+
+        // Test octal in mixed context
+        assertEquals("\u0001\u0002\u0003", HiveFieldDelimiter.convert("\\1\\2\\3"));
+        assertEquals("A\u0001B", HiveFieldDelimiter.convert("A\\1B"));
+
+        // Test hex in mixed context
+        assertEquals("A\nB", HiveFieldDelimiter.convert("A\\x0AB"));
+        assertEquals("\u0001\u0002", HiveFieldDelimiter.convert("\\x01\\x02"));
+
+        // Test unicode in mixed context
+        assertEquals("A€B", HiveFieldDelimiter.convert("A\\u20ACB"));
+        assertEquals("😀😃", HiveFieldDelimiter.convert("\\U0001F600\\U0001F603"));
+
+        // Test complex mixed sequences
+        assertEquals("Column1\tColumn2\n", HiveFieldDelimiter.convert("Column1\\tColumn2\\n"));
+        assertEquals("\u0001\t\u0002\n\u0003", HiveFieldDelimiter.convert("\\1\\t\\2\\n\\3"));
+
+        // Test invalid sequences in mixed context (should handle gracefully)
+        assertEquals("\\xGG", HiveFieldDelimiter.convert("\\xGG")); // invalid hex becomes literal
+        assertEquals("\\u004", HiveFieldDelimiter.convert("\\u004")); // invalid unicode becomes literal
+    }
+
+    @Test
+    public void testRealWorldDelimiters() {
+        // Test common Hive delimiters
+        assertEquals("\t", HiveFieldDelimiter.convert("\\t"));
+        assertEquals("\n", HiveFieldDelimiter.convert("\\n"));
+        assertEquals("\u0001", HiveFieldDelimiter.convert("\\x01"));
+        assertEquals("\u0002", HiveFieldDelimiter.convert("\\x02"));
+        assertEquals("|", HiveFieldDelimiter.convert("|"));
+        assertEquals(",", HiveFieldDelimiter.convert(","));
+
+        // Test ASCII control characters
+        assertEquals("\u0001", HiveFieldDelimiter.convert("1")); // SOH
+        assertEquals("\u0002", HiveFieldDelimiter.convert("2")); // STX
+        assertEquals("\u0003", HiveFieldDelimiter.convert("3")); // ETX
+
+        // Test combination of literal and escape
+        assertEquals("field1\tfield2", HiveFieldDelimiter.convert("field1\\tfield2"));
+    }
+
+    @Test
+    public void testEdgeCases() {
+        // Test single character
+        assertEquals("a", HiveFieldDelimiter.convert("a"));
+        assertEquals("\\", HiveFieldDelimiter.convert("\\"));
+
+        // Test multiple backslashes
+        assertEquals("\\\\", HiveFieldDelimiter.convert("\\\\\\\\"));
+
+        // Test incomplete escape sequences
+        assertEquals("\\", HiveFieldDelimiter.convert("\\"));
+        assertEquals("\\x", HiveFieldDelimiter.convert("\\x"));
+        assertEquals("\\u", HiveFieldDelimiter.convert("\\u"));
+
+        // Test very long hex strings
+        assertEquals("Hello", HiveFieldDelimiter.convert("\\x48656C6C6F"));
+
+        // Test boundary values
+        assertEquals("\u0000", HiveFieldDelimiter.convert("0"));
+    }
+
+    // Helper method to verify exception message
+    private void assertExceptionMessage(String input, String expectedMessage) {
+        try {
+            HiveFieldDelimiter.convert(input);
+            fail("Expected exception for input: " + input);
+        } catch (StarRocksConnectorException e) {
+            assertEquals(expectedMessage, e.getMessage());
+        }
+    }
+
+    // Mock exception class for testing
+    private static class StarRocksConnectorException extends RuntimeException {
+        public StarRocksConnectorException(String message) {
+            super(message);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/PartitionUpdateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/PartitionUpdateTest.java
@@ -34,7 +34,9 @@ public class PartitionUpdateTest {
         fileInfo.setPartition_path("hdfs://hadoop01:9000/tmp/starrocks/queryid/k2=2");
         fileInfo.setRecord_count(10);
         fileInfo.setFile_size_in_bytes(100);
-        PartitionUpdate pu = PartitionUpdate.get(fileInfo, stagingDir, tableLocation);
+        String fieldDelimiter = ",";
+        String serializationFormat = "";
+        PartitionUpdate pu = PartitionUpdate.get(fileInfo, stagingDir, tableLocation, fieldDelimiter, serializationFormat);
         pu.setUpdateMode(PartitionUpdate.UpdateMode.NEW);
         Assertions.assertEquals("k2=2", pu.getName());
         Assertions.assertEquals(Lists.newArrayList("myfile.parquet"), pu.getFileNames());
@@ -49,7 +51,7 @@ public class PartitionUpdateTest {
         ExceptionChecker.expectThrowsWithMsg(
                 IllegalStateException.class,
                 "Missing partition path",
-                () -> PartitionUpdate.get(fileInfo1, stagingDir, tableLocation));
+                () -> PartitionUpdate.get(fileInfo1, stagingDir, tableLocation, fieldDelimiter, serializationFormat));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
### hive table schema
```
CREATE TABLE link_dev.test_tab_delim_normal_3 (
  col1 STRING,
  col2 STRING
)
PARTITIONED BY (
  `voucher_id` string COMMENT '',
  `year` string COMMENT '',
  `month` string COMMENT ''
)
ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\1'
STORED AS TEXTFILE
;
```

### insert into hive table
```
insert into unified_catalog_hms.link_dev.test_tab_delim_normal_3 partition(year='2025',month='09', voucher_id='28') values ('lin1', 'yu1');
```

### select from this hive table
```
mysql> select * from unified_catalog_hms.link_dev.test_tab_delim_normal_3;
+----------+------+------------+------+-------+
| col1     | col2 | voucher_id | year | month |
+----------+------+------------+------+-------+
| lin1\yu1 | NULL | 28         | 2025 | 09    |
+----------+------+------------+------+-------+
1 row in set (7.28 sec)
```


### hdfs file content
```
[hadoop@bigdata-starrocks-tools01.ys ~]$ hdfs dfs -cat hdfs://xxxx/user/prod_link/link_dev/hive/link_dev/test_tab_delim_normal_3/voucher_id=28/year=2025/month=09/7d1fa80e-9d26-11f0-8708-1a256ea79c63_0_19_0.textfile | hexdump -C | head -n 10
00000000  6c 69 6e 31 5c 79 75 31  0a                       |lin1\yu1.|
00000009
```

## What I'm doing:
```
mysql> insert into unified_catalog_hms.link_dev.test_tab_delim_normal_3 partition(year='2025',month='09', voucher_id='21') values ('lin111', 'yu111');
Query OK, 1 row affected (9.30 sec)


mysql> select * from unified_catalog_hms.link_dev.test_tab_delim_normal_3;
+----------+-------+------------+------+-------+
| col1     | col2  | voucher_id | year | month |
+----------+-------+------------+------+-------+
| lin1\yu1 | NULL  | 28         | 2025 | 09    |
| lin111   | yu111 | 21         | 2025 | 09    |
+----------+-------+------------+------+-------+
2 rows in set (7.85 sec)
```

### hdfs file content
```
[hadoop@bigdata-starrocks-tools01.ys ~]$ hdfs dfs -cat hdfs://DClusterNmg2/user/prod_link/link_dev/hive/link_dev/test_tab_delim_normal_3/voucher_id=21/year=2025/month=09/46a3cae8-9d27-11f0-bfea-0242f9be7a35_0_0_0.textfile | hexdump -C | head -n 100
00000000  6c 69 6e 31 31 31 01 79  75 31 31 31 0a           |lin111.yu111.|
0000000d
```

#### ASCII 解码：
```
6c 69 6e 31 31 31 = lin111

01 = Hexadecimal 0x01, this is the SOH (Start of Heading) character, which is used as the field delimiter here

79 75 31 31 31 = yu111 (Content of the second field)

0a = LF (Line Feed)，Line end character

```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3