### PR TITLE
[Enhancement] Optimize MaterializedView onReload performance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.authorization.PrivilegeBuiltinConstants;
@@ -37,6 +38,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.Pair;
+import com.starrocks.common.TimeoutWatcher;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.common.util.DateUtils;
@@ -106,6 +108,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static com.starrocks.backup.mv.MVRestoreUpdater.checkMvDefinedQuery;
@@ -208,6 +212,20 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
         public boolean isFull() {
             return this == FULL;
+        }
+    }
+
+    /**
+     * Reason for materialized view being inactive.
+     * @param isActive whether the materialized view is active
+     * @param reason the reason for being inactive
+     */
+    public record InactiveReason(boolean isActive, String reason) {
+        public static InactiveReason ofInactive(String reason) {
+            return new InactiveReason(false, reason);
+        }
+        public static InactiveReason ofActive() {
+            return new InactiveReason(true, null);
         }
     }
 
@@ -620,7 +638,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     // Use a flag to prevent MV reload too many times while recursively reloading every mv at FE start time
     // and in each round of checkpoint
-    private boolean reloaded = false;
+    private AtomicBoolean reloaded = new AtomicBoolean(false);
 
     public MaterializedView() {
         super(TableType.MATERIALIZED_VIEW);
@@ -702,12 +720,18 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         CachingMvPlanContextBuilder.getInstance().cacheMaterializedView(this);
     }
 
+    /**
+     * This can be time costing because `evictMaterializedViewCache` may visit all its base tables to build ast key, so only use
+     * it when necessary.
+     * @param reason the reason for being inactive
+     */
     public synchronized void setInactiveAndReason(String reason) {
         LOG.warn("set {} to inactive because of {}", name, reason);
         this.active = false;
         this.inactiveReason = reason;
         // reset cached variables
         resetMetadataCache();
+        // evict mv rewrite cache when it is inactive
         CachingMvPlanContextBuilder.getInstance().evictMaterializedViewCache(this);
     }
 
@@ -870,11 +894,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     public boolean hasReloaded() {
-        return reloaded;
+        return reloaded.get();
     }
 
     public void setReloaded(boolean reloaded) {
-        this.reloaded = reloaded;
+        this.reloaded.set(reloaded);
     }
 
     public RefreshMode getRefreshMode() {
@@ -1066,6 +1090,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         mv.refreshScheme = this.refreshScheme.copy();
         mv.maxMVRewriteStaleness = this.maxMVRewriteStaleness;
         mv.viewDefineSql = this.viewDefineSql;
+        mv.warehouseId = this.warehouseId;
         if (this.baseTableIds != null) {
             mv.baseTableIds = Sets.newHashSet(this.baseTableIds);
         }
@@ -1085,6 +1110,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         mv.refBaseTablePartitionSlotsOpt = this.refBaseTablePartitionSlotsOpt;
         mv.refBaseTablePartitionColumnsOpt = this.refBaseTablePartitionColumnsOpt;
         mv.tableToBaseTableInfoCache = this.tableToBaseTableInfoCache;
+        mv.defineQueryParseNode = this.defineQueryParseNode;
+        mv.reloaded = this.reloaded;
     }
 
     @Override
@@ -1190,34 +1217,92 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     /**
      * Reload the materialized view with original active state.
      * NOTE: This method will not try to activate the materialized view.
-     *
-     * @param postLoadImage: whether this reload is called after FE's image loading process.
+     * @param isReloadAsync whether reload mv asynchronously when it is desired to be active.
      */
-    public void onReload(boolean postLoadImage) {
-        onReload(postLoadImage, isActive());
+    public void onReload(boolean isReloadAsync) {
+        onReload(isReloadAsync, isActive());
     }
 
     /**
-     * `postLoadImage` is used to distinct wether it's called after FE's image loading process,
+     * `isReLoadAsync` is used to distinct wether it's called after FE's image loading process,
      * such as FE startup or checkpointing.
      * <p>
      * Note!! The `onReload` method is called in some other scenarios such as - schema change of a materialize view.
      * The reloaded flag was introduced only to increase the speed of FE startup and checkpointing.
      * It shouldn't affect the behavior of other operations which might indeed need to do a reload process.
      *
-     * @param postLoadImage whether this reload is called after FE's image loading process.
+     * @param isReloadAsync whether this reload is called after FE's image loading process.
      * @param desiredActive whether the materialized view should be active after reload.
      */
-    private void onReload(boolean postLoadImage, boolean desiredActive) {
+    private void onReload(boolean isReloadAsync, boolean desiredActive) {
         try {
-            active = false;
-            boolean reloadActive = onReloadImpl(postLoadImage);
-            if (desiredActive && reloadActive) {
-                setActive();
+            // set inactive first to avoid inconsistent state during reloading
+            this.active = false;
+            // set reload first
+            this.reloaded.set(false);
+            // reload mv required metadata synchronously
+            onReloadImpl();
+            // if desired to be active, check whether you can be active
+            if (desiredActive) {
+                checkAndSetActive(isReloadAsync);
             }
         } catch (Throwable e) {
             LOG.error("reload mv failed: {}", this, e);
-            setInactiveAndReason("reload failed: " + e.getMessage());
+            // only set inactive when it is desired to be active
+            if (desiredActive) {
+                if (isReloadAsync) {
+                    // try to set inactive asynchronously
+                    CachingMvPlanContextBuilder.submitAsyncTask(buildTaskName("MVSetInactiveOnReloadFailure"), () -> {
+                        try {
+                            setInActiveReason(InactiveReason.ofInactive("reload failed: " + e.getMessage()));
+                        } finally {
+                            setReloaded(true);
+                        }
+                        return null;
+                    });
+                } else {
+                    setInActiveReason(InactiveReason.ofInactive("reload failed: " + e.getMessage()));
+                }
+            }
+        } finally {
+            if (!isReloadAsync || !desiredActive) {
+                LOG.info("finish reloading mv {}. current active state: {}", getName(), isActive());
+                setReloaded(true);
+            }
+        }
+    }
+
+    private void checkAndSetActive(boolean isReloadAsync) {
+        // to avoid blocking the main replay thread and reduce fe restart time, check isActive asynchronously,
+        // this method is time costing because:
+        // - if mv contains external base tables, it may need to connect external systems to check table existence
+        // - if mv contains hierarchical mvs, it may need to recursively reload base mvs
+        // so we submit an async task to do this check
+        if (isReloadAsync) {
+            CachingMvPlanContextBuilder.submitAsyncTask(buildTaskName("MVCheckIsActive"), () -> {
+                try {
+                    InactiveReason reason = checkIsActiveOnLoadBlocking();
+                    setInActiveReason(reason);
+                } finally {
+                    setReloaded(true);
+                }
+                return null;
+            });
+        } else {
+            InactiveReason reason = checkIsActiveOnLoadBlocking();
+            setInActiveReason(reason);
+        }
+    }
+
+    private String buildTaskName(String prefix) {
+        return String.format("%s-%s-%d", prefix, getName(), getId());
+    }
+
+    private void setInActiveReason(InactiveReason reason) {
+        if (!reason.isActive) {
+            setInactiveAndReason(reason.reason);
+        } else {
+            setActive();
         }
     }
 
@@ -1232,15 +1317,34 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     /**
-     * @return active or not
+     * On reload implementation.
+     *
+     * NOTE: this method only implements the necessary reloading logic and it should not connect other external systems
+     * which may block the main replay thread.
      */
-    private boolean onReloadImpl(boolean postLoadImage) {
+    private void onReloadImpl() {
         long startMillis = System.currentTimeMillis();
+        // analyze partition info
+        analyzePartitionInfo();
+        // analyze mv partition exprs
+        analyzePartitionExprs();
+        // register constraints from global state manager
+        GlobalConstraintManager globalConstraintManager = GlobalStateMgr.getCurrentState().getGlobalConstraintManager();
+        globalConstraintManager.registerConstraint(this);
+        // log reload cost
+        long duration = System.currentTimeMillis() - startMillis;
+        LOG.info("finish reloading mv {} in {}ms, total base table count: {}", getName(), duration, baseTableInfos.size());
+    }
+
+    /**
+     * Check whether this materialized view can be active on load.
+     * @return InactiveReason, which contains whether this mv is active and the reason if not active.
+     */
+    private InactiveReason checkIsActiveOnLoadBlocking() {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             LOG.warn("db:{} do not exist. materialized view id:{} name:{} should not exist", dbId, id, name);
-            setInactiveAndReason(MaterializedViewExceptions.inactiveReasonForDbNotExists(dbId));
-            return false;
+            return InactiveReason.ofInactive(MaterializedViewExceptions.inactiveReasonForDbNotExists(dbId));
         }
         if (baseTableInfos == null) {
             baseTableInfos = Lists.newArrayList();
@@ -1249,14 +1353,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 for (long tableId : baseTableIds) {
                     Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
                     if (table == null) {
-                        setInactiveAndReason(MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(tableId));
-                        return false;
+                        return InactiveReason.ofInactive(MaterializedViewExceptions
+                                .inactiveReasonForBaseTableNotExists(tableId));
                     }
                     baseTableInfos.add(new BaseTableInfo(dbId, db.getFullName(), table.getName(), tableId));
                 }
             } else {
                 active = false;
-                return false;
+                return InactiveReason.ofInactive("Base table infos and base table ids are both null");
             }
         } else {
             // for compatibility
@@ -1266,9 +1370,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 for (BaseTableInfo baseTableInfo : baseTableInfos) {
                     Optional<Table> table = MvUtils.getTableWithIdentifier(baseTableInfo);
                     if (!table.isPresent()) {
-                        setInactiveAndReason(MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(
+                        return InactiveReason.ofInactive(MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(
                                 baseTableInfo.getTableId()));
-                        return false;
                     }
                     Table baseTable = table.get();
                     newBaseTableInfos.add(
@@ -1278,7 +1381,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             }
         }
 
-        boolean res = true;
+        InactiveReason res = InactiveReason.ofActive();
         for (BaseTableInfo baseTableInfo : baseTableInfos) {
             Table table = null;
             try {
@@ -1290,31 +1393,23 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 LOG.warn("failed to get base table {} of MV {}", baseTableInfo, this, e);
             }
             if (table == null) {
-                res = false;
-                setInactiveAndReason(
-                        MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(baseTableInfo.getTableName()));
+                res = InactiveReason.ofInactive(MaterializedViewExceptions
+                        .inactiveReasonForBaseTableNotExists(baseTableInfo.getTableName()));
                 continue;
             } else if (table.isMaterializedView()) {
                 MaterializedView baseMV = (MaterializedView) table;
-                // only consider skipping reload when postLoadImage is true
-                if (Config.enable_mv_post_image_reload_cache && postLoadImage) {
-                    if (!baseMV.hasReloaded()) {
-                        // recursive reload MV, to guarantee the order of hierarchical MV
-                        baseMV.onReload(postLoadImage);
-                        baseMV.setReloaded(true);
-                    } else {
-                        LOG.info("baseMv: {} has reloaded before, skip reload it again", baseMV.getName());
-                    }
+                if (baseMV.hasReloaded()) {
+                    LOG.info("baseMv: {} has reloaded before, skip reload it again", baseMV.getName());
                 } else {
                     // recursive reload MV, to guarantee the order of hierarchical MV
-                    baseMV.onReload(postLoadImage);
+                    baseMV.onReload(false);
                 }
+
                 if (!baseMV.isActive()) {
                     LOG.warn("tableName :{} is invalid. set materialized view:{} to invalid",
                             baseTableInfo.getTableName(), id);
-                    setInactiveAndReason(
+                    res = InactiveReason.ofInactive(
                             MaterializedViewExceptions.inactiveReasonForBaseTableActive(baseTableInfo.getTableName()));
-                    res = false;
                 }
             }
 
@@ -1330,17 +1425,28 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 );
             }
         }
-        // analyze partition info
-        analyzePartitionInfo();
-        // analyze mv partition exprs
-        analyzePartitionExprs();
-        // register constraints from global state manager
-        GlobalConstraintManager globalConstraintManager = GlobalStateMgr.getCurrentState().getGlobalConstraintManager();
-        globalConstraintManager.registerConstraint(this);
-
-        long duration = System.currentTimeMillis() - startMillis;
-        LOG.info("finish reloading mv {} in {}ms, total base table count: {}", getName(), duration, baseTableInfos.size());
         return res;
+    }
+
+    /**
+     * Wait until the materialized view has reloaded.
+     */
+    public void waitForReloaded() {
+        if (hasReloaded()) {
+            return;
+        }
+        long maxWaitMillis = Config.mv_async_reload_wait_timeout_second * 1000L;
+        TimeoutWatcher timeoutWatcher = new TimeoutWatcher(maxWaitMillis);
+        while (!hasReloaded() && !isActive()) {
+            if (timeoutWatcher.isTimedOut()) {
+                LOG.warn("Timeout waiting for MV [{}] reload (waited {} ms), continuing.",
+                        getName(), maxWaitMillis);
+                break;
+            }
+            Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MICROSECONDS);
+        }
+        LOG.info("MV [{}] reload finished, isActive: {}, hasReloaded: {}, duration(ms): {}",
+                getName(), isActive(), hasReloaded(), timeoutWatcher.getElapsedMillis());
     }
 
     private void analyzePartitionInfo() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3480,6 +3480,9 @@ public class Config extends ConfigBase {
             " If one base mv has done reload, no need to do it again while other mv that related to it is reloading ")
     public static boolean enable_mv_post_image_reload_cache = true;
 
+    @ConfField(mutable = true, comment = "The timeout for waiting async mv reload done, 5 min by default")
+    public static int mv_async_reload_wait_timeout_second = 5 * 60; // 5 min
+
     /**
      * Whether analyze the mv after refresh in async mode.
      */
@@ -3527,7 +3530,7 @@ public class Config extends ConfigBase {
     public static long mv_plan_cache_expire_interval_sec = 24L * 60L * 60L;
 
     @ConfField(mutable = true, comment = "The default thread pool size of mv plan cache")
-    public static int mv_plan_cache_thread_pool_size = 3;
+    public static int mv_plan_cache_thread_pool_size = 8;
 
     /**
      * mv plan cache expire interval in seconds

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3480,8 +3480,8 @@ public class Config extends ConfigBase {
             " If one base mv has done reload, no need to do it again while other mv that related to it is reloading ")
     public static boolean enable_mv_post_image_reload_cache = true;
 
-    @ConfField(mutable = true, comment = "The timeout for waiting async mv reload done, 5 min by default")
-    public static int mv_async_reload_wait_timeout_second = 5 * 60; // 5 min
+    @ConfField(mutable = true, comment = "The timeout for waiting async mv reload done, 3 min by default")
+    public static int mv_async_reload_wait_timeout_second = 3 * 60; // 3 min
 
     /**
      * Whether analyze the mv after refresh in async mode.

--- a/fe/fe-core/src/main/java/com/starrocks/common/TimeoutWatcher.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/TimeoutWatcher.java
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.common;
+
+public class TimeoutWatcher {
+    // unit: milliseconds
+    private final long deadline;
+    private final long startTime;
+
+    public TimeoutWatcher(long timeoutMillis) {
+        this.startTime = System.currentTimeMillis();
+        this.deadline = startTime + timeoutMillis;
+    }
+
+    public boolean isTimedOut() {
+        return System.currentTimeMillis() >= deadline;
+    }
+
+    public long getElapsedMillis() {
+        return System.currentTimeMillis() - startTime;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/mv/MaterializedViewDependencyGraph.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/mv/MaterializedViewDependencyGraph.java
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.common.mv;
+
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvId;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+public class MaterializedViewDependencyGraph {
+    private static final Logger LOG = LogManager.getLogger(MaterializedViewDependencyGraph.class);
+
+    private MaterializedViewDependencyGraph() {
+        super();
+    }
+
+    public static List<MaterializedView> buildTopologicalOrder(List<MaterializedView> allMVs) {
+        // Collect all materialized views and process them in topological order,
+        // ensuring that dependencies are handled correctly.
+        Map<Long, MaterializedView> mvById = new HashMap<>();
+        // mv -> its related mvs
+        Map<MaterializedView, Set<Long>> dependencyGraph = new HashMap<>();
+        // mv <- mvs which depend on this mv
+        Map<Long, Set<Long>> reDependencyGraph = new HashMap<>();
+
+        // First, gather all MVs across all databases.
+        for (MaterializedView mv : allMVs) {
+            long mvId = mv.getId();
+            mvById.put(mvId, mv);
+
+            // Build dependency graph: for each MV, collect its direct MV dependencies (by table id).
+            Set<Long> deps = new HashSet<>();
+            Set<MvId> relatedMVs = mv.getRelatedMaterializedViews();
+            if (CollectionUtils.isNotEmpty(relatedMVs)) {
+                for (MvId depMv : relatedMVs) {
+                    long depId = depMv.getId();
+                    deps.add(depId);
+                    reDependencyGraph.computeIfAbsent(depId, k -> new HashSet<>()).add(mvId);
+                }
+            }
+            dependencyGraph.put(mv, deps);
+        }
+
+        // Topological sort using Kahn's algorithm
+        List<MaterializedView> topoOrder = new ArrayList<>();
+        Queue<MaterializedView> ready = new ArrayDeque<>();
+        Map<Long, Integer> inDegree = new HashMap<>();
+
+        for (MaterializedView mv : allMVs) {
+            int depCount = dependencyGraph.get(mv).size();
+            inDegree.put(mv.getId(), depCount);
+            if (depCount == 0) {
+                ready.add(mv);
+            }
+        }
+
+        while (!ready.isEmpty()) {
+            MaterializedView mv = ready.poll();
+            topoOrder.add(mv);
+            // For all MVs that depend on mv, decrease their in-degree
+            Set<Long> deps = reDependencyGraph.get(mv.getId());
+            if (CollectionUtils.isNotEmpty(deps)) {
+                for (Long depId : deps) {
+                    MaterializedView other = mvById.get(depId);
+                    if (other != null) {
+                        inDegree.put(other.getId(), inDegree.get(other.getId()) - 1);
+                        if (inDegree.get(other.getId()) == 0) {
+                            ready.add(other);
+                        }
+                    }
+                }
+            }
+        }
+
+        // If topoOrder does not contain all MVs, there is a cycle
+        if (topoOrder.size() != allMVs.size()) {
+            LOG.warn("Cycle detected in Materialized View dependencies! Processing in arbitrary order. " +
+                    "All MVs: {}, Topo Order: {}", allMVs.size(), topoOrder.size());
+            // fallback: Use the original order
+            topoOrder = allMVs;
+        }
+        return topoOrder;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -103,6 +103,8 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
                     mvId, context.ctx.getDatabase()));
         }
         this.mv = (MaterializedView) table;
+        // refresh mv until mv is reloaded.
+        mv.waitForReloaded();
         this.logger = MVTraceUtils.getLogger(mv, MVTaskRunProcessor.class);
 
         // NOTE: mvId is set in Task's properties when creating

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -95,6 +95,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
+import com.starrocks.common.mv.MaterializedViewDependencyGraph;
 import com.starrocks.common.util.Daemon;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.LogUtil;
@@ -1727,24 +1728,29 @@ public class GlobalStateMgr {
     @VisibleForTesting
     public void processMvRelatedMeta() {
         long startMillis = System.currentTimeMillis();
+        List<MaterializedView> allMVs = new ArrayList<>();
         for (Database db : localMetastore.getIdToDb().values()) {
             for (MaterializedView mv : db.getMaterializedViews()) {
-                // set `postLoadImage` flag to true to indicate that this is called after image loading
-                mv.onReload(true);
+                allMVs.add(mv);
             }
         }
 
-        // we should reset reloaded flags after each round of reloading for all materializedViews
-        int count = 0;
-        for (Database db : localMetastore.getIdToDb().values()) {
-            for (MaterializedView mv : db.getMaterializedViews()) {
-                count++;
-                mv.setReloaded(false);
-            }
+        // Process in topological order
+        List<MaterializedView> topoOrder = Config.enable_mv_post_image_reload_cache ?
+                MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs) : allMVs;
+        long topoBuildDuration = System.currentTimeMillis() - startMillis;
+
+        // only load image async when FE restart and it's not checkpoint thread to avoid changing original behavior.
+        boolean isReloadAsync = Config.enable_mv_post_image_reload_cache && !isCheckpointThread();
+        for (MaterializedView mv : topoOrder) {
+            // set `postLoadImage` flag to true to indicate that this is called after image loading
+            mv.onReload(isReloadAsync);
         }
 
         long duration = System.currentTimeMillis() - startMillis;
-        LOG.info("finish processing all tables' related materialized views in {}ms, total mv count: {}", duration, count);
+        LOG.info("finish processing all tables' related materialized views in {}ms, " +
+                "isReLoadAsync:{}, total mv count: {}, topo mv order:{}, topo build cost(ms):{}", duration, isReloadAsync,
+                allMVs.size(), topoOrder.size(), topoBuildDuration);
     }
 
     public void loadHeader(DataInputStream dis) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -45,16 +45,18 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 public class CachingMvPlanContextBuilder {
     private static final Logger LOG = LogManager.getLogger(CachingMvPlanContextBuilder.class);
 
     private static final CachingMvPlanContextBuilder INSTANCE = new CachingMvPlanContextBuilder();
 
-    private static final Executor MV_PLAN_CACHE_EXECUTOR = Executors.newFixedThreadPool(
+    private static final ExecutorService MV_PLAN_CACHE_EXECUTOR = Executors.newFixedThreadPool(
             Config.mv_plan_cache_thread_pool_size,
             new ThreadFactoryBuilder().setDaemon(true).setNameFormat("mv-plan-cache-%d").build());
 
@@ -378,5 +380,23 @@ public class CachingMvPlanContextBuilder {
             keys.add(cacheKey);
         }
         return keys;
+    }
+
+    /**
+     * Submit an async task to be executed in MV plan cache executor.
+     * @param taskName: the name of the task.
+     * @param task: the task to be executed.
+     */
+    public static void submitAsyncTask(String taskName, Supplier<Void> task) {
+        CompletableFuture<?> future = CompletableFuture.supplyAsync(task, MV_PLAN_CACHE_EXECUTOR);
+        long startTime = System.currentTimeMillis();
+        future.whenComplete((result, e) -> {
+            long duration = System.currentTimeMillis() - startTime;
+            if (e == null) {
+                LOG.info("async task {} finished successfully, cost: {}ms", taskName, duration);
+            } else {
+                LOG.warn("async task {} failed: {}, cost: {}ms", taskName, e.getMessage(), duration, e);
+            }
+        });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -1004,8 +1004,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
 
             mv1.onReload(postLoadImage);
             mv2.onReload(postLoadImage);
-
-            Assertions.assertFalse(baseMv.hasReloaded());
+            Assertions.assertTrue(baseMv.hasReloaded());
             Assertions.assertEquals(1, baseTable.getRelatedMaterializedViews().size());
             Assertions.assertEquals(2, baseMv.getRelatedMaterializedViews().size());
             Assertions.assertTrue(baseMv.getRelatedMaterializedViews().contains(mv1.getMvId()));
@@ -1022,7 +1021,10 @@ public class MaterializedViewTest extends StarRocksTestBase {
             baseMv.removeRelatedMaterializedView(mv2.getMvId());
 
             mv1.onReload(postLoadImage);
+            mv1.waitForReloaded();
+
             mv2.onReload(postLoadImage);
+            mv2.waitForReloaded();
 
             Assertions.assertTrue(baseMv.hasReloaded());
             Assertions.assertEquals(1, baseTable.getRelatedMaterializedViews().size());
@@ -1043,7 +1045,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
             mv1.onReload(postLoadImage);
             mv2.onReload(postLoadImage);
 
-            Assertions.assertFalse(baseMv.hasReloaded());
+            Assertions.assertTrue(baseMv.hasReloaded());
             Assertions.assertEquals(1, baseTable.getRelatedMaterializedViews().size());
             Assertions.assertEquals(2, baseMv.getRelatedMaterializedViews().size());
             Assertions.assertTrue(baseMv.getRelatedMaterializedViews().contains(mv1.getMvId()));
@@ -1104,18 +1106,24 @@ public class MaterializedViewTest extends StarRocksTestBase {
         baseMv.removeRelatedMaterializedView(mv1.getMvId());
         baseMv.removeRelatedMaterializedView(mv2.getMvId());
 
-        Assertions.assertFalse(mv1.hasReloaded());
-        Assertions.assertFalse(mv2.hasReloaded());
-        Assertions.assertFalse(baseMv.hasReloaded());
+        baseMv.waitForReloaded();
+        mv1.waitForReloaded();
+        mv2.waitForReloaded();
+        Assertions.assertTrue(mv1.hasReloaded());
+        Assertions.assertTrue(mv2.hasReloaded());
+        Assertions.assertTrue(baseMv.hasReloaded());
 
         Config.enable_mv_post_image_reload_cache = true;
         // do post image reload
         GlobalStateMgr.getCurrentState().processMvRelatedMeta();
+        baseMv.waitForReloaded();
+        mv1.waitForReloaded();
+        mv2.waitForReloaded();
 
         // after post image reload, all materialized views should have `reloaded` flag reset to false
-        Assertions.assertFalse(mv1.hasReloaded());
-        Assertions.assertFalse(mv2.hasReloaded());
-        Assertions.assertFalse(baseMv.hasReloaded());
+        Assertions.assertTrue(mv1.hasReloaded());
+        Assertions.assertTrue(mv2.hasReloaded());
+        Assertions.assertTrue(baseMv.hasReloaded());
         Assertions.assertEquals(1, baseTable.getRelatedMaterializedViews().size());
         Assertions.assertEquals(2, baseMv.getRelatedMaterializedViews().size());
         Assertions.assertTrue(baseMv.getRelatedMaterializedViews().contains(mv1.getMvId()));

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -997,7 +997,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
             Config.enable_mv_post_image_reload_cache = false;
             boolean postLoadImage = false;
 
-            baseMv.setReloaded(false);
+            baseMv.changeReloadState(-1);
             baseTable.removeRelatedMaterializedView(baseMv.getMvId());
             baseMv.removeRelatedMaterializedView(mv1.getMvId());
             baseMv.removeRelatedMaterializedView(mv2.getMvId());
@@ -1015,7 +1015,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
             Config.enable_mv_post_image_reload_cache = true;
             boolean postLoadImage = true;
 
-            baseMv.setReloaded(false);
+            baseMv.changeReloadState(-1);
             baseTable.removeRelatedMaterializedView(baseMv.getMvId());
             baseMv.removeRelatedMaterializedView(mv1.getMvId());
             baseMv.removeRelatedMaterializedView(mv2.getMvId());
@@ -1037,7 +1037,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
             Config.enable_mv_post_image_reload_cache = true;
             boolean postLoadImage = false;
 
-            baseMv.setReloaded(false);
+            baseMv.changeReloadState(-1);
             baseTable.removeRelatedMaterializedView(baseMv.getMvId());
             baseMv.removeRelatedMaterializedView(mv1.getMvId());
             baseMv.removeRelatedMaterializedView(mv2.getMvId());

--- a/fe/fe-core/src/test/java/com/starrocks/common/mv/MaterializedViewDependencyGraphTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/mv/MaterializedViewDependencyGraphTest.java
@@ -1,0 +1,509 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.common.mv;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvId;
+import com.starrocks.catalog.Type;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class MaterializedViewDependencyGraphTest {
+
+    public MaterializedViewDependencyGraphTest() {
+        super();
+    }
+
+    /**
+     * Helper method to create a MaterializedView with given id and dependencies
+     */
+    private MaterializedView createMockMV(long id, Long... dependencies) {
+        List<Column> columns = new ArrayList<>();
+        columns.add(new Column("c1", Type.INT));
+        
+        MaterializedView mv = new MaterializedView(id, 1L, "mv_" + id, columns, KeysType.DUP_KEYS,
+                null, null, null);
+        
+        // Set dependencies
+        Set<MvId> mvIds = new HashSet<>();
+        for (Long depId : dependencies) {
+            mvIds.add(new MvId(1L, depId));
+        }
+        mv.getRelatedMaterializedViews().addAll(mvIds);
+        
+        return mv;
+    }
+
+    @Test
+    public void testEmptyList() {
+        List<MaterializedView> allMVs = new ArrayList<>();
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testSingleMVNoDependencies() {
+        MaterializedView mv1 = createMockMV(1L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv1);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(1L, result.get(0).getId());
+    }
+
+    @Test
+    public void testMultipleMVsNoDependencies() {
+        MaterializedView mv1 = createMockMV(1L);
+        MaterializedView mv2 = createMockMV(2L);
+        MaterializedView mv3 = createMockMV(3L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv1, mv2, mv3);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(3, result.size());
+        // All MVs should be in result (order doesn't matter without dependencies)
+        Set<Long> ids = new HashSet<>();
+        for (MaterializedView mv : result) {
+            ids.add(mv.getId());
+        }
+        Assertions.assertTrue(ids.contains(1L));
+        Assertions.assertTrue(ids.contains(2L));
+        Assertions.assertTrue(ids.contains(3L));
+    }
+
+    @Test
+    public void testLinearDependencyChain() {
+        // mv3 depends on mv2, mv2 depends on mv1
+        MaterializedView mv1 = createMockMV(1L);
+        MaterializedView mv2 = createMockMV(2L, 1L);
+        MaterializedView mv3 = createMockMV(3L, 2L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv3, mv2, mv1);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(3, result.size());
+        
+        // mv1 should come before mv2, mv2 should come before mv3
+        int idx1 = -1;
+        int idx2 = -1;
+        int idx3 = -1;
+        for (int i = 0; i < result.size(); i++) {
+            long id = result.get(i).getId();
+            if (id == 1L) {
+                idx1 = i;
+            }
+            if (id == 2L) {
+                idx2 = i;
+            }
+            if (id == 3L) {
+                idx3 = i;
+            }
+        }
+        Assertions.assertTrue(idx1 < idx2, "mv1 should come before mv2");
+        Assertions.assertTrue(idx2 < idx3, "mv2 should come before mv3");
+    }
+
+    @Test
+    public void testDiamondDependency() {
+        // mv4 depends on mv2 and mv3
+        // mv2 depends on mv1
+        // mv3 depends on mv1
+        MaterializedView mv1 = createMockMV(1L);
+        MaterializedView mv2 = createMockMV(2L, 1L);
+        MaterializedView mv3 = createMockMV(3L, 1L);
+        MaterializedView mv4 = createMockMV(4L, 2L, 3L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv4, mv3, mv2, mv1);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(4, result.size());
+        
+        // mv1 should come before mv2 and mv3
+        // mv2 and mv3 should come before mv4
+        int idx1 = -1;
+        int idx2 = -1;
+        int idx3 = -1;
+        int idx4 = -1;
+        for (int i = 0; i < result.size(); i++) {
+            long id = result.get(i).getId();
+            if (id == 1L) {
+                idx1 = i;
+            }
+            if (id == 2L) {
+                idx2 = i;
+            }
+            if (id == 3L) {
+                idx3 = i;
+            }
+            if (id == 4L) {
+                idx4 = i;
+            }
+        }
+        Assertions.assertTrue(idx1 < idx2, "mv1 should come before mv2");
+        Assertions.assertTrue(idx1 < idx3, "mv1 should come before mv3");
+        Assertions.assertTrue(idx2 < idx4, "mv2 should come before mv4");
+        Assertions.assertTrue(idx3 < idx4, "mv3 should come before mv4");
+    }
+
+    @Test
+    public void testCircularDependency() {
+        // mv2 depends on mv1
+        // mv1 depends on mv2 (circular)
+        MaterializedView mv1 = createMockMV(1L, 2L);
+        MaterializedView mv2 = createMockMV(2L, 1L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv1, mv2);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        // Should return original order when cycle is detected
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertEquals(allMVs, result);
+    }
+
+    @Test
+    public void testSelfDependency() {
+        // mv1 depends on itself
+        MaterializedView mv1 = createMockMV(1L, 1L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv1);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        // Should return original order when cycle is detected
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(allMVs, result);
+    }
+
+    @Test
+    public void testComplexGraph() {
+        // Complex dependency graph:
+        // mv1, mv2 are roots (no dependencies)
+        // mv3 depends on mv1
+        // mv4 depends on mv1
+        // mv5 depends on mv2
+        // mv6 depends on mv3 and mv4
+        // mv7 depends on mv5 and mv6
+        MaterializedView mv1 = createMockMV(1L);
+        MaterializedView mv2 = createMockMV(2L);
+        MaterializedView mv3 = createMockMV(3L, 1L);
+        MaterializedView mv4 = createMockMV(4L, 1L);
+        MaterializedView mv5 = createMockMV(5L, 2L);
+        MaterializedView mv6 = createMockMV(6L, 3L, 4L);
+        MaterializedView mv7 = createMockMV(7L, 5L, 6L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv7, mv6, mv5, mv4, mv3, mv2, mv1);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(7, result.size());
+        
+        // Get indices
+        int idx1 = -1;
+        int idx2 = -1;
+        int idx3 = -1;
+        int idx4 = -1;
+        int idx5 = -1;
+        int idx6 = -1;
+        int idx7 = -1;
+        for (int i = 0; i < result.size(); i++) {
+            long id = result.get(i).getId();
+            if (id == 1L) {
+                idx1 = i;
+            }
+            if (id == 2L) {
+                idx2 = i;
+            }
+            if (id == 3L) {
+                idx3 = i;
+            }
+            if (id == 4L) {
+                idx4 = i;
+            }
+            if (id == 5L) {
+                idx5 = i;
+            }
+            if (id == 6L) {
+                idx6 = i;
+            }
+            if (id == 7L) {
+                idx7 = i;
+            }
+        }
+        
+        // Verify dependencies are respected
+        Assertions.assertTrue(idx1 < idx3, "mv1 should come before mv3");
+        Assertions.assertTrue(idx1 < idx4, "mv1 should come before mv4");
+        Assertions.assertTrue(idx2 < idx5, "mv2 should come before mv5");
+        Assertions.assertTrue(idx3 < idx6, "mv3 should come before mv6");
+        Assertions.assertTrue(idx4 < idx6, "mv4 should come before mv6");
+        Assertions.assertTrue(idx5 < idx7, "mv5 should come before mv7");
+        Assertions.assertTrue(idx6 < idx7, "mv6 should come before mv7");
+    }
+
+    @Test
+    public void testPartialCircularDependency() {
+        // mv1, mv2, mv3 form a cycle
+        // mv4 depends on mv1
+        MaterializedView mv1 = createMockMV(1L, 3L);
+        MaterializedView mv2 = createMockMV(2L, 1L);
+        MaterializedView mv3 = createMockMV(3L, 2L);
+        MaterializedView mv4 = createMockMV(4L, 1L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv1, mv2, mv3, mv4);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        // Should return original order when cycle is detected
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(4, result.size());
+        Assertions.assertEquals(allMVs, result);
+    }
+
+    @Test
+    public void testMVDependsOnNonExistentMV() {
+        // mv2 depends on mv999 which doesn't exist in the list
+        MaterializedView mv1 = createMockMV(1L);
+        MaterializedView mv2 = createMockMV(2L, 999L);
+        MaterializedView mv3 = createMockMV(3L, 1L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv1, mv2, mv3);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(3, result.size());
+        
+        // mv2's dependency on non-existent mv999 is ignored
+        // So mv2 should be treated as having no dependencies
+        int idx1 = -1;
+        int idx2 = -1;
+        int idx3 = -1;
+        for (int i = 0; i < result.size(); i++) {
+            long id = result.get(i).getId();
+            if (id == 1L) {
+                idx1 = i;
+            }
+            if (id == 2L) {
+                idx2 = i;
+            }
+            if (id == 3L) {
+                idx3 = i;
+            }
+        }
+        Assertions.assertTrue(idx1 < idx3, "mv1 should come before mv3");
+    }
+
+    @Test
+    public void testMultipleDependenciesOnSameMV() {
+        // mv3 and mv4 both depend on mv1
+        // mv5 depends on mv2
+        // mv6 depends on mv3, mv4, and mv5
+        MaterializedView mv1 = createMockMV(1L);
+        MaterializedView mv2 = createMockMV(2L);
+        MaterializedView mv3 = createMockMV(3L, 1L);
+        MaterializedView mv4 = createMockMV(4L, 1L);
+        MaterializedView mv5 = createMockMV(5L, 2L);
+        MaterializedView mv6 = createMockMV(6L, 3L, 4L, 5L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv6, mv5, mv4, mv3, mv2, mv1);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(6, result.size());
+        
+        // Get indices
+        int idx1 = -1;
+        int idx2 = -1;
+        int idx3 = -1;
+        int idx4 = -1;
+        int idx5 = -1;
+        int idx6 = -1;
+        for (int i = 0; i < result.size(); i++) {
+            long id = result.get(i).getId();
+            if (id == 1L) {
+                idx1 = i;
+            }
+            if (id == 2L) {
+                idx2 = i;
+            }
+            if (id == 3L) {
+                idx3 = i;
+            }
+            if (id == 4L) {
+                idx4 = i;
+            }
+            if (id == 5L) {
+                idx5 = i;
+            }
+            if (id == 6L) {
+                idx6 = i;
+            }
+        }
+        
+        // Verify all dependencies are respected
+        Assertions.assertTrue(idx1 < idx3, "mv1 should come before mv3");
+        Assertions.assertTrue(idx1 < idx4, "mv1 should come before mv4");
+        Assertions.assertTrue(idx2 < idx5, "mv2 should come before mv5");
+        Assertions.assertTrue(idx3 < idx6, "mv3 should come before mv6");
+        Assertions.assertTrue(idx4 < idx6, "mv4 should come before mv6");
+        Assertions.assertTrue(idx5 < idx6, "mv5 should come before mv6");
+    }
+
+    @Test
+    public void testLongDependencyChain() {
+        // Create a chain: mv1 <- mv2 <- mv3 <- mv4 <- mv5
+        MaterializedView mv1 = createMockMV(1L);
+        MaterializedView mv2 = createMockMV(2L, 1L);
+        MaterializedView mv3 = createMockMV(3L, 2L);
+        MaterializedView mv4 = createMockMV(4L, 3L);
+        MaterializedView mv5 = createMockMV(5L, 4L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv5, mv4, mv3, mv2, mv1);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(5, result.size());
+        
+        // Verify the chain order
+        List<Long> ids = new ArrayList<>();
+        for (MaterializedView mv : result) {
+            ids.add(mv.getId());
+        }
+        Assertions.assertTrue(ids.indexOf(1L) < ids.indexOf(2L));
+        Assertions.assertTrue(ids.indexOf(2L) < ids.indexOf(3L));
+        Assertions.assertTrue(ids.indexOf(3L) < ids.indexOf(4L));
+        Assertions.assertTrue(ids.indexOf(4L) < ids.indexOf(5L));
+    }
+
+    @Test
+    public void testDisconnectedComponents() {
+        // Two separate chains:
+        // Chain 1: mv1 <- mv2 <- mv3
+        // Chain 2: mv4 <- mv5 <- mv6
+        MaterializedView mv1 = createMockMV(1L);
+        MaterializedView mv2 = createMockMV(2L, 1L);
+        MaterializedView mv3 = createMockMV(3L, 2L);
+        MaterializedView mv4 = createMockMV(4L);
+        MaterializedView mv5 = createMockMV(5L, 4L);
+        MaterializedView mv6 = createMockMV(6L, 5L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv3, mv6, mv2, mv5, mv1, mv4);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(6, result.size());
+        
+        // Get indices
+        int idx1 = -1;
+        int idx2 = -1;
+        int idx3 = -1;
+        int idx4 = -1;
+        int idx5 = -1;
+        int idx6 = -1;
+        for (int i = 0; i < result.size(); i++) {
+            long id = result.get(i).getId();
+            if (id == 1L) {
+                idx1 = i;
+            }
+            if (id == 2L) {
+                idx2 = i;
+            }
+            if (id == 3L) {
+                idx3 = i;
+            }
+            if (id == 4L) {
+                idx4 = i;
+            }
+            if (id == 5L) {
+                idx5 = i;
+            }
+            if (id == 6L) {
+                idx6 = i;
+            }
+        }
+        
+        // Verify both chains are ordered correctly
+        Assertions.assertTrue(idx1 < idx2 && idx2 < idx3, "Chain 1 should be ordered");
+        Assertions.assertTrue(idx4 < idx5 && idx5 < idx6, "Chain 2 should be ordered");
+    }
+
+    @Test
+    public void testNullRelatedMaterializedViews() {
+        List<Column> columns = new ArrayList<>();
+        columns.add(new Column("c1", Type.INT));
+        
+        MaterializedView mv1 = new MaterializedView(1L, 1L, "mv_1", columns, KeysType.DUP_KEYS,
+                null, null, null);
+        MaterializedView mv2 = new MaterializedView(2L, 1L, "mv_2", columns, KeysType.DUP_KEYS,
+                null, null, null);
+        
+        // Set mv1's related MVs to null to test null handling
+        mv1.getRelatedMaterializedViews().clear();
+        
+        List<MaterializedView> allMVs = Lists.newArrayList(mv1, mv2);
+        
+        // Should handle null/empty gracefully
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testEmptyRelatedMaterializedViews() {
+        MaterializedView mv1 = createMockMV(1L);
+        MaterializedView mv2 = createMockMV(2L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv1, mv2);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testComplexCycleDetection() {
+        // Create a more complex cycle: mv1 -> mv2 -> mv3 -> mv4 -> mv2
+        MaterializedView mv1 = createMockMV(1L, 2L);
+        MaterializedView mv2 = createMockMV(2L, 3L);
+        MaterializedView mv3 = createMockMV(3L, 4L);
+        MaterializedView mv4 = createMockMV(4L, 2L);
+        MaterializedView mv5 = createMockMV(5L, 1L);
+        List<MaterializedView> allMVs = Lists.newArrayList(mv1, mv2, mv3, mv4, mv5);
+        
+        List<MaterializedView> result = MaterializedViewDependencyGraph.buildTopologicalOrder(allMVs);
+        
+        // Should return original order when cycle is detected
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(5, result.size());
+        Assertions.assertEquals(allMVs, result);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Fixes https://github.com/StarRocks/starrocks/issues/59152

## What I'm doing:
- Ensure mv's `onReload` to not visit external systems(external catalog...) since if external catalog is unavialable it can cause fe restart hang a lot of time.


In my testing with 500+ MVs(which only contain 30+ mvs with external tables), this pr can optimize the fe restart time from 4242ms to 2870ms.

After
```
-- enable_mv_post_image_reload_cache = true
2025-10-20 16:47:03.343+08:00 INFO (UNKNOWN 172.17.0.1_9112_1760693947590(-1)|1) [GlobalStateMgr.processMvRelatedMeta():1751] finish processing all tables' related materialized views in 2870ms, isReLoadAsync:true, total mv count: 574, topo mv order:574, topo build cost(ms):5
2025-10-20 16:48:06.560+08:00 INFO (global_state_checkpoint_worker|413) [GlobalStateMgr.processMvRelatedMeta():1751] finish processing all tables' related materialized views in 1382ms, isReLoadAsync:false, total mv count: 574, topo mv order:574, topo build cost(ms):1

-- enable_mv_post_image_reload_cache = false

2025-10-20 16:49:22.497+08:00 INFO (UNKNOWN 172.17.0.1_9112_1760693947590(-1)|1) [GlobalStateMgr.processMvRelatedMeta():1751] finish processing all tables' related materialized views in 4242ms, isReLoadAsync:false, total mv count: 574, topo mv order:574, topo build cost(ms):1
2025-10-20 16:50:25.173+08:00 INFO (global_state_checkpoint_worker|431) [GlobalStateMgr.processMvRelatedMeta():1751] finish processing all tables' related materialized views in 1509ms, isReLoadAsync:false, total mv count: 574, topo mv order:574, topo build cost(ms):0

```

Before
```
2025-10-20 16:56:36.112+08:00 INFO (UNKNOWN 172.17.0.1_9112_1760693947590(-1)|1) [GlobalStateMgr.processMvRelatedMeta():1747] finish processing all tables' related materialized views in 4159ms, total mv count: 574
```

Add tests: https://github.com/StarRocks/StarRocksTest/pull/10468


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
