### PR TITLE
[Enhancement] Add limited support for global low-cardinality optimization in join

### DIFF
--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -229,9 +229,6 @@ static TExprOpcode::type maybe_invert_in_and_equal_op(const TExprOpcode::type op
 // ------------------------------------------------------------------------------------
 
 BoxedExpr::BoxedExpr(Expr* root_expr) : root_expr(root_expr) {}
-bool BoxedExpr::is_dict_mapping_expr() const {
-    return dynamic_cast<DictMappingExpr*>(root_expr) != nullptr;
-}
 Expr* BoxedExpr::root() const {
     return get_root_expr(root_expr);
 }
@@ -250,9 +247,6 @@ StatusOr<ExprContext*> BoxedExpr::expr_context(ObjectPool* obj_pool, RuntimeStat
 }
 
 BoxedExprContext::BoxedExprContext(ExprContext* expr_ctx) : expr_ctx(expr_ctx) {}
-bool BoxedExprContext::is_dict_mapping_expr() const {
-    return dynamic_cast<DictMappingExpr*>(expr_ctx->root()) != nullptr;
-}
 Expr* BoxedExprContext::root() const {
     return get_root_expr(expr_ctx);
 }

--- a/be/src/exec/olap_scan_prepare.h
+++ b/be/src/exec/olap_scan_prepare.h
@@ -58,7 +58,6 @@ struct ScanConjunctsManagerOptions {
 struct BoxedExpr {
     explicit BoxedExpr(Expr* root_expr);
 
-    bool is_dict_mapping_expr() const;
     Expr* root() const;
     StatusOr<ExprContext*> expr_context(ObjectPool* obj_pool, RuntimeState* state) const;
 
@@ -69,7 +68,6 @@ struct BoxedExpr {
 struct BoxedExprContext {
     explicit BoxedExprContext(ExprContext* expr_ctx);
 
-    bool is_dict_mapping_expr() const;
     Expr* root() const;
     StatusOr<ExprContext*> expr_context(ObjectPool* obj_pool, RuntimeState* state) const;
 

--- a/be/src/exec/olap_scan_prepare.h
+++ b/be/src/exec/olap_scan_prepare.h
@@ -58,6 +58,7 @@ struct ScanConjunctsManagerOptions {
 struct BoxedExpr {
     explicit BoxedExpr(Expr* root_expr);
 
+    bool is_dict_mapping_expr() const;
     Expr* root() const;
     StatusOr<ExprContext*> expr_context(ObjectPool* obj_pool, RuntimeState* state) const;
 
@@ -68,6 +69,7 @@ struct BoxedExpr {
 struct BoxedExprContext {
     explicit BoxedExprContext(ExprContext* expr_ctx);
 
+    bool is_dict_mapping_expr() const;
     Expr* root() const;
     StatusOr<ExprContext*> expr_context(ObjectPool* obj_pool, RuntimeState* state) const;
 
@@ -125,6 +127,7 @@ private:
 
     Status _get_column_predicates(PredicateParser* parser, ColumnPredicatePtrs& col_preds_owner);
 
+    // Push down runtime bitset filter to storage layer, only used for index filter.
     Status _build_bitset_in_predicates(PredicateCompoundNode<Type>& tree_root, PredicateParser* parser,
                                        ColumnPredicatePtrs& col_preds_owner);
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -368,6 +368,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ALWAYS_COLLECT_LOW_CARD_DICT = "always_collect_low_card_dict";
     public static final String ALWAYS_COLLECT_LOW_CARD_DICT_ON_LAKE = "always_collect_low_card_dict_on_lake";
     public static final String CBO_ENABLE_LOW_CARDINALITY_OPTIMIZE = "cbo_enable_low_cardinality_optimize";
+    public static final String CBO_ENABLE_LOW_CARDINALITY_OPTIMIZE_FOR_JOIN = "cbo_enable_low_cardinality_optimize_for_join";
     public static final String LOW_CARDINALITY_OPTIMIZE_V2 = "low_cardinality_optimize_v2";
     public static final String LOW_CARDINALITY_OPTIMIZE_ON_LAKE = "low_cardinality_optimize_on_lake";
     public static final String ARRAY_LOW_CARDINALITY_OPTIMIZE = "array_low_cardinality_optimize";
@@ -1546,6 +1547,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = CBO_ENABLE_LOW_CARDINALITY_OPTIMIZE)
     private boolean enableLowCardinalityOptimize = true;
+
+    @VariableMgr.VarAttr(name = CBO_ENABLE_LOW_CARDINALITY_OPTIMIZE_FOR_JOIN)
+    private boolean enableLowCardinalityOptimizeForJoin = true;
 
     @VariableMgr.VarAttr(name = LOW_CARDINALITY_OPTIMIZE_V2)
     private boolean useLowCardinalityOptimizeV2 = true;
@@ -4024,6 +4028,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableLowCardinalityOptimize() {
         return enableLowCardinalityOptimize;
+    }
+
+    public boolean isEnableLowCardinalityOptimizeForJoin() {
+        return enableLowCardinalityOptimizeForJoin;
     }
 
     public boolean isUseLowCardinalityOptimizeV2() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -409,7 +409,6 @@ public class CostModel {
                     EXECUTE_COST_PENALTY);
             double memCost = StatisticUtils.multiplyOutputSize(rightSize, EXECUTE_COST_PENALTY * 100D);
 
-
             if (join.getJoinType().isCrossJoin()) {
                 cpuCost = StatisticUtils.multiplyOutputSize(cpuCost, crossJoinCostPenalty);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -355,13 +355,8 @@ public class CostModel {
             Statistics statistics = context.getStatistics();
             Preconditions.checkNotNull(statistics);
 
-            Statistics leftStatistics = context.getChildStatistics(0);
-            Statistics rightStatistics = context.getChildStatistics(1);
-
-            List<BinaryPredicateOperator> eqOnPredicates =
-                    JoinHelper.getEqualsPredicate(leftStatistics.getUsedColumns(),
-                            rightStatistics.getUsedColumns(),
-                            Utils.extractConjuncts(join.getOnPredicate()));
+            List<BinaryPredicateOperator> eqOnPredicates = JoinHelper.getEqualsPredicate(context.getChildOutputColumns(0),
+                    context.getChildOutputColumns(1), Utils.extractConjuncts(join.getOnPredicate()));
 
             Preconditions.checkState(!(join.getJoinType().isCrossJoin() || eqOnPredicates.isEmpty()),
                     "should be handled by nestloopjoin");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.TableFunction;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
@@ -41,6 +42,7 @@ import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDecodeOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
@@ -70,9 +72,12 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
 
     private final DecodeContext context;
 
-    public DecodeRewriter(ColumnRefFactory factory, DecodeContext context) {
+    private final SessionVariable sessionVariable;
+
+    public DecodeRewriter(ColumnRefFactory factory, DecodeContext context, SessionVariable sessionVariable) {
         this.factory = factory;
         this.context = context;
+        this.sessionVariable = sessionVariable;
     }
 
     public OptExpression rewrite(OptExpression optExpression) {
@@ -160,6 +165,37 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         op.setPredicate(rewritePredicate(op.getPredicate(), info.inputStringColumns));
         op.setProjection(rewriteProjection(op.getProjection(), info.inputStringColumns));
         return rewriteOptExpression(optExpression, op, info.outputStringColumns);
+    }
+
+    private ScalarOperator rewriteJoinOnPredicate(ScalarOperator predicate, ColumnRefSet inputs) {
+        if (predicate == null) {
+            return null;
+        }
+
+        // replace string predicate to dict predicate
+        JoinOnPredicateReplacer replacer = new JoinOnPredicateReplacer(context.stringRefToDictRefMap, inputs);
+        return predicate.accept(replacer, null);
+    }
+
+    @Override
+    public OptExpression visitPhysicalHashJoin(OptExpression optExpression, ColumnRefSet fragmentUseDictExprs) {
+        if (!sessionVariable.isEnableLowCardinalityOptimizeForJoin()) {
+            return super.visitPhysicalHashJoin(optExpression, fragmentUseDictExprs);
+        }
+
+        PhysicalHashJoinOperator join = optExpression.getOp().cast();
+        DecodeInfo info = context.operatorDecodeInfo.getOrDefault(join, DecodeInfo.EMPTY);
+
+        ScalarOperator newOnPredicate = rewriteJoinOnPredicate(join.getOnPredicate(), info.inputStringColumns);
+        ScalarOperator newPredicate = rewritePredicate(join.getPredicate(), info.inputStringColumns);
+        Projection newProjection = rewriteProjection(join.getProjection(), info.inputStringColumns);
+
+        PhysicalHashJoinOperator newJoin = new PhysicalHashJoinOperator(
+                join.getJoinType(), newOnPredicate, join.getJoinHint(), join.getLimit(), newPredicate, newProjection,
+                join.getSkewColumn(), join.getSkewValues());
+        newJoin.setSkewJoinFriend(join.getSkewJoinFriend().orElse(null));
+
+        return rewriteOptExpression(optExpression, newJoin, info.outputStringColumns);
     }
 
     @Override
@@ -303,8 +339,9 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         exchange.setGlobalDictsExpr(computeDictExpr(fragmentUseDictExprs));
 
         if (!(exchange.getDistributionSpec() instanceof HashDistributionSpec)) {
-            return optExpression;
+            return rewriteOptExpression(optExpression, exchange, info.outputStringColumns);
         }
+
         HashDistributionSpec spec = (HashDistributionSpec) exchange.getDistributionSpec();
         List<DistributionCol> shuffledColumns = Lists.newArrayList();
         for (DistributionCol column : spec.getHashDistributionDesc().getDistributionCols()) {
@@ -626,6 +663,31 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
                     && supportColumns.containsAll(scalarOperator.getUsedColumns())) {
                 return Optional.of(exprMapping.get(scalarOperator));
             }
+            return Optional.empty();
+        }
+    }
+
+    private static class JoinOnPredicateReplacer extends BaseScalarOperatorShuttle {
+        private final Map<ColumnRefOperator, ColumnRefOperator> stringRefToDictRefMap;
+        private final ColumnRefSet supportColumns;
+
+        public JoinOnPredicateReplacer(Map<ColumnRefOperator, ColumnRefOperator> stringRefToDictRefMap,
+                                       ColumnRefSet supportColumns) {
+            this.stringRefToDictRefMap = stringRefToDictRefMap;
+            this.supportColumns = supportColumns;
+        }
+
+        @Override
+        public Optional<ScalarOperator> preprocess(ScalarOperator scalarOperator) {
+            if (!(scalarOperator instanceof ColumnRefOperator)) {
+                return Optional.empty();
+            }
+
+            ColumnRefOperator columnRef = (ColumnRefOperator) scalarOperator;
+            if (stringRefToDictRefMap.containsKey(columnRef) && supportColumns.containsAll(columnRef.getUsedColumns())) {
+                return Optional.of(stringRefToDictRefMap.get(columnRef));
+            }
+
             return Optional.empty();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/LowCardinalityRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/LowCardinalityRewriteRule.java
@@ -39,7 +39,7 @@ public class LowCardinalityRewriteRule implements TreeRewriteRule {
                 return root;
             }
         }
-        DecodeRewriter rewriter = new DecodeRewriter(factory, context);
+        DecodeRewriter rewriter = new DecodeRewriter(factory, context, session);
         return rewriter.rewrite(root);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
 import com.starrocks.persist.gson.GsonUtils;
 
 import java.nio.ByteBuffer;
@@ -69,5 +70,59 @@ public final class ColumnDict extends StatsVersion {
         jsonMap.put("collectedVersion", collectedVersion);
         jsonMap.put("version", version);
         return gson.toJson(jsonMap);
+    }
+
+    /**
+     * Merge two dictionaries and return two new dictionaries.
+     * The id of each dictionary is a continuous integer from 1 to n, where n is the number of words in the dictionary.
+     * Ensure that the lexicographical order of the dictionary words is consistent with the order of the ids.
+     * If the merged dictionary size exceeds Config.low_cardinality_threshold, return null.
+     */
+    public static Pair<ColumnDict, ColumnDict> merge(ColumnDict d1, ColumnDict d2) {
+        final int n1 = d1.getDict().size() + 1;
+        final int n2 = d2.getDict().size() + 1;
+        ByteBuffer[] sortedKeys1 = new ByteBuffer[n1];
+        ByteBuffer[] sortedKeys2 = new ByteBuffer[n2];
+        d1.getDict().forEach((key, idx) -> sortedKeys1[idx] = key);
+        d2.getDict().forEach((key, idx) -> sortedKeys2[idx] = key);
+
+        ImmutableMap.Builder<ByteBuffer, Integer> builder =
+                ImmutableMap.builderWithExpectedSize(Math.min(n1 + n2 - 2, Config.low_cardinality_threshold));
+        int idx1 = 1;
+        int idx2 = 1;
+        int newIdx = 1;
+        while (idx1 < n1 && idx2 < n2) {
+            ByteBuffer key1 = sortedKeys1[idx1];
+            ByteBuffer key2 = sortedKeys2[idx2];
+            int cmp = key1.compareTo(key2);
+            if (cmp == 0) {
+                builder.put(key1, newIdx);
+                idx1++;
+                idx2++;
+            } else if (cmp < 0) {
+                builder.put(key1, newIdx);
+                idx1++;
+            } else {
+                builder.put(key2, newIdx);
+                idx2++;
+            }
+            newIdx++;
+        }
+
+        while (idx1 < n1) {
+            builder.put(sortedKeys1[idx1++], newIdx++);
+        }
+        while (idx2 < n2) {
+            builder.put(sortedKeys2[idx2++], newIdx++);
+        }
+
+        if (newIdx > Config.low_cardinality_threshold) {
+            return null;
+        }
+
+        final ImmutableMap<ByteBuffer, Integer> newDict = builder.build();
+        ColumnDict newD1 = new ColumnDict(newDict, d1.getCollectedVersion(), d1.getVersion());
+        ColumnDict newD2 = new ColumnDict(newDict, d2.getCollectedVersion(), d2.getVersion());
+        return new Pair<>(newD1, newD2);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ColumnDictTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ColumnDictTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,5 +56,92 @@ public class ColumnDictTest {
 
         ColumnDict dict = new ColumnDict(dictMap, 1);
         Assertions.assertEquals(300, dict.getDictSize());
+    }
+
+    @Test
+    public void testMergeDictSuccess() {
+        ImmutableMap.Builder<ByteBuffer, Integer> builder1 = ImmutableMap.builder();
+        ImmutableMap.Builder<ByteBuffer, Integer> builder2 = ImmutableMap.builder();
+
+        addWords(builder1, 1, 101, "common-");
+        addWords(builder1, 101, 121, "unique1-");
+        addWords(builder2, 1, 101, "common-");
+        addWords(builder2, 101, 131, "unique2-");
+
+        ImmutableMap<ByteBuffer, Integer> dictMap1 = builder1.build();
+        ImmutableMap<ByteBuffer, Integer> dictMap2 = builder2.build();
+        ColumnDict dict1 = new ColumnDict(dictMap1, 1);
+        ColumnDict dict2 = new ColumnDict(dictMap2, 2);
+
+        Pair<ColumnDict, ColumnDict> res = ColumnDict.merge(dict1, dict2);
+
+        Assertions.assertNotNull(res);
+        ColumnDict newDict1 = res.first;
+        ColumnDict newDict2 = res.second;
+        Assertions.assertEquals(newDict1.getVersion(), dict1.getVersion());
+        Assertions.assertEquals(newDict2.getVersion(), dict2.getVersion());
+
+        Assertions.assertEquals(150, newDict1.getDictSize());
+        for (int i = 1; i < 101; i++) {
+            String key = "common-" + i;
+            ByteBuffer keyBuffer = toByteBuffer(key);
+            Assertions.assertEquals(i, newDict1.getDict().get(keyBuffer));
+        }
+        for (int i = 101; i < 121; i++) {
+            String key = "unique1-" + i;
+            ByteBuffer keyBuffer = toByteBuffer(key);
+            Assertions.assertEquals(i, newDict1.getDict().get(keyBuffer));
+        }
+        for (int i = 101; i < 131; i++) {
+            String key = "unique2-" + i;
+            ByteBuffer keyBuffer = toByteBuffer(key);
+            Assertions.assertEquals(i + 20, newDict1.getDict().get(keyBuffer));
+        }
+
+        Assertions.assertEquals(newDict1.getDict(), newDict2.getDict());
+
+        res = ColumnDict.merge(newDict1, newDict2);
+
+        Assertions.assertNotNull(res);
+        ColumnDict newDict11 = res.first;
+        ColumnDict newDict21 = res.second;
+        Assertions.assertEquals(newDict11.getDict(), newDict1.getDict());
+        Assertions.assertEquals(newDict11.getDict(), newDict21.getDict());
+    }
+
+    @Test
+    public void testMergeDictFail() {
+        ImmutableMap.Builder<ByteBuffer, Integer> builder1 = ImmutableMap.builder();
+        ImmutableMap.Builder<ByteBuffer, Integer> builder2 = ImmutableMap.builder();
+
+        addWords(builder1, 1, 101, "common-");
+        addWords(builder1, 101, 121, "unique1-");
+        addWords(builder2, 1, 101, "common-");
+        addWords(builder2, 101, 511, "unique2-");
+
+        ImmutableMap<ByteBuffer, Integer> dictMap1 = builder1.build();
+        ImmutableMap<ByteBuffer, Integer> dictMap2 = builder2.build();
+        ColumnDict dict1 = new ColumnDict(dictMap1, 1);
+        ColumnDict dict2 = new ColumnDict(dictMap2, 2);
+
+        Pair<ColumnDict, ColumnDict> res = ColumnDict.merge(dict1, dict2);
+
+        Assertions.assertNull(res);
+    }
+
+    private void addWords(ImmutableMap.Builder<ByteBuffer, Integer> builder, int start, int end, String prefix) {
+        for (int i = start; i < end; i++) {
+            String key = prefix + i;
+            ByteBuffer keyBuffer = toByteBuffer(key);
+            builder.put(keyBuffer, i);
+        }
+    }
+
+    private ByteBuffer toByteBuffer(String str) {
+        byte[] keyBytes = str.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer keyBuffer = ByteBuffer.allocate(keyBytes.length);
+        keyBuffer.put(keyBytes);
+        keyBuffer.flip();
+        return keyBuffer;
     }
 }

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_join
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_join
@@ -34,7 +34,9 @@ CREATE TABLE t1 (
     low1 string NULL,
     low2 string NULL,
     low3 string NULL,
-    str1 string NULL
+    str1 string NULL,
+    low_char1 CHAR(40) NULL,
+    str_char1 CHAR(40) NULL
 ) ENGINE=OLAP
 DUPLICATE KEY(`k1`)
 DISTRIBUTED BY HASH(`k1`) BUCKETS 64
@@ -43,10 +45,20 @@ PROPERTIES (
 );
 -- result:
 -- !result
-insert into t1 select idx, concat('common-low1-', idx % 100), concat('common-low2-', idx % 200), concat('common-low3-', idx % 200), concat('common-str1-', idx) from __row_util;
+insert into t1 select 
+    idx, 
+    concat('common-low1-', idx % 100), concat('common-low2-', idx % 200), concat('common-low3-', idx % 200), 
+    concat('common-str1-', idx),
+    concat('common-low_char1-', idx % 100), concat('common-str_char1-', idx)
+from __row_util;
 -- result:
 -- !result
-insert into t1 select idx, concat('t1-low1-', idx % 50), concat('t1-low2-', idx % 20), concat('t1-low3-', idx % 50), concat('t1-str1-', idx) from __row_util;
+insert into t1 select 
+    idx, 
+    concat('t1-low1-', idx % 50), concat('t1-low2-', idx % 20), concat('t1-low3-', idx % 50), 
+    concat('t1-str1-', idx),
+    concat('t1-low_char1-', idx % 50), concat('t1-str_char1-', idx)
+from __row_util;
 -- result:
 -- !result
 insert into t1(k1) select 10000000;
@@ -57,7 +69,9 @@ CREATE TABLE t2 (
     low1 string NULL,
     low2 string NULL,
     low3 string NULL,
-    str1 string NULL
+    str1 string NULL,
+    low_char1 CHAR(40) NULL,
+    str_char1 CHAR(40) NULL
 ) ENGINE=OLAP
 DUPLICATE KEY(`k1`)
 DISTRIBUTED BY HASH(`k1`) BUCKETS 64
@@ -66,29 +80,51 @@ PROPERTIES (
 );
 -- result:
 -- !result
-insert into t2 select idx, concat('common-low1-', idx % 100), concat('common-low2-', idx % 200), concat('common-low3-', idx % 200), concat('common-str1-', idx) from __row_util where idx <= 1000;
+insert into t2 select 
+    idx, 
+    concat('common-low1-', idx % 100), concat('common-low2-', idx % 200), concat('common-low3-', idx % 200), 
+    concat('common-str1-', idx),
+    concat('common-low_char1-', idx % 100), concat('common-str_char1-', idx)
+from __row_util where idx <= 1000;
 -- result:
 -- !result
-insert into t2 select idx + 1000, concat('t2-low1-', idx % 50), concat('t2-low2-', idx % 20), concat('t2-low3-', idx % 50), concat('t2-str1-', idx) from __row_util where idx <= 1000;
+insert into t2 select 
+    idx + 1000, 
+    concat('t2-low1-', idx % 50), concat('t2-low2-', idx % 20), concat('t2-low3-', idx % 50), 
+    concat('t2-str1-', idx), 
+    concat('t2-low_char1-', idx % 50), concat('t2-str_char1-', idx) 
+from __row_util where idx <= 1000;
 -- result:
 -- !result
 insert into t2(k1) select 10000000;
 -- result:
 -- !result
-SELECT COUNT(DISTINCT t1.low1)
+SELECT COUNT(DISTINCT t1.low1), SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
 FROM t1 JOIN t2 on t1.low1 = t2.low1;
 -- result:
-100
+100	120785980008000	120785980008000	48953462276000	48953462276000	5137044724000	5137044724000	2655454375310	9474888055200
 -- !result
-SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
-FROM t1 JOIN t2 on t1.low1 <=> t2.low1;
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low1 = t2.low1 where t2.k1 % 4 = 0;
 -- result:
-120785980008000	120785980008000	48953462276000	48953462276000	5137044724000	5137044724000	2655454375310	9474888055200
+200000
 -- !result
-SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low1 <=> t2.low1;
+-- result:
+800001
+-- !result
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low1 <=> t2.low1 where t2.k1 % 4 = 0;
+-- result:
+200001
+-- !result
+SELECT COUNT(1)
 FROM t1 JOIN t2 on t1.low1 <=> t2.low1 and t1.low2 <=> t2.low2 and t1.low3 <=> t2.low3;
 -- result:
-60392990004000	60392990004000	24476731138000	24476731138000	2568522362000	2568522362000	1327727187655	4737444027600
+400001
+-- !result
+SELECT COUNT(1)
+FROM t1 JOIN t2 on t1.low1 <=> t2.low1 and t1.low2 <=> t2.low2 and t1.low3 <=> t2.low3 where t2.k1 % 4 = 0;
+-- result:
+100001
 -- !result
 SELECT COUNT(1)
 FROM t1 
@@ -225,4 +261,136 @@ SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
 FROM w1 t1 JOIN [bucket] w1 t2 on t1.low1 = t2.low1 and t2.k1 < 1000;
 -- result:
 18080610935200	18080610935200
+-- !result
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str1 = t2.str1;
+-- result:
+1000
+-- !result
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str1 = t2.str1 where t2.k1 % 4 = 0;
+-- result:
+250
+-- !result
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str1 <=> t2.str1;
+-- result:
+1001
+-- !result
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str1 <=> t2.str1 where t2.k1 % 4 = 0;
+-- result:
+251
+-- !result
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low_char1 = t2.low_char1;
+-- result:
+800000
+-- !result
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low_char1 = t2.low_char1 where t2.k1 % 4 = 0;
+-- result:
+200000
+-- !result
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low_char1 <=> t2.low_char1;
+-- result:
+800001
+-- !result
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low_char1 <=> t2.low_char1 where t2.k1 % 4 = 0;
+-- result:
+200001
+-- !result
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str_char1 = t2.str_char1;
+-- result:
+1000
+-- !result
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str_char1 = t2.str_char1 where t2.k1 % 4 = 0;
+-- result:
+250
+-- !result
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str_char1 <=> t2.str_char1;
+-- result:
+1001
+-- !result
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str_char1 <=> t2.str_char1 where t2.k1 % 4 = 0;
+-- result:
+251
+-- !result
+SELECT COUNT(1) FROM t1 WHERE low1 = 'common-low1-10';
+-- result:
+800
+-- !result
+SELECT COUNT(1) FROM t1 WHERE low1 = 'non-exist-low1';
+-- result:
+0
+-- !result
+SELECT COUNT(1) FROM t1 WHERE low1 IS NULL;
+-- result:
+1
+-- !result
+SELECT COUNT(1) FROM t1 WHERE low1 IS NOT NULL;
+-- result:
+160000
+-- !result
+SELECT COUNT(1) FROM t1 WHERE low1 IN ('common-low1-10', 'common-low1-20', 'non-exist-low1') OR low1 is NULL;
+-- result:
+1601
+-- !result
+SELECT COUNT(1) FROM t1 WHERE low1 IN ('common-low1-10', 'common-low1-20', NULL);
+-- result:
+1600
+-- !result
+SELECT COUNT(1) FROM t1 WHERE low1 NOT IN ('common-low1-10', 'common-low1-20');
+-- result:
+158400
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str1 = 'common-str1-10';
+-- result:
+1
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str1 = 'non-exist-str1';
+-- result:
+0
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str1 IS NULL;
+-- result:
+1
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str1 IS NOT NULL;
+-- result:
+160000
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str1 IN ('common-str1-10', 'common-str1-20', 'non-exist-str1');
+-- result:
+2
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str1 IN ('common-str1-10', 'common-str1-20', NULL);
+-- result:
+2
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str1 NOT IN ('common-str1-10', 'common-str1-20');
+-- result:
+159998
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str_char1 = 'common-str_char1-10';
+-- result:
+1
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str_char1 = 'non-exist-str_char1';
+-- result:
+0
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str_char1 IS NULL;
+-- result:
+1
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str_char1 IS NOT NULL;
+-- result:
+160000
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str_char1 IN ('common-str_char1-10', 'common-str_char1-20', 'non-exist-str_char1');
+-- result:
+2
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str_char1 IN ('common-str_char1-10', 'common-str_char1-20', NULL);
+-- result:
+2
+-- !result
+SELECT COUNT(1) FROM t1 WHERE str_char1 NOT IN ('common-str_char1-10', 'common-str_char1-20');
+-- result:
+159998
 -- !result

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_join
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_join
@@ -1,0 +1,214 @@
+-- name: test_low_cardinality_join
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base;-- 20000
+insert into __row_util_base select * from __row_util_base;-- 40000
+insert into __row_util_base select * from __row_util_base;-- 80000
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 640
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 bigint NULL,
+    low1 string NULL,
+    low2 string NULL,
+    low3 string NULL,
+    str1 string NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 select idx, concat('common-low1-', idx % 100), concat('common-low2-', idx % 200), concat('common-low3-', idx % 200), concat('common-str1-', idx) from __row_util;
+-- result:
+-- !result
+insert into t1 select idx, concat('t1-low1-', idx % 50), concat('t1-low2-', idx % 20), concat('t1-low3-', idx % 50), concat('t1-str1-', idx) from __row_util;
+-- result:
+-- !result
+insert into t1(k1) select 10000000;
+-- result:
+-- !result
+CREATE TABLE t2 (
+    k1 bigint NULL,
+    low1 string NULL,
+    low2 string NULL,
+    low3 string NULL,
+    str1 string NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t2 select idx, concat('common-low1-', idx % 100), concat('common-low2-', idx % 200), concat('common-low3-', idx % 200), concat('common-str1-', idx) from __row_util where idx <= 1000;
+-- result:
+-- !result
+insert into t2 select idx + 1000, concat('t2-low1-', idx % 50), concat('t2-low2-', idx % 20), concat('t2-low3-', idx % 50), concat('t2-str1-', idx) from __row_util where idx <= 1000;
+-- result:
+-- !result
+insert into t2(k1) select 10000000;
+-- result:
+-- !result
+SELECT COUNT(DISTINCT t1.low1)
+FROM t1 JOIN t2 on t1.low1 = t2.low1;
+-- result:
+100
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
+FROM t1 JOIN t2 on t1.low1 <=> t2.low1;
+-- result:
+120785980008000	120785980008000	48953462276000	48953462276000	5137044724000	5137044724000	2655454375310	9474888055200
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
+FROM t1 JOIN t2 on t1.low1 <=> t2.low1 and t1.low2 <=> t2.low2 and t1.low3 <=> t2.low3;
+-- result:
+60392990004000	60392990004000	24476731138000	24476731138000	2568522362000	2568522362000	1327727187655	4737444027600
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 <=> t2.low1
+    JOIN t2 t3 on t1.low2 <=> t3.low2
+    JOIN t2 t4 on t1.low3 <=> t4.low3;
+-- result:
+3019649500200000	3019649500200000
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = lower(t2.low1) 
+    JOIN t2 t3 on t1.low2 = t3.low2;
+-- result:
+603929900040000	603929900040000
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1
+    JOIN t2 t3 on t1.low1 = lower(t3.low2);
+-- result:
+None	None
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1
+    JOIN [shuffle] t2 t3 on t1.low1 = t3.low2;
+-- result:
+None	None
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1
+    JOIN [shuffle] t2 t3 on t1.low2 = t3.low2;
+-- result:
+603929900040000	603929900040000
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 JOIN [colocate] t1 t2 on t1.k1 = t2.k1 and t1.low1 = t2.low1 and t2.k1 < 1000;
+-- result:
+86835453503	86835453503
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 JOIN [bucket] t1 t2 on t1.k1 = t2.k1 and t1.low1 = t2.low1 and t2.k1 < 1000;
+-- result:
+86835453503	86835453503
+-- !result
+with w1 as (select distinct low1, k1 from t1)
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM w1 t1 JOIN [bucket] w1 t2 on t1.low1 = t2.low1 and t2.k1 < 1000;
+-- result:
+18080610935200	18080610935200
+-- !result
+set cbo_enable_low_cardinality_optimize_for_join = false;
+-- result:
+-- !result
+SELECT COUNT(DISTINCT t1.low1)
+FROM t1 JOIN t2 on t1.low1 = t2.low1;
+-- result:
+100
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
+FROM t1 JOIN t2 on t1.low1 <=> t2.low1;
+-- result:
+120785980008000	120785980008000	48953462276000	48953462276000	5137044724000	5137044724000	2655454375310	9474888055200
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
+FROM t1 JOIN t2 on t1.low1 <=> t2.low1 and t1.low2 <=> t2.low2 and t1.low3 <=> t2.low3;
+-- result:
+60392990004000	60392990004000	24476731138000	24476731138000	2568522362000	2568522362000	1327727187655	4737444027600
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 <=> t2.low1
+    JOIN t2 t3 on t1.low2 <=> t3.low2
+    JOIN t2 t4 on t1.low3 <=> t4.low3;
+-- result:
+3019649500200000	3019649500200000
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = lower(t2.low1) 
+    JOIN t2 t3 on t1.low2 = t3.low2;
+-- result:
+603929900040000	603929900040000
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1
+    JOIN t2 t3 on t1.low1 = lower(t3.low2);
+-- result:
+None	None
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1
+    JOIN [shuffle] t2 t3 on t1.low1 = t3.low2;
+-- result:
+None	None
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1
+    JOIN [shuffle] t2 t3 on t1.low2 = t3.low2;
+-- result:
+603929900040000	603929900040000
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 JOIN [colocate] t1 t2 on t1.k1 = t2.k1 and t1.low1 = t2.low1 and t2.k1 < 1000;
+-- result:
+86835453503	86835453503
+-- !result
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 JOIN [bucket] t1 t2 on t1.k1 = t2.k1 and t1.low1 = t2.low1 and t2.k1 < 1000;
+-- result:
+86835453503	86835453503
+-- !result
+with w1 as (select distinct low1, k1 from t1)
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM w1 t1 JOIN [bucket] w1 t2 on t1.low1 = t2.low1 and t2.k1 < 1000;
+-- result:
+18080610935200	18080610935200
+-- !result

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_join
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_join
@@ -90,6 +90,20 @@ FROM t1 JOIN t2 on t1.low1 <=> t2.low1 and t1.low2 <=> t2.low2 and t1.low3 <=> t
 -- result:
 60392990004000	60392990004000	24476731138000	24476731138000	2568522362000	2568522362000	1327727187655	4737444027600
 -- !result
+SELECT COUNT(1)
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1 and t2.k1 % 2 = 0
+    JOIN t2 t3 on t1.low2 = t3.low2;
+-- result:
+2000000
+-- !result
+SELECT COUNT(1)
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1 and t2.k1 % 7 = 0
+    JOIN t2 t3 on t1.low2 = t3.low2;
+-- result:
+568000
+-- !result
 SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
 FROM t1 
     JOIN t2 on t1.low1 <=> t2.low1

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_join
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_join
@@ -1,0 +1,166 @@
+-- name: test_low_cardinality_join
+
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base;-- 20000
+insert into __row_util_base select * from __row_util_base;-- 40000
+insert into __row_util_base select * from __row_util_base;-- 80000
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 640
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+CREATE TABLE t1 (
+    k1 bigint NULL,
+    low1 string NULL,
+    low2 string NULL,
+    low3 string NULL,
+    str1 string NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t1 select idx, concat('common-low1-', idx % 100), concat('common-low2-', idx % 200), concat('common-low3-', idx % 200), concat('common-str1-', idx) from __row_util;
+insert into t1 select idx, concat('t1-low1-', idx % 50), concat('t1-low2-', idx % 20), concat('t1-low3-', idx % 50), concat('t1-str1-', idx) from __row_util;
+insert into t1(k1) select 10000000;
+
+CREATE TABLE t2 (
+    k1 bigint NULL,
+    low1 string NULL,
+    low2 string NULL,
+    low3 string NULL,
+    str1 string NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into t2 select idx, concat('common-low1-', idx % 100), concat('common-low2-', idx % 200), concat('common-low3-', idx % 200), concat('common-str1-', idx) from __row_util where idx <= 1000;
+insert into t2 select idx + 1000, concat('t2-low1-', idx % 50), concat('t2-low2-', idx % 20), concat('t2-low3-', idx % 50), concat('t2-str1-', idx) from __row_util where idx <= 1000;
+insert into t2(k1) select 10000000;
+
+
+SELECT COUNT(DISTINCT t1.low1)
+FROM t1 JOIN t2 on t1.low1 = t2.low1;
+
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
+FROM t1 JOIN t2 on t1.low1 <=> t2.low1;
+
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
+FROM t1 JOIN t2 on t1.low1 <=> t2.low1 and t1.low2 <=> t2.low2 and t1.low3 <=> t2.low3;
+
+-- The number of words for low3 after merging exceeds 256.
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 <=> t2.low1
+    JOIN t2 t3 on t1.low2 <=> t3.low2
+    JOIN t2 t4 on t1.low3 <=> t4.low3;
+
+-- DefineExpr cannot use low-cardinality optimization for join.
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = lower(t2.low1) 
+    JOIN t2 t3 on t1.low2 = t3.low2;
+
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1
+    JOIN t2 t3 on t1.low1 = lower(t3.low2);
+
+-- Shuffle join cannot use low-cardinality optimization for join.
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1
+    JOIN [shuffle] t2 t3 on t1.low1 = t3.low2;
+
+
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1
+    JOIN [shuffle] t2 t3 on t1.low2 = t3.low2;
+
+-- Colocate join cannot use low-cardinality optimization for join.
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 JOIN [colocate] t1 t2 on t1.k1 = t2.k1 and t1.low1 = t2.low1 and t2.k1 < 1000;
+
+-- Local Bucket shuffle join cannot use low-cardinality optimization for join.
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 JOIN [bucket] t1 t2 on t1.k1 = t2.k1 and t1.low1 = t2.low1 and t2.k1 < 1000;
+
+-- Bucket shuffle join cannot use low-cardinality optimization for join.
+with w1 as (select distinct low1, k1 from t1)
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM w1 t1 JOIN [bucket] w1 t2 on t1.low1 = t2.low1 and t2.k1 < 1000;
+
+
+set cbo_enable_low_cardinality_optimize_for_join = false;
+
+
+SELECT COUNT(DISTINCT t1.low1)
+FROM t1 JOIN t2 on t1.low1 = t2.low1;
+
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
+FROM t1 JOIN t2 on t1.low1 <=> t2.low1;
+
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
+FROM t1 JOIN t2 on t1.low1 <=> t2.low1 and t1.low2 <=> t2.low2 and t1.low3 <=> t2.low3;
+
+-- The number of words for low3 after merging exceeds 256.
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 <=> t2.low1
+    JOIN t2 t3 on t1.low2 <=> t3.low2
+    JOIN t2 t4 on t1.low3 <=> t4.low3;
+
+-- DefineExpr cannot use low-cardinality optimization for join.
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = lower(t2.low1) 
+    JOIN t2 t3 on t1.low2 = t3.low2;
+
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1
+    JOIN t2 t3 on t1.low1 = lower(t3.low2);
+
+-- Shuffle join cannot use low-cardinality optimization for join.
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1
+    JOIN [shuffle] t2 t3 on t1.low1 = t3.low2;
+
+
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1
+    JOIN [shuffle] t2 t3 on t1.low2 = t3.low2;
+
+-- Colocate join cannot use low-cardinality optimization for join.
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 JOIN [colocate] t1 t2 on t1.k1 = t2.k1 and t1.low1 = t2.low1 and t2.k1 < 1000;
+
+-- Local Bucket shuffle join cannot use low-cardinality optimization for join.
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM t1 JOIN [bucket] t1 t2 on t1.k1 = t2.k1 and t1.low1 = t2.low1 and t2.k1 < 1000;
+
+-- Bucket shuffle join cannot use low-cardinality optimization for join.
+with w1 as (select distinct low1, k1 from t1)
+SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
+FROM w1 t1 JOIN [bucket] w1 t2 on t1.low1 = t2.low1 and t2.k1 < 1000;

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_join
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_join
@@ -66,6 +66,16 @@ FROM t1 JOIN t2 on t1.low1 <=> t2.low1;
 SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
 FROM t1 JOIN t2 on t1.low1 <=> t2.low1 and t1.low2 <=> t2.low2 and t1.low3 <=> t2.low3;
 
+SELECT COUNT(1)
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1 and t2.k1 % 2 = 0
+    JOIN t2 t3 on t1.low2 = t3.low2;
+
+SELECT COUNT(1)
+FROM t1 
+    JOIN t2 on t1.low1 = t2.low1 and t2.k1 % 7 = 0
+    JOIN t2 t3 on t1.low2 = t3.low2;
+
 -- The number of words for low3 after merging exceeds 256.
 SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
 FROM t1 

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_join
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_join
@@ -28,7 +28,9 @@ CREATE TABLE t1 (
     low1 string NULL,
     low2 string NULL,
     low3 string NULL,
-    str1 string NULL
+    str1 string NULL,
+    low_char1 CHAR(40) NULL,
+    str_char1 CHAR(40) NULL
 ) ENGINE=OLAP
 DUPLICATE KEY(`k1`)
 DISTRIBUTED BY HASH(`k1`) BUCKETS 64
@@ -36,8 +38,18 @@ PROPERTIES (
     "replication_num" = "1"
 );
 
-insert into t1 select idx, concat('common-low1-', idx % 100), concat('common-low2-', idx % 200), concat('common-low3-', idx % 200), concat('common-str1-', idx) from __row_util;
-insert into t1 select idx, concat('t1-low1-', idx % 50), concat('t1-low2-', idx % 20), concat('t1-low3-', idx % 50), concat('t1-str1-', idx) from __row_util;
+insert into t1 select 
+    idx, 
+    concat('common-low1-', idx % 100), concat('common-low2-', idx % 200), concat('common-low3-', idx % 200), 
+    concat('common-str1-', idx),
+    concat('common-low_char1-', idx % 100), concat('common-str_char1-', idx)
+from __row_util;
+insert into t1 select 
+    idx, 
+    concat('t1-low1-', idx % 50), concat('t1-low2-', idx % 20), concat('t1-low3-', idx % 50), 
+    concat('t1-str1-', idx),
+    concat('t1-low_char1-', idx % 50), concat('t1-str_char1-', idx)
+from __row_util;
 insert into t1(k1) select 10000000;
 
 CREATE TABLE t2 (
@@ -45,26 +57,41 @@ CREATE TABLE t2 (
     low1 string NULL,
     low2 string NULL,
     low3 string NULL,
-    str1 string NULL
+    str1 string NULL,
+    low_char1 CHAR(40) NULL,
+    str_char1 CHAR(40) NULL
 ) ENGINE=OLAP
 DUPLICATE KEY(`k1`)
 DISTRIBUTED BY HASH(`k1`) BUCKETS 64
 PROPERTIES (
     "replication_num" = "1"
 );
-insert into t2 select idx, concat('common-low1-', idx % 100), concat('common-low2-', idx % 200), concat('common-low3-', idx % 200), concat('common-str1-', idx) from __row_util where idx <= 1000;
-insert into t2 select idx + 1000, concat('t2-low1-', idx % 50), concat('t2-low2-', idx % 20), concat('t2-low3-', idx % 50), concat('t2-str1-', idx) from __row_util where idx <= 1000;
+insert into t2 select 
+    idx, 
+    concat('common-low1-', idx % 100), concat('common-low2-', idx % 200), concat('common-low3-', idx % 200), 
+    concat('common-str1-', idx),
+    concat('common-low_char1-', idx % 100), concat('common-str_char1-', idx)
+from __row_util where idx <= 1000;
+insert into t2 select 
+    idx + 1000, 
+    concat('t2-low1-', idx % 50), concat('t2-low2-', idx % 20), concat('t2-low3-', idx % 50), 
+    concat('t2-str1-', idx), 
+    concat('t2-low_char1-', idx % 50), concat('t2-str_char1-', idx) 
+from __row_util where idx <= 1000;
 insert into t2(k1) select 10000000;
 
 
-SELECT COUNT(DISTINCT t1.low1)
+SELECT COUNT(DISTINCT t1.low1), SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
 FROM t1 JOIN t2 on t1.low1 = t2.low1;
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low1 = t2.low1 where t2.k1 % 4 = 0;
 
-SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
-FROM t1 JOIN t2 on t1.low1 <=> t2.low1;
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low1 <=> t2.low1;
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low1 <=> t2.low1 where t2.k1 % 4 = 0;
 
-SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1)), SUM(murmur_hash3_32(t1.low2)), SUM(murmur_hash3_32(t2.low2)), SUM(murmur_hash3_32(t1.low3)), SUM(murmur_hash3_32(t2.low3)), SUM(murmur_hash3_32(t1.str1)), SUM(murmur_hash3_32(t2.str1))
+SELECT COUNT(1)
 FROM t1 JOIN t2 on t1.low1 <=> t2.low1 and t1.low2 <=> t2.low2 and t1.low3 <=> t2.low3;
+SELECT COUNT(1)
+FROM t1 JOIN t2 on t1.low1 <=> t2.low1 and t1.low2 <=> t2.low2 and t1.low3 <=> t2.low3 where t2.k1 % 4 = 0;
 
 SELECT COUNT(1)
 FROM t1 
@@ -174,3 +201,51 @@ FROM t1 JOIN [bucket] t1 t2 on t1.k1 = t2.k1 and t1.low1 = t2.low1 and t2.k1 < 1
 with w1 as (select distinct low1, k1 from t1)
 SELECT SUM(murmur_hash3_32(t1.low1)), SUM(murmur_hash3_32(t2.low1))
 FROM w1 t1 JOIN [bucket] w1 t2 on t1.low1 = t2.low1 and t2.k1 < 1000;
+
+-- non-low-cardinality VARCHAR join key
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str1 = t2.str1;
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str1 = t2.str1 where t2.k1 % 4 = 0;
+
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str1 <=> t2.str1;
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str1 <=> t2.str1 where t2.k1 % 4 = 0;
+
+-- CHAR join key
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low_char1 = t2.low_char1;
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low_char1 = t2.low_char1 where t2.k1 % 4 = 0;
+
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low_char1 <=> t2.low_char1;
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.low_char1 <=> t2.low_char1 where t2.k1 % 4 = 0;
+
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str_char1 = t2.str_char1;
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str_char1 = t2.str_char1 where t2.k1 % 4 = 0;
+
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str_char1 <=> t2.str_char1;
+SELECT COUNT(1) FROM t1 JOIN t2 on t1.str_char1 <=> t2.str_char1 where t2.k1 % 4 = 0;
+
+-- low-cardinality predicates
+SELECT COUNT(1) FROM t1 WHERE low1 = 'common-low1-10';
+SELECT COUNT(1) FROM t1 WHERE low1 = 'non-exist-low1';
+SELECT COUNT(1) FROM t1 WHERE low1 IS NULL;
+SELECT COUNT(1) FROM t1 WHERE low1 IS NOT NULL;
+SELECT COUNT(1) FROM t1 WHERE low1 IN ('common-low1-10', 'common-low1-20', 'non-exist-low1') OR low1 is NULL;
+SELECT COUNT(1) FROM t1 WHERE low1 IN ('common-low1-10', 'common-low1-20', NULL);
+SELECT COUNT(1) FROM t1 WHERE low1 NOT IN ('common-low1-10', 'common-low1-20');
+
+-- non-low-cardinality predicates
+SELECT COUNT(1) FROM t1 WHERE str1 = 'common-str1-10';
+SELECT COUNT(1) FROM t1 WHERE str1 = 'non-exist-str1';
+SELECT COUNT(1) FROM t1 WHERE str1 IS NULL;
+SELECT COUNT(1) FROM t1 WHERE str1 IS NOT NULL;
+SELECT COUNT(1) FROM t1 WHERE str1 IN ('common-str1-10', 'common-str1-20', 'non-exist-str1');
+SELECT COUNT(1) FROM t1 WHERE str1 IN ('common-str1-10', 'common-str1-20', NULL);
+SELECT COUNT(1) FROM t1 WHERE str1 NOT IN ('common-str1-10', 'common-str1-20');
+
+-- CHAR predicates
+SELECT COUNT(1) FROM t1 WHERE str_char1 = 'common-str_char1-10';
+SELECT COUNT(1) FROM t1 WHERE str_char1 = 'non-exist-str_char1';
+SELECT COUNT(1) FROM t1 WHERE str_char1 IS NULL;
+SELECT COUNT(1) FROM t1 WHERE str_char1 IS NOT NULL;
+SELECT COUNT(1) FROM t1 WHERE str_char1 IN ('common-str_char1-10', 'common-str_char1-20', 'non-exist-str_char1');
+SELECT COUNT(1) FROM t1 WHERE str_char1 IN ('common-str_char1-10', 'common-str_char1-20', NULL);
+SELECT COUNT(1) FROM t1 WHERE str_char1 NOT IN ('common-str_char1-10', 'common-str_char1-20');
+


### PR DESCRIPTION
## Why I'm doing:

Support low-cardinality dictionary optimization on joins.

The low-cardinality dictionaries of the left and right keys need to be merged.

**Constraints:**
- Both left and right keys in the ON equality condition must be low-cardinality column refs.  
- Each low-cardinality column can participate in only one equality condition.  
- Low-cardinality columns cannot be `DefineExpr`.  
- Currently only supports broadcast join; otherwise, distribution changes before and after decoding must be considered, which can easily lead to bugs.  
- The merged size of the left and right key dictionaries must not exceed the threshold `low_cardinality_threshold`.

**Runtime Filter Considerations**
- **Disable pushing down runtime bitset filters to index.**  
  Runtime bitset filters are pushed down to the storage layer to be applied on indexes.  
  However, low-cardinality dictionary columns can only use VARCHAR-type predicates during the index phase,  
  so if the runtime bitset filter corresponds to a global low-cardinality dictionary column,  
  it cannot be pushed down to the storage layer for index application.

- **Disable runtime filter pushdown.**  
  When a pushed-down runtime filter is applied, VARCHAR columns use local dictionary IDs instead of global dictionary IDs.  
  Therefore, global low-cardinality dictionary columns cannot be pushed down.

- **For runtime IN filters**, each value must be decoded from the global dictionary ID into a string.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable join-time low‑cardinality dictionary optimization with dict merging, guarded RF pushdown, IN/NOT IN decoding, a session toggle, and comprehensive tests.
> 
> - **Optimizer (FE)**:
>   - **Join low-cardinality optimization**: Detect and retain low-cardinality columns in join ON equality; merge dictionaries via `ColumnDict.merge` with threshold checks; rewrite join ON predicates to dict-ids when enabled; limit to broadcast joins and one-equality-per-column; skip DefineExpr columns.
>   - **Controls**: New session variable `cbo_enable_low_cardinality_optimize_for_join` with getter; rule passes session into `DecodeRewriter`.
>   - **Infrastructure**: Track join eq groups in `DecodeCollector`; add `JoinOnPredicateReplacer`; propagate dict usage across exchanges; minor cost model tweak for extracting equals predicates.
>   - **Utilities**: Add `ColumnDict.merge(...)` and unit tests.
> - **Scan/Runtime Filters (BE)**:
>   - Skip pushing down runtime bitset filters and runtime RF predicates for columns using global low-cardinality dicts.
>   - Normalize `IN`/`NOT IN` for VARCHAR with global dict by decoding values; extend join RF normalization with decoders and mapping types.
> - **Tests**:
>   - Add extensive planner and SQL tests for low-cardinality joins and behaviors; new test suite `test_low_cardinality_join`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3abb7e33bd4d6cfef8937318918ee56f0532161. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->