### PR TITLE
[Enhancement] Disable Full Vacuum

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3214,7 +3214,7 @@ public class Config extends ConfigBase {
     public static long lake_fullvacuum_meta_expired_seconds = 3600L * 24L * 2L;
 
     @ConfField(mutable = true, comment = "Whether to enable full vacuum daemon")
-    public static boolean enable_lake_fullvacuum = false;
+    public static boolean lake_enable_fullvacuum = false;
 
     @ConfField(mutable = true, comment =
             "Whether enable throttling ingestion speed when compaction score exceeds the threshold.\n" +

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3213,6 +3213,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "metadata expired time from full vacuum begin running")
     public static long lake_fullvacuum_meta_expired_seconds = 3600L * 24L * 2L;
 
+    @ConfField(mutable = true, comment = "Whether to enable full vacuum daemon")
+    public static boolean enable_lake_fullvacuum = false;
+
     @ConfField(mutable = true, comment =
             "Whether enable throttling ingestion speed when compaction score exceeds the threshold.\n" +
                     "Only takes effect for tables in clusters with run_mode=shared_data.")

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
@@ -74,6 +74,9 @@ public class FullVacuumDaemon extends FrontendDaemon implements Writable {
 
     @Override
     protected void runAfterCatalogReady() {
+        if (!Config.enable_lake_fullvacuum) {
+            return;
+        }
         if (FeConstants.runningUnitTest) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
@@ -74,7 +74,7 @@ public class FullVacuumDaemon extends FrontendDaemon implements Writable {
 
     @Override
     protected void runAfterCatalogReady() {
-        if (!Config.enable_lake_fullvacuum) {
+        if (!Config.lake_enable_fullvacuum) {
             return;
         }
         if (FeConstants.runningUnitTest) {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -387,7 +387,7 @@ public class VacuumTest {
             }
         };
 
-        Config.enable_lake_fullvacuum = true;
+        Config.lake_enable_fullvacuum = true;
         FeConstants.runningUnitTest = false;
         int oldValue1 = Config.lake_fullvacuum_parallel_partitions;
         long oldValue2 = Config.lake_fullvacuum_partition_naptime_seconds;
@@ -397,7 +397,7 @@ public class VacuumTest {
         Config.lake_fullvacuum_partition_naptime_seconds = oldValue2;
         Config.lake_fullvacuum_parallel_partitions = oldValue1;
         FeConstants.runningUnitTest = true;
-        Config.enable_lake_fullvacuum = false;
+        Config.lake_enable_fullvacuum = false;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -387,6 +387,7 @@ public class VacuumTest {
             }
         };
 
+        Config.enable_lake_fullvacuum = true;
         FeConstants.runningUnitTest = false;
         int oldValue1 = Config.lake_fullvacuum_parallel_partitions;
         long oldValue2 = Config.lake_fullvacuum_partition_naptime_seconds;
@@ -396,6 +397,7 @@ public class VacuumTest {
         Config.lake_fullvacuum_partition_naptime_seconds = oldValue2;
         Config.lake_fullvacuum_parallel_partitions = oldValue1;
         FeConstants.runningUnitTest = true;
+        Config.enable_lake_fullvacuum = false;
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0.3 
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `lake_enable_fullvacuum` (default false) and runs `FullVacuumDaemon` only when enabled; updates tests to toggle the flag.
> 
> - **Config**:
>   - Add boolean `Config.lake_enable_fullvacuum` (default `false`) to control the full vacuum daemon.
> - **Daemon Behavior**:
>   - `FullVacuumDaemon.runAfterCatalogReady()` returns early when `lake_enable_fullvacuum` is `false`.
> - **Tests**:
>   - Update `VacuumTest.testFullVacuumBasic` to enable `lake_enable_fullvacuum` during execution and restore afterward.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cd417107ac953782b9b690f4eaa403c2e0e188a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->