### PR TITLE
[UT] fix unstable FE UT CatalogRecycleBinLakeTableTest.testRecycleLakeDatabase

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -556,7 +556,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         LOG.info("Finished log erase tables: {}", StringUtils.join(tableIds, ","));
     }
 
-    private List<RecycleTableInfo> removeTableFromRecycleBin(List<Long> tableIds) {
+    List<RecycleTableInfo> removeTableFromRecycleBin(List<Long> tableIds) {
         List<RecycleTableInfo> removedTableInfos = Lists.newArrayListWithCapacity(tableIds.size());
         for (Long tableId : tableIds) {
             Map<Long, RecycleTableInfo> column = idToTableInfo.column(tableId);
@@ -1164,8 +1164,15 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         return info != null && asyncDeleteForTables.get(info) != null;
     }
 
-
-
+    @VisibleForTesting
+    synchronized boolean isDeletingTableDone(long id) {
+        RecycleTableInfo info = getRecycleTableInfo(id);
+        if (info == null) {
+            return true;
+        }
+        CompletableFuture<Boolean> future = asyncDeleteForTables.get(info);
+        return future != null && future.isDone();
+    }
 
     public static class RecycleDatabaseInfo implements Writable {
         @SerializedName("d")

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.ImmutableList;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.jmockit.Deencapsulation;
@@ -51,6 +52,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -156,12 +158,31 @@ public class CatalogRecycleBinLakeTableTest {
 
     private static void waitTableToBeDone(CatalogRecycleBin recycleBin, long id, long time) {
         while (recycleBin.isDeletingTable(id)) {
-            recycleBin.eraseTable(time);
+            if (recycleBin.isDeletingTableDone(id)) {
+                recycleBin.eraseTable(time);
+            }
             try {
                 Thread.sleep(100);
             } catch (Exception ignore) {
             }
         }
+    }
+
+    private static void waitAllTablesToBeDone(CatalogRecycleBin recycleBin, List<Long> ids, long time) {
+        ids.forEach(x -> Assertions.assertTrue(recycleBin.isDeletingTable(x)));
+        long doingCount = ids.size();
+        // Note that the eraseTable() will add new async delete tasks if the deletion failed but retryable.
+        // In case of multiple tables in the recycle bin, we must wait until all tables are done before calling
+        // the eraseTable(). Otherwise the completed retryable tables will be added into the async delete tasks again.
+        while (doingCount > 0) {
+            doingCount = ids.stream().filter(x -> !recycleBin.isDeletingTableDone(x)).count();
+            try {
+                Thread.sleep(100);
+            } catch (Exception ignore) {
+                // nothing to do
+            }
+        }
+        recycleBin.eraseTable(time);
     }
 
     private static void waitPartitionToBeDone(CatalogRecycleBin recycleBin, long id, long time) {
@@ -399,11 +420,23 @@ public class CatalogRecycleBinLakeTableTest {
         // Now the retry interval has reached
         long delay = Math.max(Config.catalog_trash_expire_second * 1000, CatalogRecycleBin.getMinEraseLatency()) + 1;
         recycleBin.eraseTable(System.currentTimeMillis() + delay);
-        waitTableToBeDone(recycleBin, table1.getId(), System.currentTimeMillis() + delay);
-        waitTableToBeDone(recycleBin, table2.getId(), System.currentTimeMillis() + delay);
+
+        List<Long> tableIds = ImmutableList.of(table1.getId(), table2.getId());
+        // both tables should be submitted for deletion, the future is saved in asyncDeleteForTables
+        Assertions.assertTrue(recycleBin.isDeletingTable(table1.getId()));
+        Assertions.assertTrue(recycleBin.isDeletingTable(table2.getId()));
+        // must wait all tables done and then do the cleanup with eraseTable()
+        waitAllTablesToBeDone(recycleBin, tableIds, System.currentTimeMillis() + delay);
+
         Assertions.assertThrows(DdlException.class, () -> recoverDatabase(connectContext, recoverDbSql));
         Assertions.assertNotNull(recycleBin.getTable(db.getId(), table1.getId()));
         Assertions.assertNotNull(recycleBin.getTable(db.getId(), table2.getId()));
+
+        // NOTE: the tables are still in recycle bin because the deletion failed, may affect other cases running
+        // after this one, so here we clear them directly from RecycleBin.
+        recycleBin.removeTableFromRecycleBin(tableIds);
+        Assertions.assertNull(recycleBin.getTable(db.getId(), table1.getId()));
+        Assertions.assertNull(recycleBin.getTable(db.getId(), table2.getId()));
     }
 
     @Test


### PR DESCRIPTION
* finally ...

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes CatalogRecycleBin lake table UTs by correctly waiting for async table deletions and adds minimal testing hooks in CatalogRecycleBin.
> 
> - **Tests (`CatalogRecycleBinLakeTableTest`)**:
>   - Update `waitTableToBeDone` to call `eraseTable` only after `isDeletingTableDone`.
>   - Add `waitAllTablesToBeDone(...)` to wait for multiple tables' async deletions before a single `eraseTable` call; use it in `testRecycleLakeDatabase`.
>   - Post-test cleanup: directly remove tables via `recycleBin.removeTableFromRecycleBin(...)`.
> - **Catalog (`CatalogRecycleBin`)**:
>   - Add `@VisibleForTesting synchronized boolean isDeletingTableDone(long id)`.
>   - Relax visibility of `removeTableFromRecycleBin(...)` for test access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01f332ff0cdfb3fceb520efd6b4468282c432893. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->