### PR TITLE
[Enhancement] support collect statistics  for iceberg table with bucket/truncate partition transform

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
@@ -264,7 +264,11 @@ public class IcebergPartitionUtils {
             int width = extractTransformParam(partitionField.transform().toString());
             Type partitionType = table.getColumn(partitionColumn).getType();
             if (partitionType.isBinaryType()) {
-                partitionValue = new String(Base64.getDecoder().decode(partitionValue));
+                try {
+                    partitionValue = new String(Base64.getDecoder().decode(partitionValue));
+                } catch (Exception e) {
+                    throw new StarRocksConnectorException("Invalid base64 partition value: %s", partitionValue, e);
+                }
             }
             String fn = FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX + "truncate";
             return String.format("%s(%s, %d) = '%s'", fn, partitionCol, width, partitionValue);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -43,6 +44,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 import java.util.List;
 
 import static com.starrocks.connector.iceberg.IcebergPartitionTransform.YEAR;
@@ -150,7 +152,9 @@ public class IcebergPartitionUtils {
                 transform == YEAR ||
                 transform == IcebergPartitionTransform.MONTH ||
                 transform == IcebergPartitionTransform.DAY ||
-                transform == IcebergPartitionTransform.HOUR;
+                transform == IcebergPartitionTransform.HOUR ||
+                transform == IcebergPartitionTransform.BUCKET ||
+                transform == IcebergPartitionTransform.TRUNCATE;
     }
 
     public static LocalDateTime addDateTimeInterval(LocalDateTime dateTime, IcebergPartitionTransform transform) {
@@ -224,10 +228,49 @@ public class IcebergPartitionUtils {
         }
     }
 
-    public static String convertPartitionFieldToPredicate(IcebergTable table, String partitionColumn,
-                                                          String partitionValue) {
-        Range<String> range = toPartitionRange(table, partitionColumn, partitionValue, true);
+    /**
+     * Convert iceberg partition transform to sql predicate
+     * eg.
+     * Iceberg table partition column: day(dt)
+     * partition value      : 2023-01-02
+     * generated predicate  : dt >= '2023-01-01 00:08:00' and dt < '2023-01-02:00:08:00'
+     */
+    public static String convertPartitionTransformToPredicate(IcebergTable table, String partitionColumn,
+                                                              String partitionValue) {
+
+        PartitionField partitionField = table.getPartitionFiled(partitionColumn);
+        if (partitionField == null) {
+            throw new StarRocksConnectorException("Partition column %s not found in table %s.%s.%s",
+                    partitionColumn, table.getCatalogName(), table.getCatalogDBName(), table.getCatalogTableName());
+        }
+        IcebergPartitionTransform transform =
+                IcebergPartitionTransform.fromString(partitionField.transform().toString());
         String partitionCol = StatisticUtils.quoting(partitionColumn);
+
+        // Handle bucket and truncate explicitly
+        if (transform == IcebergPartitionTransform.BUCKET) {
+            // transform string format: bucket[<num>]
+            int numBuckets = extractTransformParam(partitionField.transform().toString());
+            int bucketId;
+            try {
+                bucketId = Integer.parseInt(partitionValue);
+            } catch (NumberFormatException e) {
+                throw new StarRocksConnectorException("Invalid bucket partition value: %s", partitionValue);
+            }
+            String fn = FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX + "bucket";
+            return String.format("%s(%s, %d) = %d", fn, partitionCol, numBuckets, bucketId);
+        } else if (transform == IcebergPartitionTransform.TRUNCATE) {
+            // transform string format: truncate[<width>]
+            int width = extractTransformParam(partitionField.transform().toString());
+            Type partitionType = table.getColumn(partitionColumn).getType();
+            if (partitionType.isBinaryType()) {
+                partitionValue = new String(Base64.getDecoder().decode(partitionValue));
+            }
+            String fn = FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX + "truncate";
+            return String.format("%s(%s, %d) = '%s'", fn, partitionCol, width, partitionValue);
+        }
+
+        Range<String> range = toPartitionRange(table, partitionColumn, partitionValue, true);
         if (range.lowerEndpoint().equals(range.upperEndpoint())) {
             return String.format("%s = '%s'", partitionCol, range.lowerEndpoint());
         } else {
@@ -235,6 +278,19 @@ public class IcebergPartitionUtils {
             String upperEndpoint = range.upperEndpoint();
             return String.format("%s >= '%s' and %s < '%s'", partitionCol, lowerEndpoint, partitionCol, upperEndpoint);
         }
+    }
+
+    private static int extractTransformParam(String transform) {
+        int l = transform.indexOf('[');
+        int r = transform.indexOf(']');
+        if (l >= 0 && r > l) {
+            try {
+                return Integer.parseInt(transform.substring(l + 1, r));
+            } catch (NumberFormatException ignore) {
+                // fall through
+            }
+        }
+        throw new StarRocksConnectorException("Unsupported or missing transform parameter: %s", transform);
     }
 
     public static Expr getIcebergTablePartitionPredicateExpr(IcebergTable table,

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -198,7 +198,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
                 if (partitionValue.equals(nullValue)) {
                     partitionPredicate.add(StatisticUtils.quoting(partitionColumnName) + " IS NULL");
                 } else if (isSupportedPartitionTransform(partitionColumnName)) {
-                    partitionPredicate.add(IcebergPartitionUtils.convertPartitionFieldToPredicate((IcebergTable) table,
+                    partitionPredicate.add(IcebergPartitionUtils.convertPartitionTransformToPredicate((IcebergTable) table,
                             partitionColumnName, partitionValue));
                 } else {
                     partitionPredicate.add(StatisticUtils.quoting(partitionColumnName) + " = '" + partitionValue + "'");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -88,6 +88,7 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     public static final String MOCKED_PARTITIONED_DAY_TABLE_NAME = "t0_day";
     public static final String MOCKED_PARTITIONED_HOUR_TABLE_NAME = "t0_hour";
     public static final String MOCKED_PARTITIONED_BUCKET_TABLE_NAME = "t0_bucket";
+    public static final String MOCKED_PARTITIONED_TRUNCATE_TABLE_NAME = "t0_truncate";
     // partition table with transforms and partition column type is timestamp with timezone
     public static final String MOCKED_PARTITIONED_YEAR_TZ_TABLE_NAME = "t0_year_tz";
     public static final String MOCKED_PARTITIONED_MONTH_TZ_TABLE_NAME = "t0_month_tz";
@@ -106,6 +107,7 @@ public class MockIcebergMetadata implements ConnectorMetadata {
             ImmutableList.of(MOCKED_PARTITIONED_YEAR_TABLE_NAME, MOCKED_PARTITIONED_MONTH_TABLE_NAME,
                     MOCKED_PARTITIONED_DAY_TABLE_NAME, MOCKED_PARTITIONED_HOUR_TABLE_NAME,
                     MOCKED_PARTITIONED_BUCKET_TABLE_NAME,
+                    MOCKED_PARTITIONED_TRUNCATE_TABLE_NAME,
                     MOCKED_PARTITIONED_YEAR_TZ_TABLE_NAME, MOCKED_PARTITIONED_MONTH_TZ_TABLE_NAME,
                     MOCKED_PARTITIONED_DAY_TZ_TABLE_NAME, MOCKED_PARTITIONED_HOUR_TZ_TABLE_NAME,
                     MOCKED_PARTITIONED_EVOLUTION_DATE_MONTH_IDENTITY_TABLE_NAME);
@@ -333,6 +335,14 @@ public class MockIcebergMetadata implements ConnectorMetadata {
                                 + MOCKED_PARTITIONED_BUCKET_TABLE_NAME), MOCKED_PARTITIONED_BUCKET_TABLE_NAME,
                         schema, spec, 1);
             }
+            case MOCKED_PARTITIONED_TRUNCATE_TABLE_NAME: {
+                PartitionSpec spec =
+                        PartitionSpec.builderFor(schema).truncate("data", 5).build();
+                return TestTables.create(
+                        new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_TRANSFORMS_DB_NAME + "/"
+                                + MOCKED_PARTITIONED_TRUNCATE_TABLE_NAME), MOCKED_PARTITIONED_TRUNCATE_TABLE_NAME,
+                        schema, spec, 1);
+            }
             case MOCKED_PARTITIONED_YEAR_TZ_TABLE_NAME: {
                 PartitionSpec spec =
                         PartitionSpec.builderFor(schema).year("ts").build();
@@ -413,6 +423,9 @@ public class MockIcebergMetadata implements ConnectorMetadata {
             case MOCKED_PARTITIONED_BUCKET_TABLE_NAME:
                 return Lists.newArrayList("ts_bucket=0", "ts_bucket=1",
                         "ts_bucket=2", "ts_bucket=3", "ts_bucket=4");
+            case MOCKED_PARTITIONED_TRUNCATE_TABLE_NAME:
+                return Lists.newArrayList("data_trunc=aaaaa", "data_trunc=bbbbb",
+                        "data_trunc=ccccc", "data_trunc=ddddd", "data_trunc=eeeee");
             case MOCKED_PARTITIONED_EVOLUTION_DATE_MONTH_IDENTITY_TABLE_NAME:
                 return Lists.newArrayList("ts=2024-01-01", "ts_month=2024-01",
                         "ts=2024-02", "ts=2024-03");

--- a/test/sql/test_iceberg/R/test_iceberg_collect_stats
+++ b/test/sql/test_iceberg/R/test_iceberg_collect_stats
@@ -1,0 +1,130 @@
+-- name: test_iceberg_collect_stats
+create external catalog iceberg_collect_stats_${uuid0} PROPERTIES (
+    "type"="iceberg",
+    "iceberg.catalog.type"="hive", 
+    "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+create database iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_collect_stats_${uuid0}/test_iceberg_partition_transform/${uuid0}"
+);
+-- result:
+-- !result
+create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1 (
+    c1 int,
+    c2 bigint,
+    c3 date,
+    c4 decimal(10,3)
+) partition by c1,c2,c3,c4;
+-- result:
+-- !result
+insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1 values(1, 2, '2022-01-01', 10.23);
+-- result:
+-- !result
+[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1;
+-- result:
+iceberg_collect_stats_d5e9d38ec7144c578e456e16e1134134.iceberg_collect_stats_db_d5e9d38ec7144c578e456e16e1134134.t1	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1', 'cardinality=1')
+-- result:
+None
+-- !result
+drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1 force;
+-- result:
+-- !result
+create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t2 (
+    c1 int,
+    c2 bigint,
+    c3 date
+) partition by truncate(c1, 50), bucket(c2, 10), year(c3);
+-- result:
+-- !result
+insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t2 values(1,2,'2022-01-01'), (49,38,'2022-12-12');
+-- result:
+-- !result
+[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t2;
+-- result:
+iceberg_collect_stats_d5e9d38ec7144c578e456e16e1134134.iceberg_collect_stats_db_d5e9d38ec7144c578e456e16e1134134.t2	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t2', 'cardinality=2')
+-- result:
+None
+-- !result
+drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t2 force;
+-- result:
+-- !result
+create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t3 (
+    c1 date,
+    c2 date,
+    c3 date,
+    c4 datetime
+) partition by year(c1), month(c2), day(c3), hour(c4);
+-- result:
+-- !result
+insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t3 values('2022-01-01', '2022-01-01' ,'2022-01-01', '2022-01-01 12:13:14'), ('2022-01-02', '2022-01-02' ,'2022-01-01', '2022-01-01 12:15:14'), ('2022-01-03', '2022-01-03' ,'2022-01-01', '2022-01-01 12:17:14');
+-- result:
+-- !result
+[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t3;
+-- result:
+iceberg_collect_stats_d5e9d38ec7144c578e456e16e1134134.iceberg_collect_stats_db_d5e9d38ec7144c578e456e16e1134134.t3	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t3', 'cardinality=3')
+-- result:
+None
+-- !result
+drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t3 force;
+-- result:
+-- !result
+create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t4 (
+    c1 varchar(100)
+) partition by truncate(c1, 1);
+-- result:
+-- !result
+insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t4 values('测试1'), ('测试2'),('测试3');
+-- result:
+-- !result
+[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t4;
+-- result:
+iceberg_collect_stats_d5e9d38ec7144c578e456e16e1134134.iceberg_collect_stats_db_d5e9d38ec7144c578e456e16e1134134.t4	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t4', 'cardinality: 3')
+-- result:
+None
+-- !result
+drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t4 force;
+-- result:
+-- !result
+create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5 (
+    c1 varbinary(100)
+) partition by truncate(c1, 1);
+-- result:
+-- !result
+insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5 values('abc'), ('edf');
+-- result:
+-- !result
+[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5;
+-- result:
+iceberg_collect_stats_d5e9d38ec7144c578e456e16e1134134.iceberg_collect_stats_db_d5e9d38ec7144c578e456e16e1134134.t5	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5', 'cardinality: 2')
+-- result:
+None
+-- !result
+drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5 force;
+-- result:
+-- !result
+drop database iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_collect_stats_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/iceberg_collect_stats_${uuid0}/test_iceberg_partition_transform/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_collect_stats
+++ b/test/sql/test_iceberg/T/test_iceberg_collect_stats
@@ -1,0 +1,71 @@
+-- name: test_iceberg_collect_stats
+create external catalog iceberg_collect_stats_${uuid0} PROPERTIES (
+    "type"="iceberg",
+    "iceberg.catalog.type"="hive", 
+    "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+create database iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_collect_stats_${uuid0}/test_iceberg_partition_transform/${uuid0}"
+);
+
+create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1 (
+    c1 int,
+    c2 bigint,
+    c3 date,
+    c4 decimal(10,3)
+) partition by c1,c2,c3,c4;
+
+insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1 values(1, 2, '2022-01-01', 10.23);
+[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1;
+function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1', 'cardinality=1')
+drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1 force;
+
+create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t2 (
+    c1 int,
+    c2 bigint,
+    c3 date
+) partition by truncate(c1, 50), bucket(c2, 10), year(c3);
+
+insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t2 values(1,2,'2022-01-01'), (49,38,'2022-12-12');
+[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t2;
+function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t2', 'cardinality=2')
+drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t2 force;
+
+create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t3 (
+    c1 date,
+    c2 date,
+    c3 date,
+    c4 datetime
+) partition by year(c1), month(c2), day(c3), hour(c4);
+insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t3 values('2022-01-01', '2022-01-01' ,'2022-01-01', '2022-01-01 12:13:14'), ('2022-01-02', '2022-01-02' ,'2022-01-01', '2022-01-01 12:15:14'), ('2022-01-03', '2022-01-03' ,'2022-01-01', '2022-01-01 12:17:14');
+[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t3;
+function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t3', 'cardinality=3')
+drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t3 force;
+
+create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t4 (
+    c1 varchar(100)
+) partition by truncate(c1, 1);
+insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t4 values('测试1'), ('测试2'),('测试3');
+[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t4;
+function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t4', 'cardinality: 3')
+drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t4 force;
+
+create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5 (
+    c1 varbinary(100)
+) partition by truncate(c1, 1);
+insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5 values('abc'), ('edf');
+[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5;
+function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5', 'cardinality: 2')
+drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5 force;
+
+
+drop database iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0};
+drop catalog iceberg_collect_stats_${uuid0};
+
+
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/iceberg_collect_stats_${uuid0}/test_iceberg_partition_transform/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:
StarRocks do not support collecting statistics for iceberg table with bucket/truncate partition transform
## What I'm doing:
This pull request enhances Iceberg connector support for partition transforms in StarRocks, particularly enabling statistics collection on tables partitioned by `bucket` and `truncate` transforms. It refactors and extends partition predicate generation, updates related tests, and adds new integration test cases to ensure correctness.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds predicate generation for Iceberg bucket/truncate partitions and updates stats collection to support them, with new mocks and tests.
> 
> - **Iceberg Connector**:
>   - Add support for `BUCKET` and `TRUNCATE` in `IcebergPartitionUtils.isSupportedConvertPartitionTransform`.
>   - New `convertPartitionTransformToPredicate(...)` handling `bucket[...]` and `truncate[...]` (incl. binary base64 decode) and range predicates for time transforms.
>   - Helper `extractTransformParam(...)` to parse transform parameters.
> - **Statistics Collection**:
>   - `ExternalFullStatisticsCollectJob` now uses `convertPartitionTransformToPredicate(...)` to build partition predicates for Iceberg tables.
> - **Tests**:
>   - Update `StatisticsCollectJobTest` to validate bucket predicate and add truncate predicate test.
>   - Extend `MockIcebergMetadata` with truncate-partitioned table and partition names.
>   - Add integration SQL tests `test/sql/test_iceberg/{T,R}/test_iceberg_collect_stats` covering identity, year/month/day/hour, bucket, and truncate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ea1ab60820f8846117f27ebc84624312486aabe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->