### PR TITLE
[Enhancement] add metric for page_cache

### DIFF
--- a/be/src/cache/mem_cache/local_mem_cache_engine.h
+++ b/be/src/cache/mem_cache/local_mem_cache_engine.h
@@ -107,6 +107,15 @@ public:
     // Get the cache hit count.
     virtual size_t hit_count() const = 0;
 
+    // Get the insert count.
+    virtual size_t insert_count() const = 0;
+
+    // Get the insert evict count.
+    virtual size_t insert_evict_count() const = 0;
+
+    // Get the release evict count.
+    virtual size_t release_evict_count() const = 0;
+
     // Remove all cache entries that are not actively in use.
     virtual Status prune() = 0;
 };

--- a/be/src/cache/mem_cache/lrucache_engine.cpp
+++ b/be/src/cache/mem_cache/lrucache_engine.cpp
@@ -111,6 +111,18 @@ size_t LRUCacheEngine::hit_count() const {
     return _cache->get_hit_count();
 }
 
+size_t LRUCacheEngine::insert_count() const {
+    return _cache->get_insert_count();
+}
+
+size_t LRUCacheEngine::insert_evict_count() const {
+    return _cache->get_insert_evict_count();
+}
+
+size_t LRUCacheEngine::release_evict_count() const {
+    return _cache->get_release_evict_count();
+}
+
 bool LRUCacheEngine::_check_write(size_t charge, const MemCacheWriteOptions& options) const {
     if (options.evict_probability >= 100) {
         return true;

--- a/be/src/cache/mem_cache/lrucache_engine.h
+++ b/be/src/cache/mem_cache/lrucache_engine.h
@@ -57,6 +57,12 @@ public:
 
     size_t hit_count() const override;
 
+    size_t insert_count() const override;
+
+    size_t insert_evict_count() const override;
+
+    size_t release_evict_count() const override;
+
     Status prune() override;
 
 private:

--- a/be/src/cache/mem_cache/page_cache.h
+++ b/be/src/cache/mem_cache/page_cache.h
@@ -103,6 +103,12 @@ public:
 
     uint64_t get_hit_count() const;
 
+    uint64_t get_insert_count() const;
+
+    uint64_t get_insert_evict_count() const;
+
+    uint64_t get_release_evict_count() const;
+
     bool adjust_capacity(int64_t delta, size_t min_capacity = 0);
 
     void prune();

--- a/be/src/util/lru_cache.h
+++ b/be/src/util/lru_cache.h
@@ -183,6 +183,9 @@ public:
     virtual size_t get_memory_usage() const = 0;
     virtual size_t get_lookup_count() const = 0;
     virtual size_t get_hit_count() const = 0;
+    virtual size_t get_insert_count() const = 0;
+    virtual size_t get_insert_evict_count() const = 0;
+    virtual size_t get_release_evict_count() const = 0;
 
     //  Decrease or increase cache capacity.
     virtual bool adjust_capacity(int64_t delta, size_t min_capacity = 0) = 0;
@@ -278,6 +281,9 @@ public:
 
     uint64_t get_lookup_count() const;
     uint64_t get_hit_count() const;
+    uint64_t get_insert_count() const;
+    uint64_t get_insert_evict_count() const;
+    uint64_t get_release_evict_count() const;
     size_t get_usage() const;
     size_t get_capacity() const;
     static size_t key_handle_size(const CacheKey& key) { return sizeof(LRUHandle) - 1 + key.size(); }
@@ -305,6 +311,9 @@ private:
 
     uint64_t _lookup_count{0};
     uint64_t _hit_count{0};
+    uint64_t _insert_count{0};
+    uint64_t _insert_evict_count{0};
+    uint64_t _release_evict_count{0};
 };
 
 static const int kNumShardBits = 5;
@@ -330,6 +339,9 @@ public:
     size_t get_capacity() const override;
     size_t get_lookup_count() const override;
     size_t get_hit_count() const override;
+    size_t get_insert_count() const override;
+    size_t get_insert_evict_count() const override;
+    size_t get_release_evict_count() const override;
     bool adjust_capacity(int64_t delta, size_t min_capacity = 0) override;
 
 private:

--- a/docs/en/administration/management/monitoring/metrics.md
+++ b/docs/en/administration/management/monitoring/metrics.md
@@ -1077,6 +1077,21 @@ For more information on how to build a monitoring service for your StarRocks clu
 - Unit: Count
 - Description: Total number of hits in the storage page cache.
 
+### page_cache_insert_count
+
+- Unit: Count
+- Description: Total number of insert operations in the storage page cache.
+
+### page_cache_insert_evict_count
+
+- Unit: Count
+- Description: Total number of cache entries evicted during insert operations due to capacity constraints.
+
+### page_cache_release_evict_count
+
+- Unit: Count
+- Description: Total number of cache entries evicted during release operations when cache usage exceeds capacity.
+
 ### bytes_read_total (Deprecated)
 
 ### update_rowset_commit_request_total

--- a/docs/ja/administration/management/monitoring/metrics.md
+++ b/docs/ja/administration/management/monitoring/metrics.md
@@ -1076,6 +1076,21 @@ StarRocks クラスタのモニタリングサービスの構築方法につい�
 - 単位: Count
 - 説明: ストレージページキャッシュのヒット総数。
 
+### page_cache_insert_count
+
+- 単位: Count
+- 説明: ストレージページキャッシュの挿入操作総数。
+
+### page_cache_insert_evict_count
+
+- 単位: Count
+- 説明: 容量制限により、挿入操作中にエビクトされたキャッシュエントリの総数。
+
+### page_cache_release_evict_count
+
+- 単位: Count
+- 説明: キャッシュ使用量が容量を超えた場合、リリース操作中にエビクトされたキャッシュエントリの総数。
+
 ### bytes_read_total (Deprecated)
 
 ### update_rowset_commit_request_total

--- a/docs/zh/administration/management/monitoring/metrics.md
+++ b/docs/zh/administration/management/monitoring/metrics.md
@@ -1076,6 +1076,21 @@ displayed_sidebar: docs
 - 单位：个
 - 描述：Storage Page Cache 中的命中总次数。
 
+### page_cache_insert_count
+
+- 单位：个
+- 描述：Storage Page Cache 中的插入操作总次数。
+
+### page_cache_insert_evict_count
+
+- 单位：个
+- 描述：由于容量限制，在插入操作期间被淘汰的缓存项总次数。
+
+### page_cache_release_evict_count
+
+- 单位：个
+- 描述：当缓存使用量超过容量时，在释放操作期间被淘汰的缓存项总次数。
+
 ### bytes_read_total（已弃用）
 
 ### update_rowset_commit_request_total


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Add three new metrics to track cache eviction behavior:
- `page_cache_insert_count`: Total number of insert operations
- `page_cache_insert_evict_count`: Number of evictions during insert operations
- `page_cache_release_evict_count`: Number of evictions during release operations


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add page cache metrics for insert operations and eviction events with engine/plumbing support and docs updates.
> 
> - **Cache/Backend**:
>   - Extend `LocalMemCacheEngine` and `LRUCacheEngine` with `insert_count()`, `insert_evict_count()`, and `release_evict_count()`.
>   - Implement counters in `LRUCache` (track on insert and release) and aggregate via `ShardedLRUCache` getters.
>   - Expose new counters through `StoragePageCache` getters.
> - **Metrics**:
>   - Define and register gauges: `page_cache_insert_count`, `page_cache_insert_evict_count`, `page_cache_release_evict_count` with hooks in `page_cache.cpp`.
> - **Docs**:
>   - Document the three new metrics in `docs/*/administration/management/monitoring/metrics.md` (EN/JA/ZH).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc7a7381a8e67f61a87bfb899c03b2daba06d92b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->