### PR TITLE
[Feature] support explain return type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/QueryColumnType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/QueryColumnType.java
@@ -1,0 +1,61 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.common;
+
+import com.google.gson.annotations.SerializedName;
+
+public class QueryColumnType {
+    @SerializedName(value = "columnName")
+    private String columnName;
+
+    @SerializedName(value = "columnType")
+    private String columnType;
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public void setColumnName(String columnName) {
+        this.columnName = columnName;
+    }
+
+    public String getColumnType() {
+        return columnType;
+    }
+
+    public void setColumnType(String columnType) {
+        this.columnType = columnType;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1720,7 +1720,9 @@ public class StmtExecutor {
                     buildExplainString(execPlan, parsedStmt, context, ResourceGroupClassifier.QueryType.SELECT,
                             parsedStmt.getExplainLevel());
             if (executeInFe) {
-                explainString = "EXECUTE IN FE\n" + explainString;
+                if (parsedStmt.getExplainLevel() != StatementBase.ExplainLevel.TYPE) {
+                    explainString = "EXECUTE IN FE\n" + explainString;
+                }
             }
             handleExplainStmt(explainString);
             return;
@@ -2575,6 +2577,13 @@ public class StmtExecutor {
             String resourceGroupStr =
                     resourceGroup != null ? resourceGroup.getName() : ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME;
             explainString += "RESOURCE GROUP: " + resourceGroupStr + "\n\n";
+        }
+        if (parsedStmt.getExplainLevel() == StatementBase.ExplainLevel.TYPE
+                && execPlan != null) {
+            String columnTypeStr = execPlan.getColumnTypeExplain(context.getQueryId().toString());
+            LOG.info("sql queryId: " + context.getQueryId() + " column type result:" + columnTypeStr);
+            explainString += columnTypeStr;
+            return explainString;
         }
         // marked delete will get execPlan null
         if (execPlan == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -9019,6 +9019,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             explainLevel = StatementBase.ExplainLevel.ANALYZE;
         } else if (context.VERBOSE() != null) {
             explainLevel = StatementBase.ExplainLevel.VERBOSE;
+        } else if (context.TYPE() != null) {
+            explainLevel = StatementBase.ExplainLevel.TYPE;
         } else if (context.COSTS() != null) {
             explainLevel = StatementBase.ExplainLevel.COSTS;
         } else if (context.SCHEDULER() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -18,7 +18,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.IdGenerator;
+import com.starrocks.common.QueryColumnType;
 import com.starrocks.common.util.ProfilingExecPlan;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.planner.DescriptorTable;
 import com.starrocks.planner.ExecGroup;
 import com.starrocks.planner.HashJoinNode;
@@ -32,6 +34,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.Explain;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
@@ -39,6 +42,8 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.thrift.TExplainLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -47,6 +52,7 @@ import java.util.Map;
 import java.util.UUID;
 
 public class ExecPlan {
+    private static final Logger LOG = LoggerFactory.getLogger(ExecPlan.class);
     private final ConnectContext connectContext;
     private final List<String> colNames;
     private final List<ScanNode> scanNodes = new ArrayList<>();
@@ -336,5 +342,26 @@ public class ExecPlan {
 
     public boolean isShortCircuit() {
         return isShortCircuit;
+    }
+
+    public String getColumnTypeExplain(String queryId) {
+        List<QueryColumnType> queryColumnTypes = new ArrayList<>();
+        if (colNames.size() != outputExprs.size()) {
+            return GsonUtils.GSON.newBuilder().disableHtmlEscaping()
+                    .create().toJson(queryColumnTypes);
+        }
+        for (int i = 0; i < outputExprs.size(); i++) {
+            if (outputExprs.get(i) instanceof SlotRef) {
+                SlotRef slotRef = (SlotRef) outputExprs.get(i);
+                QueryColumnType queryColumnType = new QueryColumnType();
+                queryColumnType.setColumnName(colNames.get(i));
+                queryColumnType.setColumnType(slotRef.getType().toString());
+                queryColumnTypes.add(queryColumnType);
+            } else {
+                LOG.info("sql queryId : " + queryId + " other slotRef :" + outputExprs.get(i).toString());
+            }
+        }
+        return GsonUtils.GSON.newBuilder().disableHtmlEscaping()
+                .create().toJson(queryColumnTypes);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GetQueryColumnPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GetQueryColumnPlanTest.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.QueryState;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class GetQueryColumnPlanTest extends PlanTestBase {
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @Test
+    public void testQueryColumnType() throws Exception {
+        String explainString = getColumnTypeExecPlan("select pk,v1,v2 from tprimary");
+        Assertions.assertEquals(explainString,
+                "[{\"columnName\":\"pk\",\"columnType\":\"BIGINT\"}," +
+                        "{\"columnName\":\"v1\",\"columnType\":\"VARCHAR\"}," +
+                        "{\"columnName\":\"v2\",\"columnType\":\"INT\"}]");
+        testExplain("explain type select pk,v1,v2 from tprimary");
+    }
+
+    private void testExplain(String explainStmt) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        connectContext.getState().reset();
+        List<StatementBase> statements =
+                com.starrocks.sql.parser.SqlParser.parse(explainStmt, connectContext.getSessionVariable().getSqlMode());
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statements.get(0));
+        stmtExecutor.execute();
+        Assertions.assertEquals(connectContext.getState().getStateType(), QueryState.MysqlStateType.EOF);
+    }
+
+    private static String getColumnTypeExecPlan(String originStmt) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
+        StatementBase statementBase =
+                com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable().getSqlMode())
+                        .get(0);
+        connectContext.getDumpInfo().setOriginStmt(originStmt);
+        ExecPlan execPlan = new StatementPlanner().plan(statementBase, connectContext);
+
+        String ret = execPlan.getColumnTypeExplain(connectContext.getQueryId().toString());
+        return ret;
+    }
+}

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2921,7 +2921,7 @@ backupRestoreTableDesc
     ;
 
 explainDesc
-    : (DESC | DESCRIBE | EXPLAIN) (LOGICAL | ANALYZE | VERBOSE | COSTS | SCHEDULER)?
+    : (DESC | DESCRIBE | EXPLAIN) (LOGICAL | ANALYZE | VERBOSE | COSTS | SCHEDULER | TYPE)?
     ;
 
 optimizerTrace

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/StatementBase.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/StatementBase.java
@@ -39,7 +39,8 @@ public abstract class StatementBase implements ParseNode {
         OPTIMIZER,
         REWRITE,
         SCHEDULER,
-        PLAN_ADVISOR;
+        PLAN_ADVISOR,
+        TYPE;
 
         public static ExplainLevel defaultValue() {
             return NORMAL;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #63716

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `EXPLAIN TYPE` to output query result column names/types as JSON, with parser, executor, plan support, and tests.
> 
> - **Explain output enhancements**:
>   - Add new explain level `TYPE` to output query result column schema as JSON.
>   - `StmtExecutor.buildExplainString(...)`: when level is `TYPE`, returns column types JSON; suppresses "EXECUTE IN FE" prefix for TYPE.
> - **Parser/Grammar**:
>   - Extend grammar (`StarRocks.g4`) to accept `TYPE` in `EXPLAIN`.
>   - `AstBuilder`: map `EXPLAIN TYPE` to `StatementBase.ExplainLevel.TYPE`.
>   - `StatementBase`: add `TYPE` to `ExplainLevel` enum.
> - **Plan/Utilities**:
>   - `ExecPlan.getColumnTypeExplain(...)`: produce JSON array of `{columnName,columnType}` from output expressions; logs non-slot refs.
>   - New model `QueryColumnType` (name/type with Gson annotations).
> - **Tests**:
>   - `GetQueryColumnPlanTest`: validates JSON schema output and `explain type` path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13d073a7365a72ea43c6e78759e84136461ad41c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->