### PR TITLE
[BugFix] window function with ignore-nulls-flag can not be consolidated with its counterpart without ignore-nulls-flag (backport #63958)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
@@ -219,7 +219,8 @@ public class AnalyticExpr extends Expr {
                 Objects.equals(partitionHint, o.partitionHint) &&
                 Objects.equals(skewHint, o.skewHint) &&
                 Objects.equals(useHashBasedPartition, o.useHashBasedPartition) &&
-                Objects.equals(isSkewed, o.isSkewed);
+                Objects.equals(isSkewed, o.isSkewed) &&
+                Objects.equals(fnCall.getIgnoreNulls(), o.fnCall.getIgnoreNulls());
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -15,15 +15,44 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
+import com.starrocks.planner.AnalyticEvalNode;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.utframe.StarRocksAssert;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WindowTest extends PlanTestBase {
 
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withTable("CREATE TABLE `s1` (    \n" +
+                "  `v1` bigint(20) NULL COMMENT \"\",    \n" +
+                "  `v2` int(11) NULL COMMENT \"\",    \n" +
+                "  `a1` array<varchar(65533)> NULL COMMENT \"\",    \n" +
+                "  `a2` array<varchar(65533)> NULL COMMENT \"\"    \n" +
+                ") ENGINE=OLAP    \n" +
+                "DUPLICATE KEY(`v1`)    \n" +
+                "COMMENT \"OLAP\"    \n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 10    \n" +
+                "PROPERTIES (    \n" +
+                "\"replication_num\" = \"1\",       \n" +
+                "\"in_memory\" = \"false\",    \n" +
+                "\"enable_persistent_index\" = \"true\",    \n" +
+                "\"replicated_storage\" = \"false\",    \n" +
+                "\"light_schema_change\" = \"true\",    \n" +
+                "\"compression\" = \"LZ4\"    \n" +
+                ");");
+    }
+    
     @Test
     public void testLagWindowFunction() throws Exception {
         String sql = "select lag(id_datetime, 1, '2020-01-01') over(partition by t1c) from test_all_type;";
@@ -1640,5 +1669,37 @@ public class WindowTest extends PlanTestBase {
                         " rows between unbounded PRECEDING and unbounded following) from t0";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "window: ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING");
+    }
+
+    @Test
+    public void testFirstValueIgnoreNullsAndFirstValueMerging() throws Exception {
+
+        String sql = "select  \n" +
+                "  v1, v2,\n" +
+                "  first_value(v2 ignore nulls) over(order by v1, v2),\n" +
+                "  first_value(v2) over(order by v1, v2)\n" +
+                "from s1;";
+
+        ExecPlan execPlan = getExecPlan(sql);
+        List<AnalyticEvalNode> analyticNodes = new ArrayList<>();
+        execPlan.getTopFragment().getPlanRoot().collect(AnalyticEvalNode.class, analyticNodes);
+        Assertions.assertFalse(analyticNodes.isEmpty());
+        Assertions.assertEquals(analyticNodes.get(0).getAnalyticFnCalls().size(), 2);
+        Assertions.assertTrue(analyticNodes.get(0).getAnalyticFnCalls().get(0).getIgnoreNulls());
+        Assertions.assertFalse(analyticNodes.get(0).getAnalyticFnCalls().get(1).getIgnoreNulls());
+    }
+
+    @Test
+    public void testFirstValueValueRange() throws Exception {
+
+        String sql = "select v1,v2,v3,\n" +
+                "      first_value(v3 ignore nulls) \n" +
+                "      \tover(partition by v1 order by v2 range between UNBOUNDED preceding and current row)\n" +
+                "from t0;";
+
+        ExecPlan execPlan = getExecPlan(sql);
+        List<AnalyticEvalNode> analyticNodes = new ArrayList<>();
+        execPlan.getTopFragment().getPlanRoot().collect(AnalyticEvalNode.class, analyticNodes);
+        Assertions.assertFalse(analyticNodes.isEmpty());
     }
 }


### PR DESCRIPTION
(cherry picked from commit 0ff8217aa9741482b68659d789d8af5065334846)
cp #63958 

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


