### PR TITLE
[Enhancement] Enhance AstToSQLBuilder formatting for CASE-WHEN and CTE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
@@ -148,11 +148,12 @@ public class AST2SQLVisitor extends AST2StringVisitor {
             sqlBuilder.append("DISTINCT ");
         }
 
-        List<String> selectItems = visitSelectItemList(stmt);
         if (options.isEnablePrettyFormat()) {
             // Pretty format: each column on a new line with proper indentation
+            // Increase indent BEFORE visiting items so nested expressions get correct indent
             options.increaseIndent();
             try {
+                List<String> selectItems = visitSelectItemList(stmt);
                 if (!selectItems.isEmpty()) {
                     for (int i = 0; i < selectItems.size(); i++) {
                         if (i > 0) {
@@ -167,6 +168,7 @@ public class AST2SQLVisitor extends AST2StringVisitor {
             }
         } else {
             // Default format: comma-separated on same line
+            List<String> selectItems = visitSelectItemList(stmt);
             sqlBuilder.append(Joiner.on(", ").join(selectItems));
         }
 
@@ -299,7 +301,7 @@ public class AST2SQLVisitor extends AST2StringVisitor {
         } else {
             // Default format: inline
             sqlBuilder.append(visit(relation.getCteQueryStatement()));
-            sqlBuilder.append(")");
+            sqlBuilder.append(") ");
         }
         
         return sqlBuilder.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/FormatOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/FormatOptions.java
@@ -41,6 +41,8 @@ public class FormatOptions {
 
     private boolean enableHints = true;
 
+    private boolean enablePrettyFormat = false;
+
     private int indentLevel = 0;
     
     // Two spaces for indentation
@@ -90,6 +92,10 @@ public class FormatOptions {
 
     public boolean isEnableHints() {
         return enableHints;
+    }
+
+    public boolean isEnablePrettyFormat() {
+        return enablePrettyFormat;
     }
 
     public FormatOptions setColumnSimplifyTableName(boolean columnSimplifyTableName) {
@@ -144,6 +150,11 @@ public class FormatOptions {
 
     public FormatOptions setEnableHints(boolean enableHints) {
         this.enableHints = enableHints;
+        return this;
+    }
+
+    public FormatOptions setEnablePrettyFormat(boolean enablePrettyFormat) {
+        this.enablePrettyFormat = enablePrettyFormat;
         return this;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/FormatOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/FormatOptions.java
@@ -41,6 +41,11 @@ public class FormatOptions {
 
     private boolean enableHints = true;
 
+    private int indentLevel = 0;
+    
+    // Two spaces for indentation
+    private String indentString = "  ";
+
     private FormatOptions() {}
 
     public static FormatOptions allEnable() {
@@ -144,5 +149,29 @@ public class FormatOptions {
 
     public String newLine() {
         return enableNewLine ? "\n" : " ";
+    }
+
+
+    public String indent() {
+        if (!enableNewLine) {
+            return " ";
+        }
+        return "\n" + indentString.repeat(indentLevel);
+    }
+
+    public FormatOptions increaseIndent() {
+        indentLevel++;
+        return this;
+    }
+
+    public FormatOptions decreaseIndent() {
+        if (indentLevel > 0) {
+            indentLevel--;
+        }
+        return this;
+    }
+
+    public int getIndentLevel() {
+        return indentLevel;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
@@ -37,7 +37,7 @@ public class AstToSQLBuilderTest {
             StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
             Assertions.assertEquals(
                     "CREATE PIPE IF NOT EXISTS pipe1 PROPERTIES(\"auto_ingest\" = \"true\") AS INSERT INTO `t0` (`v1`,`v2`) " +
-                            "SELECT *\nFROM FILES(\"aws.s3.access_key\" = \"***\", \"aws.s3.region\" = \"us-west-1\", " +
+                            "SELECT \n  *\nFROM FILES(\"aws.s3.access_key\" = \"***\", \"aws.s3.region\" = \"us-west-1\", " +
                             "\"aws.s3.secret_key\" = \"***\", \"format\" = \"parquet\", \"path\" = \"s3://xxx/zzz\")",
                     AstToSQLBuilder.toSQL(stmt));
         }
@@ -49,7 +49,7 @@ public class AstToSQLBuilderTest {
             StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
             Assertions.assertEquals(
                     "CREATE OR REPLACE PIPE pipe1 AS INSERT INTO `t0` (`v1`,`v2`) " +
-                            "SELECT *\nFROM FILES(\"aws.s3.access_key\" = \"***\", \"aws.s3.region\" = \"us-west-1\", " +
+                            "SELECT \n  *\nFROM FILES(\"aws.s3.access_key\" = \"***\", \"aws.s3.region\" = \"us-west-1\", " +
                             "\"aws.s3.secret_key\" = \"***\", \"format\" = \"parquet\", \"path\" = \"s3://xxx/zzz\")",
                     AstToSQLBuilder.toSQL(stmt));
         }
@@ -63,7 +63,7 @@ public class AstToSQLBuilderTest {
         StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
         Assertions.assertEquals(
                 "INSERT INTO `t0` (`v1`,`v2`) " +
-                        "SELECT *\nFROM FILES(\"aws.s3.access_key\" = \"***\", \"aws.s3.region\" = \"us-west-1\", " +
+                        "SELECT \n  *\nFROM FILES(\"aws.s3.access_key\" = \"***\", \"aws.s3.region\" = \"us-west-1\", " +
                         "\"aws.s3.secret_key\" = \"***\", \"format\" = \"parquet\", \"path\" = \"s3://xxx/zzz\")",
                 AstToSQLBuilder.toSQL(stmt));
     }
@@ -71,12 +71,12 @@ public class AstToSQLBuilderTest {
     public void testSelectStarExcludeToSQL() throws Exception {
         String sql = "SELECT * EXCLUDE (name, email) FROM test_exclude;";
         StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
-        Assertions.assertEquals("SELECT * EXCLUDE ( \"name\",\"email\" ) \nFROM `test_exclude`",
+        Assertions.assertEquals("SELECT \n  * EXCLUDE ( \"name\",\"email\" ) \nFROM `test_exclude`",
                 AstToSQLBuilder.toSQL(stmt));
         
         sql = "SELECT test_exclude.* EXCLUDE (name) FROM test_exclude";
         stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
-        Assertions.assertEquals("SELECT test_exclude.* EXCLUDE ( \"name\" ) \nFROM `test_exclude`",
+        Assertions.assertEquals("SELECT \n  test_exclude.* EXCLUDE ( \"name\" ) \nFROM `test_exclude`",
                 AstToSQLBuilder.toSQL(stmt));
     }
 
@@ -84,12 +84,106 @@ public class AstToSQLBuilderTest {
     public void testFunctionTable() {
         String sql = "SELECT * from tarray, unnest(v3) as t(x)";
         StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
-        Assertions.assertEquals("SELECT *\nFROM `tarray` , unnest(`v3`) t(`x`) ",
+        Assertions.assertEquals("SELECT \n  *\nFROM `tarray` , unnest(`v3`) t(`x`) ",
                 AstToSQLBuilder.toSQL(stmt));
 
         sql = "SELECT * from t0, generate_series(v1, v2, 1) as t(x)";
         stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
-        Assertions.assertEquals("SELECT *\nFROM `t0` , generate_series(`v1`,`v2`,1) t(`x`) ",
+        Assertions.assertEquals("SELECT \n  *\nFROM `t0` , generate_series(`v1`,`v2`,1) t(`x`) ",
                 AstToSQLBuilder.toSQL(stmt));
+    }
+
+
+    @Test
+    public void testCaseWhenFormatting() {
+        String sql = "SELECT CASE WHEN v1 < 10 THEN 'low' WHEN v1 >= 10 AND v1 < 20 THEN 'medium' ELSE 'high' END FROM t0";
+        StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+        String expected = "SELECT \n" +
+                "  CASE\n" +
+                "    WHEN (`v1` < 10) THEN 'low'\n" +
+                "    WHEN ((`v1` >= 10) AND (`v1` < 20)) THEN 'medium'\n" +
+                "    ELSE 'high'\n" +
+                "  END\n" +
+                "FROM `t0`";
+        Assertions.assertEquals(expected, AstToSQLBuilder.toSQL(stmt));
+    }
+
+    @Test
+    public void testComplexCTEFormatting() {
+        String sql = "WITH cte1 AS (SELECT v1, v2 FROM t0), " +
+                "cte2 AS (SELECT v1, v3 FROM t1) " +
+                "SELECT * FROM cte1 JOIN cte2 ON cte1.v1 = cte2.v1";
+        StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+        String expected = "WITH `cte1` AS (\n" +
+                "  SELECT \n" +
+                "    `v1`,\n" +
+                "    `v2`\n" +
+                "FROM `t0`\n" +
+                "),\n" +
+                "`cte2` AS (\n" +
+                "  SELECT \n" +
+                "    `v1`,\n" +
+                "    `v3`\n" +
+                "FROM `t1`\n" +
+                ")\n" +
+                "SELECT \n" +
+                "  *\n" +
+                "FROM `cte1` INNER JOIN `cte2` ON `cte1`.`v1` = `cte2`.`v1`";
+        Assertions.assertEquals(expected, AstToSQLBuilder.toSQL(stmt));
+    }
+
+    @Test
+    public void testComplexNestedCTEWithCaseWhen() {
+        // This is a complex query from issue #64056
+        String sql = "WITH cte01 (id, region, len_bucket) AS " +
+                "(SELECT cw.tbl01.id, cw.tbl01.region, " +
+                "CASE WHEN (array_length(cw.tbl01.col_arr) < 2) THEN 'bucket1' " +
+                "WHEN ((array_length(cw.tbl01.col_arr) >= 2) AND (array_length(cw.tbl01.col_arr) < 4)) THEN 'bucket2-3' " +
+                "ELSE NULL END AS len_bucket " +
+                "FROM cw.tbl01), " +
+                "cte02 (id, region, priority) AS " +
+                "(SELECT cte01.id, cte01.region, " +
+                "CASE WHEN ((cte01.len_bucket = 'bucket1') AND (cte01.region = 'EMEA')) THEN 'priority1' " +
+                "WHEN ((cte01.len_bucket = 'bucket1') AND (cte01.region = 'APAC')) THEN 'priority2' " +
+                "WHEN ((cte01.len_bucket = 'bucket1') AND (cte01.region = 'NORAM')) THEN 'priority3' " +
+                "WHEN ((cte01.len_bucket = 'bucket1') AND (cte01.region = 'LATAM')) THEN 'priority4' " +
+                "ELSE NULL END AS priority " +
+                "FROM cte01) " +
+                "SELECT cte02.id, cte02.region, cte02.priority " +
+                "FROM cte02 " +
+                "WHERE cte02.priority IS NOT NULL";
+        StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+        String expected = "WITH `cte01` (`id`, `region`, `len_bucket`) AS (\n" +
+                "  SELECT \n" +
+                "    `cw`.`tbl01`.`id`,\n" +
+                "    `cw`.`tbl01`.`region`,\n" +
+                "    CASE\n" +
+                "      WHEN ((array_length(`cw`.`tbl01`.`col_arr`)) < 2) THEN 'bucket1'\n" +
+                "      WHEN (((array_length(`cw`.`tbl01`.`col_arr`)) >= 2) AND " +
+                "((array_length(`cw`.`tbl01`.`col_arr`)) < 4)) THEN 'bucket2-3'\n" +
+                "      ELSE NULL\n" +
+                "    END AS `len_bucket`\n" +
+                "FROM `cw`.`tbl01`\n" +
+                "),\n" +
+                "`cte02` (`id`, `region`, `priority`) AS (\n" +
+                "  SELECT \n" +
+                "    `cte01`.`id`,\n" +
+                "    `cte01`.`region`,\n" +
+                "    CASE\n" +
+                "      WHEN ((`cte01`.`len_bucket` = 'bucket1') AND (`cte01`.`region` = 'EMEA')) THEN 'priority1'\n" +
+                "      WHEN ((`cte01`.`len_bucket` = 'bucket1') AND (`cte01`.`region` = 'APAC')) THEN 'priority2'\n" +
+                "      WHEN ((`cte01`.`len_bucket` = 'bucket1') AND (`cte01`.`region` = 'NORAM')) THEN 'priority3'\n" +
+                "      WHEN ((`cte01`.`len_bucket` = 'bucket1') AND (`cte01`.`region` = 'LATAM')) THEN 'priority4'\n" +
+                "      ELSE NULL\n" +
+                "    END AS `priority`\n" +
+                "FROM `cte01`\n" +
+                ")\n" +
+                "SELECT \n" +
+                "  `cte02`.`id`,\n" +
+                "  `cte02`.`region`,\n" +
+                "  `cte02`.`priority`\n" +
+                "FROM `cte02`\n" +
+                "WHERE `cte02`.`priority` IS NOT NULL";
+        Assertions.assertEquals(expected, AstToSQLBuilder.toSQL(stmt));
     }
 }


### PR DESCRIPTION
Improve SQL formatting capabilities in AstToSQLBuilder to provide better readability for complex SQL structures.

- Format each SELECT column on a separate line with proper indentation
- Format CASE-WHEN with proper indentation for WHEN/ELSE/END clauses
- Format CTE definitions with proper multi-line structure
- Format multiple CTEs with comma at line end
- Add indentation management methods to FormatOptions

Fixes: #64056

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Formats SELECT items on separate indented lines, adds proper CASE/WHEN and CTE (WITH) multi-line formatting, and introduces indentation utilities with updated tests.
> 
> - **SQL formatting enhancements**:
>   - `SELECT` items rendered on separate lines with indentation.
>   - `CASE ... WHEN ... THEN ... ELSE ... END` formatted across lines with consistent indent.
>   - CTEs in `WITH` clause formatted as multi-line blocks; supports multiple CTEs separated by comma and newline.
>   - `visitQueryStatement` handles `WITH`, main query, `ORDER BY`, and `LIMIT` output sequencing.
> - **Indentation utilities**:
>   - Add `indentLevel`, `indentString`, `indent()`, `increaseIndent()`, `decreaseIndent()`, `getIndentLevel()` in `FormatOptions`.
> - **Tests**:
>   - Update expectations for multi-line `SELECT` outputs.
>   - Add tests for CASE formatting, CTE formatting, and complex nested CTE with CASE.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2437f706807656e2fd72af3ea796187175592a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->