### PR TITLE
[BugFix] window function with ignore-nulls-flag can not be consolidated with its counterpart without ignore-nulls-flag

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/AnalyticExpr.java
@@ -222,7 +222,8 @@ public class AnalyticExpr extends Expr {
                 Objects.equals(partitionHint, o.partitionHint) &&
                 Objects.equals(skewHint, o.skewHint) &&
                 Objects.equals(useHashBasedPartition, o.useHashBasedPartition) &&
-                Objects.equals(isSkewed, o.isSkewed);
+                Objects.equals(isSkewed, o.isSkewed) &&
+                Objects.equals(fnCall.getIgnoreNulls(), o.fnCall.getIgnoreNulls());
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:
first_value and first_value(ignore nulls) are consolidated mistakenly

```
create table t1 (a int, b int NULL) properties("replication_num"="1");

insert into t1 select i % 3 as a,case  when i%2=0 then NULL else i+1 end as b from table(generate_series(1,10)) t(i);

```

The results of  first_value(b) and first_value(b ignore nulls) in separate queries are different.
```
select a, b, first_value(b) over(order by a,b) from t1;
+------+------+----------------------------------------------+
| a    | b    | first_value(b) OVER (ORDER BY a ASC, b ASC ) |
+------+------+----------------------------------------------+
|    0 | NULL |                                         NULL |
|    0 |    4 |                                         NULL |
|    0 |   10 |                                         NULL |
|    1 | NULL |                                         NULL |
|    1 | NULL |                                         NULL |
|    1 |    2 |                                         NULL |
|    1 |    8 |                                         NULL |
|    2 | NULL |                                         NULL |
|    2 | NULL |                                         NULL |
|    2 |    6 |                                         NULL |
+------+------+----------------------------------------------+

mysql> select a, b,  first_value(b ignore nulls) over(order by a,b) from t1;
+------+------+-----------------------------------------------------------+
| a    | b    | first_value(b ignore nulls) OVER (ORDER BY a ASC, b ASC ) |
+------+------+-----------------------------------------------------------+
|    0 | NULL |                                                      NULL |
|    0 |    4 |                                                         4 |
|    0 |   10 |                                                         4 |
|    1 | NULL |                                                         4 |
|    1 | NULL |                                                         4 |
|    1 |    2 |                                                         4 |
|    1 |    8 |                                                         4 |
|    2 | NULL |                                                         4 |
|    2 | NULL |                                                         4 |
|    2 |    6 |                                                         4 |
+------+------+-----------------------------------------------------------+
```

when these two window functions appear in the same query, they output the same results.
```
mysql> select a, b,  first_value(b ignore nulls) over(order by a,b), first_value(b) over(order by a,b) from t1;
+------+------+-----------------------------------------------------------+----------------------------------------------+
| a    | b    | first_value(b ignore nulls) OVER (ORDER BY a ASC, b ASC ) | first_value(b) OVER (ORDER BY a ASC, b ASC ) |
+------+------+-----------------------------------------------------------+----------------------------------------------+
|    0 | NULL |                                                      NULL |                                         NULL |
|    0 |    4 |                                                         4 |                                            4 |
|    0 |   10 |                                                         4 |                                            4 |
|    1 | NULL |                                                         4 |                                            4 |
|    1 | NULL |                                                         4 |                                            4 |
|    1 |    2 |                                                         4 |                                            4 |
|    1 |    8 |                                                         4 |                                            4 |
|    2 | NULL |                                                         4 |                                            4 |
|    2 | NULL |                                                         4 |                                            4 |
|    2 |    6 |                                                         4 |                                            4 |
+------+------+-----------------------------------------------------------+----------------------------------------------+
```

The plan consolidate these two functions into one mistakenly.

```
mysql> explain costs select a, b,  first_value(b ignore nulls) over(order by a,b), first_value(b) over(order by a,b) from t1;
+----------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                             |
+----------------------------------------------------------------------------------------------------------------------------+
| PLAN COST                                                                                                                  |
|   CPU: 360.0                                                                                                               |
|   Memory: 80.0                                                                                                             |
|                                                                                                                            |
| PLAN FRAGMENT 0(F01)                                                                                                       |
|   Output Exprs:1: a | 2: b | 3: first_value(2: b) | 3: first_value(2: b)                                                   |
|   Input Partition: UNPARTITIONED                                                                                           |
|   RESULT SINK                                                                                                              |
|                                                                                                                            |
|   3:ANALYTIC                                                                                                               |
|   |  functions: [, first_value[([2: b, INT, true]); args: INT; result: INT; args nullable: true; result nullable: true], ] |
|   |  order by: [1: a, INT, true] ASC, [2: b, INT, true] ASC                                                                |
|   |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW                                                              |
|   |  cardinality: 10                                                                                                       |
|   |  column statistics:                                                                                                    |
|   |  * a-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                    |
|   |  * b-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                    |
|   |  * first_value(2: b)-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                    |
|   |                                                                                                                        |
|   2:MERGING-EXCHANGE                                                                                                       |
|      distribution type: GATHER                                                                                             |
|      cardinality: 10                                                                                                       |
|      column statistics:                                                                                                    |
|      * a-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                    |
|      * b-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                    |
|                                                                                                                            |
| PLAN FRAGMENT 1(F00)                                                                                                       |
|                                                                                                                            |
|   Input Partition: RANDOM                                                                                                  |
|   OutPut Partition: UNPARTITIONED                                                                                          |
|   OutPut Exchange Id: 02                                                                                                   |
|                                                                                                                            |
|   1:SORT                                                                                                                   |
|   |  order by: [1, INT, true] ASC, [2, INT, true] ASC                                                                      |
|   |  offset: 0                                                                                                             |
|   |  cardinality: 10                                                                                                       |
|   |  column statistics:                                                                                                    |
|   |  * a-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                    |
|   |  * b-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                    |
|   |                                                                                                                        |
|   0:OlapScanNode                                                                                                           |
|      table: t1, rollup: t1                                                                                                 |
|      preAggregation: on                                                                                                    |
|      partitionsRatio=1/1, tabletsRatio=2/2                                                                                 |
|      tabletList=6759638,6759640                                                                                            |
|      actualRows=10, avgRowSize=2.0                                                                                         |
|      cardinality: 10                                                                                                       |
|      column statistics:                                                                                                    |
|      * a-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                    |
|      * b-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                    |
+----------------------------------------------------------------------------------------------------------------------------+
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
