### PR TITLE
[UT] Fix StreamLoadTaskTest timeout

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadTaskTest.java
@@ -65,7 +65,7 @@ public class StreamLoadTaskTest {
     public void setUp() {
         long id = 123L;
         String label = "label_abc";
-        long timeoutMs = 10000L;
+        long timeoutMs = 100000L;
         long createTimeMs = System.currentTimeMillis();
         boolean isRoutineLoad = false;
         streamLoadTask =
@@ -143,8 +143,6 @@ public class StreamLoadTaskTest {
             }
         };
 
-        ExceptionChecker.expectThrowsWithMsg(StarRocksException.class, ERR_NO_PARTITIONS_HAVE_DATA_LOAD.formatErrorMsg(),
-                () -> Deencapsulation.invoke(streamLoadTask, "unprotectedWaitCoordFinish"));
         ExceptionChecker.expectThrowsWithMsg(StarRocksException.class, ERR_NO_PARTITIONS_HAVE_DATA_LOAD.formatErrorMsg(),
                 () -> Deencapsulation.invoke(streamLoadTask, "unprotectedWaitCoordFinish"));
     }


### PR DESCRIPTION
## Why I'm doing:

```
com.starrocks.load.streamload.StreamLoadTaskTest.testNoPartitionsHaveDataLoad -- Time elapsed: 9.804 s <<< ERROR!
java.lang.IllegalStateException: Can't overwrite cause with com.starrocks.common.StarRocksException: Load timeout. Increase the timeout and retry
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase StreamLoadTaskTest timeout to 100s and remove a redundant exception assertion in no-data-load test.
> 
> - **Tests**:
>   - Increase `timeoutMs` in `StreamLoadTaskTest#setUp` from `10000L` to `100000L`.
>   - Remove duplicate `ExceptionChecker.expectThrowsWithMsg` call in `testNoPartitionsHaveDataLoad`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2014268694ff05101772ba0b37b69a2bf8e31a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->