### PR TITLE
[BugFix] Fix dead lock when creating exclusive work group

### DIFF
--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -269,8 +269,15 @@ ExecStateReporter::ExecStateReporter(const CpuUtil::CpuIds& cpuids, ExecStateRep
         LOG(FATAL) << "Cannot create thread pool for priority ExecStateReport: error=" << status.to_string();
     }
 
-    metrics->monitor_reporter(_thread_pool.get());
-    metrics->monitor_priority_reporter(_priority_thread_pool.get());
+    _metrics = metrics;
+    _metrics->monitor_reporter(_thread_pool.get());
+    _metrics->monitor_priority_reporter(_priority_thread_pool.get());
+}
+
+ExecStateReporter::~ExecStateReporter() {
+    // remove thread pool metrics from parent metrics
+    _metrics->unmonitor_reporter(_thread_pool.get());
+    _metrics->unmonitor_priority_reporter(_priority_thread_pool.get());
 }
 
 void ExecStateReporter::submit(std::function<void()>&& report_task, bool priority) {

--- a/be/src/exec/pipeline/exec_state_reporter.h
+++ b/be/src/exec/pipeline/exec_state_reporter.h
@@ -27,9 +27,10 @@
 #include "util/threadpool.h"
 
 namespace starrocks::pipeline {
+class ExecStateReporterMetrics;
 class ExecStateReporter {
 public:
-    explicit ExecStateReporter(const CpuUtil::CpuIds& cpuids);
+    explicit ExecStateReporter(const CpuUtil::CpuIds& cpuids, ExecStateReporterMetrics* metrics);
 
     static std::unique_ptr<TReportExecStatusParams> create_report_exec_status_params(
             QueryContext* query_ctx, FragmentContext* fragment_ctx, RuntimeProfile* profile,

--- a/be/src/exec/pipeline/exec_state_reporter.h
+++ b/be/src/exec/pipeline/exec_state_reporter.h
@@ -31,6 +31,7 @@ class ExecStateReporterMetrics;
 class ExecStateReporter {
 public:
     explicit ExecStateReporter(const CpuUtil::CpuIds& cpuids, ExecStateReporterMetrics* metrics);
+    ~ExecStateReporter();
 
     static std::unique_ptr<TReportExecStatusParams> create_report_exec_status_params(
             QueryContext* query_ctx, FragmentContext* fragment_ctx, RuntimeProfile* profile,
@@ -50,6 +51,7 @@ public:
     static Status report_epoch(const TMVMaintenanceTasks& params, ExecEnv* exec_env, const TNetworkAddress& fe_addr);
 
 private:
+    ExecStateReporterMetrics* _metrics;
     std::unique_ptr<ThreadPool> _thread_pool;
     std::unique_ptr<ThreadPool> _priority_thread_pool;
 };

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -44,7 +44,7 @@ GlobalDriverExecutor::GlobalDriverExecutor(const std::string& name, std::unique_
           _thread_pool(std::move(thread_pool)),
           _blocked_driver_poller(
                   new PipelineDriverPoller(name, _driver_queue.get(), cpuids, metrics->get_poller_metrics())),
-          _exec_state_reporter(new ExecStateReporter(cpuids)),
+          _exec_state_reporter(new ExecStateReporter(cpuids, metrics->get_exec_state_reporter_metrics())),
           _audit_statistics_reporter(new AuditStatisticsReporter()),
           _metrics(metrics->get_driver_executor_metrics()) {}
 

--- a/be/src/exec/pipeline/pipeline_metrics.h
+++ b/be/src/exec/pipeline/pipeline_metrics.h
@@ -14,10 +14,13 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "util/metrics.h"
 
 namespace starrocks {
 class MetricRegistry;
+class ThreadPool;
 namespace pipeline {
 
 struct ScanExecutorMetrics {
@@ -27,6 +30,25 @@ struct ScanExecutorMetrics {
     METRIC_DEFINE_INT_CORE_LOCAL_GAUGE(pending_tasks, MetricUnit::NOUNIT);
 
     void register_all_metrics(MetricRegistry* registry, const std::string& prefix);
+};
+
+struct ExecStateReporterMetrics {
+    void register_all_metrics();
+
+    void monitor_reporter(ThreadPool* thread_pool) {
+        std::lock_guard guard(_mutex);
+        _reporter_thr_pools.push_back(thread_pool);
+    }
+
+    void monitor_priority_reporter(ThreadPool* thread_pool) {
+        std::lock_guard guard(_mutex);
+        _priority_reporter_thr_pools.push_back(thread_pool);
+    }
+
+private:
+    std::mutex _mutex;
+    std::vector<ThreadPool*> _reporter_thr_pools;
+    std::vector<ThreadPool*> _priority_reporter_thr_pools;
 };
 
 struct DriverQueueMetrics {
@@ -54,6 +76,7 @@ public:
     DriverExecutorMetrics driver_executor_metrics;
     ScanExecutorMetrics scan_executor_metrics;
     ScanExecutorMetrics connector_scan_executor_metrics;
+    ExecStateReporterMetrics exec_state_reporter_metrics;
 
     PollerMetrics* get_poller_metrics() { return &poller_metrics; }
     DriverQueueMetrics* get_driver_queue_metrics() { return &driver_queue_metrics; }
@@ -62,6 +85,8 @@ public:
     ScanExecutorMetrics* get_scan_executor_metrics() { return &scan_executor_metrics; }
 
     ScanExecutorMetrics* get_connector_scan_executor_metrics() { return &connector_scan_executor_metrics; }
+
+    ExecStateReporterMetrics* get_exec_state_reporter_metrics() { return &exec_state_reporter_metrics; }
 
     void register_all_metrics(MetricRegistry* registry);
 };

--- a/be/src/exec/pipeline/pipeline_metrics.h
+++ b/be/src/exec/pipeline/pipeline_metrics.h
@@ -45,7 +45,23 @@ struct ExecStateReporterMetrics {
         _priority_reporter_thr_pools.push_back(thread_pool);
     }
 
+    void unmonitor_reporter(ThreadPool* thread_pool) {
+        std::lock_guard guard(_mutex);
+        _remove_thread_pool_unlocked(thread_pool, &_reporter_thr_pools);
+    }
+    void unmonitor_priority_reporter(ThreadPool* thread_pool) {
+        std::lock_guard guard(_mutex);
+        _remove_thread_pool_unlocked(thread_pool, &_priority_reporter_thr_pools);
+    }
+
 private:
+    void _remove_thread_pool_unlocked(ThreadPool* thread_pool, std::vector<ThreadPool*>* pools) {
+        auto it = std::find(pools->begin(), pools->end(), thread_pool);
+        if (it != pools->end()) {
+            pools->erase(it);
+        }
+    }
+
     std::mutex _mutex;
     std::vector<ThreadPool*> _reporter_thr_pools;
     std::vector<ThreadPool*> _priority_reporter_thr_pools;

--- a/be/src/util/metrics.h
+++ b/be/src/util/metrics.h
@@ -444,3 +444,12 @@ using IntCoreLocalGuage = CoreLocalGauge<int64_t>;
 
 #define METRIC_DEFINE_INT_CORE_LOCAL_GAUGE(metric_name, unit) \
     starrocks::IntCoreLocalGuage metric_name { unit }
+
+#define METRICS_DEFINE_THREAD_POOL(threadpool_name)                                             \
+    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_threadpool_size, MetricUnit::NOUNIT);            \
+    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_executed_tasks_total, MetricUnit::NOUNIT);       \
+    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_pending_time_ns_total, MetricUnit::NANOSECONDS); \
+    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_execute_time_ns_total, MetricUnit::NANOSECONDS); \
+    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_queue_count, MetricUnit::NOUNIT);                \
+    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_running_threads, MetricUnit::NOUNIT);            \
+    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_active_threads, MetricUnit::NOUNIT)

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -55,7 +55,6 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
     REGISTER_STARROCKS_METRIC(query_scan_bytes);
     REGISTER_STARROCKS_METRIC(query_scan_rows);
 
-    pipeline_executor_metrics.register_all_metrics(&_metrics);
     REGISTER_STARROCKS_METRIC(pipe_scan_executor_queuing);
     REGISTER_STARROCKS_METRIC(pipe_driver_schedule_count);
     REGISTER_STARROCKS_METRIC(pipe_driver_execution_time);
@@ -262,6 +261,8 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
 void StarRocksMetrics::initialize(const std::vector<std::string>& paths, bool init_system_metrics,
                                   bool init_jvm_metrics, const std::set<std::string>& disk_devices,
                                   const std::vector<std::string>& network_interfaces) {
+    pipeline_executor_metrics.register_all_metrics(&_metrics);
+
     // disk usage
     for (auto& path : paths) {
         IntGauge* gauge = disks_total_capacity.add_metric(path, MetricUnit::BYTES);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -70,15 +70,6 @@ private:
     StarRocksMetrics::instance()->metrics()->register_hook(                                               \
             #name, [&]() { StarRocksMetrics::instance()->name.set_value(func()); });
 
-#define METRICS_DEFINE_THREAD_POOL(threadpool_name)                                             \
-    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_threadpool_size, MetricUnit::NOUNIT);            \
-    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_executed_tasks_total, MetricUnit::NOUNIT);       \
-    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_pending_time_ns_total, MetricUnit::NANOSECONDS); \
-    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_execute_time_ns_total, MetricUnit::NANOSECONDS); \
-    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_queue_count, MetricUnit::NOUNIT);                \
-    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_running_threads, MetricUnit::NOUNIT);            \
-    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_active_threads, MetricUnit::NOUNIT)
-
 #define REGISTER_THREAD_POOL_METRICS(name, threadpool)                                                            \
     do {                                                                                                          \
         REGISTER_GAUGE_STARROCKS_METRIC(name##_threadpool_size, [this]() { return threadpool->max_threads(); })   \

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -324,6 +324,8 @@ void assert_threadpool_metrics_register(const std::string& pool_name, MetricRegi
 }
 
 TEST_F(StarRocksMetricsTest, test_metrics_register) {
+    pipeline::ExecStateReporterMetrics exec_metrics;
+    exec_metrics.register_all_metrics();
     auto instance = StarRocksMetrics::instance()->metrics();
     ASSERT_NE(nullptr, instance->get_metric("memtable_flush_total"));
     ASSERT_NE(nullptr, instance->get_metric("memtable_flush_duration_us"));


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

condition:
thread 1: WorkGroup acquired wg mutex then try to acquire metrics mutex
thread 2: deamon thread try to update metrics. acquired metrics mutex then try to acquire workgroup mutex

Fixes introduced in #63067
```
I20251009 16:36:37.966538 139943118452288 time_guard.h:91] found slow function:Stack trace id: 8, tid: 8976 cid:139945752028736 
    0x7f48169a8fd7  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x90fd7)
    0x7f48169b3315  __pthread_rwlock_wrlock
        0x10c10342  starrocks::MetricRegistry::register_hook(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&)
         0xcb451b1  starrocks::pipeline::ExecStateReporter::ExecStateReporter(std::vector<unsigned long, std::allocator<unsigned long> > const&)
         0xc571662  starrocks::pipeline::GlobalDriverExecutor::GlobalDriverExecutor(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::unique_ptr<starrocks::ThreadPool, std::default_delete<starrocks::ThreadPool> >, bool, std::vector<u)^F
         0xc56201e  starrocks::workgroup::PipelineExecutorSet::start()
         0xc55a9b6  starrocks::workgroup::ExecutorsManager::maybe_create_exclusive_executors_unlocked(starrocks::workgroup::WorkGroup*, std::vector<unsigned long, std::allocator<unsigned long> > const&) const
         0xc550748  starrocks::workgroup::WorkGroupManager::create_workgroup_unlocked(std::shared_ptr<starrocks::workgroup::WorkGroup> const&, std::unique_lock<std::shared_mutex>&)
         0xc5514c1  starrocks::workgroup::WorkGroupManager::add_workgroup(std::shared_ptr<starrocks::workgroup::WorkGroup> const&)
        0x10737ae8  starrocks::pipeline::FragmentExecutor::_prepare_workgroup(starrocks::pipeline::UnifiedExecPlanFragmentParams const&)
        0x1073ec79  starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
        0x109db599  starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
        0x109def94  starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*)
        0x109e5f94  starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)
        0x109e63ec  std::_Function_handler<void (), starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closur'^F
        0x104edbab  starrocks::PriorityThreadPool::work_thread(int)
        0x104dfc3f  boost::detail::thread_data<std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)> >::run()
        0x14d3e4ab  thread_proxy
    0x7f48169acac3  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac3)
    0x7f4816a3e850  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x126850)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
