### PR TITLE
[BugFix] Fix create partitioned mv with NullPointerException

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionExprResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionExprResolver.java
@@ -315,7 +315,8 @@ public class MVPartitionExprResolver {
                             if (item instanceof SlotRef) {
                                 SlotRef result = (SlotRef) item;
                                 TableName actTableName = result.getTblNameWithoutAnalyzed();
-                                if (result.getColumnName() != null && result.getColumnName().equalsIgnoreCase(slot.getColumnName())
+                                if (result.getColumnName() != null
+                                        && result.getColumnName().equalsIgnoreCase(slot.getColumnName())
                                         && (expTableName == null || expTableName.equals(actTableName))) {
                                     return visitExpr(context.withExpr(result).withRelation(relation));
                                 }
@@ -324,7 +325,7 @@ public class MVPartitionExprResolver {
                             if (expTableName != null && expTableName.isFullyQualified()) {
                                 continue;
                             }
-                            if (selectListItem.getAlias() != null && selectListItem.getAlias().equalsIgnoreCase(slot.getColumnName())) {
+                            if (selectListItem.getAlias().equalsIgnoreCase(slot.getColumnName())) {
                                 return visitExpr(context.withExpr(selectListItem.getExpr()).withRelation(relation));
                             }
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionExprResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionExprResolver.java
@@ -315,7 +315,7 @@ public class MVPartitionExprResolver {
                             if (item instanceof SlotRef) {
                                 SlotRef result = (SlotRef) item;
                                 TableName actTableName = result.getTblNameWithoutAnalyzed();
-                                if (result.getColumnName().equalsIgnoreCase(slot.getColumnName())
+                                if (result.getColumnName() != null && result.getColumnName().equalsIgnoreCase(slot.getColumnName())
                                         && (expTableName == null || expTableName.equals(actTableName))) {
                                     return visitExpr(context.withExpr(result).withRelation(relation));
                                 }
@@ -324,7 +324,7 @@ public class MVPartitionExprResolver {
                             if (expTableName != null && expTableName.isFullyQualified()) {
                                 continue;
                             }
-                            if (selectListItem.getAlias().equalsIgnoreCase(slot.getColumnName())) {
+                            if (selectListItem.getAlias() != null && selectListItem.getAlias().equalsIgnoreCase(slot.getColumnName())) {
                                 return visitExpr(context.withExpr(selectListItem.getExpr()).withRelation(relation));
                             }
                         }
@@ -337,7 +337,7 @@ public class MVPartitionExprResolver {
                     SlotRef slot = context.getSlotRef();
                     if (slot.getTblNameWithoutAnalyzed() != null) {
                         String tableName = slot.getTblNameWithoutAnalyzed().getTbl();
-                        if (!node.getAlias().getTbl().equalsIgnoreCase(tableName)) {
+                        if (node.getAlias() != null && !node.getAlias().getTbl().equalsIgnoreCase(tableName)) {
                             return null;
                         }
                         slot = (SlotRef) slot.clone();
@@ -518,7 +518,7 @@ public class MVPartitionExprResolver {
                     if (slot.getTblNameWithoutAnalyzed() != null) {
                         String tableName = slot.getTblNameWithoutAnalyzed().getTbl();
                         String cteName = node.getAlias() != null ? node.getAlias().getTbl() : node.getName();
-                        if (!cteName.equalsIgnoreCase(tableName)) {
+                        if (cteName != null && !cteName.equalsIgnoreCase(tableName)) {
                             return null;
                         }
                         slot = (SlotRef) slot.clone();


### PR DESCRIPTION
## Why I'm doing:

```
java.lang.NullPointerException: Cannot invoke "com.starrocks.sql.ast.expression.TableName.getTbl()" because the return value of "com.starrocks.sql.ast.SubqueryRelation.getAlias()" is null
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$2.visitSubqueryRelation(MVPartitionExprResolver.java:340) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$2.visitSubqueryRelation(MVPartitionExprResolver.java:283) ~[fe-core-main.jar:?]
        at com.starrocks.sql.ast.SubqueryRelation.accept(SubqueryRelation.java:73) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$1.visitRelation(MVPartitionExprResolver.java:227) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$1.visitSlot(MVPartitionExprResolver.java:268) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$1.visitSlot(MVPartitionExprResolver.java:204) ~[fe-core-main.jar:?]
        at com.starrocks.sql.ast.expression.SlotRef.accept(SlotRef.java:467) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$2.visitExpr(MVPartitionExprResolver.java:299) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$2.lambda$visitSetOp$8(MVPartitionExprResolver.java:505) ~[fe-core-main.jar:?]
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[?:?]
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596) ~[?:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$2.visitSetOp(MVPartitionExprResolver.java:511) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$2.visitSetOp(MVPartitionExprResolver.java:283) ~[fe-core-main.jar:?]
        at com.starrocks.sql.ast.AstVisitorExtendInterface.visitUnion(AstVisitorExtendInterface.java:1218) ~[fe-core-main.jar:?]
        at com.starrocks.sql.ast.UnionRelation.accept(UnionRelation.java:31) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$2.visitRelation(MVPartitionExprResolver.java:291) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$2.visitCTE(MVPartitionExprResolver.java:528) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$2.visitCTE(MVPartitionExprResolver.java:283) ~[fe-core-main.jar:?]
        at com.starrocks.sql.ast.CTERelation.accept(CTERelation.java:81) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$1.visitRelation(MVPartitionExprResolver.java:227) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$1.visitSlot(MVPartitionExprResolver.java:268) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$1.visitSlot(MVPartitionExprResolver.java:204) ~[fe-core-main.jar:?]
        at com.starrocks.sql.ast.expression.SlotRef.accept(SlotRef.java:467) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$2.visitExpr(MVPartitionExprResolver.java:299) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$2.visitSelect(MVPartitionExprResolver.java:328) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$2.visitSelect(MVPartitionExprResolver.java:283) ~[fe-core-main.jar:?]
        at com.starrocks.sql.ast.SelectRelation.accept(SelectRelation.java:230) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$1.visitRelation(MVPartitionExprResolver.java:227) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$1.visitSlot(MVPartitionExprResolver.java:261) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver$1.visitSlot(MVPartitionExprResolver.java:204) ~[fe-core-main.jar:?]
        at com.starrocks.sql.ast.expression.SlotRef.accept(SlotRef.java:467) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver.resolveMVPartitionExpr(MVPartitionExprResolver.java:539) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver.getMVPartitionExprs(MVPartitionExprResolver.java:599) ~[fe-core-main.jar:?]
        at com.starrocks.mv.analyzer.MVPartitionExprResolver.getMVPartitionExprsChecked(MVPartitionExprResolver.java:559) ~[fe-core-main.jar:?]
        at com.starrocks.server.LocalMetastore.createMaterializedView(LocalMetastore.java:3119) ~[fe-core-main.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.lambda$visitCreateMaterializedViewStatement$12(DDLStmtExecutor.java:379) ~[fe-core-main.jar:?]
        at com.starrocks.common.ErrorReport.wrapWithRuntimeException(ErrorReport.java:118) ~[fe-core-main.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitCreateMaterializedViewStatement(DDLStmtExecutor.java:378) ~[fe-core-main.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitCreateMaterializedViewStatement(DDLStmtExecutor.java:210) ~[fe-core-main.jar:?]
        at com.starrocks.sql.ast.CreateMaterializedViewStatement.accept(CreateMaterializedViewStatement.java:371) ~[fe-core-main.jar:?]

```

## What I'm doing:

Add tests in : https://github.com/StarRocks/StarRocksTest/pull/10394


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
