### PR TITLE
[BugFix] Fix agg push down type cast bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
@@ -477,8 +477,9 @@ public final class AggregatedMaterializedViewPushDownRewriter extends Materializ
                 remapping.put(aggColRef, newColRef);
                 ctx.aggColRefToPushDownAggMap.put(aggColRef, aggCall);
             }
-            Map<ColumnRefOperator, CallOperator> newAggregations = Maps.newHashMap();
-            uniqueAggregations.forEach((k, v) -> newAggregations.put(v, k));
+            Map<ColumnRefOperator, CallOperator> newAggregations = uniqueAggregations.entrySet().stream()
+                            .map(e -> Maps.immutableEntry(e.getValue(), e.getKey()))
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             LogicalAggregationOperator newAggOp = LogicalAggregationOperator.builder()
                     .setAggregations(newAggregations)
                     .setType(AggType.GLOBAL)


### PR DESCRIPTION
## Why I'm doing:

Fix a bug introduced by https://github.com/StarRocks/starrocks/pull/63659 which is found by test: test_materialized_view_agg_pushdown_rewrite

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes type handling during aggregate push-down rewrite, refactors aggregation map construction, and adds a regression test to prevent incorrect casts.
> 
> - **Optimizer/MV Rewrite**:
>   - **`AggregatedMaterializedViewRewriter`**: In agg push-down, update `origColRef` type to match new agg column and map directly; otherwise generate rollup projection with strict type compatibility check.
>   - **`AggregatedMaterializedViewPushDownRewriter`**: Refactor construction of `newAggregations` using stream `toMap` for the unique aggregation mapping.
> - **Tests**:
>   - Add `testAggPushDownTypeCastBug` ensuring plans avoid incorrect cast for `count` and correctly utilize `mv1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef6b5a1cb607accd396a51b0cb2a402d3745b136. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->