### PR TITLE
[BugFix] Fix orphaned tablet replica metadata cannot be deleted in FE when replica state is DECOMMISSION

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1175,7 +1175,8 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                     }
 
                     ReplicaState state = replica.getState();
-                    if (state == ReplicaState.NORMAL || state == ReplicaState.SCHEMA_CHANGE) {
+                    if (state == ReplicaState.NORMAL || state == ReplicaState.SCHEMA_CHANGE
+                            || state == ReplicaState.DECOMMISSION) {
                         // if state is PENDING / ROLLUP / CLONE
                         // it's normal that the replica is not created in BE but exists in meta.
                         // so we do not delete it.


### PR DESCRIPTION
## Why I'm doing:
When a tablet replica is DECOMMISSION, FE would not delete it from metadata even it is not existed in BE. 
This behavior is  not reasonable

## What I'm doing:
Allow FE to delete orphaned tablet replica from metadata when replica state is DECOMMISSION.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Include `ReplicaState.DECOMMISSION` as eligible for FE metadata deletion when BE no longer has the tablet.
> 
> - **Tablet report handling (`ReportHandler.deleteFromMeta`)**:
>   - Treat `ReplicaState.DECOMMISSION` like `NORMAL`/`SCHEMA_CHANGE` to allow deleting orphaned replica metadata when BE doesn’t report the tablet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd99a2942ca2a9b1a5cd55e86e72e88e9b3c34c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->