### PR TITLE
[BugFix] Fix incorrect errmsg when dictionary has error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
@@ -23,6 +23,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
 import com.starrocks.common.ThreadPoolManager;
@@ -171,9 +172,9 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
         }
     }
 
-    public static boolean processDictionaryCacheInteranl(PProcessDictionaryCacheRequest request, String errMsg,
-                                                         List<TNetworkAddress> beNodes,
-                                                         List<PProcessDictionaryCacheResult> results) {
+    public static Pair<Boolean, String> processDictionaryCacheInteranl(PProcessDictionaryCacheRequest request,
+                                                                       List<TNetworkAddress> beNodes,
+                                                                       List<PProcessDictionaryCacheResult> results) {
         for (TNetworkAddress address : beNodes) {
             PProcessDictionaryCacheResult result = null;
             try {
@@ -182,19 +183,14 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
                 result = future.get();
             } catch (Exception e) {
                 LOG.warn(" processDictionaryCache failed in: " + address + " rpc error :" + e.getMessage());
-                if (errMsg != null) {
-                    errMsg = e.getMessage();
-                }
-                return true;
+                return new Pair<>(true, e.getMessage());
             }
 
             TStatusCode code = TStatusCode.findByValue(result.status.statusCode);
             if (code != TStatusCode.OK) {
                 LOG.warn(" processDictionaryCache failed in: " + address + " err msg " + result.status.errorMsgs);
-                if (errMsg != null) {
-                    errMsg = result.status.errorMsgs.size() == 0 ? "" : result.status.errorMsgs.get(0);
-                }
-                return true;
+                String errMsg = result.status.errorMsgs.size() == 0 ? "" : result.status.errorMsgs.get(0);
+                return new Pair<>(true, errMsg);
             }
 
             if (results != null) {
@@ -203,7 +199,7 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
         }
         LOG.info("finish processDictionaryCache dictionary id: {}, request type: {}",
                 request.dictId, request.txnId, request.type);
-        return false;
+        return new Pair<>(false, "");
     }
 
     public void createDictionary(CreateDictionaryStmt stmt, String catalogName, String dbName) throws DdlException {
@@ -291,7 +287,7 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
         List<TNetworkAddress> beNodes = Lists.newArrayList();
         fillBackendsOrComputeNodes(beNodes);
 
-        DictionaryMgr.processDictionaryCacheInteranl(request, null, beNodes, null);
+        DictionaryMgr.processDictionaryCacheInteranl(request, beNodes, null);
     }
 
     public void addDictionary(Dictionary dictionary) {
@@ -407,7 +403,7 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
         executor.submit(task);
     }
 
-    public Map<TNetworkAddress, PProcessDictionaryCacheResult> getDictionaryStatistic(Dictionary dictionary) {
+    public Pair<Map<TNetworkAddress, PProcessDictionaryCacheResult>, String> getDictionaryStatistic(Dictionary dictionary) {
         PProcessDictionaryCacheRequest request = new PProcessDictionaryCacheRequest();
         request.dictId = dictionary.getDictionaryId();
         request.type = PProcessDictionaryCacheRequestType.STATISTIC;
@@ -416,17 +412,18 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
         fillBackendsOrComputeNodes(beNodes);
 
         List<PProcessDictionaryCacheResult> results = Lists.newArrayList();
-        DictionaryMgr.processDictionaryCacheInteranl(request, null, beNodes, results);
+        Pair<Boolean, String> ret = DictionaryMgr.processDictionaryCacheInteranl(request, beNodes, results);
         Map<TNetworkAddress, PProcessDictionaryCacheResult> resultMap = new HashMap<>();
         if (results.size() < beNodes.size()) {
-            return resultMap;
+            Preconditions.checkState(ret.first);
+            return new Pair<>(null, ret.second);
         }
         Preconditions.checkState(results.size() == beNodes.size());
 
         for (int i = 0; i < results.size(); i++) {
             resultMap.put(beNodes.get(i), results.get(i));
         }
-        return resultMap;
+        return new Pair<>(resultMap, "");
     }
 
     public List<List<String>> getAllInfo(String dictionaryName) throws Exception {
@@ -441,8 +438,15 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
 
                 allInfo.add(dictionary.getInfo());
 
-                Map<TNetworkAddress, PProcessDictionaryCacheResult> resultMap = getDictionaryStatistic(dictionary);
+                Pair<Map<TNetworkAddress, PProcessDictionaryCacheResult>, String> ret = getDictionaryStatistic(dictionary);
+                Map<TNetworkAddress, PProcessDictionaryCacheResult> resultMap = ret.first;
+                String errMsg = ret.second;
+                if (!errMsg.isEmpty()) {
+                    allInfo.get(allInfo.size() - 1).add("Can not get Memory info, errMsg: " + errMsg);
+                    continue;
+                }
 
+                Preconditions.checkState(resultMap != null);
                 String memoryUsage = "";
                 for (Map.Entry<TNetworkAddress, PProcessDictionaryCacheResult> result : resultMap.entrySet()) {
                     TNetworkAddress address = result.getKey();
@@ -679,7 +683,9 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
             request.txnId = txnId;
             request.type = PProcessDictionaryCacheRequestType.BEGIN;
 
-            error = DictionaryMgr.processDictionaryCacheInteranl(request, errMsg, beNodes, null);
+            Pair<Boolean, String> ret = DictionaryMgr.processDictionaryCacheInteranl(request, beNodes, null);
+            error = ret.first;
+            errMsg = ret.second;
         }
 
         private void commit() {
@@ -696,7 +702,9 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
             request.txnId = txnId;
             request.type = PProcessDictionaryCacheRequestType.COMMIT;
 
-            error = DictionaryMgr.processDictionaryCacheInteranl(request, errMsg, beNodes, null);
+            Pair<Boolean, String> ret = DictionaryMgr.processDictionaryCacheInteranl(request, beNodes, null);
+            error = ret.first;
+            errMsg = ret.second;
         }
 
         private void finish(long dictionaryId) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
@@ -442,7 +442,7 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
                 Map<TNetworkAddress, PProcessDictionaryCacheResult> resultMap = ret.first;
                 String errMsg = ret.second;
                 if (resultMap == null) {
-                    allInfo.get(allInfo.size() - 1).add("Can not get Memory info, errMsg: " + errMsg);
+                    allInfo.get(allInfo.size() - 1).add("Can not get memory info, errMsg: " + errMsg);
                     continue;
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
@@ -441,12 +441,11 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
                 Pair<Map<TNetworkAddress, PProcessDictionaryCacheResult>, String> ret = getDictionaryStatistic(dictionary);
                 Map<TNetworkAddress, PProcessDictionaryCacheResult> resultMap = ret.first;
                 String errMsg = ret.second;
-                if (!errMsg.isEmpty()) {
+                if (resultMap == null) {
                     allInfo.get(allInfo.size() - 1).add("Can not get Memory info, errMsg: " + errMsg);
                     continue;
                 }
 
-                Preconditions.checkState(resultMap != null);
                 String memoryUsage = "";
                 for (Map.Entry<TNetworkAddress, PProcessDictionaryCacheResult> result : resultMap.entrySet()) {
                     TNetworkAddress address = result.getKey();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
@@ -52,7 +52,6 @@ public class DictionaryMgrTest {
     private List<Backend> backends = Arrays.asList(new Backend(1, "127.0.0.1", 1234));
     private List<ComputeNode> computeNodes = Arrays.asList(new ComputeNode(2, "127.0.0.2", 1235));
 
-    @Mocked
     private DictionaryMgr dictionaryMgr = new DictionaryMgr();
 
     @BeforeEach

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
@@ -184,7 +184,7 @@ public class DictionaryMgrTest {
 
         List<List<String>> allInfo = localDictionaryMgr.getAllInfo("dict");
         Assertions.assertTrue(
-                allInfo.get(0).get(allInfo.get(0).size() - 1).contains("Can not get Memory info, errMsg: test error"));
+                allInfo.get(0).get(allInfo.get(0).size() - 1).contains("Can not get memory info, errMsg: test error"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
@@ -301,11 +301,18 @@ public class DictionaryMgrTest {
             }
         };
 
-        DictionaryMgr localDictionaryMgr = new DictionaryMgr();
+        final DictionaryMgr localDictionaryMgr = new DictionaryMgr();
         DictionaryMgr.RefreshDictionaryCacheWorker worker =
                 localDictionaryMgr.new RefreshDictionaryCacheWorker(dictionary, 1L);
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public DictionaryMgr getDictionaryMgr() {
+                return localDictionaryMgr;
+            }
+        };
         
         // Test that worker can be instantiated and has proper initialization
         Assertions.assertNotNull(worker);
+        worker.run();
     }
 }


### PR DESCRIPTION
## What I'm doing:
This pr fix two issues:
1. Fix FE throw NPE if some CN/BE node has been dead when SHOW DICTIONARY.
2. Fix errmsg loss when the refresh dictionary cache has failed.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates dictionary cache RPC errors via return values and surfaces them in SHOW DICTIONARY, preventing NPEs when nodes fail.
> 
> - **Catalog/DictionaryMgr**:
>   - Change `processDictionaryCacheInteranl` to return `Pair<Boolean, String>` with explicit error message; update all call sites (`clearDictionaryCache`, refresh worker `begin/commit`).
>   - Update `getDictionaryStatistic` to return `Pair<Map<TNetworkAddress, PProcessDictionaryCacheResult>, String>`; propagate errors and validate results.
>   - Enhance `getAllInfo` to handle missing stats and append error message instead of risking NPE.
> - **Tests**:
>   - Add unit tests for error surfacing and robustness: show dictionary error handling, clear cache, statistic success, process exception path, and refresh worker flow; update mocks accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c221986ba5c4578ef916fcf1fc4d642f62695be7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->