### PR TITLE
[BugFix] Fix lake pk table with wrong rows number stat

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -34,6 +34,7 @@
 #include "storage/lake/compaction_task.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/transactions.h"
+#include "storage/lake/update_manager.h"
 #include "storage/lake/vacuum.h"
 #include "storage/lake/vacuum_full.h"
 #include "testutil/sync_point.h"
@@ -942,7 +943,9 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
                     int64_t num_rows = 0;
                     int64_t data_size = 0;
                     for (const auto& rowset : (*tablet_metadata)->rowsets()) {
-                        num_rows += rowset.num_rows();
+                        size_t num_deletes =
+                                _tablet_mgr->update_mgr()->get_rowset_num_deletes(tablet_id, version, rowset);
+                        num_rows += rowset.num_rows() - num_deletes;
                         data_size += rowset.data_size();
                     }
                     for (const auto& [_, file] : (*tablet_metadata)->delvec_meta().version_to_file()) {


### PR DESCRIPTION
## Why I'm doing:

When showing partitions for pk tables, the `RowCount` statistics in the result can't realy reflect the real row number of the table. The reason is that previousely we misstakely compute rows number without considering delvec metas

## What I'm doing:

Consider delvec while collecting lake pk tablet rows number stat.

The row number stat in pk table/partition/tablets is expected to have same value with `select count(1) from table/partitition/tablet` result

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `get_tablet_stats` to subtract per-rowset deletes via `UpdateManager`, fixing inaccurate row counts.
> 
> - **Lake Service (`lake_service.cpp`)**:
>   - **Tablet stats**: In `get_tablet_stats`, compute `num_rows` as `rowset.num_rows() - get_rowset_num_deletes(...)` using `_tablet_mgr->update_mgr()`, ensuring deleted rows are excluded.
>   - **Include**: Add `#include "storage/lake/update_manager.h"` to support delete accounting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a5c30be9fab93516561d6ea6ab17965c0349aa8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->