### PR TITLE
[UT] apply incremental cov to BE 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ build-mac/CMakeFiles/
 build-mac/build.ninja
 build-mac/build_version.cc
 build-mac/cmake_install.cmake
+
+# GCOV incremental coverage debug files
+.gcov_incremental_debug.txt

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -79,7 +79,6 @@ endif()
 message(STATUS "make test: ${MAKE_TEST}")
 
 option(WITH_GCOV "Build binary with gcov to get code coverage" OFF)
-option(WITH_GCOV_INCREMENTAL "Build binary with gcov only for changed files" OFF)
 
 option(WITH_COMPRESS "Build binary with compresss debug section" ON)
 
@@ -741,10 +740,8 @@ set(CXX_GCC_FLAGS "${CXX_GCC_FLAGS} -g -Wno-unused-local-typedefs")
 if (WITH_GCOV)
     # To generate flags to code coverage
     set(CXX_GCC_FLAGS "${CXX_GCC_FLAGS} -fprofile-arcs -ftest-coverage")
-endif()
 
-# Handle incremental gcov
-if (WITH_GCOV_INCREMENTAL)
+    # Handle incremental gcov
     message(STATUS "Incremental gcov enabled")
     if (GCOV_INCREMENTAL_FILES)
         # Split the semicolon-separated list of files
@@ -1106,8 +1103,8 @@ set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS}
     ${WL_LINK_DYNAMIC} -lresolv -liberty -lc -lm -ldl -rdynamic -pthread -Wl,-wrap,__cxa_throw -Wl,-wrap,__floattidf
 )
 
-# link gcov if WITH_GCOV or WITH_GCOV_INCREMENTAL is on
-if (WITH_GCOV OR WITH_GCOV_INCREMENTAL)
+# link gcov if WITH_GCOV is on
+if (WITH_GCOV)
     set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS} --coverage)
 endif()
 

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -79,6 +79,7 @@ endif()
 message(STATUS "make test: ${MAKE_TEST}")
 
 option(WITH_GCOV "Build binary with gcov to get code coverage" OFF)
+option(WITH_GCOV_INCREMENTAL "Build binary with gcov only for changed files" OFF)
 
 option(WITH_COMPRESS "Build binary with compresss debug section" ON)
 
@@ -742,6 +743,43 @@ if (WITH_GCOV)
     set(CXX_GCC_FLAGS "${CXX_GCC_FLAGS} -fprofile-arcs -ftest-coverage")
 endif()
 
+# Handle incremental gcov
+if (WITH_GCOV_INCREMENTAL)
+    message(STATUS "Incremental gcov enabled")
+    if (GCOV_INCREMENTAL_FILES)
+        # Split the semicolon-separated list of files
+        string(REPLACE ";" " " GCOV_FILES_LIST "${GCOV_INCREMENTAL_FILES}")
+        message(STATUS "Files for incremental coverage: ${GCOV_FILES_LIST}")
+        
+        # Check if debug file exists and log its location
+        set(GCOV_DEBUG_FILE "${CMAKE_SOURCE_DIR}/.gcov_incremental_debug.txt")
+        if (EXISTS "${GCOV_DEBUG_FILE}")
+            message(STATUS "GCOV debug file available at: ${GCOV_DEBUG_FILE}")
+        endif()
+        
+        # Apply coverage flags to specific files
+        set(INSTRUMENTED_COUNT 0)
+        foreach(file IN LISTS GCOV_FILES_LIST)
+            if (file)
+                # Convert relative path to absolute path
+                set(ABSOLUTE_FILE "${CMAKE_CURRENT_SOURCE_DIR}/src/${file}")
+                if (EXISTS "${ABSOLUTE_FILE}")
+                    set_source_files_properties("${ABSOLUTE_FILE}" PROPERTIES 
+                        COMPILE_FLAGS "-fprofile-arcs -ftest-coverage")
+                    message(STATUS "Added coverage flags to: ${file}")
+                    math(EXPR INSTRUMENTED_COUNT "${INSTRUMENTED_COUNT} + 1")
+                else()
+                    message(WARNING "File not found for incremental coverage: ${ABSOLUTE_FILE}")
+                endif()
+            endif()
+        endforeach()
+        message(STATUS "Total files instrumented for incremental coverage: ${INSTRUMENTED_COUNT}")
+    else()
+        message(WARNING "Incremental gcov enabled but no files specified, falling back to full coverage")
+        set(CXX_GCC_FLAGS "${CXX_GCC_FLAGS} -fprofile-arcs -ftest-coverage")
+    endif()
+endif()
+
 if (WITH_COMPRESS)
     # to compresss debug section. https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -gz=zlib")
@@ -1068,8 +1106,8 @@ set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS}
     ${WL_LINK_DYNAMIC} -lresolv -liberty -lc -lm -ldl -rdynamic -pthread -Wl,-wrap,__cxa_throw -Wl,-wrap,__floattidf
 )
 
-# link gcov if WITH_GCOV is on
-if (WITH_GCOV)
+# link gcov if WITH_GCOV or WITH_GCOV_INCREMENTAL is on
+if (WITH_GCOV OR WITH_GCOV_INCREMENTAL)
     set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS} --coverage)
 endif()
 

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -738,9 +738,6 @@ endif()
 set(CXX_GCC_FLAGS "${CXX_GCC_FLAGS} -g -Wno-unused-local-typedefs")
 
 if (WITH_GCOV)
-    # To generate flags to code coverage
-    set(CXX_GCC_FLAGS "${CXX_GCC_FLAGS} -fprofile-arcs -ftest-coverage")
-
     # Handle incremental gcov
     message(STATUS "Incremental gcov enabled")
     if (GCOV_INCREMENTAL_FILES)
@@ -748,18 +745,16 @@ if (WITH_GCOV)
         string(REPLACE ";" " " GCOV_FILES_LIST "${GCOV_INCREMENTAL_FILES}")
         message(STATUS "Files for incremental coverage: ${GCOV_FILES_LIST}")
         
-        # Check if debug file exists and log its location
-        set(GCOV_DEBUG_FILE "${CMAKE_SOURCE_DIR}/.gcov_incremental_debug.txt")
-        if (EXISTS "${GCOV_DEBUG_FILE}")
-            message(STATUS "GCOV debug file available at: ${GCOV_DEBUG_FILE}")
-        endif()
-        
-        # Apply coverage flags to specific files
+        # Apply coverage flags to specific files only
         set(INSTRUMENTED_COUNT 0)
         foreach(file IN LISTS GCOV_FILES_LIST)
             if (file)
+                # Strip leading/trailing whitespace from file path
+                string(STRIP "${file}" file)
+                
                 # Convert relative path to absolute path
-                set(ABSOLUTE_FILE "${CMAKE_CURRENT_SOURCE_DIR}/src/${file}")
+                set(ABSOLUTE_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${file}")
+                
                 if (EXISTS "${ABSOLUTE_FILE}")
                     set_source_files_properties("${ABSOLUTE_FILE}" PROPERTIES 
                         COMPILE_FLAGS "-fprofile-arcs -ftest-coverage")
@@ -773,6 +768,7 @@ if (WITH_GCOV)
         message(STATUS "Total files instrumented for incremental coverage: ${INSTRUMENTED_COUNT}")
     else()
         message(WARNING "Incremental gcov enabled but no files specified, falling back to full coverage")
+        # Apply coverage flags to all files (full coverage mode)
         set(CXX_GCC_FLAGS "${CXX_GCC_FLAGS} -fprofile-arcs -ftest-coverage")
     endif()
 endif()

--- a/build-support/detect_incremental_files.sh
+++ b/build-support/detect_incremental_files.sh
@@ -1,20 +1,18 @@
 #!/usr/bin/env bash
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This script detects changed C++ files for incremental GCOV coverage
 # Usage: source detect_incremental_files.sh

--- a/build-support/detect_incremental_files.sh
+++ b/build-support/detect_incremental_files.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This script detects changed C++ files for incremental GCOV coverage
+# Usage: source detect_incremental_files.sh
+# Sets the following variables:
+#   GCOV_INCREMENTAL_FILES - semicolon-separated list of changed files (relative to be/)
+#   WITH_GCOV - set to ON if falling back to full coverage
+#   WITH_GCOV_INCREMENTAL - set to OFF if falling back to full coverage
+
+detect_incremental_files() {
+    local context="$1"  # "build" or "unit-test" for debug file naming
+    
+    echo "Detecting changed files for incremental coverage..."
+    
+    # Check if we're in a git repository
+    if ! git rev-parse --git-dir > /dev/null 2>&1; then
+        echo "Warning: Not in a git repository, falling back to full coverage"
+        WITH_GCOV=ON
+        WITH_GCOV_INCREMENTAL=OFF
+        GCOV_INCREMENTAL_FILES=""
+        return
+    fi
+    
+    # Try to find base branch for comparison
+    BASE_BRANCH=""
+    if git show-ref --verify --quiet refs/heads/main; then
+        BASE_BRANCH="main"
+    else
+        BASE_BRANCH="HEAD~1"
+    fi
+    
+    echo "Using base branch: $BASE_BRANCH"
+    
+    # Get changed C++ files in be/ directory
+    CHANGED_FILES=$(git diff --name-only $BASE_BRANCH...HEAD 2>/dev/null | grep -E '^be/.*\.(cpp|cc|h|hpp)$' || true)
+    
+    if [[ -z "$CHANGED_FILES" ]]; then
+        echo "No changed C++ files detected, falling back to full coverage"
+        WITH_GCOV=ON
+        WITH_GCOV_INCREMENTAL=OFF
+        GCOV_INCREMENTAL_FILES=""
+        return
+    fi
+    
+    # Count changed files
+    FILE_COUNT=$(echo "$CHANGED_FILES" | wc -l)
+    echo "Found $FILE_COUNT changed C++ files"
+    
+    # If too many files changed, fall back to full coverage
+    if [[ $FILE_COUNT -gt 1000 ]]; then
+        echo "Too many files changed ($FILE_COUNT), falling back to full coverage"
+        WITH_GCOV=ON
+        WITH_GCOV_INCREMENTAL=OFF
+        GCOV_INCREMENTAL_FILES=""
+        return
+    fi
+    
+    # Convert to CMake-friendly format (relative to be/ directory)
+    GCOV_INCREMENTAL_FILES=$(echo "$CHANGED_FILES" | sed 's|^be/||' | tr '\n' ';')
+    echo "Incremental coverage will instrument $FILE_COUNT files"
+    echo "Changed files: $(echo "$CHANGED_FILES" | tr '\n' ' ')"
+    
+    # Write debug information to file
+    GCOV_DEBUG_FILE="${STARROCKS_HOME}/.gcov_incremental_debug.txt"
+    cat > "$GCOV_DEBUG_FILE" << EOF
+# GCOV Incremental Coverage Debug Information ($context)
+# Generated on: $(date)
+# Base branch: $BASE_BRANCH
+# Git command: git diff --name-only $BASE_BRANCH...HEAD
+# File count: $FILE_COUNT
+
+# Changed C++ files (relative to be/ directory):
+$(echo "$CHANGED_FILES" | sed 's|^be/||')
+
+# CMake format (semicolon-separated):
+$GCOV_INCREMENTAL_FILES
+EOF
+    echo "Debug information written to: $GCOV_DEBUG_FILE"
+}
+
+# Export the function so it can be used by other scripts
+export -f detect_incremental_files

--- a/build-support/detect_incremental_files.sh
+++ b/build-support/detect_incremental_files.sh
@@ -70,7 +70,8 @@ detect_incremental_files() {
     fi
     
     # Convert to CMake-friendly format (relative to be/ directory)
-    GCOV_INCREMENTAL_FILES=$(echo "$CHANGED_FILES" | sed 's|^be/||' | tr '\n' ';')
+    # Remove be/ prefix, strip whitespace, and join with semicolons
+    GCOV_INCREMENTAL_FILES=$(echo "$CHANGED_FILES" | sed 's|^be/||' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr '\n' ';' | sed 's/;$//')
     echo "Incremental coverage will instrument $FILE_COUNT files"
     echo "Changed files: $(echo "$CHANGED_FILES" | tr '\n' ' ')"
     

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -37,7 +37,6 @@ Usage: $0 <options>
      --dry-run                      dry-run unit tests
      --clean                        clean old unit tests before run
      --with-gcov                    enable to build with gcov
-     --with-gcov-incremental        enable to build with gcov only for changed files (faster than full gcov)
      --with-aws                     enable to test aws
      --with-bench                   enable to build with benchmark
      --excluding-test-suit          don't run cases of specific suit
@@ -54,7 +53,6 @@ Usage: $0 <options>
     $0 --test CompactionUtilsTest   run compaction test
     $0 --dry-run                    dry-run unit tests
     $0 --clean                      clean old unit tests before run
-    $0 --with-gcov-incremental      run unit tests with incremental coverage
     $0 --help                       display usage
     $0 --gtest_filter CompactionUtilsTest*:TabletUpdatesTest*   run the two test suites: CompactionUtilsTest and TabletUpdatesTest
   "
@@ -86,7 +84,6 @@ OPTS=$(getopt \
   -l 'dry-run' \
   -l 'clean' \
   -l 'with-gcov' \
-  -l 'with-gcov-incremental' \
   -l 'module:' \
   -l 'with-aws' \
   -l 'with-bench' \
@@ -119,7 +116,6 @@ HELP=0
 WITH_AWS=OFF
 USE_STAROS=OFF
 WITH_GCOV=OFF
-WITH_GCOV_INCREMENTAL=OFF
 WITH_STARCACHE=ON
 WITH_BRPC_KEEPALIVE=OFF
 WITH_DEBUG_SYMBOL_SPLIT=ON
@@ -135,7 +131,6 @@ while true; do
         --help) HELP=1 ; shift ;;
         --with-aws) WITH_AWS=ON; shift ;;
         --with-gcov) WITH_GCOV=ON; shift ;;
-        --with-gcov-incremental) WITH_GCOV_INCREMENTAL=ON; shift ;;
         --without-starcache) WITH_STARCACHE=OFF; shift ;;
         --with-brpc-keepalive) WITH_BRPC_KEEPALIVE=ON; shift ;;
         --excluding-test-suit) EXCLUDING_TEST_SUIT=$2; shift 2;;
@@ -148,13 +143,8 @@ while true; do
     esac
 done
 
-if [[ "${BUILD_TYPE}" == "ASAN" && ("${WITH_GCOV}" == "ON" || "${WITH_GCOV_INCREMENTAL}" == "ON") ]]; then
+if [[ "${BUILD_TYPE}" == "ASAN" && ("${WITH_GCOV}" == "ON") ]]; then
     echo "Error: ASAN and gcov cannot be enabled at the same time. Please disable one of them."
-    exit 1
-fi
-
-if [[ "${WITH_GCOV}" == "ON" && "${WITH_GCOV_INCREMENTAL}" == "ON" ]]; then
-    echo "Error: --with-gcov and --with-gcov-incremental cannot be used together. Please use only one."
     exit 1
 fi
 
@@ -165,7 +155,7 @@ fi
 
 # Handle incremental gcov: detect changed files
 GCOV_INCREMENTAL_FILES=""
-if [[ "${WITH_GCOV_INCREMENTAL}" == "ON" ]]; then
+if [[ "${WITH_GCOV}" == "ON" ]]; then
     # Source the common incremental file detection script
     source ${STARROCKS_HOME}/build-support/detect_incremental_files.sh
     detect_incremental_files "unit-test"
@@ -232,7 +222,6 @@ ${CMAKE_CMD}  -G "${CMAKE_GENERATOR}" \
             -DUSE_STAROS=${USE_STAROS} \
             -DSTARLET_INSTALL_DIR=${STARLET_INSTALL_DIR}          \
             -DWITH_GCOV=${WITH_GCOV} \
-            -DWITH_GCOV_INCREMENTAL=${WITH_GCOV_INCREMENTAL} \
             -DGCOV_INCREMENTAL_FILES="${GCOV_INCREMENTAL_FILES}" \
             -DWITH_STARCACHE=${WITH_STARCACHE} \
             -DWITH_BRPC_KEEPALIVE=${WITH_BRPC_KEEPALIVE} \


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

The gcov compiler option can significantly reduce execution speed, as it instruments every line of code.

Enable coverage only for incremental files instead of all files to enhance execution speed.

TODO: .h files would affect the translation unit, so we need to change the options for the TU instead of .h file.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3