### PR TITLE
[Enhancement] Add task run execute timeout checker

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -414,8 +414,8 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "task run ttl")
     public static int task_runs_ttl_second = 7 * 24 * 3600;     // 7 day
 
-    @ConfField(mutable = true, comment = "task run execute timeout, default 12 hours")
-    public static int task_runs_timeout_second = 12 * 3600;     // 12 hour
+    @ConfField(mutable = true, comment = "task run execute timeout, default 4 hours")
+    public static int task_runs_timeout_second = 4 * 3600;     // 4 hour
 
     @ConfField(mutable = true, comment = "max number of task run history. ")
     public static int task_runs_max_history_number = 10000;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -414,6 +414,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "task run ttl")
     public static int task_runs_ttl_second = 7 * 24 * 3600;     // 7 day
 
+    @ConfField(mutable = true, comment = "task run execute timeout, default 12 hours")
+    public static int task_runs_timeout_second = 12 * 3600;     // 12 hour
+
     @ConfField(mutable = true, comment = "max number of task run history. ")
     public static int task_runs_max_history_number = 10000;
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -218,7 +218,8 @@ public class TaskRun implements Comparable<TaskRun> {
                 }
             }
         }
-        return defaultTimeoutS;
+        // The timeout of task run should not be longer than the ttl of task runs and task
+        return Math.min(Math.min(defaultTimeoutS, Config.task_runs_ttl_second), Config.task_ttl_second);
     }
 
     public Map<String, String> refreshTaskProperties(ConnectContext ctx) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -203,7 +203,7 @@ public class TaskRun implements Comparable<TaskRun> {
     public int getExecuteTimeoutS() {
         // if `query_timeout`/`insert_timeout` is set in the execute option, use it
         int defaultTimeoutS = Config.task_runs_timeout_second;
-        if (properties != null ) {
+        if (properties != null) {
             for (Map.Entry<String, String> entry : properties.entrySet()) {
                 if (entry.getKey().equalsIgnoreCase(SessionVariable.QUERY_TIMEOUT)
                         || entry.getKey().equalsIgnoreCase(SessionVariable.INSERT_TIMEOUT)) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -60,6 +60,8 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 @TestMethodOrder(MethodName.class)
 public class TaskManagerTest {
 
@@ -70,6 +72,7 @@ public class TaskManagerTest {
     private static final ExecuteOption DEFAULT_MERGE_OPTION = makeExecuteOption(true, false);
     private static final ExecuteOption DEFAULT_NO_MERGE_OPTION = makeExecuteOption(false, false);
     private final TaskRunScheduler taskRunScheduler = new TaskRunScheduler();
+    private TaskRun taskRun;
 
     @BeforeEach
     public void setUp() {
@@ -86,6 +89,7 @@ public class TaskManagerTest {
 
             }
         };
+        taskRun = new TaskRun();
     }
 
     @BeforeAll
@@ -165,7 +169,7 @@ public class TaskManagerTest {
             }
             LOG.info("SubmitTaskRegularTest is waiting for TaskRunState retryCount:" + retryCount);
         }
-        Assertions.assertEquals(Constants.TaskRunState.SUCCESS, state);
+        assertEquals(Constants.TaskRunState.SUCCESS, state);
     }
 
     @Test
@@ -196,15 +200,15 @@ public class TaskManagerTest {
         queue.offer(taskRun4);
 
         TaskRunStatus get1 = queue.poll().getStatus();
-        Assertions.assertEquals(10, get1.getPriority());
+        assertEquals(10, get1.getPriority());
         TaskRunStatus get2 = queue.poll().getStatus();
-        Assertions.assertEquals(5, get2.getPriority());
-        Assertions.assertEquals(now, get2.getCreateTime());
+        assertEquals(5, get2.getPriority());
+        assertEquals(now, get2.getCreateTime());
         TaskRunStatus get3 = queue.poll().getStatus();
-        Assertions.assertEquals(5, get3.getPriority());
-        Assertions.assertEquals(now + 100, get3.getCreateTime());
+        assertEquals(5, get3.getPriority());
+        assertEquals(now + 100, get3.getCreateTime());
         TaskRunStatus get4 = queue.poll().getStatus();
-        Assertions.assertEquals(0, get4.getPriority());
+        assertEquals(0, get4.getPriority());
 
     }
 
@@ -240,8 +244,8 @@ public class TaskManagerTest {
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
         Assertions.assertTrue(taskRuns != null);
-        Assertions.assertEquals(1, taskRuns.size());
-        Assertions.assertEquals(10, taskRuns.get(0).getStatus().getPriority());
+        assertEquals(1, taskRuns.size());
+        assertEquals(10, taskRuns.get(0).getStatus().getPriority());
     }
 
     @Test
@@ -276,8 +280,8 @@ public class TaskManagerTest {
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
         Assertions.assertTrue(taskRuns != null);
-        Assertions.assertEquals(1, taskRuns.size());
-        Assertions.assertEquals(10, taskRuns.get(0).getStatus().getPriority());
+        assertEquals(1, taskRuns.size());
+        assertEquals(10, taskRuns.get(0).getStatus().getPriority());
 
     }
 
@@ -313,9 +317,9 @@ public class TaskManagerTest {
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
         Assertions.assertTrue(taskRuns != null);
-        Assertions.assertEquals(1, taskRuns.size());
+        assertEquals(1, taskRuns.size());
         TaskRun taskRun = taskRuns.get(0);
-        Assertions.assertEquals(now, taskRun.getStatus().getCreateTime());
+        assertEquals(now, taskRun.getStatus().getCreateTime());
     }
 
     @Test
@@ -350,9 +354,9 @@ public class TaskManagerTest {
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
         Assertions.assertTrue(taskRuns != null);
-        Assertions.assertEquals(1, taskRuns.size());
+        assertEquals(1, taskRuns.size());
         TaskRun taskRun = taskRuns.get(0);
-        Assertions.assertEquals(now, taskRun.getStatus().getCreateTime());
+        assertEquals(now, taskRun.getStatus().getCreateTime());
     }
 
     @Test
@@ -396,7 +400,7 @@ public class TaskManagerTest {
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         Collection<TaskRun> taskRuns = taskRunScheduler.getPendingTaskRunsByTaskId(taskId);
         Assertions.assertTrue(taskRuns != null);
-        Assertions.assertEquals(3, taskRuns.size());
+        assertEquals(3, taskRuns.size());
     }
 
     @Test
@@ -423,7 +427,7 @@ public class TaskManagerTest {
         taskManager.replayUpdateTaskRun(change1);
 
         TaskRunScheduler taskRunScheduler = taskManager.getTaskRunScheduler();
-        Assertions.assertEquals(1, taskRunScheduler.getRunningTaskCount());
+        assertEquals(1, taskRunScheduler.getRunningTaskCount());
     }
 
     @Test
@@ -451,8 +455,8 @@ public class TaskManagerTest {
             TaskRunStatusChange change1 = new TaskRunStatusChange(task.getId(), taskRun2.getStatus(),
                     Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
             taskManager.replayUpdateTaskRun(change1);
-            Assertions.assertEquals(1, taskRunScheduler.getRunningTaskCount());
-            Assertions.assertEquals(1, taskRunScheduler.getPendingQueueCount());
+            assertEquals(1, taskRunScheduler.getRunningTaskCount());
+            assertEquals(1, taskRunScheduler.getPendingQueueCount());
         }
 
         {
@@ -460,8 +464,8 @@ public class TaskManagerTest {
             TaskRunStatusChange change = new TaskRunStatusChange(task.getId(), taskRun2.getStatus(),
                     Constants.TaskRunState.RUNNING, Constants.TaskRunState.FAILED);
             taskManager.replayUpdateTaskRun(change);
-            Assertions.assertEquals(0, taskRunScheduler.getRunningTaskCount());
-            Assertions.assertEquals(1, taskRunScheduler.getPendingQueueCount());
+            assertEquals(0, taskRunScheduler.getRunningTaskCount());
+            assertEquals(1, taskRunScheduler.getPendingQueueCount());
         }
 
         {
@@ -469,8 +473,8 @@ public class TaskManagerTest {
             TaskRunStatusChange change = new TaskRunStatusChange(task.getId(), taskRun1.getStatus(),
                     Constants.TaskRunState.PENDING, Constants.TaskRunState.FAILED);
             taskManager.replayUpdateTaskRun(change);
-            Assertions.assertEquals(0, taskRunScheduler.getRunningTaskCount());
-            Assertions.assertEquals(0, taskRunScheduler.getPendingQueueCount());
+            assertEquals(0, taskRunScheduler.getRunningTaskCount());
+            assertEquals(0, taskRunScheduler.getPendingQueueCount());
         }
     }
 
@@ -486,7 +490,7 @@ public class TaskManagerTest {
         }
         Config.task_runs_max_history_number = 20;
         taskRunManager.getTaskRunHistory().forceGC();
-        Assertions.assertEquals(20, taskRunManager.getTaskRunHistory().getInMemoryHistory().size());
+        assertEquals(20, taskRunManager.getTaskRunHistory().getInMemoryHistory().size());
         Config.task_runs_max_history_number = 10000;
         Config.enable_task_history_archive = true;
     }
@@ -502,7 +506,7 @@ public class TaskManagerTest {
         }
         Config.task_runs_max_history_number = 20;
         taskRunManager.getTaskRunHistory().forceGC();
-        Assertions.assertEquals(10, taskRunManager.getTaskRunHistory().getInMemoryHistory().size());
+        assertEquals(10, taskRunManager.getTaskRunHistory().getInMemoryHistory().size());
         Config.task_runs_max_history_number = 10000;
     }
 
@@ -513,21 +517,21 @@ public class TaskManagerTest {
 
     @Test
     public void testGetInitialDelayTime1() throws Exception {
-        Assertions.assertEquals(50, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:50"),
+        assertEquals(50, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:50"),
                 parseLocalDateTime("2023-04-18 20:00:00")));
-        Assertions.assertEquals(30, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:30"),
+        assertEquals(30, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:30"),
                 parseLocalDateTime("2023-04-18 20:00:00")));
-        Assertions.assertEquals(20, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:30"),
+        assertEquals(20, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:30"),
                 parseLocalDateTime("2023-04-18 20:00:10")));
-        Assertions.assertEquals(0, TaskManager.getInitialDelayTime(20, parseLocalDateTime("2023-04-18 19:08:30"),
+        assertEquals(0, TaskManager.getInitialDelayTime(20, parseLocalDateTime("2023-04-18 19:08:30"),
                 parseLocalDateTime("2023-04-18 21:00:10")));
     }
 
     @Test
     public void testGetInitialDelayTime2() throws Exception {
-        Assertions.assertEquals(23, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-12-29 19:50:00"),
+        assertEquals(23, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-12-29 19:50:00"),
                 LocalDateTime.parse("2024-01-30T15:27:37.342356010")));
-        Assertions.assertEquals(50, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-12-29 19:50:00"),
+        assertEquals(50, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-12-29 19:50:00"),
                 LocalDateTime.parse("2024-01-30T15:27:10.342356010")));
     }
 
@@ -566,50 +570,50 @@ public class TaskManagerTest {
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         Collection<TaskRun> taskRuns = taskRunScheduler.getPendingTaskRunsByTaskId(taskId);
         Assertions.assertTrue(taskRuns != null);
-        Assertions.assertEquals(2, taskRunScheduler.getPendingQueueCount());
-        Assertions.assertEquals(2, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
+        assertEquals(2, taskRunScheduler.getPendingQueueCount());
+        assertEquals(2, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
 
         // If it's a sync refresh, no merge redundant anyway
         TaskRun taskRun3 = makeTaskRun(taskId, task, makeExecuteOption(false, true));
         result = taskRunManager.submitTaskRun(taskRun3, taskRun3.getExecuteOption());
         Assertions.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
-        Assertions.assertEquals(3, taskRunScheduler.getPendingQueueCount());
-        Assertions.assertEquals(3, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
+        assertEquals(3, taskRunScheduler.getPendingQueueCount());
+        assertEquals(3, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
         // merge it
         TaskRun taskRun4 = makeTaskRun(taskId, task, makeExecuteOption(true, false));
         result = taskRunManager.submitTaskRun(taskRun4, taskRun4.getExecuteOption());
         Assertions.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
 
-        Assertions.assertEquals(3, taskRunScheduler.getPendingQueueCount());
-        Assertions.assertEquals(3, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
+        assertEquals(3, taskRunScheduler.getPendingQueueCount());
+        assertEquals(3, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
 
         // no merge it
         TaskRun taskRun5 = makeTaskRun(taskId, task, makeExecuteOption(false, false));
         result = taskRunManager.submitTaskRun(taskRun5, taskRun5.getExecuteOption());
         Assertions.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
-        Assertions.assertEquals(4, taskRunScheduler.getPendingQueueCount());
-        Assertions.assertEquals(4, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
+        assertEquals(4, taskRunScheduler.getPendingQueueCount());
+        assertEquals(4, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
 
         for (int i = 4; i < Config.task_runs_queue_length; i++) {
             TaskRun taskRun = makeTaskRun(taskId, task, makeExecuteOption(false, false));
             result = taskRunManager.submitTaskRun(taskRun, taskRun.getExecuteOption());
             Assertions.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
-            Assertions.assertEquals(i + 1, taskRunScheduler.getPendingQueueCount());
-            Assertions.assertEquals(i + 1, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
+            assertEquals(i + 1, taskRunScheduler.getPendingQueueCount());
+            assertEquals(i + 1, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
         }
         // no assign it: exceed queue's size
         TaskRun taskRun6 = makeTaskRun(taskId, task, makeExecuteOption(false, false));
         result = taskRunManager.submitTaskRun(taskRun6, taskRun6.getExecuteOption());
         Assertions.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.REJECTED);
-        Assertions.assertEquals(Config.task_runs_queue_length, taskRunScheduler.getPendingQueueCount());
-        Assertions.assertEquals(Config.task_runs_queue_length, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
+        assertEquals(Config.task_runs_queue_length, taskRunScheduler.getPendingQueueCount());
+        assertEquals(Config.task_runs_queue_length, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
 
         // no assign it: exceed queue's size
         TaskRun taskRun7 = makeTaskRun(taskId, task, makeExecuteOption(false, false));
         result = taskRunManager.submitTaskRun(taskRun7, taskRun7.getExecuteOption());
         Assertions.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.REJECTED);
-        Assertions.assertEquals(Config.task_runs_queue_length, taskRunScheduler.getPendingQueueCount());
-        Assertions.assertEquals(Config.task_runs_queue_length, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
+        assertEquals(Config.task_runs_queue_length, taskRunScheduler.getPendingQueueCount());
+        assertEquals(Config.task_runs_queue_length, taskRunScheduler.getPendingTaskRunsByTaskId(taskId).size());
     }
 
 
@@ -707,7 +711,7 @@ public class TaskManagerTest {
             tm.getTaskRunManager().submitTaskRun(taskRun, taskRun.getExecuteOption());
         }
         long pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();
-        Assertions.assertEquals(pendingTaskRunsCount, 10);
+        assertEquals(pendingTaskRunsCount, 10);
     }
 
     @Test
@@ -770,7 +774,7 @@ public class TaskManagerTest {
             }
         });
         long runningTaskRunsCount = taskRunScheduler.getRunningTaskCount();
-        Assertions.assertEquals(1, runningTaskRunsCount);
+        assertEquals(1, runningTaskRunsCount);
 
         new MockUp<TaskRun>() {
             @Mock
@@ -781,9 +785,9 @@ public class TaskManagerTest {
         // running task run will not be removed if force kill is false
         TaskRunManager taskRunManager = tm.getTaskRunManager();
         taskRunManager.killTaskRun(1L, false);
-        Assertions.assertEquals(1, taskRunScheduler.getRunningTaskCount());
+        assertEquals(1, taskRunScheduler.getRunningTaskCount());
         taskRunManager.killTaskRun(1L, true);
-        Assertions.assertEquals(0, taskRunScheduler.getRunningTaskCount());
+        assertEquals(0, taskRunScheduler.getRunningTaskCount());
     }
 
     @Test
@@ -800,7 +804,7 @@ public class TaskManagerTest {
         taskRun.initStatus("1", now + 10);
         taskRun.getStatus().setPriority(0);
         TaskRunStatus taskRunStatus = taskRun.getStatus();
-        Assertions.assertEquals(taskRunStatus.getDefinition(), "select 1");
+        assertEquals(taskRunStatus.getDefinition(), "select 1");
     }
 
     @Test
@@ -897,7 +901,7 @@ public class TaskManagerTest {
             taskManager.replayCreateTaskRun(validStatus);
 
             TaskRunHistory taskRunHistory = taskManager.getTaskRunHistory();
-            Assertions.assertEquals(2, taskRunHistory.getTaskRunCount());
+            assertEquals(2, taskRunHistory.getTaskRunCount());
 
             taskManager.saveTasksV2(imageWriter);
         }
@@ -907,7 +911,7 @@ public class TaskManagerTest {
             TaskManager taskManager = new TaskManager();
             taskManager.loadTasksV2(imageReader);
             TaskRunHistory taskRunHistory = taskManager.getTaskRunHistory();
-            Assertions.assertEquals(2, taskRunHistory.getTaskRunCount());
+            assertEquals(2, taskRunHistory.getTaskRunCount());
 
             Set<Constants.TaskRunState> expectedStates = ImmutableSet.of(
                     Constants.TaskRunState.SUCCESS, Constants.TaskRunState.SKIPPED);
@@ -956,5 +960,108 @@ public class TaskManagerTest {
         validStatus.setExpireTime(System.currentTimeMillis() + 100000);
         taskManager.replayCreateTaskRun(validStatus);
         // The valid task run should be processed without errors.
+    }
+
+    @Test
+    public void removeExpiredTaskRunsShouldCancelLongRunningTasks() {
+        TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);
+        TaskRun taskRun = new TaskRun();
+        TaskRunStatus status = new TaskRunStatus();
+        status.setCreateTime(System.currentTimeMillis() - 5000);
+        new MockUp<TaskRun>() {
+            @Mock
+            public TaskRunStatus getStatus() {
+                return status;
+            }
+
+            @Mock
+            public int getExecuteTimeoutS() {
+                return 3;
+            }
+        };
+        new MockUp<TaskRunScheduler>() {
+            @Mock
+            public Set<TaskRun> getCopiedRunningTaskRuns() {
+                return ImmutableSet.of(taskRun);
+            }
+        };
+        new MockUp<TaskRunManager>() {
+            @Mock
+            void killRunningTaskRun(TaskRun taskRun, boolean force) {
+                assertEquals(status, taskRun.getStatus());
+            }
+        };
+
+        TaskManager taskManager = new TaskManager();
+        taskManager.removeExpiredTaskRuns(false);
+    }
+
+    @Test
+    public void removeExpiredTaskRunsShouldNotCancelTasksWithoutTimeout() {
+        TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);
+        TaskRun taskRun = new TaskRun();
+        TaskRunStatus status = new TaskRunStatus();
+        status.setCreateTime(System.currentTimeMillis() - 5000);
+
+        new MockUp<TaskRun>() {
+            @Mock
+            public TaskRunStatus getStatus() {
+                return status;
+            }
+
+            @Mock
+            public int getExecuteTimeoutS() {
+                return 0;
+            }
+        };
+        new MockUp<TaskRunScheduler>() {
+            @Mock
+            public Set<TaskRun> getCopiedRunningTaskRuns() {
+                return ImmutableSet.of(taskRun);
+            }
+        };
+        new MockUp<TaskRunManager>() {
+            @Mock
+            void killRunningTaskRun(TaskRun taskRun, boolean force) {
+                Assertions.fail("Task without timeout should not be canceled");
+            }
+        };
+
+        TaskManager taskManager = new TaskManager();
+        taskManager.removeExpiredTaskRuns(false);
+    }
+
+    @Test
+    public void removeExpiredTaskRunsShouldNotCancelNonExpiredTasks() {
+        TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);
+        TaskRun taskRun = new TaskRun();
+        TaskRunStatus status = new TaskRunStatus();
+        status.setCreateTime(System.currentTimeMillis() - 1000);
+        new MockUp<TaskRun>() {
+            @Mock
+            public TaskRunStatus getStatus() {
+                return status;
+            }
+
+            @Mock
+            public int getExecuteTimeoutS() {
+                return 5;
+            }
+        };
+        new MockUp<TaskRunScheduler>() {
+            @Mock
+            public Set<TaskRun> getCopiedRunningTaskRuns() {
+                return ImmutableSet.of(taskRun);
+            }
+        };
+        new MockUp<TaskRunManager>() {
+            @Mock
+            void killRunningTaskRun(TaskRun taskRun, boolean force) {
+                Assertions.fail("Non-expired task should not be canceled");
+            }
+        };
+
+        TaskManager taskManager = new TaskManager();
+        taskManager.removeExpiredTaskRuns(false);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunTest.java
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.common.Config;
+import com.starrocks.qe.SessionVariable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class TaskRunTest {
+
+    private TaskRun taskRun;
+
+    @BeforeEach
+    public void setUp() {
+        taskRun = new TaskRun();
+    }
+
+    @Test
+    public void testDefaultTimeout() {
+        taskRun.setProperties(null);
+        assertEquals(Config.task_runs_timeout_second, taskRun.getExecuteTimeoutS());
+    }
+
+    @Test
+    public void testQueryTimeoutProperty() {
+        Map<String, String> props = new HashMap<>();
+        props.put(SessionVariable.QUERY_TIMEOUT, "120");
+        taskRun.setProperties(props);
+        assertEquals(Math.max(120, Config.task_runs_timeout_second), taskRun.getExecuteTimeoutS());
+    }
+
+    @Test
+    public void testInsertTimeoutProperty() {
+        Map<String, String> props = new HashMap<>();
+        props.put(SessionVariable.INSERT_TIMEOUT, "200");
+        taskRun.setProperties(props);
+        assertEquals(Math.max(200, Config.task_runs_timeout_second), taskRun.getExecuteTimeoutS());
+    }
+
+    @Test
+    public void testInvalidTimeoutValue() {
+        Map<String, String> props = new HashMap<>();
+        props.put(SessionVariable.QUERY_TIMEOUT, "invalid");
+        taskRun.setProperties(props);
+        assertEquals(Config.task_runs_timeout_second, taskRun.getExecuteTimeoutS());
+    }
+
+    @Test
+    public void testNegativeTimeoutValue() {
+        Map<String, String> props = new HashMap<>();
+        props.put(SessionVariable.QUERY_TIMEOUT, "-10");
+        taskRun.setProperties(props);
+        assertEquals(Config.task_runs_timeout_second, taskRun.getExecuteTimeoutS());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:


This pull request introduces improvements to task run timeout management and refines task run cancellation logic, along with minor code cleanup in tests.


## What I'm doing:

**Task run timeout and cancellation enhancements:**

* Introduced a new configuration parameter `task_runs_timeout_second` in `Config.java`, allowing administrators to set a default timeout for task runs.
* Added logic in `TaskRun.java` to determine the effective execution timeout for a task run, prioritizing user-specified `query_timeout` or `insert_timeout` values if present, otherwise using the default from config.
* Updated `TaskManager.java` to periodically check running tasks and automatically cancel those exceeding their timeout, preventing resource wastage.

**Task run cancellation and method refactoring:**

* Refactored `TaskRunManager.java` to split the cancellation logic into two methods: `killRunningTaskRun` for running tasks and `killPendingTaskRuns` for pending tasks, improving code clarity and maintainability [[1]](diffhunk://#diff-298cb78798d6afda80429cb950a0b1644122d66663ded71c704f81098656896aL90-R94) [[2]](diffhunk://#diff-298cb78798d6afda80429cb950a0b1644122d66663ded71c704f81098656896aL104-L112) [[3]](diffhunk://#diff-298cb78798d6afda80429cb950a0b1644122d66663ded71c704f81098656896aR123-R146).


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a configurable task run execution timeout, auto-cancels runs exceeding it, and refactors kill logic; updates tests accordingly.
> 
> - **Scheduler/Runtime**:
>   - Auto-cancel running `TaskRun`s that exceed their execute timeout in `TaskManager.removeExpiredTaskRuns()` using `killRunningTaskRun(...)`.
>   - Refactor cancellation in `TaskRunManager`:
>     - New `killRunningTaskRun(TaskRun, boolean)` and `killPendingTaskRuns(Long)`; `killTaskRun(Long, boolean)` now calls both.
> - **TaskRun**:
>   - Add `getExecuteTimeoutS()` to compute effective timeout from `query_timeout`/`insert_timeout` or default, bounded by `task_runs_ttl_second` and `task_ttl_second`.
> - **Config**:
>   - New `Config.task_runs_timeout_second` (default 4h).
> - **Tests**:
>   - Add `TaskRunTest` for timeout logic.
>   - Extend `TaskManagerTest` to verify auto-cancel behavior and refactored kill flow; minor assertion cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af8b40ea4f7e5d79f4580b6a70047ce8d66826ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->