### PR TITLE
[Enhancement] Handle case when hudi partitions are registered but the folder location is empty

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
@@ -37,6 +37,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import org.apache.logging.log4j.LogManager;
@@ -136,6 +137,10 @@ public class HudiRemoteFileIO implements RemoteFileIO {
                 fileDescs.add(res);
             }
             return resultPartitions.put(pathKey, fileDescs).build();
+        } catch (HoodieIOException e) {
+            LOG.warn("Partition '{}' encountered I/O error during file listing, likely an empty partition registered " +
+                    "in Hive metastore before data ingestion. Returning empty file list.", partitionPath, e);
+            return resultPartitions.put(pathKey, Lists.newArrayList()).build();
         } catch (Exception e) {
             LOG.error("Failed to get hudi remote file's metadata on path: {}", partitionPath, e);
             throw new StarRocksConnectorException("Failed to get hudi remote file's metadata on path: %s. msg: %s",


### PR DESCRIPTION
## Why I'm doing:
Hudi tables can have partition locations proactively registered to the Hive Metastore in order to speed up the metadata portion of the query due to caching e.g for Trino. However, this currently results in an error being thrown by StarRocks as there is no hudi log file in that location. Trino's behavior is to ignore it and return an empty list. This MR helps improve compatibility between StarRocks and Trino. 

## What I'm doing:
Return an empty list when a partition location containing no data is encountered instead of throwing an error.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [X] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> When Hudi partition file listing throws HoodieIOException (e.g., empty registered partition), log a warning and return an empty file list instead of erroring.
> 
> - **Connector (Hudi)**:
>   - Update `HudiRemoteFileIO#getRemoteFiles` to catch `HoodieIOException` during partition file listing and return an empty list with a warning log, instead of throwing an error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0a1f68762d645d68dabc05691a922a47685b680. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->