### PR TITLE
[BugFix] fix insert select auto refresh bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -266,11 +266,12 @@ public class InsertPlanner {
     public void refreshExternalTable(QueryStatement queryStatement, ConnectContext session) {
         SessionVariable currentVariable = (SessionVariable) session.getSessionVariable();
         if (currentVariable.isEnableInsertSelectExternalAutoRefresh()) {
-            List<Table> tables = new ArrayList<>();
-            AnalyzerUtils.collectSpecifyExternalTables(queryStatement, tables, Table::isExternalTableWithFileSystem);
-            for (Table table : tables) {
-                session.getGlobalStateMgr().getMetadataMgr().refreshTable(table.getCatalogName(),
-                        table.getCatalogDBName(), table, new ArrayList<>(), false);
+            Map<TableName, Table> tables = AnalyzerUtils.collectAllTableWithAlias(queryStatement);
+            for (Map.Entry<TableName, Table> t : tables.entrySet()) {
+                if (t.getValue().isExternalTableWithFileSystem()) {
+                    session.getGlobalStateMgr().getMetadataMgr().refreshTable(t.getKey().getCatalog(),
+                            t.getKey().getDb(), t.getValue(), new ArrayList<>(), false);
+                }
             }
         }
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes [#10452](https://github.com/StarRocks/StarRocksTest/issues/10452)
Test result:
```
(venv) owen@sandbox-dla:~/code/StarRocksTest$ nosetests-3.4  -s --with-xunit --xunit-file=./result/${CLUSTER_ID}/'test_hive_extable_ist_srtbls_from_hdfs_py_TestInsertIntoSRTblFromHiveExTblHdfs_test_ist_aggregatetbl_from_hive_parquet.xml' --verbose 'case/system_case/test_ddl/test_external_table/test_hive_external_table/test_hive_extable_ist_srtbls_from_hdfs.py:TestInsertIntoSRTblFromHiveExTblHdfs.test_ist_aggregatetbl_from_hive_parquet' --nologcapture
insert into aggregate table select from hive external table with hdfs file system and parquet file format ... 
case exec connect time:  1760582643 2025-10-16 10:44:02
show backends;

case exec close time:  1760582643 2025-10-16 10:44:02
show backends;
create database test_ist_hive_hdfs_f9ca5308_aa39_11f0_8fb8_51b76cf077a8;
use test_ist_hive_hdfs_f9ca5308_aa39_11f0_8fb8_51b76cf077a8;
create external resource hive_resource_f9ca5309_aa39_11f0_8fb8_51b76cf077a8 PROPERTIES("type" = "hive","hive.metastore.uris" = "thrift://172.26.194.238:9083");
create external table ex_hive_hdfs_orc (             col_char char(100) comment "column char"             ,col_date date comment "column date"             ,col_tinyint tinyint comment "column tinyint"             ,col_string varchar(1000) comment "column string"             ,col_smallint smallint comment "column smallint"             ,col_int int comment "column int"             ,col_integer integer comment "column integer"             ,col_bigint bigint comment "column bigint"             ,col_float float comment "column float"             ,col_double double comment "column double"             ,col_double_precision double comment "column double precision"             ,col_decimal decimal comment "column decimal"             ,col_timestamp datetime comment "column timestamp"             ,col_varchar varchar(100) comment "column varchar"             ,col_boolean boolean comment "column boolean")             ENGINE=hive             properties (             "resource" = "hive_resource_f9ca5309_aa39_11f0_8fb8_51b76cf077a8",             "table" = "hive_hdfs_orc",             "database" = "hive_extbl_test");
select count(*) from ex_hive_hdfs_orc;
create external table ex_hive_hdfs_parquet (             col_char char(100) comment "column char"             ,col_date date comment "column date"             ,col_tinyint tinyint comment "column tinyint"             ,col_string varchar(1000) comment "column string"             ,col_smallint smallint comment "column smallint"             ,col_int int comment "column int"             ,col_integer integer comment "column integer"             ,col_bigint bigint comment "column bigint"             ,col_float float comment "column float"             ,col_double double comment "column double"             ,col_double_precision double comment "column double precision"             ,col_decimal decimal comment "column decimal"             ,col_timestamp datetime comment "column timestamp"             ,col_varchar varchar(100) comment "column varchar"             ,col_boolean boolean comment "column boolean")             ENGINE=hive             properties (                 "resource" = "hive_resource_f9ca5309_aa39_11f0_8fb8_51b76cf077a8",                 "table" = "hive_hdfs_parquet",                 "database" = "hive_extbl_test");
select count(*) from ex_hive_hdfs_parquet;
create external table ex_hive_hdfs_csv (              col_tinyint tinyint null comment "column tinyint"             ,col_smallint smallint comment "column smallint"             ,col_int int comment "column int"             ,col_integer integer comment "column integer"             ,col_bigint bigint comment "column bigint"             ,col_float float comment "column float"             ,col_double double comment "column double"             ,col_double_precision double comment "column double precision"             ,col_decimal decimal comment "column decimal"             ,col_timestamp datetime comment "column timestamp"             ,col_date date comment "column date"             ,col_string varchar(1000) comment "column string"             ,col_varchar varchar(100) comment "column varchar"             ,col_char char(100) comment "column char"             ,col_boolean boolean comment "column boolean")         ENGINE=hive         properties (             "resource" = "hive_resource_f9ca5309_aa39_11f0_8fb8_51b76cf077a8",             "table" = "hive_hdfs_csv",             "database" = "hive_extbl_test");
select count(*) from ex_hive_hdfs_csv;
create table duplicate_table(
            col_char char(100) comment "column char"
            ,col_date date comment "column date"
            ,col_tinyint tinyint comment "column tinyint"
            ,col_string varchar(1000) comment "column string"
            ,col_smallint smallint comment "column smallint"
            ,col_int int comment "column int"
            ,col_integer integer comment "column integer"
            ,col_bigint bigint comment "column bigint"
            ,col_float float comment "column float"
            ,col_double double comment "column double"
            ,col_double_precision double comment "column double precision"
            ,col_decimal decimal comment "column decimal"
            ,col_timestamp datetime comment "column timestamp"
            ,col_varchar varchar(100) comment "column varchar"
            ,col_boolean boolean comment "column boolean")
            ENGINE=olap
            DUPLICATE KEY(col_char, col_date, col_tinyint)
            distributed by hash(col_tinyint) buckets 5
            properties("replication_num" = "1");
create table unique_table(
            col_char char(100) comment "column char"
            ,col_date date comment "column date"
            ,col_tinyint tinyint comment "column tinyint"
            ,col_string varchar(1000) comment "column string"
            ,col_smallint smallint comment "column smallint"
            ,col_int int comment "column int"
            ,col_integer integer comment "column integer"
            ,col_bigint bigint comment "column bigint"
            ,col_float float comment "column float"
            ,col_double double comment "column double"
            ,col_double_precision double comment "column double precision"
            ,col_decimal decimal comment "column decimal"
            ,col_timestamp datetime comment "column timestamp"
            ,col_varchar varchar(100) comment "column varchar"
            ,col_boolean boolean comment "column boolean")
            UNIQUE KEY(col_char,col_date,col_tinyint)
            DISTRIBUTED BY HASH(col_char) BUCKETS 3
            PROPERTIES (
            "replication_num" = "1",
            "in_memory" = "false",
            "storage_format" = "DEFAULT");
create table aggregate_table(
            col_char char(100) comment "column char"
            ,col_date date comment "column date"
            ,col_tinyint tinyint comment "column tinyint"
            ,col_string varchar(1000) comment "column string"
            ,col_smallint smallint comment "column smallint"
            ,col_timestamp datetime comment "column timestamp"
            ,col_varchar varchar(100) comment "column varchar"
            ,col_boolean boolean comment "column boolean"
            ,col_int int sum comment "column int"
            ,col_integer integer sum comment "column integer"
            ,col_bigint bigint max comment "column bigint"
            ,col_float float sum comment "column float"
            ,col_double double sum comment "column double"
            ,col_double_precision double min comment "column double precision"
            ,col_decimal decimal max comment "column decimal")
            aggregate KEY(col_char,col_date,col_tinyint,col_string,col_smallint,col_timestamp,col_varchar,col_boolean)
            COMMENT "OLAP" 
            DISTRIBUTED BY HASH(col_char) BUCKETS 3
            PROPERTIES (
            "replication_num" = "1",
            "in_memory" = "false",
            "storage_format" = "DEFAULT");
create table primary_table(
            col_tinyint tinyint not null comment "column tinyint"
            ,col_char char(100) comment "column char"
            ,col_date date comment "column date"
            ,coltinyint tinyint comment "column tinyint"
            ,col_string varchar(1000) comment "column string"
            ,col_smallint smallint comment "column smallint"
            ,col_int int comment "column int"
            ,col_integer integer comment "column integer"
            ,col_bigint bigint comment "column bigint"
            ,col_float float comment "column float"
            ,col_double double comment "column double"
            ,col_double_precision double comment "column double precision"
            ,col_decimal decimal comment "column decimal"
            ,col_timestamp datetime comment "column timestamp"
            ,col_varchar varchar(100) comment "column varchar"
            ,col_boolean boolean comment "column boolean")
            ENGINE=olap
            primary KEY(col_tinyint)
            distributed by hash(col_tinyint) buckets 5
            properties("replication_num" = "1");
truncate table aggregate_table;
insert into aggregate_table select * from ex_hive_hdfs_parquet limit 1;
select * from aggregate_table;
(('nihao', datetime.date(2021, 5, 1), 5, 'hello world', 5, None, '5', 1, 5, 50, 510, 5110.0, 20210501121023.0, None, Decimal('1')),)
insert into aggregate_table(col_char, col_date, col_smallint) select col_char, col_date, col_smallint from ex_hive_hdfs_parquet limit 1;
select * from aggregate_table;
(('nihao', datetime.date(2021, 5, 1), 5, 'hello world', 5, None, '5', 1, 5, 50, 510, 5110.0, 20210501121023.0, None, Decimal('1')), ('nihao', datetime.date(2021, 12, 1), None, None, 12, None, None, None, None, None, None, None, None, None, None))
insert into aggregate_table select * from ex_hive_hdfs_parquet limit 100;
select * from aggregate_table;
insert into aggregate_table(col_tinyint, col_varchar, col_date, col_smallint, col_boolean) select col_tinyint, col_varchar, col_date, col_smallint, col_boolean from ex_hive_hdfs_parquet limit 100;
select * from aggregate_table;
truncate table aggregate_table;
insert into aggregate_table select * from ex_hive_hdfs_parquet;
select * from aggregate_table;
truncate table aggregate_table;
insert into aggregate_table select * from ex_hive_hdfs_parquet order by col_tinyint limit 10;
select col_tinyint, col_varchar, col_date, col_smallint, col_boolean from aggregate_table;
truncate table aggregate_table;
insert into aggregate_table select * from ex_hive_hdfs_parquet where col_tinyint = 1;
select col_tinyint, col_varchar, col_date, col_smallint, col_boolean from aggregate_table;
truncate table aggregate_table;
insert into aggregate_table(col_tinyint, col_double, col_bigint, col_integer)             select col_tinyint, max(col_double), avg(col_bigint), sum(col_smallint) from ex_hive_hdfs_parquet             where col_tinyint < 11             group by col_tinyint             order by col_tinyint             limit 5;
select * from aggregate_table order by col_tinyint;
drop database default_catalog.test_ist_hive_hdfs_f9ca5308_aa39_11f0_8fb8_51b76cf077a8 ;
DROP RESOURCE "hive_resource_f9ca5309_aa39_11f0_8fb8_51b76cf077a8";

case exec close time:  1760582649 2025-10-16 10:44:09
ok

----------------------------------------------------------------------
XML: /home/disk2/owen/code/StarRocksTest/result/test_hive_extable_ist_srtbls_from_hdfs_py_TestInsertIntoSRTblFromHiveExTblHdfs_test_ist_aggregatetbl_from_hive_parquet.xml
----------------------------------------------------------------------
Ran 1 test in 6.239s

OK
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
