### PR TITLE
[Enhancement] Add ALTER TABLE MODIFY DEFAULT BUCKETS support

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DynamicPartitionProperty;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -51,6 +52,7 @@ import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.persist.AlterViewInfo;
 import com.starrocks.persist.BatchModifyPartitionsInfo;
 import com.starrocks.persist.ModifyPartitionInfo;
+import com.starrocks.persist.ModifyTablePropertyOperationLog;
 import com.starrocks.persist.SwapTableOperationLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -64,6 +66,7 @@ import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterTableAutoIncrementClause;
 import com.starrocks.sql.ast.AlterTableCommentClause;
+import com.starrocks.sql.ast.AlterTableModifyDefaultBucketsClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.AlterViewClause;
 import com.starrocks.sql.ast.AlterViewStmt;
@@ -195,6 +198,32 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
         } else {
             for (AlterClause alterClause : statement.getAlterClauseList()) {
                 visit(alterClause, context);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitAlterTableModifyDefaultBucketsClause(AlterTableModifyDefaultBucketsClause clause,
+                                                         ConnectContext context) {
+        if (clause instanceof AlterTableModifyDefaultBucketsClause) {
+            // apply synchronously: update default distribution bucket num
+            AlterTableModifyDefaultBucketsClause c = (AlterTableModifyDefaultBucketsClause) clause;
+            if (table instanceof OlapTable) {
+                OlapTable olap = (OlapTable) table;
+                if (olap.getDefaultDistributionInfo() instanceof HashDistributionInfo) {
+                    try (AutoCloseableLock ignore =
+                                    new AutoCloseableLock(new Locker(), db.getId(),
+                                            Lists.newArrayList(table.getId()), LockType.WRITE)) {
+                        ((HashDistributionInfo) olap.getDefaultDistributionInfo())
+                                .setBucketNum(c.getBucketNum());
+                        // persist change
+                        ModifyTablePropertyOperationLog log =
+                                new ModifyTablePropertyOperationLog(db.getId(), table.getId());
+                        log.getProperties().put("default_bucket_num", String.valueOf(c.getBucketNum()));
+                        GlobalStateMgr.getCurrentState().getEditLog().logModifyDefaultBucketNum(log);
+                    }
+                }
             }
         }
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -399,6 +399,8 @@ public class TableProperty implements Writable, GsonPostProcessable {
             case OperationType.OP_MODIFY_MUTABLE_BUCKET_NUM:
                 buildMutableBucketNum();
                 break;
+            case OperationType.OP_MODIFY_DEFAULT_BUCKET_NUM:
+                break;
             case OperationType.OP_MODIFY_ENABLE_LOAD_PROFILE:
                 buildEnableLoadProfile();
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -765,6 +765,7 @@ public class EditLog {
                 case OperationType.OP_MODIFY_BINLOG_AVAILABLE_VERSION:
                 case OperationType.OP_MODIFY_BINLOG_CONFIG:
                 case OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX:
+                case OperationType.OP_MODIFY_DEFAULT_BUCKET_NUM:
                 case OperationType.OP_MODIFY_PRIMARY_INDEX_CACHE_EXPIRE_SEC:
                 case OperationType.OP_ALTER_TABLE_PROPERTIES:
                 case OperationType.OP_MODIFY_FLAT_JSON_CONFIG:
@@ -1858,6 +1859,10 @@ public class EditLog {
 
     public void logModifyMutableBucketNum(ModifyTablePropertyOperationLog info) {
         logJsonObject(OperationType.OP_MODIFY_MUTABLE_BUCKET_NUM, info);
+    }
+
+    public void logModifyDefaultBucketNum(ModifyTablePropertyOperationLog info) {
+        logJsonObject(OperationType.OP_MODIFY_DEFAULT_BUCKET_NUM, info);
     }
 
     public void logModifyEnableLoadProfile(ModifyTablePropertyOperationLog info) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
@@ -185,6 +185,7 @@ public class EditLogDeserializer {
             .put(OperationType.OP_MODIFY_MUTABLE_BUCKET_NUM, ModifyTablePropertyOperationLog.class)
             .put(OperationType.OP_MODIFY_ENABLE_LOAD_PROFILE, ModifyTablePropertyOperationLog.class)
             .put(OperationType.OP_MODIFY_BASE_COMPACTION_FORBIDDEN_TIME_RANGES, ModifyTablePropertyOperationLog.class)
+            .put(OperationType.OP_MODIFY_DEFAULT_BUCKET_NUM, ModifyTablePropertyOperationLog.class)
             .put(OperationType.OP_MODIFY_BINLOG_CONFIG, ModifyTablePropertyOperationLog.class)
             .put(OperationType.OP_MODIFY_BINLOG_AVAILABLE_VERSION, ModifyTablePropertyOperationLog.class)
             .put(OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX, ModifyTablePropertyOperationLog.class)

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -338,6 +338,9 @@ public class OperationType {
     public static final short OP_MODIFY_ENABLE_LOAD_PROFILE = 11142;
 
     @IgnorableOnReplayFailed
+    public static final short OP_MODIFY_DEFAULT_BUCKET_NUM = 11144;
+
+    @IgnorableOnReplayFailed
     public static final short OP_MODIFY_BASE_COMPACTION_FORBIDDEN_TIME_RANGES = 11143;
 
     // external table analyze

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4317,7 +4317,19 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         locker.lockDatabase(db.getId(), LockType.WRITE);
         try {
             OlapTable olapTable = (OlapTable) getTable(db.getId(), tableId);
-            if (opCode == OperationType.OP_SET_FORBIDDEN_GLOBAL_DICT) {
+            if (opCode == OperationType.OP_MODIFY_DEFAULT_BUCKET_NUM) {
+                if (olapTable != null &&
+                        olapTable.getDefaultDistributionInfo() instanceof com.starrocks.catalog.HashDistributionInfo) {
+                    String bucketNumStr = properties.get("default_bucket_num");
+                    if (bucketNumStr != null) {
+                        int bucketNum = Integer.parseInt(bucketNumStr);
+                        ((com.starrocks.catalog.HashDistributionInfo) olapTable.getDefaultDistributionInfo())
+                                .setBucketNum(bucketNum);
+                        LOG.info("Replay OP_MODIFY_DEFAULT_BUCKET_NUM: set table {} default bucket num to {}",
+                                tableId, bucketNum);
+                    }
+                }
+            } else if (opCode == OperationType.OP_SET_FORBIDDEN_GLOBAL_DICT) {
                 String enAble = properties.get(PropertyAnalyzer.ENABLE_LOW_CARD_DICT_TYPE);
                 Preconditions.checkState(enAble != null);
                 if (olapTable != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterTableModifyDefaultBucketsClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterTableModifyDefaultBucketsClause.java
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.ast;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.sql.ast.expression.TableName;
+import com.starrocks.sql.parser.NodePosition;
+
+import java.util.List;
+
+/**
+ * ALTER TABLE tbl DISTRIBUTE BY HASH(col1, col2, ...) [DEFAULT] BUCKETS N;
+ * Only modifies the table's defaultDistributionInfo bucket number (must be > 0) and
+ * requires the hash column list to match existing distribution columns exactly.
+ */
+public class AlterTableModifyDefaultBucketsClause extends AlterTableClause {
+    private final List<String> distributionColumns;
+    private final int bucketNum;
+    protected TableName tableName;
+
+    public AlterTableModifyDefaultBucketsClause(List<String> distributionColumns, int bucketNum, NodePosition pos) {
+        super(pos);
+        Preconditions.checkArgument(bucketNum > 0, "bucket num must > 0");
+        this.distributionColumns = distributionColumns;
+        this.bucketNum = bucketNum;
+    }
+
+    public List<String> getDistributionColumns() {
+        return distributionColumns;
+    }
+
+    public int getBucketNum() {
+        return bucketNum;
+    }
+
+    public void setTableName(TableName tableName) {
+        this.tableName = tableName;
+    }
+
+    public TableName getTableName() {
+        return tableName;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return ((AstVisitorExtendInterface<R, C>) visitor).visitAlterTableModifyDefaultBucketsClause(this, context);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
@@ -1110,6 +1110,10 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
         return visitNode(clause, context);
     }
 
+    default R visitAlterTableModifyDefaultBucketsClause(AlterTableModifyDefaultBucketsClause clause, C context) {
+        return visitNode(clause, context);
+    }
+
     default R visitAddFieldClause(AddFieldClause clause, C context) {
         return visitNode(clause, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -98,6 +98,7 @@ import com.starrocks.sql.ast.AlterSystemStmt;
 import com.starrocks.sql.ast.AlterTableAutoIncrementClause;
 import com.starrocks.sql.ast.AlterTableClause;
 import com.starrocks.sql.ast.AlterTableCommentClause;
+import com.starrocks.sql.ast.AlterTableModifyDefaultBucketsClause;
 import com.starrocks.sql.ast.AlterTableOperationClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.AlterUserStmt;
@@ -8744,6 +8745,19 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         } else {
             return new RandomDistributionDesc(buckets, pos);
         }
+    }
+
+    @Override
+    public ParseNode visitAlterModifyDefaultBuckets(
+            com.starrocks.sql.parser.StarRocksParser.AlterModifyDefaultBucketsContext context) {
+        NodePosition pos = createPos(context);
+        int buckets = Integer.parseInt(context.INTEGER_VALUE().getText());
+        List<Identifier> identifierList = visit(
+                context.identifierList().identifier(), Identifier.class);
+        List<String> columnNames = identifierList.stream()
+                .map(Identifier::getValue)
+                .collect(toList());
+        return new AlterTableModifyDefaultBucketsClause(columnNames, buckets, pos);
     }
 
     @Override

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -971,6 +971,7 @@ alterClause
     | addPartitionClause
     | dropPartitionClause
     | distributionClause
+    | alterModifyDefaultBuckets
     | truncatePartitionClause
     | modifyPartitionClause
     | replacePartitionClause
@@ -2919,6 +2920,10 @@ distributionDesc
     : DISTRIBUTED BY HASH identifierList (BUCKETS INTEGER_VALUE)?
     | DISTRIBUTED BY HASH identifierList
     | DISTRIBUTED BY RANDOM (BUCKETS INTEGER_VALUE)?
+    ;
+
+alterModifyDefaultBuckets
+    : DISTRIBUTED BY HASH identifierList DEFAULT BUCKETS INTEGER_VALUE
     ;
 
 refreshSchemeDesc

--- a/test/sql/test_expr_partition_default_bucket/R/test_expr_partition_default_bucket
+++ b/test/sql/test_expr_partition_default_bucket/R/test_expr_partition_default_bucket
@@ -1,0 +1,34 @@
+-- name: test_expr_partition_default_bucket
+CREATE TABLE expr_bucket_t (
+    k1 DATETIME,
+    v1 INT
+)
+PARTITION BY date_trunc('day', k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 3
+PROPERTIES(
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into expr_bucket_t values('2020-01-02', 1);
+-- result:
+-- !result
+show partitions from expr_bucket_t;
+-- result:
+[REGEX].*k1	3.*
+-- !result
+ALTER TABLE expr_bucket_t DISTRIBUTED BY HASH(k1) DEFAULT BUCKETS 8;
+-- result:
+-- !result
+SHOW CREATE TABLE expr_bucket_t;
+-- result:
+[REGEX].*BUCKETS 8.*
+-- !result
+insert into expr_bucket_t values('2020-01-01', 1);
+-- result:
+-- !result
+show partitions from expr_bucket_t;
+-- result:
+[REGEX].*k1	8.*
+.*k1	3.*
+-- !result

--- a/test/sql/test_expr_partition_default_bucket/T/test_expr_partition_default_bucket
+++ b/test/sql/test_expr_partition_default_bucket/T/test_expr_partition_default_bucket
@@ -1,0 +1,19 @@
+-- name: test_expr_partition_default_bucket
+CREATE TABLE expr_bucket_t (
+    k1 DATETIME,
+    v1 INT
+)
+PARTITION BY date_trunc('day', k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 3
+PROPERTIES(
+    "replication_num" = "1"
+);
+
+insert into expr_bucket_t values('2020-01-02', 1);
+show partitions from expr_bucket_t;
+
+ALTER TABLE expr_bucket_t DISTRIBUTED BY HASH(k1) DEFAULT BUCKETS 8;
+SHOW CREATE TABLE expr_bucket_t;
+
+insert into expr_bucket_t values('2020-01-01', 1);
+show partitions from expr_bucket_t;


### PR DESCRIPTION
Introduce a new synchronous ALTER TABLE clause to update the table’s default hash distribution bucket number without requiring a full schema change job.

## Why I'm doing:

Allow users to adjust the default bucket num for newly created partitions/tablets to better balance load and storage utilization. Avoid expensive asynchronous schema change when only the default distribution setting needs updating.

## What I'm doing:

Applies immediately if table is OLAP and current default distribution is hash-based. Logs an edit entry logModifyDefaultBucketNum for durability. Only affects future partition/tablet creations; existing ones remain unchanged.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a synchronous ALTER TABLE clause to update a table’s default hash distribution bucket number with full parse/analyze/execute support and WAL persist/replay.
> 
> - **SQL/Parser/AST**:
>   - Add `AlterTableModifyDefaultBucketsClause` and grammar `DISTRIBUTED BY HASH (...) DEFAULT BUCKETS N`.
>   - Build AST in `AstBuilder` and wire visitor in `AstVisitorExtendInterface`.
> - **Analyzer**:
>   - Validate OLAP table, hash distribution, matching columns, and `bucketNum > 0` in `AlterTableClauseAnalyzer`.
> - **Execution**:
>   - Implement handler in `AlterJobExecutor` to synchronously set `HashDistributionInfo` bucket num on table default distribution and persist change.
> - **Persistence/WAL**:
>   - Add opcode `OP_MODIFY_DEFAULT_BUCKET_NUM`; implement logging (`EditLog.logModifyDefaultBucketNum`), deserialization mapping, and replay in `LocalMetastore`.
>   - Update `TableProperty.buildProperty` switch to recognize the new op.
> - **Grammar**:
>   - Extend `StarRocks.g4` to support the new ALTER syntax.
> - **Tests**:
>   - Add SQL tests verifying default bucket change affects new partitions while existing remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8594a81d8580c1fc02bee0a1ec8d2036acb8aa1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->