### PR TITLE
[UT] Avoid resource group causing other cases to time out

### DIFF
--- a/test/sql/test_resource_group/R/test_resource_group_dedicated_cpu_cores_borrowing_cpu
+++ b/test/sql/test_resource_group/R/test_resource_group_dedicated_cpu_cores_borrowing_cpu
@@ -1,4 +1,4 @@
--- name: test_resource_group_exclusive_cpu_cores_borrowing_cpu
+-- name: test_resource_group_exclusive_cpu_cores_borrowing_cpu @sequential
 CREATE TABLE __row_util_base (
   k1 bigint NULL
 ) ENGINE=OLAP

--- a/test/sql/test_resource_group/R/test_resource_group_metrics_dead_lock
+++ b/test/sql/test_resource_group/R/test_resource_group_metrics_dead_lock
@@ -1,4 +1,4 @@
--- name: test_resource_group_metrics_dead_lock
+-- name: test_resource_group_metrics_dead_lock @sequential
 CREATE RESOURCE GROUP rgd1_${uuid0} 
     TO ( user='user_${uuid0}' ) 
     WITH ( 'exclusive_cpu_cores' = '2', 'mem_limit' = '0.99' );

--- a/test/sql/test_resource_group/T/test_resource_group_dedicated_cpu_cores_borrowing_cpu
+++ b/test/sql/test_resource_group/T/test_resource_group_dedicated_cpu_cores_borrowing_cpu
@@ -1,4 +1,4 @@
--- name: test_resource_group_exclusive_cpu_cores_borrowing_cpu
+-- name: test_resource_group_exclusive_cpu_cores_borrowing_cpu @sequential
 -- Prepare data.
 
 CREATE TABLE __row_util_base (
@@ -98,7 +98,7 @@ DROP RESOURCE GROUP rgn1_${uuid0};
 DROP RESOURCE GROUP rgn2_${uuid0};
 
 
--- name: test_resource_exclusive_cpu_cores_no_borrowing_cpu
+-- name: test_resource_exclusive_cpu_cores_no_borrowing_cpu @sequential
 -- Prepare data.
 
 CREATE TABLE __row_util_base (

--- a/test/sql/test_resource_group/T/test_resource_group_metrics_dead_lock
+++ b/test/sql/test_resource_group/T/test_resource_group_metrics_dead_lock
@@ -1,4 +1,4 @@
--- name: test_resource_group_metrics_dead_lock
+-- name: test_resource_group_metrics_dead_lock @sequential
 
 CREATE RESOURCE GROUP rgd1_${uuid0} 
     TO ( user='user_${uuid0}' ) 


### PR DESCRIPTION
## Why I'm doing:

These cases create mutually exclusive groups, causing other cases to use only a small portion of the CPU.

## What I'm doing:


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
