### PR TITLE
[Enhancement] support corrupt meta cache clear for bundle metadata

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -508,12 +508,13 @@ StatusOr<BundleTabletMetadataPtr> TabletManager::parse_bundle_tablet_metadata(co
             std::string_view(serialized_string.data() + file_size - footer_size - bundle_metadata_size);
     RETURN_IF(!bundle_metadata->ParseFromArray(bundle_metadata_str.data(), bundle_metadata_size),
               Status::Corruption(strings::Substitute("deserialized shared metadata failed")));
-
+#ifdef BE_TEST
     bool inject_error = false;
     TEST_SYNC_POINT_CALLBACK("TabletManager::parse_bundle_tablet_metadata::corruption", &inject_error);
     if (inject_error) {
         return Status::Corruption("injected error");
     }
+#endif
     return bundle_metadata;
 }
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -378,7 +378,7 @@ Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadat
     return Status::OK();
 }
 
-static Status corrupted_tablet_meta_handler(const Status& s, const std::string& metadata_location) {
+Status TabletManager::corrupted_tablet_meta_handler(const Status& s, const std::string& metadata_location) {
     if (s.is_corruption() && config::lake_clear_corrupted_cache) {
         auto drop_status = drop_local_cache(metadata_location);
         if (!drop_status.ok()) {

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -249,6 +249,7 @@ private:
                                                      int64_t expected_gtid, const std::shared_ptr<FileSystem>& fs);
     StatusOr<TxnLogPtr> load_txn_log(const std::string& txn_log_location, bool fill_cache);
     StatusOr<CombinedTxnLogPtr> load_combined_txn_log(const std::string& path, bool fill_cache);
+    Status corrupted_tablet_meta_handler(const Status& s, const std::string& metadata_location);
 
 private:
     std::shared_ptr<LocationProvider> _location_provider;

--- a/be/src/storage/protobuf_file.cpp
+++ b/be/src/storage/protobuf_file.cpp
@@ -176,6 +176,7 @@ Status ProtobufFile::load(::google::protobuf::Message* message, bool fill_cache)
     if (bool parsed = message->ParseFromString(serialized_string); !parsed) {
         return Status::Corruption(fmt::format("failed to parse protobuf file {}", _path));
     }
+    TEST_ERROR_POINT("ProtobufFile::load::corruption");
     return Status::OK();
 }
 } // namespace starrocks

--- a/be/src/storage/protobuf_file.cpp
+++ b/be/src/storage/protobuf_file.cpp
@@ -176,7 +176,8 @@ Status ProtobufFile::load(::google::protobuf::Message* message, bool fill_cache)
     if (bool parsed = message->ParseFromString(serialized_string); !parsed) {
         return Status::Corruption(fmt::format("failed to parse protobuf file {}", _path));
     }
-    TEST_ERROR_POINT("ProtobufFile::load::corruption");
-    return Status::OK();
+    Status st = Status::OK();
+    TEST_SYNC_POINT_CALLBACK("ProtobufFile::load::corruption", &st);
+    return st;
 }
 } // namespace starrocks

--- a/be/src/storage/protobuf_file.cpp
+++ b/be/src/storage/protobuf_file.cpp
@@ -176,8 +176,12 @@ Status ProtobufFile::load(::google::protobuf::Message* message, bool fill_cache)
     if (bool parsed = message->ParseFromString(serialized_string); !parsed) {
         return Status::Corruption(fmt::format("failed to parse protobuf file {}", _path));
     }
+#ifndef BE_TEST
+    return Status::OK();
+#else
     Status st = Status::OK();
     TEST_SYNC_POINT_CALLBACK("ProtobufFile::load::corruption", &st);
     return st;
+#endif
 }
 } // namespace starrocks

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -103,7 +103,6 @@ TEST_F(LakeTabletManagerTest, tablet_meta_write_and_read) {
     EXPECT_TRUE(res.status().is_not_found());
 }
 
-// NOLINTNEXTLINE
 TEST_F(LakeTabletManagerTest, tablet_meta_read_corrupted_and_recover) {
     starrocks::TabletMetadata metadata;
     auto tablet_id = next_id();


### PR DESCRIPTION
## Why I'm doing:
When the meta file is retried for writing, the serialized file content may differ, which can lead to a low-probability corruption of the meta cache in the data cache. Therefore, we introduced a data cache cleanup and retry mechanism. After file bundles were introduced in version 4.0, the same handling is required for the new bundle meta files.

## What I'm doing:
This pull request improves the robustness of tablet metadata loading in the Lake storage engine by introducing a unified handler for corrupted metadata files and enhancing test coverage for corruption scenarios. The main changes include refactoring error handling logic, adding new tests to simulate and verify recovery from corruption, and introducing error injection points for more thorough testing.

**Error handling improvements:**
* Added a new method `corrupted_tablet_meta_handler` to `TabletManager` that centralizes the logic for handling corrupted metadata files, including optional cache clearing and logging. [[1]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4R381-R395) [[2]](diffhunk://#diff-b77a64b082da0ac0fd8b28d7f521dbe7e1d235289127491a7aa865f774a6446bR252)
* Refactored `load_tablet_metadata` and `get_single_tablet_metadata` to use the new handler, improving code clarity and ensuring consistent behavior when corruption is detected. [[1]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4L390-L404) [[2]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4L584-R601)

**Testing and error injection:**
* Introduced error injection points (`TEST_ERROR_POINT`) in `ProtobufFile::load` and `TabletManager::parse_bundle_tablet_metadata` to simulate corruption during testing. [[1]](diffhunk://#diff-4e6768caf6d587c17a8f3eeb9a32cd82f72400cb19df9e6089aea5682a886a99R179) [[2]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4R511)
* Added new unit tests in `tablet_manager_test.cpp` to verify correct handling and recovery from corrupted tablet metadata, including both single and bundle tablet metadata scenarios. [[1]](diffhunk://#diff-6f0e388b15b892ba0dfe1c361354d61cc3ba3577b328fa11c1c3d49fe345fef6R106-R130) [[2]](diffhunk://#diff-6f0e388b15b892ba0dfe1c361354d61cc3ba3577b328fa11c1c3d49fe345fef6R718-R731)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
