### PR TITLE
[Refactor] Normalize database names in LabelName and ConnectContext classes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -817,7 +817,11 @@ public class ConnectContext {
     }
 
     public String getDatabase() {
-        return currentDb;
+        if (GlobalVariable.enableTableNameCaseInsensitive && currentDb != null) {
+            return currentDb.toLowerCase();
+        } else {
+            return currentDb;
+        }
     }
 
     public void setDatabase(String db) {
@@ -1020,7 +1024,7 @@ public class ConnectContext {
             // throw exception if the current warehouse is not exist.
             if (!warehouseManager.warehouseExists(this.getCurrentWarehouseName())) {
                 String errMsg = String.format("Current connection's warehouse(%s) does not exist, please " +
-                                "set to another warehouse.", this.getCurrentWarehouseName());
+                        "set to another warehouse.", this.getCurrentWarehouseName());
                 this.resetComputeResource();
                 throw new RuntimeException(errMsg);
             }
@@ -1045,6 +1049,7 @@ public class ConnectContext {
      * Get the name of the current compute resource.
      * During the execution of a statement, the compute resource should be fixed.
      * NOTE: this method will not acquire compute resource if it is not set.
+     *
      * @return: the name of the current compute resource, or empty string if not set.
      */
     public String getCurrentComputeResourceName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -3317,7 +3317,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         String label = ((Identifier) visit(context.label)).getValue();
         String db = "";
         if (context.db != null) {
-            db = ((Identifier) visit(context.db)).getValue();
+            db = normalizeName(((Identifier) visit(context.db)).getValue());
         }
         return new LabelName(db, label, createPos(context));
     }
@@ -9365,7 +9365,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         // Hierarchy: catalog.database.table
         List<String> parts = qualifiedName.getParts();
         if (parts.size() == 2) {
-            return new LabelName(parts.get(0), parts.get(1), qualifiedName.getPos());
+            return new LabelName(normalizeName(parts.get(0)), parts.get(1), qualifiedName.getPos());
         } else if (parts.size() == 1) {
             return new LabelName(null, parts.get(0), qualifiedName.getPos());
         } else {
@@ -9521,7 +9521,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
         String dbName = null;
         if (dbCtx != null) {
-            dbName = getQualifiedName(dbCtx).toString();
+            dbName = normalizeName(getQualifiedName(dbCtx).toString());
             start = dbCtx.start;
         }
 

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/LabelName.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/LabelName.java
@@ -18,7 +18,6 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Objects;
 
-import static com.starrocks.common.util.Util.normalizeName;
 
 // label name used to identify a load job
 public class LabelName implements ParseNode {
@@ -33,7 +32,7 @@ public class LabelName implements ParseNode {
 
     public LabelName(String dbName, String labelName, NodePosition pos) {
         this.pos = pos;
-        this.dbName = normalizeName(dbName);
+        this.dbName = dbName;
         this.labelName = labelName;
     }
 
@@ -42,7 +41,7 @@ public class LabelName implements ParseNode {
     }
 
     public void setDbName(String dbName) {
-        this.dbName = normalizeName(dbName);
+        this.dbName = dbName;
     }
 
     public String getLabelName() {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


This pull request introduces improvements to how database names are normalized and handled, particularly focusing on case insensitivity and consistency across SQL parsing and context management. The main changes are in the normalization logic for database names, updates to context retrieval, and a file move for better organization.

**Database name normalization and case handling:**

* In `ConnectContext.java`, the `getDatabase()` method now returns the database name in lowercase if table name case insensitivity is enabled, improving consistency for case-insensitive operations.
* In `AstBuilder.java`, all places where a database name is extracted for label creation now use `normalizeName` to ensure consistent normalization, reducing the risk of mismatches due to case or formatting. [[1]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL3320-R3320) [[2]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL9368-R9368) [[3]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL9524-R9524)

**Refactoring and code organization:**

* The `LabelName.java` file was moved from `fe-core` to `fe-parser` for improved modularity and separation of SQL AST logic.
* The normalization logic was removed from the `LabelName` constructor and setter, so normalization is now handled before `LabelName` objects are created, centralizing responsibility and simplifying the class. [[1]](diffhunk://#diff-4acda01195bb380a40ef93b12b04e056854db9ae587d30e92cdf4b47544fa9b8L36-R35) [[2]](diffhunk://#diff-4acda01195bb380a40ef93b12b04e056854db9ae587d30e92cdf4b47544fa9b8L45-R44)

**Documentation and code clarity:**

* Minor documentation and formatting improvements were made to the compute resource retrieval method for clarity.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize database names during parsing and return lowercase database from ConnectContext when case-insensitive mode is enabled.
> 
> - **Parser/AstBuilder**:
>   - Normalize database names when constructing `LabelName` (`getLabelName`, `qualifiedNameToLabelName`, `createLabelName`).
>   - Shift normalization responsibility out of `LabelName` class (constructor/setter no longer normalize).
> - **AST Model**:
>   - `LabelName` moved to `fe-parser`; removed internal `normalizeName` calls.
> - **Session/ConnectContext**:
>   - `getDatabase()` now returns lowercase when `GlobalVariable.enableTableNameCaseInsensitive` is true.
> - **Misc**:
>   - Minor formatting/Javadoc adjustments; unchanged logic elsewhere.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 182cb8165c91567186c401a2280938bb8db2ba58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->