### PR TITLE
[BugFix] Fix drop ComputeNode/Backend from starmgr bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -620,10 +620,21 @@ public class SystemInfoService implements GsonPostProcessable {
         // try to record the historical backend nodes
         tryUpdateHistoricalComputeNodes(dropComputeNode.getWarehouseId(), dropComputeNode.getWorkerGroupId());
 
+        // remove worker
+        if (RunMode.isSharedDataMode()) {
+            int starletPort = dropComputeNode.getStarletPort();
+            // only need to remove worker after be reported its starletPort
+            if (starletPort != 0) {
+                String workerAddr = NetUtils.getHostPortInAccessibleFormat(dropComputeNode.getHost(), starletPort);
+                GlobalStateMgr.getCurrentState().getStarOSAgent()
+                        .removeWorker(workerAddr, dropComputeNode.getWorkerGroupId());
+            }
+        }
+
         // log
         GlobalStateMgr.getCurrentState().getEditLog().logDropComputeNode(
                 new DropComputeNodeLog(dropComputeNode.getId()),
-                wal -> replayDropComputeNode((DropComputeNodeLog) wal));
+                wal -> removeComputeNode((DropComputeNodeLog) wal));
         LOG.info("finished to drop {}", dropComputeNode);
     }
 
@@ -738,9 +749,20 @@ public class SystemInfoService implements GsonPostProcessable {
         // try to record the historical backend nodes
         tryUpdateHistoricalBackends(droppedBackend.getWarehouseId(), droppedBackend.getWorkerGroupId());
 
+        // remove worker
+        if (RunMode.isSharedDataMode()) {
+            int starletPort = droppedBackend.getStarletPort();
+            // only need to remove worker after be reported its starletPort
+            if (starletPort != 0) {
+                String workerAddr = NetUtils.getHostPortInAccessibleFormat(droppedBackend.getHost(), starletPort);
+                GlobalStateMgr.getCurrentState().getStarOSAgent()
+                        .removeWorker(workerAddr, droppedBackend.getWorkerGroupId());
+            }
+        }
+
         // log
         GlobalStateMgr.getCurrentState().getEditLog().logDropBackend(
-                new DropBackendInfo(droppedBackend.getId()), wal -> replayDropBackend((DropBackendInfo) wal));
+                new DropBackendInfo(droppedBackend.getId()), wal -> removeBackend((DropBackendInfo) wal));
         LOG.info("finished to drop {}", droppedBackend);
 
         // backends are changed, regenerated tablet number metrics
@@ -1270,16 +1292,29 @@ public class SystemInfoService implements GsonPostProcessable {
         idToReportVersionRef = ImmutableMap.copyOf(copiedReportVersions);
     }
 
-    public void replayDropComputeNode(DropComputeNodeLog dropComputeNodeLog) {
-        LOG.debug("replayDropComputeNode: {}", dropComputeNodeLog);
-
+    private ComputeNode removeComputeNode(DropComputeNodeLog dropComputeNodeLog) {
         // update idToComputeNode
         ComputeNode cn = idToComputeNodeRef.remove(dropComputeNodeLog.getComputeNodeId());
+        if (cn == null) {
+            LOG.error("compute node {} does not exist when remove compute node", dropComputeNodeLog.getComputeNodeId());
+            return null;
+        }
 
         // BackendCoreStat is a global state, checkpoint should not modify it.
         if (!GlobalStateMgr.isCheckpointThread()) {
             // remove from BackendCoreStat
             BackendResourceStat.getInstance().removeBe(dropComputeNodeLog.getComputeNodeId());
+        }
+
+        return cn;
+    }
+
+    public void replayDropComputeNode(DropComputeNodeLog dropComputeNodeLog) {
+        LOG.debug("replayDropComputeNode: {}", dropComputeNodeLog);
+
+        ComputeNode cn = removeComputeNode(dropComputeNodeLog);
+        if (cn == null) {
+            return;
         }
 
         // clear map in starosAgent
@@ -1293,13 +1328,12 @@ public class SystemInfoService implements GsonPostProcessable {
         }
     }
 
-    public void replayDropBackend(DropBackendInfo info) {
-        LOG.debug("replayDropBackend: {}", info.getId());
+    private Backend removeBackend(DropBackendInfo info) {
         // update idToBackend
         Backend backend = idToBackendRef.remove(info.getId());
         if (backend == null) {
-            LOG.error("backend {} does not exist when replay drop backend", info.getId());
-            return;
+            LOG.error("backend {} does not exist when remove backend", info.getId());
+            return null;
         }
 
         // update idToReportVersion
@@ -1311,6 +1345,16 @@ public class SystemInfoService implements GsonPostProcessable {
         if (!GlobalStateMgr.isCheckpointThread()) {
             // remove from BackendCoreStat
             BackendResourceStat.getInstance().removeBe(backend.getId());
+        }
+        return backend;
+    }
+
+    public void replayDropBackend(DropBackendInfo info) {
+        LOG.debug("replayDropBackend: {}", info.getId());
+
+        Backend backend = removeBackend(info);
+        if (backend == null) {
+            return;
         }
 
         // clear map in starosAgent

--- a/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceEditLogTest.java
@@ -2253,4 +2253,18 @@ public class SystemInfoServiceEditLogTest {
         Assertions.assertEquals(DiskInfo.DiskState.ONLINE, followerDisk1.getState());
         Assertions.assertEquals(DiskInfo.DiskState.ONLINE, followerDisk3.getState());
     }
+
+    @Test
+    public void testReplayDropBackendNotExit() {
+        DropBackendInfo dropBackendInfo = new DropBackendInfo(10000);
+        // should not throw any exception
+        followerSystemInfoService.replayDropBackend(dropBackendInfo);
+    }
+
+    @Test
+    public void testReplayDropComputeNodeNotExit() {
+        DropComputeNodeLog dropComputeNodeInfo = new DropComputeNodeLog(10000);
+        // should not throw any exception
+        followerSystemInfoService.replayDropComputeNode(dropComputeNodeInfo);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10455

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures dropping a Backend/ComputeNode also removes its StarOS worker (shared-data mode) and refactors drop handling with new remove* methods and updated WAL callbacks.
> 
> - **SystemInfoService**:
>   - **Drop behavior (shared-data mode)**:
>     - On `dropComputeNode`/`dropBackend`, remove StarOS worker via `StarOSAgent.removeWorker` when `starletPort` is set.
>   - **WAL/replay changes**:
>     - Log callbacks now invoke `removeComputeNode`/`removeBackend` instead of replay methods.
>     - New helpers `removeComputeNode(DropComputeNodeLog)` and `removeBackend(DropBackendInfo)` centralize removal from in-memory maps and `BackendResourceStat` updates.
>     - `replayDropComputeNode`/`replayDropBackend` call the new helpers, then clear StarOS worker mapping via `removeWorkerFromMap` when applicable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf78eeb2c8fc22af82dcc3f7e129841c6c8160d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->