### PR TITLE
[Refactor] Replace TableRefPersist with TableRef in backup and restore statements

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -743,7 +743,7 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitBackupStatement(BackupStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getBackupHandler().process(stmt);
+                context.getGlobalStateMgr().getBackupHandler().process(context, stmt);
             });
             return null;
         }
@@ -751,7 +751,7 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitRestoreStatement(RestoreStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getBackupHandler().process(stmt);
+                context.getGlobalStateMgr().getBackupHandler().process(context, stmt);
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
@@ -28,7 +28,6 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
-import com.starrocks.persist.TableRefPersist;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -36,12 +35,12 @@ import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.BackupStmt;
 import com.starrocks.sql.ast.CancelBackupStmt;
 import com.starrocks.sql.ast.CatalogRef;
-import com.starrocks.sql.ast.PartitionNames;
+import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.RestoreStmt;
 import com.starrocks.sql.ast.ShowBackupStmt;
 import com.starrocks.sql.ast.ShowRestoreStmt;
 import com.starrocks.sql.ast.StatementBase;
-import com.starrocks.sql.ast.expression.TableName;
+import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -95,7 +94,7 @@ public class BackupRestoreAnalyzer {
                             "No external catalog can be backed up");
                 }
 
-                backupStmt.getExternalCatalogRefs().stream().forEach(x -> x.analyzeForBackup());
+                validateExternalCatalogsForBackup(backupStmt.getExternalCatalogRefs());
                 return null;
             }
 
@@ -109,8 +108,8 @@ public class BackupRestoreAnalyzer {
             boolean allMV = backupStmt.allMV();
             boolean allView = backupStmt.allView();
 
-            Map<String, TableRefPersist> tblPartsMap = Maps.newTreeMap();
-            List<TableRefPersist> tableRefs = backupStmt.getTableRefs();
+            Map<String, TableRef> tblPartsMap = Maps.newTreeMap();
+            List<TableRef> tableRefs = backupStmt.getTableRefs();
             // There are several cases:
             // 1. Backup all table/mv/view without `ON` clause.
             // 2. Backup all table if specify `ALL` for table.
@@ -132,21 +131,19 @@ public class BackupRestoreAnalyzer {
                         continue;
                     }
 
-                    if (tableRefs.stream().anyMatch(tableRef -> tableRef.getName().getTbl().equalsIgnoreCase(tbl.getName()))) {
+                    if (tableRefs.stream().anyMatch(tableRef -> tableRef.getTableName().equalsIgnoreCase(tbl.getName()))) {
                         continue;
                     }
 
-                    TableName tableName = new TableName(dbName, tbl.getName());
-                    TableRefPersist tableRef = new TableRefPersist(tableName, null, null);
+                    TableRef tableRef = new TableRef(QualifiedName.of(List.of(dbName, tbl.getName())), null, null);
                     tableRefs.add(tableRef);
                 }
             }
 
-            Map<Long, TableRefPersist> tableIdToTableRefMap = Maps.newHashMap();
+            Map<Long, TableRef> tableIdToTableRefMap = Maps.newHashMap();
             Map<String, MaterializedView> mvNameMVMap = Maps.newHashMap();
-            for (TableRefPersist tableRef : tableRefs) {
-                analyzeTableRef(tableRef, dbName, database, tblPartsMap, context.getCurrentCatalog(),
-                        mvNameMVMap, tableIdToTableRefMap);
+            for (TableRef tableRef : tableRefs) {
+                analyzeTableRef(tableRef, database, tblPartsMap, mvNameMVMap, tableIdToTableRefMap);
                 if (tableRef.hasExplicitAlias()) {
                     throw new SemanticException("Can not set alias for table in Backup Stmt: " + tableRef,
                             tableRef.getPos());
@@ -167,7 +164,7 @@ public class BackupRestoreAnalyzer {
                 }
 
                 // reorder the tableRefs to ensure ref tables of materialized views are ahead of the materialized view
-                Map<String, TableRefPersist> newTableRefs =
+                Map<String, TableRef> newTableRefs =
                         reorderTableRefsWithMaterializedView(database, tblPartsMap, mvNameMVMap, tableIdToTableRefMap);
                 tableRefs.clear();
                 tableRefs.addAll(newTableRefs.values());
@@ -186,6 +183,21 @@ public class BackupRestoreAnalyzer {
             analyzeBackupProperties(backupStmt);
 
             return null;
+        }
+
+        private void validateExternalCatalogsForBackup(List<CatalogRef> catalogRefs) {
+            for (CatalogRef catalogRef : catalogRefs) {
+                String catalogName = catalogRef.getCatalogName();
+                if (catalogName.equalsIgnoreCase(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                            "Do not support Backup/Restore the entire default catalog");
+                }
+
+                if (!GlobalStateMgr.getCurrentState().getCatalogMgr().catalogExists(catalogName)) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                            "external catalog " + catalogName + " does not existed.");
+                }
+            }
         }
 
         private void analyzeBackupProperties(BackupStmt backupStmt) {
@@ -226,13 +238,13 @@ public class BackupRestoreAnalyzer {
             }
         }
 
-        private Map<String, TableRefPersist> reorderTableRefsWithMaterializedView(
+        private Map<String, TableRef> reorderTableRefsWithMaterializedView(
                 Database database,
-                Map<String, TableRefPersist> tblPartsMap,
+                Map<String, TableRef> tblPartsMap,
                 Map<String, MaterializedView> mvPartsMap,
-                Map<Long, TableRefPersist> tableIdToTableRefMap) {
-            Map<String, TableRefPersist> orderedTableNameRefMap = Maps.newLinkedHashMap();
-            for (Map.Entry<String, TableRefPersist> e : tblPartsMap.entrySet()) {
+                Map<Long, TableRef> tableIdToTableRefMap) {
+            Map<String, TableRef> orderedTableNameRefMap = Maps.newLinkedHashMap();
+            for (Map.Entry<String, TableRef> e : tblPartsMap.entrySet()) {
                 collectTableRefAndDependencies(database, e.getKey(), e.getValue(), mvPartsMap, tableIdToTableRefMap,
                         orderedTableNameRefMap);
             }
@@ -241,10 +253,10 @@ public class BackupRestoreAnalyzer {
 
         private void collectTableRefAndDependencies(Database database,
                                                     String tableName,
-                                                    TableRefPersist tableRef,
+                                                    TableRef tableRef,
                                                     Map<String, MaterializedView> mvPartsMap,
-                                                    Map<Long, TableRefPersist> tableIdToTableRefMap,
-                                                    Map<String, TableRefPersist> result) {
+                                                    Map<Long, TableRef> tableIdToTableRefMap,
+                                                    Map<String, TableRef> result) {
             // table is already collected.
             if (result.containsKey(tableName)) {
                 return;
@@ -264,7 +276,7 @@ public class BackupRestoreAnalyzer {
                     if (dbOpt.get().getId() != database.getId()) {
                         // if the referred base table is not the same with the current database, skip it.
                         LOG.warn("The referred base table {} 's database is different from the materialized view {}, " +
-                                "skip backup it", baseTableInfo.getTableName(), tableRef.getName());
+                                "skip backup it", baseTableInfo.getTableName(), tableRef.getTableName());
                         continue;
                     }
                     Optional<Table> baseTableOpt = MvUtils.getTableWithIdentifier(baseTableInfo);
@@ -309,22 +321,22 @@ public class BackupRestoreAnalyzer {
 
         @Override
         public Void visitRestoreStatement(RestoreStmt restoreStmt, ConnectContext context) {
-            List<TableRefPersist> tableRefs = restoreStmt.getTableRefs();
+            List<TableRef> tableRefs = restoreStmt.getTableRefs();
             Set<String> aliasSet = Sets.newHashSet();
-            Map<String, TableRefPersist> tblPartsMap = Maps.newTreeMap();
-            for (TableRefPersist tableRef : tableRefs) {
-                TableName tableName = tableRef.getName();
+            Map<String, TableRef> tblPartsMap = Maps.newTreeMap();
+            for (TableRef tableRef : tableRefs) {
+                String tableName = tableRef.getTableName();
 
-                if (!tblPartsMap.containsKey(tableName.getTbl())) {
-                    tblPartsMap.put(tableName.getTbl(), tableRef);
+                if (!tblPartsMap.containsKey(tableName)) {
+                    tblPartsMap.put(tableName, tableRef);
                 } else {
-                    throw new SemanticException("Duplicated table: " + tableName.getTbl(), tableRef.getPos());
+                    throw new SemanticException("Duplicated table: " + tableName, tableRef.getPos());
                 }
 
-                aliasSet.add(tableRef.getName().getTbl());
+                aliasSet.add(tableName);
             }
 
-            for (TableRefPersist tblRef : tableRefs) {
+            for (TableRef tblRef : tableRefs) {
                 if (tblRef.hasExplicitAlias() && !aliasSet.add(tblRef.getExplicitAlias())) {
                     throw new SemanticException("Duplicated alias name: " + tblRef.getExplicitAlias(), tblRef.getPos());
                 }
@@ -363,7 +375,7 @@ public class BackupRestoreAnalyzer {
                         iterator.remove();
                         break;
                     case PROP_REPLICATION_NUM:
-                        replicationNum = parseInt(value);
+                        parseInt(value);
                         iterator.remove();
                         break;
                     case PROP_BACKUP_TIMESTAMP:
@@ -385,7 +397,6 @@ public class BackupRestoreAnalyzer {
             }
             restoreStmt.setTimeoutMs(timeoutMs);
             restoreStmt.setAllowLoad(allowLoad);
-            restoreStmt.setReplicationNum(replicationNum);
             restoreStmt.setMetaVersion(metaVersion);
             restoreStmt.setStarrocksMetaVersion(starrocksMetaVersion);
             if (null == backupTimestamp) {
@@ -446,22 +457,20 @@ public class BackupRestoreAnalyzer {
         }
     }
 
-    public static void analyzeTableRef(TableRefPersist tableRef, String dbName, Database db,
-                                       Map<String, TableRefPersist> tblPartsMap, String catalog,
+    public static void analyzeTableRef(TableRef tableRef, Database db,
+                                       Map<String, TableRef> tblPartsMap,
                                        Map<String, MaterializedView> tblMaterializedViewMap,
-                                       Map<Long, TableRefPersist> tableIdToTableRefMap) {
-        TableName tableName = tableRef.getName();
-        tableName.setCatalog(catalog);
-        tableName.setDb(dbName);
+                                       Map<Long, TableRef> tableIdToTableRefMap) {
 
-        PartitionNames partitionNames = tableRef.getPartitionNames();
-        Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName.getTbl());
+        String tableName = tableRef.getTableName();
+
+        Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         if (null == tbl) {
-            throw new SemanticException(ErrorCode.ERR_WRONG_TABLE_NAME.formatErrorMsg(tableName.getTbl()));
+            throw new SemanticException(ErrorCode.ERR_WRONG_TABLE_NAME.formatErrorMsg(tableName));
         }
 
         String alias = tableRef.getAlias();
-        if (!tableName.getTbl().equalsIgnoreCase(alias)) {
+        if (!tableName.equalsIgnoreCase(alias)) {
             Table tblAlias = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), alias);
             if (tblAlias != null && tbl != tblAlias) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
@@ -484,25 +493,26 @@ public class BackupRestoreAnalyzer {
             }
         }
 
-        if (partitionNames != null) {
+        if (tableRef.getPartitionRef() != null) {
+            List<String> partitionNames = tableRef.getPartitionRef().getPartitionNames();
             if (!tbl.isNativeTableOrMaterializedView()) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_TABLE_NAME, tableName.getTbl());
+                ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_TABLE_NAME, tableName);
             }
             OlapTable olapTbl = (OlapTable) tbl;
-            for (String partName : tableRef.getPartitionNames().getPartitionNames()) {
+            for (String partName : partitionNames) {
                 Partition partition = olapTbl.getPartition(partName);
                 if (partition == null) {
                     throw new SemanticException(
-                            "partition[" + partName + "] does not exist  in table" + tableName.getTbl(),
-                            tableRef.getPartitionNames().getPos());
+                            "partition[" + partName + "] does not exist  in table" + tableName,
+                            tableRef.getPartitionRef().getPos());
                 }
             }
         }
 
-        if (!tblPartsMap.containsKey(tableName.getTbl())) {
-            tblPartsMap.put(tableName.getTbl(), tableRef);
+        if (!tblPartsMap.containsKey(tableName)) {
+            tblPartsMap.put(tableName, tableRef);
         } else {
-            throw new SemanticException("Duplicated table: " + tableName.getTbl(), tableName.getPos());
+            throw new SemanticException("Duplicated table: " + tableName, tableRef.getPos());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
@@ -489,14 +489,6 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
 
     // ---------------------------------------- Backup Restore Statement -----------------------------------------------
 
-    default R visitBackupStatement(BackupStmt statement, C context) {
-        return visitDDLStatement(statement, context);
-    }
-
-    default R visitRestoreStatement(RestoreStmt statement, C context) {
-        return visitDDLStatement(statement, context);
-    }
-
     default R visitShowBackupStatement(ShowBackupStmt statement, C context) {
         return visitShowStatement(statement, context);
     }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AbstractBackupStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AbstractBackupStmt.java
@@ -12,20 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.starrocks.persist.TableRefPersist;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static com.starrocks.common.util.Util.normalizeName;
 
 public class AbstractBackupStmt extends DdlStmt {
     public enum BackupObjectType {
@@ -38,7 +34,7 @@ public class AbstractBackupStmt extends DdlStmt {
 
     protected LabelName labelName;
     protected String repoName;
-    protected List<TableRefPersist> tblRefs;
+    protected List<TableRef> tblRefs;
     protected List<FunctionRef> fnRefs;
     protected List<CatalogRef> externalCatalogRefs;
 
@@ -54,9 +50,16 @@ public class AbstractBackupStmt extends DdlStmt {
 
     protected long timeoutMs;
 
-    public AbstractBackupStmt(LabelName labelName, String repoName, List<TableRefPersist> tableRefs,
-                              List<FunctionRef> fnRefs, List<CatalogRef> externalCatalogRefs, Set<BackupObjectType> allMarker,
-                              boolean withOnClause, String originDbName, Map<String, String> properties, NodePosition pos) {
+    public AbstractBackupStmt(LabelName labelName,
+                              String repoName,
+                              List<TableRef> tableRefs,
+                              List<FunctionRef> fnRefs,
+                              List<CatalogRef> externalCatalogRefs,
+                              Set<BackupObjectType> allMarker,
+                              boolean withOnClause,
+                              String originDbName,
+                              Map<String, String> properties,
+                              NodePosition pos) {
         super(pos);
         this.labelName = labelName;
         this.repoName = repoName;
@@ -77,7 +80,7 @@ public class AbstractBackupStmt extends DdlStmt {
             this.allMarker = Sets.newHashSet();
         }
 
-        this.originDbName = normalizeName(originDbName);
+        this.originDbName = originDbName;
         this.withOnClause = withOnClause;
         this.properties = properties == null ? Maps.newHashMap() : properties;
     }
@@ -98,7 +101,7 @@ public class AbstractBackupStmt extends DdlStmt {
         return repoName;
     }
 
-    public List<TableRefPersist> getTableRefs() {
+    public List<TableRef> getTableRefs() {
         return tblRefs;
     }
 
@@ -154,4 +157,3 @@ public class AbstractBackupStmt extends DdlStmt {
         return allExternalCatalog() || !externalCatalogRefs.isEmpty();
     }
 }
-

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -701,4 +701,12 @@ public interface AstVisitor<R, C> {
     default R visitShowDataDistributionStatement(ShowDataDistributionStmt statement, C context) {
         return visitShowStatement(statement, context);
     }
+
+    default R visitBackupStatement(BackupStmt statement, C context) {
+        return visitDDLStatement(statement, context);
+    }
+
+    default R visitRestoreStatement(RestoreStmt statement, C context) {
+        return visitDDLStatement(statement, context);
+    }
 }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/BackupStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/BackupStmt.java
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
-import com.starrocks.persist.TableRefPersist;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
@@ -29,18 +27,17 @@ public class BackupStmt extends AbstractBackupStmt {
 
     private BackupType type = BackupType.FULL;
 
-    public BackupStmt(LabelName labelName, String repoName, List<TableRefPersist> tblRefs, List<FunctionRef> fnRefs,
-                      List<CatalogRef> externalCatalogRefs, Set<BackupObjectType> allMarker,
-                      boolean withOnClause, String originDbName, Map<String, String> properties) {
-        super(labelName, repoName, tblRefs, fnRefs, externalCatalogRefs,
-                allMarker, withOnClause, originDbName, properties, NodePosition.ZERO);
-    }
-
-    public BackupStmt(LabelName labelName, String repoName, List<TableRefPersist> tblRefs, List<FunctionRef> fnRefs,
-                      List<CatalogRef> externalCatalogRefs, Set<BackupObjectType> allMarker,
-                      boolean withOnClause, String originDbName, Map<String, String> properties, NodePosition pos) {
-        super(labelName, repoName, tblRefs, fnRefs, externalCatalogRefs,
-                allMarker, withOnClause, originDbName, properties, pos);
+    public BackupStmt(LabelName labelName,
+                      String repoName,
+                      List<TableRef> tblRefs,
+                      List<FunctionRef> fnRefs,
+                      List<CatalogRef> externalCatalogRefs,
+                      Set<BackupObjectType> allMarker,
+                      boolean withOnClause,
+                      String originDbName,
+                      Map<String, String> properties,
+                      NodePosition pos) {
+        super(labelName, repoName, tblRefs, fnRefs, externalCatalogRefs, allMarker, withOnClause, originDbName, properties, pos);
     }
 
     public long getTimeoutMs() {
@@ -61,7 +58,6 @@ public class BackupStmt extends AbstractBackupStmt {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitBackupStatement(this, context);
+        return visitor.visitBackupStatement(this, context);
     }
-
 }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/CatalogRef.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/CatalogRef.java
@@ -15,12 +15,6 @@
 
 package com.starrocks.sql.ast;
 
-import com.google.common.base.Preconditions;
-import com.starrocks.catalog.Catalog;
-import com.starrocks.catalog.InternalCatalog;
-import com.starrocks.common.ErrorCode;
-import com.starrocks.common.ErrorReport;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.parser.NodePosition;
 
 /**
@@ -28,10 +22,8 @@ import com.starrocks.sql.parser.NodePosition;
  */
 public class CatalogRef implements ParseNode {
     private final NodePosition pos;
-    private String catalogName;
-    private String alias;
-    private Catalog catalog;
-    private boolean isAnalyzed;
+    private final String catalogName;
+    private final String alias;
 
     public CatalogRef(String catalogName) {
         this(catalogName, "");
@@ -40,7 +32,6 @@ public class CatalogRef implements ParseNode {
     public CatalogRef(String catalogName, String alias) {
         this.catalogName = catalogName;
         this.alias = alias;
-        this.isAnalyzed = false;
         this.pos = NodePosition.ZERO;
     }
 
@@ -50,26 +41,6 @@ public class CatalogRef implements ParseNode {
 
     public String getAlias() {
         return this.alias;
-    }
-
-    public Catalog getCatalog() {
-        Preconditions.checkState(isAnalyzed);
-        return this.catalog;
-    }
-
-    public void analyzeForBackup() {
-        if (catalogName.equalsIgnoreCase(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
-                        "Do not support Backup/Restore the entire default catalog");   
-        }
-
-        if (!GlobalStateMgr.getCurrentState().getCatalogMgr().catalogExists(catalogName)) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
-                        "external catalog " + catalogName + " does not existed.");
-        }
-
-        catalog = GlobalStateMgr.getCurrentState().getCatalogMgr().getCatalogByName(catalogName);
-        isAnalyzed = true;
     }
 
     @Override

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/RestoreStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/RestoreStmt.java
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
-import com.starrocks.persist.TableRefPersist;
-import com.starrocks.server.RunMode;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
@@ -25,32 +22,26 @@ import java.util.Set;
 
 public class RestoreStmt extends AbstractBackupStmt {
     private boolean allowLoad = false;
-    private int replicationNum = RunMode.defaultReplicationNum();
     private String backupTimestamp = null;
     private int metaVersion = -1;
     private int starrocksMetaVersion = -1;
 
-    public RestoreStmt(LabelName labelName, String repoName, List<TableRefPersist> tblRefs,
-                       List<FunctionRef> fnRefs, List<CatalogRef> externalCatalogRefs, Set<BackupObjectType> allMarker,
-                       boolean withOnClause, String originDbName, Map<String, String> properties) {
-        this(labelName, repoName, tblRefs, fnRefs, externalCatalogRefs,
-                allMarker, withOnClause, originDbName, properties, NodePosition.ZERO);
-    }
-
-    public RestoreStmt(LabelName labelName, String repoName, List<TableRefPersist> tblRefs,
-                       List<FunctionRef> fnRefs, List<CatalogRef> externalCatalogRefs, Set<BackupObjectType> allMarker,
-                       boolean withOnClause, String originDbName,
-                       Map<String, String> properties, NodePosition pos) {
+    public RestoreStmt(LabelName labelName,
+                       String repoName,
+                       List<TableRef> tblRefs,
+                       List<FunctionRef> fnRefs,
+                       List<CatalogRef> externalCatalogRefs,
+                       Set<BackupObjectType> allMarker,
+                       boolean withOnClause,
+                       String originDbName,
+                       Map<String, String> properties,
+                       NodePosition pos) {
         super(labelName, repoName, tblRefs, fnRefs, externalCatalogRefs,
                 allMarker, withOnClause, originDbName, properties, pos);
     }
 
     public boolean allowLoad() {
         return allowLoad;
-    }
-
-    public int getReplicationNum() {
-        return replicationNum;
     }
 
     public String getBackupTimestamp() {
@@ -67,7 +58,7 @@ public class RestoreStmt extends AbstractBackupStmt {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitRestoreStatement(this, context);
+        return visitor.visitRestoreStatement(this, context);
     }
 
     public void setTimeoutMs(long timeoutMs) {
@@ -76,10 +67,6 @@ public class RestoreStmt extends AbstractBackupStmt {
 
     public void setAllowLoad(boolean allowLoad) {
         this.allowLoad = allowLoad;
-    }
-
-    public void setReplicationNum(int replicationNum) {
-        this.replicationNum = replicationNum;
     }
 
     public void setBackupTimestamp(String backupTimestamp) {

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/TableRef.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/TableRef.java
@@ -19,11 +19,17 @@ import com.starrocks.sql.parser.NodePosition;
 public class TableRef implements ParseNode {
     private final QualifiedName tableName;
     private final PartitionRef partitionRef;
+    private final String alias;
     private final NodePosition pos;
 
     public TableRef(QualifiedName tableName, PartitionRef partitionRef, NodePosition pos) {
+        this(tableName, partitionRef, null, pos);
+    }
+
+    public TableRef(QualifiedName tableName, PartitionRef partitionRef, String alias, NodePosition pos) {
         this.tableName = tableName;
         this.partitionRef = partitionRef;
+        this.alias = alias;
         this.pos = pos;
     }
 
@@ -55,5 +61,28 @@ public class TableRef implements ParseNode {
 
     public PartitionRef getPartitionDef() {
         return partitionRef;
+    }
+
+    public PartitionRef getPartitionRef() {
+        return partitionRef;
+    }
+
+    public QualifiedName getQualifiedName() {
+        return tableName;
+    }
+
+    public String getAlias() {
+        if (alias != null) {
+            return alias;
+        }
+        return getTableName();
+    }
+
+    public boolean hasExplicitAlias() {
+        return alias != null;
+    }
+
+    public String getExplicitAlias() {
+        return alias;
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request refactors the backup and restore logic in the StarRocks FE core to use the unified `TableRef` and `PartitionRef` structures instead of the legacy `TableRefPersist` and `PartitionNames` types. It also introduces improvements to catalog handling and replication number configuration for restore operations. These changes enhance code consistency, simplify backup/restore workflows, and improve maintainability.

**Refactoring to use `TableRef` and `PartitionRef`:**

* The backup and restore processes now use `TableRef` and `PartitionRef` instead of `TableRefPersist` and `PartitionNames`, streamlining the handling of table and partition references throughout the backup/restore pipeline. (`BackupHandler.java` [[1]](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aL382-R397) [[2]](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aL414-R427) [[3]](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aL431-R437) [[4]](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aL656-R718) [[5]](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aL690-R733) [[6]](diffhunk://#diff-3311511b364c1b9c62bb240801f539d8fdd4f8406e8b97ec241ea95bba3828c7L2338-R2339) [[7]](diffhunk://#diff-3311511b364c1b9c62bb240801f539d8fdd4f8406e8b97ec241ea95bba3828c7L2475-R2475) [[8]](diffhunk://#diff-3311511b364c1b9c62bb240801f539d8fdd4f8406e8b97ec241ea95bba3828c7L2505-R2517)
* The `process` and `backup` methods in `BackupHandler` now accept and propagate `ConnectContext`, allowing for better context-aware processing and catalog resolution. (`BackupHandler.java` [[1]](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aL268-R274) [[2]](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aL352-R358) [[3]](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aL373-R379) [[4]](diffhunk://#diff-f39e516b374db1420ceb7e1d23494dafa517c7a95993e391d3fb23b52ec10f5bL746-R754)

**Catalog and context improvements:**

* Catalog references for backup jobs are now resolved using a helper method that validates catalog existence and fetches the correct catalog object, improving robustness and error reporting. (`BackupHandler.java` [[1]](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aL512-R540) [[2]](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aR550-R559)
* When constructing `TableRefPersist` objects for backup jobs, catalog and database names are resolved using the current context if they are not explicitly provided. (`BackupHandler.java` [fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.javaL489-R512](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aL489-R512))

**Restore improvements:**

* The restore process now supports configuring the replication number via the `replication_num` property, defaulting to the system's default replication number if not specified. (`BackupHandler.java` [fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.javaR602-R609](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aR602-R609))

**Authorization and analysis adjustments:**

* The authorizer and analyzer logic is updated to use the new `TableRef` structure, ensuring privilege checks and metadata resolution are consistent with the refactored backup/restore logic. (`AuthorizerStmtVisitor.java` [[1]](diffhunk://#diff-3311511b364c1b9c62bb240801f539d8fdd4f8406e8b97ec241ea95bba3828c7L2338-R2339) [[2]](diffhunk://#diff-3311511b364c1b9c62bb240801f539d8fdd4f8406e8b97ec241ea95bba3828c7L2347-R2350) [[3]](diffhunk://#diff-3311511b364c1b9c62bb240801f539d8fdd4f8406e8b97ec241ea95bba3828c7L2475-R2475) [[4]](diffhunk://#diff-3311511b364c1b9c62bb240801f539d8fdd4f8406e8b97ec241ea95bba3828c7L2505-R2517) `BackupRestoreAnalyzer.java` [[5]](diffhunk://#diff-ce1a098a66ad60f977186e7bb795ebcfadf5368ec890d2c6dd969ef93fda0074L31-R43)

**Imports and dependency cleanup:**

* Unused imports related to `TableRefPersist` and `PartitionNames` are removed, and necessary imports for `TableRef`, `PartitionRef`, and related classes are added. (`BackupHandler.java` [[1]](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aR38) [[2]](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aR74-R76) [[3]](diffhunk://#diff-dd2096f81dda5a66eb1fa7fd191567bd49c9d2b92380d48322f1902f6d97ff9aR87-R91) `AuthorizerStmtVisitor.java` [[4]](diffhunk://#diff-3311511b364c1b9c62bb240801f539d8fdd4f8406e8b97ec241ea95bba3828c7R209) `BackupRestoreAnalyzer.java` [[5]](diffhunk://#diff-ce1a098a66ad60f977186e7bb795ebcfadf5368ec890d2c6dd969ef93fda0074L31-R43)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
