### PR TITLE
[BugFix] Add capacity_limit_reached() to table_function/nl-join-probe/hash-join-probe to avoid constructing overflowing columns (backport #64009)

### DIFF
--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -256,6 +256,10 @@ StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
 
     if (_phase == HashJoinPhase::PROBE || !_hash_join_prober->probe_chunk_empty()) {
         ASSIGN_OR_RETURN(chunk, _hash_join_prober->probe_chunk(state, &ht))
+        std::string err_msg;
+        if (UNLIKELY(chunk->capacity_limit_reached(&err_msg))) {
+            return Status::InternalError(fmt::format("HashJoin constructs an overflowing column: {}", err_msg));
+        }
         return chunk;
     }
 

--- a/be/src/exec/pipeline/table_function_operator.cpp
+++ b/be/src/exec/pipeline/table_function_operator.cpp
@@ -139,6 +139,12 @@ StatusOr<ChunkPtr> TableFunctionOperator::pull_chunk(RuntimeState* state) {
     }
 
     // Just return the chunk whether its full or not in order to keep the semantics of pipeline
+    for (const auto& column : output_columns) {
+        std::string err_msg;
+        if (UNLIKELY(column != nullptr && column->capacity_limit_reached(&err_msg))) {
+            return Status::InternalError(fmt::format("TableFunction constructed an overflowing column: {}", err_msg));
+        }
+    }
     return _build_chunk(output_columns);
 }
 


### PR DESCRIPTION
cp #64009

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

