### PR TITLE
[Enhancement] finishTransaction with table lock timeout

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -2142,6 +2142,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: The default timeout duration for a prepared transaction.
 - Introduced in: -
 
+##### finish_transaction_default_lock_timeout_ms
+
+- Default: 1000
+- Type: Int
+- Unit: MilliSeconds
+- Is mutable: Yes
+- Description: The default timeout for acquiring the db and table lock during finishing transaction.
+- Introduced in: v4.0.0, v3.5.8
+
 ##### spark_dpp_version
 
 - Default: 1.0.0

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1131,6 +1131,8 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int prepared_transaction_default_timeout_second = 86400; // 1day
 
+    @ConfField(mutable = true)
+    public static int finish_transaction_default_lock_timeout_ms = 1000; // 1000ms
     /**
      * Max load timeout applicable to all type of load except for stream load and lake compaction
      */

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -211,6 +211,10 @@ public final class MetricRepo {
     public static Histogram HISTO_SHORTCIRCUIT_RPC_LATENCY;
     public static Histogram HISTO_DEPLOY_PLAN_FRAGMENTS_LATENCY;
 
+    public static Histogram HISTO_TXN_WAIT_FOR_PUBLISH_LATENCY;
+    public static Histogram HISTO_TXN_FINISH_PUBLISH_LATENCY;
+    public static Histogram HISTO_TXN_PUBLISH_TOTAL_LATENCY;
+
     // following metrics will be updated by metric calculator
     public static GaugeMetricImpl<Double> GAUGE_QUERY_PER_SECOND;
     public static GaugeMetricImpl<Double> GAUGE_REQUEST_PER_SECOND;
@@ -640,6 +644,13 @@ public final class MetricRepo {
         HISTO_SHORTCIRCUIT_RPC_LATENCY = METRIC_REGISTER.histogram(MetricRegistry.name("shortcircuit", "latency", "ms"));
         HISTO_DEPLOY_PLAN_FRAGMENTS_LATENCY = METRIC_REGISTER.histogram(
                 MetricRegistry.name("deploy_plan_fragments", "latency", "ms"));
+
+        HISTO_TXN_WAIT_FOR_PUBLISH_LATENCY = METRIC_REGISTER.histogram(
+                MetricRegistry.name("txn", "wait_for_publish", "latency", "ms"));
+        HISTO_TXN_FINISH_PUBLISH_LATENCY = METRIC_REGISTER.histogram(
+                MetricRegistry.name("txn", "finish_publish", "latency", "ms"));
+        HISTO_TXN_PUBLISH_TOTAL_LATENCY = METRIC_REGISTER.histogram(
+                MetricRegistry.name("txn", "publish_total", "latency", "ms"));
 
         // init system metrics
         initSystemMetrics();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -95,11 +95,13 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
+import static com.starrocks.common.ErrorCode.ERR_LOCK_ERROR;
 import static com.starrocks.common.ErrorCode.ERR_NO_PARTITIONS_HAVE_DATA_LOAD;
 
 /**
@@ -1083,7 +1085,8 @@ public class DatabaseTransactionMgr {
         return true;
     }
 
-    public void finishTransaction(long transactionId, Set<Long> errorReplicaIds) throws StarRocksException {
+    public void finishTransaction(long transactionId, Set<Long> errorReplicaIds, long lockTimeoutMs)
+            throws StarRocksException {
         TransactionState transactionState = getTransactionState(transactionId);
         // add all commit errors and publish errors to a single set
         if (errorReplicaIds == null) {
@@ -1118,7 +1121,17 @@ public class DatabaseTransactionMgr {
 
         List<Long> tableIdList = transactionState.getTableIdList();
         Locker locker = new Locker();
-        locker.lockTablesWithIntensiveDbLock(db.getId(), tableIdList, LockType.WRITE);
+        if (lockTimeoutMs > 0) {
+            if (!locker.tryLockTablesWithIntensiveDbLock(db.getId(), tableIdList, LockType.WRITE, lockTimeoutMs,
+                    TimeUnit.MILLISECONDS)) {
+                finishSpan.end();
+                throw new StarRocksException(ERR_LOCK_ERROR,
+                        "Failed to acquire lock on database " + db.getId() + ", tables: " + tableIdList + " within " +
+                                lockTimeoutMs + " ms");
+            }
+        } else {
+            locker.lockTablesWithIntensiveDbLock(db.getId(), tableIdList, LockType.WRITE);
+        }
         try {
             transactionState.writeLock();
             try {
@@ -2197,6 +2210,7 @@ public class DatabaseTransactionMgr {
     }
 
     private void updateTransactionMetrics(TransactionState txnState) {
+        updateTransactionPublishMetrics(txnState);
         if (txnState.getTableIdList().isEmpty()) {
             return;
         }
@@ -2217,6 +2231,27 @@ public class DatabaseTransactionMgr {
             entity.counterStreamLoadFinishedTotal.increase(1L);
             entity.counterStreamLoadRowsTotal.increase(streamAttachment.getLoadedRows());
             entity.counterStreamLoadBytesTotal.increase(streamAttachment.getLoadedBytes());
+        }
+    }
+
+    private void updateTransactionPublishMetrics(TransactionState txnState) {
+        if (txnState.getTransactionStatus() != TransactionStatus.VISIBLE) {
+            return;
+        }
+        long commitTime = txnState.getCommitTime();
+        long publishVersionTime = txnState.getPublishVersionTime();
+        long publishVersionFinishTime = txnState.getPublishVersionFinishTime();
+        long finishTime = txnState.getFinishTime();
+        if (commitTime > 0) {
+            if (publishVersionTime >= commitTime) {
+                MetricRepo.HISTO_TXN_WAIT_FOR_PUBLISH_LATENCY.update(publishVersionTime - commitTime);
+            }
+            if (finishTime >= commitTime) {
+                MetricRepo.HISTO_TXN_PUBLISH_TOTAL_LATENCY.update(finishTime - commitTime);
+            }
+        }
+        if (publishVersionFinishTime > 0 && finishTime >= publishVersionFinishTime) {
+            MetricRepo.HISTO_TXN_FINISH_PUBLISH_LATENCY.update(finishTime - publishVersionFinishTime);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -598,7 +598,13 @@ public class GlobalTransactionMgr implements MemoryTrackable {
      */
     public void finishTransaction(long dbId, long transactionId, Set<Long> errorReplicaIds) throws StarRocksException {
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
-        dbTransactionMgr.finishTransaction(transactionId, errorReplicaIds);
+        dbTransactionMgr.finishTransaction(transactionId, errorReplicaIds, 0L);
+    }
+
+    public void finishTransaction(long dbId, long transactionId, Set<Long> errorReplicaIds, long lockTimeoutMs)
+            throws StarRocksException {
+        DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
+        dbTransactionMgr.finishTransaction(transactionId, errorReplicaIds, lockTimeoutMs);
     }
 
     public void finishTransactionBatch(long dbId, TransactionStateBatch stateBatch, Set<Long> errorReplicaIds)

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -43,6 +43,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
+import com.starrocks.common.ErrorCode;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.util.FrontendDaemon;
@@ -333,8 +334,21 @@ public class PublishVersionDaemon extends FrontendDaemon {
             }
 
             if (shouldFinishTxn) {
-                globalTransactionMgr.finishTransaction(transactionState.getDbId(), transactionState.getTransactionId(),
-                        publishErrorReplicaIds);
+                try {
+                    // Attempt to finish the transaction with a lock timeout. If it fails, it will be retried in the next cycle.
+                    // This approach prevents blocking subsequent transactions due to the current one.
+                    globalTransactionMgr.finishTransaction(transactionState.getDbId(),
+                            transactionState.getTransactionId(), publishErrorReplicaIds,
+                            Config.finish_transaction_default_lock_timeout_ms);
+                } catch (StarRocksException exception) {
+                    if (exception.getErrorCode() == ErrorCode.ERR_LOCK_ERROR) {
+                        LOG.warn("Fail to get lock to finish transaction {}, error: {}. Will retry later",
+                                transactionState.getTransactionId(), exception.getMessage());
+                        continue;
+                    } else {
+                        throw exception;
+                    }
+                }
                 if (transactionState.getTransactionStatus() != TransactionStatus.VISIBLE) {
                     transactionState.updateSendTaskTime();
                     LOG.debug("publish version for transaction {} failed, has {} error replicas during publish",

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -567,6 +567,10 @@ public class TransactionState implements Writable, GsonPreProcessable {
         return this.publishVersionTime;
     }
 
+    public long getPublishVersionFinishTime() {
+        return this.publishVersionFinishTime;
+    }
+
     public boolean hasSendTask() {
         return this.hasSendTask;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/FakeTransactionIDGenerator.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/FakeTransactionIDGenerator.java
@@ -20,11 +20,14 @@ package com.starrocks.transaction;
 import com.starrocks.persist.EditLog;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.DataOutput;
 import java.io.IOException;
 
 public final class FakeTransactionIDGenerator extends MockUp<TransactionIdGenerator> {
+    private static final Logger LOG = LogManager.getLogger(FakeTransactionIDGenerator.class);
 
     private long nextId = 1000L;
 
@@ -40,7 +43,7 @@ public final class FakeTransactionIDGenerator extends MockUp<TransactionIdGenera
 
     @Mock
     public synchronized long getNextTransactionId() {
-        System.out.println("getNextTransactionId is called");
+        LOG.info("getNextTransactionId is called");
         return nextId++;
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This enhancement adds a configurable table lock timeout mechanism to the finishTransaction operation to prevent blocking when locks cannot be acquired immediately. The change allows transaction finishing to fail gracefully with a timeout rather than blocking indefinitely, enabling retry in subsequent rounds.

Key changes:

* Added lock timeout parameter to finishTransaction methods with configurable default timeout
* Enhanced error handling to catch lock timeout exceptions and allow retries
* Added transaction latency metrics for better observability


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a configurable lock timeout for finishing transactions with retry-on-timeout and records transaction publish latency metrics.
> 
> - **Transactions**:
>   - `finishTransaction` now supports a lock timeout (`DatabaseTransactionMgr.finishTransaction(..., lockTimeoutMs)`), using try-lock and throwing `ERR_LOCK_ERROR` on timeout.
>   - `GlobalTransactionMgr` adds overload to pass `lockTimeoutMs`; `PublishVersionDaemon` uses default timeout and retries later on `ERR_LOCK_ERROR`.
> - **Metrics**:
>   - New histograms in `MetricRepo`: `txn.wait_for_publish.latency.ms`, `txn.finish_publish.latency.ms`, `txn.publish_total.latency.ms`.
>   - `DatabaseTransactionMgr` records publish latency via `updateTransactionPublishMetrics` using `TransactionState` timestamps.
>   - `TransactionState` exposes `getPublishVersionFinishTime()`.
> - **Config & Docs**:
>   - New FE config `finish_transaction_default_lock_timeout_ms` (default `1000` ms), documented in `FE_configuration.md` and added to `Config`.
> - **Tests**:
>   - Updated signatures to include lock timeout; added `testFinishTransactionWithLockTimeout`; initialized metrics in tests; minor logging adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec99b4b677a601166c5d73cda5b0a1f13b3b31ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->