### PR TITLE
[Enhancement] Optimize CSV parsing with memchr 

### DIFF
--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -197,6 +197,7 @@ set(EXEC_FILES
         ./formats/csv/default_value_converter_test.cpp
         ./formats/csv/string_converter_test.cpp
         ./formats/csv/varbinary_converter_test.cpp
+        ./formats/csv/csv_reader_test.cpp
         ./formats/json/binary_column_test.cpp
         ./formats/json/numeric_column_test.cpp
         ./formats/json/nullable_column_test.cpp

--- a/be/test/formats/csv/csv_reader_test.cpp
+++ b/be/test/formats/csv/csv_reader_test.cpp
@@ -1,0 +1,200 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/csv/csv_reader.h"
+
+#include <gtest/gtest.h>
+
+#include "runtime/types.h"
+
+namespace starrocks::csv {
+
+// Mock CSVReader for testing - implements the pure virtual function
+class MockCSVReader : public starrocks::CSVReader {
+public:
+    explicit MockCSVReader(const starrocks::CSVParseOptions& parse_options) : CSVReader(parse_options) {}
+
+protected:
+    starrocks::Status _fill_buffer() override {
+        // Mock implementation - not needed for split_record tests
+        return starrocks::Status::OK();
+    }
+
+    char* _find_line_delimiter(starrocks::CSVBuffer& buffer, size_t pos) override {
+        // Mock implementation - not needed for split_record tests
+        return nullptr;
+    }
+};
+
+class CSVReaderTest : public ::testing::Test {
+public:
+    CSVReaderTest() = default;
+
+protected:
+    void SetUp() override {
+        _parse_options.column_delimiter = ",";
+        _parse_options.row_delimiter = "\n";
+        _parse_options.trim_space = false;
+    }
+
+    starrocks::CSVParseOptions _parse_options;
+};
+
+// NOLINTNEXTLINE
+TEST_F(CSVReaderTest, test_split_record_single_delimiter) {
+    MockCSVReader reader(_parse_options);
+
+    // Test basic splitting
+    starrocks::CSVReader::Record record1{"a,b,c", 5};
+    starrocks::CSVReader::Fields fields1;
+    reader.split_record(record1, &fields1);
+
+    EXPECT_EQ(3, fields1.size());
+    EXPECT_EQ("a", fields1[0].to_string());
+    EXPECT_EQ("b", fields1[1].to_string());
+    EXPECT_EQ("c", fields1[2].to_string());
+}
+
+// NOLINTNEXTLINE
+TEST_F(CSVReaderTest, test_split_record_empty_fields) {
+    MockCSVReader reader(_parse_options);
+
+    // Test empty fields
+    starrocks::CSVReader::Record record1{",,", 2};
+    starrocks::CSVReader::Fields fields1;
+    reader.split_record(record1, &fields1);
+
+    EXPECT_EQ(3, fields1.size());
+    EXPECT_EQ("", fields1[0].to_string());
+    EXPECT_EQ("", fields1[1].to_string());
+    EXPECT_EQ("", fields1[2].to_string());
+}
+
+// NOLINTNEXTLINE
+TEST_F(CSVReaderTest, test_split_record_ends_with_delimiter) {
+    MockCSVReader reader(_parse_options);
+
+    // Test string ending with delimiter
+    starrocks::CSVReader::Record record1{"a,b,", 4};
+    starrocks::CSVReader::Fields fields1;
+    reader.split_record(record1, &fields1);
+
+    EXPECT_EQ(3, fields1.size());
+    EXPECT_EQ("a", fields1[0].to_string());
+    EXPECT_EQ("b", fields1[1].to_string());
+    EXPECT_EQ("", fields1[2].to_string());
+}
+
+// NOLINTNEXTLINE
+TEST_F(CSVReaderTest, test_split_record_starts_with_delimiter) {
+    MockCSVReader reader(_parse_options);
+
+    // Test string starting with delimiter
+    starrocks::CSVReader::Record record1{",a,b", 4};
+    starrocks::CSVReader::Fields fields1;
+    reader.split_record(record1, &fields1);
+
+    EXPECT_EQ(3, fields1.size());
+    EXPECT_EQ("", fields1[0].to_string());
+    EXPECT_EQ("a", fields1[1].to_string());
+    EXPECT_EQ("b", fields1[2].to_string());
+}
+
+// NOLINTNEXTLINE
+TEST_F(CSVReaderTest, test_split_record_single_field) {
+    MockCSVReader reader(_parse_options);
+
+    // Test single field (no delimiters)
+    starrocks::CSVReader::Record record1{"single_field", 12};
+    starrocks::CSVReader::Fields fields1;
+    reader.split_record(record1, &fields1);
+
+    EXPECT_EQ(1, fields1.size());
+    EXPECT_EQ("single_field", fields1[0].to_string());
+}
+
+// NOLINTNEXTLINE
+TEST_F(CSVReaderTest, test_split_record_empty_string) {
+    MockCSVReader reader(_parse_options);
+
+    // Test empty string
+    starrocks::CSVReader::Record record1{"", 0};
+    starrocks::CSVReader::Fields fields1;
+    reader.split_record(record1, &fields1);
+
+    EXPECT_EQ(1, fields1.size());
+    EXPECT_EQ("", fields1[0].to_string());
+}
+
+// NOLINTNEXTLINE
+TEST_F(CSVReaderTest, test_split_record_multi_character_delimiter) {
+    starrocks::CSVParseOptions options;
+    options.column_delimiter = "||";
+    options.row_delimiter = "\n";
+    options.trim_space = false;
+
+    MockCSVReader reader(options);
+
+    // Test multi-character delimiter
+    starrocks::CSVReader::Record record1{"a||b||c", 7};
+    starrocks::CSVReader::Fields fields1;
+    reader.split_record(record1, &fields1);
+
+    EXPECT_EQ(3, fields1.size());
+    EXPECT_EQ("a", fields1[0].to_string());
+    EXPECT_EQ("b", fields1[1].to_string());
+    EXPECT_EQ("c", fields1[2].to_string());
+}
+
+// NOLINTNEXTLINE
+TEST_F(CSVReaderTest, test_split_record_with_trim_space) {
+    starrocks::CSVParseOptions options;
+    options.column_delimiter = ",";
+    options.row_delimiter = "\n";
+    options.trim_space = true;
+
+    MockCSVReader reader(options);
+
+    // Test with trim_space enabled
+    starrocks::CSVReader::Record record1{" a , b , c ", 11};
+    starrocks::CSVReader::Fields fields1;
+    reader.split_record(record1, &fields1);
+
+    EXPECT_EQ(3, fields1.size());
+    EXPECT_EQ("a", fields1[0].to_string());
+    EXPECT_EQ("b", fields1[1].to_string());
+    EXPECT_EQ("c", fields1[2].to_string());
+}
+
+// NOLINTNEXTLINE
+TEST_F(CSVReaderTest, test_split_record_large_data) {
+    MockCSVReader reader(_parse_options);
+
+    // Test with larger data to verify performance optimization
+    std::string large_data;
+    for (int i = 0; i < 1000; ++i) {
+        if (i > 0) large_data += ",";
+        large_data += "field" + std::to_string(i);
+    }
+
+    starrocks::CSVReader::Record record1{large_data.c_str(), large_data.size()};
+    starrocks::CSVReader::Fields fields1;
+    reader.split_record(record1, &fields1);
+
+    EXPECT_EQ(1000, fields1.size());
+    EXPECT_EQ("field0", fields1[0].to_string());
+    EXPECT_EQ("field999", fields1[999].to_string());
+}
+
+} // namespace starrocks::csv


### PR DESCRIPTION
## PR Description 

Replace per-byte scan with memchr() to leverage libc SIMD search
Preserve exact behavior on edge cases (leading/trailing/multiple delimiters)
Keep multi-char delimiter path unchanged and safe
Add csv_reader_test covering empty, edge, and larger inputs
Refs: #63558

## Why I'm doing:
CSV parsing of single-character delimiters used a per-byte loop, which is slower than libc’s SIMD-optimized memchr(). This change improves runtime for wide rows/long fields while preserving exact semantics.

## What I'm doing:
- Replace the per-byte scan with memchr() in split_record for single-char delimiters
- Keep multi-char delimiter path (memmem) unchanged
- Fix final-field handling to avoid duplication and ensure trailing delimiter produces an empty field
- Add csv_reader_test to cover empty input, leading/trailing/multiple delimiters, trim_space, and large inputs

Fixes #63558

## Benchmark
- Method: standalone micro-benchmark; direct call of two equivalent implementations
  - loop: original for-loop version (single-char delimiter)
  - memchr: optimized memchr version (single-char delimiter; preserves trailing-empty semantics)
- Generator: synthetic rows with configurable fields-per-row (fpr) and average field length (len)
- Env: macOS, clang++ -O3 -march=native, 100k rows, 5 iters
- speedup = loop / memchr (>1 means memchr faster)

len = 8
| trim | fpr | loop(s)  | memchr(s) | speedup |
|------|-----|----------|-----------|---------|
| off  | 10  | 0.103306 | 0.068159  | 1.52x   |
| off  | 20  | 0.196496 | 0.131760  | 1.49x   |
| off  | 50  | 0.418738 | 0.252223  | 1.66x   |
| on   | 10  | 0.131991 | 0.070880  | 1.86x   |
| on   | 20  | 0.257420 | 0.135160  | 1.90x   |
| on   | 50  | 0.579589 | 0.259282  | 2.24x   |

len = 32
| trim | fpr | loop(s)  | memchr(s) | speedup |
|------|-----|----------|-----------|---------|
| off  | 10  | 0.222406 | 0.076771  | 2.90x   |
| off  | 20  | 0.450406 | 0.170856  | 2.64x   |
| off  | 50  | 1.064400 | 0.336451  | 3.16x   |
| on   | 10  | 0.259559 | 0.079658  | 3.26x   |
| on   | 20  | 0.528287 | 0.172220  | 3.07x   |
| on   | 50  | 1.268146 | 0.347396  | 3.65x   |

len = 128
| trim | fpr | loop(s)  | memchr(s) | speedup |
|------|-----|----------|-----------|---------|
| off  | 10  | 0.704962 | 0.131184  | 5.37x   |
| off  | 20  | 1.388955 | 0.249489  | 5.57x   |
| off  | 50  | 3.383101 | 0.560834  | 6.03x   |
| on   | 10  | 0.735681 | 0.130136  | 5.65x   |
| on   | 20  | 1.469387 | 0.254582  | 5.77x   |
| on   | 50  | 3.586990 | 0.572841  | 6.26x   |

len = 256
| trim | fpr | loop(s)  | memchr(s) | speedup |
|------|-----|----------|-----------|---------|
| off  | 10  | 1.326105 | 0.177839  | 7.46x   |
| off  | 20  | 2.631859 | 0.330686  | 7.96x   |
| off  | 50  | 6.474751 | 0.739055  | 8.76x   |
| on   | 10  | 1.356216 | 0.173774  | 7.80x   |
| on   | 20  | 2.709863 | 0.337874  | 8.02x   |
| on   | 50  | 6.679218 | 0.770468  | 8.67x   |

Summary
- Wide rows / long fields (len ≥ 128): ~5.3×–8.8× faster
- Short fields / dense delimiters (len ≤ 32): ~1.5×–3.7× faster
- trim_space preserved; results shown for both on/off

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimize `CSVReader::split_record` using `memchr` for single-char delimiters and add unit tests; also ensure final field handling for multi-char delimiters.
> 
> - **CSV parsing**:
>   - Optimize `CSVReader::split_record` for single-character delimiters using `memchr`; handle empty input, leading/trailing delimiters, and `trim_space` correctly.
>   - For multi-character delimiters, explicitly append the final field after the loop.
> - **Tests**:
>   - Add `formats/csv/csv_reader_test.cpp` covering empty fields, edge cases (start/end delimiters), multi-character delimiters, `trim_space`, and large data.
>   - Register the test in `be/test/CMakeLists.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2059d57f6117373441cda52df328e4b8e126d013. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->