### PR TITLE
[Enhancement] Add statistic for xx_hash3_64 function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -394,6 +394,7 @@ public class FunctionSet {
     public static final String MURMUR_HASH3_32 = "murmur_hash3_32";
     public static final String CRC32_HASH = "crc32_hash";
     public static final String XX_HASH3_64 = "xx_hash3_64";
+    public static final String XX_HASH3_128 = "xx_hash3_128";
 
     // Percentile functions:
     public static final String PERCENTILE_APPROX_RAW = "percentile_approx_raw";

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -393,6 +393,7 @@ public class FunctionSet {
     // Hash functions:
     public static final String MURMUR_HASH3_32 = "murmur_hash3_32";
     public static final String CRC32_HASH = "crc32_hash";
+    public static final String XX_HASH3_64 = "xx_hash3_64";
 
     // Percentile functions:
     public static final String PERCENTILE_APPROX_RAW = "percentile_approx_raw";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -470,6 +470,11 @@ public class ExpressionStatisticCalculator {
                     maxValue = 4294967295.0;
                     distinctValue = rowCount;
                     break;
+                case FunctionSet.XX_HASH3_64:
+                    minValue = Double.NEGATIVE_INFINITY;
+                    maxValue = Double.POSITIVE_INFINITY;
+                    distinctValue = rowCount;
+                    break;
                 case FunctionSet.POSITIVE:
                 case FunctionSet.FLOOR:
                 case FunctionSet.DFLOOR:

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.optimizer.statistics;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.ast.expression.LargeIntLiteral;
 import com.starrocks.sql.optimizer.ConstantOperatorUtils;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -477,9 +478,9 @@ public class ExpressionStatisticCalculator {
                     distinctValue = rowCount;
                     break;
                 case FunctionSet.XX_HASH3_128:
-                    // xx_hash3_128's range is int128_t
-                    minValue = -170141183460469231731687303715884105728.0;
-                    maxValue = 170141183460469231731687303715884105727.0;
+                    // xx_hash3_128's range is LARGE_INT
+                    minValue = LargeIntLiteral.LARGE_INT_MIN.doubleValue();
+                    maxValue = LargeIntLiteral.LARGE_INT_MAX.doubleValue();
                     distinctValue = rowCount;
                     break;
                 case FunctionSet.POSITIVE:

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -471,8 +471,15 @@ public class ExpressionStatisticCalculator {
                     distinctValue = rowCount;
                     break;
                 case FunctionSet.XX_HASH3_64:
-                    minValue = Double.NEGATIVE_INFINITY;
-                    maxValue = Double.POSITIVE_INFINITY;
+                    // xx_hash3_64's range is int64_t
+                    minValue = Long.MIN_VALUE;
+                    maxValue = Long.MAX_VALUE;
+                    distinctValue = rowCount;
+                    break;
+                case FunctionSet.XX_HASH3_128:
+                    // xx_hash3_128's range is int128_t
+                    minValue = -170141183460469231731687303715884105728.0;
+                    maxValue = 170141183460469231731687303715884105727.0;
                     distinctValue = rowCount;
                     break;
                 case FunctionSet.POSITIVE:

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -393,6 +393,11 @@ public class ExpressionStatisticsCalculatorTest {
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
         Assertions.assertEquals(columnStatistic.getMaxValue(), 100, 0.001);
         Assertions.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test xx_hash3_64 function
+        callOperator = new CallOperator(FunctionSet.XX_HASH3_64, Type.BIGINT, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assertions.assertEquals(columnStatistic.getMaxValue(), Double.POSITIVE_INFINITY, 0.001);
+        Assertions.assertEquals(columnStatistic.getMinValue(), Double.NEGATIVE_INFINITY, 0.001);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.LargeIntLiteral;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -401,8 +402,8 @@ public class ExpressionStatisticsCalculatorTest {
         // test xx_hash3_128 function
         callOperator = new CallOperator(FunctionSet.XX_HASH3_128, Type.BIGINT, Lists.newArrayList(columnRefOperator));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
-        Assertions.assertEquals(columnStatistic.getMaxValue(), 170141183460469231731687303715884105727.0, 0.001);
-        Assertions.assertEquals(columnStatistic.getMinValue(), -170141183460469231731687303715884105728.0, 0.001);
+        Assertions.assertEquals(columnStatistic.getMaxValue(), LargeIntLiteral.LARGE_INT_MAX.doubleValue(), 0.001);
+        Assertions.assertEquals(columnStatistic.getMinValue(), LargeIntLiteral.LARGE_INT_MIN.doubleValue(), 0.001);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -400,7 +400,7 @@ public class ExpressionStatisticsCalculatorTest {
         Assertions.assertEquals(columnStatistic.getMaxValue(), Long.MAX_VALUE, 0.001);
         Assertions.assertEquals(columnStatistic.getMinValue(), Long.MIN_VALUE, 0.001);
         // test xx_hash3_128 function
-        callOperator = new CallOperator(FunctionSet.XX_HASH3_128, Type.BIGINT, Lists.newArrayList(columnRefOperator));
+        callOperator = new CallOperator(FunctionSet.XX_HASH3_128, Type.LARGEINT, Lists.newArrayList(columnRefOperator));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
         Assertions.assertEquals(columnStatistic.getMaxValue(), LargeIntLiteral.LARGE_INT_MAX.doubleValue(), 0.001);
         Assertions.assertEquals(columnStatistic.getMinValue(), LargeIntLiteral.LARGE_INT_MIN.doubleValue(), 0.001);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -396,8 +396,13 @@ public class ExpressionStatisticsCalculatorTest {
         // test xx_hash3_64 function
         callOperator = new CallOperator(FunctionSet.XX_HASH3_64, Type.BIGINT, Lists.newArrayList(columnRefOperator));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
-        Assertions.assertEquals(columnStatistic.getMaxValue(), Double.POSITIVE_INFINITY, 0.001);
-        Assertions.assertEquals(columnStatistic.getMinValue(), Double.NEGATIVE_INFINITY, 0.001);
+        Assertions.assertEquals(columnStatistic.getMaxValue(), Long.MAX_VALUE, 0.001);
+        Assertions.assertEquals(columnStatistic.getMinValue(), Long.MIN_VALUE, 0.001);
+        // test xx_hash3_128 function
+        callOperator = new CallOperator(FunctionSet.XX_HASH3_128, Type.BIGINT, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assertions.assertEquals(columnStatistic.getMaxValue(), 170141183460469231731687303715884105727.0, 0.001);
+        Assertions.assertEquals(columnStatistic.getMinValue(), -170141183460469231731687303715884105728.0, 0.001);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

The function `XX_HASH3_64` does not have any statistics and will be set to UNKNOWN. Even though we can not set good statistics for this function, even having trivial statistics is better then not having anything as it could be helpful for follow up functions like MOD.
For example for the expression `ABS(MOD(XX_HASH3_64(a),100))` without statistics for `XX_HASH3_64` the whole expression statistics will be unknown, but with trivial `XX_HASH3_64` statistics starrocks can set the MIN to 0 and the MAX to 100 for the whole expression. 
This could be the difference between a correct and a wrong join order.

(there are probably other cases like this one)

## What I'm doing:

Adding statistic for the function XX_HASH3_64. The MIN and MAX are set to negative infinity and positive infinity. The DISTINCT COUNT is set to the number of rows.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds range/distinct estimation for `xx_hash3_64` (BIGINT) and `xx_hash3_128` (LARGEINT), registers functions, and covers with unit tests.
> 
> - **Statistics/Optimizer**:
>   - Add unary estimation for `xx_hash3_64` and `xx_hash3_128` in `ExpressionStatisticCalculator`:
>     - `xx_hash3_64`: min=`Long.MIN_VALUE`, max=`Long.MAX_VALUE`, distinct=`rowCount`.
>     - `xx_hash3_128`: min=`LargeIntLiteral.LARGE_INT_MIN`, max=`LargeIntLiteral.LARGE_INT_MAX`, distinct=`rowCount`.
> - **Catalog**:
>   - Register new hash functions in `FunctionSet` (`XX_HASH3_64`, `XX_HASH3_128`).
> - **Tests**:
>   - Add unit tests in `ExpressionStatisticsCalculatorTest` validating ranges for both functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f18b093e093b655cb9434d0f7b3e7488e82ef044. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->