### PR TITLE
[BugFix] Update column_reader.cpp

### DIFF
--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -399,7 +399,7 @@ Status ColumnReader::_parse_zone_map(LogicalType type, const ZoneMapPB& zm, Zone
         RETURN_IF_ERROR(datum_from_string(type_info.get(), &(detail->min_value()), zm.min(), nullptr));
         RETURN_IF_ERROR(datum_from_string(type_info.get(), &(detail->max_value()), zm.max(), nullptr));
     }
-    detail->set_num_rows(static_cast<size_t>(num_rows()));
+    detail->set_num_rows(static_cast<size_t>(zm.num_rows()));
     return Status::OK();
 }
 


### PR DESCRIPTION
Previously, ZoneMapDetail::num_rows() returned the total number of rows in the entire segment instead of the actual number of rows in the specific zone. This occurred because ColumnReader::_parse_zone_map() was assigning the segment’s row count (segment->num_rows()) to the zone map detail.

This commit updates the implementation to use the zone-level row count from ZoneMapPB::num_rows() instead. As a result, ZoneMapDetail now accurately represents per-zone statistics, improving the correctness of zone map metadata and reducing misleading metrics in diagnostic or optimization paths.

Changes:
- Updated ColumnReader::_parse_zone_map() to set zone map detail rows from ZoneMapPB::num_rows().
- Clarified comments in ZoneMapDetail to distinguish zone vs. segment row count.

No functional regressions expected; improves semantic accuracy only.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `ZoneMapPB::num_rows()` instead of segment `num_rows()` when populating `ZoneMapDetail::num_rows` in `ColumnReader::_parse_zone_map`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07b570be8188e8fb9eb1300df3ee6e4fd5dfe5ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->