### PR TITLE
[Enhancement] unify jdbc/es/mysql default row count

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -34,6 +34,7 @@ import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
@@ -469,7 +470,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         }
 
         if (partitionStatistics.size() == 1) {
-            Statistics partitionStats =  partitionStatistics.values().iterator().next();
+            Statistics partitionStats = partitionStatistics.values().iterator().next();
             columnMap.keySet().forEach(column ->
                     statistics.addColumnStatistic(column, partitionStats.getColumnStatistic(column)));
         }
@@ -775,7 +776,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
     private Void computeNormalExternalTableScanNode(Operator node, ExpressionContext context, Table table,
                                                     Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
-                                                    int outputRowCount) {
+                                                    long outputRowCount) {
         Statistics.Builder builder = StatisticsCalcUtils.estimateScanColumns(table, colRefToColumnMetaMap, optimizerContext);
         builder.setOutputRowCount(outputRowCount);
 
@@ -786,25 +787,25 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     @Override
     public Void visitLogicalMysqlScan(LogicalMysqlScanOperator node, ExpressionContext context) {
         return computeNormalExternalTableScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap(),
-                StatisticsEstimateCoefficient.DEFAULT_MYSQL_OUTPUT_ROWS);
+                Config.default_statistics_output_row_count);
     }
 
     @Override
     public Void visitPhysicalMysqlScan(PhysicalMysqlScanOperator node, ExpressionContext context) {
         return computeNormalExternalTableScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap(),
-                StatisticsEstimateCoefficient.DEFAULT_MYSQL_OUTPUT_ROWS);
+                Config.default_statistics_output_row_count);
     }
 
     @Override
     public Void visitLogicalEsScan(LogicalEsScanOperator node, ExpressionContext context) {
         return computeNormalExternalTableScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap(),
-                StatisticsEstimateCoefficient.DEFAULT_ES_OUTPUT_ROWS);
+                Config.default_statistics_output_row_count);
     }
 
     @Override
     public Void visitPhysicalEsScan(PhysicalEsScanOperator node, ExpressionContext context) {
         return computeNormalExternalTableScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap(),
-                StatisticsEstimateCoefficient.DEFAULT_ES_OUTPUT_ROWS);
+                Config.default_statistics_output_row_count);
     }
 
     @Override
@@ -852,13 +853,13 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     @Override
     public Void visitLogicalJDBCScan(LogicalJDBCScanOperator node, ExpressionContext context) {
         return computeNormalExternalTableScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap(),
-                StatisticsEstimateCoefficient.DEFAULT_JDBC_OUTPUT_ROWS);
+                Config.default_statistics_output_row_count);
     }
 
     @Override
     public Void visitPhysicalJDBCScan(PhysicalJDBCScanOperator node, ExpressionContext context) {
         return computeNormalExternalTableScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap(),
-                StatisticsEstimateCoefficient.DEFAULT_JDBC_OUTPUT_ROWS);
+                Config.default_statistics_output_row_count);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.statistics;
 
 public class StatisticsEstimateCoefficient {
@@ -36,12 +35,6 @@ public class StatisticsEstimateCoefficient {
     public static final double OVERLAP_INFINITE_RANGE_FILTER_COEFFICIENT = 0.5;
     // used in compute extra cost for multi distinct function, estimate whether to trigger streaming
     public static final double STREAMING_EXTRA_COST_THRESHOLD_COEFFICIENT = 0.8;
-    // default mysql external table output rows
-    public static final int DEFAULT_MYSQL_OUTPUT_ROWS = 10000;
-    // default es external table output rows
-    public static final int DEFAULT_ES_OUTPUT_ROWS = 5000;
-    // default JDBC external table output rows, JDBC maybe is a distribute system
-    public static final int DEFAULT_JDBC_OUTPUT_ROWS = 20000;
     // if after aggregate row count * DEFAULT_AGGREGATE_EFFECT_COEFFICIENT < input row count,
     // the aggregate has good effect.
     public static final double LOWER_AGGREGATE_EFFECT_COEFFICIENT = 10000;
@@ -62,7 +55,6 @@ public class StatisticsEstimateCoefficient {
     public static final long SMALL_SCALE_ROWS_LIMIT = 1000000;
     // default or predicate limit
     public static final int DEFAULT_OR_OPERATOR_LIMIT = 16;
-
 
     public static final double EXECUTE_COST_PENALTY = 2;
     public static final int BROADCAST_JOIN_MEM_EXCEED_PENALTY = 1000;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/cost/PlanFeaturesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/cost/PlanFeaturesTest.java
@@ -55,10 +55,10 @@ class PlanFeaturesTest extends PlanTestBase {
                     "| 41,0,0,0,0,0,0,0,42,0,0,0,0,0,0,0,0,0,0,43,0,0,0,0,0,0,0,0,0,45,0,0,0,0,0",
             "select * from (select * from ods_order join mysql_table where k1  = 'a' and order_dt = 'c') t1 where t1.k2 = 'c'" +
                     "| tables=[0,db1.tbl1,test.ods_order] " +
-                    "| 40,1,0,8,2,2,0,1,41,0,0,0,0,0,0,0,0,0,0,42,0,0,0,0,0,0,0,0,0,44",
+                    "| 41,1,0,8,2,2,0,1,42,0,0,0,0,0,0,0,0,0,0,43,0,0,0,0,0,0,0,0,0,45,",
             "select * from ods_order join mysql_table where k1  = 'a' and order_dt = 'c'" +
                     "| tables=[0,db1.tbl1,test.ods_order] " +
-                    "| 40,1,0,8,2,2,0,1,41,0,0,0,0,0,0,0,0,0,0,42,0,0,0,0,0,0,0,0,0,44",
+                    "| 41,1,0,8,2,2,0,1,42,0,0,0,0,0,0,0,0,0,0,43,0,0,0,0,0,0,0,0,0,45,",
 
     })
     public void testBasic(String query, String expectedTables, String expected) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/cost/PlanFeaturesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/cost/PlanFeaturesTest.java
@@ -55,10 +55,10 @@ class PlanFeaturesTest extends PlanTestBase {
                     "| 41,0,0,0,0,0,0,0,42,0,0,0,0,0,0,0,0,0,0,43,0,0,0,0,0,0,0,0,0,45,0,0,0,0,0",
             "select * from (select * from ods_order join mysql_table where k1  = 'a' and order_dt = 'c') t1 where t1.k2 = 'c'" +
                     "| tables=[0,db1.tbl1,test.ods_order] " +
-                    "| 41,1,9,8,11,11,0,1,42,0,0,0,0,0,0,0,0,0,0,43,0,0,0,0,0,0,0,0,0,45",
+                    "| 40,1,0,8,2,2,0,1,41,0,0,0,0,0,0,0,0,0,0,42,0,0,0,0,0,0,0,0,0,44",
             "select * from ods_order join mysql_table where k1  = 'a' and order_dt = 'c'" +
                     "| tables=[0,db1.tbl1,test.ods_order] " +
-                    "| 41,1,9,8,11,11,0,1,42,0,0,0,0,0,0,0,0,0,0,43,0,0,0,0,0,0,0,0,0,45",
+                    "| 40,1,0,8,2,2,0,1,41,0,0,0,0,0,0,0,0,0,0,42,0,0,0,0,0,0,0,0,0,44",
 
     })
     public void testBasic(String query, String expectedTables, String expected) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -98,11 +98,11 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
                 + " true]); args: VARCHAR; result: VARCHAR; args nullable: true; result nullable: true] = 'ocms_fengyang56' "
                 + "WHEN '0' THEN TRUE ELSE FALSE END\n"
                 + "  |  limit: 10"), replayPair.second);
-        Assertions.assertTrue(replayPair.second.contains("  4:HASH JOIN\n"
-                + "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n"
-                + "  |  equal join conjunct: [tid, BIGINT, true] = [5: customer_id, BIGINT, true]\n"
-                + "  |  build runtime filters:\n"
-                + "  |  - filter_id = 0, build_expr = (5: customer_id), remote = true"), replayPair.second);
+        Assertions.assertTrue(replayPair.second.contains("  4:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (PARTITIONED)\n" +
+                "  |  equal join conjunct: [5: customer_id, BIGINT, true] = [tid, BIGINT, true]\n" +
+                "  |  output columns: 3, 90\n" +
+                "  |  cardinality: 1"), replayPair.second);
         sessionVariable.setNewPlanerAggStage(0);
     }
 
@@ -289,10 +289,10 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/cross_reorder"), null, TExplainLevel.NORMAL);
         Assertions.assertTrue(replayPair.second.contains("  13:NESTLOOP JOIN\n" +
-                "  |  join op: INNER JOIN\n" +
-                "  |  colocate: false, reason: \n" +
-                "  |  other join predicates: CAST(CASE WHEN CAST(6: v3 AS BOOLEAN) THEN CAST(11: v2 AS VARCHAR) " +
-                "WHEN CAST(3: v3 AS BOOLEAN) THEN '123' ELSE CAST(12: v3 AS VARCHAR) END AS DOUBLE) > " +
+                        "  |  join op: INNER JOIN\n" +
+                        "  |  colocate: false, reason: \n" +
+                        "  |  other join predicates: CAST(CASE WHEN CAST(6: v3 AS BOOLEAN) THEN CAST(11: v2 AS VARCHAR) " +
+                        "WHEN CAST(3: v3 AS BOOLEAN) THEN '123' ELSE CAST(12: v3 AS VARCHAR) END AS DOUBLE) > " +
                         "1.0, (CAST(2: v2 AS DECIMAL128(38,9)) = CAST(8: v2 AS DECIMAL128(38,9))) OR (3: v3 = 8: v2)\n"),
                 replayPair.second);
         connectContext.getSessionVariable().setEnableLocalShuffleAgg(true);
@@ -1017,8 +1017,8 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
                 TExplainLevel.NORMAL);
         Assertions.assertTrue(replayPair.second.contains(
                 "get_json_string(107: mock_031, '$.\"fY21_Territory_Score__c\"')\n" +
-                "  |  \n" +
-                "  9:OlapScanNode\n" +
+                        "  |  \n" +
+                        "  9:OlapScanNode\n" +
                         "     TABLE: tbl_mock_103"), replayPair.second);
     }
 


### PR DESCRIPTION
## Why I'm doing:

It does not make any sense to set different row count for JDBC/MYSQL/ES.  Unify them all to `Config.default_row_count`.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
