### PR TITLE
[Enhancement] make sure insert select data freshness

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -959,6 +959,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_FULL_SORT_USE_GERMAN_STRING = "enable_full_sort_use_german_string";
 
+    public static final String ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH = "enable_insert_select_external_auto_refresh";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1964,6 +1966,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_FULL_SORT_USE_GERMAN_STRING)
     private boolean enableFullSortUseGermanString = true;
+
+    @VarAttr(name = ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH)
+    private boolean enableInsertSelectExternalAutoRefresh = true;
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
@@ -5333,6 +5338,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public boolean isEnableFullSortUseGermanString() {
         return this.enableFullSortUseGermanString;
     }
+
+    public boolean isEnableInsertSelectExternalAutoRefresh() {
+        return enableInsertSelectExternalAutoRefresh;
+    }
+
+    public void setEnableInsertSelectExternalAutoRefresh(boolean enableInsertSelectExternalAutoRefresh) {
+        this.enableInsertSelectExternalAutoRefresh = enableInsertSelectExternalAutoRefresh;
+    }
+
     // Serialize to thrift object
     // used for rest api
     public TQueryOptions toThrift() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTBasedRefreshProcessor.java
@@ -214,6 +214,7 @@ public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
 
             // Generate insert stmt's exec plan, make thread local ctx existed
             try (ConnectContext.ScopeGuard guard = ctx.bindScope(); Timer ignored = Tracers.watchScope("MVRefreshPlanner")) {
+                ctx.getSessionVariable().setEnableInsertSelectExternalAutoRefresh(false); //already refreshed before
                 execPlan = StatementPlanner.planInsertStmt(locker, insertStmt, ctx);
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedMVRefreshProcessor.java
@@ -425,6 +425,7 @@ public class MVIVMBasedMVRefreshProcessor extends BaseMVRefreshProcessor {
         }
 
         try (Timer ignored = Tracers.watchScope("MVRefreshPlanner")) {
+            ctx.getSessionVariable().setEnableInsertSelectExternalAutoRefresh(false); //already refreshed before
             ExecPlan execPlan = StatementPlanner.plan(insertStmt, ctx);
             mvContext.setExecPlan(execPlan);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -54,6 +54,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeState;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.ExpressionAnalyzer;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
@@ -63,6 +64,7 @@ import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.ValuesRelation;
@@ -243,6 +245,18 @@ public class InsertPlanner {
         }
     }
 
+    public void refreshExternalTable(QueryStatement queryStatement, ConnectContext session) {
+        SessionVariable currentVariable = (SessionVariable) session.getSessionVariable();
+        if (currentVariable.isEnableInsertSelectExternalAutoRefresh()) {
+            List<Table> tables = new ArrayList<>();
+            AnalyzerUtils.collectSpecifyExternalTables(queryStatement, tables, Table::isExternalTableWithFileSystem);
+            for (Table table : tables) {
+                session.getGlobalStateMgr().getMetadataMgr().refreshTable(table.getCatalogName(),
+                        table.getCatalogDBName(), table, new ArrayList<>(), false);
+            }
+        }
+    }
+
     public ExecPlan plan(InsertStmt insertStmt, ConnectContext session) {
         QueryRelation queryRelation = insertStmt.getQueryStatement().getQueryRelation();
         List<ColumnRefOperator> outputColumns = new ArrayList<>();
@@ -254,6 +268,8 @@ public class InsertPlanner {
             outputBaseSchema = targetTable.getBaseSchema();
             outputFullSchema = targetTable.getFullSchema();
         }
+
+        refreshExternalTable(insertStmt.getQueryStatement(), session);
 
         //1. Process the literal value of the insert values type and cast it into the type of the target table
         if (queryRelation instanceof ValuesRelation) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/InsertPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/InsertPlannerTest.java
@@ -1,0 +1,133 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.InsertPlanner;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Delegate;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.Verifications;
+import org.junit.jupiter.api.*;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class InsertPlannerTest {
+
+    @Test
+    public void testRefreshAllCollectedExternalTables(@Mocked ConnectContext session,
+                                        @Mocked GlobalStateMgr gsm,
+                                        @Mocked MetadataMgr metadataMgr,
+                                        @Mocked QueryStatement qs,
+                                        @Mocked SessionVariable sessVar,
+                                        @Mocked AnalyzerUtils unusedStatic,
+                                        @Mocked Table t1,
+                                        @Mocked Table t2) {
+        new Expectations() {{
+            session.getGlobalStateMgr(); result = gsm; minTimes = 0;
+            gsm.getMetadataMgr(); result = metadataMgr; minTimes = 0;
+
+            session.getSessionVariable(); result = sessVar;
+            sessVar.isEnableInsertSelectExternalAutoRefresh(); result = true;
+
+            t1.getCatalogName(); result = "c1"; minTimes = 0;
+            t1.getCatalogDBName(); result = "db1"; minTimes = 0;
+            t1.isExternalTableWithFileSystem(); result = true; minTimes = 0;
+
+            t2.getCatalogName(); result = "c2"; minTimes = 0;
+            t2.getCatalogDBName(); result = "db2"; minTimes = 0;
+            t2.isExternalTableWithFileSystem(); result = true; minTimes = 0;
+
+            AnalyzerUtils.collectSpecifyExternalTables(qs, (List<Table>) any, (Predicate<Table>) any);
+            result = new Delegate<Void>() {
+                @SuppressWarnings("unused")
+                void delegate(QueryStatement _qs, List<Table> out, Predicate<Table> pred) {
+                if (pred == null || pred.test(t1)) out.add(t1);
+                if (pred == null || pred.test(t2)) out.add(t2);
+                }
+            };
+        }};
+
+        InsertPlanner target = new InsertPlanner();
+        target.refreshExternalTable(qs, session);
+
+        new Verifications() {{
+            metadataMgr.refreshTable("c1", "db1", t1, (List<String>) any, false); times = 1;
+            metadataMgr.refreshTable("c2", "db2", t2, (List<String>) any, false); times = 1;
+        }};
+    }
+
+    @Test
+    public void testAutoRefreshDisabled(@Mocked ConnectContext session,
+                                        @Mocked SessionVariable sessVar,
+                                        @Mocked GlobalStateMgr gsm,
+                                        @Mocked MetadataMgr metadataMgr,
+                                        @Mocked QueryStatement qs,
+                                        @Mocked AnalyzerUtils unusedStatic) {
+        new Expectations() {{
+            session.getSessionVariable(); result = sessVar;
+            sessVar.isEnableInsertSelectExternalAutoRefresh(); result = false;
+        }};
+
+        InsertPlanner target = new InsertPlanner();
+        target.refreshExternalTable(qs, session);
+
+        new Verifications() {{
+            AnalyzerUtils.collectSpecifyExternalTables(qs, (List<Table>) any, (Predicate<Table>) any); times = 0;
+            metadataMgr.refreshTable(anyString, anyString, (Table) any, (List<String>) any, anyBoolean); times = 0;
+            session.getGlobalStateMgr(); times = 0; 
+        }};
+    }
+
+    @Test
+    public void testDoNothingWhenNoTableCollected(@Mocked ConnectContext session,
+                                        @Mocked GlobalStateMgr gsm,
+                                        @Mocked SessionVariable sessVar,
+                                        @Mocked MetadataMgr metadataMgr,
+                                        @Mocked QueryStatement qs,
+                                        @Mocked AnalyzerUtils unusedStatic) {
+        new Expectations() {{
+                session.getSessionVariable(); result = sessVar;
+                sessVar.isEnableInsertSelectExternalAutoRefresh(); result = true;
+                AnalyzerUtils.collectSpecifyExternalTables(qs, (List<Table>) any, (Predicate<Table>) any);
+                result = new Delegate<Void>() {
+                    @SuppressWarnings("unused")
+                    void delegate(QueryStatement _qs, List<Table> out, Predicate<Table> pred) {
+                        // no-op
+                    }
+                };
+        }};
+
+        InsertPlanner target = new InsertPlanner();
+        target.refreshExternalTable(qs, session);
+
+        new Verifications() {{
+            metadataMgr.refreshTable(anyString, anyString, (Table) any, (List<String>) any, anyBoolean); times = 0;
+        }};
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Make sure `insert into x select from y` can read the freshest data from y.
Fixes #issue

```
mysql> create table t1(c1 int);
Query OK, 0 rows affected (0.07 sec)

mysql> create table t2(c1 int);
Query OK, 0 rows affected (0.07 sec)

spark-sql (test)> insert into t1 values(1);
Time taken: 0.216 seconds

mysql> insert into t2 select * from t1;
Query OK, 1 row affected (0.78 sec)

mysql> select * from t2;
+------+
| c1   |
+------+
|    1 |
+------+
1 row in set (0.04 sec)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Before planning INSERT ... SELECT, collect and refresh referenced external filesystem tables to ensure latest metadata; add tests verifying refresh behavior.
> 
> - **Planner**:
>   - Add `planForFreshestExternalTable(QueryStatement, ConnectContext)` in `InsertPlanner` to collect external FS tables via `AnalyzerUtils.collectSpecifyExternalTables` and call `MetadataMgr.refreshTable` on each.
>   - Invoke this refresh step at the start of `InsertPlanner.plan(...)` for `INSERT` statements.
>   - Imports for `AnalyzerUtils` and `QueryStatement` added.
> - **Tests**:
>   - New `InsertPlannerTest` with cases to verify all collected external tables are refreshed and that no refresh is called when none are collected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20c36305b3bda8567d5f218e84f873d6cda45297. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->