### PR TITLE
[Enhancement] Avoid additional lz4 compression on bitshuffle encode page

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -836,12 +836,14 @@ CONF_Bool(bitmap_filter_enable_not_equal, "false");
 // storage format.
 CONF_mInt16(storage_format_version, "2");
 
-// IMPORTANT NOTE: changing this config to 1 must require all BEs to be upgraded to new version,
+// IMPORTANT NOTE: changing this config to other value must require all BEs to be upgraded to new version,
 // which support this config.
 // DO NOT change this config unless you known how.
 // 0 for BITSHUFFLE_NULL
 // 1 for LZ4_NULL
+// 3 for BITSHUFFLE_PLAIN_NULL
 CONF_mInt16(null_encoding, "0");
+CONF_mBool(enable_bitshuffle_plain_encoding, "false");
 
 // Do pre-aggregate if effect greater than the factor, factor range:[1-100].
 CONF_Int16(pre_aggregate_factor, "80");
@@ -871,9 +873,6 @@ CONF_mInt16(tablet_max_versions, "1000");
 
 // The maximum number of pending versions allowed for a primary key tablet
 CONF_mInt32(tablet_max_pending_versions, "1000");
-
-// NOTE: it will be deleted.
-CONF_mBool(enable_bitmap_union_disk_format_with_set, "false");
 
 // pipeline poller timeout guard
 CONF_mInt64(pipeline_poller_timeout_guard_ms, "-1");

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -199,6 +199,7 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     _del_vec_filter_counter = ADD_CHILD_COUNTER(_runtime_profile, "DelVecFilterRows", TUnit::UNIT, segment_read_name);
     _chunk_copy_timer = ADD_CHILD_TIMER(_runtime_profile, "ChunkCopy", segment_read_name);
     _decompress_timer = ADD_CHILD_TIMER(_runtime_profile, "DecompressT", segment_read_name);
+    _decode_page_timer = ADD_CHILD_TIMER(_runtime_profile, "DecodePageT", segment_read_name);
     _rowsets_read_count = ADD_CHILD_COUNTER(_runtime_profile, "RowsetsReadCount", TUnit::UNIT, segment_read_name);
     _segments_read_count = ADD_CHILD_COUNTER(_runtime_profile, "SegmentsReadCount", TUnit::UNIT, segment_read_name);
     _total_columns_data_page_count =
@@ -722,6 +723,7 @@ void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_io_timer, _reader->stats().io_ns);
     COUNTER_UPDATE(_read_compressed_counter, _reader->stats().compressed_bytes_read_request);
     COUNTER_UPDATE(_decompress_timer, _reader->stats().decompress_ns);
+    COUNTER_UPDATE(_decode_page_timer, _reader->stats().decode_page_ns);
     COUNTER_UPDATE(_read_uncompressed_counter, _reader->stats().uncompressed_bytes_read);
     COUNTER_UPDATE(_bytes_read_counter, _reader->stats().bytes_read);
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -165,6 +165,7 @@ private:
     RuntimeProfile::Counter* _io_timer = nullptr;
     RuntimeProfile::Counter* _read_compressed_counter = nullptr;
     RuntimeProfile::Counter* _decompress_timer = nullptr;
+    RuntimeProfile::Counter* _decode_page_timer = nullptr;
     RuntimeProfile::Counter* _read_uncompressed_counter = nullptr;
     RuntimeProfile::Counter* _raw_rows_counter = nullptr;
     RuntimeProfile::Counter* _del_vec_filter_counter = nullptr;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -227,6 +227,7 @@ struct OlapReaderStatistics {
     int64_t block_seek_num = 0;
     int64_t block_seek_ns = 0;
 
+    int64_t decode_page_ns = 0;
     int64_t decode_dict_ns = 0;
     int64_t decode_dict_count = 0; // rows * columns
     int64_t late_materialize_ns = 0;

--- a/be/src/storage/rowset/bitshuffle_wrapper.h
+++ b/be/src/storage/rowset/bitshuffle_wrapper.h
@@ -43,7 +43,36 @@ namespace starrocks::bitshuffle {
 
 // See <bitshuffle.h> for documentation on these functions.
 size_t compress_lz4_bound(size_t size, size_t elem_size, size_t block_size);
-int64_t compress_lz4(void* in, void* out, size_t size, size_t elem_size, size_t block_size);
-int64_t decompress_lz4(void* in, void* out, size_t size, size_t elem_size, size_t block_size);
+int64_t compress_lz4(const void* in, void* out, size_t size, size_t elem_size, size_t block_size);
+int64_t decompress_lz4(const void* in, void* out, size_t size, size_t elem_size, size_t block_size);
+
+int64_t encode(const void* in, void* out, const size_t size, const size_t elem_size, size_t block_size);
+int64_t decode(const void* in, void* out, const size_t size, const size_t elem_size, size_t block_size);
 
 } // namespace starrocks::bitshuffle
+
+namespace starrocks {
+struct BitShuffleEncodingLz4 {
+    static size_t encoding_size(size_t size, size_t elem_size, size_t block_size) {
+        return bitshuffle::compress_lz4_bound(size, elem_size, block_size);
+    }
+    static size_t encode(const void* in, void* out, size_t size, size_t elem_size, size_t block_size) {
+        return bitshuffle::compress_lz4(in, out, size, elem_size, block_size);
+    }
+    static size_t decode(const void* in, void* out, size_t size, size_t elem_size, size_t block_size) {
+        return bitshuffle::decompress_lz4(in, out, size, elem_size, block_size);
+    }
+};
+
+struct BitShuffleEncodingPlain {
+    static size_t encoding_size(size_t size, size_t elem_size, size_t block_size) { return size * elem_size; }
+
+    static size_t encode(const void* in, void* out, size_t size, size_t elem_size, size_t block_size) {
+        return bitshuffle::encode(in, out, size, elem_size, block_size);
+    }
+
+    static size_t decode(const void* in, void* out, size_t size, size_t elem_size, size_t block_size) {
+        return bitshuffle::decode(in, out, size, elem_size, block_size);
+    }
+};
+} // namespace starrocks

--- a/be/src/storage/rowset/dict_page.cpp
+++ b/be/src/storage/rowset/dict_page.cpp
@@ -24,7 +24,6 @@
 #include "storage/range.h"
 #include "storage/rowset/bitshuffle_page.h"
 #include "util/slice.h" // for Slice
-#include "util/unaligned_access.h"
 
 namespace starrocks {
 

--- a/be/test/exprs/bitmap_functions_test.cpp
+++ b/be/test/exprs/bitmap_functions_test.cpp
@@ -531,7 +531,6 @@ TEST_F(VecBitmapFunctionsTest, bitmapToStringTest) {
     BitmapValue b4;
 
     // enable bitmap with SET.
-    config::enable_bitmap_union_disk_format_with_set = true;
     b3.add(1);
     b3.add(2);
     b3.add(3);
@@ -561,7 +560,6 @@ TEST_F(VecBitmapFunctionsTest, bitmapToStringTest) {
         ASSERT_EQ("1,2,3,4", p->get_slice(0).to_string());
         ASSERT_EQ("4,5,6,7", p->get_slice(1).to_string());
     }
-    config::enable_bitmap_union_disk_format_with_set = false;
 }
 
 TEST_F(VecBitmapFunctionsTest, bitmapFromStringTest) {

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -54,7 +54,10 @@ enum EncodingTypePB {
     RLE = 4;
     DICT_ENCODING = 5;
     BIT_SHUFFLE = 6;
-    FOR_ENCODING = 7; // Frame-Of-Reference
+    // Frame-Of-Reference
+    FOR_ENCODING = 7;
+    // Only encoding by bit shuffle, do not compress
+    BIT_SHUFFLE_PLAIN = 8;
 }
 
 enum PageTypePB {
@@ -69,6 +72,7 @@ enum NullEncodingPB {
     BITSHUFFLE_NULL = 0;
     LZ4_NULL = 1;
     RLE_NULL = 2;
+    BITSHUFFLE_PLAIN_NULL = 3;
 }
 
 message DataPageFooterPB {


### PR DESCRIPTION
## Why I'm doing:

Currently, we perform LZ4 compression on all pages. However, our bitshuffle encoding undergoes an additional round of LZ4 compression. For bitshuffle pages, this presents the following issues:
1. External LZ4 compression typically does not yield better compression results.
2. When reading bitshuffle-encoded pages, two decompression steps are required.

These steps introduce unnecessary CPU overhead.

## What I'm doing:

This PR introduces the BITSHUFFLE_PLAIN encoding format, which only invokes bitshuffle during the encoding phase.  

```
create table tmp1 as select lo_orderkey,lo_linenumber from lineorder;

update information_schema.be_configs set value = "true" where name= "enable_bitshuffle_plain_encoding";
update information_schema.be_configs set value = "3" where name= "null_encoding";
create table tmp3 as select lo_orderkey,lo_linenumber from lineorder;

show data;
```

```
| tmp1           | 2.139 GB       | 9                   |
| tmp3           | 2.055 GB       | 9                   |
```


```
set pipeline_dop=1;

```
```
select count(lo_orderkey),count(lo_linenumber) from tmp1;
```
```
mysql> select count(lo_orderkey),count(lo_linenumber) from tmp1;
+--------------------+----------------------+
| count(lo_orderkey) | count(lo_linenumber) |
+--------------------+----------------------+
|          600037902 |            600037902 |
+--------------------+----------------------+
1 row in set (1.55 sec)

mysql> select count(lo_orderkey),count(lo_linenumber) from tmp3;
+--------------------+----------------------+
| count(lo_orderkey) | count(lo_linenumber) |
+--------------------+----------------------+
|          600037902 |            600037902 |
+--------------------+----------------------+
1 row in set (1.24 sec)
```

```
profile for tmp1
                 - DecodePageT: 1s54ms
                   - __MAX_OF_DecodePageT: 1s70ms
                   - __MIN_OF_DecodePageT: 1s43ms
                 - DecompressT: 0ns
prrofile for tmp3
                 - DecodePageT: 423.214ms
                   - __MAX_OF_DecodePageT: 425.014ms
                   - __MIN_OF_DecodePageT: 421.233ms
                 - DecompressT: 352.444ms
                   - __MAX_OF_DecompressT: 355.444ms
                   - __MIN_OF_DecompressT: 350.746ms
```



Because a new storage format has been added. This format is disabled by default. This PR will be backported to versions 3.5 and 4.0, and enabled by default in the next release.



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce BIT_SHUFFLE_PLAIN (bitshuffle-only) encoding with toggle, add BITSHUFFLE_PLAIN_NULL, wire through builders/decoders/proto, add decode-page timing metric, and remove obsolete bitmap config references.
> 
> - **Storage/Encoding**:
>   - Add `BIT_SHUFFLE_PLAIN` encoding and `BITSHUFFLE_PLAIN_NULL` null encoding; implement builders/decoders (`BitshufflePageBuilderTraits`, `BitShuffleDataDecoderPlain`), and support in `EncodingInfo` maps and resolution (guarded by `config::enable_bitshuffle_plain_encoding`).
>   - Extend bitshuffle wrapper with plain `encode/decode` APIs; refactor null flag encoding in `ColumnWriter`.
>   - Handle new encodings in page parsing/decoding (`StoragePageDecoder`, `parsed_page.cpp`).
> - **Profiling/Stats**:
>   - Add decode-page timer/counter: `DecodePageT` with `stats.decode_page_ns`; update `page_io` to time `StoragePageDecoder::decode_page`; include in `OlapChunkSource` profile.
> - **Config/Proto**:
>   - Add `enable_bitshuffle_plain_encoding` and support `null_encoding=3 (BITSHUFFLE_PLAIN_NULL)`; adjust `null_encoding` note.
>   - Update `segment.proto`: add `BIT_SHUFFLE_PLAIN` and `BITSHUFFLE_PLAIN_NULL` enums.
> - **Cleanup/Tests**:
>   - Remove `enable_bitmap_union_disk_format_with_set` usages from tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9f0fbad57a4dfe5fdf04574c625650247f0761c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->