### PR TITLE
[Draft] fix orc write meta corrupt in arm

### DIFF
--- a/be/src/formats/orc/apache-orc/c++/src/ColumnWriter.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/ColumnWriter.cc
@@ -556,7 +556,7 @@ void ByteColumnWriter::add(ColumnVectorBatch& rowBatch, uint64_t offset, uint64_
             if (enableBloomFilter) {
                 bloomFilter->addLong(data[i]);
             }
-            intStats->update(static_cast<int64_t>(byteData[i]), 1);
+            intStats->update(data[i], 1);
         }
     }
     intStats->increase(count);


### PR DESCRIPTION
## Why I'm doing:
In arm， when inserting negative value into tinyint column, the orc metadata will lose the sign.

maybe `GCC/Clang：-fsigned-char` can fix the problem.
## What I'm doing:

Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/10356)


```
(venv) owen@sandbox-dla:~/code/StarRocksTest$ nosetests-3.4 --with-flaky --no-success-flaky-report --force-flaky --max-runs=3 --min-passes=1 -s --with-xunit --xunit-file=./result/${CLUSTER_ID}/'test_hive_table_sink_insert_values_orc_py_TestHiveTableSinkTableInsertValuesORC_test_hive_sink_table_insert_values_orc.xml' --verbose 'case/system_case/test_ddl/test_hive_table_sink/test_hive_table_sink_insert_values_orc.py:TestHiveTableSinkTableInsertValuesORC.test_hive_sink_table_insert_values_orc' --nologcapture
测试hive普通表insert values ... 
case exec connect time:  1760524719 2025-10-15 18:38:39
show backends;

case exec close time:  1760524719 2025-10-15 18:38:39
show backends;
create external catalog hive_catalog_1c8a8638_a9b3_11f0_8fb8_51b76cf077a8 PROPERTIES("type" = "hive","hive.metastore.uris" = "thrift://*:9083");
set catalog hive_catalog_1c8a8638_a9b3_11f0_8fb8_51b76cf077a8;
create database hive_tbl_sink_1c8a8639_a9b3_11f0_8fb8_51b76cf077a8 properties("location" = "oss://starrocks-qa-test-data/system_data/test_temp_data/hive_table_sink/hive_tbl_sink_1c8a8639_a9b3_11f0_8fb8_51b76cf077a8");
use hive_tbl_sink_1c8a8639_a9b3_11f0_8fb8_51b76cf077a8;
create table hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(
            c_tinyint tinyint,
            c_smallint smallint,
            c_int int,
            c_bigint bigint,
            c_bool boolean,
            c_float float,
            c_double double,
            c_decimal decimal(38,18),
            c_date date,
            c_datetime datetime,
            c_char char(10),
            c_varchar varchar(20),
            c_string string)
            properties(
                "file_format" = "orc",
                "compression_codec"="zlib");
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 values
                (127,32767,2147483647,9223372036854775807,
                1,3.4E+38,1.79E+308,99999999999999999999.999999999999999999,
                '9999-12-31','9999-12-31 23:59:59',
                'ABCDEFGHIJ','HELLO,WORLD!ABCDEFGH','This column type is string.');
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 values
                (-128,-32768,-2147483648,-9223372036854775808,
                0,-3.4E+38,-1.79E+308,-99999999999999999999.999999999999999999,
                '0000-01-01','0000-01-01 00:00:00',
                '','','');
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_tinyint) values(null);
select * from hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 order by 1,2,3,4,5,6,7,8;
((None, None, None, None, None, None, None, None, None, None, None, None, None), (-128, -32768, -2147483648, -9223372036854775808, 0, -3.4e+38, -1.79e+308, Decimal('-99999999999999999999.999999999999999999'), '0000-01-01', '0000-01-01 00:00:00', '', '', ''), (127, 32767, 2147483647, 9223372036854775807, 1, 3.4e+38, 1.79e+308, Decimal('99999999999999999999.999999999999999999'), datetime.date(9999, 12, 31), datetime.datetime(9999, 12, 31, 23, 59, 59), 'ABCDEFGHIJ', 'HELLO,WORLD!ABCDEFGH', 'This column type is string.'))
insert into hive_catalog_1c8a8638_a9b3_11f0_8fb8_51b76cf077a8.hive_tbl_sink_1c8a8639_a9b3_11f0_8fb8_51b76cf077a8.hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 values(0,0,0,0,0,0,0,0,'2001-01-01','2001-01-01 00:00:01',
                ' A b ','   hello   ','  !@#$%null     ');
select * from hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 order by 1,2,3,4,5,6,7,8;
((None, None, None, None, None, None, None, None, None, None, None, None, None), (-128, -32768, -2147483648, -9223372036854775808, 0, -3.4e+38, -1.79e+308, Decimal('-99999999999999999999.999999999999999999'), '0000-01-01', '0000-01-01 00:00:00', '', '', ''), (0, 0, 0, 0, 0, 0.0, 0.0, Decimal('0E-18'), datetime.date(2001, 1, 1), datetime.datetime(2001, 1, 1, 0, 0, 1), ' A b ', '   hello   ', '  !@#$%null     '), (127, 32767, 2147483647, 9223372036854775807, 1, 3.4e+38, 1.79e+308, Decimal('99999999999999999999.999999999999999999'), datetime.date(9999, 12, 31), datetime.datetime(9999, 12, 31, 23, 59, 59), 'ABCDEFGHIJ', 'HELLO,WORLD!ABCDEFGH', 'This column type is string.'))
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_int,c_bool,c_float,c_decimal,c_date,c_varchar) 
                values
                (99,1,3.1415926,-65315.45,'9998-12-12',''),
                (-123,0,-0.3,2.5,'0002-02-02',' hello '),
                (null,-0,null,null,null,null);
select * from hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 order by 1,2,3,4,5,6,7,8;
((None, None, None, None, None, None, None, None, None, None, None, None, None), (None, None, None, None, 0, None, None, None, None, None, None, None, None), (None, None, -123, None, 0, -0.3, None, Decimal('2.500000000000000000'), datetime.date(2, 2, 2), None, None, ' hello ', None), (None, None, 99, None, 1, 3.1415925, None, Decimal('-65315.450000000000000000'), datetime.date(9998, 12, 12), None, None, '', None), (-128, -32768, -2147483648, -9223372036854775808, 0, -3.4e+38, -1.79e+308, Decimal('-99999999999999999999.999999999999999999'), '0000-01-01', '0000-01-01 00:00:00', '', '', ''), (0, 0, 0, 0, 0, 0.0, 0.0, Decimal('0E-18'), datetime.date(2001, 1, 1), datetime.datetime(2001, 1, 1, 0, 0, 1), ' A b ', '   hello   ', '  !@#$%null     '), (127, 32767, 2147483647, 9223372036854775807, 1, 3.4e+38, 1.79e+308, Decimal('99999999999999999999.999999999999999999'), datetime.date(9999, 12, 31), datetime.datetime(9999, 12, 31, 23, 59, 59), 'ABCDEFGHIJ', 'HELLO,WORLD!ABCDEFGH', 'This column type is string.'))
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_date,c_tinyint,c_string)
                values
                ('2023-03-13',126,'This column type is tring'),
                (null, -127,' '),
                ('2010-10-10',0,' Wonderful World ');
select * from hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 order by 1,2,3,4,5,6,7,8;
((None, None, None, None, None, None, None, None, None, None, None, None, None), (None, None, None, None, 0, None, None, None, None, None, None, None, None), (None, None, -123, None, 0, -0.3, None, Decimal('2.500000000000000000'), datetime.date(2, 2, 2), None, None, ' hello ', None), (None, None, 99, None, 1, 3.1415925, None, Decimal('-65315.450000000000000000'), datetime.date(9998, 12, 12), None, None, '', None), (-128, -32768, -2147483648, -9223372036854775808, 0, -3.4e+38, -1.79e+308, Decimal('-99999999999999999999.999999999999999999'), '0000-01-01', '0000-01-01 00:00:00', '', '', ''), (-127, None, None, None, None, None, None, None, None, None, None, None, ' '), (0, None, None, None, None, None, None, None, datetime.date(2010, 10, 10), None, None, None, ' Wonderful World '), (0, 0, 0, 0, 0, 0.0, 0.0, Decimal('0E-18'), datetime.date(2001, 1, 1), datetime.datetime(2001, 1, 1, 0, 0, 1), ' A b ', '   hello   ', '  !@#$%null     '), (126, None, None, None, None, None, None, None, datetime.date(2023, 3, 13), None, None, None, 'This column type is tring'), (127, 32767, 2147483647, 9223372036854775807, 1, 3.4e+38, 1.79e+308, Decimal('99999999999999999999.999999999999999999'), datetime.date(9999, 12, 31), datetime.datetime(9999, 12, 31, 23, 59, 59), 'ABCDEFGHIJ', 'HELLO,WORLD!ABCDEFGH', 'This column type is string.'))
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 values(
                0+123,round(23.56*1.5),2+65*54,10*324568/5,
                not 1,35.245*1254,5645.545/654*64218+698,9.3154*4554/5446*45975,
                date_trunc('day','1965-02-23 10:23:25'), '2036-05-06 12:25:28' + interval '8' month,
                concat('abc',' '),cast(5645.545/654*64218+698 as varchar(20)),substring('hello, world', 2, 5));
select * from hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 order by 1,2,3,4,5,6,7,8;
((None, None, None, None, None, None, None, None, None, None, None, None, None), (None, None, None, None, 0, None, None, None, None, None, None, None, None), (None, None, -123, None, 0, -0.3, None, Decimal('2.500000000000000000'), datetime.date(2, 2, 2), None, None, ' hello ', None), (None, None, 99, None, 1, 3.1415925, None, Decimal('-65315.450000000000000000'), datetime.date(9998, 12, 12), None, None, '', None), (-128, -32768, -2147483648, -9223372036854775808, 0, -3.4e+38, -1.79e+308, Decimal('-99999999999999999999.999999999999999999'), '0000-01-01', '0000-01-01 00:00:00', '', '', ''), (-127, None, None, None, None, None, None, None, None, None, None, None, ' '), (0, None, None, None, None, None, None, None, datetime.date(2010, 10, 10), None, None, None, ' Wonderful World '), (0, 0, 0, 0, 0, 0.0, 0.0, Decimal('0E-18'), datetime.date(2001, 1, 1), datetime.datetime(2001, 1, 1, 0, 0, 1), ' A b ', '   hello   ', '  !@#$%null     '), (123, 35, 3512, 649136, 0, 44197.23, 555049.083789272, Decimal('358128.295137210000000000'), datetime.date(1965, 2, 23), datetime.datetime(2037, 1, 6, 12, 25, 28), 'abc ', '555049.083789272', 'ello,'), (126, None, None, None, None, None, None, None, datetime.date(2023, 3, 13), None, None, None, 'This column type is tring'), (127, 32767, 2147483647, 9223372036854775807, 1, 3.4e+38, 1.79e+308, Decimal('99999999999999999999.999999999999999999'), datetime.date(9999, 12, 31), datetime.datetime(9999, 12, 31, 23, 59, 59), 'ABCDEFGHIJ', 'HELLO,WORLD!ABCDEFGH', 'This column type is string.'))
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_tinyint, c_smallint) values(128, 999);
select * from hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 where c_smallint = 999;
((None, 999, None, None, None, None, None, None, None, None, None, None, None),)
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_tinyint, c_smallint) values(-99, -32769);
select * from hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 where c_tinyint = -99;
((-99, None, None, None, None, None, None, None, None, None, None, None, None),)
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_int) values(2147483648);
select * from hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 where c_int = 2147483648;
()
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_bigint) values(9223372036854775808);
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_bigint,c_date) values(99999,'0000-01-00');
select * from hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 where c_bigint = 99999;
((None, None, None, 99999, None, None, None, None, None, None, None, None, None),)
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_bigint,c_datetime) values(88888,'9999-12-32 12:23:26');
select * from hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 where c_bigint = 88888;
((None, None, None, 88888, None, None, None, None, None, None, None, None, None),)
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_bigint) values(77777);
select * from hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 where c_bigint = 77777;
((None, None, None, 77777, None, None, None, None, None, None, None, None, None),)
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_map) values((2));
(1064, "Getting analyzing error. Detail message: Unknown column 'c_map' in 'hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8'.")
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_int) values('ABC');
(1064, 'Getting analyzing error. Detail message: Invalid number format: ABC.')
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_bigint,c_date) values(66666, 'ABC');
select * from hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 where c_bigint = 66666;
((None, None, None, 66666, None, None, None, None, None, None, None, None, None),)
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 values(1,2);
(5604, "Getting analyzing error. Detail message: Inserted target column count: 13 doesn't match select/value column count: 2.")
insert into hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8(c_string,c_date) values(1,2,'abc');
(5604, "Getting analyzing error. Detail message: Inserted target column count: 2 doesn't match select/value column count: 3.")
create table hive_sink_insert_struct_orc(c_string string,
            c_struct struct<col_int integer, col_string string, col_date date>)
            properties("file_format"="orc");
insert into hive_sink_insert_struct_orc(c_string,c_struct) 
                values('hello', row(2147483647,'Struct column type string',cast("9999-12-31" as date)));
(5609, 'ORC writer does not support to write STRUCT{col_int INT, col_string VARCHAR(65533), col_date DATE} type yet: BE:10003')
create table hive_sink_insert_array_orc(c_string string,
                c_array array<integer>)
                properties("file_format"="orc");
insert into hive_sink_insert_array_orc(c_string,c_array) 
                values('hello', [2147483647,null,-2147483648,0]);
(5609, 'ORC writer does not support to write ARRAY<INT> type yet: BE:10001')
create table hive_sink_insert_map_orc(c_string string,
                c_map map<boolean, string>)
                properties("file_format"="orc");
insert into hive_sink_insert_map_orc(c_string,c_map) 
                values('hello', map(cast(1 as boolean),'Hello, World.'));
(5609, 'ORC writer does not support to write MAP<BOOLEAN, VARCHAR(65533)> type yet: BE:10002')
drop table if exists hive_catalog_1c8a8638_a9b3_11f0_8fb8_51b76cf077a8.hive_tbl_sink_1c8a8639_a9b3_11f0_8fb8_51b76cf077a8.hive_tbl_1f888646_a9b3_11f0_8fb8_51b76cf077a8 force;
drop table if exists hive_catalog_1c8a8638_a9b3_11f0_8fb8_51b76cf077a8.hive_tbl_sink_1c8a8639_a9b3_11f0_8fb8_51b76cf077a8.hive_sink_insert_struct_orc force;
drop table if exists hive_catalog_1c8a8638_a9b3_11f0_8fb8_51b76cf077a8.hive_tbl_sink_1c8a8639_a9b3_11f0_8fb8_51b76cf077a8.hive_sink_insert_array_orc force;
drop table if exists hive_catalog_1c8a8638_a9b3_11f0_8fb8_51b76cf077a8.hive_tbl_sink_1c8a8639_a9b3_11f0_8fb8_51b76cf077a8.hive_sink_insert_map_orc force;
drop database hive_catalog_1c8a8638_a9b3_11f0_8fb8_51b76cf077a8.hive_tbl_sink_1c8a8639_a9b3_11f0_8fb8_51b76cf077a8;
sh: 1: hadoop: not found
DROP CATALOG hive_catalog_1c8a8638_a9b3_11f0_8fb8_51b76cf077a8;

case exec close time:  1760524731 2025-10-15 18:38:51
Succeed: Total 0 objects. Removed 0 objects.       
                                                   
0.262333(s) elapsed
ok

----------------------------------------------------------------------
XML: /home/disk2/owen/code/StarRocksTest/result/test_hive_table_sink_insert_values_orc_py_TestHiveTableSinkTableInsertValuesORC_test_hive_sink_table_insert_values_orc.xml
----------------------------------------------------------------------
Ran 1 test in 12.355s

OK
(venv) owen@sandbox-dla:~/code/StarRocksTest$ 
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `ByteColumnWriter::add` to call `intStats->update` with `data[i]` instead of the casted `byteData[i]`.
> 
> - **ORC Writer**:
>   - **Byte stats update**: In `ByteColumnWriter::add` (`be/src/formats/orc/apache-orc/c++/src/ColumnWriter.cc`), use `intStats->update(data[i], 1)` instead of updating with the casted `byteData[i]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b79b349539841a2eb41554cec160ed5d8767ba0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->