### PR TITLE
[Enhancement] remove RewriteMinMaxByMonotonicFunctionRule from AGGREGATE_REWRITE_RULES group

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -152,7 +152,6 @@ import com.starrocks.sql.optimizer.rule.transformation.RewriteBitmapCountDistinc
 import com.starrocks.sql.optimizer.rule.transformation.RewriteCountIfFunction;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteDuplicateAggregateFnRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteHllCountDistinctRule;
-import com.starrocks.sql.optimizer.rule.transformation.RewriteMinMaxByMonotonicFunctionRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToHDFSScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToMetaScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteSumByAssociativeRule;
@@ -329,8 +328,7 @@ public class RuleSet {
                     new RewriteDuplicateAggregateFnRule(),
                     new RewriteSimpleAggToMetaScanRule(),
                     new RewriteSumByAssociativeRule(),
-                    new RewriteCountIfFunction(),
-                    new RewriteMinMaxByMonotonicFunctionRule()
+                    new RewriteCountIfFunction()
             ));
 
     public static final Rule PRUNE_PROJECT_RULES = new CombinationRule(RuleType.GP_PRUNE_PROJECT, ImmutableList.of(


### PR DESCRIPTION
## Why I'm doing:
RewriteMinMaxByMonotonicFunctionRule's pattern is 
Agg -> Scan
 
 AGGREGATE_REWRITE_RULES executes in the early stage of the optimizer and hasn't processed projects yet. For the cases handled by RewriteMinMaxByMonotonicFunctionRule, there must be a project node above the scan. So it cannot be matched and can therefore be removed from AGGREGATE_REWRITE_RULE. The logical rule rewrite will call this rule again in subsequent stages.

## What I'm doing:
remove RewriteMinMaxByMonotonicFunctionRule from AGGREGATE_REWRITE_RULES group 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
