### PR TITLE
[Enhancement] optimize modifySystemVariable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -561,6 +561,9 @@ public class ConnectContext {
     }
 
     public void modifySystemVariable(SystemVariable setVar, boolean onlySetSessionVar) throws DdlException {
+        if (!globalStateMgr.getVariableMgr().containsVariable(setVar.getVariable())) {
+            return;
+        }
         globalStateMgr.getVariableMgr().setSystemVariable(sessionVariable, setVar, onlySetSessionVar);
         if (!SetType.GLOBAL.equals(setVar.getType())
                 && globalStateMgr.getVariableMgr().shouldForwardToLeader(setVar.getVariable())) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -560,15 +560,16 @@ public class ConnectContext {
         return accessControlContext;
     }
 
-    public void modifySystemVariable(SystemVariable setVar, boolean onlySetSessionVar) throws DdlException {
+    public boolean modifySystemVariable(SystemVariable setVar, boolean onlySetSessionVar) throws DdlException {
         if (!globalStateMgr.getVariableMgr().containsVariable(setVar.getVariable())) {
-            return;
+            return false;
         }
         globalStateMgr.getVariableMgr().setSystemVariable(sessionVariable, setVar, onlySetSessionVar);
         if (!SetType.GLOBAL.equals(setVar.getType())
                 && globalStateMgr.getVariableMgr().shouldForwardToLeader(setVar.getVariable())) {
             modifiedSessionVariables.put(setVar.getVariable(), setVar);
         }
+        return true;
     }
 
     public void modifyUserVariable(UserVariable userVariable) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -278,6 +278,7 @@ public class VariableMgr {
     public void checkSystemVariableExist(SystemVariable setVar) throws DdlException {
         VarContext ctx = getVarContext(setVar.getVariable());
         if (ctx == null) {
+            // NOTE: findSimilarVarNames uses fuzzy search, which is slow
             ErrorReport.reportDdlException(ErrorCode.ERR_UNKNOWN_SYSTEM_VARIABLE, setVar.getVariable(),
                     findSimilarVarNames(setVar.getVariable()));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -285,7 +285,7 @@ public class VariableMgr {
     }
 
     public boolean containsVariable(String name) {
-        return ctxByVarName.containsKey(name);
+        return ctxByVarName.containsKey(name) || aliases.containsKey(name);
     }
 
     // Entry of handling SetVarStmt

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -352,10 +352,12 @@ public class TaskRun implements Comparable<TaskRun> {
                 key = key.substring(PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX.length());
             }
             String value = entry.getValue();
+            boolean set = false;
             try {
-                runCtx.modifySystemVariable(new SystemVariable(key, new StringLiteral(value)), true);
-            } catch (DdlException e) {
-                // not session variable
+                set = (runCtx.modifySystemVariable(new SystemVariable(key, new StringLiteral(value)), true));
+            } catch (DdlException ignored) {
+            }
+            if (!set) {
                 taskRunContextProperties.put(key, properties.get(key));
             }
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


In `com.starrocks.scheduler.TaskRun#buildTaskRunContext`, it attempts to set all variables regardless of whether they are actual session variables, leading to unnecessary overhead as indicated by profiling data.

<img width="810" height="483" alt="image" src="https://github.com/user-attachments/assets/a120a300-c59e-4640-96ac-9f27fee6d099" />


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Return boolean from `ConnectContext.modifySystemVariable` and use alias-aware `VariableMgr.containsVariable` so `TaskRun` skips unknown session vars without throwing exceptions.
> 
> - **QE/Core**:
>   - `ConnectContext.modifySystemVariable` now returns `boolean`; validates var existence via `VariableMgr.containsVariable` before setting; still forwards eligible session vars.
>   - `VariableMgr.containsVariable` recognizes aliases; minor note added about fuzzy search cost.
> - **Scheduler**:
>   - `TaskRun.buildTaskRunContext` sets session vars only when `modifySystemVariable` returns true; non-session/unknown vars are recorded in task context without relying on exceptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87b5fd689378932bf4e63f321ce9e3e3018dd858. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->