### PR TITLE
[BugFix] fix iceberg truncate decimal bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -956,6 +956,19 @@ public class FunctionAnalyzer {
                 argumentTypes[1] = Type.BOOLEAN;
                 fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_IDENTICAL);
             }
+        } else if (FunctionSet.ICEBERG_TRANSFORM_BUCKET.equalsIgnoreCase(fnName) ||
+                FunctionSet.ICEBERG_TRANSFORM_TRUNCATE.equalsIgnoreCase(fnName)) {
+            Preconditions.checkState(argumentTypes.length == 2);
+            Type[] args = new Type[] {argumentTypes[0], Type.INT};
+            fn = Expr.getBuiltinFunction(fnName, args, Function.CompareMode.IS_IDENTICAL);
+            if (args[0].isDecimalV3()) {
+                fn.setArgsType(args);
+            }
+            if (FunctionSet.ICEBERG_TRANSFORM_TRUNCATE.equalsIgnoreCase(fnName)) {
+                fn.setRetType(args[0]);
+            } else {
+                fn.setRetType(Type.INT);
+            }
         }
         // add new argument types
         Arrays.stream(argumentTypes).forEach(newArgumentTypes::add);

--- a/test/sql/test_function/R/test_iceberg_transform_func
+++ b/test/sql/test_function/R/test_iceberg_transform_func
@@ -1,0 +1,23 @@
+-- name: test_iceberg_transform_func
+create table t0 (c1 decimal(4,2)) PROPERTIES ("replication_num"="1");
+-- result:
+-- !result
+insert into t0 values(10.65);
+-- result:
+-- !result
+select __iceberg_transform_truncate(c1, 50) from t0;
+-- result:
+10.50
+-- !result
+select __iceberg_transform_truncate(10.65, 50) from t0;
+-- result:
+10.50
+-- !result
+select __iceberg_transform_bucket(c1, 8) from t0;
+-- result:
+4
+-- !result
+select __iceberg_transform_bucket(10.65, 8) from t0;
+-- result:
+4
+-- !result

--- a/test/sql/test_function/T/test_iceberg_transform_func
+++ b/test/sql/test_function/T/test_iceberg_transform_func
@@ -1,0 +1,10 @@
+-- name: test_iceberg_transform_func
+
+create table t0 (c1 decimal(4,2)) PROPERTIES ("replication_num"="1");
+
+insert into t0 values(10.65);
+
+select __iceberg_transform_truncate(c1, 50) from t0;
+select __iceberg_transform_truncate(10.65, 50) from t0;
+select __iceberg_transform_bucket(c1, 8) from t0;
+select __iceberg_transform_bucket(10.65, 8) from t0;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust function resolution for `__iceberg_transform_truncate` and `__iceberg_transform_bucket` to accept decimalV3 first arg and INT second arg; add SQL tests validating results.
> 
> - **Analyzer** (`fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java`):
>   - Handle `__iceberg_transform_bucket` and `__iceberg_transform_truncate`:
>     - Force signature to `[arg0, INT]` and resolve builtin.
>     - If `arg0` is decimalV3, set precise arg types on the function.
> - **Tests**:
>   - Add `test/sql/test_function/{R,T}/test_iceberg_transform_func` verifying decimal input:
>     - `__iceberg_transform_truncate(c1, 50)` → `10.50` and same for literal `10.65`.
>     - `__iceberg_transform_bucket(c1, 8)` → `4` and same for literal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5753d30e2818bb9803621a0c2b2a6e3a632f7c47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->