### PR TITLE
[Enhancement] Remove iceberg redundant code

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
@@ -133,10 +133,6 @@ public class IcebergCatalogProperties {
         return catalogType;
     }
 
-    public boolean enableIcebergMetadataCache() {
-        return enableIcebergMetadataCache;
-    }
-
     public long getIcebergMetaCacheTtlSec() {
         return icebergMetaCacheTtlSec;
     }
@@ -144,7 +140,6 @@ public class IcebergCatalogProperties {
     public long getIcebergTableCacheRefreshIntervalSec() {
         return icebergTableCacheRefreshIntervalSec;
     }
-
 
     public int getIcebergJobPlanningThreadNum() {
         return icebergJobPlanningThreadNum;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -111,7 +111,7 @@ public class IcebergConnector implements Connector {
         if (icebergNativeCatalog == null) {
             IcebergCatalog nativeCatalog = buildIcebergNativeCatalog();
 
-            if (icebergCatalogProperties.enableIcebergMetadataCache() && !isResourceMappingCatalog(catalogName)) {
+            if (icebergCatalogProperties.isEnableIcebergMetadataCache() && !isResourceMappingCatalog(catalogName)) {
                 nativeCatalog = new CachingIcebergCatalog(catalogName, nativeCatalog,
                         icebergCatalogProperties, buildBackgroundJobPlanningExecutor());
                 GlobalStateMgr.getCurrentState().getConnectorTableMetadataProcessor()
@@ -161,7 +161,7 @@ public class IcebergConnector implements Connector {
 
     @Override
     public boolean supportMemoryTrack() {
-        return icebergCatalogProperties.enableIcebergMetadataCache() && icebergNativeCatalog != null;
+        return icebergCatalogProperties.isEnableIcebergMetadataCache() && icebergNativeCatalog != null;
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:

`IcebergCatalogProperties#enableIcebergMetadataCache` is the same as `IcebergCatalogProperties#isEnableIcebergMetadataCache`.

Just remove one.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove the redundant `enableIcebergMetadataCache()` and switch references to `isEnableIcebergMetadataCache()` in the Iceberg connector.
> 
> - **Iceberg**:
>   - **Connector** (`fe/.../IcebergConnector.java`): Replace checks for `enableIcebergMetadataCache()` with `isEnableIcebergMetadataCache()` in catalog initialization and `supportMemoryTrack()`.
>   - **Catalog Properties** (`fe/.../IcebergCatalogProperties.java`): Remove redundant `enableIcebergMetadataCache()` accessor, retaining `isEnableIcebergMetadataCache()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1162c4efb5b104d40a67174fb475ec9a20158164. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->