### PR TITLE
[Enhancement] Enhancing MySQL data types on JDBC catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -134,7 +134,7 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
                 }
                 break;
             case Types.FLOAT:
-            case Types.REAL:
+            case Types.REAL: // real => short float
                 primitiveType = PrimitiveType.FLOAT;
                 break;
             case Types.DOUBLE:

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -148,7 +148,7 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
                 return ScalarType.createVarcharType(columnSize);
             case Types.LONGVARCHAR:
                 if (lowerTypeName.equals("json")) {
-                    return ScalarType.createVarcharType(columnSize);
+                    return ScalarType.createVarcharType(1073741824);
                 } else if (lowerTypeName.startsWith("tiny") || lowerTypeName.startsWith("medium") ||
                         lowerTypeName.equals("text") || lowerTypeName.startsWith("long")) {
                     return ScalarType.createVarcharType(columnSize);
@@ -186,7 +186,7 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
                 break;
             default:
                 if (lowerTypeName.equals("json")) {
-                    return ScalarType.createVarcharType(columnSize);
+                    return ScalarType.createVarcharType(1073741824);
                 } else if (lowerTypeName.contains("geometry") || lowerTypeName.contains("point") ||
                         lowerTypeName.contains("linestring") || lowerTypeName.contains("polygon") ||
                         lowerTypeName.contains("multipoint") || lowerTypeName.contains("multilinestring") ||

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -96,9 +96,7 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
                 primitiveType = PrimitiveType.BOOLEAN;
                 break;
             case Types.TINYINT:
-                if (lowerTypeName.equals("tinyint") && columnSize == 1) {
-                    primitiveType = PrimitiveType.BOOLEAN;
-                } else if (isUnsigned) {
+                if (isUnsigned) {
                     primitiveType = PrimitiveType.SMALLINT;
                 } else {
                     primitiveType = PrimitiveType.TINYINT;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -113,17 +113,11 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
                 break;
             case Types.INTEGER:
                 if (lowerTypeName.startsWith("mediumint")) {
-                    if (isUnsigned) {
-                        primitiveType = PrimitiveType.INT;
-                    } else {
-                        primitiveType = PrimitiveType.INT;
-                    }
+                    primitiveType = PrimitiveType.INT;
+                } else if (isUnsigned) {
+                    primitiveType = PrimitiveType.BIGINT;
                 } else {
-                    if (isUnsigned) {
-                        primitiveType = PrimitiveType.BIGINT;
-                    } else {
-                        primitiveType = PrimitiveType.INT;
-                    }
+                    primitiveType = PrimitiveType.INT;
                 }
                 break;
             case Types.BIGINT:

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -19,6 +19,7 @@ import com.mockrunner.mock.jdbc.MockResultSet;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
@@ -355,9 +356,195 @@ public class MysqlSchemaResolverTest {
             JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", columns, Lists.newArrayList(),
                     "test", "catalog", properties);
             jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
-            // different mysql source may have different partition information, so we can ignore partition information parse
         } catch (Exception e) {
             Assertions.fail();
         }
+    }
+
+    @Test
+    public void testConvertNumericTypes() {
+        MysqlSchemaResolver resolver = new MysqlSchemaResolver();
+        
+        Type type = resolver.convertColumnType(java.sql.Types.BIT, "BIT", 1, 0);
+        Assertions.assertEquals(PrimitiveType.BOOLEAN, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.BIT, "BIT", 5, 0);
+        Assertions.assertEquals(PrimitiveType.BOOLEAN, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.BIT, "BIT", 64, 0);
+        Assertions.assertEquals(PrimitiveType.BOOLEAN, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.BOOLEAN, "BIT", 5, 0);
+        Assertions.assertEquals(PrimitiveType.BOOLEAN, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.BOOLEAN, "BIT", 64, 0);
+        Assertions.assertEquals(PrimitiveType.BOOLEAN, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.TINYINT, "TINYINT", 3, 0);
+        Assertions.assertEquals(PrimitiveType.TINYINT, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.TINYINT, "TINYINT UNSIGNED", 3, 0);
+        Assertions.assertEquals(PrimitiveType.SMALLINT, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.SMALLINT, "SMALLINT", 5, 0);
+        Assertions.assertEquals(PrimitiveType.SMALLINT, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.SMALLINT, "SMALLINT UNSIGNED", 5, 0);
+        Assertions.assertEquals(PrimitiveType.INT, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.INTEGER, "MEDIUMINT", 7, 0);
+        Assertions.assertEquals(PrimitiveType.INT, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.INTEGER, "MEDIUMINT UNSIGNED", 8, 0);
+        Assertions.assertEquals(PrimitiveType.INT, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.INTEGER, "INT", 10, 0);
+        Assertions.assertEquals(PrimitiveType.INT, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.INTEGER, "INT UNSIGNED", 10, 0);
+        Assertions.assertEquals(PrimitiveType.BIGINT, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.BIGINT, "BIGINT", 19, 0);
+        Assertions.assertEquals(PrimitiveType.BIGINT, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.BIGINT, "BIGINT UNSIGNED", 20, 0);
+        Assertions.assertEquals(PrimitiveType.LARGEINT, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.FLOAT, "FLOAT", 12, 0);
+        Assertions.assertEquals(PrimitiveType.FLOAT, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.DOUBLE, "DOUBLE", 22, 0);
+        Assertions.assertEquals(PrimitiveType.DOUBLE, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.DECIMAL, "DECIMAL", 10, 2);
+        Assertions.assertTrue(type.getPrimitiveType().isDecimalV3Type());
+    }
+
+    @Test
+    public void testConvertStringTypes() {
+        MysqlSchemaResolver resolver = new MysqlSchemaResolver();
+        
+        Type type = resolver.convertColumnType(java.sql.Types.CHAR, "CHAR", 10, 0);
+        Assertions.assertEquals(PrimitiveType.CHAR, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.VARCHAR, "VARCHAR", 255, 0);
+        Assertions.assertEquals(PrimitiveType.VARCHAR, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.BINARY, "BINARY", 10, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.VARBINARY, "VARBINARY", 255, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARBINARY, "TINYBLOB", 255, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARBINARY, "BLOB", 65535, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARBINARY, "MEDIUMBLOB", 16777215, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARBINARY, "LONGBLOB", 2147483647, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARCHAR, "TINYTEXT", 255, 0);
+        Assertions.assertEquals(PrimitiveType.VARCHAR, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARCHAR, "TEXT", 65535, 0);
+        Assertions.assertEquals(PrimitiveType.VARCHAR, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARCHAR, "MEDIUMTEXT", 16777215, 0);
+        Assertions.assertEquals(PrimitiveType.VARCHAR, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARCHAR, "LONGTEXT", 2147483647, 0);
+        Assertions.assertEquals(PrimitiveType.VARCHAR, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.CHAR, "ENUM", 5, 0);
+        Assertions.assertEquals(PrimitiveType.VARCHAR, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.CHAR, "SET", 21, 0);
+        Assertions.assertEquals(PrimitiveType.VARCHAR, type.getPrimitiveType());
+    }
+
+    @Test
+    public void testConvertDateTimeTypes() {
+        MysqlSchemaResolver resolver = new MysqlSchemaResolver();
+        
+        Type type = resolver.convertColumnType(java.sql.Types.DATE, "DATE", 10, 0);
+        Assertions.assertEquals(PrimitiveType.DATE, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.TIME, "TIME", 10, 0);
+        Assertions.assertEquals(PrimitiveType.TIME, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.TIME, "TIME", 16, 6);
+        Assertions.assertEquals(PrimitiveType.TIME, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.TIMESTAMP, "DATETIME", 19, 0);
+        Assertions.assertEquals(PrimitiveType.DATETIME, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.TIMESTAMP, "DATETIME", 26, 6);
+        Assertions.assertEquals(PrimitiveType.DATETIME, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.TIMESTAMP, "TIMESTAMP", 19, 0);
+        Assertions.assertEquals(PrimitiveType.DATETIME, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.TIMESTAMP, "TIMESTAMP", 26, 6);
+        Assertions.assertEquals(PrimitiveType.DATETIME, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.DATE, "YEAR", 4, 0);
+        Assertions.assertEquals(PrimitiveType.DATE, type.getPrimitiveType());
+    }
+
+    @Test
+    public void testConvertJsonType() {
+        MysqlSchemaResolver resolver = new MysqlSchemaResolver();
+        
+        Type type = resolver.convertColumnType(java.sql.Types.LONGVARCHAR, "JSON", 1073741824, 0);
+        Assertions.assertEquals(PrimitiveType.VARCHAR, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.OTHER, "JSON", 1073741824, 0);
+        Assertions.assertEquals(PrimitiveType.VARCHAR, type.getPrimitiveType());
+    }
+
+    @Test
+    public void testConvertSpatialTypes() {
+        MysqlSchemaResolver resolver = new MysqlSchemaResolver();
+        
+        Type type = resolver.convertColumnType(java.sql.Types.LONGVARBINARY, "GEOMETRY", 2147483647, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARBINARY, "POINT", 2147483647, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARBINARY, "LINESTRING", 2147483647, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARBINARY, "POLYGON", 2147483647, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARBINARY, "MULTIPOINT", 2147483647, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARBINARY, "MULTILINESTRING", 2147483647, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARBINARY, "MULTIPOLYGON", 2147483647, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARBINARY, "GEOMETRYCOLLECTION", 2147483647, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARCHAR, "GEOMETRYCOLLECTION", 1073741824, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.OTHER, "GEOMETRY", 2147483647, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.OTHER, "POINT", 2147483647, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        
+        type = resolver.convertColumnType(java.sql.Types.OTHER, "GEOMETRYCOLLECTION", 1073741824, 0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
@@ -505,9 +506,19 @@ public class MysqlSchemaResolverTest {
         
         Type type = resolver.convertColumnType(java.sql.Types.LONGVARCHAR, "JSON", 1073741824, 0);
         Assertions.assertEquals(PrimitiveType.VARCHAR, type.getPrimitiveType());
+        Assertions.assertEquals(1073741824, ((ScalarType) type).getLength());
+        
+        type = resolver.convertColumnType(java.sql.Types.LONGVARCHAR, "JSON", 0, 0);
+        Assertions.assertEquals(PrimitiveType.VARCHAR, type.getPrimitiveType());
+        Assertions.assertEquals(1073741824, ((ScalarType) type).getLength());
         
         type = resolver.convertColumnType(java.sql.Types.OTHER, "JSON", 1073741824, 0);
         Assertions.assertEquals(PrimitiveType.VARCHAR, type.getPrimitiveType());
+        Assertions.assertEquals(1073741824, ((ScalarType) type).getLength());
+        
+        type = resolver.convertColumnType(java.sql.Types.OTHER, "JSON", 0, 0);
+        Assertions.assertEquals(PrimitiveType.VARCHAR, type.getPrimitiveType());
+        Assertions.assertEquals(1073741824, ((ScalarType) type).getLength());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -380,6 +380,9 @@ public class MysqlSchemaResolverTest {
         type = resolver.convertColumnType(java.sql.Types.BOOLEAN, "BIT", 64, 0);
         Assertions.assertEquals(PrimitiveType.BOOLEAN, type.getPrimitiveType());
         
+        type = resolver.convertColumnType(java.sql.Types.TINYINT, "TINYINT", 1, 0);
+        Assertions.assertEquals(PrimitiveType.TINYINT, type.getPrimitiveType());
+        
         type = resolver.convertColumnType(java.sql.Types.TINYINT, "TINYINT", 3, 0);
         Assertions.assertEquals(PrimitiveType.TINYINT, type.getPrimitiveType());
         


### PR DESCRIPTION
## Why I'm doing:
Im trying to add some lacking data types. For example; year,json,spatial etc...
## What I'm doing:
---
<img width="378" height="553" alt="image" src="https://github.com/user-attachments/assets/86e73f12-2516-479b-a8ed-25a54b9ac4a2" />
---
<img width="1060" height="889" alt="image" src="https://github.com/user-attachments/assets/26bee197-1629-405f-9749-8dac1aa6fc70" />

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands MySQL→StarRocks JDBC type conversions (mediumint, enum/set, JSON, text/blob/binary, spatial, NUMERIC) and adds thorough unit tests.
> 
> - **MySQL JDBC type mapping (`MysqlSchemaResolver.convertColumnType`)**:
>   - Normalize `typeName` to `lowerTypeName`; detect `unsigned`.
>   - Integers: handle `mediumint*`; refine unsigned mappings.
>   - Decimals: treat `Types.NUMERIC` as decimal V3.
>   - Strings: map `enum`/`set` to `VARCHAR`; handle `TEXT` variants under `Types.LONGVARCHAR`.
>   - Binary: map `BINARY`/`VARBINARY`/`BLOB` variants to `VARBINARY`.
>   - JSON: map to `VARCHAR(1073741824)` across `LONGVARCHAR` and `OTHER`.
>   - Spatial (`geometry`, `point`, `linestring`, `polygon`, etc.): map to `VARBINARY` for `LONGVARCHAR`/`LONGVARBINARY`/`OTHER`.
> - **Tests (`MysqlSchemaResolverTest`)**:
>   - Add unit tests covering numeric, string, datetime, JSON, and spatial mappings; minor cleanup in partition tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dc05b4f9badc20ca5439bb704dc8d9127c56221. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->