### PR TITLE
[Enhancement] Support Cancel Insert Load Job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
@@ -183,6 +183,14 @@ public class InsertLoadJob extends LoadJob {
     }
 
     @Override
+    protected void unprotectedExecuteCancel(FailMsg failMsg, boolean abortTxn) {
+        super.unprotectedExecuteCancel(failMsg, abortTxn);
+        if (coordinator != null) {
+            coordinator.cancel(failMsg.getMsg());
+        }
+    }
+
+    @Override
     public Set<String> getTableNamesForShow() {
         Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (database == null) {


### PR DESCRIPTION
## Why I'm doing:
cancel insert query
## What I'm doing:
release coordinator

Fixes #63850

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [X] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> On cancel, `InsertLoadJob` now propagates cancellation to its `Coordinator`; adds a unit test to verify behavior.
> 
> - **Load/Execution**:
>   - `InsertLoadJob`: Override `unprotectedExecuteCancel` to call `coordinator.cancel(...)` after delegating to `super`.
> - **Tests**:
>   - Add `testUnprotectedExecuteCancel` ensuring coordinator cancellation, transaction abort, and callback removal are invoked; include necessary imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81cd9c5da6b9269ddaa6f73199e229fc4934e699. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->