### PR TITLE
[BugFix] Improve cache invalidation logic for Iceberg tables based on snapshot ID

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -442,7 +442,16 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     private void invalidateCache(IcebergTableName key) {
-        tables.invalidate(new IcebergTableCacheKey(key, new ConnectContext()));
+        if (key.ignoreSnapshotId) {
+            // invalidate all snapshots of this table if snapshotId is not specified
+            tables.asMap().keySet().stream()
+                    .filter(k -> k.icebergTableName.dbName.equals(key.dbName) &&
+                            k.icebergTableName.tableName.equals(key.tableName))
+                    .forEach(tables::invalidate);
+        } else {
+            // only invalidate the specified snapshot
+            tables.invalidate(new IcebergTableCacheKey(key, new ConnectContext()));
+        }
         // will invalidate all snapshots of this table
         partitionCache.invalidate(key);
         Set<String> paths = metaFileCacheMap.get(key);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -144,4 +144,30 @@ public class CachingIcebergCatalogTest {
         Assertions.assertEquals(nativeTable, cachingIcebergCatalog.getTable(connectContext, "test", "table"));
         cachingIcebergCatalog.invalidateCache("test", "table");
     }
+
+    @Test
+    public void testInvalidateCache(@Mocked IcebergCatalog icebergCatalog, @Mocked Table nativeTable) {
+        new Expectations() {
+            {
+                icebergCatalog.getTable(connectContext, "db1", "tbl1");
+                result = nativeTable;
+                times = 2; // Called twice: once for initial cache, once after invalidation
+            }
+        };
+
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, icebergCatalog,
+                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+
+        // First call - populates cache
+        Table t1 = cachingIcebergCatalog.getTable(connectContext, "db1", "tbl1");
+        Assertions.assertEquals(nativeTable, t1);
+
+        // Invalidate cache
+        cachingIcebergCatalog.invalidateCache("db1", "tbl1");
+
+        // Second call - should hit delegate again because cache was invalidated
+        Table t2 = cachingIcebergCatalog.getTable(connectContext, "db1", "tbl1");
+        Assertions.assertEquals(nativeTable, t2);
+    }
 }
+


### PR DESCRIPTION
## Why I'm doing:
Fix https://github.com/StarRocks/StarRocksTest/issues/10417

## What I'm doing:
This pull request improves the cache invalidation logic in the `CachingIcebergCatalog` , The main focus is to ensure that cache entries are invalidated properly, both for specific snapshots and for all snapshots of a table when necessary.

Cache invalidation improvements:

* Updated the `invalidateCache` method to differentiate between invalidating all snapshots of a table (when `ignoreSnapshotId` is true) and invalidating only a specific snapshot. This ensures more precise and efficient cache management.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
