### PR TITLE
[UT] fix fe unstable ut "ExecuteSqlActionTest"

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/http/ExecuteSqlActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/ExecuteSqlActionTest.java
@@ -14,22 +14,36 @@
 package com.starrocks.http;
 
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.ExecuteEnv;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import org.awaitility.Awaitility;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 @TestMethodOrder(MethodName.class)
 public class ExecuteSqlActionTest extends StarRocksHttpTestCase {
     private static final String QUERY_EXECUTE_API = "/api/v1/catalogs/default_catalog/sql";
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        setUpWithCatalog();
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> GlobalStateMgr.getCurrentState().getMetadataMgr()
+                        .getDb(new ConnectContext(), "default_catalog", DB_NAME) != null);
+    }
 
     @Override
     protected void doSetUp() throws Exception {
@@ -39,7 +53,6 @@ public class ExecuteSqlActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void test1ExecuteSqlSuccess() throws Exception {
-        super.setUpWithCatalog();
         RequestBody body =
                 RequestBody.create(JSON, "{ \"query\" :  \"kill 1\" }");
 


### PR DESCRIPTION
## Why I'm doing:
```
2025-10-14T05:24:48.2843306Z [[1;31mERROR[m] [1;31m  ExecuteSqlActionTest.test2ExecuteSqlFail » MissingInvocation Missing 1 invocation to:
2025-10-14T05:24:48.2843782Z com.starrocks.server.GlobalStateMgr#isSafeMode()
2025-10-14T05:24:48.2844184Z    on mock instance: com.starrocks.server.GlobalStateMgr@6fed59ae[m
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
