### PR TITLE
[Enhancement] Ensure require compute resource after query queue management

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1092,7 +1092,7 @@ public class ConnectContext {
         if (!RunMode.isSharedDataMode() || this.computeResource == null) {
             return;
         }
-        // acquire compute resource again to for better-schedule balance
+        // acquire compute resource again for better schedule balance
         acquireComputeResource();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -93,6 +93,7 @@ import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.LazyComputeResource;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -1008,7 +1009,8 @@ public class ConnectContext {
         // try to acquire cn group id once the warehouse is set
         final long warehouseId = this.getCurrentWarehouseId();
         final WarehouseManager warehouseManager = globalStateMgr.getWarehouseMgr();
-        this.computeResource = warehouseManager.acquireComputeResource(warehouseId, this.computeResource);
+        this.computeResource = LazyComputeResource.of(warehouseId, () ->
+                warehouseManager.acquireComputeResource(warehouseId, this.computeResource));
     }
 
     /**
@@ -1090,13 +1092,8 @@ public class ConnectContext {
         if (!RunMode.isSharedDataMode() || this.computeResource == null) {
             return;
         }
-        final WarehouseManager warehouseManager = globalStateMgr.getWarehouseMgr();
-        if (!warehouseManager.isResourceAvailable(computeResource)) {
-            this.computeResource = warehouseManager.acquireComputeResource(this.getCurrentWarehouseId());
-        } else {
-            // acquire compute resource again to for better-schedule balance
-            acquireComputeResource();
-        }
+        // acquire compute resource again to for better-schedule balance
+        acquireComputeResource();
     }
 
     public void setParentConnectContext(ConnectContext parent) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -308,7 +308,7 @@ public class DefaultCoordinator extends Coordinator {
         shortCircuitExecutor =
                 ShortCircuitExecutor.create(context, fragments, scanNodes, descTable, isBinaryRow,
                         jobSpec.isNeedReport(),
-                        jobSpec.getPlanProtocol(), coordinatorPreprocessor.getWorkerProvider());
+                        jobSpec.getPlanProtocol(), coordinatorPreprocessor.getLazyWorkerProvider());
 
         if (null != shortCircuitExecutor) {
             isShortCircuit = true;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -16,6 +16,7 @@ package com.starrocks.qe;
 
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.metric.ResourceGroupMetricMgr;
 import com.starrocks.qe.scheduler.RecoverableException;
@@ -54,6 +55,9 @@ public class QueryQueueManager {
     }
 
     public void maybeWait(ConnectContext context, DefaultCoordinator coord) throws StarRocksException, InterruptedException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Maybe wait for query queue, queryId: {}", UUIDUtil.fromTUniqueid(coord.getQueryId()).toString());
+        }
         final JobSpec jobSpec = coord.getJobSpec();
         final SlotProvider slotProvider = jobSpec.getSlotProvider();
         long startMs = System.currentTimeMillis();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitExecutor.java
@@ -23,7 +23,7 @@ import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ScanNode;
-import com.starrocks.qe.scheduler.WorkerProvider;
+import com.starrocks.qe.scheduler.LazyWorkerProvider;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.system.Backend;
@@ -58,12 +58,12 @@ public class ShortCircuitExecutor {
 
     protected Map<String, RuntimeProfile> perBeExecutionProfile;
 
-    protected final WorkerProvider workerProvider;
+    protected final LazyWorkerProvider workerProvider;
 
     protected ShortCircuitExecutor(ConnectContext context, PlanFragment planFragment,
                                    List<TScanRangeLocations> scanRangeLocations, TDescriptorTable tDescriptorTable,
                                    boolean isBinaryRow,
-                                   boolean enableProfile, String protocol, WorkerProvider workerProvider) {
+                                   boolean enableProfile, String protocol, LazyWorkerProvider workerProvider) {
         this.context = context;
         this.planFragment = planFragment;
         this.scanRangeLocations = scanRangeLocations;
@@ -82,7 +82,7 @@ public class ShortCircuitExecutor {
     public static ShortCircuitExecutor create(ConnectContext context, List<PlanFragment> fragments, List<ScanNode> scanNodes,
                                               TDescriptorTable tDescriptorTable, boolean isBinaryRow, boolean enableProfile,
                                               String protocol,
-                                              WorkerProvider workerProvider) {
+                                              LazyWorkerProvider workerProvider) {
         if (fragments.size() != 1 || !fragments.get(0).isShortCircuit()) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
@@ -30,8 +30,8 @@ import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanNode;
 import com.starrocks.planner.ProjectNode;
 import com.starrocks.proto.PExecShortCircuitResult;
+import com.starrocks.qe.scheduler.LazyWorkerProvider;
 import com.starrocks.qe.scheduler.NonRecoverableException;
-import com.starrocks.qe.scheduler.WorkerProvider;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.ConfigurableSerDesFactory;
 import com.starrocks.rpc.PBackendService;
@@ -76,7 +76,7 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
     public ShortCircuitHybridExecutor(ConnectContext context, PlanFragment planFragment,
                                       List<TScanRangeLocations> scanRangeLocations, TDescriptorTable tDescriptorTable,
                                       boolean isBinaryRow, boolean enableProfile, String protocol,
-                                      WorkerProvider workerProvider) {
+                                      LazyWorkerProvider workerProvider) {
         super(context, planFragment, scanRangeLocations, tDescriptorTable, isBinaryRow, enableProfile,
                 protocol, workerProvider);
     }
@@ -220,7 +220,7 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
 
             Optional<Backend> be = pick(scanBackendIds, aliveIdToBackends);
             if (be.isEmpty()) {
-                workerProvider.reportWorkerNotFoundException();
+                workerProvider.get().reportWorkerNotFoundException();
             }
             be.ifPresent(backend -> backend2Tablets.put(be.get().getBrpcAddress(), tabletWithVersion));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/LazyWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/LazyWorkerProvider.java
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.starrocks.qe.ConnectContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Introduce lazy loading for WorkerProvider to avoid unnecessary computation and ensure that compute resources
+ * are acquired after the query queue scheduling is completed.
+ *
+ * @param lazy the lazy supplier of WorkerProvider
+ */
+public record LazyWorkerProvider(Supplier<WorkerProvider> lazy) {
+    private static final Logger LOG = LogManager.getLogger(LazyWorkerProvider.class);
+
+    public LazyWorkerProvider(Supplier<WorkerProvider> lazy) {
+        this.lazy = Suppliers.memoize(lazy);
+    }
+
+    public static LazyWorkerProvider of(Supplier<WorkerProvider> lazy) {
+        return new LazyWorkerProvider(lazy);
+    }
+
+    public WorkerProvider get() {
+        if (LOG.isDebugEnabled()) {
+            String queryId = ConnectContext.get() != null ? ConnectContext.get().getQueryId().toString() : "N/A";
+            LOG.debug("Materializing WorkerProvider in LazyWorkerProvider, queryId:{}", queryId);
+        }
+        return lazy.get();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/cngroup/LazyComputeResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/cngroup/LazyComputeResource.java
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+package com.starrocks.warehouse.cngroup;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.starrocks.qe.ConnectContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Introduce lazy loading for ComputeResource to avoid unnecessary computation and ensure that compute resources
+ * are acquired after the query queue scheduling is completed.
+ *
+ * @param warehouseId the id of the warehouse
+ * @param lazy the lazy supplier of ComputeResource
+ */
+public record LazyComputeResource(long warehouseId, Supplier<ComputeResource> lazy) implements ComputeResource {
+    private static final Logger LOG = LogManager.getLogger(LazyComputeResource.class);
+
+    public LazyComputeResource(long warehouseId, Supplier<ComputeResource> lazy) {
+        this.warehouseId = warehouseId;
+        this.lazy = Suppliers.memoize(lazy);
+    }
+
+    public static LazyComputeResource of(long warehouseId, Supplier<ComputeResource> lazy) {
+        return new LazyComputeResource(warehouseId, lazy);
+    }
+
+    public ComputeResource get() {
+        if (LOG.isDebugEnabled()) {
+            String queryId = ConnectContext.get() != null ? ConnectContext.get().getQueryId().toString() : "N/A";
+            LOG.debug("Materializing ComputeResource in LazyComputeResource, queryId: {}", queryId);
+        }
+        return lazy.get();
+    }
+
+    @Override
+    public long getWarehouseId() {
+        return warehouseId;
+    }
+
+    @Override
+    public long getWorkerGroupId() {
+        return get().getWorkerGroupId();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/cngroup/LazyComputeResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/cngroup/LazyComputeResource.java
@@ -53,7 +53,9 @@ public class LazyComputeResource implements ComputeResource {
         }
 
         ComputeResource result = lazy.get();
-        initialized.set(true);
+        if (result != null) {
+            initialized.set(true);
+        }
         return result;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/LazyWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/LazyWorkerProviderTest.java
@@ -1,0 +1,182 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.system.ComputeNode;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class LazyWorkerProviderTest {
+    
+    /**
+     * Simple stub implementation of WorkerProvider for testing purposes.
+     */
+    private static class StubWorkerProvider implements WorkerProvider {
+        private final String name;
+        
+        public StubWorkerProvider(String name) {
+            this.name = name;
+        }
+        
+        @Override
+        public String toString() {
+            return name;
+        }
+        
+        @Override
+        public long selectNextWorker() throws NonRecoverableException {
+            return 0;
+        }
+        
+        @Override
+        public void selectWorker(long workerId) throws NonRecoverableException {
+        }
+        
+        @Override
+        public List<Long> selectAllComputeNodes() {
+            return Collections.emptyList();
+        }
+        
+        @Override
+        public Collection<ComputeNode> getAllWorkers() {
+            return Collections.emptyList();
+        }
+        
+        @Override
+        public ComputeNode getWorkerById(long workerId) {
+            return null;
+        }
+        
+        @Override
+        public boolean isDataNodeAvailable(long dataNodeId) {
+            return false;
+        }
+        
+        @Override
+        public void reportDataNodeNotFoundException() throws NonRecoverableException {
+        }
+
+        @Override
+        public void reportWorkerNotFoundException() throws NonRecoverableException {
+
+        }
+
+
+        @Override
+        public boolean isWorkerSelected(long workerId) {
+            return false;
+        }
+        
+        @Override
+        public List<Long> getSelectedWorkerIds() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<Long> getAllAvailableNodes() {
+            return List.of();
+        }
+
+        @Override
+        public void selectWorkerUnchecked(long workerId) {
+
+        }
+
+
+        @Override
+        public boolean allowUsingBackupNode() {
+            return false;
+        }
+
+        @Override
+        public long selectBackupWorker(long workerId) {
+            return 0;
+        }
+
+        @Override
+        public ComputeResource getComputeResource() {
+            return null;
+        }
+    }
+    
+    @Test
+    public void capturesWorkerProviderLazily() {
+        WorkerProvider mockWorkerProvider = new StubWorkerProvider("MockWorkerProvider");
+
+        LazyWorkerProvider lazyWorkerProvider = LazyWorkerProvider.of(() -> mockWorkerProvider);
+        Assertions.assertNotNull(lazyWorkerProvider);
+        Assertions.assertEquals("MockWorkerProvider", lazyWorkerProvider.get().toString());
+    }
+
+    @Test
+    public void memoizesSupplierInvocationOnce() {
+        java.util.concurrent.atomic.AtomicInteger invocationCount = new java.util.concurrent.atomic.AtomicInteger();
+        WorkerProvider mockWorkerProvider = new StubWorkerProvider("MemoizedProvider");
+
+        LazyWorkerProvider lazyWorkerProvider = LazyWorkerProvider.of(() -> {
+            invocationCount.incrementAndGet();
+            return mockWorkerProvider;
+        });
+
+        Assertions.assertEquals(0, invocationCount.get());
+        WorkerProvider first = lazyWorkerProvider.get();
+        WorkerProvider second = lazyWorkerProvider.get();
+        Assertions.assertSame(first, second);
+        Assertions.assertEquals(1, invocationCount.get());
+    }
+
+    @Test
+    public void returnsNullWhenSupplierProvidesNull() {
+        LazyWorkerProvider lazyWorkerProvider = LazyWorkerProvider.of(() -> null);
+        Assertions.assertNull(lazyWorkerProvider.get());
+        // Subsequent calls should still return null (memoized)
+        Assertions.assertNull(lazyWorkerProvider.get());
+    }
+
+    @Test
+    public void materializesWithConnectContextPresent() {
+        WorkerProvider mockWorkerProvider = new StubWorkerProvider("ProviderWithContext");
+
+        // Test that LazyWorkerProvider can materialize when ConnectContext.get() returns null
+        // This simulates the case where no query context is present
+        LazyWorkerProvider lazyWorkerProvider = LazyWorkerProvider.of(() -> mockWorkerProvider);
+        WorkerProvider result = lazyWorkerProvider.get();
+        
+        // Verify the provider is returned correctly
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("ProviderWithContext", result.toString());
+        // Verify memoization - should return the same instance
+        Assertions.assertSame(result, lazyWorkerProvider.get());
+    }
+
+    @Test
+    public void handlesConnectContextNullGracefully() {
+        WorkerProvider mockWorkerProvider = new StubWorkerProvider("ProviderWithNullContext");
+
+        // Test that LazyWorkerProvider works even when ConnectContext.get() returns null
+        // This is the normal case when no query context is active
+        LazyWorkerProvider lazyWorkerProvider = LazyWorkerProvider.of(() -> mockWorkerProvider);
+        
+        // The get() method should work fine even with null ConnectContext
+        WorkerProvider result = lazyWorkerProvider.get();
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("ProviderWithNullContext", result.toString());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestNoneDBBase.java
@@ -88,7 +88,9 @@ public class SchedulerTestNoneDBBase extends PlanTestNoneDBBase {
 
         Config.statistic_collect_interval_sec = prevStatisticCollectIntervalSec;
         Config.tablet_sched_disable_colocate_overall_balance = false;
-        connectContext.getSessionVariable().setPipelineDop(0);
+        if (connectContext != null && connectContext.getSessionVariable() != null) {
+            connectContext.getSessionVariable().setPipelineDop(0);
+        }
     }
 
     @BeforeEach

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -49,6 +49,7 @@ import com.starrocks.utframe.MockedBackend;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.WarehouseComputeResourceProvider;
 import mockit.Mock;
 import mockit.MockUp;
 import org.awaitility.Awaitility;
@@ -119,6 +120,12 @@ public class LakePublishBatchTest {
             @Mock
             public void runOneCycle() {
 
+            }
+        };
+        new MockUp<WarehouseComputeResourceProvider>() {
+            @Mock
+            public boolean isResourceAvailable(ComputeResource computeResource) {
+                return true;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/warehouse/cngroup/LazyComputeResourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/warehouse/cngroup/LazyComputeResourceTest.java
@@ -1,0 +1,156 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+package com.starrocks.warehouse.cngroup;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class LazyComputeResourceTest {
+    
+    /**
+     * Simple stub implementation of ComputeResource for testing purposes.
+     */
+    private static class StubComputeResource implements ComputeResource {
+        private final long warehouseId;
+        private final long workerGroupId;
+        private final String name;
+        
+        public StubComputeResource(long warehouseId, long workerGroupId, String name) {
+            this.warehouseId = warehouseId;
+            this.workerGroupId = workerGroupId;
+            this.name = name;
+        }
+        
+        @Override
+        public long getWarehouseId() {
+            return warehouseId;
+        }
+        
+        @Override
+        public long getWorkerGroupId() {
+            return workerGroupId;
+        }
+        
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+    
+    @Test
+    public void capturesComputeResourceLazily() {
+        ComputeResource mockComputeResource = new StubComputeResource(123L, 456L, "MockComputeResource");
+
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(123L, () -> mockComputeResource);
+        Assertions.assertNotNull(lazyComputeResource);
+        Assertions.assertEquals(123L, lazyComputeResource.getWarehouseId());
+        Assertions.assertEquals(456L, lazyComputeResource.getWorkerGroupId());
+    }
+
+    @Test
+    public void memoizesSupplierInvocationOnce() {
+        java.util.concurrent.atomic.AtomicInteger invocationCount = new java.util.concurrent.atomic.AtomicInteger();
+        ComputeResource mockComputeResource = new StubComputeResource(789L, 101112L, "MemoizedComputeResource");
+
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(789L, () -> {
+            invocationCount.incrementAndGet();
+            return mockComputeResource;
+        });
+
+        Assertions.assertEquals(0, invocationCount.get());
+        ComputeResource first = lazyComputeResource.get();
+        ComputeResource second = lazyComputeResource.get();
+        Assertions.assertSame(first, second);
+        Assertions.assertEquals(1, invocationCount.get());
+    }
+
+    @Test
+    public void returnsNullWhenSupplierProvidesNull() {
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(999L, () -> null);
+        Assertions.assertNull(lazyComputeResource.get());
+        // Subsequent calls should still return null (memoized)
+        Assertions.assertNull(lazyComputeResource.get());
+    }
+
+    @Test
+    public void materializesWithConnectContextPresent() {
+        ComputeResource mockComputeResource = new StubComputeResource(111L, 222L, "ProviderWithContext");
+
+        // Test that LazyComputeResource can materialize when ConnectContext.get() returns null
+        // This simulates the case where no query context is present
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(111L, () -> mockComputeResource);
+        ComputeResource result = lazyComputeResource.get();
+        
+        // Verify the provider is returned correctly
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("ProviderWithContext", result.toString());
+        // Verify memoization - should return the same instance
+        Assertions.assertSame(result, lazyComputeResource.get());
+    }
+
+    @Test
+    public void handlesConnectContextNullGracefully() {
+        ComputeResource mockComputeResource = new StubComputeResource(333L, 444L, "ProviderWithNullContext");
+
+        // Test that LazyComputeResource works even when ConnectContext.get() returns null
+        // This is the normal case when no query context is active
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(333L, () -> mockComputeResource);
+        
+        // The get() method should work fine even with null ConnectContext
+        ComputeResource result = lazyComputeResource.get();
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("ProviderWithNullContext", result.toString());
+    }
+
+    @Test
+    public void delegatesWarehouseIdCorrectly() {
+        long expectedWarehouseId = 555L;
+        ComputeResource mockComputeResource = new StubComputeResource(expectedWarehouseId, 666L, "WarehouseTest");
+
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(expectedWarehouseId, () -> mockComputeResource);
+        
+        // Verify that the warehouse ID is stored and returned correctly
+        Assertions.assertEquals(expectedWarehouseId, lazyComputeResource.getWarehouseId());
+    }
+
+    @Test
+    public void delegatesWorkerGroupIdCorrectly() {
+        long expectedWorkerGroupId = 777L;
+        ComputeResource mockComputeResource = new StubComputeResource(888L, expectedWorkerGroupId, "WorkerGroupTest");
+
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(888L, () -> mockComputeResource);
+        
+        // Verify that the worker group ID is delegated correctly
+        Assertions.assertEquals(expectedWorkerGroupId, lazyComputeResource.getWorkerGroupId());
+    }
+
+    @Test
+    public void handlesMultipleInstancesIndependently() {
+        ComputeResource resource1 = new StubComputeResource(100L, 200L, "Resource1");
+        ComputeResource resource2 = new StubComputeResource(300L, 400L, "Resource2");
+
+        LazyComputeResource lazy1 = LazyComputeResource.of(100L, () -> resource1);
+        LazyComputeResource lazy2 = LazyComputeResource.of(300L, () -> resource2);
+
+        // Verify that each instance works independently
+        Assertions.assertEquals(100L, lazy1.getWarehouseId());
+        Assertions.assertEquals(200L, lazy1.getWorkerGroupId());
+        Assertions.assertEquals("Resource1", lazy1.get().toString());
+
+        Assertions.assertEquals(300L, lazy2.getWarehouseId());
+        Assertions.assertEquals(400L, lazy2.getWorkerGroupId());
+        Assertions.assertEquals("Resource2", lazy2.get().toString());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/warehouse/cngroup/LazyComputeResourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/warehouse/cngroup/LazyComputeResourceTest.java
@@ -17,6 +17,8 @@ package com.starrocks.warehouse.cngroup;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public class LazyComputeResourceTest {
     
     /**
@@ -152,5 +154,174 @@ public class LazyComputeResourceTest {
         Assertions.assertEquals(300L, lazy2.getWarehouseId());
         Assertions.assertEquals(400L, lazy2.getWorkerGroupId());
         Assertions.assertEquals("Resource2", lazy2.get().toString());
+    }
+
+    @Test
+    public void isInitializedReturnsFalseBeforeGet() {
+        ComputeResource mockComputeResource = new StubComputeResource(123L, 456L, "TestResource");
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(123L, () -> mockComputeResource);
+
+        // Before calling get(), the resource should not be initialized
+        Assertions.assertFalse(lazyComputeResource.isInitialized(),
+                "Resource should not be initialized before get() is called");
+    }
+
+    @Test
+    public void isInitializedReturnsTrueAfterGet() {
+        ComputeResource mockComputeResource = new StubComputeResource(789L, 101112L, "TestResource");
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(789L, () -> mockComputeResource);
+
+        // Before calling get()
+        Assertions.assertFalse(lazyComputeResource.isInitialized());
+
+        // Call get() to materialize the resource
+        lazyComputeResource.get();
+
+        // After calling get(), the resource should be initialized
+        Assertions.assertTrue(lazyComputeResource.isInitialized(),
+                "Resource should be initialized after get() is called");
+    }
+
+    @Test
+    public void isInitializedRemainsTrueAfterMultipleGetCalls() {
+        ComputeResource mockComputeResource = new StubComputeResource(555L, 666L, "TestResource");
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(555L, () -> mockComputeResource);
+
+        Assertions.assertFalse(lazyComputeResource.isInitialized());
+
+        // Call get() multiple times
+        lazyComputeResource.get();
+        Assertions.assertTrue(lazyComputeResource.isInitialized());
+
+        lazyComputeResource.get();
+        Assertions.assertTrue(lazyComputeResource.isInitialized(),
+                "Resource should remain initialized after multiple get() calls");
+
+        lazyComputeResource.get();
+        Assertions.assertTrue(lazyComputeResource.isInitialized());
+    }
+
+    @Test
+    public void isInitializedWorksWithNullResource() {
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(999L, () -> null);
+
+        Assertions.assertFalse(lazyComputeResource.isInitialized());
+
+        // Even when the supplier returns null, isInitialized should be true after get()
+        lazyComputeResource.get();
+        Assertions.assertTrue(lazyComputeResource.isInitialized(),
+                "Resource should be marked as initialized even when supplier returns null");
+    }
+
+    @Test
+    public void tracksInitializationStatusForQueueScheduling() {
+        // This test verifies that isInitialized() can be used to ensure compute resources
+        // are acquired after query queue scheduling completes
+        
+        AtomicBoolean queueSchedulingComplete = new AtomicBoolean(false);
+        AtomicBoolean resourceAcquisitionStarted = new AtomicBoolean(false);
+        
+        ComputeResource mockComputeResource = new StubComputeResource(111L, 222L, "QueueTestResource");
+        
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(111L, () -> {
+            // This lambda is invoked when get() is called
+            Assertions.assertTrue(queueSchedulingComplete.get(),
+                    "Queue scheduling should be complete before resource acquisition starts");
+            resourceAcquisitionStarted.set(true);
+            return mockComputeResource;
+        });
+        
+        // Phase 1: Before queue scheduling
+        Assertions.assertFalse(lazyComputeResource.isInitialized(),
+                "Resource should not be initialized before queue scheduling");
+        
+        // Phase 2: Simulate queue scheduling (e.g., manager.maybeWait)
+        queueSchedulingComplete.set(true);
+        Assertions.assertFalse(lazyComputeResource.isInitialized(),
+                "Resource should not be initialized during/immediately after queue scheduling");
+        
+        // Phase 3: Acquire compute resource after queue scheduling
+        ComputeResource result = lazyComputeResource.get();
+        
+        // Phase 4: Verify initialization status
+        Assertions.assertTrue(resourceAcquisitionStarted.get());
+        Assertions.assertTrue(lazyComputeResource.isInitialized(),
+                "Resource should be initialized after get() is called");
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("QueueTestResource", result.toString());
+    }
+
+    @Test
+    public void isInitializedRemainsFalseWhenGetThrowsException() {
+        // Test that isInitialized() remains false if get() throws an exception
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(999L, () -> {
+            throw new RuntimeException("Simulated resource acquisition failure");
+        });
+
+        Assertions.assertFalse(lazyComputeResource.isInitialized(),
+                "Resource should not be initialized before get() is called");
+
+        // Try to materialize the resource - this should throw an exception
+        Assertions.assertThrows(RuntimeException.class, () -> {
+            lazyComputeResource.get();
+        });
+
+        // After exception, isInitialized should still be false
+        Assertions.assertFalse(lazyComputeResource.isInitialized(),
+                "Resource should not be marked as initialized when get() throws an exception");
+    }
+
+    @Test
+    public void isInitializedThreadSafety() throws InterruptedException {
+        // Test that isInitialized() is thread-safe across concurrent calls
+        java.util.concurrent.atomic.AtomicInteger invocationCount = new java.util.concurrent.atomic.AtomicInteger(0);
+        java.util.concurrent.CountDownLatch startLatch = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch completeLatch = new java.util.concurrent.CountDownLatch(10);
+        
+        ComputeResource mockComputeResource = new StubComputeResource(777L, 888L, "ThreadSafeResource");
+        
+        LazyComputeResource lazyComputeResource = LazyComputeResource.of(777L, () -> {
+            invocationCount.incrementAndGet();
+            try {
+                Thread.sleep(100); // Simulate some work
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return mockComputeResource;
+        });
+
+        // Create multiple threads that will call get() and isInitialized() concurrently
+        for (int i = 0; i < 10; i++) {
+            new Thread(() -> {
+                try {
+                    startLatch.await(); // Wait for all threads to be ready
+                    
+                    // Some threads call get(), others call isInitialized()
+                    if (Thread.currentThread().getId() % 2 == 0) {
+                        lazyComputeResource.get();
+                    } else {
+                        lazyComputeResource.isInitialized();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    completeLatch.countDown();
+                }
+            }).start();
+        }
+
+        // Start all threads at once
+        startLatch.countDown();
+        
+        // Wait for all threads to complete
+        completeLatch.await();
+
+        // Verify that the supplier was invoked exactly once (memoization works)
+        Assertions.assertEquals(1, invocationCount.get(),
+                "Supplier should be invoked exactly once despite concurrent access");
+        
+        // Verify that after all threads complete, isInitialized returns true
+        Assertions.assertTrue(lazyComputeResource.isInitialized(),
+                "Resource should be initialized after concurrent get() calls complete");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/warehouse/cngroup/LazyComputeResourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/warehouse/cngroup/LazyComputeResourceTest.java
@@ -209,7 +209,7 @@ public class LazyComputeResourceTest {
 
         // Even when the supplier returns null, isInitialized should be true after get()
         lazyComputeResource.get();
-        Assertions.assertTrue(lazyComputeResource.isInitialized(),
+        Assertions.assertFalse(lazyComputeResource.isInitialized(),
                 "Resource should be marked as initialized even when supplier returns null");
     }
 


### PR DESCRIPTION
## Why I'm doing:
For a query, the correct order to acquire compute resource should be as below:
- CoordinatorPreprocessor#maybeWait: to check whether the queue's resource is enough or trigger auto-scaling.
- WorkerProvider#captureAvailableWorkers: trigger to acquire compute resources to capture available workers.

but in current implementation, it will always trigger to acquire compute resources before `CoordinatorPreprocessor#maybeWait`.

## What I'm doing:
- Introduce `LazyWorkerProvider` and `LazyComputeResource` to make compute resource acquire as late as possible.
- Correct the acquire compute resource and query queue schedule order.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
