### PR TITLE
[BugFix] Reset Sort Property in Join's Output Property

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -3486,4 +3486,29 @@ public class JoinTest extends PlanTestBase {
                 "  |  asof join conjunct: 2: v2 <= 5: v5\n" +
                 "  |  other join predicates: (3: v3 = 6: v6) OR (3: v3 = 4: v4)");
     }
+    
+    @Test
+    public void testJoinWithMultiAnalytic() throws Exception {
+        FeConstants.runningUnitTest = true;
+        String query = "with cte0 as (\n" +
+                "    select max(v1) over (partition by v1 order by v2) mx, v1, v2, v3 from t0\n" +
+                "),\n" +
+                "cte1 as (\n" +
+                "    select l.mx g1, l.v1 g2, l.v2 g3, l.v3 g4, max(v5) over (partition by l.v1 order by l.v2) g5 from \n" +
+                "    cte0 l join [broadcast] t1 r on v1 = v4\n" +
+                ")\n" +
+                "select sum(g1),sum(g2), sum(g3), sum(g4), sum(g5) from cte1;";
+        String plan = getFragmentPlan(query);
+        assertContains(plan, "  8:ANALYTIC\n" +
+                "  |  functions: [, max(6: v5), ]\n" +
+                "  |  partition by: 1: v1\n" +
+                "  |  order by: 2: v2 ASC\n" +
+                "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                "  |  \n" +
+                "  7:SORT\n" +
+                "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC\n" +
+                "  |  analytic partition by: 1: v1\n" +
+                "  |  offset: 0");
+        FeConstants.runningUnitTest = false;
+    }
 }

--- a/test/sql/test_window_function/R/test_window_function_with_join
+++ b/test/sql/test_window_function/R/test_window_function_with_join
@@ -1,0 +1,84 @@
+-- name: test_window_function_with_join
+CREATE TABLE `nt0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 48
+PROPERTIES (
+"colocate_with" = "nt0",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into nt0 SELECT generate_series %4096, 4096 - generate_series, generate_series %4096 FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+insert into nt0 select * from nt0;
+-- result:
+-- !result
+create table nt1 as select * from nt0;
+-- result:
+-- !result
+create table nt2 as select * from nt0;
+-- result:
+-- !result
+CREATE TABLE `nt3` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 48
+PROPERTIES (
+"colocate_with" = "nt0",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into nt3 select * from nt0;
+-- result:
+-- !result
+with cte0 as (
+    select max(c1) over (partition by c0 order by c2) mx, c0, c1, c2 from nt0
+),
+cte1 as (
+    select l.mx g1, l.c0 g2, l.c1 g3, l.c2 g4, max(r.c1) over (partition by l.c0 order by l.c2) g5, r.c0 g6, r.c1 g7, r.c2 g8 from cte0 l join [bucket] nt1 r on l.c0 = r.c0
+)
+select sum(g1),sum(g2), sum(g3), sum(g4), sum(g5), sum(g6), sum(g7), sum(g8) from cte1;
+-- result:
+3354624000	3354624000	-26844364800	3354624000	3354624000	3354624000	-26844364800	3354624000
+-- !result
+with cte0 as (
+    select max(c1) over (partition by c0 order by c2) mx, c0, c1, c2 from nt0
+),
+cte1 as (
+    select l.mx g1, l.c0 g2, l.c1 g3, l.c2 g4, max(r.c1) over (partition by l.c0 order by l.c2) g5, r.c0 g6, r.c1 g7, r.c2 g8 from cte0 l join [broadcast] nt1 r on l.c0 = r.c0
+)
+select sum(g1),sum(g2), sum(g3), sum(g4), sum(g5), sum(g6), sum(g7), sum(g8) from cte1;
+-- result:
+3354624000	3354624000	-26844364800	3354624000	3354624000	3354624000	-26844364800	3354624000
+-- !result
+with cte0 as (
+    select max(c1) over (partition by c0 order by c2) mx, c0, c1, c2 from nt0
+),
+cte1 as (
+    select l.mx g1, l.c0 g2, l.c1 g3, l.c2 g4, max(r.c1) over (partition by l.c0 order by l.c2) g5, r.c0 g6, r.c1 g7, r.c2 g8 from cte0 l join [shuffle] nt1 r on l.c0 = r.c0
+)
+select sum(g1),sum(g2), sum(g3), sum(g4), sum(g5), sum(g6), sum(g7), sum(g8) from cte1;
+-- result:
+3354624000	3354624000	-26844364800	3354624000	3354624000	3354624000	-26844364800	3354624000
+-- !result
+with cte0 as (
+    select max(c1) over (partition by c0 order by c2) mx, c0, c1, c2 from nt0
+),
+cte1 as (
+    select l.mx g1, l.c0 g2, l.c1 g3, l.c2 g4, max(r.c1) over (partition by l.c0 order by l.c2) g5, r.c0 g6, r.c1 g7, r.c2 g8 from cte0 l join [colocate] nt3 r on l.c0 = r.c0
+)
+select sum(g1),sum(g2), sum(g3), sum(g4), sum(g5), sum(g6), sum(g7), sum(g8) from cte1;
+-- result:
+3354624000	3354624000	-26844364800	3354624000	3354624000	3354624000	-26844364800	3354624000
+-- !result

--- a/test/sql/test_window_function/T/test_window_function_with_join
+++ b/test/sql/test_window_function/T/test_window_function_with_join
@@ -1,0 +1,67 @@
+-- name: test_window_function_with_join
+
+CREATE TABLE `nt0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 48
+PROPERTIES (
+"colocate_with" = "nt0",
+"replication_num" = "1"
+);
+
+insert into nt0 SELECT generate_series %4096, 4096 - generate_series, generate_series %4096 FROM TABLE(generate_series(1,  40960));
+insert into nt0 select * from nt0;
+
+create table nt1 as select * from nt0;
+create table nt2 as select * from nt0;
+
+CREATE TABLE `nt3` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 48
+PROPERTIES (
+"colocate_with" = "nt0",
+"replication_num" = "1"
+);
+
+insert into nt3 select * from nt0;
+
+with cte0 as (
+    select max(c1) over (partition by c0 order by c2) mx, c0, c1, c2 from nt0
+),
+cte1 as (
+    select l.mx g1, l.c0 g2, l.c1 g3, l.c2 g4, max(r.c1) over (partition by l.c0 order by l.c2) g5, r.c0 g6, r.c1 g7, r.c2 g8 from cte0 l join [bucket] nt1 r on l.c0 = r.c0
+)
+select sum(g1),sum(g2), sum(g3), sum(g4), sum(g5), sum(g6), sum(g7), sum(g8) from cte1;
+
+with cte0 as (
+    select max(c1) over (partition by c0 order by c2) mx, c0, c1, c2 from nt0
+),
+cte1 as (
+    select l.mx g1, l.c0 g2, l.c1 g3, l.c2 g4, max(r.c1) over (partition by l.c0 order by l.c2) g5, r.c0 g6, r.c1 g7, r.c2 g8 from cte0 l join [broadcast] nt1 r on l.c0 = r.c0
+)
+select sum(g1),sum(g2), sum(g3), sum(g4), sum(g5), sum(g6), sum(g7), sum(g8) from cte1;
+
+with cte0 as (
+    select max(c1) over (partition by c0 order by c2) mx, c0, c1, c2 from nt0
+),
+cte1 as (
+    select l.mx g1, l.c0 g2, l.c1 g3, l.c2 g4, max(r.c1) over (partition by l.c0 order by l.c2) g5, r.c0 g6, r.c1 g7, r.c2 g8 from cte0 l join [shuffle] nt1 r on l.c0 = r.c0
+)
+select sum(g1),sum(g2), sum(g3), sum(g4), sum(g5), sum(g6), sum(g7), sum(g8) from cte1;
+
+with cte0 as (
+    select max(c1) over (partition by c0 order by c2) mx, c0, c1, c2 from nt0
+),
+cte1 as (
+    select l.mx g1, l.c0 g2, l.c1 g3, l.c2 g4, max(r.c1) over (partition by l.c0 order by l.c2) g5, r.c0 g6, r.c1 g7, r.c2 g8 from cte0 l join [colocate] nt3 r on l.c0 = r.c0
+)
+select sum(g1),sum(g2), sum(g3), sum(g4), sum(g5), sum(g6), sum(g7), sum(g8) from cte1;


### PR DESCRIPTION
## Why I'm doing:

The join algorithm cannot guarantee the sort property. Therefore, after joining, the sort property must be reset.

## What I'm doing:

Currently, neither spill join nor partition join can guarantee ordered join output. Therefore, reset the property when these optimizations are enabled.

baseline:
```
|   8:AGGREGATE (update serialize)                                                        |
|   |  output: sum(4: max(1: v1)), sum(1: v1), sum(2: v2), sum(3: v3), sum(8: max(5: v4)) |
|   |  group by:                                                                          |
|   |                                                                                     |
|   7:Project                                                                             |
|   |  <slot 1> : 1: v1                                                                   |
|   |  <slot 2> : 2: v2                                                                   |
|   |  <slot 3> : 3: v3                                                                   |
|   |  <slot 4> : 4: max(1: v1)                                                           |
|   |  <slot 8> : 8: max(5: v4)                                                           |
|   |                                                                                     |
|   6:ANALYTIC                                                                            |
|   |  functions: [, max(5: v4), ]                                                        |
|   |  partition by: 1: v1                                                                |
|   |  order by: 2: v2 ASC                                                                |
|   |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW                          |
|   |                                                                                     |
|   5:HASH JOIN                                                                           |
|   |  join op: INNER JOIN (BUCKET_SHUFFLE)                                               |
|   |  colocate: false, reason:                                                           |
|   |  equal join conjunct: 1: v1 = 5: v4                                                 |
|   |                                                                                     |
|   |----4:EXCHANGE                                                                       |
|   |                                                                                     |
|   2:ANALYTIC                                                                            |
|   |  functions: [, max(1: v1), ]                                                        |
|   |  partition by: 1: v1                                                                |
|   |  order by: 2: v2 ASC                                                                |
|   |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW                          |
|   |                                                                                     |
|   1:SORT                                                                                |
|   |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC                                   |
|   |  analytic partition by: 1: v1                                                       |
|   |  offset: 0                                                                          |
|   |                                                                                     |
|   0:OlapScanNode                                                                        |
|      TABLE: t0                                                                          |
|      PREAGGREGATION: ON                                                                 |
|      PREDICATES: 1: v1 IS NOT NULL                                                      |
|      partitions=1/1                                                                     |
|      rollup: t0                                                                         |
|      tabletRatio=3/3                                                                    |
|      tabletList=3434559,3434561,3434563                                                 |
|      cardinality=1                                                                      |
|      avgRowSize=24.0                                                                    |
|                                                                                         |
```

patched:

```
|   7:ANALYTIC                                                                            |
|   |  functions: [, max(5: v4), ]                                                        |
|   |  partition by: 1: v1                                                                |
|   |  order by: 2: v2 ASC                                                                |
|   |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW                          |
|   |                                                                                     |
|   6:SORT                                                                                |
|   |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC                                   |
|   |  analytic partition by: 1: v1                                                       |
|   |  offset: 0                                                                          |
|   |                                                                                     |
|   5:HASH JOIN                                                                           |
|   |  join op: INNER JOIN (BUCKET_SHUFFLE)                                               |
|   |  colocate: false, reason:                                                           |
|   |  equal join conjunct: 1: v1 = 5: v4                                                 |
|   |                                                                                     |
|   |----4:EXCHANGE                                                                       |
|   |                                                                                     |
|   2:ANALYTIC                                                                            |
|   |  functions: [, max(1: v1), ]                                                        |
|   |  partition by: 1: v1                                                                |
|   |  order by: 2: v2 ASC                                                                |
|   |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW                          |
|   |                                                                                     |
|   1:SORT                                                                                |
|   |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC                                   |
|   |  analytic partition by: 1: v1                                                       |
|   |  offset: 0                                                                          |
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clear join output sort property when spill or partition hash join can break order; add tests validating window functions with joins.
> 
> - **Optimizer**:
>   - Add `resetSortProperty` in `OutputPropertyDeriver` to clear `SortProperty` when `enable_spill` or partition hash join is on.
>   - Apply reset for join outputs:
>     - Broadcast joins: return `resetSortProperty(leftChildOutputProperty)`.
>     - Bucket joins: apply `resetSortProperty` on computed output before propagating.
> - **Tests**:
>   - Add `testJoinWithMultiAnalytic` in `JoinTest` to assert required sort before analytic after joins.
>   - Add SQL tests `test/sql/test_window_function/{R,T}/test_window_function_with_join` covering window functions with joins across bucket/broadcast/shuffle/colocate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30d3085438e34eba141b28ec582a51c5a9a7c272. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->