### PR TITLE
[Feature] UI: Add functions to analyze profile and view formatted SQL

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -889,6 +889,12 @@ under the License.
             <artifactId>zero-allocation-hashing</artifactId>
             <version>0.16</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.vertical-blank</groupId>
+            <artifactId>sql-formatter</artifactId>
+            <version>2.0.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3945,4 +3945,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "The threshold to flatten compound predicate from deep tree to a balanced tree to " +
             "avoid stack over flow")
     public static int compound_predicate_flatten_threshold = 512;
+
+    @ConfField
+    public static int ui_queries_sql_statement_max_length = Integer.MAX_VALUE;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -75,6 +75,7 @@ public class ProfileManager implements MemoryTrackable {
     public static final String QUERY_TYPE = "Query Type";
     public static final String QUERY_STATE = "Query State";
     public static final String SQL_STATEMENT = "Sql Statement";
+    public static final String SQL_DIALECT = "Sql Dialect";
     public static final String USER = "User";
     public static final String DEFAULT_DB = "Default Db";
     public static final String VARIABLES = "Variables";
@@ -89,7 +90,7 @@ public class ProfileManager implements MemoryTrackable {
 
     public static final ArrayList<String> PROFILE_HEADERS = new ArrayList<>(
             Arrays.asList(QUERY_ID, USER, DEFAULT_DB, SQL_STATEMENT, QUERY_TYPE,
-                    START_TIME, END_TIME, TOTAL_TIME, QUERY_STATE, WAREHOUSE_CNGROUP));
+                    START_TIME, END_TIME, TOTAL_TIME, QUERY_STATE, WAREHOUSE_CNGROUP, SQL_DIALECT));
 
     public static class ProfileElement {
         public Map<String, String> infoStrings = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/QueryAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/QueryAction.java
@@ -35,6 +35,7 @@
 package com.starrocks.http.action;
 
 import com.google.common.base.Strings;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
@@ -118,7 +119,15 @@ public class QueryAction extends WebBaseAction {
                     continue;
                 }
                 buffer.append("<td>");
-                buffer.append(row.get(i));
+                if (columnHeaders.get(i).equals(ProfileManager.SQL_STATEMENT)) {
+                    String statement = row.get(i);
+                    if (statement != null && statement.length() > Config.ui_queries_sql_statement_max_length) {
+                        statement = statement.substring(0, Math.max(Config.ui_queries_sql_statement_max_length, 0)) + " ...";
+                    }
+                    buffer.append(statement);
+                } else {
+                    buffer.append(row.get(i));
+                }
                 buffer.append("</td>");
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/QueryProfileAction.java
@@ -34,12 +34,16 @@
 
 package com.starrocks.http.action;
 
+import com.github.vertical_blank.sqlformatter.SqlFormatter;
 import com.google.common.base.Strings;
+import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.ProfileManager;
+import com.starrocks.common.util.RuntimeProfileParser;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.sql.ExplainAnalyzer;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.logging.log4j.LogManager;
@@ -49,10 +53,17 @@ import org.owasp.encoder.Encode;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.Collections;
+
+import static com.github.vertical_blank.sqlformatter.languages.Dialect.MySql;
+import static com.github.vertical_blank.sqlformatter.languages.Dialect.StandardSql;
 
 public class QueryProfileAction extends WebBaseAction {
 
     private static final Logger LOG = LogManager.getLogger(QueryProfileAction.class);
+    private static final String ANSI_REGEX = "\\u001B\\[[;?0-9]*[a-zA-Z]";
+    private static final SqlFormatter.Formatter MYSQL_FORMATTER = SqlFormatter.of(MySql);
+    private static final SqlFormatter.Formatter STANDARDSQL_FORMATTER = SqlFormatter.of(StandardSql);
 
     public QueryProfileAction(ActionController controller) {
         super(controller);
@@ -74,25 +85,65 @@ public class QueryProfileAction extends WebBaseAction {
             return;
         }
 
-        // HTML encode the queryId to prevent XSS
-        String encodedQueryId = Encode.forHtml(queryId);
-        String queryProfileStr = ProfileManager.getInstance().getProfile(queryId);
-        if (queryProfileStr != null) {
-            appendCopyButton(response.getContent());
-            appendQueryProfile(response.getContent(), queryProfileStr);
+        ProfileManager.ProfileElement queryProfile = ProfileManager.getInstance().getProfileElement(queryId);
+        if (queryProfile != null) {
+            String content;
+            String contentType = request.getSingleParameter("content_type");
+            if ("sql".equalsIgnoreCase(contentType)) {
+                content = getFormattedSql(queryProfile);
+            } else if ("analyze".equalsIgnoreCase(contentType)) {
+                content = getAnalyzeProfileResult(queryProfile);
+            } else {
+                // Profile String
+                content = ProfileManager.getInstance().getProfile(queryId);
+                if (content == null) {
+                    content = String.format("Failed to decompress profile content of %s\n", queryId);
+                }
+            }
+            appendButtons(response.getContent());
+            appendContent(response.getContent(), content);
             getPageFooter(response.getContent());
             writeResponse(request, response);
         } else {
-            appendQueryProfile(response.getContent(), "query id " + encodedQueryId + " not found.");
+            // HTML encode the queryId to prevent XSS
+            String encodedQueryId = Encode.forHtml(queryId);
+            appendContent(response.getContent(), "query id " + encodedQueryId + " not found.");
             getPageFooter(response.getContent());
             writeResponse(request, response, HttpResponseStatus.NOT_FOUND);
         }
     }
 
-    private void appendQueryProfile(StringBuilder buffer, String queryProfileStr) {
+    // com.github.vertical_blank.sqlformatter provides best-effort formatting. It doesn't  throw exceptions for malformed or
+    // invalid SQL syntax.
+    private String getFormattedSql(ProfileManager.ProfileElement queryProfile) {
+        String sqlStatement = queryProfile.infoStrings.getOrDefault(ProfileManager.SQL_STATEMENT, "");
+        String formattedSql;
+        if ("StarRocks".equalsIgnoreCase(queryProfile.infoStrings.get(ProfileManager.SQL_DIALECT))) {
+            formattedSql = MYSQL_FORMATTER.format(sqlStatement);
+        } else {
+            formattedSql = STANDARDSQL_FORMATTER.format(sqlStatement);
+        }
+        return formattedSql;
+    }
+
+    private String getAnalyzeProfileResult(ProfileManager.ProfileElement queryProfile) {
+        String analysis;
+        try {
+            analysis = ExplainAnalyzer.analyze(queryProfile.plan, RuntimeProfileParser.parseFrom(
+                    CompressionUtils.gzipDecompressString(queryProfile.profileContent)), Collections.emptyList(), false);
+            analysis = analysis.replaceAll(ANSI_REGEX, "");
+        } catch (Exception e) {
+            String queryId = queryProfile.infoStrings.getOrDefault(ProfileManager.QUERY_ID, "unknown");
+            LOG.warn("Failed to analyze profile of {}", queryId, e);
+            analysis = String.format("Failed to analyze profile of %s\n%s\n", queryId, e);
+        }
+        return analysis;
+    }
+
+    private void appendContent(StringBuilder buffer, String content) {
         buffer.append("<pre id='profile'>");
 
-        BufferedReader reader = new BufferedReader(new StringReader(queryProfileStr));
+        BufferedReader reader = new BufferedReader(new StringReader(content));
         String line;
         try {
             while ((line = reader.readLine()) != null) {
@@ -109,9 +160,27 @@ public class QueryProfileAction extends WebBaseAction {
         buffer.append("</pre>");
     }
 
-    private void appendCopyButton(StringBuilder buffer) {
+    private void appendButtons(StringBuilder buffer) {
         buffer.append("<script type=\"text/javascript\">\n" +
-                "function copyProfile(){\n" +
+                "function viewProfile() {\n" +
+                "  const params = new URLSearchParams(window.location.search);\n" +
+                "  const query_id = params.get('query_id');\n" +
+                "  window.location.href = '/query_profile?query_id=' + query_id + '&content_type=profile';\n" +
+                "}" + "</script>");
+        buffer.append("<script type=\"text/javascript\">\n" +
+                "function formattedSql() {\n" +
+                "  const params = new URLSearchParams(window.location.search);\n" +
+                "  const query_id = params.get('query_id');\n" +
+                "  window.location.href = '/query_profile?query_id=' + query_id + '&content_type=sql';\n" +
+                "}" + "</script>");
+        buffer.append("<script type=\"text/javascript\">\n" +
+                "function analyzeProfile() {\n" +
+                "  const params = new URLSearchParams(window.location.search);\n" +
+                "  const query_id = params.get('query_id');\n" +
+                "  window.location.href = '/query_profile?query_id=' + query_id + '&content_type=analyze';\n" +
+                "}" + "</script>");
+        buffer.append("<script type=\"text/javascript\">\n" +
+                "function copy(){\n" +
                 "  v = $('#profile').html()\n" +
                 "  const t = document.createElement('textarea')\n" +
                 "  t.style.cssText = 'position: absolute;top:0;left:0;opacity:0'\n" +
@@ -123,7 +192,7 @@ public class QueryProfileAction extends WebBaseAction {
                 "}\n" +
                 "</script>");
         buffer.append("<script type=\"text/javascript\">\n" +
-                "function downloadProfile() {\n" +
+                "function download() {\n" +
                 "  content = $('#profile').html()\n" +
                 "  const file = new Blob([content], { type: \"text/plain\" });\n" +
                 "  const params = new URLSearchParams(window.location.search);\n" +
@@ -135,7 +204,10 @@ public class QueryProfileAction extends WebBaseAction {
                 "\n" +
                 "  URL.revokeObjectURL(a.href);\n" +
                 "}" + "</script>");
-        buffer.append("<input type=\"button\" onclick=\"copyProfile();\" value=\"Copy Profile\"></input>");
-        buffer.append("<input type=\"button\" onclick=\"downloadProfile();\" value=\"Download Profile\"></input>");
+        buffer.append("<input type=\"button\" onclick=\"viewProfile();\" value=\"View Profile\"></input>");
+        buffer.append("<input type=\"button\" onclick=\"formattedSql();\" value=\"Formatted SQL\"></input>");
+        buffer.append("<input type=\"button\" onclick=\"analyzeProfile();\" value=\"Analyze Profile\"></input>");
+        buffer.append("<input type=\"button\" onclick=\"copy();\" value=\"Copy\"></input>");
+        buffer.append("<input type=\"button\" onclick=\"download();\" value=\"Download\"></input>");
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -381,6 +381,9 @@ public class StmtExecutor {
         // Add some import variables in profile
         SessionVariable variables = context.getSessionVariable();
         if (variables != null) {
+            // Add SQL dialect as a separate info string
+            summaryProfile.addInfoString(ProfileManager.SQL_DIALECT, variables.getSqlDialect());
+
             StringBuilder sb = new StringBuilder();
             sb.append(SessionVariable.PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM).append("=")
                     .append(variables.getParallelExecInstanceNum()).append(",");

--- a/fe/fe-core/src/test/java/com/starrocks/http/QueryProfileActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/QueryProfileActionTest.java
@@ -45,7 +45,7 @@ public class QueryProfileActionTest extends StarRocksHttpTestCase {
     @Test
     public void testEscapeHtmlInPreTag() throws Exception {
         Class<QueryProfileAction> clazz = QueryProfileAction.class;
-        Method method = clazz.getDeclaredMethod("appendQueryProfile", StringBuilder.class, String.class);
+        Method method = clazz.getDeclaredMethod("appendContent", StringBuilder.class, String.class);
         Assertions.assertNotNull(method);
         method.setAccessible(true);
 

--- a/licenses-binary/LICENSE-sql-formatter.txt
+++ b/licenses-binary/LICENSE-sql-formatter.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 Yohei Yamana
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Why I'm doing:

Make it easier to analyze query profiles

## What I'm doing:

1. UI: Allow truncating SQL statements in Queries page
2. UI: Add functions to analyze profile and view formatted SQL

<img width="3130" height="1634" alt="image" src="https://github.com/user-attachments/assets/9d1f1ba4-656e-4884-a2b3-7930f6005b9a" />

<img width="3212" height="1468" alt="image" src="https://github.com/user-attachments/assets/f475e8b6-1a0a-4fef-8a2b-ccfc3ef60c32" />

<img width="3214" height="1568" alt="image" src="https://github.com/user-attachments/assets/08c980ce-6dc5-4a86-83e0-c84348417260" />



## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds formatted SQL and analyze views to query profile page, truncates long SQL in Queries table, and records SQL dialect in profiles.
> 
> - **UI/Profile**:
>   - Add buttons to view profile, formatted SQL, and analyze profile in `QueryProfileAction` with `content_type` support (profile/sql/analyze).
>   - Truncate `Sql Statement` in `/query` table rows based on `Config.ui_queries_sql_statement_max_length`.
> - **Profile metadata**:
>   - Record and display `Sql Dialect` (from session variable) in `ProfileManager.PROFILE_HEADERS` and profiles.
> - **Analysis/formatting**:
>   - Use `ExplainAnalyzer` to analyze profiles; strip ANSI codes.
>   - Integrate `sql-formatter` (MySQL/Standard SQL) to pretty-print SQL from profiles.
> - **Config**:
>   - New `Config.ui_queries_sql_statement_max_length`.
> - **Deps/License**:
>   - Add `com.github.vertical-blank:sql-formatter` and include its MIT license.
> - **Tests**:
>   - Update `QueryProfileActionTest` for refactored content rendering method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0139b888888aa0e1cec5d48de1d1f7b414968467. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->