### PR TITLE
[Tool] Support compilation on Mac 14: insert and select run successfully

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -241,7 +241,9 @@ void run_create_tablet_task(const std::shared_ptr<CreateTabletAgentTaskRequest>&
     }
     if (create_status.ok()) {
         if (tablet_type == TTabletType::TABLET_TYPE_LAKE) {
+#ifndef __APPLE__
             create_status = exec_env->lake_tablet_manager()->create_tablet(create_tablet_req);
+#endif
         } else {
             create_status = StorageEngine::instance()->create_tablet(create_tablet_req);
         }

--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -123,8 +123,8 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
             }
         }
     }
-    span->SetAttribute("num_partition", num_partition);
-    span->SetAttribute("num_tablet", num_active_tablet);
+    span->SetAttribute("num_partition", static_cast<uint64_t>(num_partition));
+    span->SetAttribute("num_tablet", static_cast<uint64_t>(num_active_tablet));
 
     std::mutex affected_dirs_lock;
     CountDownLatch latch(static_cast<int>(tablet_tasks.size()));

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -111,7 +111,9 @@ public:
 
     void assign(size_t n, size_t idx) override {
         auto& datas = get_data();
-        datas.assign(n, _data[idx]);
+        // Avoid use-after-free: save value before assign() deallocates _data
+        T value = _data[idx];
+        datas.assign(n, value);
     }
 
     void remove_first_n_values(size_t count) override;

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -185,8 +185,12 @@ static void failure_handler_after_output_log() {
     static bool start_dump = false;
     if (!start_dump && config::enable_core_file_size_optimization && base::get_cur_core_file_limit() != 0) {
         ExecEnv::GetInstance()->try_release_resource_before_core_dump();
+#ifndef __APPLE__
         DataCache::GetInstance()->try_release_resource_before_core_dump();
+#endif
+#ifndef __APPLE__
         dontdump_unused_pages();
+#endif
     }
     start_dump = true;
 }
@@ -211,7 +215,9 @@ bool init_glog(const char* basename, bool install_signal_handler) {
     }
 
     if (install_signal_handler) {
+#ifndef __APPLE__
         google::InstallFailureSignalHandler();
+#endif
     }
 
     // only write fatal log to stderr
@@ -309,7 +315,7 @@ bool init_glog(const char* basename, bool install_signal_handler) {
     if (config::dump_trace_info) {
         google::InstallFailureWriter(failure_writer);
         google::InstallFailureFunction((google::logging_fail_func_t)failure_function);
-#ifndef MACOS_DISABLE_GLOG_STACKTRACE
+#ifndef __APPLE__
         // This symbol may be unavailable on macOS builds using system glog.
         google::InstallFailureHandlerAfterOutputLog(failure_handler_after_output_log);
 #endif

--- a/be/src/common/prof/heap_prof.cpp
+++ b/be/src/common/prof/heap_prof.cpp
@@ -72,22 +72,31 @@ bool dump_snapshot(const std::string& filename) {
 std::string exec(const std::string& cmd);
 
 void HeapProf::enable_prof() {
+#ifndef __APPLE__
     LOG(INFO) << "try to enable the heap profiling";
     std::lock_guard guard(_mutex);
     set_jemalloc_profiling(true);
+#endif
 }
 
 void HeapProf::disable_prof() {
+#ifndef __APPLE__
     LOG(INFO) << "try to disable the heap profiling";
     std::lock_guard guard(_mutex);
     set_jemalloc_profiling(false);
+#endif
 }
 
 bool HeapProf::has_enable() {
+#ifndef __APPLE__
     return has_enable_heap_profile();
+#else
+    return false;
+#endif
 }
 
 std::string HeapProf::snapshot() {
+#ifndef __APPLE__
     std::string output_name = fmt::format("{}/heap_profile.{}.{}", config::pprof_profile_dir, getpid(), rand());
     LOG(INFO) << "try to dump the heap profile " << output_name;
     //
@@ -97,6 +106,9 @@ std::string HeapProf::snapshot() {
     } else {
         return "";
     }
+#else
+    return "";
+#endif
 }
 
 std::string HeapProf::to_dot_format(const std::string& heapdump_filename) {
@@ -106,7 +118,11 @@ std::string HeapProf::to_dot_format(const std::string& heapdump_filename) {
     auto base_home = getenv("STARROCKS_HOME");
     std::string jeprof = fmt::format("{}/bin/jeprof", base_home);
     std::string binary = fmt::format("{}/lib/starrocks_be", base_home);
+#ifdef __APPLE__
+    return "not support on MacOS";
+#else
     return exec(fmt::format("{} --dot {} {}", jeprof, binary, heapdump_filename));
+#endif
 }
 
 } // namespace starrocks

--- a/be/src/connector/connector.cpp
+++ b/be/src/connector/connector.cpp
@@ -18,7 +18,9 @@
 #include "connector/es_connector.h"
 #include "connector/file_connector.h"
 #include "connector/hive_connector.h"
+#ifndef __APPLE__
 #include "connector/iceberg_connector.h"
+#endif
 #include "connector/jdbc_connector.h"
 #include "connector/lake_connector.h"
 #include "connector/mysql_connector.h"
@@ -61,7 +63,9 @@ public:
         cm->put(Connector::FILE, std::make_unique<FileConnector>());
         cm->put(Connector::LAKE, std::make_unique<LakeConnector>());
         cm->put(Connector::BINLOG, std::make_unique<BinlogConnector>());
+#ifndef __APPLE__
         cm->put(Connector::ICEBERG, std::make_unique<IcebergConnector>());
+#endif
     }
 };
 

--- a/be/src/exec/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/arrow_to_starrocks_converter.cpp
@@ -29,7 +29,9 @@
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "exec/arrow_type_traits.h"
+#ifndef __APPLE__
 #include "exec/file_scanner/parquet_scanner.h"
+#endif
 #include "gutil/strings/fastmem.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/datetime_value.h"
@@ -840,9 +842,13 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, ArrayGuard<LT>> {
 
         Filter child_chunk_filter;
         child_chunk_filter.resize(col_array->elements_column()->size() + child_array_num_elements, 1);
+#ifndef __APPLE__
         return ParquetScanner::convert_array_to_column(conv_func->children[0].get(), child_array_num_elements,
                                                        child_array, col_array->elements_column(), child_array_start_idx,
                                                        col_array->elements_column()->size(), &child_chunk_filter, ctx);
+#else
+        return Status::NotSupported("Parquet nested type conversion is not supported on this build");
+#endif
     }
 };
 
@@ -867,11 +873,15 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, MapGuard<LT>> {
                 return Status::InternalError(fmt::format("Unnest arrow array type({}) fail", array->type()->name()));
             }
 
+#ifndef __APPLE__
             Filter child_chunk_filter;
             child_chunk_filter.resize(kv_size[i] + child_array_num_elements, 1);
             RETURN_IF_ERROR(ParquetScanner::convert_array_to_column(
                     conv_func->children[i].get(), child_array_num_elements, child_array, kv_columns[i],
                     child_array_start_idx, kv_size[i], &child_chunk_filter, ctx));
+#else
+            return Status::NotSupported("Parquet nested type conversion is not supported on this build");
+#endif
         }
         return Status::OK();
     }
@@ -899,9 +909,13 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, StructGurad<LT>> {
                 continue;
             }
 
+#ifndef __APPLE__
             RETURN_IF_ERROR(ParquetScanner::convert_array_to_column(conv_func->children[i].get(), num_elements,
                                                                     child_array.get(), child_col, array_start_idx,
                                                                     chunk_start_idx, chunk_filter, ctx));
+#else
+            return Status::NotSupported("Parquet nested type conversion is not supported on this build");
+#endif
         }
 
         return Status::OK();

--- a/be/src/exec/file_scan_node.cpp
+++ b/be/src/exec/file_scan_node.cpp
@@ -18,11 +18,17 @@
 #include <sstream>
 
 #include "column/chunk.h"
+#ifndef __APPLE__
 #include "exec/file_scanner/avro_scanner.h"
+#endif
 #include "exec/file_scanner/csv_scanner.h"
 #include "exec/file_scanner/json_scanner.h"
+#ifndef __APPLE__
 #include "exec/file_scanner/orc_scanner.h"
+#endif
+#ifndef __APPLE__
 #include "exec/file_scanner/parquet_scanner.h"
+#endif
 #include "exprs/expr.h"
 #include "fs/fs.h"
 #include "runtime/current_thread.h"
@@ -203,15 +209,23 @@ void FileScanNode::debug_string(int ident_level, std::stringstream* out) const {
 
 std::unique_ptr<FileScanner> FileScanNode::_create_scanner(const TBrokerScanRange& scan_range,
                                                            ScannerCounter* counter) {
-    if (scan_range.ranges[0].format_type == TFileFormatType::FORMAT_ORC) {
+    TFileFormatType::type format_type = scan_range.ranges[0].format_type;
+    switch (format_type) {
+#ifndef __APPLE__
+    case TFileFormatType::FORMAT_ORC:
         return std::make_unique<ORCScanner>(runtime_state(), runtime_profile(), scan_range, counter);
-    } else if (scan_range.ranges[0].format_type == TFileFormatType::FORMAT_PARQUET) {
+#endif
+#ifndef __APPLE__
+    case TFileFormatType::FORMAT_PARQUET:
         return std::make_unique<ParquetScanner>(runtime_state(), runtime_profile(), scan_range, counter);
-    } else if (scan_range.ranges[0].format_type == TFileFormatType::FORMAT_JSON) {
+#endif
+    case TFileFormatType::FORMAT_JSON:
         return std::make_unique<JsonScanner>(runtime_state(), runtime_profile(), scan_range, counter);
-    } else if (scan_range.ranges[0].format_type == TFileFormatType::FORMAT_AVRO) {
+#ifndef __APPLE__
+    case TFileFormatType::FORMAT_AVRO:
         return std::make_unique<AvroScanner>(runtime_state(), runtime_profile(), scan_range, counter);
-    } else {
+#endif
+    default:
         return std::make_unique<CSVScanner>(runtime_state(), runtime_profile(), scan_range, counter);
     }
 }

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -53,9 +53,14 @@ Status ResultSinkOperator::prepare(RuntimeState* state) {
     case TResultSinkType::HTTP_PROTOCAL:
         _writer = std::make_shared<HttpResultWriter>(_sender.get(), _output_expr_ctxs, profile, _format_type);
         break;
+#ifndef __APPLE__
     case TResultSinkType::METADATA_ICEBERG:
         _writer = std::make_shared<MetadataResultWriter>(_sender.get(), _output_expr_ctxs, profile, _sink_type);
         break;
+#else
+    case TResultSinkType::METADATA_ICEBERG:
+        return Status::NotSupported("Iceberg metadata result sink is disabled on macOS");
+#endif
     case TResultSinkType::CUSTOMIZED:
         // CustomizedResultWriter is a general-purposed result writer that used by FE to executing internal
         // query, the result is serialized in packed binary format. FE can parse the result row into object

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -529,9 +529,13 @@ Status PhysicalSplitMorselQueue::_init_segment() {
                                                                _range_start_key, _range_end_key, &_tablet_seek_ranges,
                                                                &_mempool));
             } else {
+#ifndef __APPLE__
                 RETURN_IF_ERROR(lake::TabletReader::parse_seek_range(*_tablet_schema, _range_start_op, _range_end_op,
                                                                      _range_start_key, _range_end_key,
                                                                      &_tablet_seek_ranges, &_mempool));
+#else
+                return Status::RuntimeError("Lake storage is disabled on macOS");
+#endif
             }
         }
         // Read a new rowset.
@@ -868,9 +872,13 @@ Status LogicalSplitMorselQueue::_init_tablet() {
                                                            _range_start_key, _range_end_key, &_tablet_seek_ranges,
                                                            &_mempool));
         } else {
+#ifndef __APPLE__
             RETURN_IF_ERROR(lake::TabletReader::parse_seek_range(*_tablet_schema, _range_start_op, _range_end_op,
                                                                  _range_start_key, _range_end_key, &_tablet_seek_ranges,
                                                                  &_mempool));
+#else
+            return Status::RuntimeError("Lake storage is disabled on macOS");
+#endif
         }
     }
 

--- a/be/src/exec/pipeline/sink/mysql_table_sink_operator.h
+++ b/be/src/exec/pipeline/sink/mysql_table_sink_operator.h
@@ -79,10 +79,14 @@ private:
     std::vector<TExpr> _t_output_expr;
     std::vector<ExprContext*> _output_expr_ctxs;
     TMysqlTableSink _t_mysql_table_sink;
+#ifndef __APPLE__
     int32_t _num_sinkers;
+#endif
 
     std::shared_ptr<MysqlTableSinkIOBuffer> _mysql_table_sink_buffer;
+#ifndef __APPLE__
     FragmentContext* _fragment_ctx = nullptr;
+#endif
 };
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exprs/arrow_function_call.cpp
+++ b/be/src/exprs/arrow_function_call.cpp
@@ -130,7 +130,11 @@ std::unique_ptr<UDFCallStub> ArrowFunctionCallExpr::_build_stub(int32_t driver_i
         py_func_desc.content = _fn.content;
         return build_py_call_stub(context, py_func_desc);
     }
+#ifndef __APPLE__
     return create_error_call_stub(Status::NotFound(fmt::format("unsupported function type:{}", binary_type)));
+#else
+    return nullptr;
+#endif
 }
 
 } // namespace starrocks

--- a/be/src/exprs/function_context.cpp
+++ b/be/src/exprs/function_context.cpp
@@ -20,12 +20,12 @@
 #include "column/map_column.h"
 #include "column/struct_column.h"
 #include "column/type_traits.h"
-#ifndef MACOS_DISABLE_JAVA
+#ifndef __APPLE__
 #include "exprs/agg/java_udaf_function.h"
 #endif
 #include "runtime/runtime_state.h"
 #include "types/logical_type_infra.h"
-#ifndef MACOS_DISABLE_JAVA
+#ifndef __APPLE__
 #include "udf/java/java_udf.h"
 #endif
 #include "util/bloom_filter.h"
@@ -42,7 +42,7 @@ FunctionContext* FunctionContext::create_context(RuntimeState* state, MemPool* p
     ctx->_mem_pool = pool;
     ctx->_return_type = return_type;
     ctx->_arg_types = arg_types;
-#if !defined(MACOS_DISABLE_JAVA) && !defined(BUILD_FORMAT_LIB)
+#if !defined(__APPLE__) && !defined(BUILD_FORMAT_LIB)
     ctx->_jvm_udaf_ctxs = std::make_unique<JavaUDAFContext>();
 #endif
     return ctx;
@@ -58,7 +58,7 @@ FunctionContext* FunctionContext::create_context(RuntimeState* state, MemPool* p
     ctx->_mem_pool = pool;
     ctx->_return_type = return_type;
     ctx->_arg_types = arg_types;
-#if !defined(MACOS_DISABLE_JAVA) && !defined(BUILD_FORMAT_LIB)
+#if !defined(__APPLE__) && !defined(BUILD_FORMAT_LIB)
     ctx->_jvm_udaf_ctxs = std::make_unique<JavaUDAFContext>();
 #endif
     ctx->_is_distinct = is_distinct;
@@ -141,7 +141,7 @@ void* FunctionContext::get_function_state(FunctionStateScope scope) const {
 }
 
 void FunctionContext::release_mems() {
-#ifndef MACOS_DISABLE_JAVA
+#ifndef __APPLE__
     if (_jvm_udaf_ctxs != nullptr && _jvm_udaf_ctxs->states) {
         auto env = JVMFunctionHelper::getInstance().getEnv();
         _jvm_udaf_ctxs->states->clear(this, env);

--- a/be/src/exprs/function_context.h
+++ b/be/src/exprs/function_context.h
@@ -35,7 +35,7 @@ class RuntimeState;
 class Column;
 class Slice;
 struct JavaUDAFContext;
-#if defined(MACOS_DISABLE_JAVA)
+#if defined(__APPLE__)
 // On macOS build, Java is disabled. Provide an empty definition so that
 // std::unique_ptr<JavaUDAFContext> has a complete type and can be destroyed
 // without pulling in JNI headers.

--- a/be/src/exprs/table_function/list_rowsets.cpp
+++ b/be/src/exprs/table_function/list_rowsets.cpp
@@ -80,6 +80,7 @@ static void fill_rowset_row(Columns& columns, const RowsetMetadataPB& rowset) {
 
 std::pair<Columns, UInt32Column::Ptr> ListRowsets::process(RuntimeState* runtime_state,
                                                            TableFunctionState* base_state) const {
+#ifndef __APPLE__
     auto state = down_cast<MyState*>(base_state);
 
     if (UNLIKELY(state->get_columns().size() != 2)) {
@@ -160,6 +161,11 @@ std::pair<Columns, UInt32Column::Ptr> ListRowsets::process(RuntimeState* runtime
     offsets->append_datum(Datum((uint32_t)result[0]->size()));
 
     return std::make_pair(std::move(result), std::move(offsets));
+#else
+    // Lake storage is disabled on macOS
+    state->set_status(Status::RuntimeError("Lake storage is disabled on macOS"));
+    return {};
+#endif
 }
 
 } // namespace starrocks

--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -229,7 +229,9 @@ public:
 #ifdef USE_STAROS
         s_sr_posix_write_iosize.Observe(bytes_written);
 #endif
+#ifndef __APPLE__
         IOProfiler::add_write(bytes_written, watch.elapsed_time());
+#endif
         return Status::OK();
     }
 
@@ -318,7 +320,9 @@ public:
             _pending_sync = false;
             RETURN_IF_ERROR(do_sync(_fd, _filename));
         }
+#ifndef __APPLE__
         IOProfiler::add_sync(watch.elapsed_time());
+#endif
         return Status::OK();
     }
 

--- a/be/src/gutil/strings/fastmem.h
+++ b/be/src/gutil/strings/fastmem.h
@@ -193,6 +193,9 @@ ALWAYS_INLINE inline void memcpy_inlined(void* __restrict _dst, const void* __re
 }
 
 ALWAYS_INLINE inline void memcpy_inlined_overflow16(void* __restrict _dst, const void* __restrict _src, ssize_t size) {
+#if defined(__APPLE__)
+    memcpy(_dst, _src, size);
+#else
     auto* __restrict dst = static_cast<uint8_t*>(_dst);
     const auto* __restrict src = static_cast<const uint8_t*>(_src);
 
@@ -210,6 +213,7 @@ ALWAYS_INLINE inline void memcpy_inlined_overflow16(void* __restrict _dst, const
         // Inhibit loop-idiom optimization of compilers, which would collapse the per-16B copies into a single memcpy.
         __asm__ __volatile__("" : : : "memory");
     }
+#endif
 }
 
 } // namespace strings

--- a/be/src/http/action/pprof_actions.cpp
+++ b/be/src/http/action/pprof_actions.cpp
@@ -195,12 +195,14 @@ void SymbolAction::handle(HttpRequest* req) {
             std::string func_name;
             unsigned int lineno = 0;
             const char* old_ptr = ptr;
+#ifndef __APPLE__
             if (!_parser->decode_address(ptr, &ptr, &file_name, &func_name, &lineno)) {
                 result.append(old_ptr, ptr - old_ptr);
                 result.push_back('\t');
                 result.append(func_name);
                 result.push_back('\n');
             }
+#endif
             if (ptr < end && *ptr == '+') {
                 ptr++;
             }

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -89,6 +89,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             _exec_env->thread_pool()->set_num_thread(config::scanner_thread_pool_thread_num);
             return Status::OK();
         });
+#ifndef __APPLE__
         _config_callback.emplace("storage_page_cache_limit", [&]() -> Status {
             StoragePageCache* cache = DataCache::GetInstance()->page_cache();
             if (cache == nullptr || !cache->is_initialized()) {
@@ -100,6 +101,8 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             cache->set_capacity(cache_limit);
             return Status::OK();
         });
+#endif
+#ifndef __APPLE__
         _config_callback.emplace("disable_storage_page_cache", [&]() -> Status {
             StoragePageCache* cache = DataCache::GetInstance()->page_cache();
             if (cache == nullptr || !cache->is_initialized()) {
@@ -114,6 +117,8 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             }
             return Status::OK();
         });
+#endif
+#ifndef __APPLE__
         _config_callback.emplace("datacache_mem_size", [&]() -> Status {
             LocalMemCacheEngine* cache = DataCache::GetInstance()->local_mem_cache();
             if (cache == nullptr || !cache->is_initialized()) {
@@ -155,6 +160,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             }
             return cache->update_inline_cache_count_limit(config::datacache_inline_item_count_limit);
         });
+#endif
         _config_callback.emplace("max_compaction_concurrency", [&]() -> Status {
             if (!config::enable_event_based_compaction_framework) {
                 return Status::InvalidArgument(

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -17,6 +17,13 @@
 #include <cstdint>
 #include <string>
 
+#ifdef __APPLE__
+#include <pthread.h>
+#else
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
+
 #include "fmt/format.h"
 #include "gen_cpp/Types_types.h"
 #include "gutil/macros.h"
@@ -220,8 +227,19 @@ private:
         int64_t _try_consume_mem_size = 0; // Last time tried to consumed bytes
     };
 
+    // Platform-specific thread ID retrieval
+    static inline int32_t get_thread_id() {
+#ifdef __APPLE__
+        uint64_t tid;
+        pthread_threadid_np(NULL, &tid);
+        return static_cast<int32_t>(tid);
+#else
+        return syscall(SYS_gettid);
+#endif
+    }
+
 public:
-    CurrentThread() : _lwp_id(syscall(SYS_gettid)) { tls_is_thread_status_init = true; }
+    CurrentThread() : _lwp_id(get_thread_id()) { tls_is_thread_status_init = true; }
     ~CurrentThread();
 
     void mem_tracker_ctx_shift() { _mem_cache_manager.commit(true); }

--- a/be/src/runtime/metadata_result_writer.cpp
+++ b/be/src/runtime/metadata_result_writer.cpp
@@ -95,12 +95,17 @@ StatusOr<TFetchDataResultPtr> MetadataResultWriter::_process_chunk(Chunk* chunk)
     }
 
     if (_sink_type == TResultSinkType::METADATA_ICEBERG) {
+#ifdef __APPLE__
+        return Status::NotSupported("Iceberg metadata result sink is disabled on macOS");
+#else
         RETURN_IF_ERROR(_fill_iceberg_metadata(result_columns, chunk, result.get()));
+#endif
     }
 
     return result;
 }
 
+#ifndef __APPLE__
 // Columns is fixed in the first version of logical iceberg metadata table.
 // In principle, there will be no changes in the future.
 // Only new columns are allowed if necessary. The newly added columns need to check if nullable.
@@ -201,4 +206,5 @@ Status MetadataResultWriter::_fill_iceberg_metadata(const Columns& columns, cons
 
     return Status::OK();
 }
+#endif // __APPLE__
 } // namespace starrocks

--- a/be/src/runtime/mysql_table_sink.h
+++ b/be/src/runtime/mysql_table_sink.h
@@ -76,7 +76,9 @@ public:
 private:
     ObjectPool* _pool;
     const std::vector<TExpr>& _t_output_expr;
+#ifndef __APPLE__
     int _chunk_size;
+#endif
 
     std::vector<ExprContext*> _output_expr_ctxs;
 

--- a/be/src/runtime/result_sink.cpp
+++ b/be/src/runtime/result_sink.cpp
@@ -41,7 +41,9 @@
 #include "runtime/buffer_control_block.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
+#ifndef __APPLE__
 #include "runtime/file_result_writer.h"
+#endif
 #include "runtime/mem_tracker.h"
 #include "runtime/mysql_result_writer.h"
 #include "runtime/result_buffer_mgr.h"
@@ -65,10 +67,12 @@ ResultSink::ResultSink(const RowDescriptor& row_desc, const std::vector<TExpr>& 
         _format_type = sink.format;
     }
 
+#ifndef __APPLE__
     if (_sink_type == TResultSinkType::FILE) {
         CHECK(sink.__isset.file_options);
         _file_opts = std::make_shared<ResultFileOptions>(sink.file_options);
     }
+#endif
 
     _is_binary_format = sink.is_binary_row;
 }
@@ -103,10 +107,12 @@ Status ResultSink::prepare(RuntimeState* state) {
         _writer.reset(new (std::nothrow)
                               MysqlResultWriter(_sender.get(), _output_expr_ctxs, _is_binary_format, _profile));
         break;
+#ifndef __APPLE__
     case TResultSinkType::FILE:
         CHECK(_file_opts.get() != nullptr);
         _writer.reset(new (std::nothrow) FileResultWriter(_file_opts.get(), _output_expr_ctxs, _profile));
         break;
+#endif
     case TResultSinkType::STATISTIC:
         _writer.reset(new (std::nothrow) StatisticResultWriter(_sender.get(), _output_expr_ctxs, _profile));
         break;

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -485,6 +485,7 @@ bool KafkaDataConsumer::match(StreamLoadContext* ctx) {
 }
 
 // init pulsar consumer will only set common configs
+#ifndef __APPLE__
 Status PulsarDataConsumer::init(StreamLoadContext* ctx) {
     std::unique_lock<std::mutex> l(_lock);
     if (_init) {
@@ -702,5 +703,6 @@ bool PulsarDataConsumer::match(StreamLoadContext* ctx) {
 
     return true;
 }
+#endif
 
 } // end namespace starrocks

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -503,6 +503,7 @@ bool RuntimeState::is_jit_enabled() const {
 }
 
 void RuntimeState::update_load_datacache_metrics(TReportExecStatusParams* load_params) const {
+#ifndef __APPLE__
     if (!_query_options.__isset.catalog) {
         return;
     }
@@ -539,6 +540,7 @@ void RuntimeState::update_load_datacache_metrics(TReportExecStatusParams* load_p
             load_params->__set_load_datacache_metrics(metrics);
         }
     }
+#endif // __APPLE__
 }
 
 } // end namespace starrocks

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -51,7 +51,9 @@
 #include "runtime/broker_mgr.h"
 #include "runtime/exec_env.h"
 #include "storage/index/index_descriptor.h"
+#ifndef __APPLE__
 #include "storage/index/inverted/clucene/clucene_plugin.h"
+#endif
 #include "storage/snapshot_manager.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"
@@ -1012,9 +1014,11 @@ Status SnapshotLoader::_replace_tablet_id(const std::string& file_name, int64_t 
                _end_with(file_name, ".vi")) {
         *new_file_name = file_name;
         return Status::OK();
+#ifndef __APPLE__
     } else if (CLucenePlugin::is_index_files(file_name)) {
         *new_file_name = file_name;
         return Status::OK();
+#endif
     } else {
         return Status::InternalError("invalid tablet file name: " + file_name);
     }

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -15,8 +15,6 @@
 #include "serde/column_array_serde.h"
 
 #include <fmt/format.h>
-#include <lz4/lz4.h>
-#include <lz4/lz4frame.h>
 #include <streamvbyte.h>
 #include <streamvbytedelta.h>
 
@@ -38,6 +36,7 @@
 #include "types/hll.h"
 #include "types/variant_value.h"
 #include "util/coding.h"
+#include "util/compression/compression_headers.h"
 #include "util/json.h"
 #include "util/percentile_value.h"
 

--- a/be/src/service/backend_base.cpp
+++ b/be/src/service/backend_base.cpp
@@ -123,6 +123,9 @@ void BackendServiceBase::fetch_data(TFetchDataResult& return_val, const TFetchDa
 }
 
 void BackendServiceBase::submit_routine_load_task(TStatus& t_status, const std::vector<TRoutineLoadTask>& tasks) {
+#ifdef __APPLE__
+    Status::NotSupported("submit_routine_load_task is not supported on MacOS").to_thrift(&t_status);
+#else
     for (auto& task : tasks) {
         Status st = _exec_env->routine_load_task_executor()->submit_task(task);
         if (!st.ok()) {
@@ -132,6 +135,7 @@ void BackendServiceBase::submit_routine_load_task(TStatus& t_status, const std::
     }
 
     return Status::OK().to_thrift(&t_status);
+#endif
 }
 
 void BackendServiceBase::finish_stream_load_channel(TStatus& t_status, const TStreamLoadChannel& stream_load_channel) {

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -748,7 +748,9 @@ template <typename T>
 void PInternalServiceImplBase<T>::_get_info_impl(const PProxyRequest* request, PProxyResult* response,
                                                  google::protobuf::Closure* done, int timeout_ms) {
     ClosureGuard closure_guard(done);
-
+#ifdef __APPLE__
+    Status::NotSupported("get_info is not supported on MacOS").to_protobuf(response->mutable_status());
+#else
     // If we use timeout specified by user directly, there will be an issue that librakafka connect to kafka broker
     // time out, but the BE did not have the opportunity to send the error message back to the FE , and the timer on
     // the FE side has already timed out. This mean that the FE cannot retrieve the event message from librdkafka.
@@ -816,6 +818,7 @@ void PInternalServiceImplBase<T>::_get_info_impl(const PProxyRequest* request, P
         LOG(WARNING) << "group id " << group_id << " get kafka info timeout. used time(ms) "
                      << watch.elapsed_time() / 1000 / 1000 << ". error: " << st.to_string();
     }
+#endif
 }
 
 template <typename T>
@@ -846,7 +849,9 @@ void PInternalServiceImplBase<T>::_get_pulsar_info_impl(const PPulsarProxyReques
                                                         PPulsarProxyResult* response, google::protobuf::Closure* done,
                                                         int timeout_ms) {
     ClosureGuard closure_guard(done);
-
+#ifdef __APPLE__
+    Status::NotSupported("get_pulsar_info is not supported on MacOS").to_protobuf(response->mutable_status());
+#else
     if (timeout_ms <= 0) {
         Status::TimedOut("get pulsar info timeout").to_protobuf(response->mutable_status());
         return;
@@ -898,6 +903,7 @@ void PInternalServiceImplBase<T>::_get_pulsar_info_impl(const PPulsarProxyReques
         }
     }
     Status::OK().to_protobuf(response->mutable_status());
+#endif
 }
 
 template <typename T>

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -273,9 +273,11 @@ Status HttpServiceBE::start() {
     _http_handlers.emplace_back(jit_cache_action);
 #endif
 
+#ifndef __APPLE__
     auto* datacache_action = new DataCacheAction(_cache_env->local_disk_cache(), _cache_env->local_mem_cache());
     _ev_http_server->register_handler(HttpMethod::GET, "/api/datacache/{action}", datacache_action);
     _http_handlers.emplace_back(datacache_action);
+#endif
 
     auto* pipeline_driver_poller_action = new PipelineBlockingDriversAction(_env);
     _ev_http_server->register_handler(HttpMethod::GET, "/api/pipeline_blocking_drivers/{action}",

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -15,6 +15,7 @@
 #pragma once
 #include <span>
 
+#ifndef __APPLE__
 #include "gen_cpp/lake_service.pb.h"
 
 namespace starrocks {
@@ -117,3 +118,4 @@ private:
 };
 
 } // namespace starrocks
+#endif // __APPLE__

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -32,7 +32,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <aws/core/Aws.h>
 #include <gperftools/malloc_extension.h>
 #include <sys/file.h>
 #include <unistd.h>
@@ -43,6 +42,12 @@
 
 #include <curl/curl.h>
 #include <thrift/TOutput.h>
+
+#if defined(WITH_S3) || defined(WITH_AZURE)
+#include <aws/core/Aws.h>
+
+#include "fs/s3/poco_http_client_factory.h"
+#endif
 
 #include <boost/algorithm/string.hpp>
 
@@ -55,7 +60,6 @@
 #include "common/process_exit.h"
 #include "common/status.h"
 #include "exec/pipeline/query_context.h"
-#include "fs/s3/poco_http_client_factory.h"
 #include "runtime/exec_env.h"
 #include "runtime/heartbeat_flags.h"
 #include "runtime/jdbc_driver_manager.h"
@@ -92,6 +96,7 @@ static void thrift_output(const char* x) {
 }
 } // namespace starrocks
 
+#if defined(WITH_S3) || defined(WITH_AZURE)
 static Aws::Utils::Logging::LogLevel parse_aws_sdk_log_level(const std::string& s) {
     Aws::Utils::Logging::LogLevel levels[] = {
             Aws::Utils::Logging::LogLevel::Off,   Aws::Utils::Logging::LogLevel::Fatal,
@@ -110,6 +115,7 @@ static Aws::Utils::Logging::LogLevel parse_aws_sdk_log_level(const std::string& 
     }
     return level;
 }
+#endif
 
 extern int meta_tool_main(int argc, char** argv);
 
@@ -201,6 +207,7 @@ int main(int argc, char** argv) {
         exit(-1);
     }
 
+#if defined(WITH_S3) || defined(WITH_AZURE)
     Aws::SDKOptions aws_sdk_options;
     // it is already initialized beforehead
     aws_sdk_options.httpOptions.initAndCleanupCurl = false;
@@ -217,6 +224,7 @@ int main(int argc, char** argv) {
     if (starrocks::config::enable_poco_client_for_aws_sdk) {
         Aws::Http::SetHttpClientFactory(std::make_shared<starrocks::poco::PocoHttpClientFactory>());
     }
+#endif
 
     std::vector<starrocks::StorePath> paths;
     auto olap_res = starrocks::parse_conf_store_paths(starrocks::config::storage_root_path, &paths);
@@ -262,7 +270,9 @@ int main(int argc, char** argv) {
         exit(0);
     }
 
+#if defined(WITH_S3) || defined(WITH_AZURE)
     Aws::ShutdownAPI(aws_sdk_options);
+#endif
 
     return 0;
 }

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -285,6 +285,7 @@ Status ColumnExprPredicate::try_to_rewrite_for_zone_map_filter(starrocks::Object
 }
 Status ColumnExprPredicate::seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                                 roaring::Roaring* row_bitmap) const {
+#ifndef __APPLE__
     // Only support simple (NOT) LIKE/MATCH predicate for now
     // Root must be (NOT) LIKE/MATCH, and left child must be ColumnRef, which satisfy simple (NOT) LIKE/MATCH predicate
     // format as: col (NOT) LIKE/MATCH xxx, xxx must be string literal
@@ -355,6 +356,9 @@ Status ColumnExprPredicate::seek_inverted_index(const std::string& column_name, 
         *row_bitmap &= roaring;
     }
     return Status::OK();
+#else
+    return Status::OK();
+#endif
 }
 
 Status ColumnTruePredicate::evaluate(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const {

--- a/be/src/storage/column_in_predicate.cpp
+++ b/be/src/storage/column_in_predicate.cpp
@@ -124,6 +124,7 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         InvertedIndexQueryType query_type = InvertedIndexQueryType::EQUAL_QUERY;
         roaring::Roaring indices;
         for (auto value : _values) {
@@ -133,6 +134,9 @@ public:
         }
         *row_bitmap &= indices;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 
     bool support_original_bloom_filter() const override { return true; }
@@ -309,6 +313,7 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         InvertedIndexQueryType query_type = InvertedIndexQueryType::EQUAL_QUERY;
         roaring::Roaring indices;
         for (const std::string& s : _zero_padded_strs) {
@@ -319,6 +324,9 @@ public:
         }
         *row_bitmap &= indices;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 
     bool support_original_bloom_filter() const override { return true; }

--- a/be/src/storage/column_null_predicate.cpp
+++ b/be/src/storage/column_null_predicate.cpp
@@ -80,10 +80,14 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         roaring::Roaring null_roaring;
         RETURN_IF_ERROR(iterator->read_null(column_name, &null_roaring));
         *row_bitmap &= null_roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 
     bool support_original_bloom_filter() const override { return true; }
@@ -159,10 +163,14 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         roaring::Roaring null_roaring;
         RETURN_IF_ERROR(iterator->read_null(column_name, &null_roaring));
         *row_bitmap -= null_roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 
     PredicateType type() const override { return PredicateType::kNotNull; }

--- a/be/src/storage/column_predicate_cmp.cpp
+++ b/be/src/storage/column_predicate_cmp.cpp
@@ -309,11 +309,15 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         InvertedIndexQueryType query_type = InvertedIndexQueryType::GREATER_EQUAL_QUERY;
         roaring::Roaring roaring;
         RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &this->_value, query_type, &roaring));
         *row_bitmap &= roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 
     Status convert_to(const ColumnPredicate** output, const TypeInfoPtr& target_type_info,
@@ -355,11 +359,15 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         InvertedIndexQueryType query_type = InvertedIndexQueryType::GREATER_THAN_QUERY;
         roaring::Roaring roaring;
         RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &this->_value, query_type, &roaring));
         *row_bitmap &= roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 
     Status convert_to(const ColumnPredicate** output, const TypeInfoPtr& target_type_info,
@@ -402,11 +410,15 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         InvertedIndexQueryType query_type = InvertedIndexQueryType::LESS_EQUAL_QUERY;
         roaring::Roaring roaring;
         RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &this->_value, query_type, &roaring));
         *row_bitmap &= roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 
     Status convert_to(const ColumnPredicate** output, const TypeInfoPtr& target_type_info,
@@ -449,11 +461,15 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         InvertedIndexQueryType query_type = InvertedIndexQueryType::LESS_THAN_QUERY;
         roaring::Roaring roaring;
         RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &this->_value, query_type, &roaring));
         *row_bitmap &= roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 
     Status convert_to(const ColumnPredicate** output, const TypeInfoPtr& target_type_info,
@@ -498,11 +514,15 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         InvertedIndexQueryType query_type = InvertedIndexQueryType::EQUAL_QUERY;
         roaring::Roaring roaring;
         RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &this->_value, query_type, &roaring));
         *row_bitmap &= roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 
     bool support_original_bloom_filter() const override { return true; }
@@ -549,11 +569,15 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         InvertedIndexQueryType query_type = InvertedIndexQueryType::EQUAL_QUERY;
         roaring::Roaring roaring;
         RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &this->_value, query_type, &roaring));
         *row_bitmap -= roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 
     Status convert_to(const ColumnPredicate** output, const TypeInfoPtr& target_type_info,
@@ -726,12 +750,16 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         Slice padded_value(Base::_zero_padded_str);
         InvertedIndexQueryType query_type = InvertedIndexQueryType::EQUAL_QUERY;
         roaring::Roaring roaring;
         RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &padded_value, query_type, &roaring));
         *row_bitmap &= roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 };
 
@@ -770,12 +798,16 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         Slice padded_value(Base::_zero_padded_str);
         InvertedIndexQueryType query_type = InvertedIndexQueryType::GREATER_EQUAL_QUERY;
         roaring::Roaring roaring;
         RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &padded_value, query_type, &roaring));
         *row_bitmap &= roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 };
 
@@ -813,12 +845,16 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         Slice padded_value(Base::_zero_padded_str);
         InvertedIndexQueryType query_type = InvertedIndexQueryType::GREATER_THAN_QUERY;
         roaring::Roaring roaring;
         RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &padded_value, query_type, &roaring));
         *row_bitmap &= roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 };
 
@@ -857,12 +893,16 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         Slice padded_value(Base::_zero_padded_str);
         InvertedIndexQueryType query_type = InvertedIndexQueryType::LESS_THAN_QUERY;
         roaring::Roaring roaring;
         RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &padded_value, query_type, &roaring));
         *row_bitmap &= roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 };
 
@@ -900,12 +940,16 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         Slice padded_value(Base::_zero_padded_str);
         InvertedIndexQueryType query_type = InvertedIndexQueryType::LESS_EQUAL_QUERY;
         roaring::Roaring roaring;
         RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &padded_value, query_type, &roaring));
         *row_bitmap &= roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 };
 
@@ -928,12 +972,16 @@ public:
 
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override {
+#ifndef __APPLE__
         Slice padded_value(Base::_zero_padded_str);
         InvertedIndexQueryType query_type = InvertedIndexQueryType::EQUAL_QUERY;
         roaring::Roaring roaring;
         RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &padded_value, query_type, &roaring));
         *row_bitmap -= roaring;
         return Status::OK();
+#else
+        return Status::OK();
+#endif
     }
 };
 

--- a/be/src/storage/kv_store.cpp
+++ b/be/src/storage/kv_store.cpp
@@ -94,14 +94,18 @@ int64_t KVStore::calc_rocksdb_write_buffer_size(MemTracker* mem_tracker) {
     int64_t total_mem_bytes = mem_tracker->limit();
     // 3. Calculate the write buffer memory bytes
     int64_t write_buffer_mem_bytes =
-            total_mem_bytes * std::max(std::min(100L, config::rocksdb_write_buffer_memory_percent), 0L) / 100L;
+            total_mem_bytes *
+            std::max(std::min(static_cast<int64_t>(100),
+                              static_cast<int64_t>(config::rocksdb_write_buffer_memory_percent)),
+                     static_cast<int64_t>(0)) /
+            100;
     // 4. Calculate the write buffer size for each disk, and there will be 2 memtables by default,
     //    so we will divide it by 2
-    int64_t write_buffer_mem_bytes_per_disk = write_buffer_mem_bytes / std::max(disk_cnt, 1L) / 2;
+    int64_t write_buffer_mem_bytes_per_disk = write_buffer_mem_bytes / std::max(disk_cnt, static_cast<int64_t>(1)) / 2;
 
     // should be around 64MB ~ 1GB rocksdb_max_write_buffer_memory_bytes
-    int64_t res = std::min(std::max(67108864L, write_buffer_mem_bytes_per_disk),
-                           config::rocksdb_max_write_buffer_memory_bytes);
+    int64_t res = std::min(std::max(static_cast<int64_t>(67108864), write_buffer_mem_bytes_per_disk),
+                           static_cast<int64_t>(config::rocksdb_max_write_buffer_memory_bytes));
 
     LOG(INFO) << "rocksdb write buffer size: " << res << ", total memory: " << total_mem_bytes
               << ", disk count: " << disk_cnt;

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2185,7 +2185,9 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         size_t snapshot_size = _index_file->size();
         // special case, snapshot file was written by phmap::BinaryOutputArchive which does not use system profiled API
         // so add write stats manually
+#ifndef __APPLE__
         IOProfiler::add_write(snapshot_size, watch.elapsed_time());
+#endif
         meta->clear_wals();
         IndexSnapshotMetaPB* snapshot = meta->mutable_snapshot();
         version.to_pb(snapshot->mutable_version());
@@ -2273,7 +2275,9 @@ Status ShardByLengthMutableIndex::load(const MutableIndexMetaPB& meta) {
         RETURN_IF_ERROR(load_snapshot(ar, dumped_shard_idxes));
         // special case, snapshot file was written by phmap::BinaryOutputArchive which does not use system profiled API
         // so add read stats manually
+#ifndef __APPLE__
         IOProfiler::add_read(snapshot_size, watch.elapsed_time());
+#endif
     }
     // if mutable index is empty, set _offset as 0, otherwise set _offset as snapshot size
     _offset = snapshot_off + snapshot_size;
@@ -3785,7 +3789,9 @@ public:
               _io_stat_entry(io_stat_entry) {}
 
     void run() override {
+#ifndef __APPLE__
         auto scope = IOProfiler::scope(_io_stat_entry);
+#endif
         WARN_IF_ERROR(_index->get_from_one_immutable_index(_immu_index, _num, _keys, _values, _keys_info_by_key_size,
                                                            _found_keys_info),
                       "Failed to run GetFromImmutableIndexTask");

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -55,7 +55,7 @@
 #include "runtime/types.h"
 #include "storage/column_predicate.h"
 #include "storage/index/index_descriptor.h"
-#ifndef MACOS_DISABLE_CLUCENE
+#ifndef __APPLE__
 #include "storage/index/inverted/inverted_plugin_factory.h"
 #endif
 #include "storage/rowset/array_column_iterator.h"
@@ -536,7 +536,7 @@ Status ColumnReader::_load_inverted_index(const std::shared_ptr<TabletIndex>& in
         return Status::OK();
     }
 
-#ifndef MACOS_DISABLE_CLUCENE
+#ifndef __APPLE__
     SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
     return success_once(_inverted_index_load_once,
                         [&]() {

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -42,7 +42,7 @@
 #include "gutil/strings/substitute.h"
 #include "simd/simd.h"
 #include "storage/index/inverted/inverted_index_option.h"
-#ifndef MACOS_DISABLE_CLUCENE
+#ifndef __APPLE__
 #include "storage/index/inverted/inverted_plugin_factory.h"
 #endif
 #include "storage/rowset/array_column_writer.h"
@@ -428,7 +428,7 @@ Status ScalarColumnWriter::init() {
         }
         RETURN_IF_ERROR(BloomFilterIndexWriter::create(bf_options, _type_info, &_bloom_filter_index_builder));
     }
-#ifndef MACOS_DISABLE_CLUCENE
+#ifndef __APPLE__
     if (_opts.need_inverted_index) {
         _has_index_builder = true;
         TabletIndex& inverted_tablet_index = _opts.tablet_index.at(GIN);
@@ -466,7 +466,7 @@ uint64_t ScalarColumnWriter::estimate_buffer_size() {
     if (_bloom_filter_index_builder != nullptr) {
         size += _bloom_filter_index_builder->size();
     }
-#ifndef MACOS_DISABLE_CLUCENE
+#ifndef __APPLE__
     if (_inverted_index_builder != nullptr) {
         size += _inverted_index_builder->size();
     }
@@ -575,7 +575,7 @@ Status ScalarColumnWriter::write_bloom_filter_index() {
 }
 
 Status ScalarColumnWriter::write_inverted_index() {
-#ifndef MACOS_DISABLE_CLUCENE
+#ifndef __APPLE__
     if (_inverted_index_builder != nullptr) {
         return _inverted_index_builder->finish();
     }
@@ -788,14 +788,14 @@ Status ScalarColumnWriter::append(const uint8_t* data, const uint8_t* null_flags
                     INDEX_ADD_NULLS(_zone_map_index_builder, run);
                     INDEX_ADD_NULLS(_bitmap_index_builder, run);
                     INDEX_ADD_NULLS(_bloom_filter_index_builder, run);
-#ifndef MACOS_DISABLE_CLUCENE
+#ifndef __APPLE__
                     INDEX_ADD_NULLS(_inverted_index_builder, run);
 #endif
                 } else {
                     INDEX_ADD_VALUES(_zone_map_index_builder, pdata, run);
                     INDEX_ADD_VALUES(_bitmap_index_builder, pdata, run);
                     INDEX_ADD_VALUES(_bloom_filter_index_builder, pdata, run);
-#ifndef MACOS_DISABLE_CLUCENE
+#ifndef __APPLE__
                     INDEX_ADD_VALUES(_inverted_index_builder, pdata, run);
 #endif
                 }
@@ -805,7 +805,7 @@ Status ScalarColumnWriter::append(const uint8_t* data, const uint8_t* null_flags
             INDEX_ADD_VALUES(_zone_map_index_builder, data, num_written);
             INDEX_ADD_VALUES(_bitmap_index_builder, data, num_written);
             INDEX_ADD_VALUES(_bloom_filter_index_builder, data, num_written);
-#ifndef MACOS_DISABLE_CLUCENE
+#ifndef __APPLE__
             INDEX_ADD_VALUES(_inverted_index_builder, data, num_written);
 #endif
         }

--- a/be/src/storage/rowset/column_writer.h
+++ b/be/src/storage/rowset/column_writer.h
@@ -44,7 +44,7 @@
 #include "gutil/strings/substitute.h"
 #include "runtime/global_dict/types.h"
 #include "runtime/global_dict/types_fwd_decl.h"
-#ifndef MACOS_DISABLE_CLUCENE
+#ifndef __APPLE__
 #include "storage/index/inverted/inverted_writer.h"
 #endif
 #include "storage/rowset/binary_dict_page.h"
@@ -303,7 +303,7 @@ private:
     std::unique_ptr<ZoneMapIndexWriter> _zone_map_index_builder;
     std::unique_ptr<BitmapIndexWriter> _bitmap_index_builder;
     std::unique_ptr<BloomFilterIndexWriter> _bloom_filter_index_builder;
-#ifndef MACOS_DISABLE_CLUCENE
+#ifndef __APPLE__
     std::unique_ptr<InvertedWriter> _inverted_index_builder;
 #endif
 

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -174,7 +174,11 @@ Status read_and_decompress_page_internal(const PageReadOptions& opts, PageHandle
     opts.stats->total_pages_num++;
 
     auto cache = StoragePageCache::instance();
+#ifdef __APPLE__
+    bool page_cache_available = false;
+#else
     bool page_cache_available = (cache != nullptr) && cache->available();
+#endif
     PageCacheHandle cache_handle;
     std::string cache_key = encode_cache_key(opts.read_file->filename(), opts.page_pointer.offset);
     if (opts.use_page_cache && page_cache_available && cache->lookup(cache_key, &cache_handle)) {

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -47,7 +47,9 @@
 #include "runtime/exec_env.h"
 #include "storage/del_vector.h"
 #include "storage/index/index_descriptor.h"
+#ifndef __APPLE__
 #include "storage/index/inverted/clucene/clucene_plugin.h"
+#endif
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_id_generator.h"
@@ -206,6 +208,7 @@ Status SnapshotManager::convert_rowset_ids(const string& clone_dir, int64_t tabl
     std::vector<std::string> all_files;
     std::vector<std::string> new_inverted_index_files;
     RETURN_IF_ERROR(FileSystem::Default()->get_children(clone_dir, &all_files));
+#ifndef __APPLE__
     for (const auto& file : all_files) {
         if (CLucenePlugin::is_index_files(file)) {
             auto* p1 = (char*)std::memchr(file.data(), '_', file.size());
@@ -230,6 +233,7 @@ Status SnapshotManager::convert_rowset_ids(const string& clone_dir, int64_t tabl
                                                                inverted_index_path + "/" + new_file_name));
         }
     }
+#endif
 
     std::unordered_map<string, string> old_to_new_rowsetid;
 

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -415,6 +415,9 @@ void StorageEngine::_start_disk_stat_monitor() {
 
 // TODO(lingbin): Should be in EnvPosix?
 Status StorageEngine::_check_file_descriptor_number() {
+#ifdef __APPLE__
+    LOG(INFO) << "File descriptor check skipped on macOS";
+#else
     struct rlimit l;
     int ret = getrlimit(RLIMIT_NOFILE, &l);
     if (ret != 0) {
@@ -427,6 +430,7 @@ Status StorageEngine::_check_file_descriptor_number() {
                    << config::min_file_descriptor_number;
         return Status::InternalError("file descriptors limit is too small");
     }
+#endif
     return Status::OK();
 }
 

--- a/be/src/util/brpc_stub_cache.cpp
+++ b/be/src/util/brpc_stub_cache.cpp
@@ -16,7 +16,9 @@
 
 #include "common/config.h"
 #include "gen_cpp/internal_service.pb.h"
+#ifndef __APPLE__
 #include "gen_cpp/lake_service.pb.h"
+#endif
 #include "runtime/exec_env.h"
 #include "util/failpoint/fail_point.h"
 #include "util/starrocks_metrics.h"
@@ -214,6 +216,8 @@ void HttpBrpcStubCache::cleanup_expired(const butil::EndPoint& endpoint) {
     _stub_map.erase(endpoint);
 }
 
+#ifndef __APPLE__
+
 LakeServiceBrpcStubCache* LakeServiceBrpcStubCache::getInstance() {
     static LakeServiceBrpcStubCache cache;
     return &cache;
@@ -298,5 +302,6 @@ void LakeServiceBrpcStubCache::cleanup_expired(const butil::EndPoint& endpoint) 
     LOG(INFO) << "cleanup lake service brpc stub, endpoint:" << endpoint;
     _stub_map.erase(endpoint);
 }
+#endif
 
 } // namespace starrocks

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -43,9 +43,12 @@
 #include "gen_cpp/Types_types.h" // TNetworkAddress
 #include "service/brpc.h"
 #include "util/internal_service_recoverable_stub.h"
-#include "util/lake_service_recoverable_stub.h"
 #include "util/network_util.h"
 #include "util/spinlock.h"
+
+#ifndef __APPLE__
+#include "util/lake_service_recoverable_stub.h"
+#endif
 
 namespace starrocks {
 
@@ -110,6 +113,7 @@ private:
     pipeline::PipelineTimer* _pipeline_timer;
 };
 
+#ifndef __APPLE__
 class LakeServiceBrpcStubCache {
 public:
     static LakeServiceBrpcStubCache* getInstance();
@@ -129,5 +133,6 @@ private:
             _stub_map;
     pipeline::PipelineTimer* _pipeline_timer;
 };
+#endif
 
 } // namespace starrocks

--- a/be/src/util/compression/block_compression.cpp
+++ b/be/src/util/compression/block_compression.cpp
@@ -39,18 +39,15 @@
 #ifdef __x86_64__
 #include <libdeflate.h>
 #endif
-#include <lz4/lz4.h>
-#include <lz4/lz4frame.h>
 #include <snappy/snappy-sinksource.h>
 #include <snappy/snappy.h>
 #include <zlib.h>
-#include <zstd/zstd.h>
-#include <zstd/zstd_errors.h>
 
 #include "gutil/endian.h"
 #include "gutil/strings/substitute.h"
 #include "util/coding.h"
 #include "util/compression/compression_context_pool_singletons.h"
+#include "util/compression/compression_headers.h"
 #include "util/faststring.h"
 namespace orc {
 uint64_t lzoDecompress(const char* inputAddress, const char* inputLimit, char* outputAddress, char* outputLimit);

--- a/be/src/util/compression/compression_context.h
+++ b/be/src/util/compression/compression_context.h
@@ -14,11 +14,7 @@
 
 #pragma once
 
-#include <lz4/lz4.h>
-#include <lz4/lz4frame.h>
-#include <zstd/zstd.h>
-#include <zstd/zstd_errors.h>
-
+#include "util/compression/compression_headers.h"
 #include "util/faststring.h"
 
 namespace starrocks::compression {

--- a/be/src/util/compression/compression_headers.h
+++ b/be/src/util/compression/compression_headers.h
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Platform-specific header includes for compression libraries
+// On macOS (Homebrew), headers are installed without subdirectories
+// On Linux (thirdparty), headers are in subdirectories
+
+#ifdef STARROCKS_MACOS_USE_FLAT_INCLUDES
+// macOS: Homebrew installs headers as /opt/homebrew/opt/lz4/include/lz4.h
+#include <lz4.h>
+#include <lz4frame.h>
+#include <lz4hc.h>
+#include <zstd.h>
+#include <zstd_errors.h>
+#else
+// Linux: thirdparty installs headers as include/lz4/lz4.h
+#include <lz4/lz4.h>
+#include <lz4/lz4frame.h>
+#include <lz4/lz4hc.h>
+#include <zstd/zstd.h>
+#include <zstd/zstd_errors.h>
+#endif

--- a/be/src/util/compression/stream_compression.cpp
+++ b/be/src/util/compression/stream_compression.cpp
@@ -35,15 +35,8 @@
 #include "util/compression/stream_compression.h"
 
 #include <bzlib.h>
-#include <lz4/lz4frame.h>
 #include <snappy/snappy.h>
 #include <zlib.h>
-#include <zstd/zstd.h>
-#ifdef __APPLE__
-#include <zstd_errors.h>
-#else
-#include <zstd/zstd_errors.h>
-#endif
 
 #include <memory>
 
@@ -51,6 +44,7 @@
 #include "gutil/strings/substitute.h"
 #include "util/coding.h"
 #include "util/compression/compression_context_pool_singletons.h"
+#include "util/compression/compression_headers.h"
 
 namespace orc {
 uint64_t lzoDecompress(const char* inputAddress, const char* inputLimit, char* outputAddress, char* outputLimit);

--- a/be/src/util/cpu_usage_info.cpp
+++ b/be/src/util/cpu_usage_info.cpp
@@ -55,7 +55,9 @@ int CpuUsageRecorder::cpu_used_permille() const {
 uint64_t CpuUsageRecorder::_get_proc_time() {
     FILE* fp = fopen("/proc/self/stat", "r");
     if (fp == nullptr) {
+#ifndef __APPLE__
         LOG(WARNING) << "open /proc/self/stat failed";
+#endif
         return 0;
     }
     DeferOp close_fp([fp] { fclose(fp); });

--- a/be/src/util/lru_cache.cpp
+++ b/be/src/util/lru_cache.cpp
@@ -218,7 +218,7 @@ uint64_t LRUCache::get_release_evict_count() const {
     return _release_evict_count;
 }
 
-size_t LRUCache::get_usage() const {
+uint64_t LRUCache::get_usage() const {
     std::lock_guard l(_mutex);
     return _usage;
 }
@@ -491,13 +491,14 @@ uint64_t ShardedLRUCache::new_id() {
     return ++(_last_id);
 }
 
-size_t ShardedLRUCache::_get_stat(size_t (LRUCache::*mem_fun)() const) const {
-    size_t n = 0;
+size_t ShardedLRUCache::_get_stat(uint64_t (LRUCache::*mem_fun)() const) const {
+    uint64_t n = 0;
     for (auto& shard : _shards) {
         n += (shard.*mem_fun)();
     }
-    return n;
+    return static_cast<size_t>(n);
 }
+
 size_t ShardedLRUCache::get_capacity() const {
     std::lock_guard l(_mutex);
     return _capacity;

--- a/be/src/util/lru_cache.h
+++ b/be/src/util/lru_cache.h
@@ -284,7 +284,7 @@ public:
     uint64_t get_insert_count() const;
     uint64_t get_insert_evict_count() const;
     uint64_t get_release_evict_count() const;
-    size_t get_usage() const;
+    uint64_t get_usage() const;
     size_t get_capacity() const;
     static size_t key_handle_size(const CacheKey& key) { return sizeof(LRUHandle) - 1 + key.size(); }
 
@@ -348,7 +348,7 @@ private:
     static uint32_t _hash_slice(const CacheKey& s);
     static uint32_t _shard(uint32_t hash);
     void _set_capacity(size_t capacity);
-    size_t _get_stat(size_t (LRUCache::*mem_fun)() const) const;
+    size_t _get_stat(uint64_t (LRUCache::*mem_fun)() const) const;
 
     LRUCache _shards[kNumShards];
     mutable std::mutex _mutex;

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -79,7 +79,7 @@ struct StackTraceTask {
             char buf[1024];
             bool success = false;
             // symbolize costs a lot of time, so mock it in test mode
-#ifndef BE_TEST
+#if !defined(BE_TEST) && !defined(__APPLE__)
             success = google::glog_internal_namespace_::Symbolize(addrs[i], buf, sizeof(buf));
 #else
             std::tuple<void*, char*, size_t> tuple = {addrs[i], buf, sizeof(buf)};
@@ -449,7 +449,7 @@ void __wrap___cxa_throw(void* thrown_exception, void* info, void (*dest)(void*))
     }
     // call the real __cxa_throw():
 
-#if defined(ADDRESS_SANITIZER)
+#if defined(ADDRESS_SANITIZER) && !defined(__APPLE__)
     __interceptor___cxa_throw(thrown_exception, info, dest);
 #else
     __real___cxa_throw(thrown_exception, info, dest);

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -279,7 +279,7 @@ void StarRocksMetrics::initialize(const std::vector<std::string>& paths, bool in
         _system_metrics.install(&_metrics, disk_devices, network_interfaces);
     }
 
-#ifndef MACOS_DISABLE_JAVA
+#ifndef __APPLE__
     if (init_jvm_metrics) {
         auto status = _jvm_metrics.init();
         if (!status.ok()) {

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -40,7 +40,7 @@
 #include <vector>
 
 #include "exec/pipeline/pipeline_metrics.h"
-#ifndef MACOS_DISABLE_JAVA
+#ifndef __APPLE__
 #include "util/jvm_metrics.h"
 #endif
 #include "util/metrics.h"
@@ -430,7 +430,7 @@ private:
 
     MetricRegistry _metrics;
     SystemMetrics _system_metrics;
-#ifndef MACOS_DISABLE_JAVA
+#ifndef __APPLE__
     JVMMetrics _jvm_metrics;
 #endif
     TableMetricsManager _table_metrics_mgr;

--- a/build-mac/CMakeLists.txt
+++ b/build-mac/CMakeLists.txt
@@ -385,34 +385,9 @@ set_target_properties(lz4 PROPERTIES
     IMPORTED_LOCATION ${LZ4_LIB}
     INTERFACE_INCLUDE_DIRECTORIES /opt/homebrew/opt/lz4/include)
 
-# Create a symlink in build directory to satisfy lz4/lz4.h include pattern
-execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory
-    ${CMAKE_BINARY_DIR}/lz4_symlinks/lz4
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-# Create symlinks for LZ4 headers to satisfy lz4/lz4.h include pattern
-execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-    /opt/homebrew/opt/lz4/include/lz4.h
-    ${CMAKE_BINARY_DIR}/lz4_symlinks/lz4/lz4.h
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-    /opt/homebrew/opt/lz4/include/lz4hc.h
-    ${CMAKE_BINARY_DIR}/lz4_symlinks/lz4/lz4hc.h
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-    /opt/homebrew/opt/lz4/include/lz4frame.h
-    ${CMAKE_BINARY_DIR}/lz4_symlinks/lz4/lz4frame.h
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-    /opt/homebrew/opt/lz4/include/lz4file.h
-    ${CMAKE_BINARY_DIR}/lz4_symlinks/lz4/lz4file.h
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-# Add the symlink directory to include paths
-include_directories(${CMAKE_BINARY_DIR}/lz4_symlinks)
+# On macOS, Homebrew installs headers without subdirectory
+# Add macro to use direct includes instead of subdirectory includes
+add_compile_definitions(STARROCKS_MACOS_USE_FLAT_INCLUDES=1)
 
 # Homebrew libraries - zstd
 find_library(ZSTD_LIB NAMES zstd PATHS /opt/homebrew/lib REQUIRED)
@@ -420,19 +395,6 @@ add_library(zstd STATIC IMPORTED GLOBAL)
 set_target_properties(zstd PROPERTIES
     IMPORTED_LOCATION ${ZSTD_LIB}
     INTERFACE_INCLUDE_DIRECTORIES /opt/homebrew/opt/zstd/include)
-
-# Create symlinks for zstd headers to satisfy zstd/zstd.h include pattern
-execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory
-    ${CMAKE_BINARY_DIR}/zstd_symlinks/zstd
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-    /opt/homebrew/opt/zstd/include/zstd.h
-    ${CMAKE_BINARY_DIR}/zstd_symlinks/zstd/zstd.h
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-# Add the symlink directory to include paths
-include_directories(${CMAKE_BINARY_DIR}/zstd_symlinks)
 
 # zlib (from homebrew) - use dynamic lookup
 find_library(ZLIB_LIB NAMES z PATHS
@@ -477,6 +439,11 @@ add_library(vectorscan STATIC IMPORTED GLOBAL)
 set_target_properties(vectorscan PROPERTIES
     IMPORTED_LOCATION ${THIRDPARTY_DIR}/installed/lib/libhs.a
     INTERFACE_INCLUDE_DIRECTORIES ${THIRDPARTY_DIR}/installed/include)
+
+# roaring bitmap - use only compiled static library from thirdparty
+find_library(ROARING_LIB NAMES libroaring.a PATHS
+    ${THIRDPARTY_DIR}/installed/lib
+    NO_DEFAULT_PATH)
 
 # roaring bitmap - use only compiled static library from thirdparty
 find_library(ROARING_LIB NAMES libroaring.a PATHS
@@ -1102,12 +1069,9 @@ list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*/exec/pipeline/sink/connector_sin
 set(MACOS_SHIM_SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/shims/src/gperftools_stubs.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/shims/src/bitset_resize.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/shims/src/bitshuffle_shims.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/shims/src/symbol_provider.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/shims/src/variant_shims.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/shims/src/sinks_shim.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/shims/src/connector_shims.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/shims/src/connector_core_shim.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/shims/src/disabled_components_shim.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/shims/src/tracer_shim.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/shims/src/lake_manager_stub.cpp"

--- a/build-mac/build_thirdparty.sh
+++ b/build-mac/build_thirdparty.sh
@@ -261,7 +261,6 @@ ASYNC_PROFILER_DOWNLOAD="https://github.com/async-profiler/async-profiler/releas
 ASYNC_PROFILER_NAME="async-profiler-4.1-macos.zip"
 ASYNC_PROFILER_SOURCE="async-profiler-4.1-macos"
 
-
 download_source() {
     local name="$1"
     local version="$2"

--- a/build-mac/shims/include/starrocks_macos_fmt_shims.h
+++ b/build-mac/shims/include/starrocks_macos_fmt_shims.h
@@ -64,6 +64,11 @@
 #include <string_view>
 #include <libgen.h> // ensure basename() is declared on macOS
 
+// Fix for typeof compatibility on Clang/macOS - typeof is GCC extension
+#ifndef typeof
+#define typeof __typeof__
+#endif
+
 // Prefer the lightweight format_as customization point added in fmt >= 10.
 // It lets fmt format our types via ADL by converting them to a formattable type.
 namespace starrocks {


### PR DESCRIPTION
## Why I'm doing:
For https://github.com/StarRocks/starrocks/issues/30438

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds macOS support by gating unsupported features, introducing platform-specific shims and build changes, and fixing small bugs to allow basic insert/select to run.
> 
> - **Platform/macOS support**:
>   - Widespread `#ifdef __APPLE__`/feature flags to disable unsupported subsystems (Lake, Iceberg, Pulsar, DataCache, Arrow Flight, some UDAF paths, IO profiling) with graceful NotSupported paths.
>   - macOS-specific thread ID/name handling, libevent user_data usage, fsync fallback, and signal/stack trace adjustments.
>   - Introduce `compression_headers.h` and `STARROCKS_MACOS_USE_FLAT_INCLUDES` for LZ4/ZSTD includes.
> - **Build/Tooling**:
>   - Simplify Homebrew header handling (remove symlink hacks), add flat-include macro; update build scripts to copy gensrc via rsync.
> - **Connectors/FS**:
>   - Conditional includes for Parquet/ORC/AVRO/MySQL/HDFS/S3/Azure; gate Iceberg/JDBC registration and sinks on macOS.
> - **Runtime/Services**:
>   - Skip/stub routine load, datacache endpoints, Lake service, Arrow Flight on macOS; add NotSupported responses where applicable.
> - **Storage/IO fixes**:
>   - Avoid use-after-free in `FixedLengthColumnBase::assign`.
>   - Fix page read buffer sizing and disable risky binary page cache optimization on macOS.
>   - Change `LRUCache::get_usage` to `uint64_t` and adjust aggregation.
> - **Misc**:
>   - Cast tracing attributes to `uint64_t`.
>   - Misc guards for jemalloc/heap profiling and CPU/proc access; minor include tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23379724e5562de191e7d46c08b4555bc69c9b50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->