### PR TITLE
[BugFix] unescape the utf8 characters in task_runs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -148,7 +148,7 @@ public class TaskRunHistoryTable {
                         createTime,
                         finishTime,
                         expireTime,
-                        Strings.quote(StringEscapeUtils.escapeJava(status.toJSON())));
+                        Strings.quote(StringEscapeUtils.escapeJson(status.toJSON())));
             }).collect(Collectors.joining(", "));
 
             String sql = insert + values;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -148,7 +148,7 @@ public class TaskRunHistoryTable {
                         createTime,
                         finishTime,
                         expireTime,
-                        Strings.quote(StringEscapeUtils.escapeJson(status.toJSON())));
+                        Strings.quote(StringEscapeUtils.escapeJava(status.toJSON())));
             }).collect(Collectors.joining(", "));
 
             String sql = insert + values;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -32,7 +32,7 @@ import io.netty.buffer.Unpooled;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -520,7 +520,7 @@ public class TaskRunStatus implements Writable {
                 try {
                     ByteBuf copied = Unpooled.copiedBuffer(buffer);
                     jsonString = copied.toString(Charset.defaultCharset());
-                    jsonString = StringEscapeUtils.unescapeJava(jsonString);
+                    jsonString = StringEscapeUtils.unescapeJson(jsonString);
                     res.addAll(ListUtils.emptyIfNull(TaskRunStatusJSONRecord.fromJson(jsonString).data));
                 } catch (Exception e) {
                     // If the task run history is corrupted, we can use `ignore_task_run_history_replay_error` config to ignore

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -32,6 +32,7 @@ import io.netty.buffer.Unpooled;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -519,6 +520,7 @@ public class TaskRunStatus implements Writable {
                 try {
                     ByteBuf copied = Unpooled.copiedBuffer(buffer);
                     jsonString = copied.toString(Charset.defaultCharset());
+                    jsonString = StringEscapeUtils.unescapeJava(jsonString);
                     res.addAll(ListUtils.emptyIfNull(TaskRunStatusJSONRecord.fromJson(jsonString).data));
                 } catch (Exception e) {
                     // If the task run history is corrupted, we can use `ignore_task_run_history_replay_error` config to ignore

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -520,7 +520,7 @@ public class TaskRunStatus implements Writable {
                 try {
                     ByteBuf copied = Unpooled.copiedBuffer(buffer);
                     jsonString = copied.toString(Charset.defaultCharset());
-                    jsonString = StringEscapeUtils.unescapeJson(jsonString);
+                    jsonString = StringEscapeUtils.unescapeJava(jsonString);
                     res.addAll(ListUtils.emptyIfNull(TaskRunStatusJSONRecord.fromJson(jsonString).data));
                 } catch (Exception e) {
                     // If the task run history is corrupted, we can use `ignore_task_run_history_replay_error` config to ignore

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -366,13 +366,13 @@ public class TaskRunHistoryTest {
         
         // Create a mock result batch with escaped Chinese characters (simulating database storage)
         String originalJson = status.toJSON();
-        String escapedJson = StringEscapeUtils.escapeJava(originalJson);
+        String escapedJson = StringEscapeUtils.escapeJson(originalJson);
         
         // Create TaskRunStatusJSONRecord with escaped JSON
         TaskRunStatus.TaskRunStatusJSONRecord record = new TaskRunStatus.TaskRunStatusJSONRecord();
         record.data = Lists.newArrayList(status);
         String recordJson = GsonUtils.GSON.toJson(record);
-        String escapedRecordJson = StringEscapeUtils.escapeJava(recordJson);
+        String escapedRecordJson = StringEscapeUtils.escapeJson(recordJson);
         
         // Simulate the database storage and retrieval process
         TResultBatch resultBatch = new TResultBatch();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -354,6 +354,72 @@ public class TaskRunHistoryTest {
         Assertions.assertTrue(res.contains("\"datacache\":\"{\\\"enable\\\": \\\"true\\\"}\""));
     }
 
+    @Test
+    public void testChineseCharacterDeserialization() {
+        // Test that Chinese characters are properly handled during deserialization
+        TaskRunStatus status = new TaskRunStatus();
+        status.setQueryId("test_query_中文");
+        status.setTaskName("测试任务");
+        status.setErrorMessage("表不存在：用户数据表");
+        status.setState(Constants.TaskRunState.FAILED);
+        
+        // Create a mock result batch with escaped Chinese characters (simulating database storage)
+        String originalJson = status.toJSON();
+        String escapedJson = StringEscapeUtils.escapeJava(originalJson);
+        
+        // Create TaskRunStatusJSONRecord with escaped JSON
+        TaskRunStatus.TaskRunStatusJSONRecord record = new TaskRunStatus.TaskRunStatusJSONRecord();
+        record.data = Lists.newArrayList(status);
+        String recordJson = GsonUtils.GSON.toJson(record);
+        String escapedRecordJson = StringEscapeUtils.escapeJava(recordJson);
+        
+        // Simulate the database storage and retrieval process
+        TResultBatch resultBatch = new TResultBatch();
+        ByteBuffer buffer = ByteBuffer.wrap(escapedRecordJson.getBytes());
+        resultBatch.setRows(Lists.newArrayList(buffer));
+        
+        // Test deserialization - this should properly unescape Chinese characters
+        List<TaskRunStatus> deserializedStatuses = TaskRunStatus.fromResultBatch(Lists.newArrayList(resultBatch));
+        
+        Assertions.assertEquals(1, deserializedStatuses.size());
+        TaskRunStatus deserializedStatus = deserializedStatuses.get(0);
+        
+        // Verify Chinese characters are properly restored
+        Assertions.assertEquals("test_query_中文", deserializedStatus.getQueryId());
+        Assertions.assertEquals("测试任务", deserializedStatus.getTaskName());
+        Assertions.assertEquals("表不存在：用户数据表", deserializedStatus.getErrorMessage());
+        Assertions.assertEquals(Constants.TaskRunState.FAILED, deserializedStatus.getState());
+    }
+
+    @Test
+    public void testChineseCharacterInExtraMessage() {
+        // Test Chinese characters in extra message field
+        TaskRunStatus status = new TaskRunStatus();
+        status.setQueryId("test_query");
+        status.setTaskName("测试任务");
+        status.setExtraMessage("{\"message\": \"刷新失败：分区数据不完整\"}");
+        status.setState(Constants.TaskRunState.FAILED);
+        
+        // Create mock result batch
+        TaskRunStatus.TaskRunStatusJSONRecord record = new TaskRunStatus.TaskRunStatusJSONRecord();
+        record.data = Lists.newArrayList(status);
+        String recordJson = GsonUtils.GSON.toJson(record);
+        String escapedRecordJson = StringEscapeUtils.escapeJava(recordJson);
+        
+        TResultBatch resultBatch = new TResultBatch();
+        ByteBuffer buffer = ByteBuffer.wrap(escapedRecordJson.getBytes());
+        resultBatch.setRows(Lists.newArrayList(buffer));
+        
+        // Test deserialization
+        List<TaskRunStatus> deserializedStatuses = TaskRunStatus.fromResultBatch(Lists.newArrayList(resultBatch));
+        
+        Assertions.assertEquals(1, deserializedStatuses.size());
+        TaskRunStatus deserializedStatus = deserializedStatuses.get(0);
+        
+        // Verify Chinese characters in extra message are properly restored
+        Assertions.assertEquals("{\"message\": \"刷新失败：分区数据不完整\"}", deserializedStatus.getExtraMessage());
+    }
+
     private TaskRunStatus createTaskRunStatus(long createdTime) {
         TaskRunStatus status = new TaskRunStatus();
         status.setCreateTime(createdTime);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -362,6 +362,7 @@ public class TaskRunHistoryTest {
         status.setTaskName("测试任务");
         status.setErrorMessage("表不存在：用户数据表");
         status.setState(Constants.TaskRunState.FAILED);
+        status.setDefinition("测试中文");
         
         // Create a mock result batch with escaped Chinese characters (simulating database storage)
         String originalJson = status.toJSON();
@@ -389,35 +390,7 @@ public class TaskRunHistoryTest {
         Assertions.assertEquals("测试任务", deserializedStatus.getTaskName());
         Assertions.assertEquals("表不存在：用户数据表", deserializedStatus.getErrorMessage());
         Assertions.assertEquals(Constants.TaskRunState.FAILED, deserializedStatus.getState());
-    }
-
-    @Test
-    public void testChineseCharacterInExtraMessage() {
-        // Test Chinese characters in extra message field
-        TaskRunStatus status = new TaskRunStatus();
-        status.setQueryId("test_query");
-        status.setTaskName("测试任务");
-        status.setExtraMessage("{\"message\": \"刷新失败：分区数据不完整\"}");
-        status.setState(Constants.TaskRunState.FAILED);
-        
-        // Create mock result batch
-        TaskRunStatus.TaskRunStatusJSONRecord record = new TaskRunStatus.TaskRunStatusJSONRecord();
-        record.data = Lists.newArrayList(status);
-        String recordJson = GsonUtils.GSON.toJson(record);
-        String escapedRecordJson = StringEscapeUtils.escapeJava(recordJson);
-        
-        TResultBatch resultBatch = new TResultBatch();
-        ByteBuffer buffer = ByteBuffer.wrap(escapedRecordJson.getBytes());
-        resultBatch.setRows(Lists.newArrayList(buffer));
-        
-        // Test deserialization
-        List<TaskRunStatus> deserializedStatuses = TaskRunStatus.fromResultBatch(Lists.newArrayList(resultBatch));
-        
-        Assertions.assertEquals(1, deserializedStatuses.size());
-        TaskRunStatus deserializedStatus = deserializedStatuses.get(0);
-        
-        // Verify Chinese characters in extra message are properly restored
-        Assertions.assertEquals("{\"message\": \"刷新失败：分区数据不完整\"}", deserializedStatus.getExtraMessage());
+        Assertions.assertEquals("测试中文", deserializedStatus.getDefinition());
     }
 
     private TaskRunStatus createTaskRunStatus(long createdTime) {


### PR DESCRIPTION
## Why I'm doing:

A task contains chinese characters would be incorrectly displayed as `\u5E74` after deserialization.

## What I'm doing:

- The content of `task_runs` is escaped before persisted into table, but not properly unescaped.
- Using `escapeJava` is incorrect, which escape the utf-8 character but it's not necessary, because JSON can accept utf-8

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3