### PR TITLE
[Tool] Support compilation on Mac 5: fix protobuf & leveldb build

### DIFF
--- a/build-mac/patch/leveldb_build_detect_platform.patch
+++ b/build-mac/patch/leveldb_build_detect_platform.patch
@@ -1,0 +1,26 @@
+--- a/build_detect_platform
++++ b/build_detect_platform
+@@ -154,6 +154,16 @@
+     rm -f $CXXOUTPUT 2>/dev/null
+
+     # Test if gcc SSE 4.2 is supported
++    # First check if we're on x86/x86_64 architecture before testing SSE
++    ARCH=`$CXX -dumpmachine 2>/dev/null | cut -d'-' -f1`
++    case "$ARCH" in
++      x86_64|i386|i686)
++        # Only test SSE on x86/x86_64 platforms
++        ;;
++      *)
++        echo "Non-x86 architecture detected ($ARCH), skipping SSE detection"
++        PLATFORM_SSEFLAGS=""
++        ;;
++    esac
+     $CXX $CXXFLAGS -x c++ - -o $CXXOUTPUT -msse4.2 2>/dev/null  <<EOF
+       int main() {}
+ EOF
+@@ -161,6 +168,7 @@
+         PLATFORM_SSEFLAGS="-msse4.2"
+     fi
+
+     rm -f $CXXOUTPUT 2>/dev/null
+ fi


### PR DESCRIPTION
## Why I'm doing:
For https://github.com/StarRocks/starrocks/issues/30438

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches protobuf to autotools with a libc++ hash shim and rebuilds leveldb via Makefile with SSE disabled on non‑x86; adds corresponding patch and URL fix.
> 
> - **Tooling (macOS third-party builder)**
>   - **Protobuf (`build-mac/build_thirdparty.sh`)**:
>     - Switch build from CMake to autotools for `protobuf-3.14.0`.
>     - Add and compile `src/google/protobuf/internal/hash_memory_impl.cc` shim to provide `std::__1::__hash_memory`; link into `libprotobuf.a`.
>   - **LevelDB (`build-mac/build_thirdparty.sh`)**:
>     - Change source URL to `v$LEVELDB_VERSION`.
>     - Replace CMake build with Makefile build; force `PLATFORM_SSEFLAGS=""` and use `CC=cc CXX=c++`; manually install headers and `out-static/libleveldb.a`.
>     - Apply patch to skip SSE detection on non‑x86 architectures.
>   - **Patch added**:
>     - `build-mac/patch/leveldb_build_detect_platform.patch`: guards SSE detection by architecture and sets empty SSE flags on non‑x86.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8d5bf0edec5c6409e59db5ddb7f77b3ed92a080. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->