### PR TITLE
[Enhancement] Upgrade gcs-connector version to 3.x.x (backport #64341)

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -822,6 +822,13 @@ under the License.
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>bundle</artifactId>
         </dependency>
+        
+        <!-- https://mvnrepository.com/artifact/com.google.api-client/google-api-client/2.8.1 -->
+        <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client</artifactId>
+            <version>2.8.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -50,7 +50,7 @@ under the License.
         <tomcat.version>8.5.70</tomcat.version>
         <parquet.version>1.15.2</parquet.version>
         <hadoop.version>3.4.1</hadoop.version>
-        <gcs.connector.version>hadoop3-2.2.26</gcs.connector.version>
+        <gcs.connector.version>3.0.13</gcs.connector.version>
         <skip.plugin>false</skip.plugin>
         <hudi.version>1.0.2</hudi.version>
         <hive-apache.version>3.1.2-22</hive-apache.version>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -47,7 +47,7 @@
         <protobuf-java.version>3.25.5</protobuf-java.version>
         <nimbusds.version>9.37.2</nimbusds.version>
         <commons-io.version>2.14.0</commons-io.version>
-        <gcs.connector.version>hadoop3-2.2.26</gcs.connector.version>
+        <gcs.connector.version>3.0.13</gcs.connector.version>
         <slf4j.version>1.7.36</slf4j.version>
         <arrow.version>17.0.0</arrow.version>
         <jackson.version>2.19.1</jackson.version>


### PR DESCRIPTION
## Why I'm doing:

gcs-connector 3.x adds support for non‑GCE environments using Google Cloud Workload Identity Federation (WIF). This allows StarRocks running outside Google Compute Engine to authenticate to GCS using OIDC tokens from a trusted identity provider.
The google-api-client dependency is required by FE.

## What I'm doing:

Fixes #64341

Bumped gcs-connector version from hadoop3-2.2.26 to 3.0.13 (fe/pom.xml, java-extensions/pom.xml).
Added dependency com.google.api-client:google-api-client:2.8.1 to fe-core/pom.xml.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

