### PR TITLE
[BugFix] Set the workgroup in load chunk spiller to fix the asan BE crash issue caused by the worker group check

### DIFF
--- a/be/src/storage/load_chunk_spiller.cpp
+++ b/be/src/storage/load_chunk_spiller.cpp
@@ -124,6 +124,7 @@ Status LoadChunkSpiller::_prepare(const ChunkPtr& chunk_ptr) {
         // 1. alloc & prepare spiller
         spill::SpilledOptions options;
         options.encode_level = 7;
+        options.wg = ExecEnv::GetInstance()->workgroup_manager()->get_default_workgroup();
         _spiller = _spiller_factory->create(options);
         RETURN_IF_ERROR(_spiller->prepare(_runtime_state.get()));
         DCHECK(_profile != nullptr) << "LoadChunkSpiller profile is null";


### PR DESCRIPTION

## Why I'm doing:
Now in the spill prepare function, there is a `DCHECK` to ensure the workergroup of the spiller options is not null.

```c++
Status Spiller::prepare(RuntimeState* state) {
    _chunk_builder.chunk_schema() = std::make_shared<SpilledChunkBuildSchema>();
#ifndef BE_TEST
    DCHECK(_opts.wg != nullptr) << "workgroup must be set";
#endif
```

However, the workergroup is not initialized in the load chunk spiller. So, for the asan BE, the load spill process, both for cloud native table and iceberg table, will cause the previous `DCHECK` failed, resulting BE crash.

## What I'm doing:

Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/10477)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
