### PR TITLE
[BugFix] use fixed thread pool size for starmgr grpc executor

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -3330,7 +3330,6 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Whether to use the Service Account that is bound to your Compute Engine.
 - Introduced in: v3.5.1
 
-<!--
 ##### starmgr_grpc_timeout_seconds
 
 - Default: 5
@@ -3339,7 +3338,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: Yes
 - Description:
 - Introduced in: -
--->
+
+##### starmgr_grpc_server_max_worker_threads
+
+- Default: 1024
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The maximum number of worker threads that are used by the grpc server in the FE starmgr module.
+- Introduced in: v4.0.0, v3.5.8
 
 ##### lake_compaction_score_selector_min_score
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2856,6 +2856,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int starmgr_grpc_timeout_seconds = 5;
 
+    @ConfField(mutable = true, comment = "Number of threads for handling gRPC server I/O")
+    public static int starmgr_grpc_server_max_worker_threads = 1024;
+
     @ConfField(mutable = true)
     public static int star_client_read_timeout_seconds = 15;
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a fixed-size gRPC executor for StarMgr with a new configurable `starmgr_grpc_server_max_worker_threads` and wire it into server startup and config refresh.
> 
> - **FE StarMgr gRPC server**:
>   - Add `Config.starmgr_grpc_server_max_worker_threads` (mutable `Int`, default `1024`).
>   - Create a fixed-size `ThreadPoolExecutor` via `ThreadPoolManager.newDaemonFixedThreadPool(...)` for gRPC I/O; enable core thread timeout.
>   - Pass the executor to `StarManagerServer.start(...)` and dynamically resize it on config refresh.
> - **Docs**:
>   - Document `starmgr_grpc_server_max_worker_threads` in `docs/en/administration/management/FE_configuration.md` with default, type, mutability, and description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daad9db00cd7b7025243988926615b7cc1c854bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->