### PR TITLE
[BugFix] Disable simplifying case-when with complex funtions to avoid time-consuming and tedious predicates

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -67,10 +67,11 @@ public class ScalarOperatorRewriter {
             PruneTediousPredicateRule.INSTANCE
     );
 
-    private static final List<ScalarOperatorRewriteRule> CASE_WHEN_PREDICATE_ON_SCAN_RULE = Lists.newArrayList(
-            SimplifiedCaseWhenRule.SKIP_COMPLEX_FUNCTIONS_INSTANCE,
-            PruneTediousPredicateRule.INSTANCE
-    );
+    private static final List<ScalarOperatorRewriteRule> CASE_WHEN_PREDICATE_SKIP_COMPLEX_FUNCTIONS =
+            Lists.newArrayList(
+                    SimplifiedCaseWhenRule.SKIP_COMPLEX_FUNCTIONS_INSTANCE,
+                    PruneTediousPredicateRule.INSTANCE
+            );
 
     public static final List<ScalarOperatorRewriteRule> DEFAULT_REWRITE_SCAN_PREDICATE_RULES = Lists.newArrayList(
             // required
@@ -165,9 +166,9 @@ public class ScalarOperatorRewriter {
         return op;
     }
 
-    public static ScalarOperator simplifyCaseWhen(ScalarOperator predicates, boolean isOnScan) {
-        if (isOnScan) {
-            return new ScalarOperatorRewriter().rewrite(predicates, CASE_WHEN_PREDICATE_ON_SCAN_RULE);
+    public static ScalarOperator simplifyCaseWhen(ScalarOperator predicates, boolean skipComplexFunctions) {
+        if (skipComplexFunctions) {
+            return new ScalarOperatorRewriter().rewrite(predicates, CASE_WHEN_PREDICATE_SKIP_COMPLEX_FUNCTIONS);
         } else {
             return new ScalarOperatorRewriter().rewrite(predicates, CASE_WHEN_PREDICATE_RULE);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SimplifyCaseWhenPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SimplifyCaseWhenPredicateRule.java
@@ -20,7 +20,6 @@ import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalRepeatOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.task.TaskContext;
@@ -71,8 +70,7 @@ public class SimplifyCaseWhenPredicateRule implements TreeRewriteRule {
             if (predicate == null) {
                 return Optional.empty();
             }
-            boolean isScan = optExpression.getOp() instanceof LogicalScanOperator;
-            ScalarOperator newPredicate = ScalarOperatorRewriter.simplifyCaseWhen(predicate, isScan);
+            ScalarOperator newPredicate = ScalarOperatorRewriter.simplifyCaseWhen(predicate, true);
             if (newPredicate == predicate) {
                 return Optional.empty();
             }
@@ -90,12 +88,12 @@ public class SimplifyCaseWhenPredicateRule implements TreeRewriteRule {
             }
             Optional<ScalarOperator> optNewOnPredicate =
                     Optional.ofNullable(joinOperator.getOnPredicate()).map(predicate -> {
-                        ScalarOperator newPredicate = ScalarOperatorRewriter.simplifyCaseWhen(predicate, false);
+                        ScalarOperator newPredicate = ScalarOperatorRewriter.simplifyCaseWhen(predicate, true);
                         return newPredicate == predicate ? null : newPredicate;
                     });
             Optional<ScalarOperator> optNewPredicate =
                     Optional.ofNullable(joinOperator.getPredicate()).map(predicate -> {
-                        ScalarOperator newPredicate = ScalarOperatorRewriter.simplifyCaseWhen(predicate, false);
+                        ScalarOperator newPredicate = ScalarOperatorRewriter.simplifyCaseWhen(predicate, true);
                         return newPredicate == predicate ? null : newPredicate;
                     });
             Operator newOperator = LogicalJoinOperator.builder().withOperator(joinOperator)


### PR DESCRIPTION
## Why I'm doing:
In this PR https://github.com/StarRocks/starrocks/pull/62505, simpifying case-when with complex functions on ScanNode is disabled, however, it is not enough.  Simplifying case-when with complex functions has no gain, so disable such complex case-when.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
