### PR TITLE
[Tool] print segment id in pk column dump

### DIFF
--- a/be/src/storage/primary_key_dump.cpp
+++ b/be/src/storage/primary_key_dump.cpp
@@ -344,7 +344,7 @@ Status PrimaryKeyDump::read_deserialize_from_file(const std::string& dump_filepa
 
 Status PrimaryKeyDump::deserialize_pkcol_pkindex_from_meta(
         const std::string& dump_filepath, const PrimaryKeyDumpPB& dump_pb,
-        const std::function<void(const Chunk&)>& column_key_func,
+        const std::function<void(uint32_t, const Chunk&)>& column_key_func,
         const std::function<void(const std::string&, const PartialKVsPB&)>& index_kvs_func) {
     std::unique_ptr<RandomAccessFile> rfile;
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dump_filepath));
@@ -367,7 +367,7 @@ Status PrimaryKeyDump::deserialize_pkcol_pkindex_from_meta(
             } else if (!st.ok()) {
                 return st;
             } else {
-                column_key_func(*chunk);
+                column_key_func(primary_key_column.segment_id(), *chunk);
             }
         }
     }

--- a/be/src/storage/primary_key_dump.h
+++ b/be/src/storage/primary_key_dump.h
@@ -84,7 +84,7 @@ public:
     // deserialize pk column and pk index from dump file.
     static Status deserialize_pkcol_pkindex_from_meta(
             const std::string& dump_filepath, const PrimaryKeyDumpPB& dump_pb,
-            const std::function<void(const Chunk&)>& column_key_func,
+            const std::function<void(uint32_t, const Chunk&)>& column_key_func,
             const std::function<void(const std::string&, const PartialKVsPB&)>& index_kvs_func);
 
     std::string dump_filepath() const { return _dump_filepath; }

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -1337,9 +1337,9 @@ int meta_tool_main(int argc, char** argv) {
         std::cout << "[pk dump] meta: " << dump_pb.Utf8DebugString() << std::endl;
         st = starrocks::PrimaryKeyDump::deserialize_pkcol_pkindex_from_meta(
                 FLAGS_file, dump_pb,
-                [&](const starrocks::Chunk& chunk) {
+                [&](uint32_t segment_id, const starrocks::Chunk& chunk) {
                     for (int i = 0; i < chunk.num_rows(); i++) {
-                        std::cout << "pk column " << chunk.debug_row(i) << std::endl;
+                        std::cout << "pk column: " << chunk.debug_row(i) << " segmentid: " << segment_id << std::endl;
                     }
                 },
                 [&](const std::string& filename, const starrocks::PartialKVsPB& kvs) {

--- a/be/test/storage/primary_index_test.cpp
+++ b/be/test/storage/primary_index_test.cpp
@@ -51,7 +51,7 @@ void test_pk_dump(PrimaryIndex* pk_index, const std::map<std::string, uint64_t>&
     {
         // read primary index dump
         ASSERT_TRUE(PrimaryKeyDump::deserialize_pkcol_pkindex_from_meta(
-                            kPrimaryIndexDumpFile, dump_pb, [&](const starrocks::Chunk& chunk) {},
+                            kPrimaryIndexDumpFile, dump_pb, [&](uint32_t segment_id, const starrocks::Chunk& chunk) {},
                             [&](const std::string& filename, const starrocks::PartialKVsPB& kvs) {
                                 for (int i = 0; i < kvs.keys_size(); i++) {
                                     auto search =

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -860,7 +860,7 @@ void TabletUpdatesTest::test_pk_dump(size_t rowset_cnt) {
         starrocks::PrimaryKeyDumpPB dump_pb;
         ASSERT_TRUE(PrimaryKeyDump::read_deserialize_from_file(dump_filepath, &dump_pb).ok());
         ASSERT_TRUE(PrimaryKeyDump::deserialize_pkcol_pkindex_from_meta(
-                            dump_filepath, dump_pb, [&](const starrocks::Chunk& chunk) {},
+                            dump_filepath, dump_pb, [&](uint32_t segment_id, const starrocks::Chunk& chunk) {},
                             [&](const std::string& filename, const starrocks::PartialKVsPB& kvs) {})
                             .ok());
         ASSERT_TRUE(dump_pb.tablet_meta().tablet_id() == _tablet->tablet_id());


### PR DESCRIPTION
## Why I'm doing:
print segment id in pk column dump

## What I'm doing:
This pull request updates the way primary key column data is processed during deserialization to include the associated `segment_id` for each chunk. This enhancement improves traceability and debugging by allowing consumers of the deserialization function to know which segment each chunk belongs to. The changes affect the function signature, its usage in tooling, and related tests.

### API and Function Signature Changes

* Modified the signature of `PrimaryKeyDump::deserialize_pkcol_pkindex_from_meta` in both `primary_key_dump.h` and `primary_key_dump.cpp` to accept a callback that takes an additional `uint32_t segment_id` parameter alongside the `Chunk`. [[1]](diffhunk://#diff-c62fd70ed1f42dd1e71cbea0da1e0afc0d51ce79a2117fe32acfdb02811b3a3bL87-R87) [[2]](diffhunk://#diff-6d8cfc8daa6b47229abe4e42d3bd7d8356ca2429d6ead5ca10f801acd1e1b637L347-R347)

### Usage and Debugging Improvements

* Updated the implementation in `primary_key_dump.cpp` to pass the `segment_id` to the callback when processing primary key columns, improving traceability of data to its segment.
* Enhanced the debug output in `meta_tool.cpp` to print both the primary key column data and its associated `segment_id`, making it easier to debug and analyze dump files.

### Test Updates

* Refactored all usages of the deserialization function in test files (`primary_index_test.cpp` and `tablet_updates_test.cpp`) to match the new callback signature, ensuring tests remain valid and up-to-date. [[1]](diffhunk://#diff-b5fffcce7d782a1e6fdb83b9b3c43a53fcf506bb7dac53f282be03566ac8dd85L54-R54) [[2]](diffhunk://#diff-6166ac5aa26092995208c10d107cab4a3dc95449253a74d80f795561766c41e0L863-R863)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
