### PR TITLE
[Enhancement] optimize tabletNum retrieval for a given backend

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -3844,6 +3844,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: The maximum number of jobs that can wait in a report queue. The report is about disk, task, and tablet information of BEs. If too many report jobs are piling up in a queue, OOM will occur.
 - Introduced in: -
 
+##### enable_collect_tablet_num_in_show_proc_backend_disk_path
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to enable the collection of tablet numbers for each disk in the `SHOW PROC /BACKENDS/{id}` command
+- Introduced in: v4.0.1, v3.5.8
+
 ##### enable_metric_calculator
 
 - Default: true

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -371,6 +371,14 @@ public class TabletInvertedIndex implements MemoryTrackable {
         }
     }
 
+    /**
+     * Get the number of tablets on the specified backend and pathHash
+     * @param backendId the ID of the backend
+     * @param pathHash the hash of the path
+     * @return the number of tablets as a long value
+     *
+     * @implNote Linear scan, invoke this interface with caution if the number of replicas is large
+     */
     public long getTabletNumByBackendIdAndPathHash(long backendId, long pathHash) {
         readLock();
         try {
@@ -379,6 +387,27 @@ public class TabletInvertedIndex implements MemoryTrackable {
         } finally {
             readUnlock();
         }
+    }
+
+    /**
+     * Get the number of tablets on the specified backend, grouped by pathHash
+     * @param backendId the ID of the backend
+     * @return Map<pathHash, tabletNum> the number of tablets grouped by pathHash
+     *
+     * @implNote Linear scan, invoke this interface with caution if the number of replicas is large
+     */
+    public Map<Long, Long> getTabletNumByBackendIdGroupByPathHash(long backendId) {
+        Map<Long, Long> pathHashToTabletNum = Maps.newHashMap();
+        readLock();
+        try {
+            Map<Long, Replica> replicaMetaWithBackend = row(backingReplicaMetaTable, backendId);
+            for (Replica r : replicaMetaWithBackend.values()) {
+                pathHashToTabletNum.compute(r.getPathHash(), (k, v) -> v == null ? 1L : v + 1);
+            }
+        } finally {
+            readUnlock();
+        }
+        return pathHashToTabletNum;
     }
 
     public Map<TStorageMedium, Long> getReplicaNumByBeIdAndStorageMedium(long backendId) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1824,6 +1824,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int report_queue_size = 100;
 
+    @ConfField(mutable = true, comment = "Whether to enable the collection of tablet numbers"
+            + " for each disk in the 'SHOW PROC /BACKENDS/{id}' command")
+    public static boolean enable_collect_tablet_num_in_show_proc_backend_disk_path = true;
+
     /**
      * If set to true, metric collector will be run as a daemon timer to collect metrics at fix interval
      */

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TabletInvertedIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TabletInvertedIndexTest.java
@@ -14,18 +14,23 @@
 
 package com.starrocks.catalog;
 
+import com.starrocks.authorization.IdGenerator;
 import com.starrocks.thrift.TStorageMedium;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.Map;
-
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Unit tests for TabletInvertedIndex class
  */
 public class TabletInvertedIndexTest {
+    private static final Logger LOG = LogManager.getLogger(TabletInvertedIndexTest.class);
 
     private TabletInvertedIndex tabletInvertedIndex;
     private TabletMeta tabletMeta;
@@ -74,5 +79,65 @@ public class TabletInvertedIndexTest {
         Assertions.assertEquals(replica1, replicas.get(1000L), "Replica on backend 1000 should match");
         Assertions.assertEquals(replica2, replicas.get(1001L), "Replica on backend 1001 should match");
         Assertions.assertEquals(replica3, replicas.get(1002L), "Replica on backend 1002 should match");
+    }
+
+    @Test
+    public void testTabletInvertedIndexPerf() {
+        // 300k tablets, each tablet has 1 replica, has 24 disks
+        tabletInvertedIndex = new TabletInvertedIndex();
+
+        int diskNum = 24;
+        Long[] diskHashes = new Long[diskNum];
+        for (int i = 0; i < diskNum; ++i) {
+            diskHashes[i] = ThreadLocalRandom.current().nextLong();
+        }
+
+        IdGenerator idGenerator = new IdGenerator();
+        long dbId = idGenerator.getNextId();
+        long tableId = idGenerator.getNextId();
+        long partitionId = idGenerator.getNextId();
+        long indexId = idGenerator.getNextId();
+        long backendId = idGenerator.getNextId();
+        int schemaHash = (int) idGenerator.getNextId();
+
+        int num = 500000;
+        // build test data, create `num` of tablets and distribute them into `diskNum` of disks
+        for (int i = 0; i < num; ++i) {
+            TabletMeta meta = new TabletMeta(dbId, tableId, partitionId, indexId, TStorageMedium.HDD);
+            long tabletId = idGenerator.getNextId();
+            tabletInvertedIndex.addTablet(tabletId, meta);
+
+            int diskIndex = ThreadLocalRandom.current().nextInt(diskNum);
+            long replicaId = idGenerator.getNextId();
+            Replica replica = new Replica(replicaId, backendId, schemaHash, Replica.ReplicaState.NORMAL);
+            replica.setPathHash(diskHashes[diskIndex]);
+            tabletInvertedIndex.addReplica(tabletId, replica);
+        }
+
+        long repeats = 1;
+        Map<Long, Long> result1 = new HashMap<>();
+        {
+            long start = System.currentTimeMillis();
+            for (int i = 0; i < repeats; ++i) {
+                for (int j = 0; j < diskNum; ++j) {
+                    result1.put(diskHashes[j],
+                            tabletInvertedIndex.getTabletNumByBackendIdAndPathHash(backendId, diskHashes[j]));
+                }
+            }
+            long end = System.currentTimeMillis();
+            LOG.warn("[tabletNum={}, diskNum={}] getTabletNumByBackendIdAndPathHash() cost {} ms", num, diskNum,
+                    end - start);
+        }
+        Map<Long, Long> result2 = new HashMap<>();
+        {
+            long start = System.currentTimeMillis();
+            for (int i = 0; i < repeats; ++i) {
+                result2 = tabletInvertedIndex.getTabletNumByBackendIdGroupByPathHash(backendId);
+            }
+            long end = System.currentTimeMillis();
+            LOG.warn("[tabletNum={}, diskNum={}] getTabletNumByBackendIdGroupByPathHash() cost {} ms", num, diskNum,
+                    end - start);
+        }
+        Assertions.assertEquals(result1, result2);
     }
 }


### PR DESCRIPTION
* batch get all pathHash tablet num stats in `show proc '/backends/xxx'`
* perf comparison
```
2025-10-14 15:08:36 [main] WARN  TabletInvertedIndexTest:128 - [tabletNum=500000, diskNum=24] getTabletNumByBackendIdAndPathHash() cost 279 ms
2025-10-14 15:08:36 [main] WARN  TabletInvertedIndexTest:138 - [tabletNum=500000, diskNum=24] getTabletNumByBackendIdGroupByPathHash cost 60 ms
```

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Batch precomputes per-disk tablet counts for `SHOW PROC /BACKENDS/{id}` via a new grouped API, gated by a new FE config; updates docs and adds a perf test.
> 
> - **FE Proc/UI**:
>   - `BackendProcNode`: Fetches all tablet counts per `pathHash` in one call and uses them to render `TabletNum`.
> - **Catalog**:
>   - `TabletInvertedIndex`: Adds `getTabletNumByBackendIdGroupByPathHash(backendId)`; documents methods.
> - **Config**:
>   - Adds `enable_collect_tablet_num_in_show_proc_backend_disk_path` (default `true`).
> - **Docs**:
>   - Documents the new config in `docs/en/administration/management/FE_configuration.md` (Introduced in: v4.0.1, v3.5.8).
> - **Tests**:
>   - Adds perf comparison test for grouped vs per-path tablet count retrieval.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b72212735cd2cf4fc6d36d5eb40cf0e3c4d743e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->