### PR TITLE
[BugFix] Fix nullptr exception during remove expried load job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -400,11 +400,13 @@ public class LoadMgr implements MemoryTrackable {
 
         // 2. remove from dbIdToLabelToLoadJobs
         Map<String, List<LoadJob>> labelToLoadJobs = dbIdToLabelToLoadJobs.get(dbId);
-        List<LoadJob> sameLabelJobs = labelToLoadJobs.get(label);
-        if (sameLabelJobs != null) {
-            sameLabelJobs.remove(job);
-            if (sameLabelJobs.isEmpty()) {
-                labelToLoadJobs.remove(label);
+        if (labelToLoadJobs != null) {
+            List<LoadJob> sameLabelJobs = labelToLoadJobs.get(label);
+            if (sameLabelJobs != null) {
+                sameLabelJobs.remove(job);
+                if (sameLabelJobs.isEmpty()) {
+                    labelToLoadJobs.remove(label);
+                }
             }
             if (labelToLoadJobs.isEmpty()) {
                 dbIdToLabelToLoadJobs.remove(dbId);


### PR DESCRIPTION
## Why I'm doing:
Some users have encountered an issue where `labelToLoadJobs` is null, which causes an exception to be thrown when removing expired load jobs. This prevents the normal recycling of expired load jobs and leads to high memory usage in the FE.
The root cause has not yet been identified. A null check will be added to prevent the FE from failing to recycle memory properly.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
