### PR TITLE
[BugFix] Fix task fail to schedule if fe restarts frequently

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/SubmitResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/SubmitResult.java
@@ -61,4 +61,12 @@ public class SubmitResult {
         REJECTED,
         FAILED
     }
+
+    @Override
+    public String toString() {
+        return "{" +
+                "queryId='" + queryId + '\'' +
+                ", status=" + status +
+                '}';
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
@@ -75,11 +75,11 @@ public class Task implements Writable {
     @SerializedName("createUserIdentity")
     private UserIdentity userIdentity;
 
-    // the last time this task is scheduled
+    // the last time this task is scheduled, unit: second
     @SerializedName("lastScheduleTime")
     private long lastScheduleTime = -1;
 
-    // the next time this task is to be scheduled
+    // the next time this task is to be scheduled, unit: second
     @SerializedName("nextScheduleTime")
     private long nextScheduleTime = -1;
 
@@ -219,18 +219,22 @@ public class Task implements Writable {
         this.postRun = postRun;
     }
 
+    // unit: second
     public long getLastScheduleTime() {
         return lastScheduleTime;
     }
 
+    // unit: second
     public void setLastScheduleTime(long lastScheduleTime) {
         this.lastScheduleTime = lastScheduleTime;
     }
 
+    // unit: second
     public long getNextScheduleTime() {
         return nextScheduleTime;
     }
 
+    // unit: second
     public void setNextScheduleTime(long nextScheduleTime) {
         this.nextScheduleTime = nextScheduleTime;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
@@ -75,6 +75,14 @@ public class Task implements Writable {
     @SerializedName("createUserIdentity")
     private UserIdentity userIdentity;
 
+    // the last time this task is scheduled
+    @SerializedName("lastScheduleTime")
+    private long lastScheduleTime = -1;
+
+    // the next time this task is to be scheduled
+    @SerializedName("nextScheduleTime")
+    private long nextScheduleTime = -1;
+
     public Task() {}
 
     public Task(String name) {
@@ -211,6 +219,22 @@ public class Task implements Writable {
         this.postRun = postRun;
     }
 
+    public long getLastScheduleTime() {
+        return lastScheduleTime;
+    }
+
+    public void setLastScheduleTime(long lastScheduleTime) {
+        this.lastScheduleTime = lastScheduleTime;
+    }
+
+    public long getNextScheduleTime() {
+        return nextScheduleTime;
+    }
+
+    public void setNextScheduleTime(long nextScheduleTime) {
+        this.nextScheduleTime = nextScheduleTime;
+    }
+
     @Override
     public String toString() {
         return "Task{" +
@@ -227,6 +251,8 @@ public class Task implements Writable {
                 ", expireTime=" + expireTime +
                 ", source=" + source +
                 ", createUser='" + createUser + '\'' +
+                ", lastScheduleTime=" + lastScheduleTime +
+                ", nextScheduleTime=" + nextScheduleTime +
                 '}';
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunFIFOQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunFIFOQueue.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
+import com.nimbusds.oauth2.sdk.util.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -251,7 +252,13 @@ public class TaskRunFIFOQueue {
         rLock.lock();
         try {
             for (Set<TaskRun> taskRuns : gIdToTaskRunsMap.values()) {
+                if (CollectionUtils.isEmpty(taskRuns)) {
+                    continue;
+                }
                 for (TaskRun taskRun : taskRuns) {
+                    if (taskRun == null) {
+                        continue;
+                    }
                     if (taskRun.getRunCtx() == null) {
                         continue;
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -96,6 +96,7 @@ public class TaskRunManager implements MemoryTrackable {
     /**
      * Kill the running task run. If force is true, it will always clear the task run from task run scheduler whether it's
      * canceled or not so can trigger the pending task runs as soon as possible.
+     * NOTE: This method is not thread safe, the caller should ensure the thread safety.
      */
     public boolean killRunningTaskRun(TaskRun taskRun, boolean force) {
         if (taskRun == null) {
@@ -128,6 +129,7 @@ public class TaskRunManager implements MemoryTrackable {
 
     /**
      * Kill all pending task runs of the input task id.
+     * NOTE: This method is not thread safe, the caller should ensure the thread safety.
      */
     public void killPendingTaskRuns(Long taskId) {
         // mark pending tasks as failed

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
@@ -222,9 +222,24 @@ public class TaskRunScheduler {
         return GsonUtils.GSON.toJson(this);
     }
 
+    /**
+     * Get all runnable task count group by warehouse id
+     */
     public Map<Long, Long> getAllRunnableTaskCount() {
+        try {
+            return getAllRunnableTaskCountImpl();
+        } catch (Exception e) {
+            LOG.warn("failed to get all runnable task count", e);
+            return Maps.newHashMap();
+        }
+    }
+
+    private Map<Long, Long> getAllRunnableTaskCountImpl() {
         Map<Long, Long> result = new HashMap<>();
         for (TaskRun taskRun : runningTaskRunMap.values()) {
+            if (taskRun == null) {
+                continue;
+            }
             if (taskRun.getRunCtx() == null) {
                 continue;
             }
@@ -232,6 +247,9 @@ public class TaskRunScheduler {
                     (key, value) -> value == null ? 1L : value + 1);
         }
         for (TaskRun taskRun : runningSyncTaskRunMap.values()) {
+            if (taskRun == null) {
+                continue;
+            }
             if (taskRun.getRunCtx() == null) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskSchedule.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TaskSchedule {
 
-    // Measured in milliseconds, between the start time and midnight, January 1, 1970 UTC.
+    // Measured in seconds, between the start time and midnight, January 1, 1970 UTC.
     @SerializedName("startTime")
     private long startTime = 0;
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -520,21 +520,21 @@ public class TaskManagerTest {
     @Test
     public void testGetInitialDelayTime1() throws Exception {
         assertEquals(50, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:50"),
-                parseLocalDateTime("2023-04-18 20:00:00"), null));
+                parseLocalDateTime("2023-04-18 20:00:00")));
         assertEquals(30, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:30"),
-                parseLocalDateTime("2023-04-18 20:00:00"), null));
+                parseLocalDateTime("2023-04-18 20:00:00")));
         assertEquals(20, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:30"),
-                parseLocalDateTime("2023-04-18 20:00:10"), null));
+                parseLocalDateTime("2023-04-18 20:00:10")));
         assertEquals(0, TaskManager.getInitialDelayTime(20, parseLocalDateTime("2023-04-18 19:08:30"),
-                parseLocalDateTime("2023-04-18 21:00:10"), null));
+                parseLocalDateTime("2023-04-18 21:00:10")));
     }
 
     @Test
     public void testGetInitialDelayTime2() throws Exception {
         assertEquals(23, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-12-29 19:50:00"),
-                LocalDateTime.parse("2024-01-30T15:27:37.342356010"), null));
+                LocalDateTime.parse("2024-01-30T15:27:37.342356010")));
         assertEquals(50, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-12-29 19:50:00"),
-                LocalDateTime.parse("2024-01-30T15:27:10.342356010"), null));
+                LocalDateTime.parse("2024-01-30T15:27:10.342356010")));
     }
 
     private static ExecuteOption makeExecuteOption(boolean isMergeRedundant, boolean isSync) {
@@ -1067,24 +1067,12 @@ public class TaskManagerTest {
         taskManager.removeExpiredTaskRuns(false);
     }
 
-
-    @Test
-    void testTriggerImmediatelyWhenLastScheduleExpired() {
-        long periodSeconds = 60;
-        LocalDateTime taskStartTime = LocalDateTime.of(2023, 4, 18, 19, 0, 0);
-        LocalDateTime currentDateTime = LocalDateTime.of(2023, 4, 18, 20, 0, 0);
-        LocalDateTime lastScheduleTime = LocalDateTime.of(2023, 4, 18, 19, 8, 30);
-        // lastScheduleTime + period < currentDateTime 且 lastScheduleTime > taskStartTime
-        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime, lastScheduleTime);
-        assertEquals(0, delay);
-    }
-
     @Test
     void testInitialDelayPositive() {
         long periodSeconds = 60;
         LocalDateTime taskStartTime = LocalDateTime.of(2023, 4, 18, 20, 0, 0);
         LocalDateTime currentDateTime = LocalDateTime.of(2023, 4, 18, 19, 8, 50);
-        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime, null);
+        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime);
         assertEquals(3070, delay);
     }
 
@@ -1093,8 +1081,8 @@ public class TaskManagerTest {
         long periodSeconds = 60;
         LocalDateTime taskStartTime = LocalDateTime.of(2023, 4, 18, 19, 0, 0);
         LocalDateTime currentDateTime = LocalDateTime.of(2023, 4, 18, 20, 0, 1, 1); // 有nano
-        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime, null);
-        assertEquals(2, delay);
+        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime);
+        assertEquals(59, delay);
     }
 
     @Test
@@ -1102,7 +1090,7 @@ public class TaskManagerTest {
         long periodSeconds = 60;
         LocalDateTime taskStartTime = LocalDateTime.of(2023, 4, 18, 19, 0, 0);
         LocalDateTime currentDateTime = LocalDateTime.of(2023, 4, 18, 20, 0, 1, 0); // nano = 0
-        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime, null);
+        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime);
         // initialDelay = -3601, extra = 0
         // ((-3601 % 60) + 60) % 60 = (-1 + 60) % 60 = 59 % 60 = 59
         assertEquals(59, delay);
@@ -1113,7 +1101,7 @@ public class TaskManagerTest {
         long periodSeconds = 20;
         LocalDateTime taskStartTime = LocalDateTime.of(2023, 4, 18, 21, 0, 10);
         LocalDateTime currentDateTime = LocalDateTime.of(2023, 4, 18, 19, 8, 30);
-        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime, null);
+        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime);
         assertEquals(1 * 3600 + 51 * 60 + 40, delay); // 1小时51分40秒
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Queues;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.ThreadUtil;
 import com.starrocks.common.util.TimeUtils;
@@ -1145,5 +1146,893 @@ public class TaskManagerTest {
         Assertions.assertNotNull(
                 taskManager.getPeriodFutureMap().get(task.getId())
         );
+    }
+
+    @Test
+    public void testRegisterSchedulerNonPeriodicalTask() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setType(Constants.TaskType.MANUAL);
+        
+        // Register scheduler should return early for non-periodical tasks
+        taskManager.registerScheduler(task);
+        
+        // Should not create a scheduled future for manual tasks
+        Assertions.assertNull(taskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerEventTriggeredTask() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        task.setType(Constants.TaskType.EVENT_TRIGGERED);
+        
+        // Register scheduler should return early for event triggered tasks
+        taskManager.registerScheduler(task);
+        
+        // Should not create a scheduled future for event triggered tasks
+        Assertions.assertNull(taskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerMVTaskTriggerImmediately() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_mv");
+        task.setSource(Constants.TaskSource.MV);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        long startTime = now - 3600000; // 1 hour ago
+        long lastScheduleTime = now - 180000; // 3 minutes ago
+        
+        schedule.setStartTime(startTime);
+        schedule.setPeriod(60); // 1 minute period
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(lastScheduleTime);
+        task.setId(1L);
+        
+        // Mock executeTask to verify it's called
+        final boolean[] executeTaskCalled = {false};
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public void executeTask(String taskName) throws DdlException {
+                executeTaskCalled[0] = true;
+                assertEquals("test_mv", taskName);
+            }
+        };
+        
+        spyTaskManager.replayCreateTask(task);
+        spyTaskManager.registerScheduler(task);
+        
+        // Should trigger immediately because lastScheduleTime + period < currentTime
+        Assertions.assertTrue(executeTaskCalled[0], "Task should be executed immediately");
+        Assertions.assertTrue(task.getLastScheduleTime() >= now, "LastScheduleTime should be updated");
+        Assertions.assertNotNull(spyTaskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerMVTaskNoImmediateTriggerWhenLastScheduleBeforeStart() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_mv");
+        task.setSource(Constants.TaskSource.MV);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        long startTime = now - 3600000; // 1 hour ago
+        long lastScheduleTime = now - 7200000; // 2 hours ago (before start time)
+        
+        schedule.setStartTime(startTime);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(lastScheduleTime);
+        task.setId(2L);
+        
+        // Mock executeTask to verify it's NOT called
+        final boolean[] executeTaskCalled = {false};
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public void executeTask(String taskName) throws DdlException {
+                executeTaskCalled[0] = true;
+            }
+        };
+        
+        spyTaskManager.replayCreateTask(task);
+        spyTaskManager.registerScheduler(task);
+        
+        // Should not trigger immediately because lastScheduleTime is before taskStartTime
+        Assertions.assertFalse(executeTaskCalled[0], "Task should not be executed immediately");
+        Assertions.assertNotNull(spyTaskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerMVTaskNoImmediateTriggerWhenNotExpired() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_mv");
+        task.setSource(Constants.TaskSource.MV);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        long startTime = now - 3600000; // 1 hour ago
+        long lastScheduleTime = now - 30000; // 30 seconds ago
+        
+        schedule.setStartTime(startTime);
+        schedule.setPeriod(60); // 1 minute period
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(lastScheduleTime);
+        task.setId(3L);
+        
+        // Mock executeTask to verify it's NOT called
+        final boolean[] executeTaskCalled = {false};
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public void executeTask(String taskName) throws DdlException {
+                executeTaskCalled[0] = true;
+            }
+        };
+        
+        spyTaskManager.replayCreateTask(task);
+        spyTaskManager.registerScheduler(task);
+        
+        // Should not trigger immediately because lastScheduleTime + period is in the future
+        Assertions.assertFalse(executeTaskCalled[0], "Task should not be executed immediately");
+        Assertions.assertNotNull(spyTaskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerNonMVTaskNoImmediateTrigger() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_ctas");
+        task.setSource(Constants.TaskSource.CTAS);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        long startTime = now - 3600000; // 1 hour ago
+        long lastScheduleTime = now - 180000; // 3 minutes ago
+        
+        schedule.setStartTime(startTime);
+        schedule.setPeriod(60); // 1 minute period
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(lastScheduleTime);
+        task.setId(4L);
+        
+        // Mock executeTask to verify it's NOT called
+        final boolean[] executeTaskCalled = {false};
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public void executeTask(String taskName) throws DdlException {
+                executeTaskCalled[0] = true;
+            }
+        };
+        
+        spyTaskManager.replayCreateTask(task);
+        spyTaskManager.registerScheduler(task);
+        
+        // Should not trigger immediately because source is not MV
+        Assertions.assertFalse(executeTaskCalled[0], "Non-MV task should not be executed immediately");
+        Assertions.assertNotNull(spyTaskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerWithMinutesTimeUnit() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_minutes");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(5); // 5 minutes
+        schedule.setTimeUnit(TimeUnit.MINUTES);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(5L);
+        
+        taskManager.registerScheduler(task);
+        
+        long nextScheduleTime = task.getNextScheduleTime();
+        Assertions.assertTrue(nextScheduleTime > 0);
+        Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerWithHoursTimeUnit() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_hours");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(2); // 2 hours
+        schedule.setTimeUnit(TimeUnit.HOURS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(6L);
+        
+        taskManager.registerScheduler(task);
+        
+        long nextScheduleTime = task.getNextScheduleTime();
+        Assertions.assertTrue(nextScheduleTime > 0);
+        Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerWithDaysTimeUnit() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_days");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(1); // 1 day
+        schedule.setTimeUnit(TimeUnit.DAYS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(7L);
+        
+        taskManager.registerScheduler(task);
+        
+        long nextScheduleTime = task.getNextScheduleTime();
+        Assertions.assertTrue(nextScheduleTime > 0);
+        Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerNextScheduleTimeCalculation() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_calculation");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(8L);
+        
+        taskManager.registerScheduler(task);
+        
+        long nextScheduleTime = task.getNextScheduleTime();
+        long currentTimeSeconds = System.currentTimeMillis() / 1000;
+        
+        // nextScheduleTime should be within reasonable range (0-60 seconds from now for a 60-second period)
+        Assertions.assertTrue(nextScheduleTime > currentTimeSeconds);
+        Assertions.assertTrue(nextScheduleTime <= currentTimeSeconds + 60);
+    }
+
+    @Test
+    public void testRegisterSchedulerExecuteTaskExceptionHandling() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_exception");
+        task.setSource(Constants.TaskSource.MV);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        long startTime = now - 3600000; // 1 hour ago
+        long lastScheduleTime = now - 180000; // 3 minutes ago
+        
+        schedule.setStartTime(startTime);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(lastScheduleTime);
+        task.setId(9L);
+        
+        // Mock executeTask to throw exception
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public void executeTask(String taskName) throws DdlException {
+                throw new DdlException("Test exception");
+            }
+        };
+        
+        spyTaskManager.replayCreateTask(task);
+        
+        // Should not throw exception, should handle it gracefully
+        Assertions.assertDoesNotThrow(() -> spyTaskManager.registerScheduler(task));
+        
+        // Should still register the scheduler despite the exception
+        Assertions.assertNotNull(spyTaskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerMultipleTasks() {
+        TaskManager taskManager = new TaskManager();
+        
+        // Register multiple tasks
+        for (int i = 0; i < 5; i++) {
+            Task task = new Task("test_task_" + i);
+            TaskSchedule schedule = new TaskSchedule();
+            
+            long now = System.currentTimeMillis();
+            schedule.setStartTime(now);
+            schedule.setPeriod(60 + i * 10); // Different periods
+            schedule.setTimeUnit(TimeUnit.SECONDS);
+            task.setSchedule(schedule);
+            task.setType(Constants.TaskType.PERIODICAL);
+            task.setState(Constants.TaskState.ACTIVE);
+            task.setLastScheduleTime(-1);
+            task.setId(10L + i);
+            
+            taskManager.registerScheduler(task);
+        }
+        
+        // All tasks should be registered
+        assertEquals(5, taskManager.getPeriodFutureMap().size());
+        
+        // Verify each task has a future
+        for (int i = 0; i < 5; i++) {
+            Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(10L + i));
+        }
+    }
+
+    @Test
+    public void testRegisterSchedulerWithPipeSource() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_pipe");
+        task.setSource(Constants.TaskSource.PIPE);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        long startTime = now - 3600000;
+        long lastScheduleTime = now - 180000;
+        
+        schedule.setStartTime(startTime);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(lastScheduleTime);
+        task.setId(15L);
+        
+        final boolean[] executeTaskCalled = {false};
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public void executeTask(String taskName) throws DdlException {
+                executeTaskCalled[0] = true;
+            }
+        };
+        
+        spyTaskManager.replayCreateTask(task);
+        spyTaskManager.registerScheduler(task);
+        
+        // PIPE source should not trigger immediately (only MV does)
+        Assertions.assertFalse(executeTaskCalled[0]);
+        Assertions.assertNotNull(spyTaskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerWithInsertSource() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_insert");
+        task.setSource(Constants.TaskSource.INSERT);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(120);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(16L);
+        
+        taskManager.registerScheduler(task);
+        
+        Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(task.getId()));
+        Assertions.assertTrue(task.getNextScheduleTime() > 0);
+    }
+
+    @Test
+    public void testRegisterSchedulerWithDatacacheSelectSource() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_datacache");
+        task.setSource(Constants.TaskSource.DATACACHE_SELECT);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(300);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(17L);
+        
+        taskManager.registerScheduler(task);
+        
+        Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(task.getId()));
+        Assertions.assertTrue(task.getNextScheduleTime() > 0);
+    }
+
+    @Test
+    public void testRegisterSchedulerMVTaskImmediateTriggerBoundaryExactly() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_mv_boundary");
+        task.setSource(Constants.TaskSource.MV);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        long periodMs = 60000; // 1 minute in milliseconds
+        long startTime = now - 3600000; // 1 hour ago
+        long lastScheduleTime = now - periodMs - 1000; // exactly period + 1 second ago
+        
+        schedule.setStartTime(startTime);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(lastScheduleTime);
+        task.setId(18L);
+        
+        final boolean[] executeTaskCalled = {false};
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public void executeTask(String taskName) throws DdlException {
+                executeTaskCalled[0] = true;
+            }
+        };
+        
+        spyTaskManager.replayCreateTask(task);
+        spyTaskManager.registerScheduler(task);
+        
+        // Should trigger immediately
+        Assertions.assertTrue(executeTaskCalled[0], "Task should be executed immediately at boundary");
+    }
+
+    @Test
+    public void testRegisterSchedulerMVTaskImmediateTriggerNotAtBoundary() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_mv_not_boundary");
+        task.setSource(Constants.TaskSource.MV);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        long periodMs = 60000; // 1 minute in milliseconds
+        long startTime = now - 3600000; // 1 hour ago
+        long lastScheduleTime = now - periodMs + 1000; // period - 1 second ago (not yet expired)
+        
+        schedule.setStartTime(startTime);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(lastScheduleTime);
+        task.setId(19L);
+        
+        final boolean[] executeTaskCalled = {false};
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public void executeTask(String taskName) throws DdlException {
+                executeTaskCalled[0] = true;
+            }
+        };
+        
+        spyTaskManager.replayCreateTask(task);
+        spyTaskManager.registerScheduler(task);
+        
+        // Should NOT trigger immediately
+        Assertions.assertFalse(executeTaskCalled[0], "Task should not be executed before period expires");
+    }
+
+    @Test
+    public void testRegisterSchedulerWithVeryShortPeriod() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_short_period");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(1); // 1 second
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(20L);
+        
+        taskManager.registerScheduler(task);
+        
+        long nextScheduleTime = task.getNextScheduleTime();
+        Assertions.assertTrue(nextScheduleTime > 0);
+        Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerWithVeryLongPeriod() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_long_period");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(7); // 7 days
+        schedule.setTimeUnit(TimeUnit.DAYS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(21L);
+        
+        taskManager.registerScheduler(task);
+        
+        long nextScheduleTime = task.getNextScheduleTime();
+        Assertions.assertTrue(nextScheduleTime > 0);
+        Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerWithTaskProperties() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_with_properties");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key1", "value1");
+        properties.put("key2", "value2");
+        task.setProperties(properties);
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(22L);
+        
+        taskManager.registerScheduler(task);
+        
+        Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(task.getId()));
+        Assertions.assertEquals(properties, task.getProperties());
+    }
+
+    @Test
+    public void testRegisterSchedulerWithNullProperties() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_null_properties");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        task.setProperties(null);
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(23L);
+        
+        // Should not throw exception
+        Assertions.assertDoesNotThrow(() -> taskManager.registerScheduler(task));
+        Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerReRegistrationSameTask() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_reregister");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(24L);
+        
+        // First registration
+        taskManager.registerScheduler(task);
+        ScheduledFuture<?> firstFuture = taskManager.getPeriodFutureMap().get(task.getId());
+        Assertions.assertNotNull(firstFuture);
+        
+        // Second registration (should replace the first one)
+        taskManager.registerScheduler(task);
+        ScheduledFuture<?> secondFuture = taskManager.getPeriodFutureMap().get(task.getId());
+        Assertions.assertNotNull(secondFuture);
+        
+        // Should have a future in the map
+        assertEquals(1, taskManager.getPeriodFutureMap().size());
+    }
+
+    @Test
+    public void testRegisterSchedulerMVTaskWithLastScheduleTimeEqualToStart() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_mv_equal_start");
+        task.setSource(Constants.TaskSource.MV);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        long startTime = now - 3600000; // 1 hour ago
+        long lastScheduleTime = startTime; // exactly at start time
+        
+        schedule.setStartTime(startTime);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(lastScheduleTime);
+        task.setId(25L);
+        
+        final boolean[] executeTaskCalled = {false};
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public void executeTask(String taskName) throws DdlException {
+                executeTaskCalled[0] = true;
+            }
+        };
+        
+        spyTaskManager.replayCreateTask(task);
+        spyTaskManager.registerScheduler(task);
+        
+        // lastScheduleTime is not after taskStartTime, so should not trigger
+        Assertions.assertFalse(executeTaskCalled[0]);
+    }
+
+    @Test
+    public void testRegisterSchedulerMVTaskWithLastScheduleTimeJustAfterStart() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_mv_just_after_start");
+        task.setSource(Constants.TaskSource.MV);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        long startTime = now - 3600000; // 1 hour ago
+        long lastScheduleTime = startTime + 1000; // 1 second after start time
+        
+        schedule.setStartTime(startTime);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(lastScheduleTime);
+        task.setId(26L);
+        
+        final boolean[] executeTaskCalled = {false};
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public void executeTask(String taskName) throws DdlException {
+                executeTaskCalled[0] = true;
+            }
+        };
+        
+        spyTaskManager.replayCreateTask(task);
+        spyTaskManager.registerScheduler(task);
+        
+        // lastScheduleTime is after taskStartTime and expired, should trigger
+        Assertions.assertTrue(executeTaskCalled[0]);
+    }
+
+    @Test
+    public void testRegisterSchedulerWithStartTimeInFuture() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_future_start");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        long futureStartTime = now + 3600000; // 1 hour in future
+        
+        schedule.setStartTime(futureStartTime);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(27L);
+        
+        taskManager.registerScheduler(task);
+        
+        long nextScheduleTime = task.getNextScheduleTime();
+        long currentTimeSeconds = System.currentTimeMillis() / 1000;
+        
+        // nextScheduleTime should be in the future
+        Assertions.assertTrue(nextScheduleTime > currentTimeSeconds);
+        Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerLastScheduleTimeUpdatedOnImmediateTrigger() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_last_schedule_update");
+        task.setSource(Constants.TaskSource.MV);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        long startTime = now - 3600000; // 1 hour ago
+        long lastScheduleTime = now - 180000; // 3 minutes ago
+        long originalLastScheduleTime = lastScheduleTime;
+        
+        schedule.setStartTime(startTime);
+        schedule.setPeriod(60); // 1 minute period
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(lastScheduleTime);
+        task.setId(28L);
+        
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public void executeTask(String taskName) throws DdlException {
+                // Do nothing
+            }
+        };
+        
+        spyTaskManager.replayCreateTask(task);
+        spyTaskManager.registerScheduler(task);
+        
+        // lastScheduleTime should be updated to current time
+        Assertions.assertTrue(task.getLastScheduleTime() > originalLastScheduleTime);
+        Assertions.assertTrue(task.getLastScheduleTime() >= now);
+    }
+
+    @Test
+    public void testRegisterSchedulerWithMillisecondsTimeUnit() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_milliseconds");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(5000); // 5000 milliseconds = 5 seconds
+        schedule.setTimeUnit(TimeUnit.MILLISECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(29L);
+        
+        taskManager.registerScheduler(task);
+        
+        long nextScheduleTime = task.getNextScheduleTime();
+        Assertions.assertTrue(nextScheduleTime > 0);
+        Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerWithPausedTaskState() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_paused");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.PAUSE); // Paused state
+        task.setLastScheduleTime(-1);
+        task.setId(30L);
+        
+        // Should still register even if paused
+        taskManager.registerScheduler(task);
+        
+        Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerNextScheduleTimeInSeconds() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_next_schedule_seconds");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long nowMs = System.currentTimeMillis();
+        long nowSeconds = nowMs / 1000;
+        
+        schedule.setStartTime(nowMs);
+        schedule.setPeriod(120);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(31L);
+        
+        taskManager.registerScheduler(task);
+        
+        long nextScheduleTime = task.getNextScheduleTime();
+        
+        // nextScheduleTime should be in seconds, not milliseconds
+        Assertions.assertTrue(nextScheduleTime < nowMs); // Should be smaller than milliseconds
+        Assertions.assertTrue(nextScheduleTime > nowSeconds - 1); // Should be close to current time in seconds
+        Assertions.assertTrue(nextScheduleTime <= nowSeconds + 120); // Within the period
+    }
+
+    @Test
+    public void testRegisterSchedulerMVTaskMultipleConditionsForNoTrigger() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_mv_no_trigger_multi");
+        task.setSource(Constants.TaskSource.MV);
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        long startTime = now - 3600000; // 1 hour ago
+        long lastScheduleTime = now - 90000; // 1.5 minutes ago
+        
+        schedule.setStartTime(startTime);
+        schedule.setPeriod(120); // 2 minute period (not expired yet)
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(lastScheduleTime);
+        task.setId(32L);
+        
+        final int[] executeTaskCallCount = {0};
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public void executeTask(String taskName) throws DdlException {
+                executeTaskCallCount[0]++;
+            }
+        };
+        
+        spyTaskManager.replayCreateTask(task);
+        spyTaskManager.registerScheduler(task);
+        
+        // Should not trigger because period hasn't expired
+        assertEquals(0, executeTaskCallCount[0], "Task should not be executed");
+        Assertions.assertNotNull(spyTaskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testRegisterSchedulerVerifySchedulerIsActive() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test_scheduler_active");
+        TaskSchedule schedule = new TaskSchedule();
+        
+        long now = System.currentTimeMillis();
+        schedule.setStartTime(now);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        task.setId(33L);
+        
+        taskManager.registerScheduler(task);
+        
+        ScheduledFuture<?> future = taskManager.getPeriodFutureMap().get(task.getId());
+        Assertions.assertNotNull(future);
+        
+        // Verify the future is not cancelled or done
+        Assertions.assertFalse(future.isCancelled(), "Scheduled future should not be cancelled");
+        Assertions.assertFalse(future.isDone(), "Scheduled future should not be done immediately");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -33,6 +33,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.history.TaskRunHistory;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
+import com.starrocks.scheduler.persist.TaskSchedule;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.SubmitTaskStmt;
 import com.starrocks.thrift.TGetTasksParams;
@@ -59,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -518,21 +520,21 @@ public class TaskManagerTest {
     @Test
     public void testGetInitialDelayTime1() throws Exception {
         assertEquals(50, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:50"),
-                parseLocalDateTime("2023-04-18 20:00:00")));
+                parseLocalDateTime("2023-04-18 20:00:00"), null));
         assertEquals(30, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:30"),
-                parseLocalDateTime("2023-04-18 20:00:00")));
+                parseLocalDateTime("2023-04-18 20:00:00"), null));
         assertEquals(20, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:30"),
-                parseLocalDateTime("2023-04-18 20:00:10")));
+                parseLocalDateTime("2023-04-18 20:00:10"), null));
         assertEquals(0, TaskManager.getInitialDelayTime(20, parseLocalDateTime("2023-04-18 19:08:30"),
-                parseLocalDateTime("2023-04-18 21:00:10")));
+                parseLocalDateTime("2023-04-18 21:00:10"), null));
     }
 
     @Test
     public void testGetInitialDelayTime2() throws Exception {
         assertEquals(23, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-12-29 19:50:00"),
-                LocalDateTime.parse("2024-01-30T15:27:37.342356010")));
+                LocalDateTime.parse("2024-01-30T15:27:37.342356010"), null));
         assertEquals(50, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-12-29 19:50:00"),
-                LocalDateTime.parse("2024-01-30T15:27:10.342356010")));
+                LocalDateTime.parse("2024-01-30T15:27:10.342356010"), null));
     }
 
     private static ExecuteOption makeExecuteOption(boolean isMergeRedundant, boolean isSync) {
@@ -1063,5 +1065,97 @@ public class TaskManagerTest {
 
         TaskManager taskManager = new TaskManager();
         taskManager.removeExpiredTaskRuns(false);
+    }
+
+
+    @Test
+    void testTriggerImmediatelyWhenLastScheduleExpired() {
+        long periodSeconds = 60;
+        LocalDateTime taskStartTime = LocalDateTime.of(2023, 4, 18, 19, 0, 0);
+        LocalDateTime currentDateTime = LocalDateTime.of(2023, 4, 18, 20, 0, 0);
+        LocalDateTime lastScheduleTime = LocalDateTime.of(2023, 4, 18, 19, 8, 30);
+        // lastScheduleTime + period < currentDateTime 且 lastScheduleTime > taskStartTime
+        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime, lastScheduleTime);
+        assertEquals(0, delay);
+    }
+
+    @Test
+    void testInitialDelayPositive() {
+        long periodSeconds = 60;
+        LocalDateTime taskStartTime = LocalDateTime.of(2023, 4, 18, 20, 0, 0);
+        LocalDateTime currentDateTime = LocalDateTime.of(2023, 4, 18, 19, 8, 50);
+        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime, null);
+        assertEquals(3070, delay);
+    }
+
+    @Test
+    void testInitialDelayNegativeWithNano() {
+        long periodSeconds = 60;
+        LocalDateTime taskStartTime = LocalDateTime.of(2023, 4, 18, 19, 0, 0);
+        LocalDateTime currentDateTime = LocalDateTime.of(2023, 4, 18, 20, 0, 1, 1); // 有nano
+        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime, null);
+        assertEquals(2, delay);
+    }
+
+    @Test
+    void testInitialDelayNegativeWithoutNano() {
+        long periodSeconds = 60;
+        LocalDateTime taskStartTime = LocalDateTime.of(2023, 4, 18, 19, 0, 0);
+        LocalDateTime currentDateTime = LocalDateTime.of(2023, 4, 18, 20, 0, 1, 0); // nano = 0
+        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime, null);
+        // initialDelay = -3601, extra = 0
+        // ((-3601 % 60) + 60) % 60 = (-1 + 60) % 60 = 59 % 60 = 59
+        assertEquals(59, delay);
+    }
+
+    @Test
+    void testInitialDelayWithNullLastScheduleTime() {
+        long periodSeconds = 20;
+        LocalDateTime taskStartTime = LocalDateTime.of(2023, 4, 18, 21, 0, 10);
+        LocalDateTime currentDateTime = LocalDateTime.of(2023, 4, 18, 19, 8, 30);
+        long delay = TaskManager.getInitialDelayTime(periodSeconds, taskStartTime, currentDateTime, null);
+        assertEquals(1 * 3600 + 51 * 60 + 40, delay); // 1小时51分40秒
+    }
+
+    // Java
+    @Test
+    public void testRegisterSchedulerSetsNextScheduleTimeAndSchedulesTask() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        TaskSchedule schedule = new TaskSchedule();
+        long now = System.currentTimeMillis() / 1000 * 1000;
+        schedule.setStartTime(now);
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(-1);
+        taskManager.registerScheduler(task);
+        long nextScheduleTime = task.getNextScheduleTime();
+        Assertions.assertTrue(nextScheduleTime > 0);
+        Assertions.assertNotNull(taskManager.getPeriodFutureMap().get(task.getId())
+        );
+    }
+
+    @Test
+    public void testRegisterSchedulerWithLastScheduleTime() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        TaskSchedule schedule = new TaskSchedule();
+        long now = System.currentTimeMillis() / 1000 * 1000;
+        schedule.setStartTime(now - 3600); // 1小时前
+        schedule.setPeriod(60);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setLastScheduleTime(now - 60);
+        taskManager.registerScheduler(task);
+        long nextScheduleTime = task.getNextScheduleTime();
+        Assertions.assertTrue(nextScheduleTime > 0);
+        Assertions.assertNotNull(
+                taskManager.getPeriodFutureMap().get(task.getId())
+        );
     }
 }


### PR DESCRIPTION
## Why I'm doing:


if fe restarts frequently, use currentDateTime and taskStartTime can always generate a time of the future
which can cause the task never to be scheduled.
so use lastScheduleTime to check if the last schedule + period is before current time to avoid this.

## What I'm doing:

This pull request introduces several improvements to the task scheduling system, focusing on more robust tracking and management of task scheduling times, better handling of long-running tasks, and enhanced thread safety. The changes also include improvements to the calculation of initial delay times for periodic tasks and add defensive coding to avoid null pointer issues.

**Task scheduling and time tracking:**

* Added new fields `lastScheduleTime` and `nextScheduleTime` to the `Task` class, along with their getters, setters, and updates to the `toString()` method for better visibility and tracking of when tasks are scheduled and when they will run next. (`Task.java`) [[1]](diffhunk://#diff-32bc53e46495c2019614db3089c92989235da203897e342018f2034d077201bfR78-R85) [[2]](diffhunk://#diff-32bc53e46495c2019614db3089c92989235da203897e342018f2034d077201bfR222-R237) [[3]](diffhunk://#diff-32bc53e46495c2019614db3089c92989235da203897e342018f2034d077201bfR254-R255)
* Updated the scheduling logic in `TaskManager` to set and update these time fields whenever a periodic task is scheduled or executed, ensuring accurate tracking across system restarts and executions. (`TaskManager.java`) [[1]](diffhunk://#diff-ed40d0f2bad300ed05a6b9e6fa7f6e8b982d908570d54cb91ff41a98822593feR294-R295) [[2]](diffhunk://#diff-ed40d0f2bad300ed05a6b9e6fa7f6e8b982d908570d54cb91ff41a98822593feL543-R601)

**Periodic task scheduling logic:**

* Refactored the calculation of initial delay for periodic tasks to consider the last schedule time, improving reliability especially after frequent system restarts. The test cases were updated to reflect the new method signature. (`TaskManager.java`, `TaskManagerTest.java`) [[1]](diffhunk://#diff-ed40d0f2bad300ed05a6b9e6fa7f6e8b982d908570d54cb91ff41a98822593feL158-L176) [[2]](diffhunk://#diff-ed40d0f2bad300ed05a6b9e6fa7f6e8b982d908570d54cb91ff41a98822593feL543-R601) [[3]](diffhunk://#diff-47e2766af08dfc4f88709fff1099c26a863e1e3a510153704cc0d542f5282690L521-R537)

**Long-running task handling and thread safety:**

* Improved management of long-running tasks by adding a mechanism to remove timeout task runs and making sure task cancellation methods are clearly marked as not thread-safe, with explicit locking and error handling to prevent resource waste. (`TaskManager.java`, `TaskRunManager.java`) [[1]](diffhunk://#diff-ed40d0f2bad300ed05a6b9e6fa7f6e8b982d908570d54cb91ff41a98822593feR1019-R1023) [[2]](diffhunk://#diff-ed40d0f2bad300ed05a6b9e6fa7f6e8b982d908570d54cb91ff41a98822593feR1043-R1053) [[3]](diffhunk://#diff-298cb78798d6afda80429cb950a0b1644122d66663ded71c704f81098656896aR99) [[4]](diffhunk://#diff-298cb78798d6afda80429cb950a0b1644122d66663ded71c704f81098656896aR132)

**Defensive coding and null checks:**

* Added null checks and defensive coding in `TaskRunFIFOQueue` and `TaskRunScheduler` to avoid null pointer exceptions when counting tasks or iterating over collections. (`TaskRunFIFOQueue.java`, `TaskRunScheduler.java`) [[1]](diffhunk://#diff-2f26a34b3dbc71792abd60d591573cce10e79beb7f747ec563376a80075678eaR255-R261) [[2]](diffhunk://#diff-be8f269ee2723b4bc40597cfb5ae2d78dfaf5a2cd33e1840a7cf4c8dd3135509R225-R252)



Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
