### PR TITLE
[Enhancement] Use original query defined mv as show mv result

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1859,7 +1859,12 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         }
         sb.append("\n)");
 
-        String define = this.getSimpleDefineSql();
+        // use originalViewDefineSql first which it's user's original defined ddl which it is because original
+        // defined ddl may contain some comments or formatting that we want to preserve.
+        String define = this.getOriginalViewDefineSql();
+        if (StringUtils.isEmpty(define)) {
+            define = this.getViewDefineSql();
+        }
         if (StringUtils.isEmpty(define) || !simple) {
             define = this.getViewDefineSql();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -4552,10 +4552,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                         "\"replication_num\" = \"1\",\n" +
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
-                        "AS SELECT `t1`.`c_1_0`, `t1`.`c_1_1`, `t1`.`c_1_2`, `t1`.`c_1_3`, `t1`.`c_1_4`, `t1`.`c_1_5`, " +
-                        "`t1`.`c_1_6`, `t1`.`c_1_7`, `t1`.`c_1_8`, `t1`.`c_1_9`, `t1`.`c_1_10`, `t1`.`c_1_11`, " +
-                        "`t1`.`c_1_12`\n" +
-                        "FROM `test`.`t1` LIMIT 10;"
+                        "AS select * from t1 limit 10;"
                 ,
                 starRocksAssert.showCreateTable("show create table mv_invalid"));
         starRocksAssert.dropMaterializedView("mv_invalid");
@@ -4576,10 +4573,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                         "\"enable_query_rewrite\" = \"false\",\n" +
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
-                        "AS SELECT `t1`.`c_1_0`, `t1`.`c_1_1`, `t1`.`c_1_2`, `t1`.`c_1_3`, `t1`.`c_1_4`, `t1`.`c_1_5`, " +
-                        "`t1`.`c_1_6`, `t1`.`c_1_7`, `t1`.`c_1_8`, `t1`.`c_1_9`, `t1`.`c_1_10`, `t1`.`c_1_11`, " +
-                        "`t1`.`c_1_12`\n" +
-                        "FROM `test`.`t1` LIMIT 10;",
+                        "AS select * from t1 limit 10;",
                 starRocksAssert.showCreateTable("show create table mv_invalid"));
         starRocksAssert.dropMaterializedView("mv_invalid");
 
@@ -4598,10 +4592,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                         "\"enable_query_rewrite\" = \"true\",\n" +
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
-                        "AS SELECT `t1`.`c_1_0`, `t1`.`c_1_1`, `t1`.`c_1_2`, `t1`.`c_1_3`, `t1`.`c_1_4`, `t1`.`c_1_5`, " +
-                        "`t1`.`c_1_6`, `t1`.`c_1_7`, `t1`.`c_1_8`, `t1`.`c_1_9`, `t1`.`c_1_10`, `t1`.`c_1_11`, " +
-                        "`t1`.`c_1_12`\n" +
-                        "FROM `test`.`t1`;",
+                        "AS select * from t1;",
                 starRocksAssert.showCreateTable("show create table mv_enable"));
         starRocksAssert.refreshMV("refresh materialized view mv_enable with sync mode");
         MaterializedView mv = starRocksAssert.getMv("test", "mv_enable");
@@ -4620,10 +4611,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                         "\"enable_query_rewrite\" = \"FALSE\",\n" +
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
-                        "AS SELECT `t1`.`c_1_0`, `t1`.`c_1_1`, `t1`.`c_1_2`, `t1`.`c_1_3`, `t1`.`c_1_4`, `t1`.`c_1_5`, " +
-                        "`t1`.`c_1_6`, `t1`.`c_1_7`, `t1`.`c_1_8`, `t1`.`c_1_9`, `t1`.`c_1_10`, `t1`.`c_1_11`, " +
-                        "`t1`.`c_1_12`\n" +
-                        "FROM `test`.`t1`;",
+                        "AS select * from t1;",
                 starRocksAssert.showCreateTable("show create table mv_enable"));
         valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, null,
                 true, false, connectContext.getSessionVariable().getOptimizerExecuteTimeout());
@@ -4651,10 +4639,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 "\"replication_num\" = \"1\",\n" +
                 "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
-                "AS SELECT `t1`.`c_1_0`, `t1`.`c_1_1`, `t1`.`c_1_2`, `t1`.`c_1_3`, `t1`.`c_1_4`, `t1`.`c_1_5`, " +
-                "`t1`.`c_1_6`, `t1`.`c_1_7`, `t1`.`c_1_8`, `t1`.`c_1_9`, `t1`.`c_1_10`, `t1`.`c_1_11`, " +
-                "`t1`.`c_1_12`\n" +
-                "FROM `test`.`t1` LIMIT 10;", sql);
+                "AS select * from t1 limit 10;", sql);
         starRocksAssert.dropMaterializedView("mv_invalid");
 
         // enable
@@ -4672,10 +4657,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                         "\"replication_num\" = \"1\",\n" +
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
-                        "AS SELECT `t1`.`c_1_0`, `t1`.`c_1_1`, `t1`.`c_1_2`, `t1`.`c_1_3`, `t1`.`c_1_4`, `t1`.`c_1_5`, " +
-                        "`t1`.`c_1_6`, `t1`.`c_1_7`, `t1`.`c_1_8`, `t1`.`c_1_9`, `t1`.`c_1_10`, `t1`.`c_1_11`, " +
-                        "`t1`.`c_1_12`\n" +
-                        "FROM `test`.`t1`;",
+                        "AS select * from t1;",
                 starRocksAssert.showCreateTable("show create table mv_enable"));
         starRocksAssert.refreshMV("refresh materialized view mv_enable with sync mode");
         MaterializedView mv = starRocksAssert.getMv("test", "mv_enable");
@@ -4694,10 +4676,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 "\"replication_num\" = \"1\",\n" +
                 "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
-                "AS SELECT `t1`.`c_1_0`, `t1`.`c_1_1`, `t1`.`c_1_2`, `t1`.`c_1_3`, `t1`.`c_1_4`, `t1`.`c_1_5`, " +
-                "`t1`.`c_1_6`, `t1`.`c_1_7`, `t1`.`c_1_8`, `t1`.`c_1_9`, `t1`.`c_1_10`, `t1`.`c_1_11`, " +
-                "`t1`.`c_1_12`\n" +
-                "FROM `test`.`t1`;", sql);
+                "AS select * from t1;", sql);
         Assertions.assertTrue(!mv.isEnableTransparentRewrite());
         Assertions.assertTrue(mv.getTransparentRewriteMode().equals(TableProperty.MVTransparentRewriteMode.FALSE));
 
@@ -4712,10 +4691,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                         "\"replication_num\" = \"1\",\n" +
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
-                        "AS SELECT `t1`.`c_1_0`, `t1`.`c_1_1`, `t1`.`c_1_2`, `t1`.`c_1_3`, `t1`.`c_1_4`, `t1`.`c_1_5`, " +
-                        "`t1`.`c_1_6`, `t1`.`c_1_7`, `t1`.`c_1_8`, `t1`.`c_1_9`, `t1`.`c_1_10`, `t1`.`c_1_11`, " +
-                        "`t1`.`c_1_12`\n" +
-                        "FROM `test`.`t1`;",
+                        "AS select * from t1;",
                 starRocksAssert.showCreateTable("show create table mv_enable"));
         Assertions.assertTrue(mv.isEnableTransparentRewrite());
         Assertions.assertTrue(mv.getTransparentRewriteMode().equals(TableProperty.MVTransparentRewriteMode.TRANSPARENT_OR_ERROR));
@@ -4730,10 +4706,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                         "\"replication_num\" = \"1\",\n" +
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
-                        "AS SELECT `t1`.`c_1_0`, `t1`.`c_1_1`, `t1`.`c_1_2`, `t1`.`c_1_3`, `t1`.`c_1_4`, `t1`.`c_1_5`, " +
-                        "`t1`.`c_1_6`, `t1`.`c_1_7`, `t1`.`c_1_8`, `t1`.`c_1_9`, `t1`.`c_1_10`, `t1`.`c_1_11`, " +
-                        "`t1`.`c_1_12`\n" +
-                        "FROM `test`.`t1`;",
+                        "AS select * from t1;",
                 starRocksAssert.showCreateTable("show create table mv_enable"));
         Assertions.assertTrue(mv.isEnableTransparentRewrite());
         Assertions.assertTrue(mv.getTransparentRewriteMode().equals(TableProperty.MVTransparentRewriteMode.TRANSPARENT_OR_DEFAULT));
@@ -5905,6 +5878,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
             starRocksAssert.withMaterializedView(sql);
         }
     }
+
     @Test
     public void testPartitionByDateTruncWithNestedMV3() throws Exception {
         String sql = "create materialized view mv1 " +
@@ -6014,5 +5988,51 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 "FROM resource_interests\n" +
                 "WHERE user_id IS NOT NULL AND user_id != ''\n" +
                 "GROUP BY dt, user_id, resource_type, resource_id;");
+    }
+
+    @Test
+    public void testCreateMVWithComment() throws Exception {
+        String sql = "create materialized view mv1 " +
+                "comment \"this is a comment2\" " +
+                "partition by date_trunc('month', date) " +
+                "distributed by random " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'\n" +
+                ") \n" +
+                "as select 'This is a test', --mocked \n" +
+                "123,v1.date, v1.id from iceberg0.partitioned_db.t2 as v1; ";
+        starRocksAssert.withMaterializedView(sql);
+        MaterializedView mv = getMv("mv1");
+        {
+            String ddl = mv.getMaterializedViewDdlStmt(true, false);
+            Assertions.assertEquals("CREATE MATERIALIZED VIEW `mv1` (`'This is a test'`, `123`, `date`, `id`)\n" +
+                    "COMMENT \"this is a comment2\"\n" +
+                    "PARTITION BY (date_trunc('month', `date`))\n" +
+                    "DISTRIBUTED BY RANDOM\n" +
+                    "REFRESH DEFERRED MANUAL\n" +
+                    "PROPERTIES (\n" +
+                    "\"replicated_storage\" = \"true\",\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"storage_medium\" = \"HDD\"\n" +
+                    ")\n" +
+                    "AS select 'This is a test', --mocked \n" +
+                    "123,v1.date, v1.id from iceberg0.partitioned_db.t2 as v1;", ddl);
+        }
+        {
+            String ddl = mv.getMaterializedViewDdlStmt(false, false);
+            Assertions.assertEquals("CREATE MATERIALIZED VIEW `mv1` (`'This is a test'`, `123`, `date`, `id`)\n" +
+                    "COMMENT \"this is a comment2\"\n" +
+                    "PARTITION BY (date_trunc('month', `date`))\n" +
+                    "DISTRIBUTED BY RANDOM\n" +
+                    "REFRESH DEFERRED MANUAL\n" +
+                    "PROPERTIES (\n" +
+                    "\"replicated_storage\" = \"true\",\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"storage_medium\" = \"HDD\"\n" +
+                    ")\n" +
+                    "AS SELECT 'This is a test' AS `'This is a test'`, 123 AS `123`, `iceberg0`.`partitioned_db`.`v1`.`date`, `iceberg0`.`partitioned_db`.`v1`.`id`\n" +
+                    "FROM `iceberg0`.`partitioned_db`.`t2` AS `v1`;", ddl);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
@@ -109,8 +109,7 @@ public class ShowCreateMaterializedViewStmtTest {
                 "\"foreign_key_constraints\" = \"default_catalog.test.tbl1(k1) REFERENCES default_catalog.test.tbl2(k1)\",\n" +
                 "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
-                "AS SELECT `tbl1`.`k1`, `tbl2`.`k2`\n" +
-                "FROM `test`.`tbl1` INNER JOIN `test`.`tbl2` ON `tbl1`.`k1` = `tbl2`.`k1`;", createTableStmt.get(0));
+                "AS select tbl1.k1, tbl2.k2 from tbl1 join tbl2 on tbl1.k1 = tbl2.k1;", createTableStmt.get(0));
     }
 
     @Test
@@ -137,8 +136,7 @@ public class ShowCreateMaterializedViewStmtTest {
                         "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) REFERENCES hive0.partitioned_db2.t2(c2)\",\n" +
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
-                        "AS SELECT `hive0`.`partitioned_db2`.`t2`.`c1`, `hive0`.`partitioned_db`.`t1`.`c2`\n" +
-                        "FROM `hive0`.`partitioned_db`.`t1` INNER JOIN `hive0`.`partitioned_db2`.`t2` ON `hive0`.`partitioned_db`.`t1`.`c2` = `hive0`.`partitioned_db2`.`t2`.`c2`;",
+                        "AS select t2.c1, t1.c2 from hive0.partitioned_db.t1 join hive0.partitioned_db2.t2 on t1.c2 = t2.c2;",
                 createTableStmt.get(0));
     }
 
@@ -165,8 +163,7 @@ public class ShowCreateMaterializedViewStmtTest {
                         "\"replication_num\" = \"1\",\n" +
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
-                        "AS SELECT `lineitem`.`l_orderkey`, `lineitem`.`l_partkey`, `lineitem`.`l_shipdate`\n" +
-                        "FROM `hive0`.`tpch`.`lineitem`;");
+                        "AS select l_orderkey,l_partkey,l_shipdate from hive0.tpch.lineitem;");
         ctx.getGlobalStateMgr().setMetadataMgr(oldMetadataMgr);
     }
 

--- a/test/sql/test_analyze_statistics/R/test_predicate_columns
+++ b/test/sql/test_analyze_statistics/R/test_predicate_columns
@@ -29,7 +29,7 @@ select table_name, column_name, usage from information_schema.column_stats_usage
 -- !result
 [UC]analyze table t1 predicate columns;
 -- result:
-analyze_test_ba8d1c9661a1461a93c99977040981fa.t1	analyze	status	OK
+analyze_test_45eb5f1e88c845558c661b352aa4160d.t1	analyze	status	OK
 -- !result
 select count(*) from t1 where c1 = 1;
 -- result:
@@ -55,20 +55,20 @@ t1	c4	normal
 -- !result
 [UC]analyze table t1 predicate columns with sync mode;
 -- result:
-analyze_test_ba8d1c9661a1461a93c99977040981fa.t1	analyze	status	OK
+analyze_test_45eb5f1e88c845558c661b352aa4160d.t1	analyze	status	OK
 -- !result
 select `table`, array_join(array_sort(split(`columns`, ',')), ',') from information_schema.analyze_status where `database`='analyze_test_${uuid0}' order by Id;
 -- result:
 t1	ALL
 t1	c1
 -- !result
-select c1, count(c1), sum(c2), max(c3), min(c4) from t1 group by c1;
+select c1, count(c1), sum(c2), max(c3), min(c4) from t1 group by c1 order by c1;
 -- result:
 1	1	1	s1	s1
 2	1	2	s2	s2
 3	1	3	s3	s3
 -- !result
-select c2, count(c1), max(c3), min(c4) from t1 where c1 > 2 group by c2;
+select c2, count(c1), max(c3), min(c4) from t1 where c1 > 2 group by c2 order by c2;
 -- result:
 3	1	s3	s3
 -- !result
@@ -84,7 +84,7 @@ t1	c4	normal
 -- !result
 [UC]analyze table t1 predicate columns;
 -- result:
-analyze_test_ba8d1c9661a1461a93c99977040981fa.t1	analyze	status	OK
+analyze_test_45eb5f1e88c845558c661b352aa4160d.t1	analyze	status	OK
 -- !result
 select `table`, array_join(array_sort(split(`columns`, ',')), ',') from information_schema.analyze_status where `database`='analyze_test_${uuid0}' order by Id;
 -- result:
@@ -99,17 +99,17 @@ properties('replication_num'='1');
 insert into t2 select * from t1;
 -- result:
 -- !result
-select * from t1 join t2 on t1.c1 = t2.c5;
+select * from t1 join t2 on t1.c1 = t2.c5 order by t1.c1, t2.c5;
 -- result:
-2	2	s2	s2	2	2	s2	s2
 1	1	s1	s1	1	1	s1	s1
+2	2	s2	s2	2	2	s2	s2
 3	3	s3	s3	3	3	s3	s3
 -- !result
-select * from t1 join t2 on t1.c1 = t2.c5 where t1.c1 > 2;
+select * from t1 join t2 on t1.c1 = t2.c5 where t1.c1 > 2 order by t1.c1, t2.c5;
 -- result:
 3	3	s3	s3	3	3	s3	s3
 -- !result
-select * from t1 join t2 on t1.c1 = t2.c5 where t1.c2 > 2 and t1.c3 = 's2';
+select * from t1 join t2 on t1.c1 = t2.c5 where t1.c2 > 2 and t1.c3 = 's2' order by t1.c1, t2.c5;
 -- result:
 -- !result
 admin execute on frontend 'import com.starrocks.statistic.columns.PredicateColumnsMgr; PredicateColumnsMgr.getInstance().persist();';
@@ -131,7 +131,7 @@ t2	c8	normal
 -- !result
 [UC]analyze table t1 predicate columns;
 -- result:
-analyze_test_ba8d1c9661a1461a93c99977040981fa.t1	analyze	status	OK
+analyze_test_45eb5f1e88c845558c661b352aa4160d.t1	analyze	status	OK
 -- !result
 select `table`, array_join(array_sort(split(`columns`, ',')), ',') from information_schema.analyze_status where `database`='analyze_test_${uuid0}' order by Id;
 -- result:

--- a/test/sql/test_analyze_statistics/T/test_predicate_columns
+++ b/test/sql/test_analyze_statistics/T/test_predicate_columns
@@ -28,8 +28,8 @@ select table_name, column_name, usage from information_schema.column_stats_usage
 select `table`, array_join(array_sort(split(`columns`, ',')), ',') from information_schema.analyze_status where `database`='analyze_test_${uuid0}' order by Id;
 
 -- aggregation
-select c1, count(c1), sum(c2), max(c3), min(c4) from t1 group by c1;
-select c2, count(c1), max(c3), min(c4) from t1 where c1 > 2 group by c2;
+select c1, count(c1), sum(c2), max(c3), min(c4) from t1 group by c1 order by c1;
+select c2, count(c1), max(c3), min(c4) from t1 where c1 > 2 group by c2 order by c2;
 admin execute on frontend 'import com.starrocks.statistic.columns.PredicateColumnsMgr; PredicateColumnsMgr.getInstance().persist();';
 select table_name, column_name, usage from information_schema.column_stats_usage where table_database = 'analyze_test_${uuid0}' and table_name = 't1' order by column_name;
 [UC]analyze table t1 predicate columns;
@@ -39,9 +39,9 @@ select `table`, array_join(array_sort(split(`columns`, ',')), ',') from informat
 create table t2(c5 int, c6 bigint, c7 string, c8 string) 
 properties('replication_num'='1');
 insert into t2 select * from t1;
-select * from t1 join t2 on t1.c1 = t2.c5;
-select * from t1 join t2 on t1.c1 = t2.c5 where t1.c1 > 2;
-select * from t1 join t2 on t1.c1 = t2.c5 where t1.c2 > 2 and t1.c3 = 's2';
+select * from t1 join t2 on t1.c1 = t2.c5 order by t1.c1, t2.c5;
+select * from t1 join t2 on t1.c1 = t2.c5 where t1.c1 > 2 order by t1.c1, t2.c5;
+select * from t1 join t2 on t1.c1 = t2.c5 where t1.c2 > 2 and t1.c3 = 's2' order by t1.c1, t2.c5;
 admin execute on frontend 'import com.starrocks.statistic.columns.PredicateColumnsMgr; PredicateColumnsMgr.getInstance().persist();';
 select table_name, column_name, usage from information_schema.column_stats_usage where table_database = 'analyze_test_${uuid0}' and table_name = 't1' order by column_name;
 select table_name, column_name, usage from information_schema.column_stats_usage where table_database = 'analyze_test_${uuid0}' and table_name = 't2' order by column_name;

--- a/test/sql/test_default_enable_replicated_storage/R/test_enable_mv
+++ b/test/sql/test_default_enable_replicated_storage/R/test_enable_mv
@@ -1,4 +1,4 @@
--- name: test_default_enable_mv @sequential
+-- name: test_default_enable_mv
 create database test_default_enable_mv;
 -- result:
 -- !result
@@ -11,7 +11,11 @@ admin set frontend config('enable_replicated_storage_as_default_engine'='true');
 create table t1(k int, v int not null) distributed by hash(k);
 -- result:
 -- !result
-create materialized view tvd distributed by hash(k) buckets 10 REFRESH ASYNC as select k, sum(v) from t1 group by k;
+create materialized view tvd distributed by hash(k) buckets 10 
+PROPERTIES (
+    "replication_num" = "1"
+)
+REFRESH ASYNC as select k, sum(v) from t1 group by k;
 -- result:
 -- !result
 show create materialized view tvd;
@@ -20,18 +24,20 @@ tvd	CREATE MATERIALIZED VIEW `tvd` (`k`, `sum(v)`)
 DISTRIBUTED BY HASH(`k`) BUCKETS 10 
 REFRESH ASYNC
 PROPERTIES (
-"replication_num" = "3",
 "replicated_storage" = "true",
+"replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `t1`.`k`, sum(`t1`.`v`) AS `sum(v)`
-FROM `test_default_enable_mv`.`t1`
-GROUP BY `t1`.`k`;
+AS select k, sum(v) from t1 group by k;
 -- !result
 admin set frontend config('enable_replicated_storage_as_default_engine'='false');
 -- result:
 -- !result
-create materialized view tvb distributed by hash(k) buckets 10 REFRESH ASYNC as select k, sum(v) from t1 group by k;
+create materialized view tvb distributed by hash(k) buckets 10 
+PROPERTIES (
+    "replication_num" = "1"
+)
+REFRESH ASYNC as select k, sum(v) from t1 group by k;
 -- result:
 -- !result
 show create materialized view tvb;
@@ -40,13 +46,11 @@ tvb	CREATE MATERIALIZED VIEW `tvb` (`k`, `sum(v)`)
 DISTRIBUTED BY HASH(`k`) BUCKETS 10 
 REFRESH ASYNC
 PROPERTIES (
-"replication_num" = "3",
 "replicated_storage" = "false",
+"replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `t1`.`k`, sum(`t1`.`v`) AS `sum(v)`
-FROM `test_default_enable_mv`.`t1`
-GROUP BY `t1`.`k`;
+AS select k, sum(v) from t1 group by k;
 -- !result
 admin set frontend config('enable_replicated_storage_as_default_engine'='true');
 -- result:

--- a/test/sql/test_default_enable_replicated_storage/T/test_enable_mv
+++ b/test/sql/test_default_enable_replicated_storage/T/test_enable_mv
@@ -1,12 +1,20 @@
--- name: test_default_enable_mv @sequential
+-- name: test_default_enable_mv
 create database test_default_enable_mv;
 use test_default_enable_mv;
 admin set frontend config('enable_replicated_storage_as_default_engine'='true');
 create table t1(k int, v int not null) distributed by hash(k);
-create materialized view tvd distributed by hash(k) buckets 10 REFRESH ASYNC as select k, sum(v) from t1 group by k;
+create materialized view tvd distributed by hash(k) buckets 10 
+PROPERTIES (
+    "replication_num" = "1"
+)
+REFRESH ASYNC as select k, sum(v) from t1 group by k;
 show create materialized view tvd;
 admin set frontend config('enable_replicated_storage_as_default_engine'='false');
-create materialized view tvb distributed by hash(k) buckets 10 REFRESH ASYNC as select k, sum(v) from t1 group by k;
+create materialized view tvb distributed by hash(k) buckets 10 
+PROPERTIES (
+    "replication_num" = "1"
+)
+REFRESH ASYNC as select k, sum(v) from t1 group by k;
 show create materialized view tvb;
 admin set frontend config('enable_replicated_storage_as_default_engine'='true');
 

--- a/test/sql/test_materialized_view/R/test_create
+++ b/test/sql/test_materialized_view/R/test_create
@@ -74,12 +74,12 @@ mv1	CREATE MATERIALIZED VIEW `mv1` (`k1`, `v1`)
 DISTRIBUTED BY RANDOM
 REFRESH ASYNC
 PROPERTIES (
-"replication_num" = "1",
 "replicated_storage" = "true",
+"replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `t0`.`k1`, `t1`.`v1`
-FROM `test_create_mv`.`t_hash` AS `t0` INNER JOIN `test_create_mv`.`t_random` AS `t1` ON `t0`.`k1` = `t1`.`k1`;
+AS select t0.k1, t1.v1
+from t_hash t0 join t_random t1 on t0.k1 = t1.k1;
 -- !result
 CREATE MATERIALIZED VIEW `mv2`
 REFRESH ASYNC 
@@ -93,13 +93,11 @@ mv2	CREATE MATERIALIZED VIEW `mv2` (`k1`, `count(v1)`)
 DISTRIBUTED BY RANDOM
 REFRESH ASYNC
 PROPERTIES (
-"replication_num" = "1",
 "replicated_storage" = "true",
+"replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `t_random`.`k1`, count(`t_random`.`v1`) AS `count(v1)`
-FROM `test_create_mv`.`t_random`
-GROUP BY `t_random`.`k1`;
+AS select k1, count(v1)  from t_random group by k1;
 -- !result
 CREATE MATERIALIZED VIEW `mv3`
 REFRESH ASYNC 
@@ -114,12 +112,12 @@ mv3	CREATE MATERIALIZED VIEW `mv3` (`k1`, `v1`)
 DISTRIBUTED BY RANDOM
 REFRESH ASYNC
 PROPERTIES (
-"replication_num" = "1",
 "replicated_storage" = "true",
+"replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `t0`.`k1`, `t1`.`v1`
-FROM `test_create_mv`.`t_hash` AS `t0` INNER JOIN `test_create_mv`.`t1` ON `t0`.`k1` = `t1`.`k1`;
+AS select t0.k1, t1.v1
+from t_hash t0 join t1 on t0.k1 = t1.k1;
 -- !result
 CREATE MATERIALIZED VIEW `mv4`
 REFRESH ASYNC 
@@ -134,12 +132,12 @@ mv4	CREATE MATERIALIZED VIEW `mv4` (`k1`, `v1`)
 DISTRIBUTED BY RANDOM
 REFRESH ASYNC
 PROPERTIES (
-"replication_num" = "1",
 "replicated_storage" = "true",
+"replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `t0`.`k1`, `t1`.`v1`
-FROM `test_create_mv`.`t_random` AS `t0` INNER JOIN `test_create_mv`.`t1` ON `t0`.`k1` = `t1`.`k1`;
+AS select t0.k1, t1.v1
+from t_random t0 join t1 on t0.k1 = t1.k1;
 -- !result
 CREATE MATERIALIZED VIEW `mv_part1`
 REFRESH ASYNC 
@@ -154,12 +152,12 @@ mv_part1	CREATE MATERIALIZED VIEW `mv_part1` (`k1`, `v1`)
 DISTRIBUTED BY RANDOM
 REFRESH ASYNC
 PROPERTIES (
-"replication_num" = "1",
 "replicated_storage" = "true",
+"replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `t1`.`k1`, `t2`.`v1`
-FROM `test_create_mv`.`t1` INNER JOIN `test_create_mv`.`t2` ON `t1`.`k1` = `t2`.`k1`;
+AS select t1.k1, t2.v1
+from t1 join t2 on t1.k1 = t2.k1;
 -- !result
 CREATE MATERIALIZED VIEW `mv5`
 PARTITION BY (`k1`)
@@ -181,13 +179,13 @@ PARTITION BY (`k1`)
 DISTRIBUTED BY HASH(`k1`) BUCKETS 2 
 REFRESH ASYNC
 PROPERTIES (
-"replication_num" = "1",
 "replicated_storage" = "true",
+"replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `t1`.`k1`, `t1`.`v1`, `t1`.`v2`
-FROM `test_create_mv`.`t1` UNION ALL SELECT `t2`.`k1`, `t2`.`v1`, `t2`.`v2`
-FROM `test_create_mv`.`t2`;
+AS select k1, v1, v2 from t1
+union all
+select k1, v1, v2 from t2;
 -- !result
 CREATE MATERIALIZED VIEW `mv6`
 PARTITION BY (`k1`)
@@ -209,11 +207,11 @@ PARTITION BY (`k1`)
 DISTRIBUTED BY RANDOM
 REFRESH ASYNC
 PROPERTIES (
-"replication_num" = "1",
 "replicated_storage" = "true",
+"replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `t1`.`k1`, `t1`.`v1`, `t1`.`v2`
-FROM `test_create_mv`.`t1` UNION ALL SELECT `t2`.`k1`, `t2`.`v1`, `t2`.`v2`
-FROM `test_create_mv`.`t2`;
+AS select k1, v1, v2 from t1
+union all
+select k1, v1, v2 from t2;
 -- !result

--- a/test/sql/test_materialized_view/R/test_show_materialized_view
+++ b/test/sql/test_materialized_view/R/test_show_materialized_view
@@ -33,9 +33,7 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
 -- !result
 show create table user_tags_mv1;
 -- result:
@@ -47,9 +45,7 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
 -- !result
 alter materialized view user_tags_mv1 set ("session.insert_timeout" = "3600");
 -- result:
@@ -69,9 +65,7 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
 -- !result
 show create table user_tags_mv1;
 -- result:
@@ -85,9 +79,7 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
 -- !result
 refresh materialized view user_tags_mv1 with sync mode;
 function: wait_show_materialized_view_finish('user_tags_mv1')
@@ -157,7 +149,7 @@ select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from info
 -- !result
 [UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name = 'user_tags_mv1';
 -- result:
-171955	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	171963	mv-171955	2025-11-04 17:44:45	2025-11-04 17:44:46	0.191	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+10598	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	10606	mv-10598	2025-11-14 17:38:45	2025-11-14 17:38:46	0.264	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
@@ -167,13 +159,11 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["019a4e41-2e23-734b-934e-d4f3113bbb9f"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-04 17:44:46	019a4e41-2e23-718e-83bb-e40fe91a4324
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;	{"queryIds":["019a81bb-475c-74f3-8bd3-846e02380586"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-14 17:38:46	019a81bb-475c-7a2e-bf81-65eafb6a9b83
 -- !result
 [UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like 'user_tags_mv1';
 -- result:
-171955	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	171963	mv-171955	2025-11-04 17:44:45	2025-11-04 17:44:46	0.191	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+10598	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	10606	mv-10598	2025-11-14 17:38:45	2025-11-14 17:38:46	0.264	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
@@ -183,13 +173,11 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["019a4e41-2e23-734b-934e-d4f3113bbb9f"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-04 17:44:46	019a4e41-2e23-718e-83bb-e40fe91a4324
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;	{"queryIds":["019a81bb-475c-74f3-8bd3-846e02380586"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-14 17:38:46	019a81bb-475c-7a2e-bf81-65eafb6a9b83
 -- !result
 [UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%user_tags_mv1%';
 -- result:
-171955	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	171963	mv-171955	2025-11-04 17:44:45	2025-11-04 17:44:46	0.191	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+10598	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	10606	mv-10598	2025-11-14 17:38:45	2025-11-14 17:38:46	0.264	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
@@ -199,13 +187,11 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["019a4e41-2e23-734b-934e-d4f3113bbb9f"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-04 17:44:46	019a4e41-2e23-718e-83bb-e40fe91a4324
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;	{"queryIds":["019a81bb-475c-74f3-8bd3-846e02380586"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-14 17:38:46	019a81bb-475c-7a2e-bf81-65eafb6a9b83
 -- !result
 [UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%%';
 -- result:
-171955	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	171963	mv-171955	2025-11-04 17:44:45	2025-11-04 17:44:46	0.191	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+10598	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	10606	mv-10598	2025-11-14 17:38:45	2025-11-14 17:38:46	0.264	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
@@ -215,16 +201,14 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["019a4e41-2e23-734b-934e-d4f3113bbb9f"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-04 17:44:46	019a4e41-2e23-718e-83bb-e40fe91a4324
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;	{"queryIds":["019a81bb-475c-74f3-8bd3-846e02380586"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-14 17:38:46	019a81bb-475c-7a2e-bf81-65eafb6a9b83
 -- !result
 [UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%bad_name%';
 -- result:
 -- !result
 [UC] show materialized views from test_show_materialized_view where name like 'user_tags_mv1';
 -- result:
-171955	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	171963	mv-171955	2025-11-04 17:44:45	2025-11-04 17:44:46	0.191	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+10598	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	10606	mv-10598	2025-11-14 17:38:45	2025-11-14 17:38:46	0.264	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
@@ -234,13 +218,11 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["019a4e41-2e23-734b-934e-d4f3113bbb9f"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-04 17:44:46	019a4e41-2e23-718e-83bb-e40fe91a4324
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;	{"queryIds":["019a81bb-475c-74f3-8bd3-846e02380586"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-14 17:38:46	019a81bb-475c-7a2e-bf81-65eafb6a9b83
 -- !result
 [UC] show materialized views from test_show_materialized_view where name like '%user_tags_mv1%';
 -- result:
-171955	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	171963	mv-171955	2025-11-04 17:44:45	2025-11-04 17:44:46	0.191	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+10598	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	10606	mv-10598	2025-11-14 17:38:45	2025-11-14 17:38:46	0.264	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
@@ -250,13 +232,11 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["019a4e41-2e23-734b-934e-d4f3113bbb9f"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-04 17:44:46	019a4e41-2e23-718e-83bb-e40fe91a4324
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;	{"queryIds":["019a81bb-475c-74f3-8bd3-846e02380586"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-14 17:38:46	019a81bb-475c-7a2e-bf81-65eafb6a9b83
 -- !result
 [UC] show materialized views from test_show_materialized_view where name = 'user_tags_mv1';
 -- result:
-171955	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	171963	mv-171955	2025-11-04 17:44:45	2025-11-04 17:44:46	0.191	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+10598	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	10606	mv-10598	2025-11-14 17:38:45	2025-11-14 17:38:46	0.264	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
@@ -266,13 +246,11 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["019a4e41-2e23-734b-934e-d4f3113bbb9f"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-04 17:44:46	019a4e41-2e23-718e-83bb-e40fe91a4324
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;	{"queryIds":["019a81bb-475c-74f3-8bd3-846e02380586"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-14 17:38:46	019a81bb-475c-7a2e-bf81-65eafb6a9b83
 -- !result
 [UC] show materialized views where name like 'user_tags_mv1';
 -- result:
-171955	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	171963	mv-171955	2025-11-04 17:44:45	2025-11-04 17:44:46	0.191	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+10598	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	10606	mv-10598	2025-11-14 17:38:45	2025-11-14 17:38:46	0.264	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
@@ -282,13 +260,11 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["019a4e41-2e23-734b-934e-d4f3113bbb9f"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-04 17:44:46	019a4e41-2e23-718e-83bb-e40fe91a4324
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;	{"queryIds":["019a81bb-475c-74f3-8bd3-846e02380586"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-14 17:38:46	019a81bb-475c-7a2e-bf81-65eafb6a9b83
 -- !result
 [UC] show materialized views where name like '%user_tags_mv1%';
 -- result:
-171955	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	171963	mv-171955	2025-11-04 17:44:45	2025-11-04 17:44:46	0.191	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+10598	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	10606	mv-10598	2025-11-14 17:38:45	2025-11-14 17:38:46	0.264	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
@@ -298,13 +274,11 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["019a4e41-2e23-734b-934e-d4f3113bbb9f"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-04 17:44:46	019a4e41-2e23-718e-83bb-e40fe91a4324
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;	{"queryIds":["019a81bb-475c-74f3-8bd3-846e02380586"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-14 17:38:46	019a81bb-475c-7a2e-bf81-65eafb6a9b83
 -- !result
 [UC] show materialized views where name = 'user_tags_mv1';
 -- result:
-171955	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	171963	mv-171955	2025-11-04 17:44:45	2025-11-04 17:44:46	0.191	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
+10598	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	10606	mv-10598	2025-11-14 17:38:45	2025-11-14 17:38:46	0.264	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
@@ -314,9 +288,7 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
-FROM `test_show_materialized_view`.`user_tags`
-GROUP BY `user_tags`.`user_id`;	{"queryIds":["019a4e41-2e23-734b-934e-d4f3113bbb9f"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-04 17:44:46	019a4e41-2e23-718e-83bb-e40fe91a4324
+AS select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;	{"queryIds":["019a81bb-475c-74f3-8bd3-846e02380586"],"isManual":true,"isSync":true,"isReplay":false,"priority":80,"lastTaskRunState":"SUCCESS"}	VALID	'root'@'%'	2025-11-14 17:38:46	019a81bb-475c-7a2e-bf81-65eafb6a9b83
 -- !result
 drop database test_show_materialized_view;
 -- result:

--- a/test/sql/test_mv/R/test_mv_with_index
+++ b/test/sql/test_mv/R/test_mv_with_index
@@ -55,8 +55,7 @@ PROPERTIES (
 "storage_medium" = "HDD",
 "bloom_filter_columns" = "c1, c2"
 )
-AS SELECT `t1`.`c0`, `t1`.`c1`, `t1`.`c2`, `t1`.`c3`
-FROM `test_mv_with_index`.`t1`;
+AS SELECT * from t1;
 -- !result
 CREATE INDEX idx1 ON test_mv1(c0) USING BITMAP COMMENT 'bitmap index on c0';
 -- result:
@@ -131,8 +130,7 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_medium" = "HDD"
 )
-AS SELECT `t1`.`c0`, `t1`.`c1`, `t1`.`c2`, `t1`.`c3`
-FROM `test_mv_with_index`.`t1`;
+AS SELECT * from t1;
 -- !result
 DROP INDEX idx2 ON test_mv1;
 -- result:


### PR DESCRIPTION
## Why I'm doing:
use originalViewDefineSql first which it's user's original defined ddl which it is because original
defined ddl may contain some comments or formatting that we want to preserve.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prefer the original MV query SQL (including comments/formatting) when generating SHOW CREATE output; update tests and add coverage for comment preservation.
> 
> - **Materialized View DDL generation**:
>   - Prefer `originalViewDefineSql` in `MaterializedView#getMaterializedViewDdlStmt(...)` to emit the user-defined query (preserving comments/formatting); fallback to `viewDefineSql` as needed.
> - **Tests**:
>   - Update expected SHOW CREATE outputs across MV tests to reflect original `select` text instead of normalized SQL.
>   - Add coverage for comment preservation in `testCreateMVWithComment`.
>   - Minor test adjustments for deterministic ordering and properties in SQL-based tests (e.g., added `order by`, explicit `replication_num`, stable UUIDs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b314ebe1924528d5df3994e9b8fb4127dcddba75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->