### PR TITLE
[Enhancement] add iceberg metadata table cache switch

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -95,11 +95,12 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         this.delegate = delegate;
         this.icebergProperties = icebergProperties;
         boolean enableCache = icebergProperties.isEnableIcebergMetadataCache();
+        boolean enableTableCache = icebergProperties.isEnableIcebergTableCache();
         this.databases = newCacheBuilder(icebergProperties.getIcebergMetaCacheTtlSec(), NEVER_CACHE,
                 enableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE).build();
         this.tables = newCacheBuilder(icebergProperties.getIcebergMetaCacheTtlSec(),
                 icebergProperties.getIcebergTableCacheRefreshIntervalSec(),
-                enableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE)
+                enableTableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE)
                 .removalListener((RemovalNotification<IcebergTableCacheKey, Table> n) -> {
                     LOG.debug("iceberg table cache removal: {}.{}, cause={}, evicted={}",
                             n.getKey().icebergTableName.dbName, n.getKey().icebergTableName.tableName,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
@@ -33,6 +33,7 @@ public class IcebergCatalogProperties {
     public static final String HIVE_METASTORE_TIMEOUT = "hive.metastore.timeout";
     public static final String ICEBERG_CUSTOM_PROPERTIES_PREFIX = "iceberg.catalog.";
     public static final String ENABLE_ICEBERG_METADATA_CACHE = "enable_iceberg_metadata_cache";
+    public static final String ENABLE_ICEBERG_TABLE_CACHE = "enable_iceberg_table_cache";
     public static final String ICEBERG_META_CACHE_TTL = "iceberg_meta_cache_ttl_sec"; // implicit for user
     public static final String ICEBERG_TABLE_CACHE_REFRESH_INVERVAL_SEC = "iceberg_table_cache_refresh_interval_sec";
     public static final String ICEBERG_JOB_PLANNING_THREAD_NUM = "iceberg_job_planning_thread_num";
@@ -55,6 +56,7 @@ public class IcebergCatalogProperties {
     private final Map<String, String> properties;
     private IcebergCatalogType catalogType;
     private boolean enableIcebergMetadataCache;
+    private boolean enableIcebergTableCache;
     private long icebergMetaCacheTtlSec;
     private int icebergJobPlanningThreadNum;
     private int backgroundIcebergJobPlanningThreadNum;
@@ -94,6 +96,7 @@ public class IcebergCatalogProperties {
 
     private void initIcebergMetadataCache() {
         this.enableIcebergMetadataCache = PropertyUtil.propertyAsBoolean(properties, ENABLE_ICEBERG_METADATA_CACHE, true);
+        this.enableIcebergTableCache = PropertyUtil.propertyAsBoolean(properties, ENABLE_ICEBERG_TABLE_CACHE, true);
 
         // one day default, for all meta including tables.
         this.icebergMetaCacheTtlSec = PropertyUtil.propertyAsLong(properties, ICEBERG_META_CACHE_TTL, 24L * 60 * 60); 
@@ -133,6 +136,14 @@ public class IcebergCatalogProperties {
         return catalogType;
     }
 
+    public boolean enableIcebergMetadataCache() {
+        return enableIcebergMetadataCache;
+    }
+
+    public boolean enableIcebergTableCache() {
+        return enableIcebergTableCache;
+    }
+
     public long getIcebergMetaCacheTtlSec() {
         return icebergMetaCacheTtlSec;
     }
@@ -159,6 +170,10 @@ public class IcebergCatalogProperties {
 
     public boolean isEnableIcebergMetadataCache() {
         return enableIcebergMetadataCache;
+    }
+
+    public boolean isEnableIcebergTableCache() {
+        return enableIcebergTableCache;
     }
 
     public double getIcebergDataFileCacheMemoryUsageRatio() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -23,6 +23,7 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mocked;
+import mockit.Verifications;
 import org.apache.iceberg.Table;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.HIVE_METASTORE_URIS;
@@ -168,6 +170,95 @@ public class CachingIcebergCatalogTest {
         // Second call - should hit delegate again because cache was invalidated
         Table t2 = cachingIcebergCatalog.getTable(connectContext, "db1", "tbl1");
         Assertions.assertEquals(nativeTable, t2);
+    }
+
+    @Test
+    public void testTableCacheEnabled_hitsDelegateOnce(@Mocked IcebergCatalog delegate,
+                                                       @Mocked IcebergCatalogProperties props,
+                                                       @Mocked ConnectContext ctx,
+                                                       @Mocked org.apache.iceberg.Table nativeTable) throws Exception {
+        new Expectations() {
+            {
+                props.isEnableIcebergMetadataCache(); 
+                result = true;
+                props.isEnableIcebergTableCache(); 
+                result = true;
+                props.getIcebergMetaCacheTtlSec(); 
+                result = 24L * 60 * 60;
+                props.getIcebergDataFileCacheMemoryUsageRatio(); 
+                result = 0.0;
+                props.getIcebergDeleteFileCacheMemoryUsageRatio(); 
+                result = 0.0;
+
+                delegate.getTable(ctx, "db1", "t1"); 
+                result = nativeTable; 
+                minTimes = 0;
+            }
+        };
+
+        ExecutorService es = Executors.newFixedThreadPool(5);
+        try {
+            CachingIcebergCatalog catalog =
+                    new CachingIcebergCatalog("iceberg0", delegate, props, es);
+
+            org.apache.iceberg.Table r1 = catalog.getTable(ctx, "db1", "t1");
+            org.apache.iceberg.Table r2 = catalog.getTable(ctx, "db1", "t1");
+
+            org.junit.jupiter.api.Assertions.assertSame(r1, r2);
+
+            new Verifications() {
+                {
+                    delegate.getTable(ctx, "db1", "t1"); 
+                    times = 1;
+                }
+            };
+        } finally {
+            es.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testTableCacheDisabled_hitsDelegateTwice(@Mocked IcebergCatalog delegate,
+                                                         @Mocked IcebergCatalogProperties props,
+                                                         @Mocked ConnectContext ctx,
+                                                         @Mocked org.apache.iceberg.Table nativeTable1,
+                                                         @Mocked org.apache.iceberg.Table nativeTable2) throws Exception {
+        new Expectations() {
+            {
+                props.isEnableIcebergMetadataCache(); 
+                result = true;
+                props.isEnableIcebergTableCache(); 
+                result = false;
+                props.getIcebergMetaCacheTtlSec(); 
+                result = 60;
+                props.getIcebergDataFileCacheMemoryUsageRatio(); 
+                result = 0.0;
+                props.getIcebergDeleteFileCacheMemoryUsageRatio(); 
+                result = 0.0;
+
+                delegate.getTable(ctx, "db1", "t1"); 
+                result = nativeTable1;
+                minTimes = 0;
+            }
+        };
+
+        ExecutorService es = Executors.newFixedThreadPool(5);
+        try {
+            CachingIcebergCatalog catalog =
+                    new CachingIcebergCatalog("iceberg0", delegate, props, es);
+
+            org.apache.iceberg.Table r1 = catalog.getTable(ctx, "db1", "t1");
+            org.apache.iceberg.Table r2 = catalog.getTable(ctx, "db1", "t1");
+
+            new Verifications() {
+                {
+                    delegate.getTable(ctx, "db1", "t1"); 
+                    times = 2;
+                }
+            };
+        } finally {
+            es.shutdownNow();
+        }
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
As the cache ttl becomes implicit, we should have another option to control the cache.
## What I'm doing:
Add a new catalog property for iceberg: `enable_iceberg_table_cache`
If we turn off the `enable_iceberg_table_cache`, we can read the newest data from the table.
```
CREATE EXTERNAL CATALOG 'iceberg' 
PROPERTIES  
(  
"type"="iceberg",  
"iceberg.catalog.type"="rest",  
"iceberg.catalog.uri"="http://x",  
"iceberg.catalog.warehouse"="warehouse",
"enable_iceberg_table_cache"="false",
...
);


mysql> select * from t1;
+------+
| c1   |
+------+
|    1 |
+------+
1 row in set (0.05 sec)

spark-sql (test)> insert into t1 values(2);
Time taken: 2.934 seconds

mysql> select * from t1;
+------+
| c1   |
+------+
|    1 |
|    2 |
+------+
2 rows in set (0.08 sec)

spark-sql (test)> insert into t1 values(3);
Time taken: 0.238 seconds

mysql> select * from t1;
+------+
| c1   |
+------+
|    3 |
|    1 |
|    2 |
+------+
3 rows in set (0.05 sec)

mysql> 
```
Otherwise, the logic is kept the same as before.
```
CREATE EXTERNAL CATALOG 'iceberg' 
PROPERTIES  
(  
"type"="iceberg",  
"iceberg.catalog.type"="rest",  
"iceberg.catalog.uri"="http://x",  
"iceberg.catalog.warehouse"="warehouse",
...
);

mysql> create table t1 (c1 int);
Query OK, 0 rows affected (0.02 sec)

mysql> insert into t1 values(1);
Query OK, 1 row affected (0.14 sec)

mysql> select * from t1;
+------+
| c1   |
+------+
|    1 |
+------+
1 row in set (0.03 sec)

spark-sql (test)> insert into t1 values(2);
Time taken: 0.199 seconds

mysql> select * from t1;
+------+
| c1   |
+------+
|    1 |
+------+
1 row in set (0.02 sec)

```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `enable_iceberg_table_cache` to control Iceberg table caching independently and updates caching logic with unit tests verifying behavior.
> 
> - **Iceberg catalog properties**:
>   - Add `ENABLE_ICEBERG_TABLE_CACHE` property and backing field; initialize from properties; expose via getters (`isEnableIcebergTableCache`, `enableIcebergTableCache`).
> - **Caching behavior**:
>   - In `CachingIcebergCatalog`, gate `tables` cache size by `icebergProperties.isEnableIcebergTableCache()` instead of the general metadata cache flag.
> - **Tests**:
>   - Add tests to verify table caching hits delegate once when enabled and twice when disabled; minor test imports added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0366088ceed427a8470056570958689fbe81229c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->