### PR TITLE
[Enhancement] use crc hash for exchange op when hash partition

### DIFF
--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -572,6 +572,10 @@ public:
         return _query_options.__isset.lower_upper_support_utf8 && _query_options.lower_upper_support_utf8;
     }
 
+    bool use_crc32_hash_for_exchange() const {
+        return _query_options.__isset.use_crc32_hash_for_exchange && _query_options.use_crc32_hash_for_exchange;
+    }
+
     DebugActionMgr& debug_action_mgr() { return _debug_action_mgr; }
 
 private:

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -959,6 +959,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_FULL_SORT_USE_GERMAN_STRING = "enable_full_sort_use_german_string";
 
+    public static final String USE_CRC32_HASH_FOR_EXCHANGE = "use_crc32_hash_for_exchange";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1964,6 +1966,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_FULL_SORT_USE_GERMAN_STRING)
     private boolean enableFullSortUseGermanString = true;
+
+    // Control the hash function used in exchange sink operator for hash partitioning
+    // When true, use crc32_hash instead of fnv_hash
+    @VarAttr(name = USE_CRC32_HASH_FOR_EXCHANGE)
+    private boolean useCrc32HashForExchange = true;
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
@@ -5335,11 +5342,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public boolean isEnableFullSortUseGermanString() {
         return this.enableFullSortUseGermanString;
     }
-
-    // Control the hash function used in exchange sink operator for hash partitioning
-    // When true, use crc32_hash instead of fnv_hash
-    @VariableMgr.VarAttr(name = "use_crc32_hash_for_exchange")
-    private boolean useCrc32HashForExchange = true;
 
     public boolean isUseCrc32HashForExchange() {
         return useCrc32HashForExchange;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -5335,6 +5335,20 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public boolean isEnableFullSortUseGermanString() {
         return this.enableFullSortUseGermanString;
     }
+    
+    // Control the hash function used in exchange sink operator for hash partitioning
+    // When true, use crc32_hash instead of fnv_hash
+    @VariableMgr.VarAttr(name = "use_crc32_hash_for_exchange")
+    private boolean useCrc32HashForExchange = true;
+
+    public boolean isUseCrc32HashForExchange() {
+        return useCrc32HashForExchange;
+    }
+
+    public void setUseCrc32HashForExchange(boolean useCrc32HashForExchange) {
+        this.useCrc32HashForExchange = useCrc32HashForExchange;
+    }
+
     // Serialize to thrift object
     // used for rest api
     public TQueryOptions toThrift() {
@@ -5419,6 +5433,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setGroup_concat_max_len(groupConcatMaxLen);
         tResult.setRpc_http_min_size(rpcHttpMinSize);
         tResult.setInterleaving_group_size(interleavingGroupSize);
+<<<<<<< HEAD
+=======
+        tResult.setEnable_predicate_col_late_materialize(enablePredicateColLateMaterialize);
+        tResult.setUse_crc32_hash_for_exchange(useCrc32HashForExchange);
+>>>>>>> 998d31bf54 (use crc hash for exchange)
 
         TCompressionType loadCompressionType =
                 CompressionUtils.findTCompressionByName(loadTransmissionCompressionType);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -5335,7 +5335,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public boolean isEnableFullSortUseGermanString() {
         return this.enableFullSortUseGermanString;
     }
-    
+
     // Control the hash function used in exchange sink operator for hash partitioning
     // When true, use crc32_hash instead of fnv_hash
     @VariableMgr.VarAttr(name = "use_crc32_hash_for_exchange")
@@ -5433,11 +5433,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setGroup_concat_max_len(groupConcatMaxLen);
         tResult.setRpc_http_min_size(rpcHttpMinSize);
         tResult.setInterleaving_group_size(interleavingGroupSize);
-<<<<<<< HEAD
-=======
-        tResult.setEnable_predicate_col_late_materialize(enablePredicateColLateMaterialize);
         tResult.setUse_crc32_hash_for_exchange(useCrc32HashForExchange);
->>>>>>> 998d31bf54 (use crc hash for exchange)
 
         TCompressionType loadCompressionType =
                 CompressionUtils.findTCompressionByName(loadTransmissionCompressionType);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -349,6 +349,9 @@ struct TQueryOptions {
   191: optional i64 column_view_concat_bytes_limit;
 
   200: optional bool enable_full_sort_use_german_string;
+  
+  // whether use crc32_hash instead of fnv_hash for exchange sink operator hash partitioning
+  201: optional bool use_crc32_hash_for_exchange;
 }
 
 // A scan range plus the parameters needed to execute that scan.


### PR DESCRIPTION
## Why I'm doing:
fnv hash is much slower then crc hash.

## What I'm doing:
use crc hash when sv is set. So upgrade is safe

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
