### PR TITLE
[BugFix] Fix incorrect connection accounting when sessions change user

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
@@ -46,10 +46,13 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.Pair;
 import com.starrocks.mysql.privilege.AuthPlugin;
 import com.starrocks.mysql.ssl.SSLContextLoader;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ConnectScheduler;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.ExecuteEnv;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -246,6 +249,7 @@ public class MysqlProto {
         }
         // set database
         String db = changeUserPacket.getDb();
+        String originalDb = context.getDatabase();
         if (!Strings.isNullOrEmpty(db)) {
             try {
                 context.changeCatalogDb(db);
@@ -263,6 +267,30 @@ public class MysqlProto {
                 return false;
             }
         }
+        ConnectScheduler connectScheduler = ExecuteEnv.getInstance().getScheduler();
+        Pair<Boolean, String> userChangeResult = connectScheduler.onUserChanged(
+                context, previousQualifiedUser, context.getQualifiedUser());
+        if (!userChangeResult.first) {
+            context.getState().setErrorCode(ErrorCode.ERR_TOO_MANY_USER_CONNECTIONS);
+            context.getState().setError(userChangeResult.second);
+            sendResponsePacket(context);
+            context.getSerializer().setCapability(context.getCapability());
+            context.getSessionVariable().setResourceGroup(previousResourceGroup);
+            context.setCurrentUserIdentity(previousUserIdentity);
+            context.setCurrentRoleIds(previousRoleIds);
+            context.setQualifiedUser(previousQualifiedUser);
+
+            if (!context.getDatabase().equals(originalDb)) {
+                try {
+                    context.changeCatalogDb(originalDb);
+                } catch (DdlException e) {
+                    LOG.error("recover original database fail", e);
+                    return false;
+                }
+            }
+            return false;
+        }
+
         LOG.info("Command `Change user` succeeded, from [{}] to [{}]. ", previousQualifiedUser,
                 context.getQualifiedUser());
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TimerTask;
 import java.util.UUID;
@@ -163,6 +164,58 @@ public class ConnectScheduler {
                 arrowFlightSqlConnectContextMap.put(context.getArrowFlightSqlToken(), context);
             }
 
+            return new Pair<>(true, null);
+        } finally {
+            connStatsLock.unlock();
+        }
+    }
+
+    public Pair<Boolean, String> onUserChanged(ConnectContext ctx, String oldQualifiedUser, String newQualifiedUser) {
+        if (Objects.equals(oldQualifiedUser, newQualifiedUser)) {
+            return new Pair<>(true, null);
+        }
+
+        if (newQualifiedUser == null) {
+            return new Pair<>(false, "new qualifiedUser is null");
+        }
+
+        try {
+            connStatsLock.lock();
+            AtomicInteger newCounter = connCountByUser.computeIfAbsent(newQualifiedUser, k -> new AtomicInteger(0));
+            int currentNewCount = newCounter.get();
+            long currentUserMaxConn = GlobalStateMgr.getCurrentState().getAuthenticationMgr().getMaxConn(newQualifiedUser);
+
+            if (currentNewCount >= currentUserMaxConn) {
+                int totalConn = connCountByUser.values().stream().mapToInt(AtomicInteger::get).sum();
+                String userErrMsg = "Reach user-level(qualifiedUser: " + newQualifiedUser
+                        + ", currUserIdentity: " + ctx.getCurrentUserIdentity() + ") connection limit, "
+                        + "currentUserMaxConn=" + currentUserMaxConn + ", connectionMap.size="
+                        + connectionMap.size() + ", connByUser.totConn=" + totalConn
+                        + ", user.currConn=" + currentNewCount;
+                LOG.info("{}, details: connectionId={}, connByUser={}", userErrMsg, ctx.getConnectionId(), connCountByUser);
+                return new Pair<>(false, userErrMsg);
+            }
+
+            newCounter.incrementAndGet();
+
+            if (oldQualifiedUser != null) {
+                AtomicInteger oldCounter = connCountByUser.get(oldQualifiedUser);
+                if (oldCounter != null) {
+                    int oldCountAfterDecrement = oldCounter.decrementAndGet();
+                    if (oldCountAfterDecrement < 0) {
+                        LOG.warn("Negative connection count detected for user {} during user change of connection {}",
+                                oldQualifiedUser, ctx.getConnectionId());
+                        oldCounter.set(0);
+                        oldCountAfterDecrement = 0;
+                    }
+                    if (oldCountAfterDecrement == 0) {
+                        connCountByUser.remove(oldQualifiedUser, oldCounter);
+                    }
+                } else {
+                    LOG.warn("Missing connection counter for user {} during user change of connection {}",
+                            oldQualifiedUser, ctx.getConnectionId());
+                }
+            }
             return new Pair<>(true, null);
         } finally {
             connStatsLock.unlock();

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlProtoChangeUserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlProtoChangeUserTest.java
@@ -1,0 +1,442 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.mysql;
+
+import com.starrocks.authentication.AuthenticationMgr;
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.authorization.MockedLocalMetaStore;
+import com.starrocks.authorization.RBACMockedMetadataMgr;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.persist.EditLog;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ConnectScheduler;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.ExecuteEnv;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.CreateUserStmt;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Test cases for MysqlProto.changeUser function
+ * This test covers various scenarios including successful user changes,
+ * authentication failures, database switching, and error recovery.
+ */
+public class MysqlProtoChangeUserTest {
+    private ConnectContext context;
+    private AuthenticationMgr authMgr;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Mock EditLog to prevent NullPointerException
+        EditLog editLog = spy(new EditLog(null));
+        doNothing().when(editLog).logEdit(anyShort(), any());
+        GlobalStateMgr.getCurrentState().setEditLog(editLog);
+        
+        // Initialize test context
+        context = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        context.setQualifiedUser("root");
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setDatabase("test_db");
+        context.setCapability(MysqlCapability.DEFAULT_CAPABILITY);
+        
+        // Mock MysqlChannel
+        new MockUp<MysqlChannel>() {
+            @Mock
+            public void sendAndFlush(ByteBuffer packet) throws IOException {
+                // Mock send operation - do nothing for testing
+            }
+            
+            @Mock
+            public String getRemoteIp() {
+                return "127.0.0.1";
+            }
+        };
+        
+        // Initialize authentication manager
+        authMgr = new AuthenticationMgr();
+        GlobalStateMgr.getCurrentState().setAuthenticationMgr(authMgr);
+        
+        // Create test users
+        createTestUsers();
+    }
+
+    private void createTestUsers() throws Exception {
+        // Create user1 with password
+        CreateUserStmt createUser1 = (CreateUserStmt) SqlParser
+                .parse("create user user1 identified with mysql_native_password by 'password1'", 32).get(0);
+        Analyzer.analyze(createUser1, context);
+        authMgr.createUser(createUser1);
+        
+        // Create user2 with password
+        CreateUserStmt createUser2 = (CreateUserStmt) SqlParser
+                .parse("create user user2 identified with mysql_native_password by 'password2'", 32).get(0);
+        Analyzer.analyze(createUser2, context);
+        authMgr.createUser(createUser2);
+        
+        // Create user3 with empty password
+        CreateUserStmt createUser3 = (CreateUserStmt) SqlParser
+                .parse("create user user3 identified with mysql_native_password by ''", 32).get(0);
+        Analyzer.analyze(createUser3, context);
+        authMgr.createUser(createUser3);
+    }
+
+    /**
+     * Test change user with invalid packet format
+     */
+    @Test
+    public void testChangeUserInvalidPacket() throws IOException {
+        // Create invalid packet (wrong command code)
+        ByteBuffer invalidPacket = ByteBuffer.allocate(10);
+        invalidPacket.put((byte) 0x01); // Wrong command code
+        invalidPacket.put("test".getBytes(StandardCharsets.UTF_8));
+        invalidPacket.flip();
+        
+        // Execute change user
+        boolean result = MysqlProto.changeUser(context, invalidPacket);
+        
+        // Verify failure
+        Assertions.assertFalse(result, "Change user should fail with invalid packet");
+    }
+
+    /**
+     * Test change user with authentication failure
+     */
+    @Test
+    public void testChangeUserAuthenticationFailure() throws IOException {
+        // Create change user packet with wrong password
+        ByteBuffer changeUserPacket = createChangeUserPacket("user1", "wrong_password", "new_db");
+        
+        // Save original user info for verification
+        String originalUser = context.getQualifiedUser();
+        String originalDb = context.getDatabase();
+        UserIdentity originalUserIdentity = context.getCurrentUserIdentity();
+        
+        // Execute change user
+        boolean result = MysqlProto.changeUser(context, changeUserPacket);
+        
+        // Verify failure and rollback
+        Assertions.assertFalse(result, "Change user should fail with wrong password");
+        Assertions.assertEquals(originalUser, context.getQualifiedUser());
+        Assertions.assertEquals(originalDb, context.getDatabase());
+        Assertions.assertEquals(originalUserIdentity, context.getCurrentUserIdentity());
+    }
+
+    /**
+     * Test change user with non-existent user
+     */
+    @Test
+    public void testChangeUserNonExistentUser() throws IOException {
+        // Create change user packet for non-existent user
+        ByteBuffer changeUserPacket = createChangeUserPacket("nonexistent", "password", "new_db");
+        
+        // Save original user info for verification
+        String originalUser = context.getQualifiedUser();
+        String originalDb = context.getDatabase();
+        UserIdentity originalUserIdentity = context.getCurrentUserIdentity();
+        
+        // Execute change user
+        boolean result = MysqlProto.changeUser(context, changeUserPacket);
+        
+        // Verify failure and rollback
+        Assertions.assertFalse(result, "Change user should fail for non-existent user");
+        Assertions.assertEquals(originalUser, context.getQualifiedUser());
+        Assertions.assertEquals(originalDb, context.getDatabase());
+        Assertions.assertEquals(originalUserIdentity, context.getCurrentUserIdentity());
+    }
+
+    /**
+     * Test change user with database switching failure
+     */
+    @Test
+    public void testChangeUserDatabaseSwitchFailure() throws IOException {
+        // Create change user packet with non-existent database
+        ByteBuffer changeUserPacket = createChangeUserPacket("user1", "password1", "nonexistent_db");
+        
+        // Mock ConnectScheduler to return success
+        new MockUp<ConnectScheduler>() {
+            @Mock
+            public com.starrocks.common.Pair<Boolean, String> onUserChanged(
+                    ConnectContext context, String previousUser, String newUser) {
+                return new com.starrocks.common.Pair<>(true, "");
+            }
+        };
+        
+        // Mock ExecuteEnv
+        new MockUp<ExecuteEnv>() {
+            @Mock
+            public ConnectScheduler getScheduler() {
+                return new ConnectScheduler(1000);
+            }
+        };
+        
+        // Save original user info for verification
+        String originalUser = context.getQualifiedUser();
+        String originalDb = context.getDatabase();
+        UserIdentity originalUserIdentity = context.getCurrentUserIdentity();
+        
+        // Execute change user
+        boolean result = MysqlProto.changeUser(context, changeUserPacket);
+        
+        // Verify failure and rollback
+        Assertions.assertFalse(result, "Change user should fail when database switch fails");
+        Assertions.assertEquals(originalUser, context.getQualifiedUser());
+        Assertions.assertEquals(originalDb, context.getDatabase());
+        Assertions.assertEquals(originalUserIdentity, context.getCurrentUserIdentity());
+    }
+
+    /**
+     * Test change user with ConnectScheduler failure
+     */
+    @Test
+    public void testChangeUserSchedulerFailure() throws IOException {
+        // Create change user packet without database to avoid database switch failure
+        ByteBuffer changeUserPacket = createChangeUserPacket("user1", "password1", null);
+        
+        // Mock ConnectScheduler to return failure
+        new MockUp<ConnectScheduler>() {
+            @Mock
+            public com.starrocks.common.Pair<Boolean, String> onUserChanged(
+                    ConnectContext context, String previousUser, String newUser) {
+                return new com.starrocks.common.Pair<>(false, "Too many connections");
+            }
+        };
+        
+        // Mock ExecuteEnv
+        new MockUp<ExecuteEnv>() {
+            @Mock
+            public ConnectScheduler getScheduler() {
+                return new ConnectScheduler(1000);
+            }
+        };
+        
+        // Save original user info for verification
+        String originalUser = context.getQualifiedUser();
+        String originalDb = context.getDatabase();
+        UserIdentity originalUserIdentity = context.getCurrentUserIdentity();
+        
+        // Execute change user
+        boolean result = MysqlProto.changeUser(context, changeUserPacket);
+        
+        // Verify failure and rollback
+        Assertions.assertFalse(result, "Change user should fail when scheduler rejects");
+        Assertions.assertEquals(originalUser, context.getQualifiedUser());
+        Assertions.assertEquals(originalDb, context.getDatabase());
+        Assertions.assertEquals(originalUserIdentity, context.getCurrentUserIdentity());
+        Assertions.assertEquals(ErrorCode.ERR_TOO_MANY_USER_CONNECTIONS, context.getState().getErrorCode());
+    }
+
+    /**
+     * Test change user without database specification
+     */
+    @Test
+    public void testChangeUserWithoutDatabase() throws IOException {
+        // Create change user packet without database
+        ByteBuffer changeUserPacket = createChangeUserPacket("user1", "password1", null);
+        
+        // Mock ConnectScheduler to return success
+        new MockUp<ConnectScheduler>() {
+            @Mock
+            public com.starrocks.common.Pair<Boolean, String> onUserChanged(
+                    ConnectContext context, String previousUser, String newUser) {
+                return new com.starrocks.common.Pair<>(true, "");
+            }
+        };
+        
+        // Mock ExecuteEnv
+        new MockUp<ExecuteEnv>() {
+            @Mock
+            public ConnectScheduler getScheduler() {
+                return new ConnectScheduler(1000);
+            }
+        };
+        
+        // Execute change user
+        boolean result = MysqlProto.changeUser(context, changeUserPacket);
+        
+        // Verify success - database should remain unchanged
+        Assertions.assertTrue(result, "Change user should succeed without database change");
+        Assertions.assertEquals("user1", context.getQualifiedUser());
+        Assertions.assertEquals("test_db", context.getDatabase()); // Should remain original
+    }
+
+    /**
+     * Test change user with database recovery on ConnectScheduler failure
+     * This test verifies that when ConnectScheduler.onUserChanged() fails,
+     * the database is properly recovered to its original state.
+     */
+    @Test
+    public void testChangeUserDatabaseRecoveryOnSchedulerFailure() throws IOException {
+        // Set up mock database environment similar to UseDbTest
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        MockedLocalMetaStore localMetastore = new MockedLocalMetaStore(globalStateMgr, globalStateMgr.getRecycleBin(), null);
+        localMetastore.init();
+        globalStateMgr.setLocalMetastore(localMetastore);
+
+        RBACMockedMetadataMgr metadataMgr =
+                new RBACMockedMetadataMgr(localMetastore, globalStateMgr.getConnectorMgr());
+        globalStateMgr.setMetadataMgr(metadataMgr);
+        
+        // Set up user identity with ROOT privileges
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setCurrentRoleIds(UserIdentity.ROOT);
+        
+        // Set up initial database state
+        String originalDb = "db";
+        String newDb = "db1";
+        context.setDatabase(originalDb);
+        
+        // Create change user packet with database change
+        ByteBuffer changeUserPacket = createChangeUserPacket("user1", "password1", newDb);
+        
+        // Mock Authorizer to allow database access
+        new MockUp<Authorizer>() {
+            @Mock
+            public static void checkAnyActionOnOrInDb(ConnectContext context, String catalogName, String dbName) 
+                    throws AccessDeniedException {
+                // Allow access to all databases for testing
+            }
+        };
+        
+        // Mock ConnectScheduler to return failure (simulating user limit reached)
+        new MockUp<ConnectScheduler>() {
+            @Mock
+            public com.starrocks.common.Pair<Boolean, String> onUserChanged(
+                    ConnectContext context, String previousUser, String newUser) {
+                return new com.starrocks.common.Pair<>(false, "Too many connections");
+            }
+        };
+        
+        // Mock ExecuteEnv
+        new MockUp<ExecuteEnv>() {
+            @Mock
+            public ConnectScheduler getScheduler() {
+                return new ConnectScheduler(1000);
+            }
+        };
+        
+        // Save original user info for verification
+        String originalUser = context.getQualifiedUser();
+        UserIdentity originalUserIdentity = context.getCurrentUserIdentity();
+        
+        // Execute change user
+        boolean result = MysqlProto.changeUser(context, changeUserPacket);
+        
+        // Verify failure and database recovery
+        Assertions.assertFalse(result, "Change user should fail when scheduler rejects");
+        Assertions.assertEquals(originalUser, context.getQualifiedUser(), "User should be reverted");
+        Assertions.assertEquals(originalUserIdentity, context.getCurrentUserIdentity(), "User identity should be reverted");
+        Assertions.assertEquals(originalDb, context.getDatabase(), "Database should be recovered to original");
+        Assertions.assertEquals(ErrorCode.ERR_TOO_MANY_USER_CONNECTIONS, context.getState().getErrorCode());
+    }
+
+    /**
+     * Test change user with database recovery on database change failure
+     * This test verifies that when database change fails, the user identity
+     * is properly reverted to its original state.
+     */
+    @Test
+    public void testChangeUserUserRecoveryOnDatabaseChangeFailure() throws IOException {
+        // Create change user packet with non-existent database
+        ByteBuffer changeUserPacket = createChangeUserPacket("user1", "password1", "nonexistent_db");
+        
+        // Mock ConnectScheduler to return success (we want to test database failure, not scheduler failure)
+        new MockUp<ConnectScheduler>() {
+            @Mock
+            public com.starrocks.common.Pair<Boolean, String> onUserChanged(
+                    ConnectContext context, String previousUser, String newUser) {
+                return new com.starrocks.common.Pair<>(true, "");
+            }
+        };
+        
+        // Mock ExecuteEnv
+        new MockUp<ExecuteEnv>() {
+            @Mock
+            public ConnectScheduler getScheduler() {
+                return new ConnectScheduler(1000);
+            }
+        };
+        
+        // Save original user info for verification
+        String originalUser = context.getQualifiedUser();
+        String originalDb = context.getDatabase();
+        UserIdentity originalUserIdentity = context.getCurrentUserIdentity();
+        
+        // Execute change user
+        boolean result = MysqlProto.changeUser(context, changeUserPacket);
+        
+        // Verify failure and user recovery
+        Assertions.assertFalse(result, "Change user should fail when database change fails");
+        Assertions.assertEquals(originalUser, context.getQualifiedUser(), "User should be reverted");
+        Assertions.assertEquals(originalUserIdentity, context.getCurrentUserIdentity(), "User identity should be reverted");
+        Assertions.assertEquals(originalDb, context.getDatabase(), "Database should remain original");
+    }
+
+    /**
+     * Helper method to create a change user packet
+     */
+    private ByteBuffer createChangeUserPacket(String username, String password, String database) {
+        MysqlSerializer serializer = MysqlSerializer.newInstance();
+        
+        // Command code for COM_CHANGE_USER
+        serializer.writeInt1(MysqlCommand.COM_CHANGE_USER.getCommandCode());
+        
+        // Username
+        serializer.writeNulTerminateString(username);
+        
+        // Auth response (password)
+        byte[] authResponse;
+        if (password.isEmpty()) {
+            authResponse = MysqlPassword.EMPTY_PASSWORD;
+        } else {
+            // For testing, we'll use the password directly as auth response
+            // In real scenario, this would be scrambled
+            authResponse = password.getBytes(StandardCharsets.UTF_8);
+        }
+        serializer.writeInt1(authResponse.length);
+        serializer.writeBytes(authResponse);
+        
+        // Database name (null-terminated)
+        if (database != null) {
+            serializer.writeNulTerminateString(database);
+        } else {
+            serializer.writeInt1(0); // Empty string
+        }
+        
+        // Character set
+        serializer.writeInt2(33); // UTF8
+        
+        // Plugin name (empty for mysql_native_password)
+        serializer.writeNulTerminateString("");
+        
+        return serializer.toByteBuffer();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectionTest.java
@@ -43,12 +43,17 @@ import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ConnectionTest {
+    private static final Logger LOG = LoggerFactory.getLogger(ConnectionTest.class);
     private static StarRocksAssert starRocksAssert;
     private static int connectionId = 100;
+    private static int uniqueUserId = 0;
 
     @BeforeAll
     public static void beforeClass() throws Exception {
@@ -80,6 +85,34 @@ public class ConnectionTest {
         context.setConnectionId(connectionId++);
 
         return context;
+    }
+
+    private static String nextUserName(String prefix) {
+        return prefix + "_" + (++uniqueUserId);
+    }
+
+    private void ensureUserExists(String userName) throws Exception {
+        String createUserSql = String.format("CREATE USER '%s' IDENTIFIED BY ''", userName);
+        CreateUserStmt createUserStmt =
+                (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(createUserSql, starRocksAssert.getCtx());
+        GlobalStateMgr.getCurrentState().getAuthenticationMgr().createUser(createUserStmt);
+    }
+
+    private void setUserMaxConnections(String userName, long maxConn) throws Exception {
+        String sql = String.format("set property for '%s' 'max_user_connections' = '%d'", userName, maxConn);
+        SetUserPropertyStmt setUserPropertyStmt =
+                (SetUserPropertyStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        GlobalStateMgr.getCurrentState().getAuthenticationMgr()
+                .updateUserProperty(userName, setUserPropertyStmt.getPropertyPairList());
+    }
+
+    private int getUserConnCount(ConnectScheduler scheduler, String userName) {
+        AtomicInteger counter = scheduler.getUserConnectionMap().get(userName);
+        return counter == null ? 0 : counter.get();
+    }
+
+    private int totalTrackedConnections(ConnectScheduler scheduler) {
+        return scheduler.getUserConnectionMap().values().stream().mapToInt(AtomicInteger::get).sum();
     }
 
     @Test
@@ -259,4 +292,325 @@ public class ConnectionTest {
         connectScheduler.unregisterConnection(conn2);
         Assertions.assertEquals(0, currentConnectionMap.size());
     }
+
+    @Test
+    public void testOnUserChangedUpdatesCounters() throws Exception {
+        ExecuteEnv.setup();
+        String userA = nextUserName("change_user_a");
+        String userB = nextUserName("change_user_b");
+        ensureUserExists(userA);
+        ensureUserExists(userB);
+
+        ConnectScheduler scheduler = new ConnectScheduler(100);
+        ConnectContext ctx = createConnectContextForUser(userA);
+
+        Pair<Boolean, String> registerResult = scheduler.registerConnection(ctx);
+        Assertions.assertTrue(registerResult.first);
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA));
+        Assertions.assertEquals(0, getUserConnCount(scheduler, userB));
+        Assertions.assertEquals(1, scheduler.getCurrentConnectionMap().size());
+        Assertions.assertEquals(1, totalTrackedConnections(scheduler));
+
+        ctx.setQualifiedUser(userB);
+        ctx.setCurrentUserIdentity(new UserIdentity(userB, "%"));
+        Pair<Boolean, String> changeResult = scheduler.onUserChanged(ctx, userA, userB);
+        Assertions.assertTrue(changeResult.first);
+        Assertions.assertEquals(0, getUserConnCount(scheduler, userA));
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userB));
+        Assertions.assertEquals(1, scheduler.getCurrentConnectionMap().size());
+        Assertions.assertEquals(1, totalTrackedConnections(scheduler));
+
+        ctx.setQualifiedUser(userA);
+        ctx.setCurrentUserIdentity(new UserIdentity(userA, "%"));
+        changeResult = scheduler.onUserChanged(ctx, userB, userA);
+        Assertions.assertTrue(changeResult.first);
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA));
+        Assertions.assertEquals(0, getUserConnCount(scheduler, userB));
+        Assertions.assertEquals(1, scheduler.getCurrentConnectionMap().size());
+        Assertions.assertEquals(1, totalTrackedConnections(scheduler));
+
+        scheduler.unregisterConnection(ctx);
+        Assertions.assertEquals(0, scheduler.getCurrentConnectionMap().size());
+        Assertions.assertEquals(0, totalTrackedConnections(scheduler));
+        Assertions.assertTrue(scheduler.getUserConnectionMap().values().stream().allMatch(counter -> counter.get() >= 0));
+    }
+
+    @Test
+    public void testOnUserChangedRespectsUserLimit() throws Exception {
+        ExecuteEnv.setup();
+        String userA = nextUserName("limit_user_a");
+        String userB = nextUserName("limit_user_b");
+        ensureUserExists(userA);
+        ensureUserExists(userB);
+        setUserMaxConnections(userB, 1);
+
+        ConnectScheduler scheduler = new ConnectScheduler(100);
+
+        ConnectContext primaryCtx = createConnectContextForUser(userA);
+        Assertions.assertTrue(scheduler.registerConnection(primaryCtx).first);
+
+        ConnectContext occupiedCtx = createConnectContextForUser(userB);
+        Assertions.assertTrue(scheduler.registerConnection(occupiedCtx).first);
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userB));
+
+        primaryCtx.setQualifiedUser(userB);
+        primaryCtx.setCurrentUserIdentity(new UserIdentity(userB, "%"));
+        Pair<Boolean, String> changeResult = scheduler.onUserChanged(primaryCtx, userA, userB);
+        Assertions.assertFalse(changeResult.first);
+        Assertions.assertNotNull(changeResult.second);
+        Assertions.assertTrue(changeResult.second.contains("Reach user-level"));
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userB));
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA));
+        Assertions.assertEquals(2, totalTrackedConnections(scheduler));
+        Assertions.assertEquals(2, scheduler.getCurrentConnectionMap().size());
+
+        // revert context state to original user, as MysqlProto.changeUser would do on failure
+        primaryCtx.setQualifiedUser(userA);
+        primaryCtx.setCurrentUserIdentity(new UserIdentity(userA, "%"));
+
+        scheduler.unregisterConnection(primaryCtx);
+        scheduler.unregisterConnection(occupiedCtx);
+        Assertions.assertEquals(0, scheduler.getCurrentConnectionMap().size());
+        Assertions.assertEquals(0, totalTrackedConnections(scheduler));
+    }
+
+    @Test
+    public void testOnUserChangedWithNullNewUser() throws Exception {
+        ExecuteEnv.setup();
+        String userA = nextUserName("null_user_a");
+        ensureUserExists(userA);
+
+        ConnectScheduler scheduler = new ConnectScheduler(100);
+        ConnectContext ctx = createConnectContextForUser(userA);
+
+        Pair<Boolean, String> registerResult = scheduler.registerConnection(ctx);
+        Assertions.assertTrue(registerResult.first);
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA));
+
+        // Test with null new user
+        Pair<Boolean, String> changeResult = scheduler.onUserChanged(ctx, userA, null);
+        Assertions.assertFalse(changeResult.first);
+        Assertions.assertNotNull(changeResult.second);
+        Assertions.assertTrue(changeResult.second.contains("new qualifiedUser is null"));
+        
+        // Verify original state is preserved
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA));
+        Assertions.assertEquals(1, totalTrackedConnections(scheduler));
+        Assertions.assertEquals(1, scheduler.getCurrentConnectionMap().size());
+
+        scheduler.unregisterConnection(ctx);
+    }
+
+    @Test
+    public void testOnUserChangedWithSameUser() throws Exception {
+        ExecuteEnv.setup();
+        String userA = nextUserName("same_user_a");
+        ensureUserExists(userA);
+
+        ConnectScheduler scheduler = new ConnectScheduler(100);
+        ConnectContext ctx = createConnectContextForUser(userA);
+
+        Pair<Boolean, String> registerResult = scheduler.registerConnection(ctx);
+        Assertions.assertTrue(registerResult.first);
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA));
+
+        // Test with same user (should succeed but no state change)
+        Pair<Boolean, String> changeResult = scheduler.onUserChanged(ctx, userA, userA);
+        Assertions.assertTrue(changeResult.first);
+        Assertions.assertNull(changeResult.second);
+        
+        // Verify state remains unchanged
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA));
+        Assertions.assertEquals(1, totalTrackedConnections(scheduler));
+        Assertions.assertEquals(1, scheduler.getCurrentConnectionMap().size());
+
+        scheduler.unregisterConnection(ctx);
+    }
+
+    @Test
+    public void testOnUserChangedWithNonExistentOldUser() throws Exception {
+        ExecuteEnv.setup();
+        String userA = nextUserName("non_existent_old_a");
+        String userB = nextUserName("non_existent_old_b");
+        ensureUserExists(userA);
+        ensureUserExists(userB);
+
+        ConnectScheduler scheduler = new ConnectScheduler(100);
+        ConnectContext ctx = createConnectContextForUser(userA);
+
+        Pair<Boolean, String> registerResult = scheduler.registerConnection(ctx);
+        Assertions.assertTrue(registerResult.first);
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA));
+
+        // Test with non-existent old user (should still succeed)
+        Pair<Boolean, String> changeResult = scheduler.onUserChanged(ctx, "non_existent_user", userB);
+        Assertions.assertTrue(changeResult.first);
+        
+        // Verify new user counter is incremented, old user counter remains unchanged
+        // because the old user didn't exist in the counter map
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA)); // Still 1 because old user didn't exist
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userB)); // New user counter incremented
+        Assertions.assertEquals(2, totalTrackedConnections(scheduler)); // Both users have connections
+        Assertions.assertEquals(1, scheduler.getCurrentConnectionMap().size());
+
+        scheduler.unregisterConnection(ctx);
+    }
+
+    @Test
+    public void testOnUserChangedWithNegativeCounterRecovery() throws Exception {
+        ExecuteEnv.setup();
+        String userA = nextUserName("negative_counter_a");
+        String userB = nextUserName("negative_counter_b");
+        ensureUserExists(userA);
+        ensureUserExists(userB);
+
+        ConnectScheduler scheduler = new ConnectScheduler(100);
+        ConnectContext ctx = createConnectContextForUser(userA);
+
+        Pair<Boolean, String> registerResult = scheduler.registerConnection(ctx);
+        Assertions.assertTrue(registerResult.first);
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA));
+
+        // Manually create a negative counter scenario by manipulating the internal state
+        // This simulates a race condition or bug where counter goes negative
+        AtomicInteger userACounter = scheduler.getUserConnectionMap().get(userA);
+        userACounter.set(-1); // Force negative counter
+
+        // Now try to change user - should handle negative counter gracefully
+        Pair<Boolean, String> changeResult = scheduler.onUserChanged(ctx, userA, userB);
+        Assertions.assertTrue(changeResult.first);
+        
+        // Verify counters are correct after recovery
+        Assertions.assertEquals(0, getUserConnCount(scheduler, userA)); // Should be reset to 0
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userB));
+        Assertions.assertEquals(1, totalTrackedConnections(scheduler));
+        Assertions.assertEquals(1, scheduler.getCurrentConnectionMap().size());
+
+        scheduler.unregisterConnection(ctx);
+    }
+
+    @Test
+    public void testOnUserChangedWithMissingOldUserCounter() throws Exception {
+        ExecuteEnv.setup();
+        String userA = nextUserName("missing_counter_a");
+        String userB = nextUserName("missing_counter_b");
+        ensureUserExists(userA);
+        ensureUserExists(userB);
+
+        ConnectScheduler scheduler = new ConnectScheduler(100);
+        ConnectContext ctx = createConnectContextForUser(userA);
+
+        Pair<Boolean, String> registerResult = scheduler.registerConnection(ctx);
+        Assertions.assertTrue(registerResult.first);
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA));
+
+        // Manually remove the counter to simulate missing counter scenario
+        scheduler.getUserConnectionMap().remove(userA);
+
+        // Now try to change user - should handle missing counter gracefully
+        Pair<Boolean, String> changeResult = scheduler.onUserChanged(ctx, userA, userB);
+        Assertions.assertTrue(changeResult.first);
+        
+        // Verify new user counter is still incremented correctly
+        Assertions.assertEquals(0, getUserConnCount(scheduler, userA));
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userB));
+        Assertions.assertEquals(1, totalTrackedConnections(scheduler));
+        Assertions.assertEquals(1, scheduler.getCurrentConnectionMap().size());
+
+        scheduler.unregisterConnection(ctx);
+    }
+
+    @Test
+    public void testOnUserChangedConcurrentModification() throws Exception {
+        ExecuteEnv.setup();
+        String userA = nextUserName("concurrent_a");
+        String userB = nextUserName("concurrent_b");
+        String userC = nextUserName("concurrent_c");
+        ensureUserExists(userA);
+        ensureUserExists(userB);
+        ensureUserExists(userC);
+        setUserMaxConnections(userB, 1); // Set userB limit to 1
+
+        ConnectScheduler scheduler = new ConnectScheduler(100);
+        ConnectContext ctx1 = createConnectContextForUser(userA);
+        ConnectContext ctx2 = createConnectContextForUser(userB);
+
+        // Register both connections
+        Assertions.assertTrue(scheduler.registerConnection(ctx1).first);
+        Assertions.assertTrue(scheduler.registerConnection(ctx2).first);
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA));
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userB));
+
+        // Simulate concurrent user changes
+        // ctx1 changes from userA to userB (should fail due to userB limit)
+        ctx1.setQualifiedUser(userB);
+        ctx1.setCurrentUserIdentity(new UserIdentity(userB, "%"));
+        Pair<Boolean, String> changeResult1 = scheduler.onUserChanged(ctx1, userA, userB);
+        
+        // ctx2 changes from userB to userC (should succeed)
+        ctx2.setQualifiedUser(userC);
+        ctx2.setCurrentUserIdentity(new UserIdentity(userC, "%"));
+        Pair<Boolean, String> changeResult2 = scheduler.onUserChanged(ctx2, userB, userC);
+
+        // Verify results
+        Assertions.assertFalse(changeResult1.first); // Should fail due to userB limit
+        Assertions.assertTrue(changeResult2.first);  // Should succeed
+
+        // Verify final state
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA)); // ctx1 reverted
+        Assertions.assertEquals(0, getUserConnCount(scheduler, userB)); // ctx2 moved to userC
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userC)); // ctx2 succeeded
+        Assertions.assertEquals(2, totalTrackedConnections(scheduler)); // Both connections tracked
+        Assertions.assertEquals(2, scheduler.getCurrentConnectionMap().size());
+
+        scheduler.unregisterConnection(ctx1);
+        scheduler.unregisterConnection(ctx2);
+    }
+
+    @Test
+    public void testOnUserChangedStateConsistencyAfterFailure() throws Exception {
+        ExecuteEnv.setup();
+        String userA = nextUserName("consistency_a");
+        String userB = nextUserName("consistency_b");
+        ensureUserExists(userA);
+        ensureUserExists(userB);
+        setUserMaxConnections(userB, 1);
+
+        ConnectScheduler scheduler = new ConnectScheduler(100);
+        ConnectContext ctx1 = createConnectContextForUser(userA);
+        ConnectContext ctx2 = createConnectContextForUser(userB);
+
+        // Register both connections
+        Assertions.assertTrue(scheduler.registerConnection(ctx1).first);
+        Assertions.assertTrue(scheduler.registerConnection(ctx2).first);
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA));
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userB));
+
+        // Try to change ctx1 from userA to userB (should fail due to userB limit)
+        ctx1.setQualifiedUser(userB);
+        ctx1.setCurrentUserIdentity(new UserIdentity(userB, "%"));
+        Pair<Boolean, String> changeResult = scheduler.onUserChanged(ctx1, userA, userB);
+        
+        Assertions.assertFalse(changeResult.first);
+        Assertions.assertNotNull(changeResult.second);
+        Assertions.assertTrue(changeResult.second.contains("Reach user-level"));
+
+        // Verify state consistency after failure
+        // The onUserChanged method checks the limit before incrementing the counter
+        // So userB counter should remain 1, and the change should be considered failed
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userA)); // Should remain unchanged
+        Assertions.assertEquals(1, getUserConnCount(scheduler, userB)); // Should remain unchanged (limit check before increment)
+        Assertions.assertEquals(2, totalTrackedConnections(scheduler)); // Both connections still tracked
+        Assertions.assertEquals(2, scheduler.getCurrentConnectionMap().size());
+
+        // Verify that the context state needs to be manually reverted by caller
+        // (This is the responsibility of MysqlProto.changeUser)
+        Assertions.assertEquals(userB, ctx1.getQualifiedUser()); // Context still has new user
+        Assertions.assertEquals(userB, ctx1.getCurrentUserIdentity().getUser());
+
+        scheduler.unregisterConnection(ctx1);
+        scheduler.unregisterConnection(ctx2);
+    }
+
+
 }


### PR DESCRIPTION
## Why I'm doing:
Fixes #64265
## What I'm doing:
This pull request enhances user connection management in the MySQL protocol layer by introducing robust tracking and enforcement of user-level connection limits when a session changes users. It also adds comprehensive tests to ensure correctness and reliability of these changes.

**User connection tracking and enforcement:**

* Added a new method `onUserChanged` to `ConnectScheduler` that updates connection counters when a session changes its user, enforcing per-user connection limits and rolling back changes if limits are exceeded. This prevents users from exceeding their allowed concurrent connections during a user switch.
* Integrated the `onUserChanged` logic into the `MysqlProto.changeUser` flow, so user-level connection limits are checked and enforced when a client issues a "change user" command. If the limit is exceeded, the session is reverted to its previous state and an appropriate error is returned.

**Testing and reliability:**

* Added new unit tests in `ConnectionTest` to verify the correct updating of user connection counters on user change, and to ensure that connection limits are properly enforced and rolled back if exceeded. Helper methods were introduced to facilitate user creation, property setting, and connection counting in tests. [[1]](diffhunk://#diff-41eef280d0a42909a34bd30091fe2bb3da999a76d43b3ef7e12350741fb10f26R87-R114) [[2]](diffhunk://#diff-41eef280d0a42909a34bd30091fe2bb3da999a76d43b3ef7e12350741fb10f26R150-R230)

**Codebase maintenance:**

* Added necessary imports for new functionality, such as `Pair`, `Objects`, and `AtomicInteger`, to support the new logic and tests. [[1]](diffhunk://#diff-425c24ba273152074cc685586d97a79f50272457b996cfb3b8909d2b78a301fdR49-R55) [[2]](diffhunk://#diff-1a66c78a0e93e8768aaab46339828c1bd2674b76ff5346013d7dc287918fed46R59) [[3]](diffhunk://#diff-41eef280d0a42909a34bd30091fe2bb3da999a76d43b3ef7e12350741fb10f26R48-R53)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces per-user connection limits and updates connection counters when sessions change user, integrating checks into `MysqlProto.changeUser` and adding targeted tests.
> 
> - **Backend**:
>   - `ConnectScheduler`:
>     - Add `onUserChanged(ctx, oldQualifiedUser, newQualifiedUser)` to update per-user connection counters under lock and enforce per-user limits.
>   - `MysqlProto.changeUser`:
>     - Invoke scheduler `onUserChanged` after re-auth/database switch; on failure, set `ERR_TOO_MANY_USER_CONNECTIONS`, send error, and restore prior user/session state.
> - **Tests**:
>   - `ConnectionTest`:
>     - Add tests to validate counter updates on user switch and enforcement of per-user limits during user change.
>     - Introduce helpers for creating users, setting `max_user_connections`, and reading tracked counters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47a320c835ee712db3ccdf7d45a30fced4fd42a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->