### PR TITLE
[Enhancement] enable iceberg/deltalake table stats from metadata by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorProperties.java
@@ -35,9 +35,6 @@ public class ConnectorProperties {
     }
 
     public boolean enableGetTableStatsFromExternalMetadata() {
-        // For Iceberg and DeltaLake, we don't get table stats from metadata by default.
-        boolean defaultValue = connectorType != ConnectorType.ICEBERG && connectorType != ConnectorType.DELTALAKE;
-        return PropertyUtil.propertyAsBoolean(properties, ConnectorProperties.ENABLE_GET_STATS_FROM_EXTERNAL_METADATA,
-                defaultValue);
+        return PropertyUtil.propertyAsBoolean(properties, ConnectorProperties.ENABLE_GET_STATS_FROM_EXTERNAL_METADATA, true);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

I've done a series benchmark on tpcds-1t and 10t, and found table stats from iceberg/deltalake is very useful to generate decent plan.

So current logic of obtaining table stats is following:
- load table/column from internal table first
- if it's missing, then a stats collection job will be triggered still.
- and meanwhile,  we will use metadata to generate table/column stats

## What I'm doing:


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
