### PR TITLE
[BugFix] Fix table compaction can not be scheduled any more after FE restart if the table compaction has to be aborted. (backport #63881)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
@@ -156,7 +156,6 @@ public class CompactionMgr implements MemoryTrackable {
 
     public void handleCompactionFinished(PartitionIdentifier partition, long version, long versionTime,
                                          Quantiles compactionScore, long txnId, boolean isPartialSuccess) {
-        removeFromStartupActiveCompactionTransactionMap(txnId);
         PartitionVersion compactionVersion = new PartitionVersion(version, versionTime);
         PartitionStatistics statistics = partitionStatisticsHashMap.compute(partition, (k, v) -> {
             if (v == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -161,6 +161,7 @@ public class CompactionScheduler extends Daemon {
 
                 if (errorMsg != null) {
                     iterator.remove();
+                    compactionManager.removeFromStartupActiveCompactionTransactionMap(job.getTxnId());
                     job.finish();
                     history.offer(CompactionRecord.build(job, errorMsg));
                     compactionManager.enableCompactionAfter(partition, Config.lake_compaction_interval_ms_on_failure);
@@ -170,6 +171,7 @@ public class CompactionScheduler extends Daemon {
             }
             if (job.transactionHasCommitted() && job.waitTransactionVisible(50, TimeUnit.MILLISECONDS)) {
                 iterator.remove();
+                compactionManager.removeFromStartupActiveCompactionTransactionMap(job.getTxnId());
                 job.finish();
                 history.offer(CompactionRecord.build(job));
                 long cost = job.getFinishTs() - job.getStartTs();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -33,13 +33,19 @@ import com.starrocks.transaction.DatabaseTransactionMgr;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.utframe.MockedWarehouseManager;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -284,7 +290,7 @@ public class CompactionSchedulerTest {
         idField.setAccessible(true);
         idField.set(table, tableId);
         PhysicalPartition partition = new PhysicalPartition(3, "test_partition", 3, null);
-        CompactionJob job = new CompactionJob(db, table, partition, txnId, false, null, "");
+        CompactionJob job = new CompactionJob(db, table, partition, txnId, false);
         
         // Mock the job to simulate successful completion and transaction visibility
         new MockUp<CompactionJob>() {
@@ -392,7 +398,7 @@ public class CompactionSchedulerTest {
         idField.setAccessible(true);
         idField.set(table, tableId);
         PhysicalPartition partition = new PhysicalPartition(4, "test_partition", 4, null);
-        CompactionJob job = new CompactionJob(db, table, partition, txnId, false, null, "");
+        CompactionJob job = new CompactionJob(db, table, partition, txnId, false);
         
         // Mock the job to simulate failure (e.g., NONE_SUCCESS or PARTIAL_SUCCESS without allow partial)
         new MockUp<CompactionJob>() {
@@ -517,7 +523,7 @@ public class CompactionSchedulerTest {
         idField.setAccessible(true);
         idField.set(table, tableId);
         PhysicalPartition partition = new PhysicalPartition(5, "test_partition", 5, null);
-        CompactionJob job = new CompactionJob(db, table, partition, txnId, false, null, "");
+        CompactionJob job = new CompactionJob(db, table, partition, txnId, false);
         
         // Mock the job to simulate PARTIAL_SUCCESS without allowing partial success
         new MockUp<CompactionJob>() {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

