### PR TITLE
[BugFix] Fix exception when parsing Nullable (Decimal) type of Clickhouse

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
@@ -127,6 +127,9 @@ public class ClickhouseSchemaResolver extends JDBCSchemaResolver {
                 break;
             case Types.DECIMAL:
                 // Decimal(9,9), first 9 is precision, second 9 is scale
+                if (typeName.startsWith("Nullable")) {
+                    typeName = typeName.replace("Nullable", "");
+                }
                 String[] precisionAndScale =
                         typeName.replace("Decimal", "").replace("(", "")
                                 .replace(")", "").replace(" ", "")

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
@@ -66,21 +66,21 @@ public class ClickhouseSchemaResolverTest {
                         Types.BIGINT, Types.NUMERIC, Types.NUMERIC, Types.NUMERIC, Types.NUMERIC, Types.NUMERIC,
                         Types.FLOAT,
                         Types.DOUBLE, Types.BOOLEAN, Types.DATE, Types.TIMESTAMP, Types.VARCHAR, Types.VARCHAR,
-                        Types.DECIMAL
+                        Types.DECIMAL, Types.DECIMAL
                 ));
         columnResult.addColumn("TYPE_NAME", Arrays.asList("Int8", "UInt8", "Int16", "UInt16", "Int32", "Int64",
                 "UInt32", "UInt64", "Int128", "UInt128", "Int256", "UInt256", "Float32", "Float64", "Bool", "Date",
                 "DateTime",
-                "String", "Nullable(String)", "Decimal(9,9)"));
+                "String", "Nullable(String)", "Decimal(9,9)", "Nullable(Decimal(9,9))"));
         columnResult.addColumn("COLUMN_SIZE",
-                Arrays.asList(3, 3, 5, 5, 10, 19, 10, 20, 39, 39, 77, 78, 12, 22, 1, 10, 29, 0, 0, 9));
+                Arrays.asList(3, 3, 5, 5, 10, 19, 10, 20, 39, 39, 77, 78, 12, 22, 1, 10, 29, 0, 0, 9, 9));
         columnResult.addColumn("DECIMAL_DIGITS",
-                Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null, 0, 0, null, null, 9));
+                Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null, 0, 0, null, null, 9, 9));
         columnResult.addColumn("COLUMN_NAME", Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l",
-                "m", "n", "o", "p", "q", "r", "s", "t"));
+                "m", "n", "o", "p", "q", "r", "s", "t", "u"));
         columnResult.addColumn("IS_NULLABLE",
                 Arrays.asList("NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO",
-                        "NO", "NO", "NO", "YES", "NO"));
+                        "NO", "NO", "NO", "YES", "NO", "YES"));
         properties = new HashMap<>();
         properties.put(DRIVER_CLASS, "com.clickhouse.jdbc.ClickHouseDriver");
         properties.put(JDBCResource.URI, "jdbc:clickhouse://127.0.0.1:8123");
@@ -221,6 +221,7 @@ public class ClickhouseSchemaResolverTest {
             Assertions.assertNull(properties.get(JDBCTable.JDBC_TABLENAME));
         } catch (Exception e) {
             System.out.println(e.getMessage());
+            e.printStackTrace();
             Assertions.fail();
         }
     }


### PR DESCRIPTION
## Why I'm doing:
When executing "show create table" to query the ClickHouse table schema, if the column data type is Nullable (Decimal(a,b)), a parsing exception will occur.
The exception stack is as follows:
> For input string: "Nullable9"
java.lang.NumberFormatException: For input string: "Nullable9"
        at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
        at java.base/java.lang.Integer.parseInt(Integer.java:668)
        at java.base/java.lang.Integer.parseInt(Integer.java:786)
        at com.starrocks.connector.jdbc.ClickhouseSchemaResolver.convertColumnType(ClickhouseSchemaResolver.java:139)
        at com.starrocks.connector.jdbc.JDBCSchemaResolver.convertToSRTable(JDBCSchemaResolver.java:89)
        at com.starrocks.connector.jdbc.JDBCMetadata.lambda$getTable$1(JDBCMetadata.java:202)
        at com.starrocks.connector.jdbc.JDBCMetaCache.get(JDBCMetaCache.java:73)
        at com.starrocks.connector.jdbc.JDBCMetadata.getTable(JDBCMetadata.java:198)

## What I'm doing:
Replace "Nullable" with an empty string to complete the parsing.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
