### PR TITLE
[BugFix] Ignore uri params when getAction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
@@ -197,10 +197,11 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
 
     private BaseAction getAction(BaseRequest request) {
         String uri = request.getRequest().uri();
+        String baseUri = uri.split("\\?")[0];
         // ignore this request, which is a default request from client's browser.
-        if (uri.endsWith("/favicon.ico")) {
+        if (baseUri.endsWith("/favicon.ico")) {
             return NotFoundAction.getNotFoundAction();
-        } else if (uri.equals("/")) {
+        } else if (baseUri.equals("/")) {
             return new IndexAction(controller);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
@@ -53,6 +53,7 @@ import io.netty.util.ReferenceCountUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.net.URI;
 import java.util.concurrent.Executor;
 
 public class HttpServerHandler extends ChannelInboundHandlerAdapter {
@@ -197,7 +198,7 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
 
     private BaseAction getAction(BaseRequest request) {
         String uri = request.getRequest().uri();
-        String baseUri = uri.split("\\?")[0];
+        String baseUri = URI.create(uri).getPath();
         // ignore this request, which is a default request from client's browser.
         if (baseUri.endsWith("/favicon.ico")) {
             return NotFoundAction.getNotFoundAction();


### PR DESCRIPTION
If we visit https://fe-ip:fe-http-port/?key=value, we find 404. For example, we has filter auto add param local=zh-cn for all uri, and i think this scene should work normaly.

<img width="688" height="45" alt="image" src="https://github.com/user-attachments/assets/341d9833-77bd-4320-be1a-192566bba031" />


## Why I'm doing:
I think we should ignore this uri params when getAction

## What I'm doing:
ignore uri params

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize request URI by stripping query params before routing so '/' and '/favicon.ico' resolve correctly with parameters.
> 
> - **Backend (HTTP routing)**:
>   - Update `HttpServerHandler#getAction` to derive `baseUri` (`uri.split("\\?")[0]`) and use it for checks against `"/"` and `"/favicon.ico"`.
>     - Prevents incorrect 404s when query params are present (e.g., `/?key=value`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00df944f023aeb22afbb999cef3ff11d9d6dfbd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->