### PR TITLE
[Enhancement] disable collecting table stats when single iceberg/deltalake table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -146,7 +146,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
     public Statistics getTableStatistics(OptimizerContext session, Table table, Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit,
                                          TvrVersionRange versionRange) {
-        if (!properties.enableGetTableStatsFromExternalMetadata()) {
+        if (!properties.enableGetTableStatsFromExternalMetadata() || session.getSourceTablesCount() == 1) {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -146,7 +146,14 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
     public Statistics getTableStatistics(OptimizerContext session, Table table, Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit,
                                          TvrVersionRange versionRange) {
-        if (!properties.enableGetTableStatsFromExternalMetadata() || session.getSourceTablesCount() == 1) {
+        boolean useDefaultStats = false;
+        if (!properties.enableGetTableStatsFromExternalMetadata()) {
+            useDefaultStats = true;
+        }
+        if (session.getSessionVariable().disableTableStatsFromMetadataForSingleTable() && session.getSourceTablesCount() == 1) {
+            useDefaultStats = true;
+        }
+        if (useDefaultStats) {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1132,7 +1132,14 @@ public class IcebergMetadata implements ConnectorMetadata {
                                          ScalarOperator predicate,
                                          long limit,
                                          TvrVersionRange version) {
-        if (!properties.enableGetTableStatsFromExternalMetadata() || session.getSourceTablesCount() == 1) {
+        boolean useDefaultStats = false;
+        if (!properties.enableGetTableStatsFromExternalMetadata()) {
+            useDefaultStats = true;
+        }
+        if (session.getSessionVariable().disableTableStatsFromMetadataForSingleTable() && session.getSourceTablesCount() == 1) {
+            useDefaultStats = true;
+        }
+        if (useDefaultStats) {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
         IcebergTable icebergTable = (IcebergTable) table;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1132,7 +1132,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                                          ScalarOperator predicate,
                                          long limit,
                                          TvrVersionRange version) {
-        if (!properties.enableGetTableStatsFromExternalMetadata()) {
+        if (!properties.enableGetTableStatsFromExternalMetadata() || session.getSourceTablesCount() == 1) {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
         IcebergTable icebergTable = (IcebergTable) table;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -489,6 +489,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             "enable_read_iceberg_equality_delete_with_partition_evolution";
     public static final String ENABLE_DELTA_LAKE_COLUMN_STATISTICS = "enable_delta_lake_column_statistics";
 
+    public static final String DISABLE_TABLE_STATS_FROM_METADATA_FOR_SINGLE_TABLE =
+            "disable_table_stats_from_metadata_for_single_table";
+
     public static final String ENABLE_QUERY_TRIGGER_ANALYZE = "enable_query_trigger_analyze";
 
     public static final String ENABLE_PAIMON_COLUMN_STATISTICS = "enable_paimon_column_statistics";
@@ -2675,6 +2678,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_DELTA_LAKE_COLUMN_STATISTICS)
     private boolean enableDeltaLakeColumnStatistics = false;
 
+    @VarAttr(name = DISABLE_TABLE_STATS_FROM_METADATA_FOR_SINGLE_TABLE)
+    private boolean disableTableStatsFromMetadataForSingleTable = true;
+
     @VarAttr(name = ENABLE_QUERY_TRIGGER_ANALYZE)
     private boolean enableQueryTriggerAnalyze = true;
 
@@ -2793,6 +2799,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean enableDeltaLakeColumnStatistics() {
         return enableDeltaLakeColumnStatistics;
+    }
+
+    public boolean disableTableStatsFromMetadataForSingleTable() {
+        return disableTableStatsFromMetadataForSingleTable;
     }
 
     public boolean enableIcebergColumnStatistics() {
@@ -3739,7 +3749,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public boolean isEnableCostBasedMultiStageAgg() {
-        return newPlannerAggStage == SessionVariableConstants.AggregationStage.AUTO.ordinal() &&  enableCostBasedMultiStageAgg;
+        return newPlannerAggStage == SessionVariableConstants.AggregationStage.AUTO.ordinal() && enableCostBasedMultiStageAgg;
     }
 
     public void setMaxTransformReorderJoins(int maxReorderNodeUseExhaustive) {
@@ -5398,7 +5408,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public void setEnableFullSortUseGermanString(boolean value) {
-        this.enableFullSortUseGermanString  = value;
+        this.enableFullSortUseGermanString = value;
     }
 
     public boolean isEnableFullSortUseGermanString() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -127,7 +127,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.DefaultExpr.isValidDefaultFunction;
-import static com.starrocks.sql.StatementPlanner.collectReferenceTables;
+import static com.starrocks.sql.StatementPlanner.collectSourceTablesCount;
 import static com.starrocks.sql.optimizer.rule.mv.MVUtils.MATERIALIZED_VIEW_NAME_PREFIX;
 
 public class InsertPlanner {
@@ -565,11 +565,11 @@ public class InsertPlanner {
                 session.getSessionVariable());
         OptExpression optimizedPlan;
 
-        Pair<Integer, Integer> tablesCount = collectReferenceTables(session, insertStmt);
+        int sourceTablesCount = collectSourceTablesCount(session, insertStmt);
 
         try (Timer ignore2 = Tracers.watchScope("Optimizer")) {
             OptimizerContext optimizerContext = OptimizerFactory.initContext(session, columnRefFactory);
-            optimizerContext.setTablesCount(tablesCount);
+            optimizerContext.setSourceTablesCount(sourceTablesCount);
             Optimizer optimizer = OptimizerFactory.create(optimizerContext);
             optimizedPlan = optimizer.optimize(
                     logicalPlan.getRoot(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -447,7 +447,7 @@ public class StatementPlanner {
     }
 
     public static int collectSourceTablesCount(ConnectContext session, StatementBase queryStmt) {
-        Set<Table> sourceTables = Sets.newHashSet();
+        List<Table> sourceTables = Lists.newArrayList();
         AnalyzerUtils.collectSourceTables(queryStmt, sourceTables);
         return sourceTables.size();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -33,7 +33,6 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.LabelAlreadyUsedException;
-import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.http.HttpConnectContext;
@@ -359,7 +358,7 @@ public class StatementPlanner {
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
         boolean isSchemaValid = true;
 
-        Pair<Integer, Integer> tablesCount = collectReferenceTables(session, queryStmt);
+        int sourceTablesCount = collectSourceTablesCount(session, queryStmt);
 
         // TODO: double check relatedMvs for OlapTable
         // only collect once to save the original olapTable info
@@ -397,7 +396,7 @@ public class StatementPlanner {
                 }
                 optimizerContext.setMvTransformerContext(mvTransformerContext);
                 optimizerContext.setStatement(queryStmt);
-                optimizerContext.setTablesCount(tablesCount);
+                optimizerContext.setSourceTablesCount(sourceTablesCount);
 
                 Optimizer optimizer = OptimizerFactory.create(optimizerContext);
                 optimizedPlan = optimizer.optimize(logicalPlan.getRoot(), new PhysicalPropertySet(),
@@ -447,11 +446,10 @@ public class StatementPlanner {
         }
     }
 
-    public static Pair<Integer, Integer> collectReferenceTables(ConnectContext session, StatementBase queryStmt) {
-        Set<Table> updatedTables = Sets.newHashSet();
+    public static int collectSourceTablesCount(ConnectContext session, StatementBase queryStmt) {
         Set<Table> sourceTables = Sets.newHashSet();
-        AnalyzerUtils.collectReferenceTables(queryStmt, updatedTables, sourceTables);
-        return Pair.create(updatedTables.size(), sourceTables.size());
+        AnalyzerUtils.collectSourceTables(queryStmt, sourceTables);
+        return sourceTables.size();
     }
 
     public static Set<OlapTable> reAnalyzeStmt(StatementBase queryStmt, ConnectContext session, PlannerMetaLocker locker) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -839,7 +839,7 @@ public class AnalyzerUtils {
         new AnalyzerUtils.OlapTableCollector(olapTables).visit(statementBase);
     }
 
-    public static void collectSourceTables(StatementBase statementBase, Set<Table> sourceTables) {
+    public static void collectSourceTables(StatementBase statementBase, List<Table> sourceTables) {
         new SourceTablesCollector(sourceTables).visit(statementBase);
     }
 
@@ -1031,9 +1031,9 @@ public class AnalyzerUtils {
     }
 
     private static class SourceTablesCollector extends TableCollector {
-        private Set<Table> sourceTables;
+        private List<Table> sourceTables;
 
-        public SourceTablesCollector(Set<Table> sourceTables) {
+        public SourceTablesCollector(List<Table> sourceTables) {
             super();
             this.sourceTables = sourceTables;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -839,6 +839,10 @@ public class AnalyzerUtils {
         new AnalyzerUtils.OlapTableCollector(olapTables).visit(statementBase);
     }
 
+    public static void collectReferenceTables(StatementBase statementBase, Set<Table> updatedTables, Set<Table> sourceTables) {
+        new AnalyzerUtils.ReferenceTablesCollector(updatedTables, sourceTables).visit(statementBase);
+    }
+
     public static void collectSpecifyExternalTables(StatementBase statementBase, List<Table> tables,
                                                     Predicate<Table> filter) {
         new ExternalTableCollector(tables, filter).visit(statementBase);
@@ -1023,6 +1027,31 @@ public class AnalyzerUtils {
             olapTables.add(table);
             idMap.put(tableIndexId, copied);
             return copied;
+        }
+    }
+
+    private static class ReferenceTablesCollector extends TableCollector {
+        private Set<Table> updateTables;
+        private Set<Table> sourceTables;
+
+        public ReferenceTablesCollector(Set<Table> updateTables, Set<Table> sourceTables) {
+            super();
+            this.updateTables = updateTables;
+            this.sourceTables = sourceTables;
+        }
+
+        @Override
+        public Void visitInsertStatement(InsertStmt node, Void context) {
+            super.visitInsertStatement(node, context);
+            updateTables.add(node.getTargetTable());
+            return null;
+        }
+
+        @Override
+        public Void visitTable(TableRelation node, Void context) {
+            super.visitTable(node, context);
+            sourceTables.add(node.getTable());
+            return null;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -839,8 +839,8 @@ public class AnalyzerUtils {
         new AnalyzerUtils.OlapTableCollector(olapTables).visit(statementBase);
     }
 
-    public static void collectReferenceTables(StatementBase statementBase, Set<Table> updatedTables, Set<Table> sourceTables) {
-        new AnalyzerUtils.ReferenceTablesCollector(updatedTables, sourceTables).visit(statementBase);
+    public static void collectSourceTables(StatementBase statementBase, Set<Table> sourceTables) {
+        new SourceTablesCollector(sourceTables).visit(statementBase);
     }
 
     public static void collectSpecifyExternalTables(StatementBase statementBase, List<Table> tables,
@@ -1030,21 +1030,12 @@ public class AnalyzerUtils {
         }
     }
 
-    private static class ReferenceTablesCollector extends TableCollector {
-        private Set<Table> updateTables;
+    private static class SourceTablesCollector extends TableCollector {
         private Set<Table> sourceTables;
 
-        public ReferenceTablesCollector(Set<Table> updateTables, Set<Table> sourceTables) {
+        public SourceTablesCollector(Set<Table> sourceTables) {
             super();
-            this.updateTables = updateTables;
             this.sourceTables = sourceTables;
-        }
-
-        @Override
-        public Void visitInsertStatement(InsertStmt node, Void context) {
-            super.visitInsertStatement(node, context);
-            updateTables.add(node.getTargetTable());
-            return null;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -18,7 +18,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.ast.StatementBase;
@@ -85,8 +84,8 @@ public class OptimizerContext {
     // TvrOptContext is used to store the context for TVR optimization.
     private final TvrOptContext tvrOptContext;
 
-    // updated tables count and source tables count in the query
-    private final Pair<Integer, Integer> tablesCount = Pair.create(0, 0);
+    // source tables count in the query
+    private int sourceTablesCount = 0;
 
     OptimizerContext(ConnectContext context) {
         this.connectContext = context;
@@ -254,12 +253,11 @@ public class OptimizerContext {
     }
 
     public int getSourceTablesCount() {
-        return tablesCount.second;
+        return this.sourceTablesCount;
     }
 
-    public void setTablesCount(Pair<Integer, Integer> count) {
-        this.tablesCount.first = count.first;
-        this.tablesCount.second = count.second;
+    public void setSourceTablesCount(int count) {
+        this.sourceTablesCount = count;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -18,6 +18,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.ast.StatementBase;
@@ -83,6 +84,9 @@ public class OptimizerContext {
 
     // TvrOptContext is used to store the context for TVR optimization.
     private final TvrOptContext tvrOptContext;
+
+    // updated tables count and source tables count in the query
+    private final Pair<Integer, Integer> tablesCount = Pair.create(0, 0);
 
     OptimizerContext(ConnectContext context) {
         this.connectContext = context;
@@ -247,6 +251,15 @@ public class OptimizerContext {
 
     public TvrOptContext getTvrOptContext() {
         return tvrOptContext;
+    }
+
+    public int getSourceTablesCount() {
+        return tablesCount.second;
+    }
+
+    public void setTablesCount(Pair<Integer, Integer> count) {
+        this.tablesCount.first = count.first;
+        this.tablesCount.second = count.second;
     }
 
     /**

--- a/test/sql/test_iceberg/R/test_iceberg_collect_stats
+++ b/test/sql/test_iceberg/R/test_iceberg_collect_stats
@@ -22,12 +22,15 @@ create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1
 ) partition by c1,c2,c3,c4;
 -- result:
 -- !result
+set disable_table_stats_from_metadata_for_single_table = false;
+-- result:
+-- !result
 insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1 values(1, 2, '2022-01-01', 10.23);
 -- result:
 -- !result
 [UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1;
 -- result:
-iceberg_collect_stats_d5e9d38ec7144c578e456e16e1134134.iceberg_collect_stats_db_d5e9d38ec7144c578e456e16e1134134.t1	analyze	status	OK
+iceberg_collect_stats_52fe0835d4494e38b253b24d82123cd3.iceberg_collect_stats_db_52fe0835d4494e38b253b24d82123cd3.t1	analyze	status	OK
 -- !result
 function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1', 'cardinality=1')
 -- result:
@@ -48,7 +51,7 @@ insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t2 
 -- !result
 [UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t2;
 -- result:
-iceberg_collect_stats_d5e9d38ec7144c578e456e16e1134134.iceberg_collect_stats_db_d5e9d38ec7144c578e456e16e1134134.t2	analyze	status	OK
+iceberg_collect_stats_52fe0835d4494e38b253b24d82123cd3.iceberg_collect_stats_db_52fe0835d4494e38b253b24d82123cd3.t2	analyze	status	OK
 -- !result
 function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t2', 'cardinality=2')
 -- result:
@@ -70,7 +73,7 @@ insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t3 
 -- !result
 [UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t3;
 -- result:
-iceberg_collect_stats_d5e9d38ec7144c578e456e16e1134134.iceberg_collect_stats_db_d5e9d38ec7144c578e456e16e1134134.t3	analyze	status	OK
+iceberg_collect_stats_52fe0835d4494e38b253b24d82123cd3.iceberg_collect_stats_db_52fe0835d4494e38b253b24d82123cd3.t3	analyze	status	OK
 -- !result
 function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t3', 'cardinality=3')
 -- result:
@@ -89,7 +92,7 @@ insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t4 
 -- !result
 [UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t4;
 -- result:
-iceberg_collect_stats_d5e9d38ec7144c578e456e16e1134134.iceberg_collect_stats_db_d5e9d38ec7144c578e456e16e1134134.t4	analyze	status	OK
+iceberg_collect_stats_52fe0835d4494e38b253b24d82123cd3.iceberg_collect_stats_db_52fe0835d4494e38b253b24d82123cd3.t4	analyze	status	OK
 -- !result
 function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t4', 'cardinality: 3')
 -- result:
@@ -108,7 +111,7 @@ insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5 
 -- !result
 [UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5;
 -- result:
-iceberg_collect_stats_d5e9d38ec7144c578e456e16e1134134.iceberg_collect_stats_db_d5e9d38ec7144c578e456e16e1134134.t5	analyze	status	OK
+iceberg_collect_stats_52fe0835d4494e38b253b24d82123cd3.iceberg_collect_stats_db_52fe0835d4494e38b253b24d82123cd3.t5	analyze	error	Error statistic type : varbinary
 -- !result
 function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5', 'cardinality: 2')
 -- result:

--- a/test/sql/test_iceberg/T/test_iceberg_collect_stats
+++ b/test/sql/test_iceberg/T/test_iceberg_collect_stats
@@ -19,6 +19,8 @@ create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1
     c4 decimal(10,3)
 ) partition by c1,c2,c3,c4;
 
+set disable_table_stats_from_metadata_for_single_table = false;
+
 insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1 values(1, 2, '2022-01-01', 10.23);
 [UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1;
 function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t1', 'cardinality=1')


### PR DESCRIPTION
## Why I'm doing:

Since we enable collecting table stats from iceberg by default. https://github.com/StarRocks/starrocks/pull/64140. Every query will trigger collecting table stats.

But somehow, it's not reasonable if you just query a single table. And this is especially necessary if user just wants to preview data using `select * from T limit 10`.  if T is a very large table, then it  will take a long time to collect table stats but it's unnecessary.

## What I'm doing:

This PR is to:
- analyze query how many updated tables and source tables
- when query table stats of a iceberg table, and # of source table is 1, just return default row count.
- this could also works for delta lake table I think.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
