### PR TITLE
[Tool] Support run fe on Mac 12: update fe script

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -19,7 +19,25 @@
 curdir=`dirname "$0"`
 curdir=`cd "$curdir"; pwd`
 
-OPTS=$(getopt \
+# macOS compatibility: use GNU getopt
+GETOPT_BIN="getopt"
+if [[ "$OSTYPE" == darwin* ]]; then
+    # Try to detect gnu-getopt path dynamically
+    if command -v brew &> /dev/null; then
+        GNU_GETOPT_PREFIX=$(brew --prefix gnu-getopt 2>/dev/null)
+        if [[ -n "${GNU_GETOPT_PREFIX}" ]] && [[ -x "${GNU_GETOPT_PREFIX}/bin/getopt" ]]; then
+            GETOPT_BIN="${GNU_GETOPT_PREFIX}/bin/getopt"
+        else
+            echo "gnu-getopt is required on macOS. Please install it with 'brew install gnu-getopt'."
+            exit 1
+        fi
+    else
+        echo "Homebrew is required on macOS to install gnu-getopt. Please install Homebrew first."
+        exit 1
+    fi
+fi
+
+OPTS=$(${GETOPT_BIN} \
   -n $0 \
   -o '' \
   -l 'daemon' \
@@ -75,13 +93,39 @@ if [ -e $STARROCKS_HOME/conf/hadoop_env.sh ]; then
     source $STARROCKS_HOME/conf/hadoop_env.sh
 fi
 
+# Helper function for readlink -f (macOS compatibility)
+readlink_f() {
+    local target="$1"
+    cd "$(dirname "$target")" || return 1
+    target=$(basename "$target")
+
+    # Iterate down symlinks
+    while [ -L "$target" ]; do
+        target=$(readlink "$target")
+        cd "$(dirname "$target")" || return 1
+        target=$(basename "$target")
+    done
+
+    # Compute the absolute path
+    local phys_dir=$(pwd -P)
+    echo "$phys_dir/$target"
+}
+
 # java
 if [[ -z ${JAVA_HOME} ]]; then
     if command -v javac &> /dev/null; then
-        export JAVA_HOME="$(dirname $(dirname $(readlink -f $(which javac))))"
+        if [[ "$OSTYPE" == darwin* ]]; then
+            export JAVA_HOME="$(dirname $(dirname $(readlink_f $(which javac))))"
+        else
+            export JAVA_HOME="$(dirname $(dirname $(readlink -f $(which javac))))"
+        fi
         echo "Infered JAVA_HOME=$JAVA_HOME"
     elif command -v java &> /dev/null; then
-        export JAVA_HOME="$(dirname $(dirname $(readlink -f $(which java))))"
+        if [[ "$OSTYPE" == darwin* ]]; then
+            export JAVA_HOME="$(dirname $(dirname $(readlink_f $(which java))))"
+        else
+            export JAVA_HOME="$(dirname $(dirname $(readlink -f $(which java))))"
+        fi
     else
       cat << EOF
 Error: The environment variable JAVA_HOME is not set, and neither JDK or JRE is found.
@@ -183,8 +227,12 @@ pidfile=$PID_DIR/fe.pid
 
 if [ -f $pidfile ]; then
   oldpid=$(cat $pidfile)
-  # get the full command
-  pscmd=$(ps -q $oldpid -o cmd=)
+  # get the full command (macOS ps doesn't support -q option)
+  if [[ "$OSTYPE" == darwin* ]]; then
+    pscmd=$(ps -p $oldpid -o command= 2>/dev/null)
+  else
+    pscmd=$(ps -q $oldpid -o cmd=)
+  fi
   if echo "$pscmd" | grep -q -w StarRocksFE &>/dev/null ; then
     echo Frontend running as process $oldpid. Stop it first.
     exit 1


### PR DESCRIPTION
## Why I'm doing:
For https://github.com/StarRocks/starrocks/issues/30438

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds macOS-compatible logic to `bin/start_fe.sh` and `build.sh` (GNU getopt detection, `readlink -f` shim, ps/date variants, and JAVA_HOME inference).
> 
> - **Scripts**:
>   - `bin/start_fe.sh`:
>     - Detects and uses GNU `getopt` via Homebrew; falls back with guidance if missing.
>     - Adds `readlink_f` helper to emulate `readlink -f` on macOS and updates `JAVA_HOME` inference to use it.
>     - Adjusts process check to use `ps -p ... -o command=` on macOS.
>   - `build.sh`:
>     - Detects and uses GNU `getopt` via Homebrew.
>     - Adds `format_time` for cross-platform timestamp formatting and uses it in the final build summary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3695a8848f0c41ddee20c69b51014b5120521fd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->