### PR TITLE
[Enhancement] support cache hit ratio in audit log and metric system

### DIFF
--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -71,7 +71,7 @@ private:
     Status build_scan_range(RuntimeState* state);
     void init_counter(RuntimeState* state);
     void update_realtime_counter(Chunk* chunk);
-    void update_counter();
+    void update_counter(RuntimeState* state);
 
     Status _extend_schema_by_access_paths();
     Status init_column_access_paths(Schema* schema);

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -209,6 +209,10 @@ public:
     }
 
     void update_scan_stats(int64_t table_id, int64_t scan_rows_num, int64_t scan_bytes);
+    void incr_read_stats(int64_t read_local_cnt, int64_t read_remote_cnt) {
+        _total_read_local_cnt += read_local_cnt;
+        _total_read_remote_cnt += read_remote_cnt;
+    }
     void update_push_rows_stats(int32_t plan_node_id, int64_t push_rows) {
         auto it = _node_exec_stats.find(plan_node_id);
         if (it != _node_exec_stats.end()) {
@@ -256,6 +260,8 @@ public:
     int64_t get_scan_bytes() const { return _total_scan_bytes; }
     std::atomic_int64_t* mutable_total_spill_bytes() { return &_total_spill_bytes; }
     int64_t get_spill_bytes() { return _total_spill_bytes; }
+    int64_t get_read_local_cnt() { return _total_read_local_cnt; }
+    int64_t get_read_remote_cnt() { return _total_read_remote_cnt; }
     int64_t get_transmitted_bytes() { return _total_transmitted_bytes; }
 
     // Query start time, used to check how long the query has been running
@@ -334,6 +340,8 @@ private:
     std::atomic<int64_t> _total_scan_rows_num = 0;
     std::atomic<int64_t> _total_scan_bytes = 0;
     std::atomic<int64_t> _total_spill_bytes = 0;
+    std::atomic<int64_t> _total_read_local_cnt = 0;
+    std::atomic<int64_t> _total_read_remote_cnt = 0;
     std::atomic<int64_t> _total_transmitted_bytes = 0;
     std::atomic<int64_t> _delta_cpu_cost_ns = 0;
     std::atomic<int64_t> _delta_scan_rows_num = 0;

--- a/be/src/runtime/query_statistics.h
+++ b/be/src/runtime/query_statistics.h
@@ -60,6 +60,10 @@ public:
     void add_cpu_costs(int64_t cpu_ns) { this->cpu_ns += cpu_ns; }
     void add_mem_costs(int64_t bytes) { mem_cost_bytes += bytes; }
     void add_spill_bytes(int64_t bytes) { spill_bytes += bytes; }
+    void add_read_stats(int64_t local_cnt, int64_t remote_cnt) {
+        read_local_cnt += local_cnt;
+        read_remote_cnt += remote_cnt;
+    }
     void add_transmitted_bytes(int64_t bytes) { transmitted_bytes += bytes; }
 
     void to_pb(PQueryStatistics* statistics);
@@ -72,6 +76,8 @@ public:
     int64_t get_mem_bytes() const { return mem_cost_bytes; }
     int64_t get_transmitted_bytes() const { return transmitted_bytes; }
     int64_t get_cpu_ns() const { return cpu_ns; }
+    int64_t get_read_local_cnt() const { return read_local_cnt; }
+    int64_t get_read_remote_cnt() const { return read_remote_cnt; }
 
     void clear();
 
@@ -86,6 +92,8 @@ private:
     std::atomic_int64_t cpu_ns{0};
     std::atomic_int64_t mem_cost_bytes{0};
     std::atomic_int64_t spill_bytes{0};
+    std::atomic_int64_t read_local_cnt{0};
+    std::atomic_int64_t read_remote_cnt{0};
     std::atomic_int64_t transmitted_bytes{0};
 
     // number rows returned by query.

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -312,6 +312,7 @@ set(EXEC_FILES
         ./runtime/command_executor_test.cpp
         ./runtime/exec_env_test.cpp
         ./runtime/load_fail_point_test.cpp
+        ./runtime/query_statistics_test.cpp
         ./serde/column_array_serde_test.cpp
         ./serde/protobuf_serde_test.cpp
         ./types/bitmap_value_test.cpp

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -327,4 +327,11 @@ TEST(QueryContextManagerTest, testSetWorkgroup) {
     ASSERT_EQ(0, wg->num_running_queries());
 }
 
+TEST(QueryContextManagerTest, testReadStats) {
+    QueryContext ctx;
+    ctx.incr_read_stats(100, 200);
+    ASSERT_EQ(100, ctx.get_read_local_cnt());
+    ASSERT_EQ(200, ctx.get_read_remote_cnt());
+}
+
 } // namespace starrocks::pipeline

--- a/be/test/runtime/query_statistics_test.cpp
+++ b/be/test/runtime/query_statistics_test.cpp
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/query_statistics.h"
+
+#include <gtest/gtest.h>
+
+#include "gen_cpp/data.pb.h"
+
+namespace starrocks {
+
+class QueryStatisticsTest : public ::testing::Test {};
+
+TEST_F(QueryStatisticsTest, pb) {
+    QueryStatistics s;
+    s.set_returned_rows(1);
+    s.add_scan_stats(2, 3);
+    s.add_cpu_costs(4);
+    s.add_mem_costs(5);
+    s.add_spill_bytes(6);
+    s.add_read_stats(7, 8);
+    s.add_transmitted_bytes(9);
+
+    PQueryStatistics ps;
+    s.to_pb(&ps);
+    ASSERT_EQ(ps.returned_rows(), 1);
+    ASSERT_EQ(ps.scan_rows(), 2);
+    ASSERT_EQ(ps.scan_bytes(), 3);
+    ASSERT_EQ(ps.cpu_cost_ns(), 4);
+    ASSERT_EQ(ps.mem_cost_bytes(), 5);
+    ASSERT_EQ(ps.spill_bytes(), 6);
+    ASSERT_EQ(ps.read_local_cnt(), 7);
+    ASSERT_EQ(ps.read_remote_cnt(), 8);
+    ASSERT_EQ(ps.transmitted_bytes(), 9);
+
+    s.merge_pb(ps);
+    ASSERT_EQ(s.get_scan_rows(), 4);
+    ASSERT_EQ(s.get_mem_bytes(), 5);
+    ASSERT_EQ(s.get_transmitted_bytes(), 18);
+    ASSERT_EQ(s.get_cpu_ns(), 8);
+    ASSERT_EQ(s.get_read_local_cnt(), 14);
+    ASSERT_EQ(s.get_read_remote_cnt(), 16);
+}
+
+TEST_F(QueryStatisticsTest, basic) {
+    QueryStatistics s;
+    s.set_returned_rows(1);
+    s.add_scan_stats(2, 3);
+    s.add_cpu_costs(4);
+    s.add_mem_costs(5);
+    s.add_spill_bytes(6);
+    s.add_read_stats(7, 8);
+    s.add_transmitted_bytes(9);
+
+    QueryStatistics s2;
+    s2.merge(0, s);
+    ASSERT_EQ(s2.get_scan_rows(), 2);
+    ASSERT_EQ(s2.get_mem_bytes(), 5);
+    ASSERT_EQ(s2.get_transmitted_bytes(), 9);
+    ASSERT_EQ(s2.get_cpu_ns(), 4);
+    ASSERT_EQ(s2.get_read_local_cnt(), 7);
+    ASSERT_EQ(s2.get_read_remote_cnt(), 8);
+
+    s2.clear();
+    ASSERT_EQ(s2.get_scan_rows(), 0);
+    ASSERT_EQ(s2.get_mem_bytes(), 0);
+    ASSERT_EQ(s2.get_transmitted_bytes(), 0);
+    ASSERT_EQ(s2.get_cpu_ns(), 0);
+    ASSERT_EQ(s2.get_read_local_cnt(), 0);
+    ASSERT_EQ(s2.get_read_remote_cnt(), 0);
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/AuditStatisticsUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/AuditStatisticsUtil.java
@@ -47,6 +47,8 @@ public class AuditStatisticsUtil {
                 pb.statsItems.add(pItem);
             }
         }
+        pb.readLocalCnt = tb.getRead_local_cnt();
+        pb.readRemoteCnt = tb.getRead_remote_cnt();
         return pb;
     }
 
@@ -126,6 +128,18 @@ public class AuditStatisticsUtil {
                 }
             }
         }
+        if (from.readLocalCnt != null) {
+            if (to.readLocalCnt == null) {
+                to.readLocalCnt = 0L;
+            }
+            to.readLocalCnt += from.readLocalCnt;
+        }
+        if (from.readRemoteCnt != null) {
+            if (to.readRemoteCnt == null) {
+                to.readRemoteCnt = 0L;
+            }
+            to.readRemoteCnt += from.readRemoteCnt;
+        }
     }
 
     public static TAuditStatistics toThrift(PQueryStatistics pb) {
@@ -168,6 +182,12 @@ public class AuditStatisticsUtil {
                 }
                 tb.addToStats_items(tItem);
             }
+        }
+        if (pb.readLocalCnt != null) {
+            tb.setRead_local_cnt(pb.readLocalCnt);
+        }
+        if (pb.readRemoteCnt != null) {
+            tb.setRead_remote_cnt(pb.readRemoteCnt);
         }
         return tb;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -240,6 +240,12 @@ public final class MetricRepo {
     public static List<GaugeMetricImpl<Long>> GAUGE_MEMORY_USAGE_STATS;
     public static List<GaugeMetricImpl<Long>> GAUGE_OBJECT_COUNT_STATS;
 
+    public static Histogram HISTO_CACHE_MISS_RATIO;
+    public static GaugeMetricImpl<Float> GAUGE_CACHE_MISS_RATIO_AVERAGE;
+    public static GaugeMetricImpl<Float> GAUGE_CACHE_MISS_RATIO_P50;
+    public static GaugeMetricImpl<Float> GAUGE_CACHE_MISS_RATIO_P90;
+    public static GaugeMetricImpl<Float> GAUGE_CACHE_MISS_RATIO_P99;
+
     // Currently, we use gauge for safe mode metrics, since we do not have unTyped metrics till now
     public static GaugeMetricImpl<Integer> GAUGE_SAFE_MODE;
 
@@ -465,6 +471,32 @@ public final class MetricRepo {
         GAUGE_QUERY_LATENCY_P999.addLabel(new MetricLabel("type", "999_quantile"));
         GAUGE_QUERY_LATENCY_P999.setValue(0.0);
         STARROCKS_METRIC_REGISTER.addMetric(GAUGE_QUERY_LATENCY_P999);
+
+        HISTO_CACHE_MISS_RATIO = METRIC_REGISTER.histogram(MetricRegistry.name("query", "cache_miss_ratio", "permille"));
+
+        GAUGE_CACHE_MISS_RATIO_AVERAGE =
+                new GaugeMetricImpl<>("cache_miss_ratio", MetricUnit.NOUNIT, "average of cache miss ratio");
+        GAUGE_CACHE_MISS_RATIO_AVERAGE.addLabel(new MetricLabel("type", "average"));
+        GAUGE_CACHE_MISS_RATIO_AVERAGE.setValue(0.0f);
+        STARROCKS_METRIC_REGISTER.addMetric(GAUGE_CACHE_MISS_RATIO_AVERAGE);
+
+        GAUGE_CACHE_MISS_RATIO_P50 =
+                new GaugeMetricImpl<>("cache_miss_ratio", MetricUnit.NOUNIT, "p50 of cache miss ratio");
+        GAUGE_CACHE_MISS_RATIO_P50.addLabel(new MetricLabel("type", "50_quantile"));
+        GAUGE_CACHE_MISS_RATIO_P50.setValue(0.0f);
+        STARROCKS_METRIC_REGISTER.addMetric(GAUGE_CACHE_MISS_RATIO_P50);
+
+        GAUGE_CACHE_MISS_RATIO_P90 =
+                new GaugeMetricImpl<>("cache_miss_ratio", MetricUnit.NOUNIT, "p90 of cache miss ratio");
+        GAUGE_CACHE_MISS_RATIO_P90.addLabel(new MetricLabel("type", "90_quantile"));
+        GAUGE_CACHE_MISS_RATIO_P90.setValue(0.0f);
+        STARROCKS_METRIC_REGISTER.addMetric(GAUGE_CACHE_MISS_RATIO_P90);
+
+        GAUGE_CACHE_MISS_RATIO_P99 =
+                new GaugeMetricImpl<>("cache_miss_ratio", MetricUnit.NOUNIT, "p99 of cache miss ratio");
+        GAUGE_CACHE_MISS_RATIO_P99.addLabel(new MetricLabel("type", "99_quantile"));
+        GAUGE_CACHE_MISS_RATIO_P99.setValue(0.0f);
+        STARROCKS_METRIC_REGISTER.addMetric(GAUGE_CACHE_MISS_RATIO_P99);
 
         GAUGE_SAFE_MODE = new GaugeMetricImpl<>("safe_mode", MetricUnit.NOUNIT, "safe mode flag");
         GAUGE_SAFE_MODE.addLabel(new MetricLabel("type", "safe_mode"));

--- a/fe/fe-core/src/main/java/com/starrocks/metric/SimpleCoreMetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/SimpleCoreMetricVisitor.java
@@ -72,6 +72,8 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
 
     public static final String MAX_TABLET_COMPACTION_SCORE = "max_tablet_compaction_score";
 
+    public static final String CACHE_MISS_RATIO = "cache_miss_ratio";
+
     private static final Map<String, String> CORE_METRICS = Maps.newHashMap();
 
     static {
@@ -82,6 +84,7 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
         CORE_METRICS.put(REQUEST_PER_SECOND, TYPE_DOUBLE);
         CORE_METRICS.put(QUERY_ERR_RATE, TYPE_DOUBLE);
         CORE_METRICS.put(MAX_TABLET_COMPACTION_SCORE, TYPE_LONG);
+        CORE_METRICS.put(CACHE_MISS_RATIO, TYPE_DOUBLE);
     }
 
     private StringBuilder sb;

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -35,6 +35,7 @@
 package com.starrocks.plugin;
 
 import com.google.common.base.Joiner;
+import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 
 import java.lang.annotation.Retention;
@@ -64,6 +65,7 @@ public class AuditEvent {
         String value() default "";
 
         boolean ignore_zero() default false;
+        boolean ignore_empty() default false;
     }
 
     public EventType type;
@@ -164,6 +166,33 @@ public class AuditEvent {
 
     @AuditField(value = "QuerySource")
     public String querySource = "";
+
+    public long readLocalCnt = 0;
+    public long readRemoteCnt = 0;
+    @AuditField(value = "CacheHitRatio", ignore_empty = true)
+    public String cacheHitRatio = "";
+
+    public void calculateCacheHitRatio() {
+        if (!isQuery || RunMode.isSharedNothingMode()) {
+            return;
+        }
+        long readTotalCnt = readLocalCnt + readRemoteCnt;
+        if (readTotalCnt > 0) {
+            float percent = ((float) readLocalCnt * 100) / readTotalCnt;
+            cacheHitRatio = String.format("%.1f", percent) + "%";
+        } else {
+            cacheHitRatio = "100%";
+        }
+    }
+
+    public float getCacheMissRatio() {
+        long readTotalCnt = readLocalCnt + readRemoteCnt;
+        if (readTotalCnt > 0) {
+            return ((float) readRemoteCnt * 100) / readTotalCnt;
+        } else {
+            return 0;
+        }
+    }
 
     public static class AuditEventBuilder {
 
@@ -296,6 +325,16 @@ public class AuditEvent {
             } else {
                 auditEvent.spilledBytes += spilledBytes;
             }
+            return this;
+        }
+
+        public AuditEventBuilder addReadLocalCnt(long readLocalCnt) {
+            auditEvent.readLocalCnt += readLocalCnt;
+            return this;
+        }
+
+        public AuditEventBuilder addReadRemoteCnt(long readRemoteCnt) {
+            auditEvent.readRemoteCnt += readRemoteCnt;
             return this;
         }
 
@@ -433,6 +472,7 @@ public class AuditEvent {
         }
 
         public AuditEvent build() {
+            this.auditEvent.calculateCacheHitRatio();
             return this.auditEvent;
         }
 
@@ -443,6 +483,8 @@ public class AuditEvent {
             this.auditEvent.scanBytes = event.scanBytes;
             this.auditEvent.scanRows = event.scanRows;
             this.auditEvent.spilledBytes = event.spilledBytes;
+            this.auditEvent.readLocalCnt = event.readLocalCnt;
+            this.auditEvent.readRemoteCnt = event.readRemoteCnt;
             this.auditEvent.returnRows = event.returnRows;
             this.auditEvent.transmittedBytes = event.transmittedBytes;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
@@ -109,6 +109,12 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
                         continue;
                     }
                 }
+                if (value instanceof String) {
+                    String stringValue = (String) value;
+                    if ((stringValue == null || stringValue.isEmpty()) && af.ignore_empty()) {
+                        continue;
+                    }
+                }
 
                 if (Config.audit_log_json_format) {
                     logMap.put(af.value(), value);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
@@ -95,6 +95,7 @@ public class QueryDetail implements Serializable {
     private long cpuCostNs = -1;
     private long memCostBytes = -1;
     private long spillBytes = -1;
+    private float cacheMissRatio = 0;
     private String warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
     private String digest;
     private String catalog;
@@ -162,6 +163,7 @@ public class QueryDetail implements Serializable {
         queryDetail.cpuCostNs = this.cpuCostNs;
         queryDetail.memCostBytes = this.memCostBytes;
         queryDetail.spillBytes = this.spillBytes;
+        queryDetail.cacheMissRatio = this.cacheMissRatio;
         queryDetail.warehouse = this.warehouse;
         queryDetail.digest = this.digest;
         queryDetail.resourceGroupName = this.resourceGroupName;
@@ -357,6 +359,19 @@ public class QueryDetail implements Serializable {
 
     public void setSpillBytes(long spillBytes) {
         this.spillBytes = spillBytes;
+    }
+
+    public void calculateCacheMissRatio(long readLocalCnt, long readRemoteCnt) {
+        long readTotalCnt = readLocalCnt + readRemoteCnt;
+        if (readTotalCnt > 0) {
+            cacheMissRatio = ((float) readRemoteCnt * 100) / readTotalCnt;
+        } else {
+            cacheMissRatio = 0;
+        }
+    }
+
+    public float getCacheMissRatio() {
+        return cacheMissRatio;
     }
 
     public void setWarehouse(String warehouse) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -982,6 +982,8 @@ public class StmtExecutor {
         context.getAuditEventBuilder().addScanBytes(execStats.getScanBytes() != null ? execStats.getScanBytes() : 0);
         context.getAuditEventBuilder().addScanRows(execStats.getScanRows() != null ? execStats.getScanRows() : 0);
         context.getAuditEventBuilder().addSpilledBytes(execStats.spillBytes != null ? execStats.spillBytes : 0);
+        context.getAuditEventBuilder().addReadLocalCnt(execStats.readLocalCnt != null ? execStats.readLocalCnt : 0);
+        context.getAuditEventBuilder().addReadRemoteCnt(execStats.readRemoteCnt != null ? execStats.readRemoteCnt : 0);
         context.getAuditEventBuilder().setReturnRows(execStats.returnedRows == null ? 0 : execStats.returnedRows);
         context.getAuditEventBuilder().addTransmittedBytes(execStats.transmittedBytes != null ? execStats.transmittedBytes : 0);
     }
@@ -2432,6 +2434,12 @@ public class StmtExecutor {
         if (statisticsForAuditLog.spillBytes == null) {
             statisticsForAuditLog.spillBytes = 0L;
         }
+        if (statisticsForAuditLog.readLocalCnt == null) {
+            statisticsForAuditLog.readLocalCnt = 0L;
+        }
+        if (statisticsForAuditLog.readRemoteCnt == null) {
+            statisticsForAuditLog.readRemoteCnt = 0L;
+        }
         return statisticsForAuditLog;
     }
 
@@ -3240,6 +3248,8 @@ public class StmtExecutor {
             queryDetail.setCpuCostNs(statistics.cpuCostNs == null ? -1 : statistics.cpuCostNs);
             queryDetail.setMemCostBytes(statistics.memCostBytes == null ? -1 : statistics.memCostBytes);
             queryDetail.setSpillBytes(statistics.spillBytes == null ? -1 : statistics.spillBytes);
+            queryDetail.calculateCacheMissRatio(statistics.readLocalCnt == null ? 0 : statistics.readLocalCnt,
+                    statistics.readRemoteCnt == null ? 0 : statistics.readRemoteCnt);
         }
         queryDetail.setCatalog(ctx.getCurrentCatalog());
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/AuditStatisticsUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/AuditStatisticsUtilTest.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.starrocks.proto.PQueryStatistics;
+import com.starrocks.thrift.TAuditStatistics;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AuditStatisticsUtilTest {
+    @Test
+    public void test() {
+        TAuditStatistics ts = new TAuditStatistics();
+        ts.setScan_rows(1);
+        ts.setScan_bytes(2);
+        ts.setReturned_rows(3);
+        ts.setCpu_cost_ns(4);
+        ts.setMem_cost_bytes(5);
+        ts.setSpill_bytes(6);
+        ts.setTransmitted_bytes(7);
+        ts.setRead_local_cnt(8);
+        ts.setRead_remote_cnt(9);
+        PQueryStatistics ps = AuditStatisticsUtil.toProtobuf(ts);
+        Assertions.assertEquals(ps.scanRows, 1);
+        Assertions.assertEquals(ps.scanBytes, 2);
+        Assertions.assertEquals(ps.returnedRows, 3);
+        Assertions.assertEquals(ps.cpuCostNs, 4);
+        Assertions.assertEquals(ps.memCostBytes, 5);
+        Assertions.assertEquals(ps.spillBytes, 6);
+        Assertions.assertEquals(ps.transmittedBytes, 7);
+        Assertions.assertEquals(ps.readLocalCnt, 8);
+        Assertions.assertEquals(ps.readRemoteCnt, 9);
+
+        PQueryStatistics ps2 = new PQueryStatistics();
+        AuditStatisticsUtil.mergeProtobuf(ps, ps2);
+        Assertions.assertEquals(ps2.scanRows, 1);
+        Assertions.assertEquals(ps2.scanBytes, 2);
+        Assertions.assertEquals(ps2.returnedRows, 3);
+        Assertions.assertEquals(ps2.cpuCostNs, 4);
+        Assertions.assertEquals(ps2.memCostBytes, 5);
+        Assertions.assertEquals(ps2.spillBytes, 6);
+        Assertions.assertEquals(ps2.transmittedBytes, 7);
+        Assertions.assertEquals(ps2.readLocalCnt, 8);
+        Assertions.assertEquals(ps2.readRemoteCnt, 9);
+
+        TAuditStatistics ts2 = AuditStatisticsUtil.toThrift(ps);
+        Assertions.assertEquals(ts2.getScan_rows(), 1);
+        Assertions.assertEquals(ts2.getScan_bytes(), 2);
+        Assertions.assertEquals(ts2.getReturned_rows(), 3);
+        Assertions.assertEquals(ts2.getCpu_cost_ns(), 4);
+        Assertions.assertEquals(ts2.getMem_cost_bytes(), 5);
+        Assertions.assertEquals(ts2.getSpill_bytes(), 6);
+        Assertions.assertEquals(ts2.getTransmitted_bytes(), 7);
+        Assertions.assertEquals(ts2.getRead_local_cnt(), 8);
+        Assertions.assertEquals(ts2.getRead_remote_cnt(), 9);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
@@ -14,6 +14,9 @@
 
 package com.starrocks.plugin;
 
+import com.starrocks.server.RunMode;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +42,16 @@ public class AuditEventTest {
                 .setWarehouse("wh")
                 .setSessionId("sessionId")
                 .setCustomQueryId("customQueryId")
-                .setCNGroup("test_cngroup");
+                .setCNGroup("test_cngroup")
+                .addReadLocalCnt(100)
+                .addReadRemoteCnt(100);
+
+        new MockUp<RunMode>() {
+            @Mock
+            public static boolean isSharedNothingMode() {
+                return false;
+            }
+        };
         AuditEvent event = builder.build();
 
         Assertions.assertEquals(AuditEvent.EventType.CONNECTION, event.type);
@@ -61,5 +73,7 @@ public class AuditEventTest {
         Assertions.assertEquals("sessionId", event.sessionId);
         Assertions.assertEquals("customQueryId", event.customQueryId);
         Assertions.assertEquals("test_cngroup", event.cnGroup);
+        Assertions.assertEquals("50.0%", event.cacheHitRatio);
+        Assertions.assertEquals((float) 50, event.getCacheMissRatio());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
@@ -85,6 +85,7 @@ public class QueryDetailQueueTest extends PlanTestBase {
                 "\"cpuCostNs\":1002," +
                 "\"memCostBytes\":100003," +
                 "\"spillBytes\":-1," +
+                "\"cacheMissRatio\":0.0," +
                 "\"warehouse\":\"default_warehouse\"," +
                 "\"catalog\":\"default_catalog\"," +
                 "\"queryFeMemory\":0}]";

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailTest.java
@@ -55,6 +55,9 @@ public class QueryDetailTest {
 
         queryDetail.setLatency(10);
         Assertions.assertEquals(-1, copyOfQueryDetail.getLatency());
+
+        queryDetail.calculateCacheMissRatio(100, 100);
+        Assertions.assertEquals((float) 50, queryDetail.getCacheMissRatio());
     }
 
     private static ConnectContext connectContext;

--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -49,6 +49,8 @@ message PQueryStatistics {
     optional int64 transmitted_bytes = 7;
     repeated QueryStatisticsItemPB stats_items = 10;
     repeated NodeExecStatsItemPB node_exec_stats_items = 11;
+    optional int64 read_local_cnt = 12;
+    optional int64 read_remote_cnt = 13;
 }
 
 message QueryStatisticsItemPB {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -787,6 +787,8 @@ struct TAuditStatistics {
     8: optional i64 spill_bytes
     10: optional i64 transmitted_bytes
     9: optional list<TAuditStatisticsItem> stats_items
+    11: optional i64 read_local_cnt
+    12: optional i64 read_remote_cnt
 }
 
 struct TReportAuditStatisticsParams {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. add cache hit ratio in audit log for shared-data cluster
2. add cache hit ratio related metrics for shared-data cluster

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds read-local/remote counters end-to-end and surfaces cache hit/miss ratios in audit logs, query stats, FE metrics, and protocols.
> 
> - **BE (Lake + Query Pipeline)**:
>   - Change `LakeDataSource::update_counter` to accept `RuntimeState*` and increment query read stats via `QueryContext::incr_read_stats`.
>   - `QueryContext`: track `_total_read_local_cnt/_total_read_remote_cnt`, include in final stats and big-query log (prints `cache_hit_ratio`).
> - **Runtime QueryStatistics**:
>   - Add `read_local_cnt`/`read_remote_cnt`; propagate in `to_pb`, `to_params`, `merge`, `clear`, and getters.
> - **FE (Audit + Metrics + QueryDetail)**:
>   - `AuditEvent`: accumulate read counts, compute and log `CacheHitRatio`; support `ignore_empty` in audit fields.
>   - `StmtExecutor`/`ConnectProcessor`: feed read counts to audit; update histogram for cache miss ratio.
>   - `QueryDetail`: store/compute `cacheMissRatio` per query.
>   - `MetricRepo`/`MetricCalculator`/`SimpleCoreMetricVisitor`: add cache miss ratio histogram and gauges (avg/p50/p90/p99) and expose core metric.
> - **Protocol**:
>   - Extend `PQueryStatistics` (proto) and `TAuditStatistics` (thrift) with `read_local_cnt`/`read_remote_cnt`; FE util handles convert/merge.
> - **Tests/Build**:
>   - Add unit tests for new stats and metrics; update BE/FE test lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit babcd2c3e605ee2c10b537f21eb1be666cdbdbc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->