### PR TITLE
[Refactor] Remove poco_connection_pool_mem_tracker

### DIFF
--- a/be/src/fs/s3/poco_common.cpp
+++ b/be/src/fs/s3/poco_common.cpp
@@ -92,7 +92,6 @@ HTTPSessionPtr makeHTTPSessionImpl(const std::string& host, Poco::UInt16 port, b
 }
 
 EndpointHTTPSessionPool::Base::ObjectPtr EndpointHTTPSessionPool::allocObject() {
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
     auto session = makeHTTPSessionImpl(_host, _port, _is_https, true);
     return session;
 }

--- a/be/src/fs/s3/poco_common.h
+++ b/be/src/fs/s3/poco_common.h
@@ -68,9 +68,7 @@ class EndpointHTTPSessionPool : public PoolBase<Poco::Net::HTTPClientSession> {
 public:
     using Base = PoolBase<Poco::Net::HTTPClientSession>;
     EndpointHTTPSessionPool(std::string host, uint16_t port, bool is_https)
-            : Base(ENDPOINT_POOL_SIZE), _host(std::move(host)), _port(port), _is_https(is_https) {
-        _mem_tracker = GlobalEnv::GetInstance()->poco_connection_pool_mem_tracker();
-    }
+            : Base(ENDPOINT_POOL_SIZE), _host(std::move(host)), _port(port), _is_https(is_https) {}
 
 private:
     ObjectPtr allocObject() override;
@@ -80,7 +78,6 @@ private:
     const std::string _host;
     const uint16_t _port;
     const bool _is_https;
-    MemTracker* _mem_tracker = nullptr;
 };
 
 class HTTPSessionPools {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -241,7 +241,6 @@ Status GlobalEnv::_init_mem_tracker() {
     _consistency_mem_tracker =
             regist_tracker(MemTrackerType::CONSISTENCY, consistency_mem_limit, process_mem_tracker());
     _datacache_mem_tracker = regist_tracker(MemTrackerType::DATACACHE, -1, process_mem_tracker());
-    _poco_connection_pool_mem_tracker = regist_tracker(MemTrackerType::POCO_CONNECTION_POOL, -1, process_mem_tracker());
     _replication_mem_tracker = regist_tracker(MemTrackerType::REPLICATION, -1, process_mem_tracker());
 
     MemChunkAllocator::init_metrics();

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -160,7 +160,6 @@ public:
     MemTracker* consistency_mem_tracker() { return _consistency_mem_tracker.get(); }
     MemTracker* replication_mem_tracker() { return _replication_mem_tracker.get(); }
     MemTracker* datacache_mem_tracker() { return _datacache_mem_tracker.get(); }
-    MemTracker* poco_connection_pool_mem_tracker() { return _poco_connection_pool_mem_tracker.get(); }
     MemTracker* jemalloc_metadata_traker() { return _jemalloc_metadata_tracker.get(); }
     std::shared_ptr<MemTracker> get_mem_tracker_by_type(MemTrackerType type);
     std::vector<std::shared_ptr<MemTracker>> mem_trackers() const;
@@ -234,9 +233,6 @@ private:
 
     // The memory used for datacache
     std::shared_ptr<MemTracker> _datacache_mem_tracker;
-
-    // The memory used for poco connection pool
-    std::shared_ptr<MemTracker> _poco_connection_pool_mem_tracker;
 
     std::map<MemTrackerType, std::shared_ptr<MemTracker>> _mem_tracker_map;
 };

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -72,7 +72,6 @@ static std::vector<std::pair<MemTrackerType, std::string>> s_mem_types = {
         {MemTrackerType::UPDATE, "update"},
         {MemTrackerType::CLONE, "clone"},
         {MemTrackerType::DATACACHE, "datacache"},
-        {MemTrackerType::POCO_CONNECTION_POOL, "poco_connection_pool"},
         {MemTrackerType::REPLICATION, "replication"},
         {MemTrackerType::ROWSET_UPDATE_STATE, "rowset_update_state"},
         {MemTrackerType::INDEX_CACHE, "index_cache"},

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -111,7 +111,6 @@ enum class MemTrackerType {
     UPDATE,
     CLONE,
     DATACACHE,
-    POCO_CONNECTION_POOL,
     REPLICATION,
     ROWSET_UPDATE_STATE,
     INDEX_CACHE,


### PR DESCRIPTION
## Why I'm doing:

The poco_connection_pool does not consume much memory, and the current memory statistics method is also invalid, so it should simply be removed.

## What I'm doing:

Remove poco_connection_pool_mem_tracker

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
