### PR TITLE
[Enhancement] truncate the long sql statement in fe profiles

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3949,6 +3949,5 @@ public class Config extends ConfigBase {
             "avoid stack over flow")
     public static int compound_predicate_flatten_threshold = 512;
 
-    @ConfField
-    public static int ui_queries_sql_statement_max_length = Integer.MAX_VALUE;
+    @ConfField public static int ui_queries_sql_statement_max_length = 128;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/QueryAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/QueryAction.java
@@ -122,9 +122,18 @@ public class QueryAction extends WebBaseAction {
                 if (columnHeaders.get(i).equals(ProfileManager.SQL_STATEMENT)) {
                     String statement = row.get(i);
                     if (statement != null && statement.length() > Config.ui_queries_sql_statement_max_length) {
-                        statement = statement.substring(0, Math.max(Config.ui_queries_sql_statement_max_length, 0)) + " ...";
+                        String truncatedStatement =
+                                statement.substring(0, Math.max(Config.ui_queries_sql_statement_max_length, 0))
+                                + " ...";
+                        // Add title attribute for hover tooltip to show full statement
+                        buffer.append("<span title=\"")
+                                .append(statement.replace("\"", "&quot;"))
+                                .append("\">")
+                                .append(truncatedStatement)
+                                .append("</span>");
+                    } else {
+                        buffer.append(statement);
                     }
-                    buffer.append(statement);
                 } else {
                     buffer.append(row.get(i));
                 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

<img width="2506" height="844" alt="image" src="https://github.com/user-attachments/assets/a5e0ef5c-2fd2-4063-96ac-65406af94ab7" />


Shorten the lengthy SQL statement to streamline the table display. The complete SQL query can be accessed via the query profile or by hovering over the cursor.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
