### PR TITLE
[BugFix] add both RUNNING & FINISHED query detail for MV refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
@@ -131,6 +131,12 @@ public class QueryState {
         isFinished = true;
     }
 
+    public void resetError() {
+        this.stateType = MysqlStateType.OK;
+        this.errorCode = null;
+        this.errorMessage = null;
+    }
+
     public boolean isError() {
         return stateType == MysqlStateType.ERR;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -297,10 +297,10 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         ctx.setStmtId(STMT_ID_GENERATOR.incrementAndGet());
         // Add running query detail for MV refresh
         ctx.setQuerySource(QueryDetail.QuerySource.MV);
-        executor.addRunningQueryDetail(insertStmt);
 
         logger.info("[QueryId:{}] start to refresh mv in DML", ctx.getQueryId());
         try {
+            executor.addRunningQueryDetail(insertStmt);
             executor.handleDMLStmtWithProfile(execPlan, insertStmt);
         } catch (Exception e) {
             logger.warn("[QueryId:{}] refresh mv {} failed in DML", ctx.getQueryId(), e);
@@ -308,6 +308,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         } finally {
             logger.info("[QueryId:{}] finished to refresh mv in DML", ctx.getQueryId());
             auditAfterExec(mvTaskRunContext, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
+            executor.addFinishedQueryDetail();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -357,6 +357,8 @@ public class TaskRun implements Comparable<TaskRun> {
             } catch (DdlException e) {
                 // not session variable
                 taskRunContextProperties.put(key, properties.get(key));
+                // FIXME: it's too hack, don't pollute the session when setting variables
+                runCtx.getState().resetError();
             }
         }
         // set warehouse


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

MV refresh only generates RUNNING query detail but not FINISHED.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
