### PR TITLE
[BugFix] ensure COW works in Chunk::filter

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -305,7 +305,7 @@ size_t Chunk::filter(const Buffer<uint8_t>& selection, bool force) {
         return num_rows();
     }
     for (auto& column : _columns) {
-        MutableColumnPtr mutable_column = std::move(*column).mutate();
+        MutableColumnPtr mutable_column = Column::mutate(column);
         mutable_column->filter(selection);
         column = std::move(mutable_column);
     }
@@ -314,7 +314,7 @@ size_t Chunk::filter(const Buffer<uint8_t>& selection, bool force) {
 
 size_t Chunk::filter_range(const Buffer<uint8_t>& selection, size_t from, size_t to) {
     for (auto& column : _columns) {
-        MutableColumnPtr mutable_column = std::move(*column).mutate();
+        MutableColumnPtr mutable_column = Column::mutate(column);
         mutable_column->filter_range(selection, from, to);
         column = std::move(mutable_column);
     }

--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -16,6 +16,7 @@
 
 #include <utility>
 
+#include "column/column.h"
 #include "column/column_helper.h"
 #include "column/datum_tuple.h"
 #include "column/fixed_length_column.h"
@@ -304,14 +305,18 @@ size_t Chunk::filter(const Buffer<uint8_t>& selection, bool force) {
         return num_rows();
     }
     for (auto& column : _columns) {
-        column->filter(selection);
+        MutableColumnPtr mutable_column = std::move(*column).mutate();
+        mutable_column->filter(selection);
+        column = std::move(mutable_column);
     }
     return num_rows();
 }
 
 size_t Chunk::filter_range(const Buffer<uint8_t>& selection, size_t from, size_t to) {
     for (auto& column : _columns) {
-        column->filter_range(selection, from, to);
+        MutableColumnPtr mutable_column = std::move(*column).mutate();
+        mutable_column->filter_range(selection, from, to);
+        column = std::move(mutable_column);
     }
     return num_rows();
 }

--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -513,6 +513,8 @@ Status ScalarColumnReader::_read_range_impl(const Range<uint64_t>& range, const 
         } else {
             if (_tmp_intermediate_column == nullptr) {
                 _tmp_intermediate_column = _converter->create_src_column();
+            } else {
+                _tmp_intermediate_column->resize(0);
             }
             _tmp_intermediate_column->reserve(range.span_size());
             {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #62828

SR's COW support is currently incomplete, effectively allowing `ImmutPtr` to call non-const methods. A previous fix #62826 addressed this issue by actively calling mutate to trigger a deep copy. Chunk::filter itself doesn't guarantee COW functionality. I've implemented a fix in this pull request.

**Note that the current fix is ​​only a short-term workaround**. A long-term solution would require adding constraints to ImmutPtr to prohibit it from calling non-const methods, but this involves significant changes, so we'll implement this step-by-step.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure copy-on-write in `Chunk::{filter,filter_range}` and clear Parquet reader’s intermediate column before conversion reuse.
> 
> - **Column/Chunk**:
>   - Enforce COW by mutating columns in `Chunk::filter` and `Chunk::filter_range` before applying filters (`Column::mutate`, assign back).
> - **Parquet Reader**:
>   - When conversion is needed, clear `_tmp_intermediate_column` via `resize(0)` before reserving/reading in `_read_range_impl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 016a2e386e158aa7ba42ef5a24d2c63730dc0bc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->