### PR TITLE
[Refactor] Remove unused be conf: datacache_engine and datacache_tiered_cache_enable

### DIFF
--- a/be/src/bench/object_cache_bench.cpp
+++ b/be/src/bench/object_cache_bench.cpp
@@ -112,7 +112,6 @@ void ObjectCacheBench::init_cache(CacheType cache_type) {
     opt.max_concurrent_inserts = config::datacache_max_concurrent_inserts;
     opt.enable_checksum = config::datacache_checksum_enable;
     opt.enable_direct_io = config::datacache_direct_io_enable;
-    opt.enable_tiered_cache = config::datacache_tiered_cache_enable;
     opt.skip_read_factor = config::datacache_skip_read_factor;
     opt.scheduler_threads_per_cpu = config::datacache_scheduler_threads_per_cpu;
     opt.enable_datacache_persistence = false;

--- a/be/src/cache/datacache.cpp
+++ b/be/src/cache/datacache.cpp
@@ -241,7 +241,6 @@ StatusOr<DiskCacheOptions> DataCache::_init_disk_cache_options() {
     cache_options.max_concurrent_inserts = config::datacache_max_concurrent_inserts;
     cache_options.enable_checksum = config::datacache_checksum_enable;
     cache_options.enable_direct_io = config::datacache_direct_io_enable;
-    cache_options.enable_tiered_cache = config::datacache_tiered_cache_enable;
     cache_options.skip_read_factor = config::datacache_skip_read_factor;
     cache_options.scheduler_threads_per_cpu = config::datacache_scheduler_threads_per_cpu;
     cache_options.enable_datacache_persistence = config::datacache_persistence_enable;
@@ -284,7 +283,7 @@ void DataCache::try_release_resource_before_core_dump() {
     };
 
     if (_local_mem_cache != nullptr && need_release("data_cache")) {
-        (void)_local_mem_cache->update_mem_quota(0, false);
+        (void)_local_mem_cache->update_mem_quota(0);
     }
 }
 

--- a/be/src/cache/disk_cache/local_disk_cache_engine.h
+++ b/be/src/cache/disk_cache/local_disk_cache_engine.h
@@ -35,7 +35,6 @@ struct DiskCacheOptions {
     size_t block_size = 0;
     bool enable_checksum = false;
     bool enable_direct_io = false;
-    bool enable_tiered_cache = true;
     bool enable_datacache_persistence = false;
     size_t max_concurrent_inserts = 0;
     size_t max_flying_memory_mb = 0;

--- a/be/src/cache/disk_cache/starcache_engine.h
+++ b/be/src/cache/disk_cache/starcache_engine.h
@@ -68,8 +68,6 @@ private:
 
     std::shared_ptr<starcache::StarCache> _cache;
     std::unique_ptr<starcache::TimeBasedCacheAdaptor> _cache_adaptor;
-    bool _enable_tiered_cache = false;
-    bool _enable_datacache_persistence = false;
     std::atomic<bool> _initialized = false;
 
     std::atomic<size_t> _disk_quota = 0;

--- a/be/src/cache/mem_cache/local_mem_cache_engine.h
+++ b/be/src/cache/mem_cache/local_mem_cache_engine.h
@@ -83,7 +83,7 @@ public:
     virtual Status adjust_mem_quota(int64_t delta, size_t min_capacity) = 0;
 
     // Update the datacache memory quota.
-    virtual Status update_mem_quota(size_t quota_bytes, bool flush_to_disk) = 0;
+    virtual Status update_mem_quota(size_t quota_bytes) = 0;
 
     virtual const DataCacheMetrics cache_metrics() const = 0;
 

--- a/be/src/cache/mem_cache/lrucache_engine.cpp
+++ b/be/src/cache/mem_cache/lrucache_engine.cpp
@@ -59,7 +59,7 @@ Status LRUCacheEngine::remove(const std::string& key) {
     return Status::OK();
 }
 
-Status LRUCacheEngine::update_mem_quota(size_t quota_bytes, bool flush_to_disk) {
+Status LRUCacheEngine::update_mem_quota(size_t quota_bytes) {
     _cache->set_capacity(quota_bytes);
     return Status::OK();
 }

--- a/be/src/cache/mem_cache/lrucache_engine.h
+++ b/be/src/cache/mem_cache/lrucache_engine.h
@@ -35,7 +35,7 @@ public:
     bool exist(const std::string& key) const override;
     Status remove(const std::string& key) override;
 
-    Status update_mem_quota(size_t quota_bytes, bool flush_to_disk) override;
+    Status update_mem_quota(size_t quota_bytes) override;
 
     const DataCacheMetrics cache_metrics() const override;
 

--- a/be/src/cache/mem_cache/page_cache.cpp
+++ b/be/src/cache/mem_cache/page_cache.cpp
@@ -75,7 +75,7 @@ void StoragePageCache::prune() {
 }
 
 void StoragePageCache::set_capacity(size_t capacity) {
-    Status st = _cache->update_mem_quota(capacity, false);
+    Status st = _cache->update_mem_quota(capacity);
     LOG_IF(INFO, !st.ok()) << "Fail to set cache capacity to " << capacity << ", reason: " << st.message();
 }
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1299,19 +1299,8 @@ CONF_Bool(datacache_block_buffer_enable, "true");
 // To control how many threads will be created for datacache synchronous tasks.
 // For the default value, it means for every 8 cpu, one thread will be created.
 CONF_Double(datacache_scheduler_threads_per_cpu, "0.125");
-// To control whether cache raw data both in memory and disk.
-// If true, the raw data will be written to the tiered cache composed of memory cache and disk cache,
-// and the memory cache hotter data than disk.
-// If false, the raw data will be written to disk directly and read from disk without promotion.
-// For object data, such as parquet footer object, which can only be cached in memory are not affected
-// by this configuration.
-CONF_Bool(datacache_tiered_cache_enable, "false");
 // Whether to persist cached data
 CONF_Bool(datacache_persistence_enable, "true");
-// DataCache engines, alternatives: starcache, lrucache
-// Set the default value empty to indicate whether it is manually configured by users.
-// If not, we need to adjust the default engine based on build switches like "WITH_STARCACHE".
-CONF_String_enum(datacache_engine, "", ",starcache,lrucache");
 // The interval time (millisecond) for agent report datacache metrics to FE.
 CONF_mInt32(report_datacache_metrics_interval_ms, "60000");
 
@@ -1365,7 +1354,6 @@ CONF_Alias(datacache_block_size, block_cache_block_size);
 CONF_Alias(datacache_max_concurrent_inserts, block_cache_max_concurrent_inserts);
 CONF_Alias(datacache_checksum_enable, block_cache_checksum_enable);
 CONF_Alias(datacache_direct_io_enable, block_cache_direct_io_enable);
-CONF_Alias(datacache_engine, block_cache_engine);
 
 CONF_mInt64(l0_l1_merge_ratio, "10");
 // max wal file size in l0

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -127,7 +127,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                 LOG(WARNING) << "Failed to update datacache mem size";
                 return st;
             }
-            return cache->update_mem_quota(mem_size, true);
+            return cache->update_mem_quota(mem_size);
         });
         _config_callback.emplace("datacache_disk_size", [&]() -> Status {
             LocalDiskCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();

--- a/be/test/cache/disk_cache/test_cache_utils.h
+++ b/be/test/cache/disk_cache/test_cache_utils.h
@@ -40,7 +40,6 @@ public:
         options.enable_checksum = false;
         options.max_concurrent_inserts = 1500000;
         options.max_flying_memory_mb = 100;
-        options.enable_tiered_cache = true;
         options.block_size = block_size;
         options.skip_read_factor = 1.0;
         options.inline_item_count_limit = 1000;

--- a/be/test/cache/mem_cache/lrucache_engine_test.cpp
+++ b/be/test/cache/mem_cache/lrucache_engine_test.cpp
@@ -121,7 +121,7 @@ TEST_F(LRUCacheEngineTest, test_set_capacity) {
     ASSERT_EQ(_cache->mem_quota(), _capacity);
     ASSERT_EQ(_cache->mem_usage(), _kv_size * 128);
 
-    ASSERT_OK(_cache->update_mem_quota(8192, false));
+    ASSERT_OK(_cache->update_mem_quota(8192));
     ASSERT_EQ(_cache->mem_quota(), 8192);
     ASSERT_GT(_cache->mem_usage(), 0);
     ASSERT_LT(_cache->mem_usage(), 8192);

--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -59,7 +59,6 @@ public:
         options.enable_checksum = false;
         options.max_concurrent_inserts = 1500000;
         options.max_flying_memory_mb = 100;
-        options.enable_tiered_cache = true;
         options.block_size = block_size;
         options.skip_read_factor = 1.0;
         return options;
@@ -318,7 +317,6 @@ TEST_F(CacheInputStreamTest, test_read_with_adaptor) {
     DiskCacheOptions options = cache_options();
     // Because the cache adaptor only work for disk cache.
     options.dir_spaces.push_back({.path = cache_dir, .size = 300 * 1024 * 1024});
-    options.enable_tiered_cache = false;
     auto block_cache = TestCacheUtils::create_cache(options);
     DataCache::GetInstance()->set_block_cache(block_cache);
 


### PR DESCRIPTION
## Why I'm doing:

The PR https://github.com/StarRocks/starrocks/pull/62760 has already split the data cache into memory cache and disk cache, and then use `LRUCache` ad mem cache and use `StarCache` as disk cache, so the config `datacache_engine` is useless now.

Tiered cache is currently useless. When enabled, memory statistics are invalid and it is hard to control, so the configuration should be removed.

## What I'm doing:

Remove unused be conf: datacache_engine and datacache_tiered_cache_enable

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
