### PR TITLE
[Enhancement] support get tablet cache stats in shared-data cluster

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1797,4 +1797,7 @@ CONF_Int32(llm_max_queue_size, "4096");
 CONF_Int32(llm_max_concurrent_queries, "8");
 
 CONF_Int32(llm_cache_size, "131072");
+
+// how many threads will be used by collecting tablet cache stats
+CONF_mInt32(tablet_cache_stats_max_threads, "4");
 } // namespace starrocks::config

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -321,6 +321,11 @@ public:
     // On success, Status::OK is returned. If there is no cache, Status::NotFound is returned.
     virtual Status drop_local_cache(const std::string& path) { return Status::NotFound(path); }
 
+    // get cache stats for file, return <cached_bytes, total_bytes>
+    virtual StatusOr<std::pair<size_t, size_t>> get_cache_stats(const std::string& path, int64_t offset, int64_t size) {
+        return Status::NotSupported("FileSystem::get_cache_stats");
+    }
+
     // Batch delete the given files.
     // return ok if all success (not found error ignored), error if any failed and the message indicates the fail message
     // possibly stop at the first error if is simulating batch deletes.

--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -678,6 +678,12 @@ public:
             return Status::IOError(fmt::format("fail to get space info of path {}: {}", path, e.what()));
         }
     }
+
+    // directly return size, TEST only
+    StatusOr<std::pair<size_t, size_t>> get_cache_stats(const std::string& path, int64_t offset,
+                                                        int64_t size) override {
+        return std::make_pair(size, size);
+    }
 };
 
 // Default Posix FileSystem

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -590,6 +590,20 @@ public:
         return to_status((*fs_st)->drop_cache(pair.first, 0 /* offset */, -1 /* size */));
     }
 
+    StatusOr<std::pair<size_t, size_t>> get_cache_stats(const std::string& path, int64_t offset,
+                                                        int64_t size) override {
+        ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(path));
+        auto fs_st = get_shard_filesystem(pair.second);
+        if (!fs_st.ok()) {
+            return to_status(fs_st.status());
+        }
+        auto cache_stats_or = (*fs_st)->get_cache_stats(pair.first, offset, size);
+        if (!cache_stats_or.ok()) {
+            return to_status(cache_stats_or.status());
+        }
+        return std::make_pair((*cache_stats_or).cached_bytes, (*cache_stats_or).total_bytes);
+    }
+
     Status delete_files(std::span<const std::string> paths) override {
         using FsPtr = std::shared_ptr<staros::starlet::fslib::FileSystem>;
         using PathList = std::vector<std::string>;

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -58,6 +58,7 @@
 #include "runtime/load_channel_mgr.h"
 #include "storage/compaction_manager.h"
 #include "storage/lake/compaction_scheduler.h"
+#include "storage/lake/tablet_cache_stats_manager.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/update_manager.h"
 #include "storage/load_spill_block_manager.h"
@@ -289,6 +290,14 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
         });
         _config_callback.emplace("starlet_star_cache_mem_size_bytes", [&]() -> Status {
             update_staros_starcache();
+            return Status::OK();
+        });
+        _config_callback.emplace("tablet_cache_stats_max_threads", [&]() -> Status {
+            auto tablet_manager = _exec_env->lake_tablet_manager();
+            if (tablet_manager != nullptr) {
+                return tablet_manager->tablet_cache_stats_mgr()->update_max_threads(
+                        config::tablet_cache_stats_max_threads);
+            }
             return Status::OK();
         });
 #endif

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -109,6 +109,11 @@ public:
                               ::starrocks::GetTabletMetadatasResponse* response,
                               ::google::protobuf::Closure* done) override;
 
+    void get_tablet_cache_stats(::google::protobuf::RpcController* controller,
+                                const ::starrocks::GetTabletCacheStatsRequest* request,
+                                ::starrocks::GetTabletCacheStatsResponse* response,
+                                ::google::protobuf::Closure* done) override;
+
 private:
     void _submit_publish_log_version_task(const int64_t* tablet_ids, size_t tablet_size,
                                           std::span<const TxnInfoPB> txn_infos, const int64_t* log_versions,

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -202,6 +202,7 @@ set(STORAGE_FILES
     lake/starlet_location_provider.cpp
     lake/tablet.cpp
     lake/tablet_manager.cpp
+    lake/tablet_cache_stats_manager.cpp
     lake/tablet_reader.cpp
     lake/transactions.cpp
     lake/metadata_iterator.cpp

--- a/be/src/storage/lake/tablet_cache_stats_manager.cpp
+++ b/be/src/storage/lake/tablet_cache_stats_manager.cpp
@@ -1,0 +1,147 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef USE_STAROS
+
+#include "storage/lake/tablet_cache_stats_manager.h"
+
+#include "storage/lake/tablet_manager.h"
+#include "util/starrocks_metrics.h"
+#include "util/threadpool.h"
+
+namespace starrocks::lake {
+
+TabletCacheStatsManager::TabletCacheStatsManager(TabletManager* tablet_mgr) : _tablet_mgr(tablet_mgr) {}
+
+TabletCacheStatsManager::~TabletCacheStatsManager() {
+    if (!_stopped) {
+        stop();
+    }
+}
+
+void TabletCacheStatsManager::init() {
+    int max_threads = config::tablet_cache_stats_max_threads;
+    auto st = ThreadPoolBuilder("tablet_cache_stats")
+                      .set_min_threads(1)
+                      .set_max_threads(max_threads)
+                      .set_max_queue_size(INT_MAX)
+                      .build(&_thread_pool);
+    CHECK(st.ok()) << st;
+    REGISTER_THREAD_POOL_METRICS(tablet_cache_stats, _thread_pool);
+    _stopped = false;
+}
+
+void TabletCacheStatsManager::stop() {
+    bool expected = false;
+    if (_stopped.compare_exchange_strong(expected, true)) {
+        _thread_pool->shutdown();
+    }
+}
+
+Status TabletCacheStatsManager::update_max_threads(int max_threads) {
+    if (_thread_pool != nullptr) {
+        return _thread_pool->update_max_threads(max_threads);
+    } else {
+        return Status::InternalError("Thread pool not exist");
+    }
+}
+
+std::shared_ptr<TabletCacheStatsContext> TabletCacheStatsManager::submit_get_tablet_cache_stats(
+        int64_t tablet_id, int64_t tablet_version) {
+    auto ctx = std::make_shared<TabletCacheStatsContext>(tablet_id, tablet_version);
+    if (_stopped) {
+        ctx->fail(Status::Aborted("tablet cache stats manager stopped!"));
+        return ctx;
+    }
+    auto st = _thread_pool->submit_func(std::bind(&TabletCacheStatsManager::_get_tablet_cache_stats, this, ctx));
+    if (!st.ok()) {
+        ctx->fail(st);
+        return ctx;
+    }
+    return ctx;
+}
+
+std::shared_ptr<TabletCacheStatsContext> TabletCacheStatsManager::get_tablet_cache_stats(int64_t tablet_id,
+                                                                                         int64_t tablet_version) {
+    auto ctx = std::make_shared<TabletCacheStatsContext>(tablet_id, tablet_version);
+    if (_stopped) {
+        ctx->fail(Status::Aborted("tablet cache stats manager stopped!"));
+        return ctx;
+    }
+    _get_tablet_cache_stats(ctx);
+    return ctx;
+}
+
+void TabletCacheStatsManager::_get_tablet_cache_stats(std::shared_ptr<TabletCacheStatsContext>& ctx) {
+    int64_t tablet_id = ctx->tablet_id;
+    int64_t tablet_version = ctx->tablet_version;
+    auto tablet_metadata = _tablet_mgr->get_tablet_metadata(tablet_id, tablet_version, false /* fill_cache */);
+    if (!tablet_metadata.ok()) {
+        ctx->fail(Status::Aborted(fmt::format("fail to get tablet meta for tablet {}, version {}, error: {}", tablet_id,
+                                              tablet_version, tablet_metadata.status().message())));
+        return;
+    }
+
+    const auto& metadata = *tablet_metadata;
+    int64_t cached_bytes = 0;
+    int64_t total_bytes = 0;
+    for (const auto& rowset : metadata->rowsets()) {
+        const auto& segment_cnt = rowset.segments_size();
+        bool has_segment_size = (segment_cnt == rowset.segment_size_size());
+        bool is_bundled_file = (segment_cnt == rowset.bundle_file_offsets_size());
+        for (size_t i = 0; i < segment_cnt; ++i) {
+            std::string segment_path = _tablet_mgr->segment_location(tablet_id, rowset.segments().Get(i));
+            auto fs_or = FileSystem::CreateSharedFromString(segment_path);
+            if (!fs_or.ok()) {
+                ctx->fail(fs_or.status());
+                return;
+            }
+            auto result = (*fs_or)->get_cache_stats(
+                    segment_path, is_bundled_file ? rowset.bundle_file_offsets().Get(i) : 0 /* offset */,
+                    has_segment_size ? rowset.segment_size().Get(i) : -1 /* size */);
+            if (!result.ok()) {
+                ctx->fail(result.status());
+                return;
+            } else {
+                cached_bytes += (*result).first;
+                total_bytes += (*result).second;
+            }
+        }
+    }
+
+    for (const auto& [_, file] : metadata->delvec_meta().version_to_file()) {
+        std::string delvec_path = _tablet_mgr->delvec_location(tablet_id, file.name());
+        auto fs_or = FileSystem::CreateSharedFromString(delvec_path);
+        if (!fs_or.ok()) {
+            ctx->fail(fs_or.status());
+            return;
+        }
+        auto result = (*fs_or)->get_cache_stats(delvec_path, 0 /* offset */, file.size());
+        if (!result.ok()) {
+            ctx->fail(result.status());
+            return;
+        } else {
+            cached_bytes += (*result).first;
+            total_bytes += (*result).second;
+        }
+    }
+
+    ctx->done(cached_bytes, total_bytes);
+    VLOG(3) << "finished get cache stats for tablet: " << tablet_id << ", version: " << tablet_version
+            << ", cached_bytes: " << cached_bytes << ", total_bytes: " << total_bytes;
+}
+
+} // namespace starrocks::lake
+
+#endif

--- a/be/src/storage/lake/tablet_cache_stats_manager.h
+++ b/be/src/storage/lake/tablet_cache_stats_manager.h
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef USE_STAROS
+
+#pragma once
+
+#include <future>
+#include <memory>
+
+#include "common/status.h"
+
+namespace starrocks {
+class ThreadPool;
+} // namespace starrocks
+
+namespace starrocks::lake {
+
+class TabletManager;
+
+struct TabletCacheStatsContext {
+    const int64_t tablet_id;
+    const int64_t tablet_version;
+    std::promise<Status> promise;
+    std::future<Status> future;
+    int64_t cached_bytes;
+    int64_t total_bytes;
+
+    TabletCacheStatsContext(int64_t id, int64_t version)
+            : tablet_id(id), tablet_version(version), future(promise.get_future()), cached_bytes(0), total_bytes(0) {}
+
+    void fail(Status status) { promise.set_value(std::move(status)); }
+
+    void done(int64_t cached_bytes, int64_t total_bytes) {
+        this->cached_bytes = cached_bytes;
+        this->total_bytes = total_bytes;
+        promise.set_value(Status::OK());
+    }
+
+    Status get() { // TODO: add timeout
+        return future.get();
+    }
+};
+
+class TabletCacheStatsManager {
+public:
+    explicit TabletCacheStatsManager(TabletManager* tablet_mgr);
+    ~TabletCacheStatsManager();
+
+    void init();
+
+    void stop();
+
+    ThreadPool* thread_pool() { return _thread_pool.get(); }
+
+    std::shared_ptr<TabletCacheStatsContext> submit_get_tablet_cache_stats(int64_t tablet_id, int64_t tablet_version);
+    std::shared_ptr<TabletCacheStatsContext> get_tablet_cache_stats(int64_t tablet_id, int64_t tablet_version);
+
+    Status update_max_threads(int max_threads);
+
+private:
+    void _get_tablet_cache_stats(std::shared_ptr<TabletCacheStatsContext>& ctx);
+
+    TabletManager* _tablet_mgr;
+    std::unique_ptr<ThreadPool> _thread_pool;
+    std::atomic<bool> _stopped = true;
+};
+
+} // namespace starrocks::lake
+
+#endif

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -52,6 +52,7 @@ using TabletAndRowsets = std::tuple<std::shared_ptr<Tablet>, std::vector<BaseRow
 class CompactionScheduler;
 class Metacache;
 class VersionedTablet;
+class TabletCacheStatsManager;
 
 class TabletManager {
     friend class Tablet;
@@ -229,6 +230,10 @@ public:
     // only for TEST purpose
     void TEST_set_global_schema_cache(int64_t index_id, TabletSchemaPtr schema);
 
+#ifdef USE_STAROS
+    TabletCacheStatsManager* tablet_cache_stats_mgr() { return _tablet_cache_stats_manager.get(); }
+#endif
+
     // update cache size of the segment with the given key, optionally provide the segment address hint.
     // If segment_addr_hint is provided and it's non-zero, the cache size will be only updated when the
     // instance address matches the address provided by the segment_addr_hint. This is used to prevent
@@ -283,6 +288,10 @@ private:
     std::unique_ptr<Metacache> _metacache;
     std::unique_ptr<CompactionScheduler> _compaction_scheduler;
     UpdateManager* _update_mgr = nullptr;
+
+#ifdef USE_STAROS
+    std::unique_ptr<TabletCacheStatsManager> _tablet_cache_stats_manager;
+#endif
 
     std::shared_mutex _meta_lock;
     std::unordered_map<int64_t, int64_t> _tablet_in_writing_size;

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -367,6 +367,7 @@ public:
     METRICS_DEFINE_THREAD_POOL(put_aggregate_metadata);
     METRICS_DEFINE_THREAD_POOL(exec_state_report);
     METRICS_DEFINE_THREAD_POOL(priority_exec_state_report);
+    METRICS_DEFINE_THREAD_POOL(tablet_cache_stats);
 
     METRIC_DEFINE_UINT_GAUGE(load_rpc_threadpool_size, MetricUnit::NOUNIT);
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -502,6 +502,7 @@ SET(DW_TEST_FILES
     ./storage/lake/lake_persistent_index_test.cpp
     ./storage/lake/lake_primary_key_consistency_test.cpp
     ./storage/lake/lake_scan_node_test.cpp
+    ./storage/lake/tablet_cache_stats_manager_test.cpp
     ./storage/lake/metacache_test.cpp
     ./storage/lake/meta_file_test.cpp
     ./storage/lake/partial_update_test.cpp

--- a/be/test/fs/fs_starlet_test.cpp
+++ b/be/test/fs/fs_starlet_test.cpp
@@ -452,6 +452,22 @@ TEST_P(StarletFileSystemTest, test_drop_cache) {
     config::lake_clear_corrupted_cache_data = old;
 }
 
+TEST_P(StarletFileSystemTest, test_get_cache_stats) {
+    std::string test_type = GetParam();
+    if (test_type == "s3") {
+        return;
+    }
+    auto uri = StarletPath("cache_stats.dat");
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(uri));
+    ASSIGN_OR_ABORT(auto wf, fs->new_writable_file(uri));
+    ASSERT_OK(wf->append("hello"));
+    ASSERT_OK(wf->append(" world!"));
+    ASSERT_OK(wf->close());
+    auto s = fs->get_cache_stats(uri, 0 /* offset */, 11 /* size */);
+    ASSERT_TRUE(s.ok());
+    ASSERT_EQ((*s).second, 11);
+}
+
 INSTANTIATE_TEST_CASE_P(StarletFileSystem, StarletFileSystemTest,
                         ::testing::Values(std::string("s3"), std::string("cachefs")));
 

--- a/be/test/storage/lake/tablet_cache_stats_manager_test.cpp
+++ b/be/test/storage/lake/tablet_cache_stats_manager_test.cpp
@@ -1,0 +1,160 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef USE_STAROS
+
+#include "storage/lake/tablet_cache_stats_manager.h"
+
+#include <gtest/gtest.h>
+
+#include "column/chunk.h"
+#include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "fs/fs.h"
+#include "fs/fs_util.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/location_provider.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_writer.h"
+#include "storage/lake/update_manager.h"
+#include "storage/lake/versioned_tablet.h"
+#include "storage/options.h"
+#include "storage/tablet_schema.h"
+#include "test_util.h"
+#include "testutil/assert.h"
+#include "util/filesystem_util.h"
+
+namespace starrocks::lake {
+
+using namespace starrocks;
+
+class TabletCacheStatsManagerTest : public testing::Test {
+public:
+    TabletCacheStatsManagerTest() : _test_dir(){};
+
+    void SetUp() override {
+        std::vector<starrocks::StorePath> paths;
+        CHECK_OK(starrocks::parse_conf_store_paths(starrocks::config::storage_root_path, &paths));
+        _test_dir = paths[0].path + "/lake";
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(_test_dir);
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->metadata_root_location(1)));
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->txn_log_root_location(1)));
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->segment_root_location(1)));
+        _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider, _mem_tracker.get());
+        _tablet_manager = new starrocks::lake::TabletManager(_location_provider, _update_manager.get(), 1024 * 1024);
+    }
+
+    void TearDown() override {
+        delete _tablet_manager;
+        FileSystem::Default()->delete_dir_recursive(_test_dir);
+    }
+    starrocks::lake::TabletManager* _tablet_manager{nullptr};
+    std::string _test_dir;
+    std::shared_ptr<lake::LocationProvider> _location_provider{nullptr};
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::unique_ptr<lake::UpdateManager> _update_manager;
+};
+
+TEST_F(TabletCacheStatsManagerTest, basic) {
+    lake::TabletCacheStatsManager mgr(_tablet_manager);
+    mgr.init();
+
+    std::shared_ptr<TabletMetadata> tablet_metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    std::shared_ptr<TabletSchema> tablet_schema = TabletSchema::create(tablet_metadata->schema());
+    std::shared_ptr<Schema> schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema));
+
+    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+    std::vector<int> k1{30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
+    std::vector<int> v1{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    auto c2 = Int32Column::create();
+    auto c3 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c2->append_numbers(k1.data(), k1.size() * sizeof(int));
+    c3->append_numbers(v1.data(), v1.size() * sizeof(int));
+
+    Chunk chunk0({std::move(c0), std::move(c1)}, schema);
+    Chunk chunk1({std::move(c2), std::move(c3)}, schema);
+
+    VersionedTablet tablet(_tablet_manager, tablet_metadata);
+    {
+        int64_t txn_id = next_id();
+        // write rowset 1 with 2 segments
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(WriterType::kHorizontal, txn_id));
+        ASSERT_OK(writer->open());
+
+        // write rowset data
+        // segment #1
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->write(chunk1));
+        ASSERT_OK(writer->finish());
+
+        // segment #2
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->write(chunk1));
+        ASSERT_OK(writer->finish());
+
+        auto files = writer->files();
+        ASSERT_EQ(2, files.size());
+
+        // add rowset metadata
+        auto* rowset = tablet_metadata->add_rowsets();
+        rowset->set_overlapped(true);
+        rowset->set_id(1);
+        auto* segs = rowset->mutable_segments();
+        auto* segs_size = rowset->mutable_segment_size();
+        for (auto& file : writer->files()) {
+            segs->Add(std::move(file.path));
+            segs_size->Add(std::move(file.size.value()));
+        }
+
+        writer->close();
+    }
+
+    // write tablet metadata
+    int64_t version = 2;
+    tablet_metadata->set_version(version);
+    // set fake delvec meta
+    auto& item = (*tablet_metadata->mutable_delvec_meta()->mutable_version_to_file())[version];
+    item.set_name("delvec");
+    item.set_size(10);
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*tablet_metadata));
+
+    auto ctx = mgr.submit_get_tablet_cache_stats(tablet_metadata->id(), version);
+    auto s = ctx->get();
+    EXPECT_TRUE(s.ok());
+
+    ctx = mgr.get_tablet_cache_stats(tablet_metadata->id() + 10086, version);
+    s = ctx->get();
+    EXPECT_TRUE(s.is_aborted());
+
+    EXPECT_TRUE(mgr.update_max_threads(1).ok());
+
+    mgr.stop();
+    ctx = mgr.submit_get_tablet_cache_stats(tablet_metadata->id(), version);
+    s = ctx->get();
+    EXPECT_FALSE(s.ok());
+}
+
+} // namespace starrocks::lake
+
+#endif // USE_STAROS

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -2165,6 +2165,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：在存算分离集群中，RPC 请求的最大并发数。当达到此阈值时，新请求会被拒绝。将此项设置为 `0` 表示对并发不做限制。
 - 引入版本：-
 
+##### tablet_cache_stats_max_threads
+
+- 默认值: 4
+- 类型: Int32
+- 单位: -
+- 是否可变: Yes
+- 描述: 存算分离集群中，获取 Tablet 缓存信息的线程数量。
+- 引入版本: v4.0
+
 ##### query_max_memory_limit_percent
 
 - 默认值：90

--- a/fe/fe-core/src/main/java/com/starrocks/lake/CacheStatsExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/CacheStatsExecutor.java
@@ -1,0 +1,122 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.proto.GetTabletCacheStatsMeta;
+import com.starrocks.proto.GetTabletCacheStatsRequest;
+import com.starrocks.proto.GetTabletCacheStatsResponse;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.LakeService;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.RefreshCacheStatsStatement;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.ComputeResourceProvider;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+public class CacheStatsExecutor {
+    public static ShowResultSet execute(RefreshCacheStatsStatement statement,
+                                        ConnectContext connectContext) throws DdlException {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        WarehouseManager warehouseManager = globalStateMgr.getWarehouseMgr();
+        Warehouse wh = warehouseManager.getWarehouse(connectContext.getCurrentWarehouseName());
+        ComputeResourceProvider computeResourceProvider = warehouseManager.getComputeResourceProvider();
+        List<ComputeResource> computeResources = computeResourceProvider.getComputeResources(wh);
+
+        Map<Long, RefreshCacheStatsStatement.PartitionSnapshot> tablets = statement.prepare();
+        for (ComputeResource computeResource : computeResources) {
+            if (!computeResourceProvider.isResourceAvailable(computeResource)) {
+                continue;
+            }
+            Map<Long /* beId */, List<Pair<Long /* tabletId */, Long /* version */>>> tabletsByBeMap = new HashMap<>();
+            for (Map.Entry<Long, RefreshCacheStatsStatement.PartitionSnapshot> entry : tablets.entrySet()) {
+                try {
+                    long beId = globalStateMgr.getStarOSAgent().getPrimaryComputeNodeIdByShard(
+                            entry.getKey(), computeResource.getWorkerGroupId());
+                    tabletsByBeMap.computeIfAbsent(beId,
+                            k -> Lists.newArrayList()).add(Pair.of(entry.getKey(), entry.getValue().visibleVersion));
+                } catch (StarRocksException e) {
+                    throw new DdlException(String.format("Fail to get replica for tablet %d, error: %s.",
+                            entry.getKey(), e.getMessage()));
+                }
+            }
+
+            Map<Long, Future<GetTabletCacheStatsResponse>> futureMap = new HashMap<>();
+            for (Map.Entry<Long, List<Pair<Long, Long>>> entry : tabletsByBeMap.entrySet()) {
+                long beId = entry.getKey();
+                ComputeNode node = globalStateMgr.getNodeMgr().getClusterInfo()
+                        .getBackendOrComputeNode(beId);
+                if (node == null) {
+                    throw new DdlException(String.format("Node %d not exist.", beId));
+                }
+
+                List<GetTabletCacheStatsMeta> metas = Lists.newArrayList();
+                for (Pair<Long, Long> e : entry.getValue()) {
+                    GetTabletCacheStatsMeta meta = new GetTabletCacheStatsMeta();
+                    meta.tabletId = e.getKey();
+                    meta.version = e.getValue();
+                    metas.add(meta);
+                }
+                GetTabletCacheStatsRequest request = new GetTabletCacheStatsRequest();
+                request.tablets = metas;
+                try {
+                    LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
+                    futureMap.put(beId, lakeService.getTabletCacheStats(request));
+                } catch (Throwable e) {
+                    throw new DdlException(String.format("Fail to send rpc request to node: %s. error: %s.",
+                            node.toString(), e.getMessage()));
+                }
+            }
+
+            for (Map.Entry<Long, Future<GetTabletCacheStatsResponse>> entry : futureMap.entrySet()) {
+                long beId = entry.getKey();
+                Future<GetTabletCacheStatsResponse> future = entry.getValue();
+                GetTabletCacheStatsResponse response = null;
+                try {
+                    response = future.get();
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    throw new DdlException(
+                            String.format("Interrupted while waiting for response from node: %d, error: %s.",
+                            beId, exception.getMessage()));
+                } catch (Exception e) {
+                    throw new DdlException(String.format("Failed to get response from node: %d, error: %s.",
+                            beId, e.getMessage()));
+                }
+                if (response.status != null && response.status.statusCode != 0) {
+                    throw new DdlException(
+                            String.format("Failed to get cache stats from node: %d, error: %s.",
+                            beId, response.status.errorMsgs.get(0)));
+                }
+                if (response.cacheStats != null) {
+                    statement.submitResult(computeResource.getWorkerGroupId(), response.cacheStats);
+                }
+            }
+        }
+        return statement.getResult();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -34,6 +34,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.datacache.DataCacheMgr;
 import com.starrocks.datacache.DataCacheSelectExecutor;
 import com.starrocks.datacache.DataCacheSelectMetrics;
+import com.starrocks.lake.CacheStatsExecutor;
 import com.starrocks.load.EtlJobType;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.Task;
@@ -127,6 +128,7 @@ import com.starrocks.sql.ast.PauseRoutineLoadStmt;
 import com.starrocks.sql.ast.RecoverDbStmt;
 import com.starrocks.sql.ast.RecoverPartitionStmt;
 import com.starrocks.sql.ast.RecoverTableStmt;
+import com.starrocks.sql.ast.RefreshCacheStatsStatement;
 import com.starrocks.sql.ast.RefreshDictionaryStmt;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
 import com.starrocks.sql.ast.RefreshTableStmt;
@@ -1202,6 +1204,15 @@ public class DDLStmtExecutor {
             }
 
             return metrics.getShowResultSet(statement.isVerbose());
+        }
+
+        @Override
+        public ShowResultSet visitRefreshCacheStatsStatement(RefreshCacheStatsStatement statement, ConnectContext context) {
+            try {
+                return CacheStatsExecutor.execute(statement, context);
+            } catch (Exception e) {
+                throw new RuntimeException(e.getMessage());
+            }
         }
 
         //=========================================== Dictionary Statement ==================================================

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -32,6 +32,8 @@ import com.starrocks.proto.DeleteTxnLogRequest;
 import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
+import com.starrocks.proto.GetTabletCacheStatsRequest;
+import com.starrocks.proto.GetTabletCacheStatsResponse;
 import com.starrocks.proto.LockTabletMetadataRequest;
 import com.starrocks.proto.LockTabletMetadataResponse;
 import com.starrocks.proto.PublishLogVersionBatchRequest;
@@ -72,6 +74,7 @@ public interface LakeService {
     long TIMEOUT_ABORT_COMPACTION = 5 * MILLIS_PER_SECOND;
     long TIMEOUT_VACUUM = MILLIS_PER_HOUR;
     long TIMEOUT_VACUUM_FULL = MILLIS_PER_HOUR * 24;
+    long TIMEOUT_GET_TABLET_CACHE_STATS = 3 * MILLIS_PER_MINUTE;
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "publish_version", onceTalkTimeout = TIMEOUT_PUBLISH_VERSION)
     Future<PublishVersionResponse> publishVersion(PublishVersionRequest request);
@@ -130,5 +133,9 @@ public interface LakeService {
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "vacuum_full", onceTalkTimeout = TIMEOUT_VACUUM_FULL)
     Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request);
+
+    @ProtobufRPC(serviceName = "LakeService", methodName = "get_tablet_cache_stats",
+            onceTalkTimeout = TIMEOUT_GET_TABLET_CACHE_STATS)
+    Future<GetTabletCacheStatsResponse> getTabletCacheStats(GetTabletCacheStatsRequest request);
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
@@ -30,6 +30,8 @@ import com.starrocks.proto.DeleteTxnLogRequest;
 import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
+import com.starrocks.proto.GetTabletCacheStatsRequest;
+import com.starrocks.proto.GetTabletCacheStatsResponse;
 import com.starrocks.proto.LockTabletMetadataRequest;
 import com.starrocks.proto.LockTabletMetadataResponse;
 import com.starrocks.proto.PublishLogVersionBatchRequest;
@@ -176,5 +178,11 @@ public class LakeServiceWithMetrics implements LakeService {
     public Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request) {
         increaseMetrics();
         return lakeService.vacuumFull(request);
+    }
+
+    @Override
+    public Future<GetTabletCacheStatsResponse> getTabletCacheStats(GetTabletCacheStatsRequest request) {
+        increaseMetrics();
+        return lakeService.getTabletCacheStats(request);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -109,6 +109,7 @@ import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RecoverDbStmt;
 import com.starrocks.sql.ast.RecoverPartitionStmt;
 import com.starrocks.sql.ast.RecoverTableStmt;
+import com.starrocks.sql.ast.RefreshCacheStatsStatement;
 import com.starrocks.sql.ast.RefreshDictionaryStmt;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
 import com.starrocks.sql.ast.RefreshTableStmt;
@@ -914,6 +915,12 @@ public class Analyzer {
 
         @Override
         public Void visitDataCacheSelectStatement(DataCacheSelectStatement statement, ConnectContext context) {
+            DataCacheStmtAnalyzer.analyze(statement, context);
+            return null;
+        }
+
+        @Override
+        public Void visitRefreshCacheStatsStatement(RefreshCacheStatsStatement statement, ConnectContext context) {
             DataCacheStmtAnalyzer.analyze(statement, context);
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -146,6 +146,7 @@ import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RecoverDbStmt;
 import com.starrocks.sql.ast.RecoverPartitionStmt;
 import com.starrocks.sql.ast.RecoverTableStmt;
+import com.starrocks.sql.ast.RefreshCacheStatsStatement;
 import com.starrocks.sql.ast.RefreshConnectionsStmt;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
 import com.starrocks.sql.ast.RefreshTableStmt;
@@ -2003,6 +2004,19 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
     public Void visitDataCacheSelectStatement(DataCacheSelectStatement statement, ConnectContext context) {
         // check we have permission access source data
         visitQueryStatement(statement.getInsertStmt().getQueryStatement(), context);
+        return null;
+    }
+
+    @Override
+    public Void visitRefreshCacheStatsStatement(RefreshCacheStatsStatement statement, ConnectContext context) {
+        try {
+            Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
+        } catch (AccessDeniedException e) {
+            AccessDeniedException.reportAccessDenied(
+                    InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                    PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), null);
+        }
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DataCacheStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DataCacheStmtAnalyzer.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.ast.DataCacheSelectStatement;
 import com.starrocks.sql.ast.DropDataCacheRuleStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.RefreshCacheStatsStatement;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRelation;
@@ -167,6 +168,18 @@ public class DataCacheStmtAnalyzer {
             }
             statement.setTTLSeconds(ttlSeconds);
 
+            return null;
+        }
+
+        @Override
+        public Void visitRefreshCacheStatsStatement(RefreshCacheStatsStatement statement, ConnectContext context) {
+            statement.getTableName().normalization(context);
+            if (!CatalogMgr.isInternalCatalog(statement.getTableName().getCatalog())) {
+                throw new SemanticException("Refresh cache stats only supported in internal catalog.");
+            }
+            if (RunMode.isSharedNothingMode()) {
+                throw new SemanticException("Refresh cache stats only supported in shared-data cluster.");
+            }
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
@@ -384,6 +384,10 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
         return visitDDLStatement(statement, context);
     }
 
+    default R visitRefreshCacheStatsStatement(RefreshCacheStatsStatement statement, C context) {
+        return visitDDLStatement(statement, context);
+    }
+
     // --------------------------------------- Export Statement --------------------------------------------------------
 
     default R visitExportStatement(ExportStmt statement, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshCacheStatsStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshCacheStatsStatement.java
@@ -1,0 +1,92 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.catalog.TableName;
+import com.starrocks.common.DdlException;
+import com.starrocks.monitor.unit.ByteSizeValue;
+import com.starrocks.proto.TabletCacheStats;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.sql.parser.NodePosition;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public abstract class RefreshCacheStatsStatement extends DdlStmt {
+    public class PartitionSnapshot {
+        public PartitionSnapshot(int partitionNameIndex, long visibleVersion) {
+            this.partitionNameIndex = partitionNameIndex;
+            this.visibleVersion = visibleVersion;
+        }
+        public final int partitionNameIndex; // index in `partitionNames`, only used for `PARTITION` level
+        public final long visibleVersion;
+    }
+
+    protected final TableName tableName;
+
+    protected Map<Long, PartitionSnapshot> tablets;
+
+    public RefreshCacheStatsStatement(TableName tableName, NodePosition pos) {
+        super(pos);
+        this.tableName = tableName;
+        this.tablets = new HashMap<>();
+    }
+
+    public TableName getTableName() {
+        return tableName;
+    }
+
+    public abstract Map<Long, PartitionSnapshot> prepare() throws DdlException;
+
+    public abstract void submitResult(long workerGroupId, List<TabletCacheStats> tabletCacheStats);
+
+    public abstract ShowResultSet getResult();
+
+    public String getResult(TreeMap<Long, TabletCacheStats> stats) {
+        StringBuilder sb = new StringBuilder();
+        if (stats.entrySet() == null) {
+            return sb.toString();
+        }
+        for (Map.Entry<Long, TabletCacheStats> e : stats.entrySet()) {
+            sb.append("{");
+            sb.append("cn_group: ");
+            sb.append(Long.toString(e.getKey()));
+            sb.append(", ");
+            sb.append("cached_size: ");
+            sb.append(new ByteSizeValue(e.getValue().cachedBytes).toString());
+            sb.append(", ");
+            sb.append("total_size: ");
+            sb.append(new ByteSizeValue(e.getValue().totalBytes).toString());
+            sb.append(", ");
+            sb.append("percent: ");
+            if (e.getValue().totalBytes > 0) {
+                sb.append(String.format("%.1f", (double) e.getValue().cachedBytes / e.getValue().totalBytes * 100));
+                sb.append("%");
+            }
+            sb.append("}\n");
+        }
+        if (!sb.isEmpty()) {
+            sb.deleteCharAt(sb.length() - 1);
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return ((AstVisitorExtendInterface<R, C>) visitor).visitRefreshCacheStatsStatement(this, context);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshPartitionCacheStatsStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshPartitionCacheStatsStatement.java
@@ -1,0 +1,140 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableName;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.proto.TabletCacheStats;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.qe.ShowResultSetMetaData;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.type.TypeFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class RefreshPartitionCacheStatsStatement extends RefreshCacheStatsStatement {
+    private static final ShowResultSetMetaData PARTITION_META_DATA = ShowResultSetMetaData.builder()
+            .addColumn(new Column("PARTITION_NAME", TypeFactory.createVarchar(256)))
+            .addColumn(new Column("DETAIL", TypeFactory.createVarchar(4096)))
+            .build();
+
+    private final List<String> partitionNames;
+    private Map<String, TreeMap<Long, TabletCacheStats>> cacheStats;
+
+    public RefreshPartitionCacheStatsStatement(TableName tableName, List<String> partitionNames, NodePosition pos) {
+        super(tableName, pos);
+        this.partitionNames = partitionNames;
+        this.cacheStats = new HashMap<>();
+    }
+
+    @Override
+    public Map<Long, PartitionSnapshot> prepare() throws DdlException {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(tableName.getDb());
+        if (db == null) {
+            throw new DdlException(String.format("db %s does not exist.", tableName.getDb()));
+        }
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName.getTbl());
+        if (table == null) {
+            throw new DdlException(String.format("table %s does not exist.", tableName.getTbl()));
+        }
+        if (!table.isCloudNativeTableOrMaterializedView()) {
+            throw new DdlException("only support cloud table or cloud mv.");
+        }
+        OlapTable olapTable = (OlapTable) table;
+        if (!olapTable.getTableProperty().getStorageInfo().isEnableDataCache()) {
+            throw new DdlException(String.format("table %s property(%s) is false, does not support refresh.", tableName.getTbl(),
+                    PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE));
+        }
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
+        try {
+            for (int i = 0; i < partitionNames.size(); ++i) {
+                Partition partition = olapTable.getPartition(partitionNames.get(i));
+                if (partition == null) {
+                    throw new DdlException(String.format("partition %s not found", partitionNames.get(i)));
+                }
+                final int idx = i;
+                partition.getSubPartitions().forEach(physicalPartition -> {
+                    long visibleVersion = physicalPartition.getVisibleVersion();
+                    physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
+                            .forEach(materializedIndex ->
+                                    materializedIndex.getTablets().forEach(tablet ->
+                                    tablets.put(tablet.getId(), new PartitionSnapshot(idx, visibleVersion))));
+                });
+            }
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
+        }
+        return tablets;
+    }
+
+    @Override
+    public void submitResult(long workerGroupId, List<TabletCacheStats> tabletCacheStats) {
+        for (TabletCacheStats e : tabletCacheStats) {
+            PartitionSnapshot snapshot = tablets.get(e.tabletId);
+            String partitionName = partitionNames.get(snapshot.partitionNameIndex);
+            Map<Long, TabletCacheStats> mapStats = cacheStats.computeIfAbsent(partitionName, k -> new TreeMap<>());
+            TabletCacheStats stats = mapStats.computeIfAbsent(workerGroupId, k -> {
+                TabletCacheStats s = new TabletCacheStats();
+                s.cachedBytes = 0L;
+                s.totalBytes = 0L;
+                return s;
+            });
+            stats.cachedBytes += e.cachedBytes;
+            stats.totalBytes += e.totalBytes;
+        }
+    }
+
+    @Override
+    public ShowResultSet getResult() {
+        List<List<String>> rows = Lists.newArrayList();
+        for (String partitionName : partitionNames) {
+            List<String> row = Lists.newArrayList();
+            row.add(partitionName);
+            TreeMap<Long, TabletCacheStats> stats = cacheStats.get(partitionName);
+            row.add(getResult(stats));
+            rows.add(row);
+        }
+        return new ShowResultSet(PARTITION_META_DATA, rows);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("REFRESH CACHE STATS FOR TABLE ");
+        sb.append(tableName.getTbl());
+        sb.append(" PARTITION ");
+        for (String partitionName : partitionNames) {
+            sb.append(partitionName);
+            sb.append(',');
+        }
+        sb.deleteCharAt(sb.length() - 1);
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshTableCacheStatsStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshTableCacheStatsStatement.java
@@ -1,0 +1,119 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableName;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.proto.TabletCacheStats;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.qe.ShowResultSetMetaData;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.type.TypeFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class RefreshTableCacheStatsStatement extends RefreshCacheStatsStatement {
+    private static final ShowResultSetMetaData TABLE_META_DATA = ShowResultSetMetaData.builder()
+            .addColumn(new Column("TABLE_NAME", TypeFactory.createVarchar(256)))
+            .addColumn(new Column("DETAIL", TypeFactory.createVarchar(4096)))
+            .build();
+
+    private TreeMap<Long, TabletCacheStats> cacheStats;
+
+    public RefreshTableCacheStatsStatement(TableName tableName, NodePosition pos) {
+        super(tableName, pos);
+        this.cacheStats = new TreeMap<>();
+    }
+
+    @Override
+    public Map<Long, PartitionSnapshot> prepare() throws DdlException {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(tableName.getDb());
+        if (db == null) {
+            throw new DdlException(String.format("db %s does not exist.", tableName.getDb()));
+        }
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName.getTbl());
+        if (table == null) {
+            throw new DdlException(String.format("table %s does not exist.", tableName.getTbl()));
+        }
+        if (!table.isCloudNativeTableOrMaterializedView()) {
+            throw new DdlException("only support cloud table or cloud mv.");
+        }
+        OlapTable olapTable = (OlapTable) table;
+        if (!olapTable.getTableProperty().getStorageInfo().isEnableDataCache()) {
+            throw new DdlException(String.format("table %s property(%s) is false, does not support refresh.", tableName.getTbl(),
+                    PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE));
+        }
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
+        try {
+            olapTable.getAllPartitions().forEach(partition -> {
+                partition.getSubPartitions().forEach(physicalPartition -> {
+                    long visibleVersion = physicalPartition.getVisibleVersion();
+                    physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
+                            .forEach(materializedIndex ->
+                                    materializedIndex.getTablets().forEach(tablet ->
+                                    tablets.put(tablet.getId(), new PartitionSnapshot(-1, visibleVersion))));
+                });
+            });
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
+        }
+        return tablets;
+    }
+
+    @Override
+    public void submitResult(long workerGroupId, List<TabletCacheStats> tabletCacheStats) {
+        TabletCacheStats stats = cacheStats.computeIfAbsent(workerGroupId, k -> {
+            TabletCacheStats s = new TabletCacheStats();
+            s.cachedBytes = 0L;
+            s.totalBytes = 0L;
+            return s;
+        });
+        for (TabletCacheStats e : tabletCacheStats) {
+            stats.cachedBytes += e.cachedBytes;
+            stats.totalBytes += e.totalBytes;
+        }
+    }
+
+    @Override
+    public ShowResultSet getResult() {
+        List<List<String>> rows = Lists.newArrayList();
+        List<String> row = Lists.newArrayList();
+        row.add(tableName.getTbl());
+        row.add(getResult(cacheStats));
+        rows.add(row);
+        return new ShowResultSet(TABLE_META_DATA, rows);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("REFRESH CACHE STATS FOR TABLE ");
+        sb.append(tableName.getTbl());
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshTabletCacheStatsStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshTabletCacheStatsStatement.java
@@ -1,0 +1,143 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableName;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.proto.TabletCacheStats;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.qe.ShowResultSetMetaData;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.type.TypeFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class RefreshTabletCacheStatsStatement extends RefreshCacheStatsStatement {
+    private static final ShowResultSetMetaData TABLET_META_DATA = ShowResultSetMetaData.builder()
+            .addColumn(new Column("TABLET_ID", TypeFactory.createVarchar(16)))
+            .addColumn(new Column("DETAIL", TypeFactory.createVarchar(4096)))
+            .build();
+
+    private final List<Long> tabletIds;
+    private Map<Long, TreeMap<Long, TabletCacheStats>> cacheStats;
+
+    public RefreshTabletCacheStatsStatement(TableName tableName, List<Long> tabletIds, NodePosition pos) {
+        super(tableName, pos);
+        this.tabletIds = tabletIds;
+        this.cacheStats = new HashMap<>();
+    }
+
+    @Override
+    public Map<Long, PartitionSnapshot> prepare() throws DdlException {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(tableName.getDb());
+        if (db == null) {
+            throw new DdlException(String.format("db %s does not exist.", tableName.getDb()));
+        }
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName.getTbl());
+        if (table == null) {
+            throw new DdlException(String.format("table %s does not exist.", tableName.getTbl()));
+        }
+        if (!table.isCloudNativeTableOrMaterializedView()) {
+            throw new DdlException("only support cloud table or cloud mv.");
+        }
+        OlapTable olapTable = (OlapTable) table;
+        if (!olapTable.getTableProperty().getStorageInfo().isEnableDataCache()) {
+            throw new DdlException(String.format("table %s property(%s) is false, does not support refresh.", tableName.getTbl(),
+                    PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE));
+        }
+        TabletInvertedIndex index = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        List<TabletMeta> metas = Lists.newArrayList();
+        for (Long tabletId : tabletIds) {
+            TabletMeta meta = index.getTabletMeta(tabletId);
+            if (meta == null) {
+                throw new DdlException(String.format("tablet %d not found", tabletId));
+            }
+            metas.add(meta);
+        }
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
+        try {
+            for (int i = 0; i < metas.size(); ++i) {
+                long tabletId = tabletIds.get(i);
+                PhysicalPartition physicalPartition = olapTable.getPhysicalPartition(metas.get(i).getPhysicalPartitionId());
+                if (physicalPartition == null) {
+                    throw new DdlException(String.format("can not find physical partition %d for tablet %d",
+                            metas.get(i).getPhysicalPartitionId(), tabletId));
+                }
+                tablets.put(tabletId, new PartitionSnapshot(-1, physicalPartition.getVisibleVersion()));
+            }
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
+        }
+        return tablets;
+    }
+
+    @Override
+    public void submitResult(long workerGroupId, List<TabletCacheStats> tabletCacheStats) {
+        for (TabletCacheStats e : tabletCacheStats) {
+            Map<Long, TabletCacheStats> mapStats = cacheStats.computeIfAbsent(e.tabletId, k -> new TreeMap<>());
+            TabletCacheStats stats = mapStats.computeIfAbsent(workerGroupId, k -> {
+                TabletCacheStats s = new TabletCacheStats();
+                s.cachedBytes = 0L;
+                s.totalBytes = 0L;
+                return s;
+            });
+            stats.cachedBytes += e.cachedBytes;
+            stats.totalBytes += e.totalBytes;
+        }
+    }
+
+    @Override
+    public ShowResultSet getResult() {
+        List<List<String>> rows = Lists.newArrayList();
+        for (Long tabletId : tabletIds) {
+            List<String> row = Lists.newArrayList();
+            row.add(Long.toString(tabletId));
+            TreeMap<Long, TabletCacheStats> stats = cacheStats.get(tabletId);
+            row.add(getResult(stats));
+            rows.add(row);
+        }
+        return new ShowResultSet(TABLET_META_DATA, rows);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("REFRESH CACHE STATS FOR TABLE ");
+        sb.append(tableName.getTbl());
+        sb.append(" TABLET ");
+        for (Long tabletId : tabletIds) {
+            sb.append(Long.toString(tabletId));
+            sb.append(',');
+        }
+        sb.deleteCharAt(sb.length() - 1);
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CacheStatsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CacheStatsExecutorTest.java
@@ -1,0 +1,107 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.starrocks.catalog.TableName;
+import com.starrocks.lake.StarOSAgent;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.LakeService;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.CreateDbStmt;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.RefreshTableCacheStatsStatement;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.WarehouseComputeResource;
+import com.starrocks.warehouse.cngroup.WarehouseComputeResourceProvider;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class CacheStatsExecutorTest {
+    private static ConnectContext connectContext;
+
+    @Mocked
+    private LakeService lakeService;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        // create database
+        String createDbStmtStr = "create database cache_stats_executor;";
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(createDbStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createDb(createDbStmt.getFullDbName());
+        // create table
+        String createTableStr = "create table cache_stats_executor.aaa (key1 int, key2 varchar(10))\n" +
+                "distributed by hash(key1) buckets 3\n" +
+                "properties('replication_num' = '1');";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createTableStr, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
+    }
+
+    @Test
+    void testBasic() throws Exception {
+        TableName tableName = new TableName("cache_stats_executor", "aaa");
+        RefreshTableCacheStatsStatement stmt = new RefreshTableCacheStatsStatement(tableName, null);
+
+        new MockUp<WarehouseComputeResourceProvider>() {
+            @Mock
+            public boolean isResourceAvailable(ComputeResource computeResource) {
+                return true;
+            }
+        };
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public long getPrimaryComputeNodeIdByShard(long shardId, long workerGroupId) {
+                return 10001L;
+            }
+        };
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public ComputeNode getBackendOrComputeNode(long nodeId) {
+                return new ComputeNode(10001L, "127.0.0.1", 10002);
+            }
+        };
+        new MockUp<BrpcProxy>() {
+            @Mock
+            public LakeService getLakeService(String host, int port) {
+                return lakeService;
+            }
+        };
+
+        new MockUp<RefreshTableCacheStatsStatement>() {
+            @Mock
+            public ShowResultSet getResult() {
+                return new ShowResultSet(null, null);
+            }
+        };
+        new MockUp<WarehouseComputeResource>() {
+            @Mock
+            public long getWorkerGroupId() {
+                return 20002;
+            }
+        };
+        CacheStatsExecutor.execute(stmt, connectContext);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -43,6 +43,8 @@ import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
 import com.starrocks.proto.ExecuteCommandRequestPB;
 import com.starrocks.proto.ExecuteCommandResultPB;
+import com.starrocks.proto.GetTabletCacheStatsRequest;
+import com.starrocks.proto.GetTabletCacheStatsResponse;
 import com.starrocks.proto.LockTabletMetadataRequest;
 import com.starrocks.proto.LockTabletMetadataResponse;
 import com.starrocks.proto.PCancelPlanFragmentRequest;
@@ -1211,6 +1213,11 @@ public class PseudoBackend {
 
         @Override
         public Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<GetTabletCacheStatsResponse> getTabletCacheStats(GetTabletCacheStatsRequest request) {
             return CompletableFuture.completedFuture(null);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/RefreshCacheStatsStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/RefreshCacheStatsStatementTest.java
@@ -1,0 +1,178 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.catalog.TableName;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.ExceptionChecker;
+import com.starrocks.proto.TabletCacheStats;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.CreateDbStmt;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+class RefreshCacheStatsStatementTest {
+    private static ConnectContext connectContext;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        // create database
+        String createDbStmtStr = "create database refresh_cache_stats;";
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(createDbStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createDb(createDbStmt.getFullDbName());
+        // create table
+        String createTableStr = "create table refresh_cache_stats.aaa (key1 int, key2 varchar(10))\n" +
+                "distributed by hash(key1) buckets 3\n" +
+                "properties('replication_num' = '1');";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createTableStr, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
+    }
+
+    @Test
+    void testTableRefreshCacheStats() throws Exception {
+        {
+            TableName tableName = new TableName("refresh_cache_stats_aaa", "aaa");
+            RefreshTableCacheStatsStatement stmt = new RefreshTableCacheStatsStatement(tableName, null);
+            ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                    "db refresh_cache_stats_aaa does not exist.", () -> stmt.prepare());
+        }
+        {
+            TableName tableName = new TableName("refresh_cache_stats", "bbb");
+            RefreshTableCacheStatsStatement stmt = new RefreshTableCacheStatsStatement(tableName, null);
+            ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                    "table bbb does not exist.", () -> stmt.prepare());
+        }
+        TableName tableName = new TableName("refresh_cache_stats", "aaa");
+        RefreshTableCacheStatsStatement stmt = new RefreshTableCacheStatsStatement(tableName, null);
+        Map<Long, RefreshCacheStatsStatement.PartitionSnapshot> tablets = stmt.prepare();
+        Assertions.assertEquals(tablets.size(), 3);
+
+        List<TabletCacheStats> stats = new ArrayList<>();
+        {
+            TabletCacheStats s = new TabletCacheStats();
+            s.cachedBytes = 100L;
+            s.totalBytes = 200L;
+            stats.add(s);
+        }
+        {
+            TabletCacheStats s = new TabletCacheStats();
+            s.cachedBytes = 200L;
+            s.totalBytes = 400L;
+            stats.add(s);
+        }
+        stmt.submitResult(0 /* workerGroupId */, stats);
+        Assertions.assertEquals(1, stmt.getResult().getResultRows().size());
+
+        String str = stmt.toString();
+        Assertions.assertEquals(str, "REFRESH CACHE STATS FOR TABLE aaa");
+    }
+
+    @Test
+    void testPartitionRefreshCacheStats() throws Exception {
+        List<String> partitionNames = new ArrayList<>();
+        partitionNames.add("aaa");
+        {
+            TableName tableName = new TableName("refresh_cache_stats_aaa", "aaa");
+            RefreshPartitionCacheStatsStatement stmt = new RefreshPartitionCacheStatsStatement(
+                    tableName, partitionNames, null);
+            ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                    "db refresh_cache_stats_aaa does not exist.", () -> stmt.prepare());
+        }
+        {
+            TableName tableName = new TableName("refresh_cache_stats", "bbb");
+            RefreshPartitionCacheStatsStatement stmt = new RefreshPartitionCacheStatsStatement(
+                    tableName, partitionNames, null);
+            ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                    "table bbb does not exist.", () -> stmt.prepare());
+        }
+        TableName tableName = new TableName("refresh_cache_stats", "aaa");
+        RefreshPartitionCacheStatsStatement stmt = new RefreshPartitionCacheStatsStatement(
+                tableName, partitionNames, null);
+        Map<Long, RefreshCacheStatsStatement.PartitionSnapshot> tablets = stmt.prepare();
+        Assertions.assertEquals(tablets.size(), 3);
+
+        List<TabletCacheStats> stats = new ArrayList<>();
+        for (Long tabletId : tablets.keySet()) {
+            TabletCacheStats s = new TabletCacheStats();
+            s.tabletId = tabletId;
+            s.cachedBytes = 100L;
+            s.totalBytes = 200L;
+            stats.add(s);
+        }
+        stmt.submitResult(0 /* workerGroupId */, stats);
+        Assertions.assertEquals(1, stmt.getResult().getResultRows().size());
+
+        String str = stmt.toString();
+        Assertions.assertEquals(str, "REFRESH CACHE STATS FOR TABLE aaa PARTITION aaa");
+    }
+
+    @Test
+    void testTabletRefreshCacheStats() throws Exception {
+        List<Long> tabletIds = new ArrayList<>();
+        {
+            TableName tableName = new TableName("refresh_cache_stats_aaa", "aaa");
+            RefreshTabletCacheStatsStatement stmt = new RefreshTabletCacheStatsStatement(
+                    tableName, tabletIds, null);
+            ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                    "db refresh_cache_stats_aaa does not exist.", () -> stmt.prepare());
+        }
+        {
+            TableName tableName = new TableName("refresh_cache_stats", "bbb");
+            RefreshTabletCacheStatsStatement stmt = new RefreshTabletCacheStatsStatement(
+                    tableName, tabletIds, null);
+            ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                    "table bbb does not exist.", () -> stmt.prepare());
+        }
+        TableName tableName = new TableName("refresh_cache_stats", "aaa");
+        // prepare tablet id
+        {
+            RefreshTableCacheStatsStatement stmt = new RefreshTableCacheStatsStatement(tableName, null);
+            Map<Long, RefreshCacheStatsStatement.PartitionSnapshot> tablets = stmt.prepare();
+            for (Long tabletId : tablets.keySet()) {
+                tabletIds.add(tabletId);
+            }
+        }
+        RefreshTabletCacheStatsStatement stmt = new RefreshTabletCacheStatsStatement(
+                tableName, tabletIds, null);
+        Map<Long, RefreshCacheStatsStatement.PartitionSnapshot> tablets = stmt.prepare();
+        Assertions.assertEquals(tablets.size(), 3);
+
+        List<TabletCacheStats> stats = new ArrayList<>();
+        for (Long tabletId : tablets.keySet()) {
+            TabletCacheStats s = new TabletCacheStats();
+            s.tabletId = tabletId;
+            s.cachedBytes = 100L;
+            s.totalBytes = 200L;
+            stats.add(s);
+        }
+        stmt.submitResult(0 /* workerGroupId */, stats);
+        Assertions.assertEquals(3, stmt.getResult().getResultRows().size());
+
+        String str = stmt.toString();
+        Assertions.assertTrue(str.startsWith("REFRESH CACHE STATS FOR TABLE aaa TABLET"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -38,6 +38,8 @@ import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
 import com.starrocks.proto.ExecuteCommandRequestPB;
 import com.starrocks.proto.ExecuteCommandResultPB;
+import com.starrocks.proto.GetTabletCacheStatsRequest;
+import com.starrocks.proto.GetTabletCacheStatsResponse;
 import com.starrocks.proto.LockTabletMetadataRequest;
 import com.starrocks.proto.LockTabletMetadataResponse;
 import com.starrocks.proto.PCancelPlanFragmentRequest;
@@ -715,6 +717,11 @@ public class MockedBackend {
 
         @Override
         public Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<GetTabletCacheStatsResponse> getTabletCacheStats(GetTabletCacheStatsRequest request) {
             return CompletableFuture.completedFuture(null);
         }
     }

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -269,6 +269,7 @@ statement
     | dropDataCacheRuleStatement
     | clearDataCacheRulesStatement
     | dataCacheSelectStatement
+    | refreshCacheStatsStatement
 
     // Export Statement
     | exportStatement
@@ -2043,6 +2044,10 @@ clearDataCacheRulesStatement
 
 dataCacheSelectStatement
     : CACHE SELECT selectItem (',' selectItem)* FROM qualifiedName (WHERE where=expression)? properties?
+    ;
+
+refreshCacheStatsStatement
+    : REFRESH CACHE STATS FOR TABLE qualifiedName (partitionNames | tabletList)?
     ;
 
 // ------------------------------------------- Export Statement --------------------------------------------------------

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -402,6 +402,27 @@ message GetTabletMetadatasResponse {
     repeated TabletMetadatas tablet_metadatas = 2;
 }
 
+message GetTabletCacheStatsMeta {
+    optional int64 tablet_id = 1;
+    optional int64 version = 2;
+}
+
+message TabletCacheStats {
+    optional int64 tablet_id = 1;
+    optional int64 version = 2;
+    optional int64 cached_bytes = 3;
+    optional int64 total_bytes = 4;
+}
+
+message GetTabletCacheStatsRequest {
+    repeated GetTabletCacheStatsMeta tablets = 1;
+}
+
+message GetTabletCacheStatsResponse {
+    optional StatusPB status = 1;
+    repeated TabletCacheStats cache_stats = 2;
+}
+
 service LakeService {
     rpc publish_version(PublishVersionRequest) returns (PublishVersionResponse);
     rpc aggregate_publish_version(AggregatePublishVersionRequest) returns (PublishVersionResponse);
@@ -424,5 +445,6 @@ service LakeService {
     rpc aggregate_compact(AggregateCompactRequest) returns (CompactResponse);
     rpc find_split_point(FindSplitPointRequest) returns (FindSplitPointResponse);
     rpc get_tablet_metadatas(GetTabletMetadatasRequest) returns (GetTabletMetadatasResponse);
+    rpc get_tablet_cache_stats(GetTabletCacheStatsRequest) returns (GetTabletCacheStatsResponse);
 }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
mysql> refresh cache stats for table lineorder;
+------------+---------------------------------------------------------------------+
| TABLE_NAME | DETAIL                                                              |
+------------+---------------------------------------------------------------------+
| lineorder  | {CnGroup: 0, cachedSize: 542.4MB, totalSize: 1.4GB, percent: 37.3%} |
+------------+---------------------------------------------------------------------+
1 row in set (0.02 sec)

mysql> refresh cache stats for table lineorder partition p1,p5;
+----------------+----------------------------------------------------------------------+
| PARTITION_NAME | DETAIL                                                               |
+----------------+----------------------------------------------------------------------+
| p1             | {CnGroup: 0, cachedSize: 78.9MB, totalSize: 222.9MB, percent: 35.4%} |
| p5             | {CnGroup: 0, cachedSize: 76.3MB, totalSize: 220.3MB, percent: 34.6%} |
+----------------+----------------------------------------------------------------------+
2 rows in set (0.01 sec)

mysql> refresh cache stats for table lineorder tablet 12167,12180;
+-----------+-------------------------------------------------------------------+
| TABLET_ID | DETAIL                                                            |
+-----------+-------------------------------------------------------------------+
| 12167     | {CnGroup: 0, cachedSize: 1.5MB, totalSize: 4.5MB, percent: 34.1%} |
| 12180     | {CnGroup: 0, cachedSize: 1.5MB, totalSize: 4.5MB, percent: 34.4%} |
+-----------+-------------------------------------------------------------------+
2 rows in set (0.01 sec)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds end-to-end tablet cache stats retrieval via new LakeService RPC and REFRESH CACHE STATS SQL, including a thread-pooled backend manager and config.
> 
> - **Backend (Lake/BE)**:
>   - **Tablet cache stats**: Introduces `TabletCacheStatsManager` with thread pool and metrics; integrated into `TabletManager` (init/stop).
>   - **New RPC**: Implements `get_tablet_cache_stats` in `LakeService` (server + .proto messages) to collect per-tablet cached/total bytes.
>   - **FileSystem API**: Adds `FileSystem::get_cache_stats(path, offset, size)` with Posix test stub and Starlet implementation.
>   - **Config**: Adds `config::tablet_cache_stats_max_threads` with dynamic update hook via HTTP `update_config`.
> - **Frontend (FE)**:
>   - **SQL**: Adds `REFRESH CACHE STATS FOR TABLE ...` with `PARTITION`/`TABLET` variants; new AST/analyzer/authorizer wiring and executor `CacheStatsExecutor`.
>   - **RPC client**: Adds FE `LakeService.getTabletCacheStats` with timeout and metrics.
> - **Docs**: BE config doc updated for `tablet_cache_stats_max_threads`.
> - **Tests**: New unit tests for FS starlet cache stats, LakeService RPC, manager, executor, and SQL parsing/behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d16b3ebfacf29582ca64a24329328b76854e25f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->