### PR TITLE
[BugFix] fix cache key of iceberg split tasks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
@@ -133,6 +133,14 @@ public class GetRemoteFilesParams {
         this.useCache = useCache;
     }
 
+    public void setPredicate(ScalarOperator predicate) {
+        this.predicate = predicate;
+    }
+
+    public void setTableVersionRange(TvrVersionRange tableVersionRange) {
+        this.tableVersionRange = tableVersionRange;
+    }
+
     public boolean isCheckPartitionExistence() {
         return checkPartitionExistence;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
@@ -68,12 +68,16 @@ public class PredicateSearchKey {
         if (getPredicate() == null && that.getPredicate() != null) {
             return false;
         }
+        if (getPredicate() != null && !getPredicate().equivalent(that.getPredicate())) {
+            return false;
+        }
+        if (params.isEnableColumnStats() != that.params.isEnableColumnStats()) {
+            return false;
+        }
 
         return Objects.equals(getVersion(), that.getVersion()) &&
                 Objects.equals(databaseName, that.databaseName) &&
-                Objects.equals(tableName, that.tableName) &&
-                getPredicate().equivalent(that.getPredicate()) &&
-                params.isEnableColumnStats() == that.params.isEnableColumnStats();
+                Objects.equals(tableName, that.tableName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
@@ -25,7 +25,7 @@ public class PredicateSearchKey {
     private final GetRemoteFilesParams params;
 
     public static PredicateSearchKey of(String databaseName, String tableName, GetRemoteFilesParams params) {
-        return of(databaseName, tableName, params);
+        return new PredicateSearchKey(databaseName, tableName, params);
     }
 
     public PredicateSearchKey(String databaseName, String tableName, GetRemoteFilesParams params) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
@@ -64,6 +64,11 @@ public class PredicateSearchKey {
             return false;
         }
         PredicateSearchKey that = (PredicateSearchKey) o;
+
+        if (getPredicate() == null && that.getPredicate() != null) {
+            return false;
+        }
+
         return Objects.equals(getVersion(), that.getVersion()) &&
                 Objects.equals(databaseName, that.databaseName) &&
                 Objects.equals(tableName, that.tableName) &&

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
@@ -65,11 +65,16 @@ public class PredicateSearchKey {
         }
         PredicateSearchKey that = (PredicateSearchKey) o;
 
-        if (getPredicate() == null && that.getPredicate() != null) {
-            return false;
-        }
-        if (getPredicate() != null && !getPredicate().equivalent(that.getPredicate())) {
-            return false;
+        ScalarOperator thisPredicate = getPredicate();
+        ScalarOperator thatPredicate = that.getPredicate();
+        if (thisPredicate == null) {
+            if (thatPredicate != null) {
+                return false;
+            }
+        } else {
+            if (thatPredicate == null || !thisPredicate.equivalent(thatPredicate)) {
+                return false;
+            }
         }
         if (params.isEnableColumnStats() != that.params.isEnableColumnStats()) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
@@ -123,7 +124,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         String dbName = deltaLakeTable.getCatalogDBName();
         String tableName = deltaLakeTable.getCatalogTableName();
         PredicateSearchKey key =
-                PredicateSearchKey.of(dbName, tableName, params.getTableVersionRange().end().get(), params.getPredicate());
+                PredicateSearchKey.of(dbName, tableName, params);
 
         triggerDeltaLakePlanFilesIfNeeded(key, table, params.getPredicate(), params.getFieldNames());
 
@@ -138,7 +139,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
 
     @Override
     public RemoteFileInfoSource getRemoteFilesAsync(Table table, GetRemoteFilesParams params) {
-        return buildRemoteInfoSource(table, params.getPredicate(), false);
+        return buildRemoteInfoSource(table, params);
     }
 
     @Override
@@ -155,7 +156,13 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         String tableName = deltaLakeTable.getCatalogTableName();
         Engine engine = deltaLakeTable.getDeltaEngine();
         StructType schema = deltaLakeTable.getDeltaMetadata().getSchema();
-        PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, snapshot.getVersion(engine), predicate);
+
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setTableVersionRange(TvrTableSnapshot.of(snapshot.getVersion(engine)))
+                .setPredicate(predicate)
+                .setLimit(limit)
+                .build();
+        PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, params);
 
         DeltaUtils.checkProtocolAndMetadata(snapshot.getProtocol(), snapshot.getMetadata());
 
@@ -236,7 +243,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
 
                 DeletionVectorDescriptor dv = InternalScanFileUtils.getDeletionVectorDescriptorFromRow(scanFileRow);
                 return ScanFileUtils.convertFromRowToFileScanTask(enableCollectColumnStats, scanFileRow, metadata,
-                                estimateRowSize, dv);
+                        estimateRowSize, dv);
             }
 
             private void ensureOpen() {
@@ -264,9 +271,9 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         };
     }
 
-    private RemoteFileInfoSource buildRemoteInfoSource(Table table, ScalarOperator operator, boolean enableCollectColumnStats) {
+    private RemoteFileInfoSource buildRemoteInfoSource(Table table, GetRemoteFilesParams params) {
         Iterator<Pair<FileScanTask, DeltaLakeAddFileStatsSerDe>> iterator =
-                buildFileScanTaskIterator(table, operator, enableCollectColumnStats);
+                buildFileScanTaskIterator(table, params.getPredicate(), params.isEnableColumnStats());
         return new RemoteFileInfoSource() {
             @Override
             public RemoteFileInfo getOutput() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1161,7 +1161,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                 return statisticProvider.getCardinalityStats(columns, icebergScanTasks);
             }
         } else {
-            return statisticProvider.getTableStatistics(icebergTable, columns, session, predicate, version);
+            return statisticProvider.getTableStatistics(icebergTable, columns, session, params);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -589,22 +589,16 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     @Override
     public List<RemoteFileInfo> getRemoteFiles(Table table, GetRemoteFilesParams params) {
-        TvrVersionRange version = params.getTableVersionRange();
-        return getRemoteFiles((IcebergTable) table, version, params.getPredicate(), params.getLimit());
-    }
-
-    private List<RemoteFileInfo> getRemoteFiles(IcebergTable table, TvrVersionRange version,
-                                                ScalarOperator predicate, long limit) {
         String dbName = table.getCatalogDBName();
         String tableName = table.getCatalogTableName();
 
-        PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, version, predicate);
-        triggerIcebergPlanFilesIfNeeded(key, table, predicate, limit);
+        PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, params);
+        triggerIcebergPlanFilesIfNeeded(key, table);
 
         List<FileScanTask> icebergScanTasks = splitTasks.get(key);
         if (icebergScanTasks == null) {
             throw new StarRocksConnectorException("Missing iceberg split task for table:[{}.{}]. predicate:[{}]",
-                    dbName, tableName, predicate);
+                    dbName, tableName, params.getPredicate());
         }
 
         return icebergScanTasks.stream().map(IcebergRemoteFileInfo::new).collect(Collectors.toList());
@@ -619,7 +613,6 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     @Override
     public boolean prepareMetadata(MetaPreparationItem item, Tracers tracers, ConnectContext connectContext) {
-        PredicateSearchKey key;
         IcebergTable icebergTable;
         icebergTable = (IcebergTable) item.getTable();
         String dbName = icebergTable.getCatalogDBName();
@@ -629,7 +622,13 @@ public class IcebergMetadata implements ConnectorMetadata {
             return true;
         }
 
-        key = PredicateSearchKey.of(dbName, tableName, versionRange, item.getPredicate());
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setPredicate(item.getPredicate())
+                .setLimit(item.getLimit())
+                .setTableVersionRange(versionRange)
+                .build();
+
+        PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, params);
         if (!preparedTables.add(key)) {
             return true;
         }
@@ -646,7 +645,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             connectContext = ConnectContext.get();
         }
 
-        triggerIcebergPlanFilesIfNeeded(key, icebergTable, item.getPredicate(), item.getLimit(), tracers, connectContext);
+        triggerIcebergPlanFilesIfNeeded(key, icebergTable, tracers, connectContext);
         return true;
     }
 
@@ -705,17 +704,16 @@ public class IcebergMetadata implements ConnectorMetadata {
         return new IcebergMetaSpec(serializedTable, remoteMetaSplits, loadColumnStats);
     }
 
-    private void triggerIcebergPlanFilesIfNeeded(PredicateSearchKey key, IcebergTable table,
-                                                 ScalarOperator predicate, long limit) {
-        triggerIcebergPlanFilesIfNeeded(key, table, predicate, limit, null, ConnectContext.get());
+    private void triggerIcebergPlanFilesIfNeeded(PredicateSearchKey key, Table table) {
+        triggerIcebergPlanFilesIfNeeded(key, table, null, ConnectContext.get());
     }
 
-    private void triggerIcebergPlanFilesIfNeeded(PredicateSearchKey key, IcebergTable table, ScalarOperator predicate,
-                                                 long limit, Tracers tracers, ConnectContext connectContext) {
+    private void triggerIcebergPlanFilesIfNeeded(PredicateSearchKey key, Table table,
+                                                 Tracers tracers, ConnectContext connectContext) {
         if (!scannedTables.contains(key)) {
             tracers = tracers == null ? Tracers.get() : tracers;
             try (Timer ignored = Tracers.watchScope(tracers, EXTERNAL, "ICEBERG.processSplit." + key)) {
-                collectTableStatisticsAndCacheIcebergSplit(key, table, predicate, limit, tracers, connectContext);
+                collectTableStatisticsAndCacheIcebergSplit(key, table, tracers, connectContext);
             }
         }
     }
@@ -728,8 +726,14 @@ public class IcebergMetadata implements ConnectorMetadata {
             return new ArrayList<>();
         }
 
-        PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, version, predicate);
-        triggerIcebergPlanFilesIfNeeded(key, icebergTable, predicate, limit);
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setPredicate(predicate)
+                .setLimit(limit)
+                .setTableVersionRange(version)
+                .build();
+
+        PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, params);
+        triggerIcebergPlanFilesIfNeeded(key, icebergTable);
 
         List<PartitionKey> partitionKeys = new ArrayList<>();
         List<FileScanTask> icebergSplitTasks = splitTasks.get(key);
@@ -795,8 +799,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         return partitionKeys;
     }
 
-    private void collectTableStatisticsAndCacheIcebergSplit(PredicateSearchKey key, Table table,
-                                                            ScalarOperator predicate, long limit, Tracers tracers,
+    private void collectTableStatisticsAndCacheIcebergSplit(PredicateSearchKey key, Table table, Tracers tracers,
                                                             ConnectContext connectContext) {
         IcebergTable icebergTable = (IcebergTable) table;
         TvrVersionRange tvrVersionRange = key.getVersion();
@@ -805,17 +808,18 @@ public class IcebergMetadata implements ConnectorMetadata {
             return;
         }
 
+        GetRemoteFilesParams params = key.getParams();
+        boolean enableCollectColumnStatistics = params.isEnableColumnStats();
+
         String dbName = icebergTable.getCatalogDBName();
         String tableName = icebergTable.getCatalogTableName();
 
         org.apache.iceberg.Table nativeTbl = icebergTable.getNativeTable();
         Types.StructType schema = nativeTbl.schema().asStruct();
 
-        List<ScalarOperator> scalarOperators = Utils.extractConjuncts(predicate);
+        List<ScalarOperator> scalarOperators = Utils.extractConjuncts(params.getPredicate());
         ScalarOperatorToIcebergExpr.IcebergContext icebergContext = new ScalarOperatorToIcebergExpr.IcebergContext(schema);
         Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(scalarOperators, icebergContext);
-
-        boolean enableCollectColumnStatistics = enableCollectColumnStatistics(connectContext);
 
         Iterator<FileScanTask> iterator =
                 buildFileScanTaskIterator((IcebergTable) table, icebergPredicate, tvrVersionRange,
@@ -888,7 +892,7 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         String dbName = table.getCatalogDBName();
         String tableName = table.getCatalogTableName();
-        PredicateSearchKey predicateSearchKey = PredicateSearchKey.of(dbName, tableName, tvrVersionRange, param.getPredicate());
+        PredicateSearchKey predicateSearchKey = PredicateSearchKey.of(dbName, tableName, params);
         RemoteFileInfoSource baseSource;
         if (splitTasks.containsKey(predicateSearchKey)) {
             baseSource = buildRemoteInfoSource(splitTasks.get(predicateSearchKey));
@@ -906,8 +910,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         } else {
             // build remote file info source for table with equality delete files.
             IcebergRemoteFileInfoSourceKey remoteFileInfoSourceKey = IcebergRemoteFileInfoSourceKey.of(
-                    dbName, tableName, tvrVersionRange, param.getPredicate(), tableFullMORParams.getMORId(),
-                    param.getMORParams());
+                    dbName, tableName, params, tableFullMORParams.getMORId(), param.getMORParams());
 
             if (!remoteFileInfoSources.containsKey(remoteFileInfoSourceKey)) {
                 IcebergRemoteSourceTrigger trigger = new IcebergRemoteSourceTrigger(baseSource, tableFullMORParams);
@@ -917,7 +920,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                 // Therefore, here we initialize the remoteFileInfoSource of all iceberg mor params for the first time.
                 for (IcebergMORParams morParams : tableFullMORParams.getMorParamsList()) {
                     IcebergRemoteFileInfoSourceKey key = IcebergRemoteFileInfoSourceKey.of(
-                            dbName, tableName, tvrVersionRange, param.getPredicate(), tableFullMORParams.getMORId(), morParams);
+                            dbName, tableName, params, tableFullMORParams.getMORId(), morParams);
                     Deque<RemoteFileInfo> remoteFileInfoDeque = trigger.getQueue(morParams);
                     remoteFileInfoSources.put(key, new QueueIcebergRemoteFileInfoSource(trigger, remoteFileInfoDeque));
                 }
@@ -1137,10 +1140,16 @@ public class IcebergMetadata implements ConnectorMetadata {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
 
-        PredicateSearchKey key = PredicateSearchKey.of(
-                icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(), version, predicate);
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setPredicate(predicate)
+                .setLimit(limit)
+                .setTableVersionRange(version)
+                .setEnableColumnStats(session.getSessionVariable().enableIcebergColumnStatistics())
+                .build();
 
-        triggerIcebergPlanFilesIfNeeded(key, icebergTable, predicate, limit);
+        PredicateSearchKey key = PredicateSearchKey.of(
+                icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(), params);
+        triggerIcebergPlanFilesIfNeeded(key, icebergTable);
 
         if (!session.getSessionVariable().enableIcebergColumnStatistics()) {
             List<FileScanTask> icebergScanTasks = splitTasks.get(key);
@@ -1333,7 +1342,7 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     public BatchWrite getBatchWrite(Transaction transaction, boolean isOverwrite, boolean isRewrite) {
-        if (isRewrite) {     
+        if (isRewrite) {
             return new RewriteData(transaction);
         } else if (isOverwrite) {
             return new DynamicOverwrite(transaction);
@@ -1436,26 +1445,26 @@ public class IcebergMetadata implements ConnectorMetadata {
     public static class IcebergSinkExtra {
         private final Set<DataFile> scannedDataFiles;
         private final Set<DeleteFile> appliedDeleteFiles;
-        
+
         public IcebergSinkExtra() {
             this.scannedDataFiles = new HashSet<>();
             this.appliedDeleteFiles = new HashSet<>();
         }
 
-        public void addScannedDataFiles(Set<DataFile> o) { 
-            scannedDataFiles.addAll(o); 
+        public void addScannedDataFiles(Set<DataFile> o) {
+            scannedDataFiles.addAll(o);
         }
 
         public void addAppliedDeleteFiles(Set<DeleteFile> o) {
-            appliedDeleteFiles.addAll(o); 
+            appliedDeleteFiles.addAll(o);
         }
 
-        public Set<DataFile> getScannedDataFiles() { 
-            return scannedDataFiles;   
+        public Set<DataFile> getScannedDataFiles() {
+            return scannedDataFiles;
         }
 
-        public Set<DeleteFile> getAppliedDeleteFiles() { 
-            return appliedDeleteFiles; 
+        public Set<DeleteFile> getAppliedDeleteFiles() {
+            return appliedDeleteFiles;
         }
     }
 
@@ -1503,7 +1512,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         public void addFile(DataFile file) {
             rewriteFiles.addFile(file);
         }
-        
+
         @Override
         public void deleteFile(DeleteFile file) {
             rewriteFiles.deleteFile(file);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRemoteFileInfoSourceKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRemoteFileInfoSourceKey.java
@@ -16,7 +16,6 @@ package com.starrocks.connector.iceberg;
 
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.PredicateSearchKey;
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 
 import java.util.Objects;
 
@@ -39,11 +38,6 @@ public class IcebergRemoteFileInfoSourceKey extends PredicateSearchKey {
                                                     GetRemoteFilesParams params,
                                                     long morId,
                                                     IcebergMORParams icebergMORParams) {
-        if (params.getPredicate() == null) {
-            GetRemoteFilesParams copy = params.copy();
-            copy.setPredicate(ConstantOperator.TRUE);
-            params = copy;
-        }
         return new IcebergRemoteFileInfoSourceKey(databaseName, tableName, params, morId, icebergMORParams);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRemoteFileInfoSourceKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRemoteFileInfoSourceKey.java
@@ -14,10 +14,9 @@
 
 package com.starrocks.connector.iceberg;
 
-import com.starrocks.common.tvr.TvrVersionRange;
+import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.PredicateSearchKey;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.Objects;
 
@@ -27,23 +26,26 @@ public class IcebergRemoteFileInfoSourceKey extends PredicateSearchKey {
 
     private IcebergRemoteFileInfoSourceKey(String databaseName,
                                            String tableName,
-                                           TvrVersionRange tvrVersionRange,
-                                           ScalarOperator predicate,
+                                           GetRemoteFilesParams params,
                                            long morId,
                                            IcebergMORParams icebergMORParams) {
-        super(databaseName, tableName, tvrVersionRange, predicate);
+        super(databaseName, tableName, params);
         this.morId = morId;
         this.icebergMORParams = icebergMORParams;
     }
 
     public static IcebergRemoteFileInfoSourceKey of(String databaseName,
                                                     String tableName,
-                                                    TvrVersionRange tvrVersionRange,
-                                                    ScalarOperator predicate,
+                                                    GetRemoteFilesParams params,
                                                     long morId,
                                                     IcebergMORParams icebergMORParams) {
-        predicate = predicate == null ? ConstantOperator.TRUE : predicate;
-        return new IcebergRemoteFileInfoSourceKey(databaseName, tableName, tvrVersionRange, predicate, morId, icebergMORParams);
+        if (params.getPredicate() == null) {
+            GetRemoteFilesParams copy = params.copy();
+            copy.setPredicate(ConstantOperator.TRUE);
+            params = copy;
+        }
+
+        return new IcebergRemoteFileInfoSourceKey(databaseName, tableName, params, morId, icebergMORParams);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRemoteFileInfoSourceKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRemoteFileInfoSourceKey.java
@@ -44,7 +44,6 @@ public class IcebergRemoteFileInfoSourceKey extends PredicateSearchKey {
             copy.setPredicate(ConstantOperator.TRUE);
             params = copy;
         }
-
         return new IcebergRemoteFileInfoSourceKey(databaseName, tableName, params, morId, icebergMORParams);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -23,7 +23,6 @@ import com.starrocks.connector.PredicateSearchKey;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import org.apache.iceberg.BlobMetadata;
@@ -95,11 +94,11 @@ public class IcebergStatisticProvider {
     public Statistics getTableStatistics(IcebergTable icebergTable,
                                          Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
                                          OptimizerContext session,
-                                         ScalarOperator predicate,
-                                         TvrVersionRange version) {
+                                         GetRemoteFilesParams params) {
         Table nativeTable = icebergTable.getNativeTable();
         Statistics.Builder statisticsBuilder = Statistics.builder();
         String uuid = icebergTable.getUUID();
+        TvrVersionRange version = params.getTableVersionRange();
         if (version.end().isPresent()) {
             Set<Integer> primitiveColumnsFieldIds = nativeTable.schema().columns().stream()
                     .filter(column -> column.type().isPrimitiveType())
@@ -120,12 +119,6 @@ public class IcebergStatisticProvider {
                     colIdToNdvs.putAll(partitionSourceIdToNdv);
                 }
             }
-
-            GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
-                    .setTableVersionRange(version)
-                    .setPredicate(predicate)
-                    .setEnableColumnStats(true)
-                    .build();
 
             PredicateSearchKey key = PredicateSearchKey.of(icebergTable.getCatalogDBName(),
                     icebergTable.getCatalogTableName(), params);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -18,6 +18,7 @@ import com.google.common.collect.HashMultimap;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.tvr.TvrVersionRange;
+import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.PredicateSearchKey;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -120,8 +121,14 @@ public class IcebergStatisticProvider {
                 }
             }
 
+            GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                    .setTableVersionRange(version)
+                    .setPredicate(predicate)
+                    .setEnableColumnStats(true)
+                    .build();
+
             PredicateSearchKey key = PredicateSearchKey.of(icebergTable.getCatalogDBName(),
-                    icebergTable.getCatalogTableName(), version, predicate);
+                    icebergTable.getCatalogTableName(), params);
             IcebergFileStats icebergFileStats;
             if (!icebergFileStatistics.containsKey(key)) {
                 icebergFileStats = new IcebergFileStats(1);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ColumnTypeConverter;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
@@ -290,8 +291,13 @@ public class PaimonMetadata implements ConnectorMetadata {
             // System table does not have snapshotId, ignore it.
             LOG.warn("Cannot get snapshot because {}", e.getMessage());
         }
+
+        GetRemoteFilesParams copyParams = params.copy();
+        copyParams.setTableVersionRange(TvrTableSnapshot.of(latestSnapshotId));
+
         PredicateSearchKey filter = PredicateSearchKey.of(paimonTable.getCatalogDBName(),
-                paimonTable.getCatalogTableName(), latestSnapshotId, params.getPredicate());
+                paimonTable.getCatalogTableName(), copyParams);
+
         if (!paimonSplits.containsKey(filter)) {
             ReadBuilder readBuilder = paimonTable.getNativeTable().newReadBuilder();
             int[] projected =

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -171,7 +171,10 @@ public class IcebergMetadataTest extends TableTestBase {
     public static final Map<String, String> DEFAULT_CONFIG = new HashMap<>();
     public static ConnectContext connectContext;
 
-    public static GetRemoteFilesParams emptyParams = GetRemoteFilesParams.newBuilder().build();
+    public static GetRemoteFilesParams emptyParams = GetRemoteFilesParams.newBuilder()
+            .setTableVersionRange(TvrTableSnapshot.of((long) 1))
+            .setPredicate(ConstantOperator.TRUE)
+            .build();
 
     static {
         DEFAULT_CONFIG.put(HIVE_METASTORE_URIS, "thrift://188.122.12.1:8732"); // non-exist ip, prevent to connect local service
@@ -1119,7 +1122,8 @@ public class IcebergMetadataTest extends TableTestBase {
         Assertions.assertEquals(3, ((IcebergRemoteFileInfo) res.get(0)).getFileScanTask().file().recordCount());
 
         PredicateSearchKey filter = PredicateSearchKey.of("db", "table", emptyParams);
-        Assertions.assertEquals("Filter{databaseName='db', tableName='table', version=Snapshot@(1), predicate=true}",
+        Assertions.assertEquals(
+                "Filter{databaseName='db', tableName='table', version=Snapshot@(1), predicate=true, enableColumnStats=false}",
                 filter.toString());
     }
 
@@ -1402,8 +1406,8 @@ public class IcebergMetadataTest extends TableTestBase {
         PredicateSearchKey newFilter = PredicateSearchKey.of("db", "table", newCallParams);
         Assertions.assertEquals(filter, newFilter);
 
-        Assertions.assertEquals(newFilter, PredicateSearchKey.of("db", "table", callParams));
-        Assertions.assertNotEquals(newFilter, PredicateSearchKey.of("db", "table", newCallParams));
+        Assertions.assertEquals(newFilter, PredicateSearchKey.of("db", "table", newCallParams));
+        Assertions.assertNotEquals(newFilter, PredicateSearchKey.of("db", "table", emptyParams));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.iceberg.cost;
 
 import com.google.common.collect.Lists;
@@ -22,6 +21,7 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
+import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.iceberg.TableTestBase;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -71,7 +71,10 @@ public class IcebergStatisticProviderTest extends TableTestBase {
 
         TvrVersionRange version = TvrTableSnapshot.of(Optional.of(
                 mockedNativeTableA.currentSnapshot().snapshotId()));
-        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, null, version);
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setTableVersionRange(version)
+                .build();
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, params);
         Assertions.assertEquals(1.0, statistics.getOutputRowCount(), 0.001);
     }
 
@@ -110,8 +113,11 @@ public class IcebergStatisticProviderTest extends TableTestBase {
         ColumnRefOperator columnRefOperator2 = new ColumnRefOperator(4, Type.STRING, "data", true);
         colRefToColumnMetaMap.put(columnRefOperator1, new Column("id", Type.INT));
         colRefToColumnMetaMap.put(columnRefOperator2, new Column("data", Type.STRING));
+
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder().
+                setTableVersionRange(TvrTableSnapshot.empty()).build();
         Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap,
-                null, null, TvrTableSnapshot.empty());
+                null, params);
         Assertions.assertEquals(1.0, statistics.getOutputRowCount(), 0.001);
     }
 

--- a/test/sql/test_iceberg/R/test_iceberg_v2
+++ b/test/sql/test_iceberg/R/test_iceberg_v2
@@ -5,6 +5,9 @@ create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", 
 set enable_connector_incremental_scan_ranges=true;
 -- result:
 -- !result
+set new_planner_optimize_timeout = 30000;
+-- result:
+-- !result
 /*
  CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_orc_unpartitioned_table` (
   `k1` INT NOT NULL,

--- a/test/sql/test_iceberg/R/test_iceberg_v2_filter_all_rows
+++ b/test/sql/test_iceberg/R/test_iceberg_v2_filter_all_rows
@@ -2,6 +2,9 @@
 create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
 -- result:
 -- !result
+set new_planner_optimize_timeout = 30000;
+-- result:
+-- !result
 select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_eq_all_row_filter order by k1 limit 1;
 -- result:
 1	6

--- a/test/sql/test_iceberg/T/test_iceberg_v2
+++ b/test/sql/test_iceberg/T/test_iceberg_v2
@@ -5,6 +5,7 @@ create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", 
 -- Currently only flink can write iceberg equality delete file. The table in the case was created in advance and some test data was inserted using flink. If you want test more cases, you could contact stephen5217@163.com
 
 set enable_connector_incremental_scan_ranges=true;
+set new_planner_optimize_timeout = 30000;
 
 -- unpartitioned table with orc (eq-delete && pos-delete) 
 /*

--- a/test/sql/test_iceberg/T/test_iceberg_v2_filter_all_rows
+++ b/test/sql/test_iceberg/T/test_iceberg_v2_filter_all_rows
@@ -2,6 +2,8 @@
 
 create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
 
+set new_planner_optimize_timeout = 30000;
+
 select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_eq_all_row_filter order by k1 limit 1;
 
 drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

I implemented optimization of min/max on iceberg, which was based on column stats from file tasks.

However if we enable cache of file split tasks, the cache key does not store the flag of 'using column stats or not'.

So at the first time when constructing file split tasks, `columnStats` is not enabled.

and the next time when I use the file split tasks cache,  the cache value contaisn file tasks without any column stats.

## What I'm doing:

I change the fields in `PredicateSearchKey`,  and put `GetRemoteFileParams` in it.

And when check equality of two search keys,  you have to compare `enableColumnStats` too.

Fixes https://github.com/StarRocks/StarRocksTest/issues/10465

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `PredicateSearchKey` to encapsulate `GetRemoteFilesParams` so cache keys include version, predicate, and `enableColumnStats`, updating Iceberg/Delta/Paimon call sites and tests accordingly.
> 
> - **Core**:
>   - Refactor `PredicateSearchKey` to store `GetRemoteFilesParams` instead of separate `version`/`predicate`.
>     - `equals`/`hashCode` now consider `version`, predicate equivalence, and `params.isEnableColumnStats()`; `toString` updated.
>     - Add accessors `getVersion()`, `getPredicate()`, and `getParams()`.
>   - `GetRemoteFilesParams`:
>     - Add `setPredicate(...)` and `setTableVersionRange(...)`; support `copy()` preserving flags.
> - **Iceberg**:
>   - Use `PredicateSearchKey.of(db, table, params)` across `getRemoteFiles`, `getRemoteFilesAsync`, stats, partition pruning, and preparation.
>   - Simplify planning triggers to use `key`/`params`; column-stats collection uses `params.isEnableColumnStats()`.
>   - `IcebergRemoteFileInfoSourceKey` now built from `params` (normalizes null predicate to `true`).
>   - `IcebergStatisticProvider` builds keys via `params` with `enableColumnStats=true`.
> - **Delta Lake**:
>   - Build keys from `params`; async and iterator builders accept `params`.
> - **Paimon**:
>   - Build keys from `params` (with snapshot wrapped into `TvrTableSnapshot`).
> - **Tests**:
>   - Update usages to construct keys via `GetRemoteFilesParams`; adjust assertions accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a194d32ef0e0f6e76a235ad3b0e04a8d84c228f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->