### PR TITLE
[Enhancement] use tini as the container entrypoint

### DIFF
--- a/docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile
+++ b/docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile
@@ -33,7 +33,7 @@ ARG DEPLOYDIR=/data/deploy
 ENV SR_HOME=${DEPLOYDIR}/starrocks
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
-        binutils-dev openjdk-17-jdk python2 mysql-client curl vim tree net-tools less tzdata linux-tools-common linux-tools-generic supervisor nginx netcat locales && \
+        binutils-dev openjdk-17-jdk python2 mysql-client curl vim tree net-tools less tzdata linux-tools-common linux-tools-generic supervisor nginx netcat locales tini && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \
@@ -58,4 +58,7 @@ RUN cat be.conf >> $DEPLOYDIR/starrocks/be/conf/be.conf && \
     mkdir -p $DEPLOYDIR/starrocks/fe/meta $DEPLOYDIR/starrocks/be/storage && touch /.dockerenv
 
 HEALTHCHECK --interval=30s --timeout=15s --start-period=30s CMD ./health_check.sh
-CMD ./entrypoint.sh
+
+ENTRYPOINT ["/usr/bin/tini-static", "--"]
+
+CMD ["./entrypoint.sh"]

--- a/docker/dockerfiles/be/be-ubuntu.Dockerfile
+++ b/docker/dockerfiles/be/be-ubuntu.Dockerfile
@@ -46,7 +46,7 @@ ARG MINIMAL
 # TODO: switch to `openjdk-##-jre` when the starrocks core is ready.
 RUN OPTIONAL_PKGS="" && if [ "x$MINIMAL" = "xfalse" ] ; then OPTIONAL_PKGS="binutils-dev openjdk-17-jdk curl vim tree net-tools less pigz inotify-tools rclone gdb" ; fi && \
         apt-get update -y && apt-get install -y --no-install-recommends \
-        openjdk-17-jdk mysql-client tzdata locales $OPTIONAL_PKGS && \
+        openjdk-17-jdk mysql-client tzdata locales tini $OPTIONAL_PKGS && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \
@@ -74,6 +74,7 @@ COPY --chown=$USER:$GROUP docker/dockerfiles/be/*.sh $STARROCKS_ROOT/
 # Create directory for BE storage, create cn symbolic link to be
 RUN mkdir -p $STARROCKS_ROOT/be/storage && ln -sfT be $STARROCKS_ROOT/cn
 
+ENTRYPOINT ["/usr/bin/tini-static", "--"]
 
 FROM base_image AS runas_minimal_true
 # Nothing to do, the USER is set to $USER in base_image

--- a/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
+++ b/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
@@ -44,7 +44,7 @@ ARG MINIMAL
 # TODO: switch to `openjdk-##-jre` when the starrocks core is ready.
 RUN OPTIONAL_PKGS="" && if [ "x$MINIMAL" = "xfalse" ] ; then OPTIONAL_PKGS="openjdk-17-jdk curl vim tree net-tools less pigz rclone" ; fi && \
         apt-get update -y && apt-get install -y --no-install-recommends \
-        openjdk-17-jdk mysql-client tzdata locales netcat $OPTIONAL_PKGS && \
+        openjdk-17-jdk mysql-client tzdata locales netcat tini $OPTIONAL_PKGS && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \
@@ -71,6 +71,8 @@ COPY --chown=$USER:$GROUP docker/dockerfiles/fe/*.sh $STARROCKS_ROOT/
 
 # Create directory for FE metadata
 RUN mkdir -p $STARROCKS_ROOT/fe/meta
+
+ENTRYPOINT ["/usr/bin/tini-static", "--"]
 
 
 FROM base_image AS runas_minimal_true


### PR DESCRIPTION
* properly handle signals and manage child processes by tini (the tiny init for containers)

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Install tini and set it as the container ENTRYPOINT for allin1, BE, and FE Ubuntu images; switch allin1 CMD to exec form.
> 
> - **Dockerfiles (Ubuntu)**:
>   - **Entrypoint**: Set `ENTRYPOINT ["/usr/bin/tini-static", "--"]` in `docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile`, `docker/dockerfiles/be/be-ubuntu.Dockerfile`, and `docker/dockerfiles/fe/fe-ubuntu.Dockerfile`.
>   - **Packages**: Add `tini` to `apt-get install` in all three Dockerfiles.
>   - **Command**: Change allin1 `CMD` to exec form: `CMD ["./entrypoint.sh"]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78d40db92cd5e2d6505323cb7c724b5743721af9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->