### PR TITLE
[Enhancement] to avoid memory stats inaccurate case

### DIFF
--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -17,7 +17,6 @@
 #include "exec/connector_scan_node.h"
 #include "exec/pipeline/pipeline_driver.h"
 #include "exec/pipeline/scan/balanced_chunk_buffer.h"
-#include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {
@@ -763,7 +762,7 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
         RETURN_IF_ERROR(_open_data_source(state, &mem_alloc_failed));
         if (mem_alloc_failed) {
             _mem_alloc_failed_count += 1;
-            return Status::TimedOut("");
+            return Status::EAgain("");
         }
         if (state->is_cancelled()) {
             return Status::Cancelled("canceled state");


### PR DESCRIPTION
## Why I'm doing:

I find a case that memory statistics maybe is inaccurate.  And that case happens only when "there is memory contention" in scan operators.

here is the reproducible case

```
INSERT INTO BLACKHOLE()
with T(
    col1, col2, col3,
    col4, col5, col6, col7, col8, col9, col10,
    col11, col12, col13, col14, col15, col16, col17, col18, col19, col20,
    col21, col22, col23, col24, col25, col26, col27, col28, col29, col30,
    col31, col32, col33, col34, col35, col36, col37, col38, col39, col40,
    col41, col42, col43, col44, col45, col46, col47, col48, col49, col50,
    col51, col52, col53, col54, col55, col56, col57, col58, col59, col60,
    col61, col62, col63, col64, col65, col66, col67, col68, col69, col70,
    col71, col72, col73, col74, col75, col76, col77, col78, col79, col80,
    col81, col82, col83, col84, col85, col86, col87, col88, col89, col90,
    col91, col92, col93, col94, col95, col96, col97, col98, col99, col100
) as (
    SELECT * FROM etl_scan_test 
UNION ALL
SELECT * FROM etl_scan_test WHERE col3 BETWEEN 10 AND 19
UNION ALL
SELECT * FROM etl_scan_test WHERE col3 BETWEEN 20 AND 29
UNION ALL
SELECT * FROM etl_scan_test WHERE col3 BETWEEN 30 AND 39
UNION ALL
SELECT * FROM etl_scan_test WHERE col3 BETWEEN 40 AND 49
UNION ALL
SELECT * FROM etl_scan_test WHERE col3 BETWEEN 50 AND 59
UNION ALL
SELECT * FROM etl_scan_test WHERE col3 BETWEEN 60 AND 69
UNION ALL
SELECT * FROM etl_scan_test WHERE col3 BETWEEN 70 AND 79
UNION ALL
SELECT * FROM etl_scan_test WHERE col3 BETWEEN 80 AND 89
UNION ALL
SELECT * FROM etl_scan_test WHERE col3 BETWEEN 90 AND 99
UNION ALL
SELECT * FROM etl_scan_test WHERE col3 >= 100
)
SELECT * from T;    


```

the base table has a lot of columns, so to scan them may consume a lot of memory, which leas to memory contention between scan operators. 

## What I'm doing:

I find if tI add some wait between each retry, the memory stats will be accurate.  So in nutshell, I don't find the root cause but I find a way to workaround it.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
