### PR TITLE
[UT] Add setNextConnectionId method for testing connection ID generation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.qe;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -362,6 +363,11 @@ public class ConnectScheduler {
         return (frontend.getFid() & 0xFF) << 24 | (connectionIdGenerator.incrementAndGet() & 0xFFFFFF);
     }
 
+    @VisibleForTesting
+    public void setNextConnectionId(int connectionId) {
+        connectionIdGenerator.counter.set(connectionId);
+    }
+
     public static class ConnectionIdGenerator {
         // Atomic counter to ensure thread-safe increments
         private final AtomicInteger counter;
@@ -384,8 +390,7 @@ public class ConnectScheduler {
          * @return the updated counter value after incrementing
          */
         public int incrementAndGet() {
-            return counter.updateAndGet(currentValue -> (currentValue + 1 >= threshold) ? 0 : currentValue + 1
-            );
+            return counter.updateAndGet(currentValue -> (currentValue + 1 >= threshold) ? 0 : currentValue + 1);
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/GlobalConnectionIdTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/GlobalConnectionIdTest.java
@@ -41,9 +41,7 @@ public class GlobalConnectionIdTest {
 
         ConnectScheduler scheduler = new ConnectScheduler(10);
         int threshold = 1 << 24;
-        for (int i = 1; i < threshold; i++) {
-            scheduler.getNextConnectionId();
-        }
+        scheduler.setNextConnectionId(threshold);
 
         Assertions.assertEquals(0, scheduler.getNextConnectionId());
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request introduces a minor enhancement to the `ConnectScheduler` class to improve testability, specifically by allowing the internal connection ID counter to be set directly in tests.

Enhancements for testing:

* Added a `setNextConnectionId(int connectionId)` method to `ConnectScheduler`, annotated with `@VisibleForTesting`, to allow tests to set the internal connection ID counter. (`ConnectScheduler.java`) [[1]](diffhunk://#diff-1a66c78a0e93e8768aaab46339828c1bd2674b76ff5346013d7dc287918fed46R37) [[2]](diffhunk://#diff-1a66c78a0e93e8768aaab46339828c1bd2674b76ff5346013d7dc287918fed46R366-R370)
* Updated `GlobalConnectionIdTest` to use the new `setNextConnectionId` method instead of incrementing the counter in a loop, improving test performance and clarity. (`GlobalConnectionIdTest.java`)

Other minor cleanup:

* Minor formatting change in the lambda expression inside `incrementAndGet()` for readability. (`ConnectScheduler.java`)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add @VisibleForTesting setter to control the connection ID counter and update the GlobalConnectionIdTest to use it; minor formatting cleanup.
> 
> - **QE**:
>   - `ConnectScheduler`: add `@VisibleForTesting` `setNextConnectionId(int)` to set the internal counter used by `getNextConnectionId()`.
>   - Minor lambda formatting tweak in `ConnectionIdGenerator.incrementAndGet()`.
> - **Tests**:
>   - `GlobalConnectionIdTest`: replace counter loop with `setNextConnectionId(threshold)` to validate wrap-around and FE ID bits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de4091176a6978e7788828a6aa4e472d1ee8b353. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->