### PR TITLE
[BugFix] Fix error message for altering MV

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -237,7 +237,7 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
         }
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(mvName.getDb(), mvName.getTbl());
         if (table == null) {
-            throw new SemanticException("Table %s is not found", mvName);
+            throw new SemanticException("Materialized view %s is not found", mvName);
         }
         if (!table.isMaterializedView()) {
             throw new SemanticException("The specified table [" + mvName + "] is not a view");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -1633,7 +1633,7 @@ public class MaterializedViewAnalyzer {
             Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, statement.getMvName().getCatalog(),
                     statement.getMvName().getDb(), statement.getMvName().getTbl());
             if (table == null) {
-                throw new SemanticException("Table %s is not found", mvName);
+                throw new SemanticException("Materialized view %s is not found", mvName);
             }
             if (!(table instanceof MaterializedView)) {
                 throw new SemanticException(mvName.getTbl() + " is not async materialized view", mvName.getPos());


### PR DESCRIPTION
## Why I'm doing:
The error message should say "Materialized view not found" instead of "Table not found" when altering a materialized view, to make it more accurate and clear.

## What I'm doing:

as title

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes not-found errors to "Materialized view %s is not found" when altering an MV in `AlterJobExecutor` and `MaterializedViewAnalyzer`.
> 
> - **Error Message Consistency**:
>   - Update null-check messages to `"Materialized view %s is not found"` instead of `"Table %s is not found"` when altering MVs.
>     - `fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java`
>     - `fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2df8d2c735aee040b0f7e05e053c4f1992d0c544. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->