### PR TITLE
[BugFix] Fix the bug where datacache_evict_probability does not take effect in DataCacheMem

### DIFF
--- a/be/src/cache/disk_cache/local_disk_cache_engine.h
+++ b/be/src/cache/disk_cache/local_disk_cache_engine.h
@@ -57,11 +57,6 @@ struct DiskCacheWriteOptions {
     bool allow_zero_copy = false;
     std::function<void(int, const std::string&)> callback = nullptr;
 
-    // The probability to evict other items if the cache space is full, which can help avoid frequent cache replacement
-    // and improve cache hit rate sometimes.
-    // It is expressed as a percentage. If evict_probability is 10, it means the probability to evict other data is 10%.
-    int32_t evict_probability = 100;
-
     // The base frequency for target cache.
     // When using multiple segment lru, a higher frequency may cause the cache is written to warm segment directly.
     // For the default cache options, that `lru_segment_freq_bits` is 0:

--- a/be/src/cache/disk_cache/starcache_engine.cpp
+++ b/be/src/cache/disk_cache/starcache_engine.cpp
@@ -85,7 +85,7 @@ Status StarCacheEngine::write(const std::string& key, const IOBuffer& buffer, Di
     } else {
         opts.mode = starcache::WriteOptions::WriteMode::WRITE_THROUGH;
     }
-    opts.evict_probability = options->evict_probability;
+    opts.evict_probability = 100;
     opts.ignore_inline = true;
     Status st;
     {

--- a/be/src/cache/mem_cache/local_mem_cache_engine.h
+++ b/be/src/cache/mem_cache/local_mem_cache_engine.h
@@ -28,6 +28,11 @@ struct MemCacheOptions {
 struct MemCacheWriteOptions {
     // The priority of the cache object, only support 0 and 1 now.
     int8_t priority = 0;
+
+    // The probability to evict other items if the cache space is full, which can help avoid frequent cache replacement
+    // and improve cache hit rate sometimes.
+    // It is expressed as a percentage. If evict_probability is 10, it means the probability to evict other data is 10%.
+    int32_t evict_probability = 100;
 };
 
 struct MemCacheReadOptions {};

--- a/be/src/cache/mem_cache/lrucache_engine.h
+++ b/be/src/cache/mem_cache/lrucache_engine.h
@@ -60,6 +60,8 @@ public:
     Status prune() override;
 
 private:
+    bool _check_write(size_t charge, const MemCacheWriteOptions& options) const;
+
     std::atomic<bool> _initialized = false;
     std::unique_ptr<ShardedLRUCache> _cache;
 };

--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -471,6 +471,7 @@ StatusOr<FileMetaDataPtr> FileMetaDataParser::get_file_metadata() {
     if (file_metadata_size > 0) {
         auto deleter = [](const starrocks::CacheKey& key, void* value) { delete (FileMetaDataPtr*)value; };
         MemCacheWriteOptions options;
+        options.evict_probability = _datacache_options->datacache_evict_probability;
         auto capture = std::make_unique<FileMetaDataPtr>(file_metadata);
         Status st = _cache->insert(metacache_key, (void*)(capture.get()), file_metadata_size, deleter, options,
                                    &cache_handle);

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -92,7 +92,7 @@ Status PageReader::_deal_page_with_cache() {
             return Status::OK();
         }
         RETURN_IF_ERROR(_read_and_decompress_internal(true));
-        MemCacheWriteOptions opts;
+        MemCacheWriteOptions opts{.evict_probability = _opts.datacache_options->datacache_evict_probability};
         auto st = _cache->insert(page_cache_key, _cache_buf, opts, &cache_handle);
         if (st.ok()) {
             _page_handle = PageHandle(std::move(cache_handle));

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -153,14 +153,13 @@ Status CacheInputStream::_read_from_cache(const int64_t offset, const int64_t si
         read_size = block_size;
 
         if (res.ok() && _enable_populate_cache) {
-            DiskCacheWriteOptions options;
-            options.async = _enable_async_populate_mode;
-            options.evict_probability = _datacache_evict_probability;
-            options.priority = _priority;
-            options.ttl_seconds = _ttl_seconds;
-            options.frequency = _frequency;
-            options.allow_zero_copy = true;
-            _write_cache(block_offset, block.buffer, &options);
+            DiskCacheWriteOptions write_options;
+            write_options.async = _enable_async_populate_mode;
+            write_options.priority = _priority;
+            write_options.ttl_seconds = _ttl_seconds;
+            write_options.frequency = _frequency;
+            write_options.allow_zero_copy = true;
+            _write_cache(block_offset, block.buffer, &write_options);
         }
     }
 
@@ -447,7 +446,6 @@ void CacheInputStream::_populate_to_cache(const char* p, int64_t offset, int64_t
     auto f = [sb, this](const char* buf, size_t off, size_t size) {
         DiskCacheWriteOptions options;
         options.async = _enable_async_populate_mode;
-        options.evict_probability = _datacache_evict_probability;
         options.priority = _priority;
         options.ttl_seconds = _ttl_seconds;
         options.frequency = _frequency;

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -76,8 +76,6 @@ public:
 
     void set_enable_cache_io_adaptor(bool v) { _enable_cache_io_adaptor = v; }
 
-    void set_datacache_evict_probability(int32_t v) { _datacache_evict_probability = v; }
-
     void set_priority(const int8_t priority) { _priority = priority; }
 
     void set_frequency(const int8_t frequency) { _frequency = frequency; }
@@ -128,7 +126,6 @@ protected:
     bool _enable_async_populate_mode = false;
     bool _enable_block_buffer = false;
     bool _enable_cache_io_adaptor = false;
-    int32_t _datacache_evict_probability = 100;
 
     std::string _peer_host;
     int32_t _peer_port = 0;

--- a/be/src/util/table_metrics.cpp
+++ b/be/src/util/table_metrics.cpp
@@ -84,8 +84,8 @@ void TableMetricsManager::cleanup(bool force) {
     if (!config::enable_table_metrics) {
         return;
     }
-    int64_t current_second = MonotonicSeconds();
 #ifndef BE_TEST
+    int64_t current_second = MonotonicSeconds();
     if (!force && current_second - _last_cleanup_ts <= kCleanupIntervalSeconds) {
         return;
     }

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -385,7 +385,7 @@ DataCacheOptions FileReaderTest::_mock_datacache_options() {
                             .enable_datacache_async_populate_mode = true,
                             .enable_datacache_io_adaptor = true,
                             .modification_time = 100000,
-                            .datacache_evict_probability = 0,
+                            .datacache_evict_probability = 100,
                             .datacache_priority = 0,
                             .datacache_ttl_seconds = 0};
 }


### PR DESCRIPTION
## Why I'm doing:

This PR: https://github.com/StarRocks/starrocks/pull/63759 incorrectly deleted `datacache_evict_probability`, which caused this session variable to stop working. Therefore, this PR adds it back. According to the original design, `datacache_evict_probability` does not take effect for the disk cache, so the parameters and configurations related to `DiskDataCache` are removed.

## What I'm doing:

Fix the bug where datacache_evict_probability does not take effect in DataCacheMem

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
