### PR TITLE
[Enhancement] Optimize VARCHAR join key when length <= 16

### DIFF
--- a/be/src/column/adaptive_nullable_column.cpp
+++ b/be/src/column/adaptive_nullable_column.cpp
@@ -262,9 +262,9 @@ uint32_t AdaptiveNullableColumn::serialize_default(uint8_t* pos) const {
 }
 
 size_t AdaptiveNullableColumn::serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval,
-                                                           size_t start, size_t count) const {
+                                                           uint32_t max_row_size, size_t start, size_t count) const {
     materialized_nullable();
-    return NullableColumn::serialize_batch_at_interval(dst, byte_offset, byte_interval, start, count);
+    return NullableColumn::serialize_batch_at_interval(dst, byte_offset, byte_interval, max_row_size, start, count);
 }
 
 void AdaptiveNullableColumn::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,

--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -356,8 +356,8 @@ public:
         return NullableColumn::create(_data_column->clone_empty(), _null_column->clone_empty());
     }
 
-    size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, size_t start,
-                                       size_t count) const override;
+    size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, uint32_t max_row_size,
+                                       size_t start, size_t count) const override;
 
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
 

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -242,6 +242,12 @@ public:
         return sizeof(uint32_t) + binary_size;
     }
 
+    size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, uint32_t max_row_size,
+                                       size_t start, size_t count) const override;
+    size_t serialize_batch_at_interval_with_null_masks(uint8_t* dst, size_t byte_offset, size_t byte_interval,
+                                                       uint32_t max_row_size, size_t start, size_t count,
+                                                       const uint8_t* null_masks) const override;
+
     uint32_t serialize_default(uint8_t* pos) const override;
 
     void serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,

--- a/be/src/column/column.cpp
+++ b/be/src/column/column.cpp
@@ -20,6 +20,19 @@
 
 namespace starrocks {
 
+size_t Column::serialize_batch_at_interval_with_null_masks(uint8_t* dst, size_t byte_offset, size_t byte_interval,
+                                                           uint32_t max_row_size, size_t start, size_t count,
+                                                           const uint8_t* null_masks) const {
+    for (size_t i = start; i < start + count; i++) {
+        if (null_masks[i] == 0) {
+            serialize(i, dst + (i - start) * byte_interval + byte_offset + 1);
+        } else {
+            serialize_default(dst + (i - start) * byte_interval + byte_offset + 1);
+        }
+    }
+    return type_size();
+}
+
 void Column::serialize_batch_with_null_masks(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
                                              uint32_t max_one_row_size, const uint8_t* null_masks,
                                              bool has_null) const {

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -314,10 +314,14 @@ public:
     // (dst + byte_offset) with an interval between each element. It returns size of the data type
     // (which should be fixed size) of this column if this column supports this method, otherwise
     // it returns 0.
-    virtual size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, size_t start,
-                                               size_t count) const {
+    virtual size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval,
+                                               uint32_t max_row_size, size_t start, size_t count) const {
         return 0;
-    };
+    }
+
+    virtual size_t serialize_batch_at_interval_with_null_masks(uint8_t* dst, size_t byte_offset, size_t byte_interval,
+                                                               uint32_t max_row_size, size_t start, size_t count,
+                                                               const uint8_t* null_masks) const;
 
     // A dedicated serialization method used by NullableColumn to serialize data columns with null_masks.
     virtual void serialize_batch_with_null_masks(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -253,8 +253,9 @@ void FixedLengthColumnBase<T>::serialize_batch_with_null_masks(uint8_t* __restri
 
 template <typename T>
 size_t FixedLengthColumnBase<T>::serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval,
-                                                             size_t start, size_t count) const {
+                                                             uint32_t max_row_size, size_t start, size_t count) const {
     const size_t value_size = sizeof(T);
+    DCHECK_EQ(max_row_size, value_size);
     const auto key_data = this->immutable_data();
     uint8_t* buf = dst + byte_offset;
     for (size_t i = start; i < start + count; ++i) {

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -208,8 +208,8 @@ public:
                                          uint32_t max_one_row_size, const uint8_t* null_masks,
                                          bool has_null) const override;
 
-    size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, size_t start,
-                                       size_t count) const override;
+    size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, uint32_t max_row_size,
+                                       size_t start, size_t count) const override;
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -307,18 +307,14 @@ uint32_t NullableColumn::serialize_default(uint8_t* pos) const {
     return sizeof(bool);
 }
 
-size_t NullableColumn::serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, size_t start,
-                                                   size_t count) const {
+size_t NullableColumn::serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval,
+                                                   uint32_t max_row_size, size_t start, size_t count) const {
     const auto null_data = _null_column->immutable_data();
-    _null_column->serialize_batch_at_interval(dst, byte_offset, byte_interval, start, count);
-    for (size_t i = start; i < start + count; i++) {
-        if (null_data[i] == 0) {
-            _data_column->serialize(i, dst + (i - start) * byte_interval + byte_offset + 1);
-        } else {
-            _data_column->serialize_default(dst + (i - start) * byte_interval + byte_offset + 1);
-        }
-    }
-    return _null_column->type_size() + _data_column->type_size();
+    const size_t null_size = _null_column->type_size();
+    _null_column->serialize_batch_at_interval(dst, byte_offset, byte_interval, null_size, start, count);
+    const size_t data_size = _data_column->serialize_batch_at_interval_with_null_masks(
+            dst, byte_offset, byte_interval, max_row_size - null_size, start, count, null_data.data());
+    return null_size + data_size;
 }
 
 void NullableColumn::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -211,8 +211,8 @@ public:
         return create(_data_column->clone_empty(), _null_column->clone_empty());
     }
 
-    size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, size_t start,
-                                       size_t count) const override;
+    size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, uint32_t max_row_size,
+                                       size_t start, size_t count) const override;
 
     size_t filter_range(const Filter& filter, size_t from, size_t to) override;
 

--- a/be/src/exec/join/join_hash_map_helper.h
+++ b/be/src/exec/join/join_hash_map_helper.h
@@ -113,6 +113,8 @@ public:
     static void serialize_fixed_size_key_column(const Columns& key_columns, Column* fixed_size_key_column,
                                                 const std::vector<uint32_t>& serialized_fixed_size_key_bytes,
                                                 uint32_t start, uint32_t count) {
+        DCHECK_EQ(serialized_fixed_size_key_bytes.size(), key_columns.size());
+
         using CppType = typename RunTimeTypeTraits<LT>::CppType;
         using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
 

--- a/be/src/exec/join/join_hash_table_descriptor.h
+++ b/be/src/exec/join/join_hash_table_descriptor.h
@@ -203,6 +203,8 @@ struct JoinHashTableItems {
 
     std::unique_ptr<MemPool> build_pool = nullptr;
     std::vector<JoinKeyDesc> join_keys;
+
+    std::vector<uint32_t> serialized_fixed_size_key_bytes;
 };
 
 struct HashTableProbeState {

--- a/be/src/exec/join/join_key_constructor.hpp
+++ b/be/src/exec/join/join_key_constructor.hpp
@@ -110,8 +110,8 @@ void BuildKeyConstructorForSerializedFixedSize<LT>::build_key(RuntimeState* stat
         }
     }
     // Serialize to key columns.
-    JoinHashMapHelper::serialize_fixed_size_key_column<LT>(data_columns, table_items->build_key_column.get(), 1,
-                                                           row_count);
+    JoinHashMapHelper::serialize_fixed_size_key_column<LT>(data_columns, table_items->build_key_column.get(),
+                                                           table_items->serialized_fixed_size_key_bytes, 1, row_count);
     // Build key is_nulls.
     if (!null_columns.empty()) {
         table_items->build_key_nulls.resize(row_count + 1);
@@ -154,8 +154,8 @@ void ProbeKeyConstructorForSerializedFixedSize<LT>::build_key(const JoinHashTabl
 
     // Build key and is_nulls.
     const uint32_t row_count = probe_state->probe_row_count;
-    JoinHashMapHelper::serialize_fixed_size_key_column<LT>(data_columns, probe_state->probe_key_column.get(), 0,
-                                                           row_count);
+    JoinHashMapHelper::serialize_fixed_size_key_column<LT>(data_columns, probe_state->probe_key_column.get(),
+                                                           table_items.serialized_fixed_size_key_bytes, 0, row_count);
 
     if (null_columns.empty()) {
         probe_state->null_array = std::nullopt;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -447,6 +447,11 @@ public:
                _query_options.enable_hash_join_linear_chained_opt;
     }
 
+    bool enable_hash_join_serialize_fixed_size_string() const {
+        return _query_options.__isset.enable_hash_join_serialize_fixed_size_string &&
+               _query_options.enable_hash_join_serialize_fixed_size_string;
+    }
+
     const std::vector<TTabletCommitInfo>& tablet_commit_infos() const { return _tablet_commit_infos; }
 
     std::vector<TTabletCommitInfo>& tablet_commit_infos() { return _tablet_commit_infos; }

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -1050,7 +1050,9 @@ TEST_F(JoinHashMapTest, CompileFixedSizeKeyColumn) {
     auto c2 = JoinHashMapTest::create_int32_column(2, 2);
     Columns columns{c1, c2};
 
-    JoinHashMapHelper::serialize_fixed_size_key_column<LogicalType::TYPE_BIGINT>(columns, data_column.get(), 0, 2);
+    std::vector<uint32_t> serialized_fixed_size_key_bytes{4, 4};
+    JoinHashMapHelper::serialize_fixed_size_key_column<LogicalType::TYPE_BIGINT>(columns, data_column.get(),
+                                                                                 serialized_fixed_size_key_bytes, 0, 2);
 
     auto* c3 = ColumnHelper::as_raw_column<Int64Column>(data_column);
     ASSERT_EQ(c3->get_data()[0], 8589934592l);

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -1370,6 +1370,8 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildProbeFunc) {
     probe_state.next.resize(config::vector_chunk_size, 0);
     Columns probe_columns{probe_column1, probe_column2};
     probe_state.key_columns = &probe_columns;
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
 
     using BuildKeyConstructor = BuildKeyConstructorForSerializedFixedSize<LogicalType::TYPE_BIGINT>;
     using ProbeKeyConstructor = ProbeKeyConstructorForSerializedFixedSize<LogicalType::TYPE_BIGINT>;
@@ -1430,6 +1432,8 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildProbeFuncNullable) {
     probe_state.next.resize(config::vector_chunk_size, 0);
     Columns probe_columns{probe_column1, probe_column2};
     probe_state.key_columns = &probe_columns;
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
 
     using BuildKeyConstructor = BuildKeyConstructorForSerializedFixedSize<LogicalType::TYPE_BIGINT>;
     using ProbeKeyConstructor = ProbeKeyConstructorForSerializedFixedSize<LogicalType::TYPE_BIGINT>;
@@ -2246,6 +2250,8 @@ TEST_F(JoinHashMapTest, BuildKeyConstructorForSerializedFixedSizeForNotNullableC
     column_1->append(*create_column(TYPE_INT, 0, build_row_count));
     table_items.key_columns.emplace_back(std::move(column_1));
     table_items.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
 
     // Add int column
     auto column_2 = create_column(TYPE_INT);
@@ -2286,6 +2292,8 @@ TEST_F(JoinHashMapTest, BuildKeyConstructorForSerializedFixedSizeForNullableColu
     column_1->append(*create_nullable_column(TYPE_INT, nulls_1, 0, build_row_count));
     table_items.key_columns.emplace_back(std::move(column_1));
     table_items.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
 
     // Add int column
     auto nulls_2 = create_bools(build_row_count, 0);
@@ -2327,6 +2335,8 @@ TEST_F(JoinHashMapTest, BuildKeyConstructorForSerializedFixedSizeForPartialNulla
     column_1->append(*create_nullable_column(TYPE_INT, nulls_1, 0, build_row_count));
     table_items.key_columns.emplace_back(std::move(column_1));
     table_items.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
 
     // Add int column
     auto nulls_2 = create_bools(build_row_count, 2);
@@ -3121,6 +3131,8 @@ TEST_F(JoinHashMapTest, TestBuildKeyConstructorForSerializedFixedSizeNonNullable
     build_column2->append_datum(Datum(0));
     build_column2->append(*JoinHashMapTest::create_int32_column(10, 100), 0, 10);
     table_items.key_columns.emplace_back(build_column2);
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
 
     BuildKeyBuilder::prepare(nullptr, &table_items);
     BuildKeyBuilder::build_key(nullptr, &table_items);
@@ -3152,6 +3164,8 @@ TEST_F(JoinHashMapTest, TestBuildKeyConstructorForSerializedFixedSizeNullable) {
     build_column2->append_datum(Datum(0));
     build_column2->append(*JoinHashMapTest::create_int32_column(10, 100), 0, 10);
     table_items.key_columns.emplace_back(build_column2);
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
 
     {
         table_items.row_count = 10;
@@ -3197,6 +3211,8 @@ TEST_F(JoinHashMapTest, TestProbeKeyConstructorForSerializedFixedSizeNullable) {
     JoinHashTableItems table_items;
     table_items.join_keys.emplace_back(JoinKeyDesc{&int_type, false, nullptr});
     table_items.join_keys.emplace_back(JoinKeyDesc{&int_type, false, nullptr});
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
+    table_items.serialized_fixed_size_key_bytes.emplace_back(4);
 
     HashTableProbeState probe_state;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -454,6 +454,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_HASH_JOIN_RANGE_DIRECT_MAPPING_OPT = "enable_hash_join_range_direct_mapping_opt";
     public static final String ENABLE_HASH_JOIN_LINEAR_CHAINED_OPT = "enable_hash_join_linear_chained_opt";
+    public static final String ENABLE_HASH_JOIN_SERIALIZE_FIXED_SIZE_STRING = "enable_hash_join_serialize_fixed_size_string";
 
     public static final String ENABLE_PIPELINE_LEVEL_MULTI_PARTITIONED_RF =
             "enable_pipeline_level_multi_partitioned_rf";
@@ -1645,6 +1646,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_HASH_JOIN_LINEAR_CHAINED_OPT)
     private boolean enableHashJoinLinearChainedOpt = true;
+
+    @VarAttr(name = ENABLE_HASH_JOIN_SERIALIZE_FIXED_SIZE_STRING)
+    private boolean enableHashJoinSerializeFixedSizeString = true;
 
     @VarAttr(name = ENABLE_PIPELINE_LEVEL_MULTI_PARTITIONED_RF)
     private boolean enablePipelineLevelMultiPartitionedRf = false;
@@ -5496,6 +5500,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setColumn_view_concat_bytes_limit(columnViewConcatRowsLimit);
         tResult.setEnable_hash_join_range_direct_mapping_opt(enableHashJoinRangeDirectMappingOpt);
         tResult.setEnable_hash_join_linear_chained_opt(enableHashJoinLinearChainedOpt);
+        tResult.setEnable_hash_join_serialize_fixed_size_string(enableHashJoinSerializeFixedSizeString);
 
         return tResult;
     }

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -339,6 +339,7 @@ struct TQueryOptions {
   161: optional bool enable_join_runtime_bitset_filter;
   162: optional bool enable_hash_join_range_direct_mapping_opt;
   163: optional bool enable_hash_join_linear_chained_opt;
+  164: optional bool enable_hash_join_serialize_fixed_size_string;
 
   170: optional bool enable_parquet_reader_bloom_filter;
   171: optional bool enable_parquet_reader_page_index;

--- a/test/sql/test_join/R/test_join_fixed_size_string
+++ b/test/sql/test_join/R/test_join_fixed_size_string
@@ -1,0 +1,178 @@
+-- name: test_join_fixed_size_string
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_int int NULL,
+    c_bigint bigint NULL,
+
+    c_str4 STRING NULL,
+    c_str8 STRING NULL,
+    c_str16 STRING NULL,
+    c_str32 STRING NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 
+select
+    idx,
+    
+    idx,
+    idx,
+    substr(lpad(idx, 4, '-'), 1, 4),
+    substr(lpad(idx, 8, '-'), 1, 8),
+    substr(lpad(idx, 16, '-'), 1, 16),
+    substr(lpad(idx, 32, '-'), 1, 32)
+from __row_util where idx <= 10000;
+-- result:
+-- !result
+insert into t1 (k1) select 1001;
+-- result:
+-- !result
+CREATE TABLE t2 (
+    k1 bigint NULL,
+
+    c_int int NULL,
+    c_bigint bigint NULL,
+
+    c_str4 STRING NULL,
+    c_str8 STRING NULL,
+    c_str16 STRING NULL,
+    c_str32 STRING NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t2 select idx, t1.c_int, t1.c_bigint, t1.c_str4, t1.c_str8, t1.c_str16, t1.c_str32 from __row_util join t1 on idx % 1000 = t1.k1;
+-- result:
+-- !result
+insert into t2 (k1) select 320000;
+-- result:
+-- !result
+insert into t2 select idx, idx, idx, uuid(), uuid(), uuid(), uuid() from __row_util where idx <= 10000;
+-- result:
+-- !result
+select count(1), sum(murmur_hash3_32(t1.c_str4)), sum(murmur_hash3_32(t2.c_str4))
+from t1 join t2 on t1.c_str4 = t2.c_str4;
+-- result:
+319680	-3096761756800	-3096761756800
+-- !result
+select count(1), sum(murmur_hash3_32(t1.c_str4)), sum(murmur_hash3_32(t2.c_str4))
+from t1 join t2 on t1.c_str4 <=> t2.c_str4;
+-- result:
+319681	-3096761756800	-3096761756800
+-- !result
+select count(1), sum(murmur_hash3_32(t1.c_str4)), sum(murmur_hash3_32(t2.c_str4))
+from t1 join t2 on t1.c_str4 = t2.c_str4 and t1.c_int = t2.c_int;
+-- result:
+319680	-3096761756800	-3096761756800
+-- !result
+select count(1), sum(murmur_hash3_32(t1.c_str8)), sum(murmur_hash3_32(t2.c_str8))
+from t1 join t2 on t1.c_str8 = t2.c_str8;
+-- result:
+319680	13357060748480	13357060748480
+-- !result
+select count(1), sum(murmur_hash3_32(t1.c_str8)), sum(murmur_hash3_32(t2.c_str8))
+from t1 join t2 on t1.c_str8 <=> t2.c_str8;
+-- result:
+319681	13357060748480	13357060748480
+-- !result
+select count(1), sum(murmur_hash3_32(t1.c_str8)), sum(murmur_hash3_32(t2.c_str8))
+from t1 join t2 on t1.c_str8 = t2.c_str8 and t1.c_int = t2.c_int;
+-- result:
+319680	13357060748480	13357060748480
+-- !result
+select count(1), sum(murmur_hash3_32(t1.c_str16)), sum(murmur_hash3_32(t2.c_str16))
+from t1 join t2 on t1.c_str16 = t2.c_str16;
+-- result:
+319680	-20821759700800	-20821759700800
+-- !result
+select count(1), sum(murmur_hash3_32(t1.c_str16)), sum(murmur_hash3_32(t2.c_str16))
+from t1 join t2 on t1.c_str16 <=> t2.c_str16;
+-- result:
+319681	-20821759700800	-20821759700800
+-- !result
+select count(1), sum(murmur_hash3_32(t1.c_str16)), sum(murmur_hash3_32(t2.c_str16))
+from t1 join t2 on t1.c_str16 = t2.c_str16 and t1.c_int = t2.c_int;
+-- result:
+319680	-20821759700800	-20821759700800
+-- !result
+select count(1), sum(murmur_hash3_32(t1.c_str32)), sum(murmur_hash3_32(t2.c_str32))
+from t1 join t2 on t1.c_str32 = t2.c_str32;
+-- result:
+319680	886564872640	886564872640
+-- !result
+insert into t2
+select
+    320001,
+    
+    320001,
+    320001,
+    '\0\0\0\0',
+    '\0\0\0\0\0\0\0\0',
+    '\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',
+    '\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0';
+-- result:
+-- !result
+select count(1), sum(murmur_hash3_32(t1.c_str8)), sum(murmur_hash3_32(t2.c_str8))
+from t1 join t2 on t1.c_str8 <=> t2.c_str8;
+-- result:
+319681	13357060748480	13357060748480
+-- !result
+insert into t1
+select
+    320001,
+    
+    320001,
+    320001,
+    '\0\0\0\0',
+    '\0\0\0\0\0\0\0\0',
+    '\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',
+    '\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0';
+-- result:
+-- !result
+select count(1), sum(murmur_hash3_32(t1.c_str8)), sum(murmur_hash3_32(t2.c_str8))
+from t1 join t2 on t1.c_str8 <=> t2.c_str8;
+-- result:
+319682	13356360567154	13356360567154
+-- !result

--- a/test/sql/test_join/T/test_join_fixed_size_string
+++ b/test/sql/test_join/T/test_join_fixed_size_string
@@ -1,0 +1,142 @@
+
+-- name: test_join_fixed_size_string
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_int int NULL,
+    c_bigint bigint NULL,
+
+    c_str4 STRING NULL,
+    c_str8 STRING NULL,
+    c_str16 STRING NULL,
+    c_str32 STRING NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t1 
+select
+    idx,
+    
+    idx,
+    idx,
+    substr(lpad(idx, 4, '-'), 1, 4),
+    substr(lpad(idx, 8, '-'), 1, 8),
+    substr(lpad(idx, 16, '-'), 1, 16),
+    substr(lpad(idx, 32, '-'), 1, 32)
+from __row_util where idx <= 10000;
+insert into t1 (k1) select 1001;
+
+CREATE TABLE t2 (
+    k1 bigint NULL,
+
+    c_int int NULL,
+    c_bigint bigint NULL,
+
+    c_str4 STRING NULL,
+    c_str8 STRING NULL,
+    c_str16 STRING NULL,
+    c_str32 STRING NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into t2 select idx, t1.c_int, t1.c_bigint, t1.c_str4, t1.c_str8, t1.c_str16, t1.c_str32 from __row_util join t1 on idx % 1000 = t1.k1;
+insert into t2 (k1) select 320000;
+-- prober contains rows whose string length exceeds fixed size.
+insert into t2 select idx, idx, idx, uuid(), uuid(), uuid(), uuid() from __row_util where idx <= 10000;
+
+
+-- fixed size 4 bytes
+select count(1), sum(murmur_hash3_32(t1.c_str4)), sum(murmur_hash3_32(t2.c_str4))
+from t1 join t2 on t1.c_str4 = t2.c_str4;
+
+-- fixed size 8 bytes
+select count(1), sum(murmur_hash3_32(t1.c_str4)), sum(murmur_hash3_32(t2.c_str4))
+from t1 join t2 on t1.c_str4 <=> t2.c_str4;
+
+select count(1), sum(murmur_hash3_32(t1.c_str4)), sum(murmur_hash3_32(t2.c_str4))
+from t1 join t2 on t1.c_str4 = t2.c_str4 and t1.c_int = t2.c_int;
+
+select count(1), sum(murmur_hash3_32(t1.c_str8)), sum(murmur_hash3_32(t2.c_str8))
+from t1 join t2 on t1.c_str8 = t2.c_str8;
+
+-- fixed size 16 bytes
+select count(1), sum(murmur_hash3_32(t1.c_str8)), sum(murmur_hash3_32(t2.c_str8))
+from t1 join t2 on t1.c_str8 <=> t2.c_str8;
+
+select count(1), sum(murmur_hash3_32(t1.c_str8)), sum(murmur_hash3_32(t2.c_str8))
+from t1 join t2 on t1.c_str8 = t2.c_str8 and t1.c_int = t2.c_int;
+
+select count(1), sum(murmur_hash3_32(t1.c_str16)), sum(murmur_hash3_32(t2.c_str16))
+from t1 join t2 on t1.c_str16 = t2.c_str16;
+
+-- non-fixed size
+select count(1), sum(murmur_hash3_32(t1.c_str16)), sum(murmur_hash3_32(t2.c_str16))
+from t1 join t2 on t1.c_str16 <=> t2.c_str16;
+
+select count(1), sum(murmur_hash3_32(t1.c_str16)), sum(murmur_hash3_32(t2.c_str16))
+from t1 join t2 on t1.c_str16 = t2.c_str16 and t1.c_int = t2.c_int;
+
+select count(1), sum(murmur_hash3_32(t1.c_str32)), sum(murmur_hash3_32(t2.c_str32))
+from t1 join t2 on t1.c_str32 = t2.c_str32;
+
+
+-- prober contains zero-tailing string, which still can use serialized fixed-size optimization.
+insert into t2
+select
+    320001,
+    
+    320001,
+    320001,
+    '\0\0\0\0',
+    '\0\0\0\0\0\0\0\0',
+    '\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',
+    '\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0';
+select count(1), sum(murmur_hash3_32(t1.c_str8)), sum(murmur_hash3_32(t2.c_str8))
+from t1 join t2 on t1.c_str8 <=> t2.c_str8;
+
+-- builder contains zero-tailing string, which cannot use serialized fixed-size optimization.
+insert into t1
+select
+    320001,
+    
+    320001,
+    320001,
+    '\0\0\0\0',
+    '\0\0\0\0\0\0\0\0',
+    '\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',
+    '\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0';
+select count(1), sum(murmur_hash3_32(t1.c_str8)), sum(murmur_hash3_32(t2.c_str8))
+from t1 join t2 on t1.c_str8 <=> t2.c_str8;


### PR DESCRIPTION
## Why I'm doing:

If all builder strings have a length ≤ 16, they can be represented using fixed-length INT/BIGINT/LARGEINT types instead of strings. This representation is guaranteed to use less memory than the original string form, which requires both a `Slice` (16 bytes) and the string data itself.

Representation format using fixed-length INT/BIGINT/LARGEINT:
- Record the maximum string length among all builders as `max_str_length`.
  For each string, the first `length` bytes store the actual string content, and the remaining bytes from `length + 1` to `max_str_length` are filled with `'\0'`. Therefore, if any string ends with a `'\0'`, this optimization cannot be applied.
- During the probe phase, a string may exceed `max_str_length` or end with `'\0'`.
  In such cases, represent it as `0xFF`, **since `0xFF` is an invalid UTF-8 byte and our VARCHAR type must use UTF-8 encoding**. The maximum VARCHAR value (`0xFF`) also leverages this property.

### Test
Environment
- 3 BE (each 16Cores, 64GB Memory)

Q1: right table contains 100,000 rows, and left table contains 409,600,000 rows.
- Before: 0.968s
- After: 0.788s

Q2: right table contains 1,280,000 rows, and left table contains 655,360,000 rows.
- Before: 1.509s
- After: 1.144s

Q3: right table contains 1,280,001 rows, and left table contains 655,360,000 rows. Right table contains string which is end  with `'\0'`, which cannot use this optimization.
- Before: 1.505s
- After: 1.504s


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a fixed-size serialization path for VARCHAR join keys (≤16 bytes), updates column serialization APIs to support it, wires a session/thrift option, and adds tests.
> 
> - **Join/Key construction**:
>   - Detects short `VARCHAR` keys (≤16), rejects tail-`\0`, and serializes as fixed-size `INT`/`BIGINT`/`LARGEINT` with `0xFF` fallback for overflow/invalid probe.
>   - Chooses new constructor in `JoinHashMapSelector`; tracks per-key `serialized_fixed_size_key_bytes`; handles nullable via null masks.
> - **Column Serialization API**:
>   - Changes `serialize_batch_at_interval(...)` signature to include `max_row_size`; adds `serialize_batch_at_interval_with_null_masks(...)`.
>   - Implements for `BinaryColumnBase`, `FixedLengthColumnBase`, `NullableColumn`, and `AdaptiveNullableColumn` (forwarding to `NullableColumn`).
> - **Runtime/FE/Thrift**:
>   - Adds `enable_hash_join_serialize_fixed_size_string` session variable (`SessionVariable`, `RuntimeState`) and propagates via `TQueryOptions`.
> - **Tests**:
>   - Extends BE unit tests and introduces SQL tests validating fixed-size string join behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f6bb5bf039e3d76622ea266058f09f6d7c940ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->