### PR TITLE
[BugFix] window function with ignore-nulls-flag can not be consolidated with its counterpart without ignore-nulls-flag (backport #63958)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
@@ -219,7 +219,8 @@ public class AnalyticExpr extends Expr {
                 Objects.equals(partitionHint, o.partitionHint) &&
                 Objects.equals(skewHint, o.skewHint) &&
                 Objects.equals(useHashBasedPartition, o.useHashBasedPartition) &&
-                Objects.equals(isSkewed, o.isSkewed);
+                Objects.equals(isSkewed, o.isSkewed) &&
+                Objects.equals(fnCall.getIgnoreNulls(), o.fnCall.getIgnoreNulls());
     }
 
     /**


### PR DESCRIPTION
(cherry picked from commit 0ff8217aa9741482b68659d789d8af5065334846)
cp #63958 

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


