### PR TITLE
[BugFix] Resolve issues with tablet migration and pk index lookup concurrency

### DIFF
--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -393,6 +393,8 @@ public:
 
     bool rowset_check_file_existence() const;
 
+    std::shared_timed_mutex* get_index_lock() { return &_index_lock; }
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;
@@ -518,8 +520,6 @@ private:
     bool is_apply_stop() { return _apply_stopped.load(); }
 
     bool compaction_running() { return _compaction_running; }
-
-    std::shared_timed_mutex* get_index_lock() { return &_index_lock; }
 
     bool _use_light_apply_compaction(Rowset* rowset);
 

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -563,10 +563,10 @@ Status EngineStorageMigrationTask::_finish_primary_key_migration(const TabletSha
             break;
         }
 
+        auto manager = StorageEngine::instance()->update_manager();
         // clear index cache
         {
-            std::lock_guard lg(*tablet.updates()->get_index_lock());
-            auto manager = StorageEngine::instance()->update_manager();
+            std::lock_guard lg(*tablet->updates()->get_index_lock());
             auto& index_cache = manager->index_cache();
             auto index_entry = index_cache.get_or_create(_tablet_id);
             index_entry->update_expire_time(MonotonicMillis() + manager->get_cache_expire_ms());


### PR DESCRIPTION
## Why I'm doing:
When tablet migration, it will unload PK index without holding index lock, and it may lead to crash when concurrency pk index lookup happens:
```
** Aborted at 1758739747 (unix time) try "date -d @1758739747" if you are using GNU date ***
PC: @          0x60ec407 starrocks::PrimaryIndex::_get_from_persistent_index(starrocks::Column const&, std::vector<unsigned long, std::allocator<unsigned long> >*) const
*** SIGSEGV (@0x0) received by PID 51869 (TID 0x14f557ddb700) from PID 0; stack trace: ***
    @     0x14f7ad36f457 (/usr/lib64/[libpthread-2.28.so](http://libpthread-2.28.so/)+0x10456)
    @          0x7dc3dc0 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x14f7ad3722c0 (/usr/lib64/[libpthread-2.28.so](http://libpthread-2.28.so/)+0x132bf)
    @          0x60ec407 starrocks::PrimaryIndex::_get_from_persistent_index(starrocks::Column const&, std::vector<unsigned long, std::allocator<unsigned long> >*) const
    @          0x60ec530 starrocks::PrimaryIndex::get(starrocks::Column const&, std::vector<unsigned long, std::allocator<unsigned long> >*) const
    @          0x6220225 starrocks::TabletUpdates::get_rss_rowids_by_pk_unlock(starrocks::Tablet*, starrocks::Column const&, starrocks::EditVersion*, std::vector<unsigned long, std::allocator<unsigned long> >*)
    @          0x6220747 starrocks::TabletUpdates::get_rss_rowids_by_pk(starrocks::Tablet*, starrocks::Column const&, starrocks::EditVersion*, std::vector<unsigned long, std::allocator<unsigned long> >*, long)
    @          0x60d94d6 starrocks::LocalTabletReader::multi_get(starrocks::Chunk const&, std::vector<unsigned int, std::allocator<unsigned int> > const&, std::vector<bool, std::allocator<bool> >&, starrocks::Chunk&)
```

## What I'm doing:

This pull request adds a thread-safe block to clear the index cache in the `EngineStorageMigrationTask::_finish_primary_key_migration` method. The main change is the introduction of a lock to ensure that cache operations are performed safely in a concurrent environment.

Cache management improvements:

* Wrapped the index cache clearing logic in a `std::lock_guard` using the tablet's index lock to ensure thread safety during cache operations in `engine_storage_migration_task.cpp`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
