### PR TITLE
[Enhancement] Add configuration for collecting stats IO tasks per connector operator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2161,6 +2161,12 @@ public class Config extends ConfigBase {
     public static long statistic_cache_columns = 100000;
 
     /**
+     * The max number of io tasks for each connector operator in collect statistic
+     */
+    @ConfField(mutable = true)
+    public static int collect_stats_io_tasks_per_connector_operator = 4;
+
+    /**
      * The size of the thread-pool which will be used to refresh statistic caches
      */
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -120,6 +120,9 @@ public class StatisticUtils {
         context.getSessionVariable().setCboCteReuse(true);
         context.getSessionVariable().setCboCTERuseRatio(0);
         context.getSessionVariable().setEnablePlanSerializeConcurrently(false);
+        // set the max task num of connector io tasks per scan operator to collectStatsIoTasksPerConnectorOperator,
+        // default value is 4, avoid generate too many chunk source for collect stats in BE
+        context.getSessionVariable().setConnectorIoTasksPerScanOperator(Config.collect_stats_io_tasks_per_connector_operator);
 
         WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         Warehouse warehouse = manager.getBackgroundWarehouse();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -183,9 +183,6 @@ public abstract class StatisticsCollectJob {
         // acceleration, then page cache is better filled with the user's data.
         sessionVariable.setUsePageCache(false);
         sessionVariable.setEnableMaterializedViewRewrite(false);
-        // set the max task num of connector io tasks per scan operator to 4, default is 16,
-        // to avoid generate too many chunk source for collect stats in BE
-        sessionVariable.setConnectorIoTasksPerScanOperator(4);
     }
 
     public void setPartitionTabletRowCounts(com.google.common.collect.Table<Long, Long, Long> partitionTabletRowCounts) {


### PR DESCRIPTION
## Why I'm doing:
 io task for each connector scan operator is set to 4 by default when collect statistics for external table , It needs to be configuable
## What I'm doing:
add Fe config collect_stats_io_tasks_per_connector_operator, to set the max number of io tasks for each connector operator in collect statistic, default value is 4.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds FE config `collect_stats_io_tasks_per_connector_operator` (default 4) and uses it to set `connector_io_tasks_per_scan_operator` in stats sessions, removing the previous hardcoded value.
> 
> - **Statistics config**:
>   - Add `Config.collect_stats_io_tasks_per_connector_operator` (mutable, default `4`).
> - **Session behavior for stats collection**:
>   - In `StatisticUtils.buildConnectContext()`, set `sessionVariable.connector_io_tasks_per_scan_operator` from `Config.collect_stats_io_tasks_per_connector_operator`.
>   - In `StatisticsCollectJob.setDefaultSessionVariable()`, remove the hardcoded `connector_io_tasks_per_scan_operator(4)` override.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 266503157c8548a08a1f34202d41f01879152a4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->