### PR TITLE
[Enhancement] Support oauth2 auth for iceberg REST catalog with jwt token

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
@@ -131,15 +131,16 @@ class OAuth2SecurityConfigBuilder {
             strSecurity = NONE.name();
         }
 
-        if (strSecurity.equals(NONE.name())) {
+        OAuth2SecurityConfig config = new OAuth2SecurityConfig();
+        if (strSecurity.equalsIgnoreCase(NONE.name())) {
             return new OAuth2SecurityConfig();
-        } else if (strSecurity.equals(JWT.name())) {
-            return new OAuth2SecurityConfig().setSecurity(JWT);
+        } else if (strSecurity.equalsIgnoreCase(JWT.name())) {
+            config.setSecurity(JWT);
+        } else if (strSecurity.equalsIgnoreCase(OAUTH2.name())) {
+            config = config.setSecurity(OAUTH2);
         }
 
-        OAuth2SecurityConfig config = new OAuth2SecurityConfig();
-        config = config.setSecurity(OAUTH2)
-                .setCredential(properties.get(OAuth2SecurityConfig.OAUTH2_CREDENTIAL))
+        config.setCredential(properties.get(OAuth2SecurityConfig.OAUTH2_CREDENTIAL))
                 .setScope(properties.get(OAuth2SecurityConfig.OAUTH2_SCOPE))
                 .setToken(properties.get(OAuth2SecurityConfig.OAUTH2_TOKEN))
                 .setAudience(properties.get(OAuth2SecurityConfig.OAUTH2_AUDIENCE))

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.iceberg.rest;
 
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
 
 import java.net.URI;
@@ -138,6 +139,8 @@ class OAuth2SecurityConfigBuilder {
             config.setSecurity(JWT);
         } else if (strSecurity.equalsIgnoreCase(OAUTH2.name())) {
             config = config.setSecurity(OAUTH2);
+        } else {
+            throw new StarRocksConnectorException("Invalid security: %s", strSecurity);
         }
 
         config.setCredential(properties.get(OAuth2SecurityConfig.OAUTH2_CREDENTIAL))

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityProperties.java
@@ -28,19 +28,19 @@ public class OAuth2SecurityProperties {
         requireNonNull(securityConfig, "securityConfig is null");
 
         ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builder();
+        securityConfig.getCredential().ifPresent(
+                credential -> {
+                    propertiesBuilder.put(OAuth2Properties.CREDENTIAL, credential);
+                    securityConfig.getScope()
+                            .ifPresent(scope -> propertiesBuilder.put(OAuth2Properties.SCOPE, scope));
+                });
+        securityConfig.getToken().ifPresent(
+                value -> propertiesBuilder.put(OAuth2Properties.TOKEN, value));
+        securityConfig.getServerUri().ifPresent(
+                value -> propertiesBuilder.put(OAuth2Properties.OAUTH2_SERVER_URI, value.toString()));
+        securityConfig.getAudience().ifPresent(
+                value -> propertiesBuilder.put(OAuth2Properties.AUDIENCE, value));
         if (securityConfig.getSecurity() == IcebergRESTCatalog.Security.OAUTH2) {
-            securityConfig.getCredential().ifPresent(
-                    credential -> {
-                        propertiesBuilder.put(OAuth2Properties.CREDENTIAL, credential);
-                        securityConfig.getScope()
-                                .ifPresent(scope -> propertiesBuilder.put(OAuth2Properties.SCOPE, scope));
-                    });
-            securityConfig.getToken().ifPresent(
-                    value -> propertiesBuilder.put(OAuth2Properties.TOKEN, value));
-            securityConfig.getServerUri().ifPresent(
-                    value -> propertiesBuilder.put(OAuth2Properties.OAUTH2_SERVER_URI, value.toString()));
-            securityConfig.getAudience().ifPresent(
-                    value -> propertiesBuilder.put(OAuth2Properties.AUDIENCE, value));
             securityConfig.isTokenRefreshEnabled().ifPresent(
                     value -> propertiesBuilder.put(OAuth2Properties.TOKEN_REFRESH_ENABLED, Boolean.toString(value)));
         } else if (securityConfig.getSecurity() == IcebergRESTCatalog.Security.JWT) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfigTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.starrocks.connector.iceberg.rest.IcebergRESTCatalog.Security.JWT;
 import static com.starrocks.connector.iceberg.rest.IcebergRESTCatalog.Security.NONE;
 import static com.starrocks.connector.iceberg.rest.IcebergRESTCatalog.Security.OAUTH2;
 
@@ -57,6 +58,14 @@ public class OAuth2SecurityConfigTest {
         properties.put("oauth2.scope", "PRINCIPAL");
         config = OAuth2SecurityConfigBuilder.build(properties);
         Assertions.assertEquals(NONE, config.getSecurity());
+        
+        // Test JWT security
+        properties = new HashMap<>();
+        properties.put("security", "jwt");
+        properties.put("oauth2.token", "jwt-token-value");
+        config = OAuth2SecurityConfigBuilder.build(properties);
+        Assertions.assertEquals(JWT, config.getSecurity());
+        Assertions.assertEquals("jwt-token-value", config.getToken().get());
     }
 
     @Test
@@ -76,5 +85,17 @@ public class OAuth2SecurityConfigTest {
         config = OAuth2SecurityConfigBuilder.build(properties);
         oauth2Properties = new OAuth2SecurityProperties(config);
         Assertions.assertEquals(0, oauth2Properties.get().size());
+        
+        // Test JWT properties
+        properties = new HashMap<>();
+        properties.put("security", "jwt");
+        properties.put("oauth2.token", "jwt-token-value");
+        properties.put("oauth2.audience", "test-audience");
+        config = OAuth2SecurityConfigBuilder.build(properties);
+        oauth2Properties = new OAuth2SecurityProperties(config);
+        Assertions.assertEquals("jwt-token-value", oauth2Properties.get().get(OAuth2Properties.TOKEN));
+        Assertions.assertEquals("test-audience", oauth2Properties.get().get(OAuth2Properties.AUDIENCE));
+        // check token refresh disabled for JWT
+        Assertions.assertEquals("false", oauth2Properties.get().get(OAuth2Properties.TOKEN_REFRESH_ENABLED));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
In https://github.com/StarRocks/starrocks/pull/58850, SR supports JWT auth, but do not set ouath2 relative properties,  SR cannot connect to rest catalog server if server needs oauth2 auth
## What I'm doing:
This pull request improves the handling and configuration of OAuth2 and JWT security options in the Iceberg REST catalog connector. The changes enhance case-insensitive parsing of security types, ensure correct property mapping for different security modes, and add comprehensive unit tests for JWT support.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make OAuth2/JWT security handling case-insensitive, validate security values, map JWT/OAuth2 properties correctly, and add JWT unit tests.
> 
> - **Iceberg REST security config**:
>   - Case-insensitive parsing for `security` (`none`, `jwt`, `oauth2`), with validation and error on invalid values.
>   - Properly sets `JWT` and `OAUTH2` modes; preserves `NONE`.
>   - Always applies optional fields (`credential`, `scope`, `token`, `audience`, `server-uri`); `TOKEN_REFRESH_ENABLED` applied for OAuth2.
> - **Security properties mapping**:
>   - Exposes common fields (`credential`, `scope`, `token`, `audience`, `oauth2.server-uri`) regardless of mode.
>   - Disables `TOKEN_REFRESH_ENABLED` for `JWT` explicitly.
> - **Tests**:
>   - Add/extend unit tests for `JWT` mode (build and properties), case-insensitive `security`, and token refresh behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47b0eee75cd6319dd49fbf938aeeb2833f16e667. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->