### PR TITLE
[BugFix] Fix tablets channel use-after-free issue

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -465,13 +465,16 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
         int64_t tablet_id = tablet_ids[row_indexes[from]];
         auto delta_writer_iter = _delta_writers.find(tablet_id);
         if (delta_writer_iter == _delta_writers.end()) {
-            LOG(WARNING) << "LakeTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
-                         << " not found tablet_id: " << tablet_id;
-            response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
-            response->mutable_status()->add_error_msgs(
-                    fmt::format("Failed to add_chunk since tablet_id {} not exists, txn_id: {}, load_id: {}", tablet_id,
-                                _txn_id, print_id(request.id())));
-            return;
+            // SHOULD NEVER HAPPEN! The check is already done in _create_write_context() when chunk != nullptr.
+            auto msg = fmt::format(
+                    "Failed to add chunk because the DeltaWriter for the tablet is not found, txn_id: "
+                    "{}, load_id: {}, tablet_id: {}",
+                    _txn_id, print_id(request.id()), tablet_id);
+            LOG(WARNING) << msg;
+            context->update_status(Status::InternalError(msg));
+            count_down_latch.count_down(channel_size - i);
+            // DO NOT return!!!
+            break;
         }
 
         // back pressure OlapTableSink since there are too many memtables need to flush
@@ -854,8 +857,17 @@ StatusOr<std::unique_ptr<LakeTabletsChannel::WriteContext>> LakeTabletsChannel::
     auto tablet_ids_size = request.tablet_ids_size();
     // compute row indexes for each channel
     for (uint32_t i = 0; i < tablet_ids_size; ++i) {
-        uint32_t channel_index = _tablet_id_to_sorted_indexes[tablet_ids[i]];
-        channel_row_idx_start_points[channel_index]++;
+        auto tablet_id = tablet_ids[i];
+        auto it = _tablet_id_to_sorted_indexes.find(tablet_id);
+        if (UNLIKELY(it == _tablet_id_to_sorted_indexes.end())) {
+            auto msg = fmt::format(
+                    "Failed in _create_write_context because the channel for the tablet is not found, txn_id: "
+                    "{}, load_id: {}, tablet_id: {}",
+                    _txn_id, print_id(request.id()), tablet_id);
+            LOG(WARNING) << msg;
+            return Status::InternalError(msg);
+        }
+        channel_row_idx_start_points[it->second]++;
     }
 
     // NOTE: we make the last item equal with number of rows of this chunk
@@ -865,11 +877,9 @@ StatusOr<std::unique_ptr<LakeTabletsChannel::WriteContext>> LakeTabletsChannel::
 
     for (int i = tablet_ids_size - 1; i >= 0; --i) {
         const auto& tablet_id = tablet_ids[i];
-        auto it = _tablet_id_to_sorted_indexes.find(tablet_id);
-        if (UNLIKELY(it == _tablet_id_to_sorted_indexes.end())) {
-            return Status::InternalError("invalid tablet id");
-        }
-        uint32_t channel_index = it->second;
+        // Already checked in previous loop, so use DCHECK here just in case.
+        DCHECK(_tablet_id_to_sorted_indexes.find(tablet_id) != _tablet_id_to_sorted_indexes.end());
+        uint32_t channel_index = _tablet_id_to_sorted_indexes[tablet_id];
         row_indexes[channel_row_idx_start_points[channel_index] - 1] = i;
         channel_row_idx_start_points[channel_index]--;
     }

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -280,6 +280,8 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     auto start_submit_write_task_ts = watch.elapsed_time();
     int64_t wait_memtable_flush_time_us = 0;
     int32_t total_row_num = 0;
+
+    // NOTE: don't try to do early return, there might be delta_writer write requests on the fly.
     for (int i = 0; i < channel_size; ++i) {
         size_t from = channel_row_idx_start_points[i];
         size_t size = channel_row_idx_start_points[i + 1] - from;
@@ -290,14 +292,17 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
         auto tablet_id = tablet_ids[row_indexes[from]];
         auto it = _delta_writers.find(tablet_id);
         if (it == _delta_writers.end()) {
-            LOG(WARNING) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
-                         << " not found tablet_id: " << tablet_id;
-            response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
-            response->mutable_status()->add_error_msgs(
-                    fmt::format("Failed to add_chunk since tablet_id {} not exists, txn_id: {}, load_id: {}", tablet_id,
-                                _txn_id, print_id(request.id())));
-            return;
+            // SHOULD NEVER HAPPEN!
+            // The tablet ids are already checked in _create_write_context() when chunk != nullptr.
+            auto msg = fmt::format(
+                    "Failed to add the chunk because the DeltaWriter for the tablet is not found, txn_id: {}, "
+                    "load_id: {}, tablet_id: {}",
+                    _txn_id, print_id(request.id()), tablet_id);
+            LOG(WARNING) << msg;
+            context->update_status(Status::InternalError(msg));
+            break;
         }
+
         auto& delta_writer = it->second;
 
         // back pressure OlapTableSink since there are too many memtables need to flush
@@ -869,10 +874,22 @@ StatusOr<std::shared_ptr<LocalTabletsChannel::WriteContext>> LocalTabletsChannel
     auto& row_indexes = context->_row_indexes;
     auto& channel_row_idx_start_points = context->_channel_row_idx_start_points;
 
+    auto tablet_ids = request.tablet_ids().data();
+    auto tablet_ids_size = request.tablet_ids_size();
+
     // compute row indexes for each channel
-    for (uint32_t i = 0; i < request.tablet_ids_size(); ++i) {
-        uint32_t channel_index = _tablet_id_to_sorted_indexes[request.tablet_ids(i)];
-        channel_row_idx_start_points[channel_index]++;
+    for (uint32_t i = 0; i < tablet_ids_size; ++i) {
+        auto tablet_id = tablet_ids[i];
+        auto it = _tablet_id_to_sorted_indexes.find(tablet_id);
+        if (UNLIKELY(it == _tablet_id_to_sorted_indexes.end())) {
+            auto msg = fmt::format(
+                    "Failed in _create_write_context because the channel for the tablet is not found, txn_id: {}, "
+                    "load_id: {}, tablet_id: {}",
+                    _txn_id, print_id(request.id()), tablet_id);
+            LOG(WARNING) << msg;
+            return Status::InternalError(msg);
+        }
+        channel_row_idx_start_points[it->second]++;
     }
 
     // NOTE: we make the last item equal with number of rows of this chunk
@@ -880,15 +897,11 @@ StatusOr<std::shared_ptr<LocalTabletsChannel::WriteContext>> LocalTabletsChannel
         channel_row_idx_start_points[i] += channel_row_idx_start_points[i - 1];
     }
 
-    auto tablet_ids = request.tablet_ids().data();
-    auto tablet_ids_size = request.tablet_ids_size();
     for (int i = tablet_ids_size - 1; i >= 0; --i) {
         const auto& tablet_id = tablet_ids[i];
-        auto it = _tablet_id_to_sorted_indexes.find(tablet_id);
-        if (UNLIKELY(it == _tablet_id_to_sorted_indexes.end())) {
-            return Status::InternalError("invalid tablet id");
-        }
-        uint32_t channel_index = it->second;
+        // Already checked in the previous for-loop, so use DCHECK just in case.
+        DCHECK(_tablet_id_to_sorted_indexes.find(tablet_id) != _tablet_id_to_sorted_indexes.end());
+        uint32_t channel_index = _tablet_id_to_sorted_indexes[tablet_id];
         row_indexes[channel_row_idx_start_points[channel_index] - 1] = i;
         channel_row_idx_start_points[channel_index]--;
     }

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -704,11 +704,10 @@ TEST_F(LakeTabletsChannelTest, test_tablet_not_existed) {
     auto open_request = _open_request;
     open_request.set_num_senders(1);
 
+    // 4 tablets opened: 10086/10087/10088/10089
     ASSERT_OK(_tablets_channel->open(open_request, &_open_response, _schema_param, false));
 
-    constexpr int kChunkSize = 128;
-    constexpr int kChunkSizePerTablet = kChunkSize / 4;
-    auto chunk = generate_data(kChunkSize);
+    constexpr int num_rows = 128;
     PTabletWriterAddChunkRequest add_chunk_request;
     PTabletWriterAddBatchResult add_chunk_response;
     add_chunk_request.set_index_id(kIndexId);
@@ -717,24 +716,25 @@ TEST_F(LakeTabletsChannelTest, test_tablet_not_existed) {
     add_chunk_request.set_packet_seq(0);
     add_chunk_request.set_timeout_ms(60000);
 
-    for (int i = 0; i < kChunkSize; i++) {
-        int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
+    for (int i = 0; i < num_rows; i++) {
+        // generate tablet_id: [10086,10087,10088,10089,10090], 10090 not opened in open_request
+        int64_t tablet_id = 10086 + i % 5;
         add_chunk_request.add_tablet_ids(tablet_id);
         add_chunk_request.add_partition_ids(tablet_id < 10088 ? 10 : 11);
     }
 
-    ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
-    add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
-
-    add_chunk_request.add_tablet_ids(10000); // Not existed tablet id
-
-    bool close_channel;
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
-    ASSERT_NE(TStatusCode::INTERNAL_ERROR, add_chunk_response.status().status_code());
-    ASSERT_FALSE(close_channel);
+    {
+        // `chunk` is only available inside the scope, will be released out of the scope to simulate resource release after RPC done.
+        auto chunk = generate_data(num_rows);
+        ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+        add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
+        bool close_channel;
+        _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
+        ASSERT_EQ(TStatusCode::INTERNAL_ERROR, add_chunk_response.status().status_code());
+        ASSERT_FALSE(close_channel);
+    }
 
     _tablets_channel->abort();
-
     ASSERT_FALSE(fs::path_exist(_tablet_manager->txn_log_location(10086, kTxnId)));
     ASSERT_FALSE(fs::path_exist(_tablet_manager->txn_log_location(10087, kTxnId)));
     ASSERT_FALSE(fs::path_exist(_tablet_manager->txn_log_location(10088, kTxnId)));


### PR DESCRIPTION
* Prevent early returns in add_chunk that bypass latch decrement or cb completion
* Ensure proper synchronization of async operations
* Add validation for tablet ID existence in write context creation

## Why I'm doing:

```
    @          0x406ef03 starrocks::FixedLengthColumnBase<starrocks::TimestampValue>::append_selective(starrocks::Column const&, unsigned int const*, unsigned int, unsigned int)
    @          0x635da25 starrocks::MemTable::insert(starrocks::Chunk const&, unsigned int const*, unsigned int, unsigned int)
    @          0x63529c5 starrocks::DeltaWriter::write(starrocks::Chunk const&, unsigned int const*, unsigned int, unsigned int)
    @          0x62c92a6 starrocks::AsyncDeltaWriter::_execute(void*, bthread::TaskIterator<starrocks::AsyncDeltaWriter::Task>&)
    @          0x7f2a85c bthread::ExecutionQueueBase::_execute(bthread::TaskNode*, bool, int*)
    @          0x7f2b84b bthread::ExecutionQueueBase::_execute_tasks(void*)
    @          0x398b053 starrocks::ThreadPool::dispatch_thread()
    @          0x3983296 starrocks::Thread::supervise_thread(void*)
    @     0x14914ac89d22 start_thread
    @     0x14914ad0ed40 __clone3
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoid early returns in add_chunk and add strict tablet→channel validation, improving error handling and synchronization; update tests accordingly.
> 
> - **Runtime**:
>   - **LakeTabletsChannel**:
>     - `add_chunk`: on missing `DeltaWriter`, log and `context->update_status(...)`, count down remaining latch, and break (no early return).
>     - `_create_write_context`: validate tablet→channel mapping; on missing mapping, return `InternalError` with detailed msg; later loop uses `DCHECK` and direct index.
>   - **LocalTabletsChannel**:
>     - `add_chunk`: avoid early return on missing `DeltaWriter`; log, `context->update_status(...)`, and break; add note to avoid early returns.
>     - `_create_write_context`: same validation logic as Lake; prefetch `tablet_ids`/size; use `DCHECK` in second pass.
> - **Tests**:
>   - Update `LakeTabletsChannelTest.test_tablet_not_existed` to expect `INTERNAL_ERROR` and scope `chunk` to simulate release.
>   - Add `LocalTabletsChannelTest.test_add_chunk_not_exist_tablet_for_chunk_rows` to assert error when some rows target unopened tablets.
>   - Minor adjustments/comments for malformed requests and timeout validation cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60279243d2b0a3f9b09cc89ad4ad91975716aebb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->