### PR TITLE
[Enhancement] Support disabling optimizer rules via cbo_disabled_rules session variable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -393,6 +393,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_JSON_V2_REWRITE = "cbo_json_v2_rewrite";
     public static final String CBO_JSON_V2_DICT_OPT = "cbo_json_v2_dict_opt";
 
+    public static final String CBO_DISABLED_RULES = "cbo_disabled_rules";
+
     public static final String CBO_PUSH_DOWN_DISTINCT_BELOW_WINDOW = "cbo_push_down_distinct_below_window";
     public static final String CBO_PUSH_DOWN_AGGREGATE = "cbo_push_down_aggregate";
     public static final String CBO_PUSH_DOWN_GROUPINGSET = "cbo_push_down_groupingset";
@@ -1114,6 +1116,20 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // Default sqlMode is ONLY_FULL_GROUP_BY
     @VariableMgr.VarAttr(name = SQL_MODE_STORAGE_NAME, alias = SQL_MODE, show = SQL_MODE)
     private long sqlMode = 32L;
+    
+    /**
+     * Comma-separated list of optimizer rule types to disable
+     * 
+     * This is used to temporarily disable specific optimizer rules when they cause query errors,
+     * allowing queries to complete successfully while the rule bug is being fixed.
+     * 
+     * Supports TF_ (Transformation rules) and GP_ (Group combination rules) rule types.
+     * 
+     * Example:
+     *   SET cbo_disabled_rules = 'TF_JOIN_COMMUTATIVITY,GP_PRUNE_COLUMNS';
+     */
+    @VariableMgr.VarAttr(name = CBO_DISABLED_RULES)
+    private String cboDisabledRules = "";
 
     // The specified resource group of this session
     @VariableMgr.VarAttr(name = RESOURCE_GROUP, flag = VariableMgr.SESSION_ONLY)
@@ -3215,6 +3231,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setSqlMode(long sqlMode) {
         this.sqlMode = sqlMode;
+    }
+    
+    public String getCboDisabledRules() {
+        return cboDisabledRules;
+    }
+    
+    public void setCboDisabledRules(String rulesStr) {
+        this.cboDisabledRules = rulesStr;
     }
 
     public long getSqlSelectLimit() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Enums;
 import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.starrocks.authentication.UserAuthenticationInfo;
@@ -60,6 +61,7 @@ import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.ast.expression.Subquery;
 import com.starrocks.sql.common.QueryDebugOptions;
+import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.system.HeartbeatFlags;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TTabletInternalParallelMode;
@@ -122,6 +124,16 @@ public class SetStmtAnalyzer {
             String value = resolvedExpression.getStringValue();
             if (!value.equalsIgnoreCase("broadcast") && !value.equalsIgnoreCase("shuffle")) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_VALUE_FOR_VAR, "prefer_join_method", value);
+            }
+        }
+
+        if (variable.equalsIgnoreCase(SessionVariable.CBO_DISABLED_RULES)) {
+            String value = resolvedExpression.getStringValue();
+            if (!Strings.isNullOrEmpty(value)) {
+                String errorMsg = validateCboDisabledRules(value);
+                if (errorMsg != null) {
+                    throw new SemanticException(errorMsg);
+                }
             }
         }
 
@@ -358,6 +370,48 @@ public class SetStmtAnalyzer {
         }
 
         var.setResolvedExpression(resolvedExpression);
+    }
+
+    /**
+     * Validate cbo_disabled_rules value - ensures all rule names are valid TF_/GP_ rules
+     * 
+     * @param value comma-separated rule names
+     * @return error message if validation fails, null if valid
+     */
+    private static String validateCboDisabledRules(String value) {
+        try {
+            Splitter splitter = Splitter.on(',').trimResults().omitEmptyStrings();
+            List<String> ruleNames = splitter.splitToList(value);
+            
+            List<String> invalidRules = new ArrayList<>();
+            List<String> nonTfGpRules = new ArrayList<>();
+            
+            for (String ruleName : ruleNames) {
+                try {
+                    RuleType ruleType = RuleType.valueOf(ruleName);
+                    // Only TF_ (Transformation) and GP_ (Group combination) rules can be disabled
+                    if (!ruleType.name().startsWith("TF_") && !ruleType.name().startsWith("GP_")) {
+                        nonTfGpRules.add(ruleName);
+                    }
+                } catch (IllegalArgumentException e) {
+                    invalidRules.add(ruleName);
+                }
+            }
+            
+            // Report all invalid rules at once for better user experience
+            if (!invalidRules.isEmpty()) {
+                return "Unknown rule name(s): " + String.join(", ", invalidRules);
+            }
+            
+            if (!nonTfGpRules.isEmpty()) {
+                return "Only TF_ (Transformation) and GP_ (Group combination) rules can be disabled, invalid: " + 
+                       String.join(", ", nonTfGpRules);
+            }
+            
+            return null;
+        } catch (Exception e) {
+            return "Failed to parse rule names: " + e.getMessage();
+        }
     }
 
     private static void checkRangeLongVariable(LiteralExpr resolvedExpression, String field, Long min, Long max) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -93,7 +93,7 @@ public class OptimizerContext {
         this.cteContext.setInlineCTERatio(getSessionVariable().getCboCTERuseRatio());
         this.cteContext.setMaxCTELimit(getSessionVariable().getCboCTEMaxLimit());
 
-        this.optimizerOptions = OptimizerOptions.defaultOpt();
+        this.optimizerOptions = new OptimizerOptions();
         this.enableJoinIsNullPredicateDerive = getSessionVariable().isCboDeriveJoinIsNullPredicate();
         this.tvrOptContext = new TvrOptContext(getSessionVariable());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerFactory.java
@@ -46,6 +46,7 @@ public class OptimizerFactory {
         OptimizerContext oc = new OptimizerContext(context);
         oc.setColumnRefFactory(columnRefFactory);
         oc.setOptimizerOptions(config);
+        config.applyDisableRuleFromSessionVariable(context.getSessionVariable());
         return oc;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerFactory.java
@@ -30,14 +30,14 @@ public class OptimizerFactory {
 
     @VisibleForTesting
     public static OptimizerContext mockContext(ConnectContext context, ColumnRefFactory columnRefFactory) {
-        return mockContext(context, columnRefFactory, OptimizerOptions.defaultOpt());
+        return mockContext(context, columnRefFactory, new OptimizerOptions());
     }
 
     @VisibleForTesting
     public static OptimizerContext mockContext(ColumnRefFactory columnRefFactory) {
         OptimizerContext oc = new OptimizerContext(new ConnectContext());
         oc.setColumnRefFactory(columnRefFactory);
-        oc.setOptimizerOptions(OptimizerOptions.defaultOpt());
+        oc.setOptimizerOptions(new OptimizerOptions());
         return oc;
     }
 
@@ -51,7 +51,7 @@ public class OptimizerFactory {
     }
 
     public static OptimizerContext initContext(ConnectContext context, ColumnRefFactory columnRefFactory) {
-        return initContext(context, columnRefFactory, OptimizerOptions.defaultOpt());
+        return initContext(context, columnRefFactory, new OptimizerOptions());
     }
 
     public static Optimizer create(OptimizerContext context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerOptions.java
@@ -14,11 +14,21 @@
 
 package com.starrocks.sql.optimizer;
 
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.BitSet;
+import java.util.List;
+import java.util.Set;
 
 public class OptimizerOptions {
+    private static final Logger LOG = LogManager.getLogger(OptimizerOptions.class);
+    
     public enum OptimizerStrategy {
         RULE_BASED,
         COST_BASED,
@@ -72,5 +82,51 @@ public class OptimizerOptions {
 
     public static OptimizerOptions newShortCircuitOpt() {
         return new OptimizerOptions(OptimizerStrategy.SHORT_CIRCUIT);
+    }
+
+    public void applyDisableRuleFromSessionVariable(SessionVariable sessionVariable) {
+        if (sessionVariable == null) {
+            return;
+        }
+
+        String disabledRulesStr = sessionVariable.getCboDisabledRules();
+        if (Strings.isNullOrEmpty(disabledRulesStr)) {
+            return;
+        }
+
+        Set<RuleType> disabledRules = parseDisabledRules(disabledRulesStr);
+        for (RuleType ruleType : disabledRules) {
+            ruleSwitches.clear(ruleType.ordinal());
+        }
+    }
+
+    private static Set<RuleType> parseDisabledRules(String rulesStr) {
+        Set<RuleType> result = Sets.newHashSet();
+
+        if (Strings.isNullOrEmpty(rulesStr)) {
+            return result;
+        }
+
+        try {
+            List<String> ruleNames = Splitter.on(',')
+                    .trimResults()
+                    .omitEmptyStrings()
+                    .splitToList(rulesStr);
+
+            for (String ruleName : ruleNames) {
+                try {
+                    RuleType ruleType = RuleType.valueOf(ruleName);
+                    if (ruleType.name().startsWith("TF_") || ruleType.name().startsWith("GP_")) {
+                        result.add(ruleType);
+                    }
+                } catch (IllegalArgumentException e) {
+                    LOG.warn("Ignoring unknown rule name: {} (may be from different version)", ruleName);
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Unexpected error parsing disabled rules: '{}', returning empty set", rulesStr, e);
+        }
+
+        return result;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/SetStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/SetStmtTest.java
@@ -401,4 +401,107 @@ public class SetStmtTest {
             ;
         }
     }
+
+    @Test
+    public void testCboDisabledRules() {
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CBO_DISABLED_RULES,
+                    new StringLiteral("TF_JOIN_COMMUTATIVITY"));
+            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+            Assertions.assertEquals("TF_JOIN_COMMUTATIVITY", setVar.getResolvedExpression().getStringValue());
+        }
+
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CBO_DISABLED_RULES,
+                    new StringLiteral("GP_PRUNE_COLUMNS"));
+            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+            Assertions.assertEquals("GP_PRUNE_COLUMNS", setVar.getResolvedExpression().getStringValue());
+        }
+
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CBO_DISABLED_RULES,
+                    new StringLiteral("TF_JOIN_COMMUTATIVITY,GP_PRUNE_COLUMNS,TF_PARTITION_PRUNE"));
+            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+            Assertions.assertEquals("TF_JOIN_COMMUTATIVITY,GP_PRUNE_COLUMNS,TF_PARTITION_PRUNE",
+                    setVar.getResolvedExpression().getStringValue());
+        }
+
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CBO_DISABLED_RULES,
+                    new StringLiteral(""));
+            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+            Assertions.assertEquals("", setVar.getResolvedExpression().getStringValue());
+        }
+
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CBO_DISABLED_RULES,
+                    new StringLiteral(" TF_JOIN_COMMUTATIVITY , GP_PRUNE_COLUMNS "));
+            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+            Assertions.assertEquals(" TF_JOIN_COMMUTATIVITY , GP_PRUNE_COLUMNS ",
+                    setVar.getResolvedExpression().getStringValue());
+        }
+
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CBO_DISABLED_RULES,
+                    new StringLiteral("INVALID_RULE_NAME"));
+            try {
+                SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                Assertions.fail("should fail for unknown rule name");
+            } catch (SemanticException e) {
+                assertThat(e.getMessage(), containsString("Unknown rule name(s): INVALID_RULE_NAME"));
+            }
+        }
+
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CBO_DISABLED_RULES,
+                    new StringLiteral("IMP_OLAP_LSCAN_TO_PSCAN"));
+            try {
+                SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                Assertions.fail("should fail for non-TF/GP rule");
+            } catch (SemanticException e) {
+                assertThat(e.getMessage(), containsString("Only TF_ (Transformation) and GP_ (Group combination)" +
+                        " rules can be disabled"));
+                assertThat(e.getMessage(), containsString("IMP_OLAP_LSCAN_TO_PSCAN"));
+            }
+        }
+
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CBO_DISABLED_RULES,
+                    new StringLiteral("TRANSFORMATION_RULES"));
+            try {
+                SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                Assertions.fail("should fail for category marker");
+            } catch (SemanticException e) {
+                assertThat(e.getMessage(), containsString("Only TF_ (Transformation) and GP_ (Group combination)" +
+                        " rules can be disabled"));
+            }
+        }
+
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CBO_DISABLED_RULES,
+                    new StringLiteral("TF_JOIN_COMMUTATIVITY,INVALID_RULE,GP_PRUNE_COLUMNS"));
+            try {
+                SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                Assertions.fail("should fail when any rule is invalid");
+            } catch (SemanticException e) {
+                assertThat(e.getMessage(), containsString("Unknown rule name(s): INVALID_RULE"));
+            }
+        }
+
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CBO_DISABLED_RULES,
+                    new StringLiteral("INVALID1,INVALID2,INVALID3"));
+            try {
+                SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                Assertions.fail("should fail for multiple invalid rules");
+            } catch (SemanticException e) {
+                assertThat(e.getMessage(), containsString("Unknown rule name(s)"));
+                assertThat(e.getMessage(), containsString("INVALID1"));
+                assertThat(e.getMessage(), containsString("INVALID2"));
+                assertThat(e.getMessage(), containsString("INVALID3"));
+            }
+        }
+    }
+
+    
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -258,7 +258,7 @@ public abstract class MVTestBase extends StarRocksTestBase {
     }
 
     public static OptExpression getOptimizedPlan(String sql, ConnectContext connectContext) {
-        return getOptimizedPlan(sql, connectContext, OptimizerOptions.defaultOpt());
+        return getOptimizedPlan(sql, connectContext, new OptimizerOptions());
     }
 
     public static StatementBase getAnalyzedPlan(String sql, ConnectContext connectContext) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EmptyValueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EmptyValueTest.java
@@ -269,6 +269,11 @@ public class EmptyValueTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         connectContext.getSessionVariable().setCboCTERuseRatio(1.5);
         assertContains(plan, "0:EMPTYSET");
+
+        connectContext.getSessionVariable().setCboDisabledRules("TF_PRUNE_EMPTY_JOIN, TF_PRUNE_EMPTY_SCAN");
+        plan = getFragmentPlan(sql);
+        assertNotContains(plan, "EMPTYSET");
+        connectContext.getSessionVariable().setCboDisabledRules("");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PredicatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PredicatePushDownTest.java
@@ -167,4 +167,16 @@ public class PredicatePushDownTest extends PlanTestBase {
                 "  |  \n" +
                 "  0:OlapScanNode");
     }
+
+    @Test
+    public void testDisablePredicatePushdown() throws Exception {
+        connectContext.getSessionVariable().setCboDisabledRules("GP_PUSH_DOWN_PREDICATE");
+        String sql = "select * from t0 where coalesce(v1 < 2)";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "1:SELECT\n" +
+                "  |  predicates: 1: v1 < 2\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+        connectContext.getSessionVariable().setCboDisabledRules("");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
Currently, some optimizer rules provide session variables for control, but many rules lack such switches. When an optimizer rule has a bug, users have no way to bypass it, which can block their queries and cause production issues. This creates a significant limitation in troubleshooting and workaround scenarios.

For example, if a transformation rule like `TF_PRUNE_EMPTY_UNION` or a group combination rule like `GP_PRUNE_COLUMNS` encounters a bug, users must wait for a fix and upgrade, with no immediate workaround available.


## What I'm doing:
This PR introduces a universal mechanism to enable/disable optimizer rules via a new session variable `cbo_disabled_rules`.
 **New Session Variable: `cbo_disabled_rules`**. it is mainly used to provide a workaround when users encounter issues in the online environment 

   - Accepts comma-separated rule type names (e.g., `TF_JOIN_COMMUTATIVITY,GP_PRUNE_COLUMNS`)
   - Supports both TF_ (Transformation rules) and GP_ (Group combination rules)
   - Persists across sessions when set globally (`SET GLOBAL`)
   - Example usage:
     ```sql
     -- Disable specific rules temporarily
     SET cbo_disabled_rules = 'TF_JOIN_COMMUTATIVITY,GP_PRUNE_COLUMNS';
     
     -- Persist globally (survives FE restart)
     SET GLOBAL cbo_disabled_rules = 'TF_PARTITION_PRUNE';
     
     -- Clear disabled rules
     SET cbo_disabled_rules = '';
     ```

### Scope and Limitations:

**Physical Rewrite Rules**: Currently, physical rewrite stage (in `QueryOptimizer.physicalRuleRewrite()`) are not managed by `RuleType` and therefore cannot be controlled by `cbo_disabled_rules`. However, most physical rewrite rules already have their own session variables for control (e.g., `enable_pre_aggregate`, `enable_low_cardinality_optimize`). We will adapt this mechanism to support physical rewrite rules once they are migrated to the `RuleType` management framework in the future
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

