### PR TITLE
[BugFix] Guard mixed files() inserts with planner lock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -126,6 +126,15 @@ public class QueryAnalyzer {
         new Visitor().process(node, new Scope(RelationId.anonymous(), new RelationFields()));
     }
 
+    /**
+     * Analyze only files() table functions without touching normal table metadata.
+     * This is used to infer files() schema (RPC to BE) without holding PlannerMetaLock,
+     * while deferring normal table analysis to the locked phase.
+     */
+    public void analyzeFilesOnly(StatementBase node) {
+        new FilesOnlyVisitor().process(node, new Scope(RelationId.anonymous(), new RelationFields()));
+    }
+
     public void analyze(StatementBase node, Scope parent) {
         new Visitor().process(node, parent);
     }
@@ -496,6 +505,20 @@ public class QueryAnalyzer {
                 return pivotRelation;
             } else if (relation instanceof FileTableFunctionRelation) {
                 FileTableFunctionRelation tableFunctionRelation = (FileTableFunctionRelation) relation;
+                // If files() was pre-resolved in an unlock phase, reuse it to avoid RPC under lock
+                if (tableFunctionRelation.getTable() instanceof TableFunctionTable) {
+                    TableFunctionTable preResolved = (TableFunctionTable) tableFunctionRelation.getTable();
+                    Consumer<TableFunctionTable> pushDown = tableFunctionRelation.getPushDownSchemaFunc();
+                    if (pushDown != null && !preResolved.isListFilesOnly()) {
+                        pushDown.accept(preResolved);
+                        tableFunctionRelation.setTable(preResolved);
+                    }
+                    if (preResolved.isListFilesOnly()) {
+                        return convertFileTableFunctionRelation(preResolved);
+                    }
+                    return relation;
+                }
+
                 Table table = resolveTableFunctionTable(
                         tableFunctionRelation.getProperties(), tableFunctionRelation.getPushDownSchemaFunc());
                 TableFunctionTable tableFunctionTable = (TableFunctionTable) table;
@@ -1463,6 +1486,107 @@ public class QueryAnalyzer {
             return node.getScope();
         }
 
+    }
+
+    /**
+     * A lightweight visitor that only resolves FileTableFunctionRelation so that
+     * files() schema can be inferred without acquiring DB/table locks. Normal tables/views are skipped.
+     */
+    private class FilesOnlyVisitor implements AstVisitorExtendInterface<Scope, Scope> {
+        public FilesOnlyVisitor() {}
+
+        public Scope process(ParseNode node, Scope scope) {
+            return node.accept(this, scope);
+        }
+
+        @Override
+        public Scope visitQueryStatement(QueryStatement node, Scope parent) {
+            return process(node.getQueryRelation(), parent);
+        }
+
+        @Override
+        public Scope visitQueryRelation(QueryRelation node, Scope parent) {
+            return process(node, parent);
+        }
+
+        @Override
+        public Scope visitSelect(SelectRelation selectRelation, Scope scope) {
+            Relation r = selectRelation.getRelation();
+            // Only touch files(); keep others intact
+            if (r instanceof FileTableFunctionRelation) {
+                FileTableFunctionRelation f = (FileTableFunctionRelation) r;
+                initializeFileTableIfAbsent(f);
+            } else if (r instanceof JoinRelation) {
+                visitJoin((JoinRelation) r, scope);
+            } else if (r instanceof SubqueryRelation) {
+                visitSubqueryRelation((SubqueryRelation) r, scope);
+            } else if (r instanceof SetOperationRelation) {
+                visitSetOp((SetOperationRelation) r, scope);
+            } else if (r instanceof PivotRelation) {
+                PivotRelation p = (PivotRelation) r;
+                process(p.getQuery(), scope);
+            }
+            return scope;
+        }
+
+        public Scope visitJoin(JoinRelation join, Scope scope) {
+            Relation l = join.getLeft();
+            Relation r = join.getRight();
+            // SubqueryRelation/SetOperationRelation/PivotRelation are intentionally skipped here, because
+            // pre-analyzing them would still require table metadata and locks; the full analyzer pass will
+            // revisit them after files() has been resolved where necessary.
+            if (l instanceof FileTableFunctionRelation) {
+                FileTableFunctionRelation f = (FileTableFunctionRelation) l;
+                initializeFileTableIfAbsent(f);
+            } else if (l instanceof JoinRelation) {
+                visitJoin((JoinRelation) l, scope);
+            } else if (l instanceof SelectRelation) {
+                visitSelect((SelectRelation) l, scope);
+            } else if (l instanceof SubqueryRelation) {
+                visitSubqueryRelation((SubqueryRelation) l, scope);
+            } else if (l instanceof SetOperationRelation) {
+                visitSetOp((SetOperationRelation) l, scope);
+            }
+
+            // Same as the left side. We continue to recurse into joins, subqueries and set operations to locate
+            // nested files() invocations, while still avoiding any metadata access for normal table relations.
+            if (r instanceof FileTableFunctionRelation) {
+                FileTableFunctionRelation f = (FileTableFunctionRelation) r;
+                initializeFileTableIfAbsent(f);
+                // Do NOT mark lateral here: the relation remains a FileTableFunctionRelation, and the main analyzer
+                // will decide whether lateral semantics are required once it has the final relation type.
+            } else if (r instanceof JoinRelation) {
+                visitJoin((JoinRelation) r, scope);
+            } else if (r instanceof SelectRelation) {
+                visitSelect((SelectRelation) r, scope);
+            } else if (r instanceof SubqueryRelation) {
+                visitSubqueryRelation((SubqueryRelation) r, scope);
+            } else if (r instanceof SetOperationRelation) {
+                visitSetOp((SetOperationRelation) r, scope);
+            }
+            return scope;
+        }
+
+        private void initializeFileTableIfAbsent(FileTableFunctionRelation relation) {
+            if (relation.getTable() instanceof TableFunctionTable) {
+                return;
+            }
+
+            Table table = resolveTableFunctionTable(relation.getProperties(), relation.getPushDownSchemaFunc());
+            relation.setTable(table);
+        }
+
+        public Scope visitSubqueryRelation(SubqueryRelation subquery, Scope scope) {
+            process(subquery.getQueryStatement(), scope);
+            return scope;
+        }
+
+        public Scope visitSetOp(SetOperationRelation set, Scope scope) {
+            for (QueryRelation qr : set.getRelations()) {
+                process(qr, scope);
+            }
+            return scope;
+        }
     }
 
     public Table resolveTable(TableRelation tableRelation) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
@@ -14,20 +14,41 @@
 
 package com.starrocks.sql;
 
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.TableFunctionTable;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
+import com.starrocks.sql.analyzer.QueryAnalyzer;
+import com.starrocks.sql.ast.FileTableFunctionRelation;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.JoinRelation;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.Relation;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SetOperationRelation;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.SubqueryRelation;
+import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StatementPlannerTest extends PlanTestBase {
@@ -56,6 +77,215 @@ class StatementPlannerTest extends PlanTestBase {
             StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
             assertTrue(StatementPlanner.analyzeStatement(stmt, connectContext, locker));
+        }
+    }
+
+    @Test
+    public void testFilesTableMixedWithNormalTableForcesLockAndCachesSchema() throws Exception {
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+            String sql = "insert into t0 select t.v1, t.v2, t.v3 "
+                    + "from files(\"path\"=\"fake://test\", \"format\"=\"csv\") as f "
+                    + "join t0 as t on true";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
+
+            List<FileTableFunctionRelation> preRelations =
+                    AnalyzerUtils.collectFileTableFunctionRelation(((InsertStmt) stmt).getQueryStatement());
+            assertEquals(1, preRelations.size());
+            FileTableFunctionRelation relation = preRelations.get(0);
+            Consumer<TableFunctionTable> original = relation.getPushDownSchemaFunc();
+            AtomicInteger analyzeCount = new AtomicInteger();
+            relation.setPushDownSchemaFunc(table -> {
+                analyzeCount.incrementAndGet();
+                if (original != null) {
+                    original.accept(table);
+                }
+            });
+
+            boolean deferred = StatementPlanner.analyzeStatement(stmt, connectContext, locker);
+            assertFalse(deferred);
+
+            List<FileTableFunctionRelation> relations =
+                    AnalyzerUtils.collectFileTableFunctionRelation(((InsertStmt) stmt).getQueryStatement());
+            assertEquals(1, relations.size());
+            assertNotNull(relations.get(0).getTable());
+            assertEquals(1, analyzeCount.get());
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+        }
+    }
+
+    @Test
+    public void testPreAnalyzedFilesTableStillAppliesPushDown() throws Exception {
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+            String sql = "insert into t0 select 1, 2, 3 "
+                    + "from files(\"path\"=\"fake://test\", \"format\"=\"csv\") as f";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            QueryStatement queryStatement = ((InsertStmt) stmt).getQueryStatement();
+
+            List<FileTableFunctionRelation> relations =
+                    AnalyzerUtils.collectFileTableFunctionRelation(queryStatement);
+            assertEquals(1, relations.size());
+            FileTableFunctionRelation relation = relations.get(0);
+
+            new QueryAnalyzer(connectContext).analyzeFilesOnly(queryStatement);
+            TableFunctionTable tableBefore = (TableFunctionTable) relation.getTable();
+            assertNotNull(tableBefore);
+            assertEquals(2, tableBefore.getFullSchema().size());
+            assertEquals(Type.INT, tableBefore.getFullSchema().get(0).getType());
+
+            AtomicBoolean pushDownApplied = new AtomicBoolean(false);
+            relation.setPushDownSchemaFunc(table -> {
+                pushDownApplied.set(true);
+                List<Column> newSchema = table.getFullSchema().stream()
+                        .map(Column::new)
+                        .collect(Collectors.toList());
+                newSchema.forEach(column -> column.setType(Type.BIGINT));
+                table.setNewFullSchema(newSchema);
+            });
+
+            new QueryAnalyzer(connectContext).analyze(queryStatement);
+
+            TableFunctionTable tableAfter = (TableFunctionTable) relation.getTable();
+            assertTrue(pushDownApplied.get());
+            assertEquals(Type.BIGINT, tableAfter.getFullSchema().get(0).getType());
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+        }
+    }
+
+    @Test
+    public void testFilesOnlyVisitorDoesNotForceLateralForListing() throws Exception {
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+            String sql = "select * from (select 1) t cross join "
+                    + "files(\"path\"=\"fake://test\", \"list_files_only\"=\"true\") as f";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            QueryStatement queryStatement = (QueryStatement) stmt;
+            SelectRelation selectRelation = (SelectRelation) queryStatement.getQueryRelation();
+            JoinRelation joinRelation = (JoinRelation) selectRelation.getRelation();
+
+            assertFalse(joinRelation.isLateral());
+
+            new QueryAnalyzer(connectContext).analyzeFilesOnly(queryStatement);
+
+            assertFalse(joinRelation.isLateral());
+            Relation rightAfterFilesOnly = joinRelation.getRight();
+            if (rightAfterFilesOnly instanceof FileTableFunctionRelation) {
+                TableFunctionTable table = (TableFunctionTable) ((FileTableFunctionRelation) rightAfterFilesOnly).getTable();
+                assertNotNull(table);
+                assertTrue(table.isListFilesOnly());
+            } else {
+                assertTrue(rightAfterFilesOnly instanceof ValuesRelation,
+                        "Unexpected right relation after files-only analysis: " + rightAfterFilesOnly.getClass());
+            }
+
+            new QueryAnalyzer(connectContext).analyze(queryStatement);
+
+            assertFalse(joinRelation.isLateral());
+            assertTrue(joinRelation.getRight() instanceof ValuesRelation);
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+        }
+    }
+
+    @Test
+    public void testFilesOnlyVisitorDoesNotForceLateralForLoad() throws Exception {
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+            String sql = "select * from (select 1) t join "
+                    + "files(\"path\"=\"fake://test\", \"format\"=\"csv\") as f on true";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            QueryStatement queryStatement = (QueryStatement) stmt;
+            SelectRelation selectRelation = (SelectRelation) queryStatement.getQueryRelation();
+            JoinRelation joinRelation = (JoinRelation) selectRelation.getRelation();
+
+            assertFalse(joinRelation.isLateral());
+
+            new QueryAnalyzer(connectContext).analyzeFilesOnly(queryStatement);
+
+            assertFalse(joinRelation.isLateral());
+            assertTrue(joinRelation.getRight() instanceof FileTableFunctionRelation);
+            TableFunctionTable table =
+                    (TableFunctionTable) ((FileTableFunctionRelation) joinRelation.getRight()).getTable();
+            assertNotNull(table);
+            assertFalse(table.isListFilesOnly());
+
+            new QueryAnalyzer(connectContext).analyze(queryStatement);
+
+            assertFalse(joinRelation.isLateral());
+            assertTrue(joinRelation.getRight() instanceof FileTableFunctionRelation);
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+        }
+    }
+
+    @Test
+    public void testFilesOnlyVisitorHandlesNestedFilesJoins() throws Exception {
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+            String sql = "select * from files(\"path\"=\"fake://left\", \"format\"=\"csv\") as f "
+                    + "join files(\"path\"=\"fake://mid\", \"format\"=\"csv\") as m on true "
+                    + "join files(\"path\"=\"fake://right\", \"format\"=\"csv\") as r on true";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            QueryStatement queryStatement = (QueryStatement) stmt;
+
+            new QueryAnalyzer(connectContext).analyzeFilesOnly(queryStatement);
+
+            SelectRelation selectRelation = (SelectRelation) queryStatement.getQueryRelation();
+            JoinRelation outerJoin = (JoinRelation) selectRelation.getRelation();
+
+            assertTrue(outerJoin.getRight() instanceof FileTableFunctionRelation);
+            assertNotNull(((FileTableFunctionRelation) outerJoin.getRight()).getTable());
+
+            assertTrue(outerJoin.getLeft() instanceof JoinRelation);
+            JoinRelation innerJoin = (JoinRelation) outerJoin.getLeft();
+
+            assertTrue(innerJoin.getLeft() instanceof FileTableFunctionRelation);
+            assertNotNull(((FileTableFunctionRelation) innerJoin.getLeft()).getTable());
+
+            assertTrue(innerJoin.getRight() instanceof FileTableFunctionRelation);
+            assertNotNull(((FileTableFunctionRelation) innerJoin.getRight()).getTable());
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+        }
+    }
+
+    @Test
+    public void testFilesOnlyVisitorTraversesSubqueryAndSetOp() throws Exception {
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+            String sql = "select * from (select * from files(\"path\"=\"fake://a\", \"format\"=\"csv\") "
+                    + "union all select * from files(\"path\"=\"fake://b\", \"format\"=\"csv\")) as u";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            QueryStatement queryStatement = (QueryStatement) stmt;
+
+            new QueryAnalyzer(connectContext).analyzeFilesOnly(queryStatement);
+
+            SelectRelation outerSelect = (SelectRelation) queryStatement.getQueryRelation();
+            assertTrue(outerSelect.getRelation() instanceof SubqueryRelation);
+            SubqueryRelation subquery = (SubqueryRelation) outerSelect.getRelation();
+
+            QueryRelation innerRelation = subquery.getQueryStatement().getQueryRelation();
+            assertTrue(innerRelation instanceof SetOperationRelation);
+            SetOperationRelation setOperationRelation = (SetOperationRelation) innerRelation;
+
+            for (QueryRelation relation : setOperationRelation.getRelations()) {
+                assertTrue(relation instanceof SelectRelation);
+                Relation child = ((SelectRelation) relation).getRelation();
+                assertTrue(child instanceof FileTableFunctionRelation);
+                assertNotNull(((FileTableFunctionRelation) child).getTable());
+            }
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
         }
     }
 


### PR DESCRIPTION
- pre-analyze files() relations without lock and disable deferred lock when normal tables participate
- reuse cached TableFunctionTable to avoid repeated BE RPCs during locked analysis
- extend StatementPlannerTest to assert schema caching and single files() analysis

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pre-analyzes files() without lock, forces planner lock when normal tables participate, reuses cached TableFunctionTable to avoid extra RPCs, and adds focused tests.
> 
> - **Planner (StatementPlanner)**:
>   - Adjust deferred-lock logic for `INSERT ... SELECT` with `files()`:
>     - Pre-analyze `files()` without lock via `QueryAnalyzer.analyzeFilesOnly`.
>     - If `files()` and normal tables both present, disable deferred lock; otherwise allow it.
> - **Analyzer (QueryAnalyzer)**:
>   - Add `analyzeFilesOnly` with `FilesOnlyVisitor` to resolve only `FileTableFunctionRelation`.
>   - Reuse pre-resolved `TableFunctionTable`, apply `pushDownSchemaFunc`, and avoid RPC under lock.
>   - Handle `list_files_only` by converting to `ValuesRelation`; preserve non-listing `files()` and avoid forcing lateral.
> - **Tests**:
>   - Add tests asserting mixed `files()` + table forces lock and caches schema.
>   - Verify pushdown schema applies after pre-analysis.
>   - Ensure files-only path doesn’t force lateral and correctly handles listing vs load cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d68bb5f4f351c890f059cef9ccbbb5c12e3b7591. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->