### PR TITLE
[UT] fix flaky test testAlterMVOnView

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -320,6 +320,7 @@ public class AlterMaterializedViewTest extends MVTestBase  {
         starRocksAssert.withView("CREATE VIEW view1 as select v1, sum(v2) as k2 from t0 group by v1");
         starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW " + mvName +
                 "                DISTRIBUTED BY HASH(v1) BUCKETS 10\n" +
+                "                REFRESH DEFERRED ASYNC\n" +
                 "                PROPERTIES(\n" +
                 "                    \"replication_num\" = \"1\"\n" +
                 "                )\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.commons.collections.CollectionUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
@@ -1212,7 +1213,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             @Mock
             public void refreshTable(String catalogName, String srDbName, Table table,
                                      List<String> partitionNames, boolean onlyCachedPartitions) {
-                calls.add(partitionNames);
+                if (CollectionUtils.isNotEmpty(partitionNames)) {
+                    calls.add(partitionNames);
+                }
             }
         };
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

#### testAlterMVOnView
In execution sequence:
```
create materialized view xxx;
alter view view1 as xxx;
alter materialized view active;
```

The expected execution sequence is sequential to allow us to verify the intermediate status. However, the `alter view view1` statement might execute after the default background refresh task of the `create materialized view` operation. This could lead to the error `column schema not compatible` instead of the anticipated message `base-view changed: view1`.

#### testRefreshExternalTablePrecise
The `refreshTable` function could be executed with an empty partition list.



Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
