### PR TITLE
[Enhancement] Add capacity_limit_reached() to table_function/nl-join-probe/hash-join-probe to avoid constructing overflowing columns

### DIFF
--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -302,6 +302,7 @@ StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
 
     if (_phase == HashJoinPhase::PROBE || !_hash_join_prober->probe_chunk_empty()) {
         ASSIGN_OR_RETURN(chunk, _hash_join_prober->probe_chunk(state))
+        RETURN_IF_ERROR(chunk->capacity_limit_reached());
         return chunk;
     }
 

--- a/be/src/exec/pipeline/table_function_operator.cpp
+++ b/be/src/exec/pipeline/table_function_operator.cpp
@@ -139,6 +139,9 @@ StatusOr<ChunkPtr> TableFunctionOperator::pull_chunk(RuntimeState* state) {
     }
 
     // Just return the chunk whether its full or not in order to keep the semantics of pipeline
+    for (const auto& column : output_columns) {
+        RETURN_IF_ERROR(column->capacity_limit_reached());
+    }
     return _build_chunk(output_columns);
 }
 

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -500,6 +500,7 @@ Status ChunkAccumulator::push(ChunkPtr&& chunk) {
         if (_tmp_chunk) {
             need_rows = std::min(_desired_size - _tmp_chunk->num_rows(), remain_rows);
             TRY_CATCH_BAD_ALLOC(_tmp_chunk->append(*chunk, start, need_rows));
+            RETURN_IF_ERROR(_tmp_chunk->capacity_limit_reached());
         } else {
             need_rows = std::min(_desired_size, remain_rows);
             _tmp_chunk = chunk->clone_empty(_desired_size);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add capacity_limit_reached checks in hash join probe output, table function output columns, and chunk accumulator to prevent column overflows.
> 
> - **Exec**:
>   - `exec/hash_joiner.cpp`: After probing, validate `chunk->capacity_limit_reached()` before returning probe output.
>   - `exec/pipeline/table_function_operator.cpp`: Validate each output column with `capacity_limit_reached()` before building the chunk.
> - **Storage**:
>   - `storage/chunk_helper.cpp` (`ChunkAccumulator::push`): After appending to `_tmp_chunk`, check `capacity_limit_reached()` to guard against overflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5007d5c80f863dbea3ab0699f8ac645ff94fd141. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->