### PR TITLE
[BugFix] Fixed potential deadlock during initialization of ExceptionStackContext

### DIFF
--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -416,10 +416,10 @@ void __wrap___cxa_throw(void* thrown_exception, std::type_info* info, void (*des
 #elif defined(__GNUC__)
 void __wrap___cxa_throw(void* thrown_exception, void* info, void (*dest)(void*)) {
 #endif
+    // to avoid recursively throwing std::bad_alloc exception when check memory limit in memory tracker.
+    SCOPED_SET_CATCHED(false);
     auto print_level = ExceptionStackContext::get_instance()->get_level();
     if (print_level != 0) {
-        // to avoid recursively throwing std::bad_alloc exception when check memory limit in memory tracker.
-        SCOPED_SET_CATCHED(false);
         string exception_name = ExceptionStackContext::get_exception_name((void*)info);
         if ((print_level == 1 && ExceptionStackContext::get_instance()->prefix_in_white_list(exception_name)) ||
             print_level == -1 ||


### PR DESCRIPTION




## Why I'm doing:

ExceptionStackContext will allocate memory. If the `catched` property is true at this point, it may throw an exception which will cause a deadlock

```                                                                                                                                                                   
| tid: 9000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
|     0x14aae9e0688b  (/usr/lib/x86_64-linux-gnu/libc.so.6 (deleted)+0x11e88b)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
|         0x14dcb230  __cxa_guard_acquire                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
|          0xd384dbf  __wrap___cxa_throw                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|         0x14dcb49a  (/home/disk1/sr/be/lib/starrocks_be+0x14dcb49a)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
|          0x871a183  std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > strings::internal::Splitter<strings::delimiter::Literal, strings                                                                                                                                                                                                                                                                                |
|          0xd3863f5  starrocks::ExceptionStackContext::ExceptionStackContext()                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
|          0xd384dd6  __wrap___cxa_throw                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|          0xab58c3a  (/home/disk1/sr/be/lib/starrocks_be+0xab58c3a)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
|          0x87413f6  phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<starrocks::SliceWithHash>, starrocks::HashOnSliceWithHash, starrocks::EqualOnSliceWithHash, starrocks::AggregateStateAllocator<starrocks::SliceWithHash> >::resize(unsigned long)                                                                                                                                                                                                                                                                                                        |
|          0x874195e  phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<starrocks::SliceWithHash>, starrocks::HashOnSliceWithHash, starrocks::EqualOnSliceWithHash, starrocks::AggregateStateAllocator<starrocks::SliceWithHash> >::prepare_insert(unsigned long)                                                                                                                                                                                                                                                                                                |
|          0x8741a05  std::pair<unsigned long, bool> phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<starrocks::SliceWithHash>, starrocks::HashOnSliceWithHash, starrocks::EqualOnSliceWithHash, starrocks::AggregateStateAllocator<starrocks::SliceWithHash> >::find_or_prep                                                                                                                                                                                                                                                                                |
|          0x8741b3d  starrocks::AdaptiveSliceHashSet::emplace(starrocks::MemPool*, starrocks::Slice)                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
|          0x91fb9f7  starrocks::TDistinctAggregateFunction<(starrocks::LogicalType)13, (starrocks::LogicalType)13, starrocks::DistinctAggregateStateV2, (starrocks::AggDistinctType)0, starrocks::Slice>::merge(starrocks::FunctionContext*, starrocks::Column const*, unsigned char*                                                                                                                                                                                                                                                                                |
|          0x92f3311  starrocks::NullableAggregateFunctionUnary<std::shared_ptr<starrocks::TDistinctAggregateFunction<(starrocks::LogicalType)13, (starrocks::LogicalType)13, starrocks::DistinctAggregateStateV2, (starrocks::AggDistinctType)0, starrocks::Slice> >, starrocks::Null                                                                                                                                                                                                                                                                                |
|          0xab4d8d4  starrocks::Aggregator::compute_batch_agg_states(starrocks::Chunk*, unsigned long)                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
|          0xb716c85  starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)                                                                                                                                                                                                                                                                                                                                                                                                                |
|          0xa9d1b63  starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
|          0xb248509  starrocks::pipeline::GlobalDriverExecutor::_worker_thread()                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
|          0xd3d8888  starrocks::ThreadPool::dispatch_thread()                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
|          0xd3cf425  starrocks::Thread::supervise_thread(void*)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
|     0x14aae9d7cac3  (/usr/lib/x86_64-linux-gnu/libc.so.6 (deleted)+0x94ac3)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
|     0x14aae9e0e850  (/usr/lib/x86_64-linux-gnu/libc.so.6 (deleted)+0x126850)
```

## What I'm doing:

port getInstance() to set_catched scope

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
