### PR TITLE
[BugFix] Fix the bug where updating the memory quota of the data cache does not task effect

### DIFF
--- a/be/src/cache/cache_metrics.h
+++ b/be/src/cache/cache_metrics.h
@@ -55,19 +55,4 @@ struct DataCacheStatusUtils {
     }
 };
 
-struct DataCacheMetrics {
-    DataCacheStatus status;
-
-    size_t mem_quota_bytes;
-    size_t mem_used_bytes;
-    size_t disk_quota_bytes;
-    size_t disk_used_bytes;
-    size_t meta_used_bytes = 0;
-};
-
-#ifdef WITH_STARCACHE
-using StarCacheMetrics = starcache::CacheMetrics;
-using StarCacheStatus = starcache::CacheStatus;
-#endif
-
 } // namespace starrocks

--- a/be/src/cache/datacache_utils.cpp
+++ b/be/src/cache/datacache_utils.cpp
@@ -19,6 +19,8 @@
 
 #include <filesystem>
 
+#include "absl/status/statusor.h"
+#include "absl/strings/str_split.h"
 #include "cache/mem_cache/local_mem_cache_engine.h"
 #include "fs/fs.h"
 #include "gutil/strings/split.h"

--- a/be/src/cache/datacache_utils.cpp
+++ b/be/src/cache/datacache_utils.cpp
@@ -19,28 +19,30 @@
 
 #include <filesystem>
 
-#include "absl/status/statusor.h"
-#include "absl/strings/str_split.h"
 #include "fs/fs.h"
 #include "gutil/strings/split.h"
 #include "util/parse_util.h"
+#include "cache/mem_cache/local_mem_cache_engine.h"
 
 namespace starrocks {
-void DataCacheUtils::set_metrics_from_thrift(TDataCacheMetrics& t_metrics, const DataCacheMetrics& metrics) {
+
+void DataCacheUtils::set_metrics_to_thrift(TDataCacheMetrics& t_metrics, const DataCacheDiskMetrics& metrics) {
     t_metrics.__set_status(DataCacheStatusUtils::to_thrift(metrics.status));
     t_metrics.__set_disk_quota_bytes(metrics.disk_quota_bytes);
     t_metrics.__set_disk_used_bytes(metrics.disk_used_bytes);
+}
+
+void DataCacheUtils::set_metrics_to_thrift(TDataCacheMetrics& t_metrics, const DataCacheMemMetrics& metrics) {
+
     t_metrics.__set_mem_quota_bytes(metrics.mem_quota_bytes);
     t_metrics.__set_mem_used_bytes(metrics.mem_used_bytes);
 }
 
 #ifdef WITH_STARCACHE
-void DataCacheUtils::set_metrics_from_thrift(TDataCacheMetrics& t_metrics, const StarCacheMetrics& metrics) {
+void DataCacheUtils::set_disk_metrics_to_thrift(TDataCacheMetrics& t_metrics, const StarCacheMetrics& metrics) {
     t_metrics.__set_status(DataCacheStatusUtils::to_thrift(static_cast<DataCacheStatus>(metrics.status)));
     t_metrics.__set_disk_quota_bytes(metrics.disk_quota_bytes);
     t_metrics.__set_disk_used_bytes(metrics.disk_used_bytes);
-    t_metrics.__set_mem_quota_bytes(metrics.mem_quota_bytes);
-    t_metrics.__set_mem_used_bytes(metrics.mem_used_bytes);
 }
 #endif
 

--- a/be/src/cache/datacache_utils.cpp
+++ b/be/src/cache/datacache_utils.cpp
@@ -19,10 +19,10 @@
 
 #include <filesystem>
 
+#include "cache/mem_cache/local_mem_cache_engine.h"
 #include "fs/fs.h"
 #include "gutil/strings/split.h"
 #include "util/parse_util.h"
-#include "cache/mem_cache/local_mem_cache_engine.h"
 
 namespace starrocks {
 
@@ -33,7 +33,6 @@ void DataCacheUtils::set_metrics_to_thrift(TDataCacheMetrics& t_metrics, const D
 }
 
 void DataCacheUtils::set_metrics_to_thrift(TDataCacheMetrics& t_metrics, const DataCacheMemMetrics& metrics) {
-
     t_metrics.__set_mem_quota_bytes(metrics.mem_quota_bytes);
     t_metrics.__set_mem_used_bytes(metrics.mem_used_bytes);
 }

--- a/be/src/cache/datacache_utils.h
+++ b/be/src/cache/datacache_utils.h
@@ -15,18 +15,21 @@
 #pragma once
 
 #include "cache/cache_metrics.h"
-#include "cache/disk_cache/local_disk_cache_engine.h"
+#include "cache/disk_cache/starcache_engine.h"
 #include "gen_cpp/DataCache_types.h"
 #include "storage/options.h"
 
 namespace starrocks {
 
+class DataCacheMemMetrics;
+
 class DataCacheUtils {
 public:
-    static void set_metrics_from_thrift(TDataCacheMetrics& t_metrics, const DataCacheMetrics& metrics);
+    static void set_metrics_to_thrift(TDataCacheMetrics& t_metrics, const DataCacheDiskMetrics& metrics);
+    static void set_metrics_to_thrift(TDataCacheMetrics& t_metrics, const DataCacheMemMetrics& metrics);
 
 #ifdef WITH_STARCACHE
-    static void set_metrics_from_thrift(TDataCacheMetrics& t_metrics, const StarCacheMetrics& metrics);
+    static void set_disk_metrics_to_thrift(TDataCacheMetrics& t_metrics, const StarCacheMetrics& metrics);
 #endif
 
     static Status parse_conf_datacache_mem_size(const std::string& conf_mem_size_str, int64_t mem_limit,

--- a/be/src/cache/disk_cache/local_disk_cache_engine.h
+++ b/be/src/cache/disk_cache/local_disk_cache_engine.h
@@ -80,7 +80,6 @@ struct DiskCacheReadOptions {
     } stats;
 };
 
-
 struct DataCacheDiskMetrics {
     DataCacheStatus status;
 

--- a/be/src/cache/disk_cache/local_disk_cache_engine.h
+++ b/be/src/cache/disk_cache/local_disk_cache_engine.h
@@ -80,6 +80,14 @@ struct DiskCacheReadOptions {
     } stats;
 };
 
+
+struct DataCacheDiskMetrics {
+    DataCacheStatus status;
+
+    size_t disk_quota_bytes;
+    size_t disk_used_bytes;
+};
+
 class LocalDiskCacheEngine {
 public:
     virtual ~LocalDiskCacheEngine() = default;
@@ -105,7 +113,7 @@ public:
     // Update the datacache inline cache count limit
     virtual Status update_inline_cache_count_limit(int32_t limit) = 0;
 
-    virtual const DataCacheMetrics cache_metrics() const = 0;
+    virtual const DataCacheDiskMetrics cache_metrics() const = 0;
 
     virtual void record_read_remote(size_t size, int64_t latency_us) = 0;
 

--- a/be/src/cache/disk_cache/starcache_engine.cpp
+++ b/be/src/cache/disk_cache/starcache_engine.cpp
@@ -140,14 +140,11 @@ const StarCacheMetrics StarCacheEngine::starcache_metrics(int level) const {
     return _cache->metrics(level);
 }
 
-const DataCacheMetrics StarCacheEngine::cache_metrics() const {
+const DataCacheDiskMetrics StarCacheEngine::cache_metrics() const {
     auto starcache_metrics = _cache->metrics(0);
-    DataCacheMetrics metrics = {.status = static_cast<DataCacheStatus>(starcache_metrics.status),
-                                .mem_quota_bytes = starcache_metrics.mem_quota_bytes,
-                                .mem_used_bytes = starcache_metrics.mem_used_bytes,
-                                .disk_quota_bytes = starcache_metrics.disk_quota_bytes,
-                                .disk_used_bytes = starcache_metrics.disk_used_bytes,
-                                .meta_used_bytes = starcache_metrics.meta_used_bytes};
+    DataCacheDiskMetrics metrics = {.status = static_cast<DataCacheStatus>(starcache_metrics.status),
+                                    .disk_quota_bytes = starcache_metrics.disk_quota_bytes,
+                                    .disk_used_bytes = starcache_metrics.disk_used_bytes};
     return metrics;
 }
 

--- a/be/src/cache/disk_cache/starcache_engine.h
+++ b/be/src/cache/disk_cache/starcache_engine.h
@@ -21,6 +21,10 @@
 
 namespace starrocks {
 
+#ifdef WITH_STARCACHE
+using StarCacheMetrics = starcache::CacheMetrics;
+#endif
+
 class StarCacheEngine : public LocalDiskCacheEngine {
 public:
     StarCacheEngine() = default;
@@ -43,7 +47,7 @@ public:
 
     const StarCacheMetrics starcache_metrics(int level) const;
 
-    const DataCacheMetrics cache_metrics() const override;
+    const DataCacheDiskMetrics cache_metrics() const override;
 
     void record_read_remote(size_t size, int64_t latency_us) override;
 

--- a/be/src/cache/mem_cache/local_mem_cache_engine.h
+++ b/be/src/cache/mem_cache/local_mem_cache_engine.h
@@ -49,6 +49,11 @@ using MemCacheHandlePtr = MemCacheHandle*;
 // cache deleter when using a lru cache module.
 using MemCacheDeleter = void (*)(const CacheKey&, void*);
 
+struct DataCacheMemMetrics {
+    size_t mem_quota_bytes = 0;
+    size_t mem_used_bytes = 0;
+};
+
 class LocalMemCacheEngine {
 public:
     virtual ~LocalMemCacheEngine() = default;
@@ -85,7 +90,7 @@ public:
     // Update the datacache memory quota.
     virtual Status update_mem_quota(size_t quota_bytes) = 0;
 
-    virtual const DataCacheMetrics cache_metrics() const = 0;
+    virtual const DataCacheMemMetrics cache_metrics() const = 0;
 
     virtual Status shutdown() = 0;
 

--- a/be/src/cache/mem_cache/lrucache_engine.cpp
+++ b/be/src/cache/mem_cache/lrucache_engine.cpp
@@ -64,13 +64,8 @@ Status LRUCacheEngine::update_mem_quota(size_t quota_bytes) {
     return Status::OK();
 }
 
-const DataCacheMetrics LRUCacheEngine::cache_metrics() const {
-    return DataCacheMetrics{.status = DataCacheStatus::NORMAL,
-                            .mem_quota_bytes = _cache->get_capacity(),
-                            .mem_used_bytes = _cache->get_memory_usage(),
-                            .disk_quota_bytes = 0,
-                            .disk_used_bytes = 0,
-                            .meta_used_bytes = 0};
+const DataCacheMemMetrics LRUCacheEngine::cache_metrics() const {
+    return DataCacheMemMetrics{.mem_quota_bytes = _cache->get_capacity(), .mem_used_bytes = _cache->get_memory_usage()};
 }
 
 Status LRUCacheEngine::shutdown() {

--- a/be/src/cache/mem_cache/lrucache_engine.h
+++ b/be/src/cache/mem_cache/lrucache_engine.h
@@ -37,7 +37,7 @@ public:
 
     Status update_mem_quota(size_t quota_bytes) override;
 
-    const DataCacheMetrics cache_metrics() const override;
+    const DataCacheMemMetrics cache_metrics() const override;
 
     Status shutdown() override;
     bool has_mem_cache() const override { return _cache->get_capacity() > 0; }

--- a/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
@@ -68,9 +68,14 @@ Status SchemaBeDataCacheMetricsScanner::get_next(ChunkPtr* chunk, bool* eos) {
     row.emplace_back(_be_id);
 
     // TODO: Support LRUCacheEngine
-    auto* cache = DataCache::GetInstance()->local_disk_cache();
-    if (cache != nullptr && cache->is_initialized()) {
-        auto* starcache = reinterpret_cast<StarCacheEngine*>(cache);
+    auto* mem_cache = DataCache::GetInstance()->local_mem_cache();
+    DataCacheMemMetrics mem_metrics;
+    if (mem_cache != nullptr && mem_cache->is_initialized()) {
+        mem_metrics = mem_cache->cache_metrics();
+    }
+    auto* disk_cache = DataCache::GetInstance()->local_disk_cache();
+    if (disk_cache != nullptr && disk_cache->is_initialized()) {
+        auto* starcache = reinterpret_cast<StarCacheEngine*>(disk_cache);
         // retrieve different priority's used bytes from level = 2 metrics
         metrics = starcache->starcache_metrics(2);
 
@@ -79,8 +84,8 @@ Status SchemaBeDataCacheMetricsScanner::get_next(ChunkPtr* chunk, bool* eos) {
         row.emplace_back(Slice(status));
         row.emplace_back(metrics.disk_quota_bytes);
         row.emplace_back(metrics.disk_used_bytes);
-        row.emplace_back(metrics.mem_quota_bytes);
-        row.emplace_back(metrics.mem_used_bytes);
+        row.emplace_back(mem_metrics.mem_quota_bytes);
+        row.emplace_back(mem_metrics.mem_used_bytes);
         row.emplace_back(metrics.meta_used_bytes);
 
         const auto& dir_spaces = metrics.disk_dir_spaces;

--- a/be/src/http/action/datacache_action.cpp
+++ b/be/src/http/action/datacache_action.cpp
@@ -101,7 +101,8 @@ void DataCacheAction::_handle_stat(HttpRequest* req) {
         auto mem_used_rate = 0.0;
         if (mem_metrics.mem_quota_bytes > 0) {
             mem_used_rate =
-                    std::round(double(mem_metrics.mem_used_bytes) / double(mem_metrics.mem_quota_bytes) * 100.0) / 100.0;
+                    std::round(double(mem_metrics.mem_used_bytes) / double(mem_metrics.mem_quota_bytes) * 100.0) /
+                    100.0;
         }
         auto disk_used_rate = 0.0;
         if (metrics.disk_quota_bytes > 0) {

--- a/be/src/http/action/datacache_action.cpp
+++ b/be/src/http/action/datacache_action.cpp
@@ -23,6 +23,7 @@
 
 #include "cache/disk_cache/block_cache_hit_rate_counter.hpp"
 #include "cache/disk_cache/local_disk_cache_engine.h"
+#include "cache/mem_cache/local_mem_cache_engine.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
@@ -56,7 +57,7 @@ void DataCacheAction::handle(HttpRequest* req) {
     if (!_check_request(req)) {
         return;
     }
-    if (!_local_cache || !_local_cache->is_initialized()) {
+    if (!_disk_cache || !_disk_cache->is_initialized()) {
         _handle_error(req, strings::Substitute("Cache system is not ready"));
     } else if (req->param(ACTION_KEY) == ACTION_STAT) {
         _handle_stat(req);
@@ -79,23 +80,28 @@ void DataCacheAction::_handle(HttpRequest* req, const std::function<void(rapidjs
 void DataCacheAction::_handle_stat(HttpRequest* req) {
     _handle(req, [=](rapidjson::Document& root) {
 #ifdef WITH_STARCACHE
+        DataCacheMemMetrics mem_metrics;
+        if (_mem_cache != nullptr) {
+            mem_metrics = _mem_cache->cache_metrics();
+        }
+
         auto& allocator = root.GetAllocator();
-        auto* starcache = reinterpret_cast<StarCacheEngine*>(_local_cache);
+        auto* starcache = reinterpret_cast<StarCacheEngine*>(_disk_cache);
         auto&& metrics = starcache->starcache_metrics(2);
         std::string status = DataCacheStatusUtils::to_string(static_cast<DataCacheStatus>(metrics.status));
 
         rapidjson::Value status_value;
         status_value.SetString(status.c_str(), status.length(), allocator);
         root.AddMember("status", status_value, allocator);
-        root.AddMember("mem_quota_bytes", rapidjson::Value(metrics.mem_quota_bytes), allocator);
-        root.AddMember("mem_used_bytes", rapidjson::Value(metrics.mem_used_bytes), allocator);
+        root.AddMember("mem_quota_bytes", rapidjson::Value(mem_metrics.mem_quota_bytes), allocator);
+        root.AddMember("mem_used_bytes", rapidjson::Value(mem_metrics.mem_used_bytes), allocator);
         root.AddMember("disk_quota_bytes", rapidjson::Value(metrics.disk_quota_bytes), allocator);
         root.AddMember("disk_used_bytes", rapidjson::Value(metrics.disk_used_bytes), allocator);
 
         auto mem_used_rate = 0.0;
-        if (metrics.mem_quota_bytes > 0) {
+        if (mem_metrics.mem_quota_bytes > 0) {
             mem_used_rate =
-                    std::round(double(metrics.mem_used_bytes) / double(metrics.mem_quota_bytes) * 100.0) / 100.0;
+                    std::round(double(mem_metrics.mem_used_bytes) / double(mem_metrics.mem_quota_bytes) * 100.0) / 100.0;
         }
         auto disk_used_rate = 0.0;
         if (metrics.disk_quota_bytes > 0) {

--- a/be/src/http/action/datacache_action.h
+++ b/be/src/http/action/datacache_action.h
@@ -29,10 +29,13 @@
 namespace starrocks {
 
 class LocalDiskCacheEngine;
+class LocalMemCacheEngine;
+
 // TODO: support mem metrics
 class DataCacheAction : public HttpHandler {
 public:
-    explicit DataCacheAction(LocalDiskCacheEngine* local_cache) : _local_cache(local_cache) {}
+    explicit DataCacheAction(LocalDiskCacheEngine* disk_cache, LocalMemCacheEngine* mem_cache)
+            : _disk_cache(disk_cache), _mem_cache(mem_cache) {}
     ~DataCacheAction() override = default;
 
     void handle(HttpRequest* req) override;
@@ -44,7 +47,8 @@ private:
     void _handle_app_stat(HttpRequest* req);
     void _handle_error(HttpRequest* req, const std::string& error_msg);
 
-    LocalDiskCacheEngine* _local_cache;
+    LocalDiskCacheEngine* _disk_cache;
+    LocalMemCacheEngine* _mem_cache;
 };
 
 } // namespace starrocks

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -514,23 +514,27 @@ void RuntimeState::update_load_datacache_metrics(TReportExecStatusParams* load_p
     metrics.__set_write_time_ns(_num_datacache_write_time_ns.load(std::memory_order_relaxed));
     metrics.__set_count(_num_datacache_count.load(std::memory_order_relaxed));
 
+    TDataCacheMetrics t_metrics{};
+    const auto* mem_cache = DataCache::GetInstance()->local_mem_cache();
+    if (mem_cache != nullptr && mem_cache->is_initialized()) {
+        t_metrics.__set_status(TDataCacheStatus::NORMAL);
+        DataCacheUtils::set_metrics_to_thrift(t_metrics, mem_cache->cache_metrics());
+    }
+
     if (_query_options.catalog == "default_catalog") {
 #ifdef USE_STAROS
         if (config::starlet_use_star_cache) {
-            TDataCacheMetrics t_metrics{};
             starcache::CacheMetrics cache_metrics;
             staros::starlet::fslib::star_cache_get_metrics(&cache_metrics);
-            DataCacheUtils::set_metrics_from_thrift(t_metrics, cache_metrics);
+            DataCacheUtils::set_disk_metrics_to_thrift(t_metrics, cache_metrics);
             metrics.__set_metrics(t_metrics);
             load_params->__set_load_datacache_metrics(metrics);
         }
 #endif // USE_STAROS
     } else {
-        // TODO: mem_metrics + disk_metrics
-        const LocalDiskCacheEngine* cache = DataCache::GetInstance()->local_disk_cache();
-        if (cache != nullptr && cache->is_initialized()) {
-            TDataCacheMetrics t_metrics{};
-            DataCacheUtils::set_metrics_from_thrift(t_metrics, cache->cache_metrics());
+        const LocalDiskCacheEngine* disk_cache = DataCache::GetInstance()->local_disk_cache();
+        if (disk_cache != nullptr && disk_cache->is_initialized()) {
+            DataCacheUtils::set_metrics_to_thrift(t_metrics, disk_cache->cache_metrics());
             metrics.__set_metrics(t_metrics);
             load_params->__set_load_datacache_metrics(metrics);
         }

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -273,7 +273,7 @@ Status HttpServiceBE::start() {
     _http_handlers.emplace_back(jit_cache_action);
 #endif
 
-    auto* datacache_action = new DataCacheAction(_cache_env->local_disk_cache());
+    auto* datacache_action = new DataCacheAction(_cache_env->local_disk_cache(), _cache_env->local_mem_cache());
     _ev_http_server->register_handler(HttpMethod::GET, "/api/datacache/{action}", datacache_action);
     _http_handlers.emplace_back(datacache_action);
 

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -304,7 +304,7 @@ void SystemMetrics::_update_datacache_mem_tracker() {
         LocalMemCacheEngine* local_cache = DataCache::GetInstance()->local_mem_cache();
         if (local_cache != nullptr && local_cache->is_initialized()) {
             auto datacache_metrics = local_cache->cache_metrics();
-            datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;
+            datacache_mem_bytes = datacache_metrics.mem_used_bytes;
         }
 #ifdef USE_STAROS
         if (!config::datacache_unified_instance_enable) {

--- a/be/test/cache/datacache_utils_test.cpp
+++ b/be/test/cache/datacache_utils_test.cpp
@@ -25,23 +25,23 @@
 namespace starrocks {
 class DataCacheUtilsTest : public ::testing::Test {};
 
-TEST_F(DataCacheUtilsTest, test_set_metrics_from_thrift) {
+TEST_F(DataCacheUtilsTest, test_add_metrics_from_thrift) {
     TDataCacheMetrics t_metrics{};
-    DataCacheMetrics metrics{};
+    DataCacheDiskMetrics metrics{};
     metrics.status = DataCacheStatus::NORMAL;
-    DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
+    DataCacheUtils::set_metrics_to_thrift(t_metrics, metrics);
     ASSERT_EQ(t_metrics.status, TDataCacheStatus::NORMAL);
 
     metrics.status = DataCacheStatus::UPDATING;
-    DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
+    DataCacheUtils::set_metrics_to_thrift(t_metrics, metrics);
     ASSERT_EQ(t_metrics.status, TDataCacheStatus::UPDATING);
 
     metrics.status = DataCacheStatus::LOADING;
-    DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
+    DataCacheUtils::set_metrics_to_thrift(t_metrics, metrics);
     ASSERT_EQ(t_metrics.status, TDataCacheStatus::LOADING);
 
     metrics.status = DataCacheStatus::ABNORMAL;
-    DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
+    DataCacheUtils::set_metrics_to_thrift(t_metrics, metrics);
     ASSERT_EQ(t_metrics.status, TDataCacheStatus::ABNORMAL);
 }
 

--- a/be/test/cache/disk_cache/block_cache_test.cpp
+++ b/be/test/cache/disk_cache/block_cache_test.cpp
@@ -223,7 +223,6 @@ TEST_F(BlockCacheTest, update_cache_quota) {
 
     {
         auto metrics = local_cache->cache_metrics();
-        ASSERT_EQ(metrics.mem_quota_bytes, options.mem_space_size);
         ASSERT_EQ(metrics.disk_quota_bytes, quota);
     }
 

--- a/be/test/http/datacache_action_test.cpp
+++ b/be/test/http/datacache_action_test.cpp
@@ -66,7 +66,7 @@ protected:
 };
 
 TEST_F(DataCacheActionTest, stat_success) {
-    DataCacheAction action(_cache.get());
+    DataCacheAction action(_cache.get(), nullptr);
 
     HttpRequest request(_evhttp_req);
     request._method = HttpMethod::GET;
@@ -84,7 +84,7 @@ TEST_F(DataCacheActionTest, app_stat_success) {
     BlockCacheHitRateCounter* counter = BlockCacheHitRateCounter::instance();
     counter->reset();
 
-    DataCacheAction action(_cache.get());
+    DataCacheAction action(_cache.get(), nullptr);
 
     {
         HttpRequest request(_evhttp_req);
@@ -124,7 +124,7 @@ TEST_F(DataCacheActionTest, app_stat_success) {
 
 TEST_F(DataCacheActionTest, stat_with_uninitialized_cache) {
     auto cache = std::make_shared<StarCacheEngine>();
-    DataCacheAction action(cache.get());
+    DataCacheAction action(cache.get(), nullptr);
 
     HttpRequest request(_evhttp_req);
     request._method = HttpMethod::GET;


### PR DESCRIPTION
## Why I'm doing:

PR https://github.com/StarRocks/starrocks/pull/62760 has already split the data cache into memory cache and disk cache, but the metrics are still fetching disk cache metrics instead of memory cache metrics, resulting in incorrect results.

## What I'm doing:

Fix the bug where updating the memory quota of the data cache does not task effect

fix https://github.com/StarRocks/StarRocksTest/issues/10228

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
