### PR TITLE
[Enhancement] Support ivm/pct refresh automatic switch in auto refresh mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -289,7 +289,7 @@ public class AlterJobMgr {
         List<Column> newColumns = createStmt.getMvColumnItems().stream()
                 .sorted(Comparator.comparing(Column::getName))
                 .collect(Collectors.toList());
-        List<Column> existedColumns = materializedView.getOrderedOutputColumns().stream()
+        List<Column> existedColumns = materializedView.getOrderedOutputColumns(true).stream()
                 .sorted(Comparator.comparing(Column::getName))
                 .collect(Collectors.toList());
         if (newColumns.size() != existedColumns.size()) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -57,9 +57,12 @@ import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.analyzer.SetStmtAnalyzer;
+import com.starrocks.sql.analyzer.mv.IVMAnalyzer;
 import com.starrocks.sql.ast.AlterMaterializedViewStatusClause;
 import com.starrocks.sql.ast.AsyncRefreshSchemeDesc;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
+import com.starrocks.sql.ast.ParseNode;
+import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RefreshSchemeClause;
 import com.starrocks.sql.ast.SetListItem;
 import com.starrocks.sql.ast.SetStmt;
@@ -84,7 +87,9 @@ import org.threeten.extra.PeriodDuration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -152,8 +157,42 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             partitionRefreshStrategy = PropertyAnalyzer.analyzePartitionRefreshStrategy(properties);
         }
         String mvRefreshMode = null;
+        MaterializedView.RefreshMode currentRefreshMode = MaterializedView.RefreshMode.PCT;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_MV_REFRESH_MODE)) {
             mvRefreshMode = PropertyAnalyzer.analyzeRefreshMode(properties);
+
+            // cannot alter original pct based mv to incremental or auto, only support original ivm/pct based mv
+            currentRefreshMode = MaterializedView.RefreshMode.valueOf(mvRefreshMode.toUpperCase(Locale.ROOT));
+            if (currentRefreshMode.isIncrementalOrAuto()) {
+                ParseNode mvDefinedQueryParseNode = materializedView.getDefineQueryParseNode();
+                if (mvDefinedQueryParseNode != null && (mvDefinedQueryParseNode instanceof QueryStatement)) {
+                    QueryStatement queryStatement = (QueryStatement) mvDefinedQueryParseNode;
+                    IVMAnalyzer ivmAnalyzer = new IVMAnalyzer(context, queryStatement);
+
+                    Optional<IVMAnalyzer.IVMAnalyzeResult> result = Optional.empty();
+                    try {
+                        result = ivmAnalyzer.rewrite(
+                                MaterializedView.RefreshMode.valueOf(mvRefreshMode.toUpperCase(Locale.ROOT)));
+                    } catch (SemanticException e) {
+                        throw new SemanticException("Cannot alter materialized view refresh mode to %s: %s",
+                                mvRefreshMode, e.getMessage());
+                    }
+                    if (result.isEmpty()) {
+                        throw new SemanticException("Cannot alter materialized view refresh mode to %s," +
+                                " because the materialized view is not eligible for %s refresh mode",
+                                mvRefreshMode, mvRefreshMode);
+                    }
+                    // if materialized's original refresh mode is not auto or ivm, throw exception
+                    if (!materializedView.getCurrentRefreshMode().isIncrementalOrAuto()) {
+                        throw new SemanticException("Cannot alter materialized view refresh mode to %s," +
+                                " only support alter original incremental/auto based materialized view",
+                                mvRefreshMode);
+                    }
+                    currentRefreshMode = result.get().currentRefreshMode();
+                } else {
+                    throw new SemanticException("Cannot alter materialized view refresh mode to %s", mvRefreshMode);
+                }
+            }
         }
         String resourceGroup = null;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP)) {
@@ -363,6 +402,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             curProp.put(PropertyAnalyzer.PROPERTIES_MV_REFRESH_MODE, String.valueOf(mvRefreshMode));
             materializedView.getTableProperty().setMvRefreshMode(mvRefreshMode);
             isChanged = true;
+            materializedView.setCurrentRefreshMode(currentRefreshMode);
         } else if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT) &&
                 materializedView.getTableProperty().getAutoRefreshPartitionsLimit() != autoRefreshPartitionsLimit) {
             curProp.put(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT, String.valueOf(autoRefreshPartitionsLimit));

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -338,8 +338,12 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
 
     @Override
     public void increaseRefreshJobStatus(Constants.TaskRunState status) {
+        if (status == null || !status.isFinishState()) {
+            return;
+        }
         this.counterRefreshJobTotal.increase(1L);
         switch (status) {
+            case MERGED:
             case SKIPPED:
                 this.counterRefreshJobEmptyTotal.increase(1L);
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -16,6 +16,7 @@ package com.starrocks.scheduler;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
@@ -254,7 +255,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
                 }
                 Tracers.record("MVRefreshRetryTimes", String.valueOf(refreshFailedTimes));
                 Tracers.record("MVRefreshLockRetryTimes", String.valueOf(lockFailedTimes));
-                return mvRefreshProcessor.doProcessTaskRun(taskRunContext, this);
+                return doProcessTaskRun(taskRunContext, this);
             } catch (LockTimeoutException e) {
                 // if lock timeout, retry to refresh
                 lockFailedTimes += 1;
@@ -263,7 +264,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
                 lastException = e;
             } catch (Throwable e) {
                 refreshFailedTimes += 1;
-                logger.warn("refresh mv failed at {}th time: {}", refreshFailedTimes, DebugUtil.getRootStackTrace(e));
+                logger.warn("refresh mv failed at {}th time: {}", refreshFailedTimes, e);
                 lastException = e;
             }
 
@@ -275,6 +276,32 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         String errorMsg = MvUtils.shrinkToSize(DebugUtil.getRootStackTrace(lastException), MAX_FIELD_VARCHAR_LENGTH);
         throw new DmlException("Refresh mv %s failed after %s times, try lock failed: %s, error-msg : " +
                 "%s", lastException, mv.getName(), refreshFailedTimes, lockFailedTimes, errorMsg);
+    }
+
+    /**
+     * 1. prepare to check some conditions
+     * 2. sync partitions with base tables(add or drop partitions, which will be optimized  by dynamic partition creation later)
+     * 3. decide which partitions of mv to refresh and the corresponding base tables' source partitions
+     * 4. construct the refresh sql and execute it
+     * 5. update the source table version map if refresh task completes successfully
+     */
+    public Constants.TaskRunState doProcessTaskRun(TaskRunContext taskRunContext,
+                                                   MVRefreshExecutor executor) throws Exception {
+        Stopwatch watch = Stopwatch.createStarted();
+        final BaseMVRefreshProcessor.ProcessExecPlan processExecPlan = mvRefreshProcessor.getProcessExecPlan(taskRunContext);
+        if (processExecPlan.state() == Constants.TaskRunState.SKIPPED) {
+            logger.info("MV {} refresh task skipped, no partitions to refresh", mv.getName());
+            long elapsed = watch.elapsed(TimeUnit.MILLISECONDS);
+            mvMetricsEntity.updateRefreshDuration(elapsed);
+            return Constants.TaskRunState.SKIPPED;
+        }
+
+        // refresh materialized view
+        Constants.TaskRunState result = mvRefreshProcessor.execProcessExecPlan(taskRunContext, processExecPlan, executor);
+        long elapsed = watch.elapsed(TimeUnit.MILLISECONDS);
+        logger.info("refresh mv success, cost time(ms): {}", DebugUtil.DECIMAL_FORMAT_SCALE_3.format(elapsed));
+        mvMetricsEntity.updateRefreshDuration(elapsed);
+        return result;
     }
 
     @Override
@@ -335,7 +362,8 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
                 TaskRunStatus status = mvTaskRunContext.getStatus();
                 if (status != null && status.getMvTaskRunExtraMessage() != null) {
                     MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
-
+                    // current refresh mode
+                    sb.append("RefreshMode: " + extraMessage.getRefreshMode());
                     // mv partitions to refresh
                     Set<String> mvPartitionsToRefresh = extraMessage.getMvPartitionsToRefresh();
                     if (!CollectionUtils.isEmpty(mvPartitionsToRefresh)) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
@@ -40,6 +40,8 @@ public class MVRefreshParams {
     // whether the refresh is tentative, when it's true, it means the refresh is triggered temporarily and used for
     // find candidate partitions to refresh.
     private boolean isTentative = false;
+    // whether can generate next task runs, if false, the scheduler will not generate next task runs.
+    private boolean isCanGenerateNextTaskRun = true;
 
     public MVRefreshParams(MaterializedView mv,
                            Map<String, String> properties) {
@@ -106,6 +108,14 @@ public class MVRefreshParams {
 
     public Set<PListCell> getListValues() {
         return listValues;
+    }
+
+    public void setCanGenerateNextTaskRun(boolean canGenerateNextTaskRun) {
+        this.isCanGenerateNextTaskRun = canGenerateNextTaskRun;
+    }
+
+    public boolean isCanGenerateNextTaskRun() {
+        return isCanGenerateNextTaskRun;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
@@ -1,0 +1,166 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv.hybrid;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.tvr.TvrVersionRange;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.metric.IMaterializedViewMetricsEntity;
+import com.starrocks.scheduler.Constants;
+import com.starrocks.scheduler.MvTaskRunContext;
+import com.starrocks.scheduler.TaskRunContext;
+import com.starrocks.scheduler.mv.BaseMVRefreshProcessor;
+import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
+import com.starrocks.scheduler.mv.MVRefreshExecutor;
+import com.starrocks.scheduler.mv.MVRefreshParams;
+import com.starrocks.scheduler.mv.ivm.MVIVMBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.ivm.TvrTableSnapshotInfo;
+import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.sql.plan.ExecPlan;
+
+import java.util.Map;
+import java.util.Set;
+
+public final class MVHybridBasedRefreshProcessor extends BaseMVRefreshProcessor {
+    private final MVPCTBasedRefreshProcessor pctProcessor;
+    private final MVIVMBasedRefreshProcessor ivmProcessor;
+
+    // This map is used to store the temporary tvr version range for each base table
+    private final Map<BaseTableInfo, TvrVersionRange> tempMvTvrVersionRangeMap = Maps.newConcurrentMap();
+
+    public MVHybridBasedRefreshProcessor(Database db,
+                                         MaterializedView mv,
+                                         MvTaskRunContext mvContext,
+                                         IMaterializedViewMetricsEntity mvEntity,
+                                         MaterializedView.RefreshMode refreshMode) {
+        super(db, mv, mvContext, mvEntity, refreshMode, MVHybridBasedRefreshProcessor.class);
+        this.ivmProcessor = new MVIVMBasedRefreshProcessor(db, mv, mvContext, mvEntity,
+                MaterializedView.RefreshMode.INCREMENTAL);
+        this.pctProcessor = new MVPCTBasedRefreshProcessor(db, mv, mvContext, mvEntity,
+                MaterializedView.RefreshMode.AUTO);
+    }
+
+    @Override
+    public ProcessExecPlan getProcessExecPlan(TaskRunContext taskRunContext) throws Exception {
+        if (isIVMRefreshEnabled(mvRefreshParams)) {
+            // if ivm refresh is enabled, try ivm first
+            return switchToIVMRefresh(taskRunContext);
+        } else {
+            return switchToPCTRefresh(taskRunContext);
+        }
+    }
+
+    private boolean isIVMRefreshEnabled(MVRefreshParams mvRefreshParams) {
+        // if this is not a complete refresh and is a partial refresh, use pct refresh instead.
+        if (!mvRefreshParams.isCompleteRefresh()) {
+            return false;
+        }
+        return true;
+    }
+
+    private ProcessExecPlan switchToIVMRefresh(TaskRunContext taskRunContext) throws Exception {
+        // try ivm first, and if failed, transfer to pct
+        try {
+            this.currentRefreshMode = MaterializedView.RefreshMode.INCREMENTAL;
+            logger.info("Try to do ivm refresh for mv: {}, current refresh mode: {}",
+                    mv.getName(), this.currentRefreshMode);
+            updateTaskRunStatus(status -> {
+                status.getMvTaskRunExtraMessage().setRefreshMode(currentRefreshMode.name());
+            });
+            return ivmProcessor.getProcessExecPlan(taskRunContext);
+        } catch (Exception e) {
+            logger.warn("Failed to do ivm refresh for mv: {}, try pct refresh. error: {}",
+                    mv.getName(), e);
+            return switchToPCTRefresh(taskRunContext);
+        }
+    }
+
+    private ProcessExecPlan switchToPCTRefresh(TaskRunContext taskRunContext) throws Exception {
+        this.currentRefreshMode = MaterializedView.RefreshMode.AUTO;
+        // update the task run status to pct refresh
+        updateTaskRunStatus(status -> {
+            status.getMvTaskRunExtraMessage().setRefreshMode(MaterializedView.RefreshMode.PCT.name());
+        });
+        // reset the task run id for pct
+        this.mvContext.getCtx().setQueryId(UUIDUtil.genUUID());
+        // If the refresh is transferred to pct, we need to refresh the changed partitions once
+        // and cannot generate multi-task-runs.
+        pctProcessor.getMvRefreshParams().setCanGenerateNextTaskRun(false);
+
+        // try get the tvr version range map from ivm processor
+        final Map<BaseTableInfo, TvrVersionRange> mvTvrVersionRangeMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoTvrVersionRangeMap();
+        for (BaseTableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
+            TvrVersionRange changedVersionRange = ivmProcessor.getBaseTableChangedVersionRange(snapshotInfo,
+                    mvTvrVersionRangeMap, this.currentRefreshMode);
+            logger.info("Base table: {}, changed version range: {}",
+                    snapshotInfo.getBaseTableInfo().getTableName(), changedVersionRange);
+            // collect changed version range
+            TvrTableSnapshotInfo tvrTableSnapshotInfo = new TvrTableSnapshotInfo(snapshotInfo.getBaseTableInfo(),
+                    snapshotInfo.getBaseTable());
+            tempMvTvrVersionRangeMap.put(snapshotInfo.getBaseTableInfo(), changedVersionRange);
+            // update the snapshot info with the changed version range
+            tvrTableSnapshotInfo.setTvrSnapshot(changedVersionRange);
+        }
+        return pctProcessor.getProcessExecPlan(taskRunContext);
+    }
+
+    @VisibleForTesting
+    public BaseMVRefreshProcessor getCurrentProcessor() {
+        if (this.currentRefreshMode == MaterializedView.RefreshMode.AUTO) {
+            return pctProcessor;
+        } else {
+            return ivmProcessor;
+        }
+    }
+
+    @Override
+    public Constants.TaskRunState execProcessExecPlan(TaskRunContext taskRunContext,
+                                                      ProcessExecPlan processExecPlan,
+                                                      MVRefreshExecutor executor) throws Exception {
+        return getCurrentProcessor().execProcessExecPlan(taskRunContext, processExecPlan, executor);
+    }
+
+    @Override
+    public BaseTableSnapshotInfo buildBaseTableSnapshotInfo(BaseTableInfo baseTableInfo, Table table) {
+        return getCurrentProcessor().buildBaseTableSnapshotInfo(baseTableInfo, table);
+    }
+
+    @Override
+    public void generateNextTaskRunIfNeeded() {
+        getCurrentProcessor().generateNextTaskRunIfNeeded();
+    }
+
+    @Override
+    public void updateVersionMeta(ExecPlan execPlan,
+                                  Set<String> mvRefreshedPartitions,
+                                  Map<BaseTableSnapshotInfo, Set<String>> refTableAndPartitionNames) {
+        if (this.currentRefreshMode == MaterializedView.RefreshMode.INCREMENTAL) {
+            ivmProcessor.updateVersionMeta(execPlan, mvRefreshedPartitions, refTableAndPartitionNames);
+        } else {
+            if (mvContext.hasNextBatchPartition()) {
+                updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions, Maps.newHashMap());
+            } else {
+                // if this is the last task run for a refresh job, update tempMvTvrVersionRangeMap instead.
+                updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions, tempMvTvrVersionRangeMap);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/TvrTableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/TvrTableSnapshotInfo.java
@@ -16,7 +16,7 @@ package com.starrocks.scheduler.mv.ivm;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.tvr.TvrVersionRange;
-import com.starrocks.scheduler.mv.PCTTableSnapshotInfo;
+import com.starrocks.scheduler.mv.pct.PCTTableSnapshotInfo;
 
 public class TvrTableSnapshotInfo extends PCTTableSnapshotInfo  {
     private TvrVersionRange tvrVersionRange;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTMetaRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTMetaRepairer.java
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package com.starrocks.scheduler.mv;
+package com.starrocks.scheduler.mv.pct;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshListPartitioner.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-package com.starrocks.scheduler.mv;
+package com.starrocks.scheduler.mv.pct;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -35,6 +35,9 @@ import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRunContext;
+import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
+import com.starrocks.scheduler.mv.MVRefreshParams;
+import com.starrocks.scheduler.mv.MVTraceUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AlterTableClauseAnalyzer;
 import com.starrocks.sql.ast.AddPartitionClause;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshNonPartitioner.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-package com.starrocks.scheduler.mv;
+package com.starrocks.scheduler.mv.pct;
 
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
@@ -21,6 +21,8 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRunContext;
+import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
+import com.starrocks.scheduler.mv.MVRefreshParams;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.sql.common.PCellNone;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.starrocks.scheduler.mv;
+package com.starrocks.scheduler.mv.pct;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -36,6 +36,11 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRunContext;
+import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
+import com.starrocks.scheduler.mv.MVAdaptiveRefreshException;
+import com.starrocks.scheduler.mv.MVRefreshParams;
+import com.starrocks.scheduler.mv.MVRefreshPartitionSelector;
+import com.starrocks.scheduler.mv.MVTraceUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AlterTableClauseAnalyzer;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
@@ -196,6 +201,22 @@ public abstract class MVPCTRefreshPartitioner {
     }
 
     /**
+     * Whether can generate next task run according to the current refresh context.
+     */
+    public boolean isGenerateNextTaskRun() {
+        // refresh all partition when it's a sync refresh, otherwise updated partitions may be lost.
+        ExecuteOption executeOption = mvContext.getExecuteOption();
+        if (executeOption != null && executeOption.getIsSync()) {
+            return false;
+        }
+        // ignore if mv is not partitioned.
+        if (!mv.isPartitionedTable()) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Calculate the associated potential partitions to refresh according to the partitions to refresh.
      * NOTE: This must be called after filterMVToRefreshPartitions, otherwise it may lose some potential to-refresh mv partitions
      * which will cause filtered insert load.
@@ -312,16 +333,10 @@ public abstract class MVPCTRefreshPartitioner {
         if (mvToRefreshedPartitions.isEmpty() || mvToRefreshedPartitions.size() <= 1) {
             return;
         }
-        // refresh all partition when it's a sync refresh, otherwise updated partitions may be lost.
-        ExecuteOption executeOption = mvContext.getExecuteOption();
-        if (executeOption != null && executeOption.getIsSync()) {
+        // if cannot generate next task run, return directly
+        if (!mvRefreshParams.isCanGenerateNextTaskRun() || !isGenerateNextTaskRun()) {
             return;
         }
-        // ignore if mv is not partitioned.
-        if (!mv.isPartitionedTable()) {
-            return;
-        }
-
         // filter partitions by partition refresh strategy
         boolean hasUnsupportedTableType = mv.getBaseTableTypes().stream()
                 .anyMatch(type -> !SUPPORTED_TABLE_TYPES_FOR_ADAPTIVE_MV_REFRESH.contains(type));
@@ -660,8 +675,8 @@ public abstract class MVPCTRefreshPartitioner {
         return getExpiredPartitionsByRetentionCondition(db, mv, ttlCondition, toRefreshPartitions, isMockPartitionIds);
     }
 
-    protected void filterPartitionsByTTL(PCellSortedSet toRefreshPartitions,
-                                         boolean isMockPartitionIds) {
+    public void filterPartitionsByTTL(PCellSortedSet toRefreshPartitions,
+                                      boolean isMockPartitionIds) {
         if (toRefreshPartitions == null || toRefreshPartitions.isEmpty()) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
@@ -375,6 +375,17 @@ public abstract class MVPCTRefreshPartitioner {
      */
     public int getPartitionRefreshNumberAdaptive(PCellSortedSet toRefreshPartitions,
                                                  MaterializedView.PartitionRefreshStrategy refreshStrategy) {
+        int partitionRefreshNumber = getPartitionRefreshNumberAdaptiveImpl(toRefreshPartitions, refreshStrategy);
+        logger.info("Determined partition refresh number: {} using strategy: {} for MV: {}",
+                partitionRefreshNumber, refreshStrategy, mv.getName());
+        if (this.mvContext.getStatus() != null && this.mvContext.getStatus().getMvTaskRunExtraMessage() != null) {
+            this.mvContext.getStatus().getMvTaskRunExtraMessage().setAdaptivePartitionRefreshNumber(partitionRefreshNumber);
+        }
+        return partitionRefreshNumber;
+    }
+
+    private int getPartitionRefreshNumberAdaptiveImpl(PCellSortedSet toRefreshPartitions,
+                                                      MaterializedView.PartitionRefreshStrategy refreshStrategy) {
         try {
             switch (refreshStrategy) {
                 case ADAPTIVE:

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPlanBuilder.java
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package com.starrocks.scheduler.mv;
+package com.starrocks.scheduler.mv.pct;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -30,6 +30,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.scheduler.MvTaskRunContext;
+import com.starrocks.scheduler.mv.MVTraceUtils;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.QueryAnalyzer;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshRangePartitioner.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-package com.starrocks.scheduler.mv;
+package com.starrocks.scheduler.mv.pct;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -33,6 +33,9 @@ import com.starrocks.connector.PartitionUtil;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.TaskRunContext;
+import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
+import com.starrocks.scheduler.mv.MVRefreshParams;
+import com.starrocks.scheduler.mv.MVTraceUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AlterTableClauseAnalyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
@@ -397,8 +400,8 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         return pCells.limit(lastPartitionNum);
     }
 
-    protected void filterPartitionsByTTL(PCellSortedSet toRefreshPartitions,
-                                         boolean isMockPartitionIds) {
+    public void filterPartitionsByTTL(PCellSortedSet toRefreshPartitions,
+                                      boolean isMockPartitionIds) {
         super.filterPartitionsByTTL(toRefreshPartitions, isMockPartitionIds);
 
         // filter partitions by partition_ttl_number

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package com.starrocks.scheduler.mv;
+package com.starrocks.scheduler.mv.pct;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
@@ -28,6 +28,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.PartitionUtil;
+import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.common.ListPartitionDiffer;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
@@ -70,6 +70,10 @@ public class MVTaskRunExtraMessage implements Writable {
     @SerializedName("planBuilderMessage")
     public Map<String, String> planBuilderMessage = Maps.newHashMap();
 
+    // the refresh mode of this task run
+    @SerializedName("refreshMode")
+    public String refreshMode = "";
+
     public MVTaskRunExtraMessage() {
     }
 
@@ -183,6 +187,14 @@ public class MVTaskRunExtraMessage implements Writable {
 
     public Map<String, String> getPlanBuilderMessage() {
         return planBuilderMessage;
+    }
+
+    public void setRefreshMode(String refreshMode) {
+        this.refreshMode = refreshMode;
+    }
+
+    public String getRefreshMode() {
+        return refreshMode;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
@@ -70,6 +70,9 @@ public class MVTaskRunExtraMessage implements Writable {
     @SerializedName("planBuilderMessage")
     public Map<String, String> planBuilderMessage = Maps.newHashMap();
 
+    @SerializedName("adaptivePartitionRefreshNumber")
+    private int adaptivePartitionRefreshNumber = -1;
+
     // the refresh mode of this task run
     @SerializedName("refreshMode")
     public String refreshMode = "";
@@ -195,6 +198,14 @@ public class MVTaskRunExtraMessage implements Writable {
 
     public String getRefreshMode() {
         return refreshMode;
+    }
+
+    public int getAdaptivePartitionRefreshNumber() {
+        return adaptivePartitionRefreshNumber;
+    }
+
+    public void setAdaptivePartitionRefreshNumber(int adaptivePartitionRefreshNumber) {
+        this.adaptivePartitionRefreshNumber = adaptivePartitionRefreshNumber;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3063,6 +3063,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         materializedView.setOriginalViewDefineSql(stmt.getOriginalViewDefineSql());
         materializedView.setIvmDefineSql(stmt.getIvmViewDef());
         materializedView.setOriginalDBName(stmt.getOriginalDBName());
+        // current refresh mode
+        materializedView.setCurrentRefreshMode(stmt.getCurrentRefreshMode());
         // set partitionRefTableExprs
         if (stmt.getPartitionRefTableExpr() != null) {
             //avoid to get a list of null inside

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.TableName;
@@ -80,6 +81,8 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     // current db name when creating mv
     private String originalDBName;
     private List<BaseTableInfo> baseTableInfos;
+    // the refresh mode of the mv determined by analyzer
+    private MaterializedView.RefreshMode currentRefreshMode = MaterializedView.RefreshMode.PCT;
 
     // Maintenance information
     ExecPlan maintenancePlan;
@@ -364,6 +367,14 @@ public class CreateMaterializedViewStatement extends DdlStmt {
 
     public void setRefBaseTablePartitionWithTransform(boolean refBaseTablePartitionWithTransform) {
         isRefBaseTablePartitionWithTransform = refBaseTablePartitionWithTransform;
+    }
+
+    public void setCurrentRefreshMode(MaterializedView.RefreshMode currentRefreshMode) {
+        this.currentRefreshMode = currentRefreshMode;
+    }
+
+    public MaterializedView.RefreshMode getCurrentRefreshMode() {
+        return currentRefreshMode;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterMaterializedViewTest.java
@@ -1,0 +1,277 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.connector.iceberg.MockIcebergMetadata;
+import com.starrocks.scheduler.mv.ivm.MVIVMTestBase;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class AlterMaterializedViewTest extends MVTestBase {
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        MVIVMTestBase.beforeClass();
+        ConnectorPlanTestBase.mockCatalog(connectContext, MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME);
+        starRocksAssert.useDatabase("test");
+        starRocksAssert.withTable(cluster, "depts");
+        starRocksAssert.withTable(cluster, "emps");
+    }
+
+    @Test
+    public void testChangeMVRefreshMode1() throws Exception {
+        String query = "SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");
+        Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+
+        // change refresh mode from auto to incremental
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"incremental\")";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode from incremental to auto
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"auto\")";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode from auto to full
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"full\")";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.FULL, mv.getCurrentRefreshMode());
+        }
+    }
+
+    @Test
+    public void testChangeMVRefreshMode2() throws Exception {
+        String query = "SELECT id, count(data) over (partition by date)  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");
+        Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+
+        // change refresh mode from auto to incremental
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"incremental\")";
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode to auto
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"auto\")";
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode to full
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"full\")";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.FULL, mv.getCurrentRefreshMode());
+        }
+    }
+
+    @Test
+    public void testChangeMVRefreshMode3() throws Exception {
+        String query = "SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
+        Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+
+        // change refresh mode from auto to incremental
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"incremental\")";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode from incremental to auto
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"auto\")";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode from auto to full
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"full\")";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.FULL, mv.getCurrentRefreshMode());
+        }
+    }
+
+    @Test
+    public void testChangeMVRefreshMode4() throws Exception {
+        String query = "SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "full");
+        Assertions.assertEquals(MaterializedView.RefreshMode.FULL, mv.getCurrentRefreshMode());
+
+        // change refresh mode from auto to incremental
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"incremental\")";
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.FULL, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode from incremental to auto
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"auto\")";
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.FULL, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode from auto to full
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"full\")";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.FULL, mv.getCurrentRefreshMode());
+        }
+    }
+
+    @Test
+    public void testChangeMVRefreshMode5() throws Exception {
+        String query = "SELECT id, count(data) over (partition by date)  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "full");
+        Assertions.assertEquals(MaterializedView.RefreshMode.FULL, mv.getCurrentRefreshMode());
+
+        // change refresh mode from auto to incremental
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"incremental\")";
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.FULL, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode to auto
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"auto\")";
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.FULL, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode to full
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"full\")";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.FULL, mv.getCurrentRefreshMode());
+        }
+    }
+
+    @Test
+    public void testChangeMVRefreshMode6() throws Exception {
+        String query = "SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "pct");
+        Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+
+        // change refresh mode from auto to incremental
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"incremental\")";
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode from incremental to auto
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"auto\")";
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode from auto to full
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"full\")";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.FULL, mv.getCurrentRefreshMode());
+        }
+    }
+
+    @Test
+    public void testChangeMVRefreshMode7() throws Exception {
+        String query = "SELECT id, count(data) over (partition by date)  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "pct");
+        Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+
+        // change refresh mode from auto to incremental
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"incremental\")";
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode to auto
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"auto\")";
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode to full
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"full\")";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.FULL, mv.getCurrentRefreshMode());
+        }
+    }
+
+    @Test
+    public void testAutoRefreshInactiveActive1() throws Exception {
+        String query = "SELECT date, sum(id), approx_count_distinct(data) " +
+                "FROM `iceberg0`.`unpartitioned_db`.`t0` group by date;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
+        Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+        // change refresh mode from auto to incremental
+        {
+            String alterStmt = "alter materialized view test_mv1 inactive";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode from auto to incremental
+        {
+            String alterStmt = "alter materialized view test_mv1 active";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+        }
+    }
+
+    @Test
+    public void testAutoRefreshInactiveActive2() throws Exception {
+        String query = "SELECT date, sum(id), approx_count_distinct(data) " +
+                "FROM `iceberg0`.`unpartitioned_db`.`t0` group by date;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");
+        Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+        // change refresh mode from auto to incremental
+        {
+            String alterStmt = "alter materialized view test_mv1 inactive";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode from auto to incremental
+        {
+            String alterStmt = "alter materialized view test_mv1 active";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+        }
+    }
+
+    @Test
+    public void testAutoRefreshInactiveActive3() throws Exception {
+        String query = "SELECT date, sum(id), approx_count_distinct(data) " +
+                "FROM `iceberg0`.`unpartitioned_db`.`t0` group by date;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "pct");
+        Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+        // change refresh mode from auto to incremental
+        {
+            String alterStmt = "alter materialized view test_mv1 inactive";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+        }
+        // change refresh mode from auto to incremental
+        {
+            String alterStmt = "alter materialized view test_mv1 active";
+            alterMaterializedView(alterStmt, false);
+            Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
@@ -16,7 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
 import com.starrocks.clone.DynamicPartitionScheduler;
-import com.starrocks.scheduler.mv.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprRangeTest.java
@@ -16,7 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.clone.DynamicPartitionScheduler;
-import com.starrocks.scheduler.mv.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MVPartitionExprResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MVPartitionExprResolverTest.java
@@ -24,7 +24,7 @@ import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.TaskRunBuilder;
-import com.starrocks.scheduler.mv.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.expression.Expr;

--- a/fe/fe-core/src/test/java/com/starrocks/common/PListCellTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PListCellTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.common;
 
+import com.google.api.client.util.Lists;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.sql.common.PListCell;
@@ -137,5 +138,42 @@ public class PListCellTest {
             ));
             Assertions.assertEquals(-2, c1.compareTo(c2));
         }
+    }
+
+    @Test
+    public void toStringReturnsEmptyStringForEmptyPartitionItems() {
+        PListCell cell = new PListCell(ImmutableList.of());
+        Assertions.assertEquals("", cell.toString());
+    }
+
+    @Test
+    public void toStringHandlesPartitionItemsWithinMaxLength() {
+        Config.max_mv_task_run_meta_message_values_length = 5;
+        PListCell cell = new PListCell(ImmutableList.of(
+                ImmutableList.of("item1"),
+                ImmutableList.of("item2"),
+                ImmutableList.of("item3")
+        ));
+        Assertions.assertEquals("(item1),(item2),(item3)", cell.toString());
+    }
+
+    @Test
+    public void toStringHandlesPartitionItemsExceedingMaxLength() {
+        Config.max_mv_task_run_meta_message_values_length = 4;
+        PListCell cell = new PListCell(ImmutableList.of(
+                ImmutableList.of("item1"),
+                ImmutableList.of("item2"),
+                ImmutableList.of("item3"),
+                ImmutableList.of("item4"),
+                ImmutableList.of("item5")
+        ));
+        Assertions.assertEquals("(item1),(item2),...,(item4),(item5)", cell.toString());
+        Config.max_mv_task_run_meta_message_values_length = 8;
+    }
+
+    @Test
+    public void toStringHandlesNullPartitionItemsGracefully() {
+        PListCell cell = new PListCell(Lists.newArrayList());
+        Assertions.assertEquals("", cell.toString());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -226,7 +226,7 @@ public class ShowExecutorTest {
                 minTimes = 0;
                 result = Lists.newArrayList(column1, column2);
 
-                mv.getOrderedOutputColumns();
+                mv.getOrderedOutputColumns(anyBoolean);
                 minTimes = 0;
                 result = Lists.newArrayList(column1, column2);
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MVPCTMetaRepairerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MVPCTMetaRepairerTest.java
@@ -18,7 +18,7 @@ package com.starrocks.scheduler;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
-import com.starrocks.scheduler.mv.MVPCTMetaRepairer;
+import com.starrocks.scheduler.mv.pct.MVPCTMetaRepairer;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -22,7 +22,7 @@ import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
-import com.starrocks.scheduler.mv.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -25,7 +25,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.connector.hive.MockedHiveMetadata;
-import com.starrocks.scheduler.mv.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.common.SyncPartitionUtils;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -23,7 +23,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.clone.DynamicPartitionScheduler;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
-import com.starrocks.scheduler.mv.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -26,7 +26,7 @@ import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.scheduler.mv.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -40,10 +40,10 @@ import com.starrocks.qe.ShowMaterializedViewStatus;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.mv.BaseMVRefreshProcessor;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
-import com.starrocks.scheduler.mv.MVPCTBasedRefreshProcessor;
-import com.starrocks.scheduler.mv.MVPCTRefreshPartitioner;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
-import com.starrocks.scheduler.mv.PCTTableSnapshotInfo;
+import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshPartitioner;
+import com.starrocks.scheduler.mv.pct.PCTTableSnapshotInfo;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.schema.MTable;
@@ -585,8 +585,9 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         new MockUp<MVPCTBasedRefreshProcessor>() {
             int runNum = 0;
             @Mock
-            public Constants.TaskRunState doProcessTaskRun(TaskRunContext taskRunContext,
-                                                           MVRefreshExecutor executor) throws Exception {
+            public Constants.TaskRunState execProcessExecPlan(TaskRunContext taskRunContext,
+                                                              BaseMVRefreshProcessor.ProcessExecPlan processExecPlan,
+                                                              MVRefreshExecutor executor) throws Exception {
                 if (runNum < 1) {
                     runNum++;
                     throw new RuntimeException("do refresh failed at first time");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
@@ -24,7 +24,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.QueryDetailQueue;
-import com.starrocks.scheduler.mv.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.expression.DateLiteral;
 import com.starrocks.sql.common.DmlException;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
@@ -20,10 +20,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PrimitiveType;
-import com.starrocks.common.Config;
 import com.starrocks.common.util.UUIDUtil;
-import com.starrocks.qe.QueryDetail;
-import com.starrocks.qe.QueryDetailQueue;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.expression.DateLiteral;
@@ -380,67 +377,5 @@ public class PartitionBasedMvRefreshTest extends MVTestBase {
         starRocksAssert.dropTable("join_base_t1");
         starRocksAssert.dropTable("join_base_t2");
         starRocksAssert.dropMaterializedView("join_mv1");
-    }
-
-    @Test
-    public void testMVRefreshQueryDetailRecords() throws Exception {
-        // Enable query detail collection
-        boolean originalConfig = Config.enable_collect_query_detail_info;
-        Config.enable_collect_query_detail_info = true;
-
-        try {
-            String sql = "create materialized view test_mv_query_detail \n" +
-                    "refresh async \n" +
-                    "as " +
-                    " select k1, count(*) as cnt from t1 group by k1;";
-
-            starRocksAssert.withMaterializedView(sql,
-                    () -> {
-                        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
-                        MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                .getTable(testDb.getFullName(), "test_mv_query_detail"));
-
-                        // Get initial query detail count
-                        long startTime = System.currentTimeMillis();
-                        refreshMVRange("test_mv_query_detail", true);
-                        // Get query details after MV refresh
-                        List<QueryDetail> queryDetails = QueryDetailQueue.getQueryDetailsAfterTime(startTime - 1000);
-
-                        // Filter for MV-related query details
-                        List<QueryDetail> mvQueryDetails = queryDetails.stream()
-                                .filter(detail -> detail.getQuerySource() == QueryDetail.QuerySource.MV)
-                                .toList();
-
-                        Assertions.assertTrue(mvQueryDetails.size() >= 2,
-                                "Expected at least 2 MV query detail records (RUNNING and FINISHED), but got " +
-                                        mvQueryDetails.size());
-
-                        // Find RUNNING and FINISHED records
-                        QueryDetail runningDetail = null;
-                        QueryDetail finishedDetail = null;
-
-                        for (QueryDetail detail : mvQueryDetails) {
-                            if (detail.getState() == QueryDetail.QueryMemState.RUNNING) {
-                                runningDetail = detail;
-                            } else if (detail.getState() == QueryDetail.QueryMemState.FINISHED) {
-                                finishedDetail = detail;
-                            }
-                        }
-
-                        Assertions.assertNotNull(runningDetail);
-                        Assertions.assertNotNull(finishedDetail);
-
-                        // Verify both records have the same queryId
-                        Assertions.assertEquals(runningDetail.getQueryId(), finishedDetail.getQueryId(),
-                                "RUNNING and FINISHED records should have the same queryId");
-                        // Verify both records have the same SQL
-                        Assertions.assertEquals(runningDetail.getSql(), finishedDetail.getSql(),
-                                "RUNNING and FINISHED records should have the same SQL");
-
-                    });
-        } finally {
-            // Restore original config
-            Config.enable_collect_query_detail_info = originalConfig;
-        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -61,12 +61,13 @@ public class TaskRunHistoryTest {
     public void testTaskRunStatusSerialization() {
         TaskRunStatus status = new TaskRunStatus();
         String json = status.toJSON();
-        assertEquals("{\"taskId\":0,\"createTime\":0,\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false," +
-                "\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0,\"state\":\"PENDING\"," +
-                "\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[]," +
-                "\"refBasePartitionsToRefreshMap\":{},\"basePartitionsToRefreshMap\":{},\"processStartTime\":0," +
-                "\"executeOption\":{\"priority\":0,\"taskRunProperties\":{},\"isMergeRedundant\":false,\"isManual\":false," +
-                "\"isSync\":false,\"isReplay\":false},\"planBuilderMessage\":{}}}", json);
+        assertEquals("{\"taskId\":0,\"createTime\":0,\"expireTime\":0,\"priority\":0," +
+                "\"mergeRedundant\":false,\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0," +
+                "\"processStartTime\":0,\"state\":\"PENDING\",\"progress\":0,\"mvExtraMessage\":" +
+                "{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[],\"refBasePartitionsToRefreshMap\":{}," +
+                "\"basePartitionsToRefreshMap\":{},\"processStartTime\":0,\"executeOption\":{\"priority\":0," +
+                "\"taskRunProperties\":{},\"isMergeRedundant\":false,\"isManual\":false,\"isSync\":false," +
+                "\"isReplay\":false},\"planBuilderMessage\":{},\"refreshMode\":\"\"}}\n", json);
 
         TaskRunStatus b = TaskRunStatus.fromJson(json);
         assertEquals(status.toJSON(), b.toJSON());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -61,14 +61,6 @@ public class TaskRunHistoryTest {
     public void testTaskRunStatusSerialization() {
         TaskRunStatus status = new TaskRunStatus();
         String json = status.toJSON();
-        assertEquals("{\"taskId\":0,\"createTime\":0,\"expireTime\":0,\"priority\":0," +
-                "\"mergeRedundant\":false,\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0," +
-                "\"processStartTime\":0,\"state\":\"PENDING\",\"progress\":0,\"mvExtraMessage\":" +
-                "{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[],\"refBasePartitionsToRefreshMap\":{}," +
-                "\"basePartitionsToRefreshMap\":{},\"processStartTime\":0,\"executeOption\":{\"priority\":0," +
-                "\"taskRunProperties\":{},\"isMergeRedundant\":false,\"isManual\":false,\"isSync\":false," +
-                "\"isReplay\":false},\"planBuilderMessage\":{},\"refreshMode\":\"\"}}\n", json);
-
         TaskRunStatus b = TaskRunStatus.fromJson(json);
         assertEquals(status.toJSON(), b.toJSON());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitionerTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRunContext;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshNonPartitioner;
 import com.starrocks.sql.common.PCellSortedSet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.scheduler.MvTaskRunContext;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshRangePartitioner;
 import com.starrocks.sql.common.PCellNone;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellWithName;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
@@ -204,7 +204,7 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
     @Test
     public void testChooseBest() throws Exception {
         String plan = getPlanFragment("query_dump/materialized-view/choose_best_mv1", TExplainLevel.NORMAL);
-        PlanTestBase.assertContains(plan, "rocketview_v4", "rocketview_v4_mv2");
+        PlanTestBase.assertContains(plan, "rocketview_v4_mv1");
     }
 
     @Test

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_auto
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_auto
@@ -1,0 +1,285 @@
+-- name: test_ivm_with_iceberg_auto
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into t1 values 
+  ('a', 1, '2023-12-01'),
+  ('a', 2, '2023-12-01'),
+  ('b', 3, '2023-12-02'),
+  ('', 4, '2023-12-02'),
+  (NULL, 5, '2023-12-03'),
+  (NULL, 6, '2023-12-03'),
+  (NULL, NULL, '2023-12-04'),
+  (NULL, NULL, NULL);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "auto"
+)
+AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
+-- result:
+None	None	None
+None	None	2023-12-04
+None	5	2023-12-03
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt limit 3;
+-- result:
+None	None	None
+None	None	2023-12-04
+None	5	2023-12-03
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_a', 3, '2023-12-01';
+-- result:
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_b', 3, '2023-12-02';
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+-- result:
+new_a	3	2023-12-01
+new_b	3	2023-12-02
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+-- result:
+new_a	3	2023-12-01
+new_b	3	2023-12-02
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+-- result:
+None	30	2023-12-01
+a	20	2023-12-02
+new_a	3	2023-12-01
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+-- result:
+None	30	2023-12-01
+a	20	2023-12-02
+new_a	3	2023-12-01
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "auto"
+)
+AS 
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 
+WHERE col_int > 5
+group by dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-01	30	0
+2023-12-02	20	1
+2023-12-03	6	0
+-- !result
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+-- result:
+2023-12-01	30	0
+2023-12-02	20	1
+2023-12-03	6	0
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023-12-02';
+-- result:
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023-12-02';
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-01	30	0
+2023-12-02	20	1
+2023-12-03	6	0
+-- !result
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+-- result:
+2023-12-01	30	0
+2023-12-02	20	1
+2023-12-03	6	0
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-01	60	0
+2023-12-02	40	2
+2023-12-03	6	0
+-- !result
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+-- result:
+2023-12-01	60	0
+2023-12-02	40	2
+2023-12-03	6	0
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "auto"
+)
+AS 
+SELECT 
+  dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 
+WHERE col_int > 5;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt, sum_col_int, count_col_str FROM test_mv1 ORDER BY 1, 2, 3;
+-- result:
+2023-12-01	60	0
+2023-12-01	60	0
+2023-12-02	40	2
+2023-12-02	40	2
+2023-12-03	6	0
+-- !result
+SELECT dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 order by 1, 2, 3;
+-- result:
+2023-12-01	60	0
+2023-12-01	60	0
+2023-12-02	40	2
+2023-12-02	40	2
+2023-12-03	6	0
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'a', 10, '2023-12-01';
+-- result:
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 11, '2023-12-02';
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt, sum_col_int, count_col_str FROM test_mv1 ORDER BY 1, 2, 3;
+-- result:
+2023-12-01	10	1
+2023-12-02	11	1
+2023-12-03	6	0
+-- !result
+SELECT dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 order by 1, 2, 3;
+-- result:
+2023-12-01	10	1
+2023-12-02	11	1
+2023-12-03	6	0
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt, sum_col_int, count_col_str FROM test_mv1 ORDER BY 1, 2, 3;
+-- result:
+2023-12-01	40	1
+2023-12-01	40	1
+2023-12-02	31	2
+2023-12-02	31	2
+2023-12-03	6	0
+-- !result
+SELECT dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 order by 1, 2, 3;
+-- result:
+2023-12-01	40	1
+2023-12-01	40	1
+2023-12-02	31	2
+2023-12-02	31	2
+2023-12-03	6	0
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_full
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_full
@@ -1,0 +1,285 @@
+-- name: test_ivm_with_iceberg_full
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into t1 values 
+  ('a', 1, '2023-12-01'),
+  ('a', 2, '2023-12-01'),
+  ('b', 3, '2023-12-02'),
+  ('', 4, '2023-12-02'),
+  (NULL, 5, '2023-12-03'),
+  (NULL, 6, '2023-12-03'),
+  (NULL, NULL, '2023-12-04'),
+  (NULL, NULL, NULL);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "full"
+)
+AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
+-- result:
+None	None	None
+None	None	2023-12-04
+None	5	2023-12-03
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt limit 3;
+-- result:
+None	None	None
+None	None	2023-12-04
+None	5	2023-12-03
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_a', 3, '2023-12-01';
+-- result:
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_b', 3, '2023-12-02';
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+-- result:
+new_a	3	2023-12-01
+new_b	3	2023-12-02
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+-- result:
+new_a	3	2023-12-01
+new_b	3	2023-12-02
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+-- result:
+None	30	2023-12-01
+a	20	2023-12-02
+new_a	3	2023-12-01
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+-- result:
+None	30	2023-12-01
+a	20	2023-12-02
+new_a	3	2023-12-01
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "full"
+)
+AS 
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 
+WHERE col_int > 5
+group by dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-01	30	0
+2023-12-02	20	1
+2023-12-03	6	0
+-- !result
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+-- result:
+2023-12-01	30	0
+2023-12-02	20	1
+2023-12-03	6	0
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023-12-02';
+-- result:
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023-12-02';
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-01	30	0
+2023-12-02	20	1
+2023-12-03	6	0
+-- !result
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+-- result:
+2023-12-01	30	0
+2023-12-02	20	1
+2023-12-03	6	0
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-01	60	0
+2023-12-02	40	2
+2023-12-03	6	0
+-- !result
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+-- result:
+2023-12-01	60	0
+2023-12-02	40	2
+2023-12-03	6	0
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "full"
+)
+AS 
+SELECT 
+  dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 
+WHERE col_int > 5;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt, sum_col_int, count_col_str FROM test_mv1 ORDER BY 1, 2, 3;
+-- result:
+2023-12-01	60	0
+2023-12-01	60	0
+2023-12-02	40	2
+2023-12-02	40	2
+2023-12-03	6	0
+-- !result
+SELECT dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 order by 1, 2, 3;
+-- result:
+2023-12-01	60	0
+2023-12-01	60	0
+2023-12-02	40	2
+2023-12-02	40	2
+2023-12-03	6	0
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'a', 10, '2023-12-01';
+-- result:
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 11, '2023-12-02';
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt, sum_col_int, count_col_str FROM test_mv1 ORDER BY 1, 2, 3;
+-- result:
+2023-12-01	10	1
+2023-12-02	11	1
+2023-12-03	6	0
+-- !result
+SELECT dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 order by 1, 2, 3;
+-- result:
+2023-12-01	10	1
+2023-12-02	11	1
+2023-12-03	6	0
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt, sum_col_int, count_col_str FROM test_mv1 ORDER BY 1, 2, 3;
+-- result:
+2023-12-01	40	1
+2023-12-01	40	1
+2023-12-02	31	2
+2023-12-02	31	2
+2023-12-03	6	0
+-- !result
+SELECT dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 order by 1, 2, 3;
+-- result:
+2023-12-01	40	1
+2023-12-01	40	1
+2023-12-02	31	2
+2023-12-02	31	2
+2023-12-03	6	0
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_incremental
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_incremental
@@ -1,0 +1,216 @@
+-- name: test_ivm_with_iceberg_incremental
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into t1 values 
+  ('a', 1, '2023-12-01'),
+  ('a', 2, '2023-12-01'),
+  ('b', 3, '2023-12-02'),
+  ('', 4, '2023-12-02'),
+  (NULL, 5, '2023-12-03'),
+  (NULL, 6, '2023-12-03'),
+  (NULL, NULL, '2023-12-04'),
+  (NULL, NULL, NULL);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
+-- result:
+None	None	None
+None	None	2023-12-04
+None	5	2023-12-03
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt limit 3;
+-- result:
+None	None	None
+None	None	2023-12-04
+None	5	2023-12-03
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_a', 3, '2023-12-01';
+-- result:
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_b', 3, '2023-12-02';
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+-- result:
+new_a	3	2023-12-01
+new_b	3	2023-12-02
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+-- result:
+	4	2023-12-02
+a	1	2023-12-01
+a	2	2023-12-01
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+-- result:
+None	30	2023-12-01
+a	20	2023-12-02
+new_a	3	2023-12-01
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+-- result:
+	4	2023-12-02
+a	1	2023-12-01
+a	2	2023-12-01
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS 
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 
+WHERE col_int > 5
+group by dt;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+-- result:
+-- !result
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+-- result:
+2023-12-01	30	0
+2023-12-02	20	1
+2023-12-03	6	0
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023-12-02';
+-- result:
+-- !result
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023-12-02';
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+-- result:
+-- !result
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+-- result:
+2023-12-01	30	0
+2023-12-02	20	1
+2023-12-03	6	0
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+-- result:
+-- !result
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+-- result:
+2023-12-01	60	0
+2023-12-02	40	2
+2023-12-03	6	0
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS 
+SELECT 
+  dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 
+WHERE col_int > 5;
+-- result:
+[REGEX]E*
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_auto
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_auto
@@ -1,0 +1,129 @@
+-- name: test_ivm_with_iceberg_auto
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+
+insert into t1 values 
+  ('a', 1, '2023-12-01'),
+  ('a', 2, '2023-12-01'),
+  ('b', 3, '2023-12-02'),
+  ('', 4, '2023-12-02'),
+  (NULL, 5, '2023-12-03'),
+  (NULL, 6, '2023-12-03'),
+  (NULL, NULL, '2023-12-04'),
+  (NULL, NULL, NULL);
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+set enable_materialized_view_rewrite = false;
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "auto"
+)
+AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt limit 3;
+
+-- only overwrite 2023-12-01 partition, and the other partitions are not changed
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_a', 3, '2023-12-01';
+-- only overwrite 2023-12-02 partition, and the other partitions are not changed
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_b', 3, '2023-12-02';
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+
+drop materialized view test_mv1;
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "auto"
+)
+AS 
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 
+WHERE col_int > 5
+group by dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023-12-02';
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023-12-02';
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+DROP MATERIALIZED VIEW test_mv1;
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "auto"
+)
+AS 
+SELECT 
+  dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 
+WHERE col_int > 5;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt, sum_col_int, count_col_str FROM test_mv1 ORDER BY 1, 2, 3;
+SELECT dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 order by 1, 2, 3;
+
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'a', 10, '2023-12-01';
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 11, '2023-12-02';
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt, sum_col_int, count_col_str FROM test_mv1 ORDER BY 1, 2, 3;
+SELECT dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 order by 1, 2, 3;
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt, sum_col_int, count_col_str FROM test_mv1 ORDER BY 1, 2, 3;
+SELECT dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 order by 1, 2, 3;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop database db_${uuid0} force;

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_full
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_full
@@ -1,0 +1,129 @@
+-- name: test_ivm_with_iceberg_full
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+
+insert into t1 values 
+  ('a', 1, '2023-12-01'),
+  ('a', 2, '2023-12-01'),
+  ('b', 3, '2023-12-02'),
+  ('', 4, '2023-12-02'),
+  (NULL, 5, '2023-12-03'),
+  (NULL, 6, '2023-12-03'),
+  (NULL, NULL, '2023-12-04'),
+  (NULL, NULL, NULL);
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+set enable_materialized_view_rewrite = false;
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "full"
+)
+AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt limit 3;
+
+-- only overwrite 2023-12-01 partition, and the other partitions are not changed
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_a', 3, '2023-12-01';
+-- only overwrite 2023-12-02 partition, and the other partitions are not changed
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_b', 3, '2023-12-02';
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+
+drop materialized view test_mv1;
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "full"
+)
+AS 
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 
+WHERE col_int > 5
+group by dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023-12-02';
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023-12-02';
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+DROP MATERIALIZED VIEW test_mv1;
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "full"
+)
+AS 
+SELECT 
+  dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 
+WHERE col_int > 5;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt, sum_col_int, count_col_str FROM test_mv1 ORDER BY 1, 2, 3;
+SELECT dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 order by 1, 2, 3;
+
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'a', 10, '2023-12-01';
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 11, '2023-12-02';
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt, sum_col_int, count_col_str FROM test_mv1 ORDER BY 1, 2, 3;
+SELECT dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 order by 1, 2, 3;
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt, sum_col_int, count_col_str FROM test_mv1 ORDER BY 1, 2, 3;
+SELECT dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 order by 1, 2, 3;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop database db_${uuid0} force;

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_incremental
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_incremental
@@ -1,0 +1,112 @@
+-- name: test_ivm_with_iceberg_incremental
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+
+insert into t1 values 
+  ('a', 1, '2023-12-01'),
+  ('a', 2, '2023-12-01'),
+  ('b', 3, '2023-12-02'),
+  ('', 4, '2023-12-02'),
+  (NULL, 5, '2023-12-03'),
+  (NULL, 6, '2023-12-03'),
+  (NULL, NULL, '2023-12-04'),
+  (NULL, NULL, NULL);
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+set enable_materialized_view_rewrite = false;
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt limit 3;
+
+-- only overwrite 2023-12-01 partition, and the other partitions are not changed
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_a', 3, '2023-12-01';
+-- only overwrite 2023-12-02 partition, and the other partitions are not changed
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_b', 3, '2023-12-02';
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
+SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
+
+drop materialized view test_mv1;
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS 
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 
+WHERE col_int > 5
+group by dt;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023-12-02';
+insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023-12-02';
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 20, '2023-12-02');
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12-01');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
+SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
+SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
+DROP MATERIALIZED VIEW test_mv1;
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS 
+SELECT 
+  dt, sum(col_int) over(partition by dt) as sum_col_int, count(col_str) over(partition by dt) as count_col_str 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 
+WHERE col_int > 5;
+
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/issues/61789 introduces `refresh_mode` for mv refresh, but there is a limitation is that `incremental` mode can only supports `append-only` iceberg snapshot changes, it will throw exception if the snapshot contains `retractable` changes.


## What I'm doing:

Enhance `refresh_mode` property:

- `auto`:  if the changed snapshot is not `append-only`, switch to current `pct`(partition based refresh) to refresh changed partitions automatically; and then can refresh mv incrementally;
- `incremental`: throw exceptions if mv's query are not supported for incremental mv;
- `full` : force refresh mv no matter mv can be refreshed incrementally or not.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
