### PR TITLE
[Refactor] Split the LocalCacheEngine interface into LocalMemCacheEngine and LocalDiskCacheEngine

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -849,7 +849,7 @@ void* ReportDataCacheMetricsTaskWorkerPool::_worker_thread_callback(void* arg_th
 
         TDataCacheMetrics t_metrics{};
         // TODO: mem_metrics + disk_metrics
-        const LocalCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();
+        const LocalDiskCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();
         if (cache != nullptr && cache->is_initialized()) {
             const auto metrics = cache->cache_metrics();
             DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);

--- a/be/src/cache/block_cache/block_cache.cpp
+++ b/be/src/cache/block_cache/block_cache.cpp
@@ -36,7 +36,7 @@ BlockCache::~BlockCache() {
     (void)shutdown();
 }
 
-Status BlockCache::init(const BlockCacheOptions& options, std::shared_ptr<LocalCacheEngine> local_cache,
+Status BlockCache::init(const BlockCacheOptions& options, std::shared_ptr<LocalDiskCacheEngine> local_cache,
                         std::shared_ptr<RemoteCacheEngine> remote_cache) {
     _block_size = std::min(options.block_size, MAX_BLOCK_SIZE);
     _local_cache = std::move(local_cache);

--- a/be/src/cache/block_cache/block_cache.h
+++ b/be/src/cache/block_cache/block_cache.h
@@ -16,7 +16,7 @@
 
 #include <atomic>
 
-#include "cache/local_cache_engine.h"
+#include "cache/local_disk_cache_engine.h"
 #include "cache/remote_cache_engine.h"
 #include "common/status.h"
 
@@ -33,7 +33,7 @@ public:
     ~BlockCache();
 
     // Init the block cache instance
-    Status init(const BlockCacheOptions& options, std::shared_ptr<LocalCacheEngine> local_cache,
+    Status init(const BlockCacheOptions& options, std::shared_ptr<LocalDiskCacheEngine> local_cache,
                 std::shared_ptr<RemoteCacheEngine> remote_cache);
 
     // Write data buffer to cache, the `offset` must be aligned by block size
@@ -73,15 +73,14 @@ public:
     bool is_initialized() const { return _initialized.load(std::memory_order_relaxed); }
 
     bool available() const { return is_initialized() && _local_cache->available(); }
-    bool mem_cache_available() const { return is_initialized() && _local_cache->mem_cache_available(); }
 
-    std::shared_ptr<LocalCacheEngine> local_cache() { return _local_cache; }
+    std::shared_ptr<LocalDiskCacheEngine> local_cache() { return _local_cache; }
 
     static const size_t MAX_BLOCK_SIZE;
 
 private:
     size_t _block_size = 0;
-    std::shared_ptr<LocalCacheEngine> _local_cache;
+    std::shared_ptr<LocalDiskCacheEngine> _local_cache;
     std::shared_ptr<RemoteCacheEngine> _remote_cache;
     std::atomic<bool> _initialized = false;
 };

--- a/be/src/cache/datacache.cpp
+++ b/be/src/cache/datacache.cpp
@@ -44,11 +44,6 @@ Status DataCache::init(const std::vector<StorePath>& store_paths) {
     _block_cache = std::make_shared<BlockCache>();
     _page_cache = std::make_shared<StoragePageCache>();
 
-#if defined(WITH_STARCACHE)
-    _local_disk_cache_engine = "starcache";
-#endif
-    _local_mem_cache_engine = "lrucache";
-
     if (!config::datacache_enable) {
         config::disable_storage_page_cache = true;
         config::block_cache_enable = false;
@@ -173,89 +168,89 @@ BlockCacheOptions DataCache::_init_block_cache_options() {
     return cache_options;
 }
 
+#if defined(WITH_STARCACHE)
 StatusOr<DiskCacheOptions> DataCache::_init_disk_cache_options() {
     DiskCacheOptions cache_options;
 
-    if (_local_disk_cache_engine == "starcache") {
 #ifdef USE_STAROS
-        std::vector<string> corresponding_starlet_dirs;
-        if (config::datacache_unified_instance_enable && !config::starlet_cache_dir.empty()) {
-            // in older versions, users might set `starlet_cache_dir` instead of `storage_root_path` for starlet cache,
-            // we need to move starlet cache into storage_root_path/datacache
-            auto s = DataCacheUtils::get_corresponding_starlet_cache_dir(_store_paths, config::starlet_cache_dir);
-            if (!s.ok()) {
-                LOG(WARNING) << s.status().message() << ", change config::datacache_unified_instance_enable to false";
-                config::datacache_unified_instance_enable = false;
-            } else {
-                corresponding_starlet_dirs = *s;
-            }
+    std::vector<string> corresponding_starlet_dirs;
+    if (config::datacache_unified_instance_enable && !config::starlet_cache_dir.empty()) {
+        // in older versions, users might set `starlet_cache_dir` instead of `storage_root_path` for starlet cache,
+        // we need to move starlet cache into storage_root_path/datacache
+        auto s = DataCacheUtils::get_corresponding_starlet_cache_dir(_store_paths, config::starlet_cache_dir);
+        if (!s.ok()) {
+            LOG(WARNING) << s.status().message() << ", change config::datacache_unified_instance_enable to false";
+            config::datacache_unified_instance_enable = false;
+        } else {
+            corresponding_starlet_dirs = *s;
         }
-        int idx = 0;
-#endif
-
-        for (auto& root_path : _store_paths) {
-            // Because we have unified the datacache between datalake and starlet, we also need to unify the
-            // cache path and quota.
-            // To reuse the old cache data in `starlet_cache` directory, we try to rename it to the new `datacache`
-            // directory if it exists. To avoid the risk of cross disk renaming of a large amount of cached data,
-            // we do not automatically rename it when the source and destination directories are on different disks.
-            // In this case, users should manually remount the directories and restart them.
-            std::string datacache_path = root_path.path + "/datacache";
-#ifdef USE_STAROS
-            if (config::datacache_unified_instance_enable) {
-                std::string starlet_cache_path;
-                if (idx < corresponding_starlet_dirs.size()) {
-                    starlet_cache_path = corresponding_starlet_dirs[idx++];
-                } else {
-                    starlet_cache_path = root_path.path + "/starlet_cache/star_cache";
-                }
-                RETURN_IF_ERROR(DataCacheUtils::change_disk_path(starlet_cache_path, datacache_path));
-            }
-#endif
-            // Create it if not exist
-            Status st = FileSystem::Default()->create_dir_if_missing(datacache_path);
-            if (!st.ok()) {
-                LOG(ERROR) << "Fail to create datacache directory: " << datacache_path << ", reason: " << st.message();
-                return Status::InternalError("Fail to create datacache directory");
-            }
-
-            ASSIGN_OR_RETURN(int64_t disk_size, DataCacheUtils::parse_conf_datacache_disk_size(
-                                                        datacache_path, config::datacache_disk_size, -1));
-#ifdef USE_STAROS
-            // If the `datacache_disk_size` is manually set a positive value, we will use the maximum cache quota between
-            // dataleke and starlet cache as the quota of the unified cache. Otherwise, the cache quota will remain zero
-            // and then automatically adjusted based on the current avalible disk space.
-            if (config::datacache_unified_instance_enable &&
-                (!config::enable_datacache_disk_auto_adjust || disk_size > 0)) {
-                ASSIGN_OR_RETURN(
-                        int64_t starlet_cache_size,
-                        DataCacheUtils::parse_conf_datacache_disk_size(
-                                datacache_path, fmt::format("{}%", config::starlet_star_cache_disk_size_percent), -1));
-                disk_size = std::max(disk_size, starlet_cache_size);
-            }
-#endif
-            cache_options.dir_spaces.push_back({.path = datacache_path, .size = static_cast<size_t>(disk_size)});
-        }
-
-        if (cache_options.dir_spaces.empty()) {
-            config::enable_datacache_disk_auto_adjust = false;
-        }
-
-        cache_options.block_size = config::datacache_block_size;
-        cache_options.max_flying_memory_mb = config::datacache_max_flying_memory_mb;
-        cache_options.max_concurrent_inserts = config::datacache_max_concurrent_inserts;
-        cache_options.enable_checksum = config::datacache_checksum_enable;
-        cache_options.enable_direct_io = config::datacache_direct_io_enable;
-        cache_options.enable_tiered_cache = config::datacache_tiered_cache_enable;
-        cache_options.skip_read_factor = config::datacache_skip_read_factor;
-        cache_options.scheduler_threads_per_cpu = config::datacache_scheduler_threads_per_cpu;
-        cache_options.enable_datacache_persistence = config::datacache_persistence_enable;
-        cache_options.inline_item_count_limit = config::datacache_inline_item_count_limit;
-        cache_options.eviction_policy = config::datacache_eviction_policy;
     }
+    int idx = 0;
+#endif
+
+    for (auto& root_path : _store_paths) {
+        // Because we have unified the datacache between datalake and starlet, we also need to unify the
+        // cache path and quota.
+        // To reuse the old cache data in `starlet_cache` directory, we try to rename it to the new `datacache`
+        // directory if it exists. To avoid the risk of cross disk renaming of a large amount of cached data,
+        // we do not automatically rename it when the source and destination directories are on different disks.
+        // In this case, users should manually remount the directories and restart them.
+        std::string datacache_path = root_path.path + "/datacache";
+#ifdef USE_STAROS
+        if (config::datacache_unified_instance_enable) {
+            std::string starlet_cache_path;
+            if (idx < corresponding_starlet_dirs.size()) {
+                starlet_cache_path = corresponding_starlet_dirs[idx++];
+            } else {
+                starlet_cache_path = root_path.path + "/starlet_cache/star_cache";
+            }
+            RETURN_IF_ERROR(DataCacheUtils::change_disk_path(starlet_cache_path, datacache_path));
+        }
+#endif
+        // Create it if not exist
+        Status st = FileSystem::Default()->create_dir_if_missing(datacache_path);
+        if (!st.ok()) {
+            LOG(ERROR) << "Fail to create datacache directory: " << datacache_path << ", reason: " << st.message();
+            return Status::InternalError("Fail to create datacache directory");
+        }
+
+        ASSIGN_OR_RETURN(int64_t disk_size, DataCacheUtils::parse_conf_datacache_disk_size(
+                                                    datacache_path, config::datacache_disk_size, -1));
+#ifdef USE_STAROS
+        // If the `datacache_disk_size` is manually set a positive value, we will use the maximum cache quota between
+        // dataleke and starlet cache as the quota of the unified cache. Otherwise, the cache quota will remain zero
+        // and then automatically adjusted based on the current avalible disk space.
+        if (config::datacache_unified_instance_enable &&
+            (!config::enable_datacache_disk_auto_adjust || disk_size > 0)) {
+            ASSIGN_OR_RETURN(
+                    int64_t starlet_cache_size,
+                    DataCacheUtils::parse_conf_datacache_disk_size(
+                            datacache_path, fmt::format("{}%", config::starlet_star_cache_disk_size_percent), -1));
+            disk_size = std::max(disk_size, starlet_cache_size);
+        }
+#endif
+        cache_options.dir_spaces.push_back({.path = datacache_path, .size = static_cast<size_t>(disk_size)});
+    }
+
+    if (cache_options.dir_spaces.empty()) {
+        config::enable_datacache_disk_auto_adjust = false;
+    }
+
+    cache_options.block_size = config::datacache_block_size;
+    cache_options.max_flying_memory_mb = config::datacache_max_flying_memory_mb;
+    cache_options.max_concurrent_inserts = config::datacache_max_concurrent_inserts;
+    cache_options.enable_checksum = config::datacache_checksum_enable;
+    cache_options.enable_direct_io = config::datacache_direct_io_enable;
+    cache_options.enable_tiered_cache = config::datacache_tiered_cache_enable;
+    cache_options.skip_read_factor = config::datacache_skip_read_factor;
+    cache_options.scheduler_threads_per_cpu = config::datacache_scheduler_threads_per_cpu;
+    cache_options.enable_datacache_persistence = config::datacache_persistence_enable;
+    cache_options.inline_item_count_limit = config::datacache_inline_item_count_limit;
+    cache_options.eviction_policy = config::datacache_eviction_policy;
 
     return cache_options;
 }
+#endif
 
 static bool parse_resource_str(const string& str, string* value) {
     if (!str.empty()) {

--- a/be/src/cache/datacache.h
+++ b/be/src/cache/datacache.h
@@ -15,7 +15,8 @@
 #pragma once
 
 #include "cache/block_cache/block_cache.h"
-#include "cache/local_cache_engine.h"
+#include "cache/local_disk_cache_engine.h"
+#include "cache/local_mem_cache_engine.h"
 #include "common/status.h"
 
 namespace starrocks {
@@ -39,16 +40,13 @@ public:
 
     void try_release_resource_before_core_dump();
 
-    void set_local_mem_cache(std::shared_ptr<LocalCacheEngine> local_mem_cache) {
-        _local_mem_cache = std::move(local_mem_cache);
-    }
-    void set_local_disk_cache(std::shared_ptr<LocalCacheEngine> local_disk_cache) {
+    void set_local_disk_cache(std::shared_ptr<LocalDiskCacheEngine> local_disk_cache) {
         _local_disk_cache = std::move(local_disk_cache);
     }
     void set_page_cache(std::shared_ptr<StoragePageCache> page_cache) { _page_cache = std::move(page_cache); }
 
-    LocalCacheEngine* local_mem_cache() { return _local_mem_cache.get(); }
-    LocalCacheEngine* local_disk_cache() { return _local_disk_cache.get(); }
+    LocalMemCacheEngine* local_mem_cache() { return _local_mem_cache.get(); }
+    LocalDiskCacheEngine* local_disk_cache() { return _local_disk_cache.get(); }
     BlockCache* block_cache() const { return _block_cache.get(); }
     void set_block_cache(std::shared_ptr<BlockCache> block_cache) { _block_cache = std::move(block_cache); }
     StoragePageCache* page_cache() const { return _page_cache.get(); }
@@ -63,11 +61,11 @@ public:
 
 private:
     StatusOr<MemCacheOptions> _init_mem_cache_options();
-    StatusOr<DiskCacheOptions> _init_disk_cache_options();
     RemoteCacheOptions _init_remote_cache_options();
     BlockCacheOptions _init_block_cache_options();
 
 #if defined(WITH_STARCACHE)
+    StatusOr<DiskCacheOptions> _init_disk_cache_options();
     Status _init_starcache_engine(DiskCacheOptions* cache_options);
     Status _init_peer_cache(const RemoteCacheOptions& cache_options);
 #endif
@@ -78,10 +76,8 @@ private:
     std::vector<StorePath> _store_paths;
 
     // cache engine
-    std::string _local_mem_cache_engine;
-    std::string _local_disk_cache_engine;
-    std::shared_ptr<LocalCacheEngine> _local_mem_cache;
-    std::shared_ptr<LocalCacheEngine> _local_disk_cache;
+    std::shared_ptr<LocalMemCacheEngine> _local_mem_cache;
+    std::shared_ptr<LocalDiskCacheEngine> _local_disk_cache;
     std::shared_ptr<RemoteCacheEngine> _remote_cache;
 
     std::shared_ptr<BlockCache> _block_cache;

--- a/be/src/cache/datacache_utils.h
+++ b/be/src/cache/datacache_utils.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "cache/cache_metrics.h"
-#include "cache/local_cache_engine.h"
+#include "cache/local_disk_cache_engine.h"
 #include "gen_cpp/DataCache_types.h"
 #include "storage/options.h"
 

--- a/be/src/cache/disk_space_monitor.cpp
+++ b/be/src/cache/disk_space_monitor.cpp
@@ -224,10 +224,10 @@ dev_t DiskSpace::FileSystemWrapper::device_id(const std::string& path) {
     return DataCacheUtils::disk_device_id(path);
 }
 
-DiskSpaceMonitor::DiskSpaceMonitor(LocalCacheEngine* cache)
+DiskSpaceMonitor::DiskSpaceMonitor(LocalDiskCacheEngine* cache)
         : _cache(cache), _fs(std::make_shared<DiskSpace::FileSystemWrapper>()) {}
 
-DiskSpaceMonitor::DiskSpaceMonitor(LocalCacheEngine* cache, std::shared_ptr<DiskSpace::FileSystemWrapper> fs)
+DiskSpaceMonitor::DiskSpaceMonitor(LocalDiskCacheEngine* cache, std::shared_ptr<DiskSpace::FileSystemWrapper> fs)
         : _cache(cache), _fs(std::move(fs)) {}
 
 DiskSpaceMonitor::~DiskSpaceMonitor() {

--- a/be/src/cache/disk_space_monitor.h
+++ b/be/src/cache/disk_space_monitor.h
@@ -20,7 +20,7 @@
 #include <unordered_map>
 
 #include "cache/cache_options.h"
-#include "cache/local_cache_engine.h"
+#include "cache/local_disk_cache_engine.h"
 #include "common/status.h"
 #include "fs/fs.h"
 #include "util/disk_info.h"
@@ -118,8 +118,8 @@ private:
 
 class DiskSpaceMonitor {
 public:
-    DiskSpaceMonitor(LocalCacheEngine* cache);
-    DiskSpaceMonitor(LocalCacheEngine* cache, std::shared_ptr<DiskSpace::FileSystemWrapper> fs);
+    DiskSpaceMonitor(LocalDiskCacheEngine* cache);
+    DiskSpaceMonitor(LocalDiskCacheEngine* cache, std::shared_ptr<DiskSpace::FileSystemWrapper> fs);
     ~DiskSpaceMonitor();
 
     Status init(std::vector<DirSpace>* dir_spaces);
@@ -152,7 +152,7 @@ private:
 
     size_t _total_cache_usage = 0;
     size_t _total_cache_quota = 0;
-    LocalCacheEngine* _cache = nullptr;
+    LocalDiskCacheEngine* _cache = nullptr;
     std::shared_ptr<DiskSpace::FileSystemWrapper> _fs = nullptr;
 };
 

--- a/be/src/cache/local_disk_cache_engine.h
+++ b/be/src/cache/local_disk_cache_engine.h
@@ -21,11 +21,9 @@
 
 namespace starrocks {
 
-enum class LocalCacheEngineType { STARCACHE, LRUCACHE };
-
-class LocalCacheEngine {
+class LocalDiskCacheEngine {
 public:
-    virtual ~LocalCacheEngine() = default;
+    virtual ~LocalDiskCacheEngine() = default;
 
     virtual bool is_initialized() const = 0;
 
@@ -37,35 +35,10 @@ public:
     virtual Status read(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
                         ReadCacheOptions* options) = 0;
 
-    // Insert object to cache
-    virtual Status insert(const std::string& key, void* value, size_t size, ObjectCacheDeleter deleter,
-                          ObjectCacheHandlePtr* handle, const ObjectCacheWriteOptions& options) = 0;
-
-    // Lookup object from cache, the `handle` wraps the object pointer.
-    // As long as the handle object is not destroyed and the user does not manually call the `handle->release()`
-    // function, the corresponding pointer will never be freed by the cache system.
-    virtual Status lookup(const std::string& key, ObjectCacheHandlePtr* handle,
-                          ObjectCacheReadOptions* options = nullptr) = 0;
-
-    // Release a handle returned by a previous insert() or lookup().
-    // The handle must have not been released yet.
-    virtual void release(ObjectCacheHandlePtr handle) = 0;
-
-    // Return the value in the given handle returned by a previous insert() or lookup().
-    // The handle must have not been released yet.
-    virtual const void* value(ObjectCacheHandlePtr handle) = 0;
-
     virtual bool exist(const std::string& key) const = 0;
 
     // Remove data from cache.
     virtual Status remove(const std::string& key) = 0;
-
-    // Adjust the cache quota by delta bytes.
-    // If the new capacity is less than `min_capacity`, skip adjusting it.
-    virtual Status adjust_mem_quota(int64_t delta, size_t min_capacity) = 0;
-
-    // Update the datacache memory quota.
-    virtual Status update_mem_quota(size_t quota_bytes, bool flush_to_disk) = 0;
 
     // Update the datacache disk space information, such as disk quota or disk path.
     virtual Status update_disk_spaces(const std::vector<DirSpace>& spaces) = 0;
@@ -81,16 +54,9 @@ public:
 
     virtual Status shutdown() = 0;
 
-    virtual LocalCacheEngineType engine_type() = 0;
-
-    virtual bool has_mem_cache() const = 0;
     virtual bool has_disk_cache() const = 0;
     virtual bool available() const = 0;
-    virtual bool mem_cache_available() const = 0;
     virtual void disk_spaces(std::vector<DirSpace>* spaces) const = 0;
-
-    virtual size_t mem_quota() const = 0;
-    virtual size_t mem_usage() const = 0;
 
     // Get the lookup count, including cache hit count and cache miss count.
     virtual size_t lookup_count() const = 0;

--- a/be/src/cache/local_mem_cache_engine.h
+++ b/be/src/cache/local_mem_cache_engine.h
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "cache/block_cache/io_buffer.h"
+#include "cache/cache_options.h"
+#include "cache/object_cache/cache_types.h"
+#include "common/status.h"
+
+namespace starrocks {
+
+class LocalMemCacheEngine {
+public:
+    virtual ~LocalMemCacheEngine() = default;
+
+    virtual bool is_initialized() const = 0;
+
+    // Insert object to cache
+    virtual Status insert(const std::string& key, void* value, size_t size, ObjectCacheDeleter deleter,
+                          ObjectCacheHandlePtr* handle, const ObjectCacheWriteOptions& options) = 0;
+
+    // Lookup object from cache, the `handle` wraps the object pointer.
+    // As long as the handle object is not destroyed and the user does not manually call the `handle->release()`
+    // function, the corresponding pointer will never be freed by the cache system.
+    virtual Status lookup(const std::string& key, ObjectCacheHandlePtr* handle,
+                          ObjectCacheReadOptions* options = nullptr) = 0;
+
+    // Release a handle returned by a previous insert() or lookup().
+    // The handle must have not been released yet.
+    virtual void release(ObjectCacheHandlePtr handle) = 0;
+
+    // Return the value in the given handle returned by a previous insert() or lookup().
+    // The handle must have not been released yet.
+    virtual const void* value(ObjectCacheHandlePtr handle) = 0;
+
+    virtual bool exist(const std::string& key) const = 0;
+
+    // Remove data from cache.
+    virtual Status remove(const std::string& key) = 0;
+
+    // Adjust the cache quota by delta bytes.
+    // If the new capacity is less than `min_capacity`, skip adjusting it.
+    virtual Status adjust_mem_quota(int64_t delta, size_t min_capacity) = 0;
+
+    // Update the datacache memory quota.
+    virtual Status update_mem_quota(size_t quota_bytes, bool flush_to_disk) = 0;
+
+    virtual const DataCacheMetrics cache_metrics() const = 0;
+
+    virtual Status shutdown() = 0;
+
+    virtual bool has_mem_cache() const = 0;
+    virtual bool available() const = 0;
+    virtual bool mem_cache_available() const = 0;
+
+    virtual size_t mem_quota() const = 0;
+    virtual size_t mem_usage() const = 0;
+
+    // Get the lookup count, including cache hit count and cache miss count.
+    virtual size_t lookup_count() const = 0;
+
+    // Get the cache hit count.
+    virtual size_t hit_count() const = 0;
+
+    // Get all cache metrics together.
+    virtual const ObjectCacheMetrics metrics() const = 0;
+
+    // Remove all cache entries that are not actively in use.
+    virtual Status prune() = 0;
+};
+
+} // namespace starrocks

--- a/be/src/cache/object_cache/cache_types.h
+++ b/be/src/cache/object_cache/cache_types.h
@@ -23,19 +23,9 @@
 
 namespace starrocks {
 
-enum class ObjectCacheModuleType { LRUCACHE, STARCACHE };
-
 struct ObjectCacheWriteOptions {
     // The priority of the cache object, only support 0 and 1 now.
     int8_t priority = 0;
-    // If ttl_seconds=0 (default), no ttl restriction will be set. If an old one exists, remove it.
-    uint64_t ttl_seconds = 0;
-    // If overwrite=true, the cache value will be replaced if it already exists.
-    bool overwrite = false;
-    // The probability to evict other items if the cache space is full, which can help avoid frequent cache replacement
-    // and improve cache hit rate sometimes.
-    // It is expressed as a percentage. If evict_probability is 10, it means the probability to evict other data is 10%.
-    int32_t evict_probability = 100;
 };
 
 struct ObjectCacheReadOptions {};
@@ -59,17 +49,5 @@ using ObjectCacheHandlePtr = ObjectCacheHandle*;
 // independent on lru cache is more appropriate, but it is not easy to convert them to the lru
 // cache deleter when using a lru cache module.
 using ObjectCacheDeleter = void (*)(const CacheKey&, void*);
-
-inline std::ostream& operator<<(std::ostream& os, const ObjectCacheModuleType& module) {
-    switch (module) {
-    case ObjectCacheModuleType::LRUCACHE:
-        os << "lrucache";
-        break;
-    case ObjectCacheModuleType::STARCACHE:
-        os << "starcache";
-        break;
-    }
-    return os;
-}
 
 } // namespace starrocks

--- a/be/src/cache/object_cache/page_cache.h
+++ b/be/src/cache/object_cache/page_cache.h
@@ -66,9 +66,9 @@ public:
     // Client should call create_global_cache before.
     static StoragePageCache* instance() { return DataCache::GetInstance()->page_cache(); }
 
-    StoragePageCache(LocalCacheEngine* cache_engine) : _cache(cache_engine), _initialized(true) {}
+    StoragePageCache(LocalMemCacheEngine* cache_engine) : _cache(cache_engine), _initialized(true) {}
 
-    void init(LocalCacheEngine* cache_engine) {
+    void init(LocalMemCacheEngine* cache_engine) {
         _cache = cache_engine;
         _initialized.store(true, std::memory_order_relaxed);
     }
@@ -115,7 +115,7 @@ public:
     size_t get_pinned_count() const;
 
 private:
-    LocalCacheEngine* _cache = nullptr;
+    LocalMemCacheEngine* _cache = nullptr;
     std::atomic<bool> _initialized = false;
 };
 
@@ -125,7 +125,12 @@ private:
 class PageCacheHandle {
 public:
     PageCacheHandle() = default;
-    PageCacheHandle(LocalCacheEngine* cache, ObjectCacheHandle* handle) : _cache(cache), _handle(handle) {}
+    PageCacheHandle(LocalMemCacheEngine* cache, ObjectCacheHandle* handle) : _cache(cache), _handle(handle) {}
+
+    // Don't allow copy and assign
+    PageCacheHandle(const PageCacheHandle&) = delete;
+    const PageCacheHandle& operator=(const PageCacheHandle&) = delete;
+
     ~PageCacheHandle() {
         if (_handle != nullptr) {
             StoragePageCacheMetrics::released_page_handle_count++;
@@ -145,16 +150,12 @@ public:
         return *this;
     }
 
-    LocalCacheEngine* cache() const { return _cache; }
+    LocalMemCacheEngine* cache() const { return _cache; }
     const void* data() const { return _cache->value(_handle); }
 
 private:
-    LocalCacheEngine* _cache = nullptr;
+    LocalMemCacheEngine* _cache = nullptr;
     ObjectCacheHandle* _handle = nullptr;
-
-    // Don't allow copy and assign
-    PageCacheHandle(const PageCacheHandle&) = delete;
-    const PageCacheHandle& operator=(const PageCacheHandle&) = delete;
 };
 
 } // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
@@ -69,7 +69,7 @@ Status SchemaBeDataCacheMetricsScanner::get_next(ChunkPtr* chunk, bool* eos) {
 
     // TODO: Support LRUCacheEngine
     auto* cache = DataCache::GetInstance()->local_disk_cache();
-    if (cache != nullptr && cache->is_initialized() && cache->engine_type() == LocalCacheEngineType::STARCACHE) {
+    if (cache != nullptr && cache->is_initialized()) {
         auto* starcache = reinterpret_cast<StarCacheEngine*>(cache);
         // retrieve different priority's used bytes from level = 2 metrics
         metrics = starcache->starcache_metrics(2);

--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -471,7 +471,6 @@ StatusOr<FileMetaDataPtr> FileMetaDataParser::get_file_metadata() {
     if (file_metadata_size > 0) {
         auto deleter = [](const starrocks::CacheKey& key, void* value) { delete (FileMetaDataPtr*)value; };
         ObjectCacheWriteOptions options;
-        options.evict_probability = _datacache_options->datacache_evict_probability;
         auto capture = std::make_unique<FileMetaDataPtr>(file_metadata);
         Status st = _cache->insert(metacache_key, (void*)(capture.get()), file_metadata_size, deleter, options,
                                    &cache_handle);

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -92,7 +92,7 @@ Status PageReader::_deal_page_with_cache() {
             return Status::OK();
         }
         RETURN_IF_ERROR(_read_and_decompress_internal(true));
-        ObjectCacheWriteOptions opts{.evict_probability = _opts.datacache_options->datacache_evict_probability};
+        ObjectCacheWriteOptions opts;
         auto st = _cache->insert(page_cache_key, _cache_buf, opts, &cache_handle);
         if (st.ok()) {
             _page_handle = PageHandle(std::move(cache_handle));

--- a/be/src/http/action/datacache_action.cpp
+++ b/be/src/http/action/datacache_action.cpp
@@ -22,7 +22,7 @@
 #include <string>
 
 #include "cache/block_cache/block_cache_hit_rate_counter.hpp"
-#include "cache/local_cache_engine.h"
+#include "cache/local_disk_cache_engine.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
@@ -58,8 +58,6 @@ void DataCacheAction::handle(HttpRequest* req) {
     }
     if (!_local_cache || !_local_cache->is_initialized()) {
         _handle_error(req, strings::Substitute("Cache system is not ready"));
-    } else if (_local_cache->engine_type() != LocalCacheEngineType::STARCACHE) {
-        _handle_error(req, strings::Substitute("No more metrics for current cache engine type"));
     } else if (req->param(ACTION_KEY) == ACTION_STAT) {
         _handle_stat(req);
     } else {

--- a/be/src/http/action/datacache_action.h
+++ b/be/src/http/action/datacache_action.h
@@ -28,11 +28,11 @@
 
 namespace starrocks {
 
-class LocalCacheEngine;
+class LocalDiskCacheEngine;
 // TODO: support mem metrics
 class DataCacheAction : public HttpHandler {
 public:
-    explicit DataCacheAction(LocalCacheEngine* local_cache) : _local_cache(local_cache) {}
+    explicit DataCacheAction(LocalDiskCacheEngine* local_cache) : _local_cache(local_cache) {}
     ~DataCacheAction() override = default;
 
     void handle(HttpRequest* req) override;
@@ -44,7 +44,7 @@ private:
     void _handle_app_stat(HttpRequest* req);
     void _handle_error(HttpRequest* req, const std::string& error_msg);
 
-    LocalCacheEngine* _local_cache;
+    LocalDiskCacheEngine* _local_cache;
 };
 
 } // namespace starrocks

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -115,7 +115,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             return Status::OK();
         });
         _config_callback.emplace("datacache_mem_size", [&]() -> Status {
-            LocalCacheEngine* cache = DataCache::GetInstance()->local_mem_cache();
+            LocalMemCacheEngine* cache = DataCache::GetInstance()->local_mem_cache();
             if (cache == nullptr || !cache->is_initialized()) {
                 return Status::InternalError("Local cache is not initialized");
             }
@@ -130,7 +130,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             return cache->update_mem_quota(mem_size, true);
         });
         _config_callback.emplace("datacache_disk_size", [&]() -> Status {
-            LocalCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();
+            LocalDiskCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();
             if (cache == nullptr || !cache->is_initialized()) {
                 return Status::InternalError("Local cache is not initialized");
             }
@@ -149,7 +149,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             return cache->update_disk_spaces(spaces);
         });
         _config_callback.emplace("datacache_inline_item_count_limit", [&]() -> Status {
-            LocalCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();
+            LocalDiskCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();
             if (cache == nullptr || !cache->is_initialized()) {
                 return Status::InternalError("Local cache is not initialized");
             }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -527,7 +527,7 @@ void RuntimeState::update_load_datacache_metrics(TReportExecStatusParams* load_p
 #endif // USE_STAROS
     } else {
         // TODO: mem_metrics + disk_metrics
-        const LocalCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();
+        const LocalDiskCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();
         if (cache != nullptr && cache->is_initialized()) {
             TDataCacheMetrics t_metrics{};
             DataCacheUtils::set_metrics_from_thrift(t_metrics, cache->cache_metrics());

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -301,7 +301,7 @@ void SystemMetrics::_update_datacache_mem_tracker() {
     int64_t datacache_mem_bytes = 0;
     auto* datacache_mem_tracker = GlobalEnv::GetInstance()->datacache_mem_tracker();
     if (datacache_mem_tracker) {
-        LocalCacheEngine* local_cache = DataCache::GetInstance()->local_mem_cache();
+        LocalMemCacheEngine* local_cache = DataCache::GetInstance()->local_mem_cache();
         if (local_cache != nullptr && local_cache->is_initialized()) {
             auto datacache_metrics = local_cache->cache_metrics();
             datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;

--- a/be/test/cache/block_cache/block_cache_test.cpp
+++ b/be/test/cache/block_cache/block_cache_test.cpp
@@ -233,13 +233,6 @@ TEST_F(BlockCacheTest, update_cache_quota) {
     }
 
     {
-        size_t new_mem_quota = 2 * 1024 * 1024;
-        ASSERT_TRUE(local_cache->update_mem_quota(new_mem_quota, false).ok());
-        auto metrics = local_cache->cache_metrics();
-        ASSERT_EQ(metrics.mem_quota_bytes, new_mem_quota);
-    }
-
-    {
         size_t new_disk_quota = 100 * 1024 * 1024;
         std::vector<DirSpace> dir_spaces;
         dir_spaces.push_back({.path = cache_dir, .size = new_disk_quota});

--- a/be/test/cache/lrucache_engine_test.cpp
+++ b/be/test/cache/lrucache_engine_test.cpp
@@ -191,9 +191,4 @@ TEST_F(LRUCacheEngineTest, test_metrics) {
     ASSERT_EQ(metrics.capacity, _capacity);
     ASSERT_EQ(metrics.object_item_count, 0);
 }
-
-TEST_F(LRUCacheEngineTest, adjust_inline_cache_count_limit) {
-    ASSERT_TRUE(_cache->update_inline_cache_count_limit(0).is_not_supported());
-}
-
 } // namespace starrocks

--- a/be/test/cache/starcache_engine_test.cpp
+++ b/be/test/cache/starcache_engine_test.cpp
@@ -27,22 +27,13 @@ protected:
     void SetUp() override;
     void TearDown() override;
 
-    static void Deleter(const CacheKey& k, void* v) { free(v); }
-
-    void insert_value(int i);
-
     void _init_local_cache();
     static std::string _int_to_string(size_t length, int num);
-    void _check_not_found(int value);
-    void _check_found(int value);
 
     std::string _cache_dir = "./starcache_engine_test";
     std::shared_ptr<StarCacheEngine> _cache;
 
-    size_t _value_size = 256 * 1024;
     int64_t _mem_quota = 64 * 1024 * 1024;
-
-    ObjectCacheWriteOptions _write_opt;
 };
 
 void StarCacheEngineTest::SetUp() {
@@ -55,34 +46,10 @@ void StarCacheEngineTest::TearDown() {
     ASSERT_OK(fs::remove_all(_cache_dir));
 }
 
-void StarCacheEngineTest::insert_value(int i) {
-    std::string key = _int_to_string(6, i);
-    int* ptr = (int*)malloc(_value_size);
-    *ptr = i;
-    ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, _write_opt));
-    _cache->release(handle);
-}
-
 std::string StarCacheEngineTest::_int_to_string(size_t length, int num) {
     std::ostringstream oss;
     oss << std::setw(length) << std::setfill('0') << num;
     return oss.str();
-}
-
-void StarCacheEngineTest::_check_not_found(int value) {
-    std::string key = _int_to_string(6, value);
-    ObjectCacheHandlePtr handle = nullptr;
-    Status st = _cache->lookup(key, &handle, nullptr);
-    ASSERT_TRUE(st.is_not_found());
-}
-
-void StarCacheEngineTest::_check_found(int value) {
-    std::string key = _int_to_string(6, value);
-    ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->lookup(key, &handle, nullptr));
-    ASSERT_EQ(*(int*)(_cache->value(handle)), value);
-    _cache->release(handle);
 }
 
 void StarCacheEngineTest::_init_local_cache() {
@@ -91,121 +58,6 @@ void StarCacheEngineTest::_init_local_cache() {
 
     _cache = std::make_shared<StarCacheEngine>();
     ASSERT_OK(_cache->init(options));
-}
-
-TEST_F(StarCacheEngineTest, insert_success) {
-    insert_value(0);
-    size_t kv_size = _cache->mem_usage();
-
-    for (int i = 1; i < 20; i++) {
-        insert_value(i);
-    }
-    ASSERT_EQ(_cache->mem_usage(), kv_size * 20);
-}
-
-TEST_F(StarCacheEngineTest, test_insert) {
-    size_t mem_size = 4096;
-    void* ptr = malloc(mem_size);
-    int* value = new (ptr) int;
-    *value = 10;
-    ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->insert("1", (void*)ptr, mem_size, &Deleter, &handle, _write_opt));
-    _cache->release(handle);
-
-    ObjectCacheHandlePtr lookup_handle = nullptr;
-    ASSERT_OK(_cache->lookup("1", &lookup_handle, nullptr));
-    const void* result = _cache->value(lookup_handle);
-    ASSERT_EQ(*(const int*)(result), 10);
-    _cache->release(lookup_handle);
-}
-
-TEST_F(StarCacheEngineTest, lookup) {
-    insert_value(0);
-    insert_value(1);
-
-    ObjectCacheHandlePtr handle = nullptr;
-    std::string key = _int_to_string(6, 1);
-    ASSERT_OK(_cache->lookup(key, &handle, nullptr));
-    ASSERT_EQ(*(int*)_cache->value(handle), 1);
-
-    ASSERT_OK(_cache->lookup(key, &handle, nullptr));
-    ASSERT_EQ(*(int*)_cache->value(handle), 1);
-    _cache->release(handle);
-
-    _check_not_found(2);
-}
-
-TEST_F(StarCacheEngineTest, insert_and_release_old_handle) {
-    std::string key = _int_to_string(6, 0);
-    int* ptr = (int*)malloc(_value_size);
-    *ptr = 0;
-    ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, _write_opt));
-
-    key = _int_to_string(6, 1);
-    ptr = (int*)malloc(_value_size);
-    *ptr = 1;
-    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, _write_opt));
-    _cache->release(handle);
-}
-
-TEST_F(StarCacheEngineTest, remove) {
-    insert_value(0);
-    insert_value(1);
-
-    ASSERT_OK(_cache->remove(_int_to_string(6, 1)));
-    _check_not_found(1);
-}
-
-TEST_F(StarCacheEngineTest, value) {
-    insert_value(1);
-
-    ObjectCacheHandlePtr handle = nullptr;
-    std::string key = _int_to_string(6, 1);
-    ASSERT_OK(_cache->lookup(key, &handle, nullptr));
-    const void* data = _cache->value(handle);
-    ASSERT_EQ(*(const int*)data, 1);
-    _cache->release(handle);
-}
-
-TEST_F(StarCacheEngineTest, set_capacity) {
-    insert_value(0);
-    size_t kv_size = _cache->mem_usage();
-
-    size_t num = _mem_quota / kv_size;
-
-    for (size_t i = 1; i < num; i++) {
-        insert_value(i);
-    }
-    _check_found(0);
-    ASSERT_LE(_cache->mem_usage(), num * kv_size);
-    ASSERT_EQ(_cache->mem_quota(), _mem_quota);
-
-    ASSERT_OK(_cache->update_mem_quota(_mem_quota / 2, false));
-    _check_not_found(1);
-    ASSERT_EQ(_cache->mem_quota(), _mem_quota / 2);
-    ASSERT_LE(_cache->mem_usage(), _mem_quota / 2);
-}
-
-TEST_F(StarCacheEngineTest, adjust_capacity) {
-    insert_value(0);
-    size_t kv_size = _cache->mem_usage();
-
-    size_t num = _mem_quota / kv_size;
-
-    for (size_t i = 1; i < num; i++) {
-        insert_value(i);
-    }
-    _check_found(0);
-    ASSERT_LE(_cache->mem_usage(), _mem_quota);
-    ASSERT_EQ(_cache->mem_quota(), _mem_quota);
-
-    ASSERT_OK(_cache->adjust_mem_quota(-1 * _mem_quota / 2, 0));
-    _check_not_found(1);
-    ASSERT_LE(_cache->mem_usage(), _mem_quota / 2);
-    ASSERT_EQ(_cache->mem_quota(), _mem_quota / 2);
-
-    ASSERT_TRUE(_cache->adjust_mem_quota(-1 * _mem_quota / 3, _mem_quota / 2).is_invalid_argument());
 }
 
 static void empty_deleter(void*) {}
@@ -239,40 +91,4 @@ TEST_F(StarCacheEngineTest, adjust_inline_cache_count_limit) {
         ASSERT_OK(_cache->read(key, 0, val.size(), &buffer, nullptr));
     }
 }
-
-TEST_F(StarCacheEngineTest, metrics) {
-    insert_value(0);
-    size_t kv_size = _cache->mem_usage();
-
-    for (size_t i = 1; i < 128; i++) {
-        insert_value(i);
-    }
-    for (size_t i = 0; i < 10; i++) {
-        _check_found(i);
-    }
-    for (size_t i = 200; i < 210; i++) {
-        _check_not_found(i);
-    }
-
-    ASSERT_EQ(_cache->mem_quota(), _mem_quota);
-    ASSERT_EQ(_cache->mem_usage(), kv_size * 128);
-    ASSERT_EQ(_cache->lookup_count(), 20);
-    ASSERT_EQ(_cache->hit_count(), 10);
-
-    auto metrics = _cache->metrics();
-    ASSERT_EQ(metrics.capacity, _mem_quota);
-    ASSERT_EQ(metrics.usage, kv_size * 128);
-    ASSERT_EQ(metrics.lookup_count, 20);
-    ASSERT_EQ(metrics.hit_count, 10);
-    ASSERT_EQ(metrics.object_item_count, 128);
-}
-
-TEST_F(StarCacheEngineTest, prune) {
-    for (size_t i = 0; i < 128; i++) {
-        insert_value(i);
-    }
-    ASSERT_OK(_cache->prune());
-    ASSERT_EQ(_cache->mem_usage(), 0);
-}
-
 } // namespace starrocks

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -22,6 +22,7 @@
 
 #include "cache/block_cache/block_cache.h"
 #include "cache/block_cache/test_cache_utils.h"
+#include "cache/lrucache_engine.h"
 #include "cache/starcache_engine.h"
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
@@ -3347,8 +3348,8 @@ TEST_F(FileReaderTest, TestStructSubfieldNoDecodeNotOutput) {
 }
 
 TEST_F(FileReaderTest, TestReadFooterCache) {
-    DiskCacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 100 * MB);
-    auto local_cache = std::make_shared<StarCacheEngine>();
+    MemCacheOptions options{.mem_space_size = 100 * MB};
+    auto local_cache = std::make_shared<LRUCacheEngine>();
     ASSERT_OK(local_cache->init(options));
     auto cache = std::make_shared<StoragePageCache>(local_cache.get());
 

--- a/be/test/http/datacache_action_test.cpp
+++ b/be/test/http/datacache_action_test.cpp
@@ -62,7 +62,7 @@ public:
 
 protected:
     evhttp_request* _evhttp_req = nullptr;
-    std::shared_ptr<LocalCacheEngine> _cache;
+    std::shared_ptr<LocalDiskCacheEngine> _cache;
 };
 
 TEST_F(DataCacheActionTest, stat_success) {

--- a/be/test/service/service_be/internal_service_test.cpp
+++ b/be/test/service/service_be/internal_service_test.cpp
@@ -181,11 +181,11 @@ TEST_F(InternalServiceTest, test_fetch_datacache_via_brpc) {
         ASSERT_FALSE(st.ok());
     }
 
-    std::shared_ptr<BlockCache> cache(new BlockCache);
+    std::shared_ptr<BlockCache> cache;
     {
-        DiskCacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 20 * MB);
+        DiskCacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 0, 20 * MB);
         options.inline_item_count_limit = 1000;
-        auto cache = TestCacheUtils::create_cache(options);
+        cache = TestCacheUtils::create_cache(options);
 
         const size_t cache_size = 1024;
         const std::string cache_key = "test_file";

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1017,7 +1017,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_rebuild_persistent_index) {
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_abort_txn) {
-    bool old_val = config::skip_pk_preload;
     config::skip_pk_preload = false;
     SyncPoint::GetInstance()->EnableProcessing();
     SyncPoint::GetInstance()->LoadDependency(


### PR DESCRIPTION
## Why I'm doing:

The PR at https://github.com/StarRocks/starrocks/pull/62760 has already split the data cache into memory cache and disk cache. Therefore, we should split the interface into a memory-specific interface and a disk-specific interface. This way, it will be easier to fix any issues related to memory/disk statistics later on.

<img width="1136" height="554" alt="image" src="https://github.com/user-attachments/assets/e3d154ed-8084-4945-99a9-099384b802eb" />

This is the first pr to Fix: https://github.com/StarRocks/StarRocksTest/issues/10228

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10228

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
