### PR TITLE
[BugFix] Fix sort agg got wrong result in shared-data mode

### DIFF
--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -690,6 +690,13 @@ void ConnectorScanNode::_init_counter() {
     _profile.scanner_queue_counter = ADD_COUNTER(_runtime_profile, "ScannerQueueCounter", TUnit::UNIT);
 }
 
+int ConnectorScanNode::io_tasks_per_scan_operator() const {
+    if (_data_source_provider->sorted_by_keys_per_tablet()) {
+        return 1;
+    }
+    return starrocks::ScanNode::io_tasks_per_scan_operator();
+}
+
 bool ConnectorScanNode::always_shared_scan() const {
     return _data_source_provider->always_shared_scan();
 }

--- a/be/src/exec/connector_scan_node.h
+++ b/be/src/exec/connector_scan_node.h
@@ -64,6 +64,7 @@ public:
 
     size_t estimated_scan_row_bytes() const { return _estimated_scan_row_bytes; }
 
+    int io_tasks_per_scan_operator() const override;
     bool output_chunk_by_bucket() const override { return _data_source_provider->output_chunk_by_bucket(); }
     bool is_asc_hint() const override { return _data_source_provider->is_asc_hint(); }
     std::optional<bool> partition_order_hint() const override { return _data_source_provider->partition_order_hint(); }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PhysicalDistributionAggOptRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PhysicalDistributionAggOptRule.java
@@ -93,6 +93,10 @@ public class PhysicalDistributionAggOptRule implements TreeRewriteRule {
             if (!agg.getType().isGlobal() || agg.getGroupBys().isEmpty()) {
                 return null;
             }
+            // Cloud Native Table is not yet optimized for bucket aggregation.
+            if (scan.getTable().isCloudNativeTableOrMaterializedView()) {
+                return null;
+            }
             agg.setUsePerBucketOptmize(true);
             scan.setNeedOutputChunkByBucket(true);
 

--- a/test/sql/test_sorted_streaming_agg/R/sorted_streaming_agg
+++ b/test/sql/test_sorted_streaming_agg/R/sorted_streaming_agg
@@ -648,3 +648,29 @@ select c0, c1, sum(c2), count(*) from t11 group by c0, c1 order by c0, c1;
 2	single2	200	1
 3	single3	300	1
 -- !result
+CREATE TABLE `large_table` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into large_table SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+insert into large_table SELECT c0,c1,c2 from large_table, UNNEST([1,2]);
+-- result:
+-- !result
+create table dummy as select max(c1)from large_table group by c0;
+-- result:
+-- !result
+select count(*) from dummy;
+-- result:
+40960
+-- !result

--- a/test/sql/test_sorted_streaming_agg/T/sorted_streaming_agg
+++ b/test/sql/test_sorted_streaming_agg/T/sorted_streaming_agg
@@ -235,3 +235,20 @@ insert into t11 values(3, 'single3', 300);
 select c0, c1, c2, count(*) from t11 group by c0, c1, c2 order by c0, c1, c2;
 select c0, sum(c2), count(*) from t11 group by c0 order by c0;
 select c0, c1, sum(c2), count(*) from t11 group by c0, c1 order by c0, c1;
+
+
+CREATE TABLE `large_table` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into large_table SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+insert into large_table SELECT c0,c1,c2 from large_table, UNNEST([1,2]);
+create table dummy as select max(c1)from large_table group by c0;
+select count(*) from dummy;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust IO task count for sorted-by-key scans, disable per-bucket agg optimization for cloud-native tables, and add large-scale sorted streaming agg tests.
> 
> - **Backend (BE)**:
>   - **Connector scan**: Override `io_tasks_per_scan_operator()` to return `1` when `sorted_by_keys_per_tablet`, else defer to `ScanNode`.
> - **Frontend (FE)**:
>   - **Optimizer**: In `PhysicalDistributionAggOptRule`, skip per-bucket aggregation when scanning a Cloud Native table/materialized view.
> - **Tests**:
>   - Add large-scale sorted streaming aggregation case (`test_sorted_streaming_agg`) with `large_table` and validation of grouped `max` results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd93f498c378fdfe6dde9c1d538873fc5996a209. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->