### PR TITLE
[BugFix] schema change canceled when bucket_size used

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -381,8 +381,6 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
                 Preconditions.checkState(physicalPartition != null);
-                TStorageMedium storageMedium = table.getPartitionInfo()
-                        .getDataProperty(physicalPartition.getParentId()).getStorageMedium();
 
                 Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(physicalPartitionId);
                 for (Map.Entry<Long, MaterializedIndex> entry : shadowIndexMap.entrySet()) {
@@ -427,7 +425,6 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                                 .setIndexId(shadowIdxId)
                                 .setTabletId(shadowTabletId)
                                 .setVersion(Partition.PARTITION_INIT_VERSION)
-                                .setStorageMedium(storageMedium)
                                 .setLatch(countDownLatch)
                                 .setEnablePersistentIndex(table.enablePersistentIndex())
                                 .setPersistentIndexType(table.getPersistentIndexType())


### PR DESCRIPTION
## Why I'm doing:
How to reproduce:

CREATE TABLE t1 (
    k1 bigint,
    k2 datetime,
    v1 varchar(20) not null
)
DUPLICATE KEY(k1)
PARTITION BY date_truc('day', datetime)
PROPERTIES (
    "bucket_size" = "1"
);
insert into t1 values(1, "2025-10-20", "1");
insert into t1 values(2, "2025-10-20", "2");
ALTER TABLE t1 SET ("bloom_filter_columns" = "v1");
show alter table column;

This schema change will cancel without any message or log, because in shared data mode, starrocks do not need and will not maintenance dataProperty, but try to get dataProperty. It will cause NPE.

## What I'm doing:
Remove codes about dataProperty

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3