### PR TITLE
[BugFix] Fix schema change publish does not retry in shared-data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -366,6 +366,8 @@ public abstract class AlterJobV2 implements Writable {
                     return publishVersionFuture.get();
                 } catch (InterruptedException | ExecutionException e) {
                     return false;
+                } finally {
+                    publishVersionFuture = null;
                 }
             } else {
                 return false;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -359,6 +359,7 @@ public abstract class AlterJobV2 implements Writable {
                 return lakePublishVersion();
             };
             publishVersionFuture = GlobalStateMgr.getCurrentState().getLakeAlterPublishExecutor().submit(task);
+            LOG.info("submit publish task for job: {}", jobId);
             return false;
         } else {
             if (publishVersionFuture.isDone()) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -68,6 +68,16 @@ public class LakeTableSchemaChangeJobTest {
     public static void setUp() throws Exception {
         UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
         connectContext = UtFrameUtils.createDefaultCtx();
+        // Schema change job is executed manually, so stop the schema change daemon to avoid interfering with the test.
+        SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler();
+        schemaChangeHandler.setStop();
+        schemaChangeHandler.interrupt();
+        long startTime = System.currentTimeMillis();
+        while (schemaChangeHandler.isRunning()) {
+            Thread.sleep(100);
+            Assertions.assertTrue(System.currentTimeMillis() - startTime < 60000,
+                    "Schema change handler is not stopped in 60 seconds");
+        }
     }
 
     private static LakeTable createTable(ConnectContext connectContext, String sql) throws Exception {


### PR DESCRIPTION
## Why I'm doing:

**what is the problem**
Lake table schema change jobs can get stuck in `FINISHED_REWRITING` and never complete if the first publish_version attempt fails (exception or false). Subsequent scheduling loops never retry the publish.
  
**why it happens**
In `AlterJobV2.publishVersion()`, a cached `publishVersionFuture` is created once and never cleared. After completion (either exception or returning false), `publishVersion()` only returns the previous result and does not resubmit a new task, because the non-null cached Future prevents re-submission.

## What I'm doing:
Reset the cached `publishVersionFuture` when the Future completes with failure or exception so that subsequent invocations can resubmit the publish task.


## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.0
  - [X] 3.5
  - [ ] 3.4
  - [ ] 3.3
