### PR TITLE
[Enhancement] Relax rule for using local shuffle one-phase agg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
@@ -108,6 +108,10 @@ public class MaterializedViewOptimizer {
         if (originalSemiJoinDeduplicateMode != -1) {
             connectContext.getSessionVariable().setSemiJoinDeduplicateMode(-1);
         }
+        final boolean originalEnableLocalShuffleAgg = connectContext.getSessionVariable().isEnableLocalShuffleAgg();
+        if (originalEnableLocalShuffleAgg) {
+            connectContext.getSessionVariable().setEnableLocalShuffleAgg(false);
+        }
 
         MVTransformerContext mvTransformerContext = new MVTransformerContext(connectContext, inlineView);
         try {
@@ -131,6 +135,7 @@ public class MaterializedViewOptimizer {
             connectContext.getSessionVariable().setDisableFunctionFoldConstants(originDisableFunctionFoldConstants);
             connectContext.getSessionVariable().setEnableInnerJoinToSemi(originalEnableInnerToSemi);
             connectContext.getSessionVariable().setSemiJoinDeduplicateMode(originalSemiJoinDeduplicateMode);
+            connectContext.getSessionVariable().setEnableLocalShuffleAgg(originalEnableLocalShuffleAgg);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -114,6 +114,7 @@ import com.starrocks.sql.optimizer.rule.tree.PreAggregateTurnOnRule;
 import com.starrocks.sql.optimizer.rule.tree.PredicateReorderRule;
 import com.starrocks.sql.optimizer.rule.tree.PruneAggregateNodeRule;
 import com.starrocks.sql.optimizer.rule.tree.PruneShuffleColumnRule;
+import com.starrocks.sql.optimizer.rule.tree.PruneShuffleDistributionNodeRule;
 import com.starrocks.sql.optimizer.rule.tree.PruneSubfieldsForComplexType;
 import com.starrocks.sql.optimizer.rule.tree.PushDownAggregateRule;
 import com.starrocks.sql.optimizer.rule.tree.PushDownDistinctAggregateRule;
@@ -990,6 +991,7 @@ public class QueryOptimizer extends Optimizer {
         // Rewrite Exchange on top of Sort to Final Sort
         result = new ExchangeSortToMergeRule().rewrite(result, rootTaskContext);
         result = new PruneAggregateNodeRule().rewrite(result, rootTaskContext);
+        result = new PruneShuffleDistributionNodeRule().rewrite(result, rootTaskContext);
         result = new PruneShuffleColumnRule().rewrite(result, rootTaskContext);
         result = new PhysicalDistributionAggOptRule().rewrite(result, rootTaskContext);
         result = new AddDecodeNodeForDictStringRule().rewrite(result, rootTaskContext);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -40,6 +40,8 @@ import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalExceptOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIntersectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalAssertOneRowOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
@@ -214,6 +216,44 @@ public class CostModel {
                     inputStatistics.getComputeSize());
         }
 
+        /**
+         * For single-node execution, if the aggregation ratio is not high enough,
+         * we prefer a single-stage aggregation (with a local shuffle) rather than a two-stage aggregation.
+         */
+        private boolean preferLocalShuffleOnePhaseAgg(PhysicalHashAggregateOperator node, ExpressionContext context) {
+            ConnectContext ctx = ConnectContext.get();
+            SessionVariable sv = ctx.getSessionVariable();
+            if (!sv.isEnableLocalShuffleAgg()) {
+                return false;
+            }
+
+            if (!GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().isSingleBackendAndComputeNode()) {
+                return false;
+            }
+
+            if (node.getGroupBys().isEmpty()) {
+                return false;
+            }
+
+            // Only consider `OlapScan->[Project->]->Streaming Agg->Global Agg` is worse than OlapScan->[Project->]->Global Agg`.
+            Operator child = context.getChildOperator(0);
+            if (child instanceof LogicalProjectOperator || child instanceof PhysicalProjectOperator) {
+                if (context.getGroupExpression() == null) {
+                    return false;
+                }
+                GroupExpression childGroup = context.getGroupExpression().getInputs().get(0).getFirstLogicalExpression();
+                child = childGroup.getInputs().get(0).getFirstLogicalExpression().getOp();
+            }
+            if (!(child instanceof LogicalOlapScanOperator || child instanceof PhysicalOlapScanOperator)) {
+                return false;
+            }
+
+            // Prefer one-phase agg, if the aggregation ratio is not high enough.
+            Statistics statistics = context.getStatistics();
+            Statistics inputStatistics = context.getChildStatistics(0);
+            return statistics.getOutputRowCount() * 4 >= inputStatistics.getOutputRowCount();
+        }
+
         @Override
         public CostEstimate visitPhysicalHashAggregate(PhysicalHashAggregateOperator node, ExpressionContext context) {
             Optional<CostEstimate> cost;
@@ -233,7 +273,7 @@ public class CostModel {
 
             if (node.getDistinctColumnDataSkew() != null) {
                 factor = computeDataSkewPenaltyOfGroupByCountDistinct(node, inputStatistics);
-            } else if (node.isSplit() && node.getType().isLocal()) {
+            } else if (node.isSplit() && node.getType().isLocal() && !preferLocalShuffleOnePhaseAgg(node, context)) {
                 factor = 0.1;
             }
 
@@ -408,7 +448,6 @@ public class CostModel {
             double cpuCost = StatisticUtils.multiplyOutputSize(StatisticUtils.multiplyOutputSize(leftSize, rightSize),
                     EXECUTE_COST_PENALTY);
             double memCost = StatisticUtils.multiplyOutputSize(rightSize, EXECUTE_COST_PENALTY * 100D);
-
 
             if (join.getJoinType().isCrossJoin()) {
                 cpuCost = StatisticUtils.multiplyOutputSize(cpuCost, crossJoinCostPenalty);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -218,7 +218,7 @@ public class CostModel {
 
         /**
          * For single-node execution, if the aggregation ratio is not high enough,
-         * we prefer a single-stage aggregation (with a local shuffle) rather than a two-stage aggregation.
+         * we prefer a one-phase aggregation (with a local shuffle) rather than a two-phase aggregation.
          */
         private boolean preferLocalShuffleOnePhaseAgg(PhysicalHashAggregateOperator node, ExpressionContext context) {
             ConnectContext ctx = ConnectContext.get();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
@@ -72,6 +72,8 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
 
     private boolean forcePreAggregation = false;
 
+    private boolean withLocalShuffle = false;
+
     private List<Pair<ConstantOperator, ConstantOperator>> groupByMinMaxStatistic = Lists.newArrayList();
 
     public PhysicalHashAggregateOperator(AggType type,
@@ -108,6 +110,7 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
         this.withoutColocateRequirement = aggregateOperator.withoutColocateRequirement;
         this.distinctColumnDataSkew = aggregateOperator.distinctColumnDataSkew;
         this.groupByMinMaxStatistic = aggregateOperator.groupByMinMaxStatistic;
+        this.withLocalShuffle = aggregateOperator.withLocalShuffle;
     }
 
     public List<ColumnRefOperator> getGroupBys() {
@@ -220,6 +223,14 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
 
     public void setForcePreAggregation(boolean forcePreAggregation) {
         this.forcePreAggregation = forcePreAggregation;
+    }
+
+    public boolean isWithLocalShuffle() {
+        return withLocalShuffle;
+    }
+
+    public void setWithLocalShuffle(boolean withLocalShuffle) {
+        this.withLocalShuffle = withLocalShuffle;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneShuffleDistributionNodeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneShuffleDistributionNodeRule.java
@@ -1,0 +1,118 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree;
+
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalProjectOperator;
+import com.starrocks.sql.optimizer.task.TaskContext;
+
+/**
+ * For a single-BE cluster, the Shuffle Exchange between Global Agg and Scan can be replaced with a Local Shuffle.
+ * Limitations:
+ * - The query must not contain operators with multiple input children, such as Join. The reason is that if one side replaces
+ *   the exchange shuffle with a local shuffle while the other side still uses an exchange shuffle, the partitions won’t align,
+ *   resulting in incorrect results.
+ * - Only the following two plans are eligible for removing the Shuffle Exchange:
+ *     - OlapScan -> [Project->] Local Agg -> Shuffle Exchange -> Global Agg
+ *     - OlapScan -> [Project->] Shuffle Exchange -> Global Agg
+ */
+public class PruneShuffleDistributionNodeRule implements TreeRewriteRule {
+    private static final Visitor VISITOR = new Visitor();
+
+    @Override
+    public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
+        SessionVariable sv = taskContext.getOptimizerContext().getConnectContext().getSessionVariable();
+        if (!sv.isEnableLocalShuffleAgg() || !sv.isEnablePipelineEngine() ||
+                !GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().isSingleBackendAndComputeNode()) {
+            return root;
+        }
+
+        return root.getOp().accept(VISITOR, root, null);
+    }
+
+    private static class Visitor extends OptExpressionVisitor<OptExpression, Void> {
+        @Override
+        public OptExpression visit(OptExpression optExpression, Void context) {
+            // Don't use local shuffle agg when the query has join or other complex operators,
+            // who accepts data from multiple children.
+            if (optExpression.getInputs().size() > 1) {
+                return optExpression;
+            }
+
+            for (int i = 0; i < optExpression.arity(); ++i) {
+                OptExpression childOptExpr = optExpression.inputAt(i);
+                optExpression.setChild(i, childOptExpr.getOp().accept(this, childOptExpr, null));
+            }
+            return optExpression;
+        }
+
+        @Override
+        public OptExpression visitPhysicalHashAggregate(OptExpression optExpression, Void context) {
+            PhysicalHashAggregateOperator agg = optExpression.getOp().cast();
+            if (!agg.getType().isGlobal() || agg.getGroupBys().isEmpty()) {
+                return visit(optExpression, context);
+            }
+
+            // Child should be a shuffle distribution.
+            OptExpression childOptExpr = optExpression.inputAt(0);
+            Operator childOperator = childOptExpr.getOp();
+            if (!(childOperator instanceof PhysicalDistributionOperator)) {
+                return visit(optExpression, context);
+            }
+            PhysicalDistributionOperator distribution = (PhysicalDistributionOperator) childOperator;
+            if (distribution.getDistributionSpec().getType() != DistributionSpec.DistributionType.SHUFFLE) {
+                return visit(optExpression, context);
+            }
+
+            if (!canPruneShuffleDistribution(childOptExpr)) {
+                return visit(optExpression, context);
+            }
+
+            agg.setWithLocalShuffle(true);
+            optExpression.setChild(0, childOptExpr.inputAt(0));
+            return optExpression;
+        }
+
+        private boolean canPruneShuffleDistribution(OptExpression distributionOptExpr) {
+            OptExpression childOptExpression = distributionOptExpr.inputAt(0);
+            Operator childOperator = childOptExpression.getOp();
+
+            if (childOperator instanceof PhysicalHashAggregateOperator) {
+                PhysicalHashAggregateOperator childAgg = childOperator.cast();
+                if (!childAgg.getType().isLocal() && !childAgg.getType().isDistinctLocal()) {
+                    return false;
+                }
+                childOptExpression = childOptExpression.inputAt(0);
+                childOperator = childOptExpression.getOp();
+            }
+
+            if (childOperator instanceof PhysicalProjectOperator) {
+                childOptExpression = childOptExpression.inputAt(0);
+                childOperator = childOptExpression.getOp();
+            }
+
+            return childOperator instanceof PhysicalOlapScanOperator;
+        }
+
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -664,6 +664,7 @@ public class ExpressionStatisticCalculator {
                             callOperator.getType().getTypeSize(), distinctValues);
                 // use child column statistics for now
                 case FunctionSet.SUBSTRING:
+                case FunctionSet.REGEXP_REPLACE:
                     return childColumnStatisticList.get(0);
                 case FunctionSet.CONCAT:
                     distinctValues = Math.min(rowCount,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.HintNode;
 import com.starrocks.sql.optimizer.ChildOutputPropertyGuarantor;
 import com.starrocks.sql.optimizer.Group;
@@ -408,8 +409,10 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         if (!OperatorType.PHYSICAL_HASH_AGG.equals(groupExpression.getOp().getOpType())) {
             return true;
         }
+
+        SessionVariable sv = ConnectContext.get().getSessionVariable();
         // respect session variable new_planner_agg_stage
-        int aggStage = ConnectContext.get().getSessionVariable().getNewPlannerAggStage();
+        int aggStage = sv.getNewPlannerAggStage();
         if (aggStage == 1) {
             return true;
         }
@@ -433,16 +436,24 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
             if (aggregate.getDistinctColumnDataSkew() != null) {
                 return true;
             }
+
             // 1.1 check default column statistics or child output row may not be accurate
             if (groupExpression.getGroup().getStatistics().getColumnStatistics().values().stream()
                     .anyMatch(ColumnStatistic::isUnknown) ||
                     childBestExpr.getGroup().getStatistics().isTableRowCountMayInaccurate()) {
                 return false;
             }
+
             // 1.2 disable one stage agg with distinct aggregate
             if (!distinctAggCallOperator.isEmpty()) {
                 return false;
             }
+
+            if (sv.isEnableLocalShuffleAgg() &&
+                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().isSingleBackendAndComputeNode()) {
+                return true;
+            }
+
             // 1.3 disable one stage agg with multi group by columns
             return aggregate.getGroupBys().size() <= 1;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -15,7 +15,6 @@
 package com.starrocks.sql.plan;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.AggregateFunction;
@@ -461,8 +460,6 @@ public class PlanFragmentBuilder {
         private final List<Integer> collectExecStatsIds = Lists.newArrayList();
         private ExecGroup currentExecGroup = execGroups.newExecGroup();
 
-        private boolean canUseLocalShuffleAgg = true;
-
         public PhysicalPlanTranslator(ColumnRefFactory columnRefFactory) {
             this.columnRefFactory = columnRefFactory;
         }
@@ -520,7 +517,6 @@ public class PlanFragmentBuilder {
 
         @Override
         public PlanFragment visit(OptExpression optExpression, ExecPlan context) {
-            canUseLocalShuffleAgg &= optExpression.arity() <= 1;
             PlanFragment fragment = optExpression.getOp().accept(this, optExpression, context);
             Projection projection = (optExpression.getOp()).getProjection();
 
@@ -609,7 +605,6 @@ public class PlanFragmentBuilder {
             for (ScalarOperator predicate : predicates) {
                 predicateColumns.union(predicate.getUsedColumns());
             }
-
 
             // ------------------------------------------------------------------------------------
             // unused Columns = required columns - predicate columns.
@@ -1472,7 +1467,6 @@ public class PlanFragmentBuilder {
             return buildIcebergScanNode(optExpression, context);
         }
 
-
         public PlanFragment buildIcebergScanNode(OptExpression expression, ExecPlan context) {
             PhysicalScanOperator node = expression.getOp().cast();
             Table referenceTable = node.getTable();
@@ -2039,7 +2033,7 @@ public class PlanFragmentBuilder {
             tupleDescriptor.computeMemLayout();
 
             RawValuesNode rawValuesNode = new RawValuesNode(
-                    context.getNextNodeId(), 
+                    context.getNextNodeId(),
                     tupleDescriptor.getId(),
                     rawValuesOperator.getConstantType(),
                     rawValuesOperator.getRawText(),
@@ -2089,78 +2083,6 @@ public class PlanFragmentBuilder {
             }
 
             return true;
-        }
-
-        /**
-         * Remove ExchangeNode between AggNode and ScanNode for the single backend.
-         * <p>
-         * This is used to generate "ScanNode->LocalShuffle->OnePhaseLocalAgg" for the single backend,
-         * which contains two steps:
-         * 1. Ignore the network cost for ExchangeNode when estimating cost model.
-         * 2. Remove ExchangeNode between AggNode and ScanNode when building fragments.
-         * <p>
-         * Specifically, transfer
-         * (AggNode->ExchangeNode)->([ProjectNode->]ScanNode)
-         * -      *inputFragment         sourceFragment
-         * to
-         * (AggNode->[ProjectNode->]ScanNode)
-         * -      *sourceFragment
-         * That is, when matching this fragment pattern, remove inputFragment and return sourceFragment.
-         *
-         * @param inputFragment The input fragment to match the above pattern.
-         * @param context       The context of building fragment, which contains all the fragments.
-         * @return SourceFragment if it matches th pattern, otherwise the original inputFragment.
-         */
-        private PlanFragment removeExchangeNodeForLocalShuffleAgg(PlanFragment inputFragment, ExecPlan context) {
-            if (ConnectContext.get() == null) {
-                return inputFragment;
-            }
-            if (!canUseLocalShuffleAgg) {
-                return inputFragment;
-            }
-            SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
-            boolean enableLocalShuffleAgg = sessionVariable.isEnableLocalShuffleAgg()
-                    && sessionVariable.isEnablePipelineEngine()
-                    && GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().isSingleBackendAndComputeNode();
-            if (!enableLocalShuffleAgg) {
-                return inputFragment;
-            }
-
-            // InputFragment should match "AggNode->ExchangeNode" pattern, where AggNode is the caller of this method.
-            if (!(inputFragment.getPlanRoot() instanceof ExchangeNode)) {
-                return inputFragment;
-            }
-
-            ExchangeNode node = (ExchangeNode) inputFragment.getPlanRoot();
-            if (node.isMerge()) {
-                return inputFragment;
-            }
-
-            // SourceFragment should match "[ProjectNode->]ScanNode" pattern.
-            PlanNode sourceFragmentRoot = inputFragment.getPlanRoot().getChild(0);
-            if (!onlyContainNodeTypes(sourceFragmentRoot, ImmutableList.of(ScanNode.class, ProjectNode.class))) {
-                return inputFragment;
-            }
-
-            // If ExchangeSink is CTE MultiCastPlanFragment, we cannot remove this ExchangeNode.
-            PlanFragment sourceFragment = sourceFragmentRoot.getFragment();
-            if (sourceFragment instanceof MultiCastPlanFragment) {
-                return inputFragment;
-            }
-
-            // Traverse fragment in reverse to delete inputFragment,
-            // because the last fragment is inputFragment for the most cases.
-            ArrayList<PlanFragment> fragments = context.getFragments();
-            for (int i = fragments.size() - 1; i >= 0; --i) {
-                if (fragments.get(i).equals(inputFragment)) {
-                    fragments.remove(i);
-                    break;
-                }
-            }
-
-            sourceFragment.clearDestination();
-            sourceFragment.clearOutputPartition();
-            return sourceFragment;
         }
 
         private static class AggregateExprInfo {
@@ -2264,10 +2186,12 @@ public class PlanFragmentBuilder {
         @Override
         public PlanFragment visitPhysicalHashAggregate(OptExpression optExpr, ExecPlan context) {
             PhysicalHashAggregateOperator node = (PhysicalHashAggregateOperator) optExpr.getOp();
-            PlanFragment originalInputFragment = visit(optExpr.inputAt(0), context);
+            PlanFragment inputFragment = visit(optExpr.inputAt(0), context);
 
-            PlanFragment inputFragment = removeExchangeNodeForLocalShuffleAgg(originalInputFragment, context);
-            boolean withLocalShuffle = inputFragment != originalInputFragment || inputFragment.isWithLocalShuffle();
+            final boolean withLocalShuffle = node.isWithLocalShuffle() || inputFragment.isWithLocalShuffle();
+            if (node.isWithLocalShuffle()) {
+                inputFragment.setWithLocalShuffleIfTrue(true);
+            }
 
             Map<ColumnRefOperator, CallOperator> aggregations = node.getAggregations();
             List<ColumnRefOperator> groupBys = node.getGroupBys();
@@ -2403,7 +2327,8 @@ public class PlanFragmentBuilder {
             aggregationNode.computeStatistics(optExpr.getStatistics());
             aggregationNode.setGroupByMinMaxStats(node.getGroupByMinMaxStatistic());
 
-            if (node.isOnePhaseAgg() || node.isMergedLocalAgg() || node.getType().isDistinctGlobal()) {
+            if (node.isOnePhaseAgg() || node.isMergedLocalAgg() || node.getType().isDistinctGlobal() ||
+                    node.getType().isGlobal()) {
                 // For ScanNode->LocalShuffle->AggNode, we needn't assign scan ranges per driver sequence.
                 inputFragment.setAssignScanRangesPerDriverSeq(!withLocalShuffle);
                 inputFragment.setWithLocalShuffleIfTrue(withLocalShuffle);
@@ -2427,8 +2352,8 @@ public class PlanFragmentBuilder {
             }
             inputFragment.setPlanRoot(aggregationNode);
             inputFragment.getPlanRoot().forceCollectExecStats();
-            inputFragment.mergeQueryDictExprs(originalInputFragment.getQueryGlobalDictExprs());
-            inputFragment.mergeQueryGlobalDicts(originalInputFragment.getQueryGlobalDicts());
+            inputFragment.mergeQueryDictExprs(inputFragment.getQueryGlobalDictExprs());
+            inputFragment.mergeQueryGlobalDicts(inputFragment.getQueryGlobalDicts());
             return inputFragment;
         }
 
@@ -2655,7 +2580,6 @@ public class PlanFragmentBuilder {
             List<Expr> preAggFnCallExprs = new ArrayList<>();
             List<SlotId> preAggOutputColumnIds = new ArrayList<>();
             TupleDescriptor preAggTuple = context.getDescTbl().createTupleDescriptor();
-
 
             if (preAggFnCalls != null) {
                 for (Map.Entry<ColumnRefOperator, CallOperator> entry : preAggFnCalls.entrySet()) {
@@ -3498,7 +3422,6 @@ public class PlanFragmentBuilder {
 
             Map<SlotId, Expr> commonSubOperatorMap = buildCommonSubExprMap(filter.getPredicateCommonOperators(), context);
 
-
             List<Expr> predicates = Utils.extractConjuncts(filter.getPredicate()).stream()
                     .map(d -> ScalarOperatorToExpr.buildExecExpression(d,
                             new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
@@ -3637,8 +3560,6 @@ public class PlanFragmentBuilder {
                     .map(ColumnRefOperator::getId).distinct().collect(Collectors.toList()));
             exchangeNode.setDataPartition(cteFragment.getDataPartition());
             exchangeNode.forceCollectExecStats();
-
-
 
             PlanFragment consumeFragment = new PlanFragment(context.getNextFragmentId(), exchangeNode,
                     cteFragment.getDataPartition());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -119,6 +119,8 @@ public class SelectStmtTest {
                 .withTable(createTable1)
                 .withTable(createTableWithPrimaryKey);
         FeConstants.enablePruneEmptyOutputScan = false;
+
+        starRocksAssert.getCtx().getSessionVariable().setEnableLocalShuffleAgg(false);
     }
 
     @BeforeEach

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -82,6 +82,9 @@ public class MaterializedViewTestBase extends PlanTestBase {
 
         starRocksAssert.withDatabase(MATERIALIZED_DB_NAME)
                 .useDatabase(MATERIALIZED_DB_NAME);
+
+        starRocksAssert.getCtx().getSessionVariable().setEnableLocalShuffleAgg(false);
+        connectContext.getSessionVariable().setEnableLocalShuffleAgg(false);
     }
 
     @AfterAll

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1505,7 +1505,7 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
             Assertions.assertEquals(0, olapScanNode.getBucketExprs().size());
             Assertions.assertFalse(containAnyColocateNode(execPlan.getFragments().get(1).getPlanRoot()));
             plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+            assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
                     "  |  output: sum(2: v2)\n" +
                     "  |  group by: 2: v2\n" +
                     "  |  withLocalShuffle: true\n" +
@@ -1523,12 +1523,12 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
             Assertions.assertFalse(containAnyColocateNode(execPlan.getFragments().get(1).getPlanRoot()));
             Assertions.assertFalse(execPlan.getFragments().get(1).isAssignScanRangesPerDriverSeq());
             plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            assertContains(plan, "  3:AGGREGATE (update finalize)\n" +
+            assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
                     "  |  output: sum(4: count)\n" +
                     "  |  group by: 2: v2, 4: count\n" +
                     "  |  withLocalShuffle: true\n" +
                     "  |  \n" +
-                    "  2:AGGREGATE (update finalize)\n" +
+                    "  1:AGGREGATE (update finalize)\n" +
                     "  |  output: count(2: v2)\n" +
                     "  |  group by: 2: v2\n" +
                     "  |  withLocalShuffle: true\n" +
@@ -1616,17 +1616,17 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
             olapScanNode = (OlapScanNode) execPlan.getScanNodes().get(0);
             Assertions.assertEquals(0, olapScanNode.getBucketExprs().size());
             plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            assertContains(plan, "1:AGGREGATE (update serialize)\n" +
+            assertContains(plan, "  2:AGGREGATE (merge finalize)\n" +
+                    "  |  output: sum(4: sum)\n" +
+                    "  |  group by: 2: v2\n" +
+                    "  |  withLocalShuffle: true\n" +
+                    "  |  \n" +
+                    "  1:AGGREGATE (update serialize)\n" +
                     "  |  STREAMING\n" +
                     "  |  output: sum(2: v2)\n" +
                     "  |  group by: 2: v2\n" +
                     "  |  \n" +
                     "  0:OlapScanNode");
-            assertContains(plan, "  3:AGGREGATE (merge finalize)\n" +
-                    "  |  output: sum(4: sum)\n" +
-                    "  |  group by: 2: v2\n" +
-                    "  |  \n" +
-                    "  2:EXCHANGE");
 
             // case 8: insert into cannot use one-phase local aggregation with local shuffle.
             isSingleBackendAndComputeNode.setRef(true);
@@ -1651,7 +1651,29 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
                     "(select v2, sum(v2) from t0 group by v2) t2 on t1.v2=t2.v2";
             execPlan = getExecPlan(sql);
             plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            assertContains(plan, "8:HASH JOIN\n" +
+            assertContains(plan, "  6:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 2: v2 = 6: v2\n" +
+                    "  |  \n" +
+                    "  |----5:AGGREGATE (update finalize)\n" +
+                    "  |    |  group by: 6: v2\n" +
+                    "  |    |  \n" +
+                    "  |    4:EXCHANGE\n" +
+                    "  |    \n" +
+                    "  2:AGGREGATE (update finalize)\n" +
+                    "  |  group by: 2: v2\n" +
+                    "  |  \n" +
+                    "  1:EXCHANGE");
+
+            isSingleBackendAndComputeNode.setRef(true);
+            cardinality.setRef(avgLowCardinality);
+            sql = "select count(1) from " +
+                    "(select v2, sum(v2) from t0 group by v2) t1 join " +
+                    "(select v2, sum(v2) from t0 group by v2) t2 on t1.v2=t2.v2";
+            execPlan = getExecPlan(sql);
+            plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+            assertContains(plan, "  8:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 2: v2 = 6: v2\n" +

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q10.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q10.sql
@@ -14,7 +14,7 @@ from
     hive0.tpch.lineitem,
     hive0.tpch.nation
 where
-        c_custkey = o_custkey
+    c_custkey = o_custkey
   and l_orderkey = o_orderkey
   and o_orderdate >= date '1994-05-01'
   and o_orderdate < date '1994-08-01'
@@ -38,16 +38,15 @@ TOP-N (order by [[39: sum DESC NULLS LAST]])
                 AGGREGATE ([LOCAL] aggregate [{142: sum=sum(140: sum)}] group by [[1: c_custkey, 2: c_name, 6: c_acctbal, 5: c_phone, 35: n_name, 3: c_address, 8: c_comment]] having [null]
                     INNER JOIN (join-predicate [4: c_nationkey = 34: n_nationkey] post-join-predicate [null])
                         INNER JOIN (join-predicate [1: c_custkey = 10: o_custkey] post-join-predicate [null])
-                            EXCHANGE SHUFFLE[1]
-                                HIVE SCAN (columns{1,2,3,4,5,6,8} predicate[1: c_custkey IS NOT NULL])
-                            EXCHANGE SHUFFLE[10]
+                            HIVE SCAN (columns{1,2,3,4,5,6,8} predicate[1: c_custkey IS NOT NULL])
+                            EXCHANGE BROADCAST
                                 INNER JOIN (join-predicate [9: o_orderkey = 18: l_orderkey] post-join-predicate [null])
                                     HIVE SCAN (columns{9,10,13} predicate[13: o_orderdate >= 1994-05-01 AND 13: o_orderdate < 1994-08-01])
                                     EXCHANGE BROADCAST
-                                        AGGREGATE ([GLOBAL] aggregate [{141: sum=sum(141: sum)}] group by [[116: l_orderkey]] having [null]
-                                            EXCHANGE SHUFFLE[116]
-                                                AGGREGATE ([LOCAL] aggregate [{141: sum=sum(126: sum_disc_price)}] group by [[116: l_orderkey]] having [null]
-                                                    SCAN (mv[lineitem_agg_mv1] columns[116: l_orderkey, 118: l_returnflag, 126: sum_disc_price] predicate[118: l_returnflag = R])
+                                        AGGREGATE ([GLOBAL] aggregate [{141: sum=sum(141: sum)}] group by [[84: l_orderkey]] having [null]
+                                            EXCHANGE SHUFFLE[84]
+                                                AGGREGATE ([LOCAL] aggregate [{141: sum=sum(94: sum_disc_price)}] group by [[84: l_orderkey]] having [null]
+                                                    SCAN (mv[lineitem_agg_mv1] columns[84: l_orderkey, 86: l_returnflag, 94: sum_disc_price] predicate[86: l_returnflag = R])
                         EXCHANGE BROADCAST
                             HIVE SCAN (columns{34,35} predicate[34: n_nationkey IS NOT NULL])
 [end]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q18.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q18.sql
@@ -11,14 +11,14 @@ from
     hive0.tpch.orders,
     hive0.tpch.lineitem
 where
-        o_orderkey in (
+    o_orderkey in (
         select
             l_orderkey
         from
             hive0.tpch.lineitem
         group by
             l_orderkey having
-                sum(l_quantity) > 315
+            sum(l_quantity) > 315
     )
   and c_custkey = o_custkey
   and o_orderkey = l_orderkey
@@ -34,13 +34,15 @@ order by
 [result]
 TOP-N (order by [[12: o_totalprice DESC NULLS LAST, 13: o_orderdate ASC NULLS FIRST]])
     TOP-N (order by [[12: o_totalprice DESC NULLS LAST, 13: o_orderdate ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{52: sum=sum(22: l_quantity)}] group by [[2: c_name, 1: c_custkey, 9: o_orderkey, 13: o_orderdate, 12: o_totalprice]] having [null]
-            LEFT SEMI JOIN (join-predicate [9: o_orderkey = 34: l_orderkey] post-join-predicate [null])
-                EXCHANGE SHUFFLE[9]
-                    SCAN (mv[lineitem_mv] columns[99: c_name, 105: l_orderkey, 107: l_quantity, 114: o_custkey, 115: o_orderdate, 119: o_totalprice] predicate[null])
-                AGGREGATE ([GLOBAL] aggregate [{155: sum=sum(155: sum)}] group by [[56: l_orderkey]] having [155: sum > 315.00]
-                    EXCHANGE SHUFFLE[56]
-                        AGGREGATE ([LOCAL] aggregate [{155: sum=sum(60: sum_qty)}] group by [[56: l_orderkey]] having [null]
-                            SCAN (mv[lineitem_agg_mv1] columns[56: l_orderkey, 60: sum_qty] predicate[null])
+        AGGREGATE ([GLOBAL] aggregate [{52: sum=sum(52: sum)}] group by [[2: c_name, 1: c_custkey, 9: o_orderkey, 13: o_orderdate, 12: o_totalprice]] having [null]
+            EXCHANGE SHUFFLE[2, 1, 9, 13, 12]
+                AGGREGATE ([LOCAL] aggregate [{52: sum=sum(22: l_quantity)}] group by [[2: c_name, 1: c_custkey, 9: o_orderkey, 13: o_orderdate, 12: o_totalprice]] having [null]
+                    LEFT SEMI JOIN (join-predicate [9: o_orderkey = 34: l_orderkey] post-join-predicate [null])
+                        SCAN (mv[lineitem_mv] columns[61: c_name, 67: l_orderkey, 69: l_quantity, 76: o_custkey, 77: o_orderdate, 81: o_totalprice] predicate[null])
+                        EXCHANGE BROADCAST
+                            AGGREGATE ([GLOBAL] aggregate [{143: sum=sum(143: sum)}] group by [[125: l_orderkey]] having [143: sum > 315.00]
+                                EXCHANGE SHUFFLE[125]
+                                    AGGREGATE ([LOCAL] aggregate [{143: sum=sum(129: sum_qty)}] group by [[125: l_orderkey]] having [null]
+                                        SCAN (mv[lineitem_agg_mv1] columns[125: l_orderkey, 129: sum_qty] predicate[null])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q20.sql
@@ -6,27 +6,27 @@ from
     hive0.tpch.supplier,
     hive0.tpch.nation
 where
-        s_suppkey in (
+    s_suppkey in (
         select
             ps_suppkey
         from
             hive0.tpch.partsupp
         where
-                ps_partkey in (
+            ps_partkey in (
                 select
                     p_partkey
                 from
                     hive0.tpch.part
                 where
-                        p_name like 'sienna%'
+                    p_name like 'sienna%'
             )
           and ps_availqty > (
             select
-                    0.5 * sum(l_quantity)
+                0.5 * sum(l_quantity)
             from
                 hive0.tpch.lineitem
             where
-                    l_partkey = ps_partkey
+                l_partkey = ps_partkey
               and l_suppkey = ps_suppkey
               and l_shipdate >= date '1993-01-01'
               and l_shipdate < date '1994-01-01'
@@ -43,18 +43,18 @@ TOP-N (order by [[2: s_name ASC NULLS FIRST]])
             EXCHANGE SHUFFLE[13]
                 INNER JOIN (join-predicate [12: ps_partkey = 28: l_partkey AND 13: ps_suppkey = 29: l_suppkey AND cast(14: ps_availqty as DECIMAL128(38,3)) > multiply(0.5, 43: sum)] post-join-predicate [null])
                     LEFT SEMI JOIN (join-predicate [12: ps_partkey = 17: p_partkey] post-join-predicate [null])
-                        EXCHANGE SHUFFLE[12]
-                            HIVE SCAN (columns{12,13,14} predicate[13: ps_suppkey IS NOT NULL])
-                        EXCHANGE SHUFFLE[17]
+                        HIVE SCAN (columns{12,13,14} predicate[13: ps_suppkey IS NOT NULL])
+                        EXCHANGE BROADCAST
                             HIVE SCAN (columns{17,18} predicate[17: p_partkey IS NOT NULL AND 18: p_name LIKE sienna%])
-                    EXCHANGE SHUFFLE[28]
-                        AGGREGATE ([GLOBAL] aggregate [{145: sum=sum(145: sum)}] group by [[65: l_partkey, 63: l_suppkey]] having [null]
-                            EXCHANGE SHUFFLE[65, 63]
-                                AGGREGATE ([LOCAL] aggregate [{145: sum=sum(66: sum_qty)}] group by [[65: l_partkey, 63: l_suppkey]] having [null]
-                                    SCAN (mv[lineitem_agg_mv2] columns[63: l_suppkey, 64: l_shipdate, 65: l_partkey, 66: sum_qty] predicate[64: l_shipdate >= 1993-01-01 AND 64: l_shipdate < 1994-01-01])
+                    EXCHANGE BROADCAST
+                        AGGREGATE ([GLOBAL] aggregate [{138: sum=sum(138: sum)}] group by [[49: l_partkey, 47: l_suppkey]] having [null]
+                            EXCHANGE SHUFFLE[49, 47]
+                                AGGREGATE ([LOCAL] aggregate [{138: sum=sum(50: sum_qty)}] group by [[49: l_partkey, 47: l_suppkey]] having [null]
+                                    SCAN (mv[lineitem_agg_mv2] columns[47: l_suppkey, 48: l_shipdate, 49: l_partkey, 50: sum_qty] predicate[48: l_shipdate >= 1993-01-01 AND 48: l_shipdate < 1994-01-01])
             EXCHANGE SHUFFLE[1]
                 INNER JOIN (join-predicate [4: s_nationkey = 8: n_nationkey] post-join-predicate [null])
                     HIVE SCAN (columns{1,2,3,4} predicate[4: s_nationkey IS NOT NULL])
                     EXCHANGE BROADCAST
                         HIVE SCAN (columns{8,9} predicate[9: n_name = ARGENTINA])
 [end]
+

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q3.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q3.sql
@@ -9,7 +9,7 @@ from
     hive0.tpch.orders,
     hive0.tpch.lineitem
 where
-  c_mktsegment = 'HOUSEHOLD'
+    c_mktsegment = 'HOUSEHOLD'
   and c_custkey = o_custkey
   and l_orderkey = o_orderkey
   and o_orderdate < date '1995-03-11'
@@ -28,15 +28,14 @@ TOP-N (order by [[35: sum DESC NULLS LAST, 13: o_orderdate ASC NULLS FIRST]])
             EXCHANGE SHUFFLE[18, 13, 16]
                 AGGREGATE ([LOCAL] aggregate [{123: sum=sum(121: sum)}] group by [[18: l_orderkey, 13: o_orderdate, 16: o_shippriority]] having [null]
                     INNER JOIN (join-predicate [10: o_custkey = 1: c_custkey] post-join-predicate [null])
-                        EXCHANGE SHUFFLE[10]
-                            INNER JOIN (join-predicate [9: o_orderkey = 18: l_orderkey] post-join-predicate [null])
-                                HIVE SCAN (columns{9,10,13,16} predicate[13: o_orderdate < 1995-03-11])
-                                EXCHANGE BROADCAST
-                                    AGGREGATE ([GLOBAL] aggregate [{122: sum=sum(122: sum)}] group by [[100: l_orderkey]] having [null]
-                                        EXCHANGE SHUFFLE[100]
-                                            AGGREGATE ([LOCAL] aggregate [{122: sum=sum(110: sum_disc_price)}] group by [[100: l_orderkey]] having [null]
-                                                SCAN (mv[lineitem_agg_mv1] columns[100: l_orderkey, 101: l_shipdate, 110: sum_disc_price] predicate[101: l_shipdate > 1995-03-11])
-                        EXCHANGE SHUFFLE[1]
+                        INNER JOIN (join-predicate [9: o_orderkey = 18: l_orderkey] post-join-predicate [null])
+                            HIVE SCAN (columns{9,10,13,16} predicate[13: o_orderdate < 1995-03-11])
+                            EXCHANGE BROADCAST
+                                AGGREGATE ([GLOBAL] aggregate [{122: sum=sum(122: sum)}] group by [[40: l_orderkey]] having [null]
+                                    EXCHANGE SHUFFLE[40]
+                                        AGGREGATE ([LOCAL] aggregate [{122: sum=sum(50: sum_disc_price)}] group by [[40: l_orderkey]] having [null]
+                                            SCAN (mv[lineitem_agg_mv1] columns[40: l_orderkey, 41: l_shipdate, 50: sum_disc_price] predicate[41: l_shipdate > 1995-03-11])
+                        EXCHANGE BROADCAST
                             HIVE SCAN (columns{1,7} predicate[7: c_mktsegment = HOUSEHOLD])
 [end]
 


### PR DESCRIPTION
## Why I'm doing:

Refine statistics logic to enable more cases for local shuffle one-phase agg  
1. Allow multi-column group by to use this optimization  
2. Apply the optimization when aggregation ratio ≤ 4  

Move the logic for removing the Exchange between GlobalAgg and ScanNode from FragmentBuilder to PruneShuffleDistributionNodeRule  
- Add support for `OlapScan -> [Project->] Local Agg -> Shuffle Exchange -> Global Agg` in addition to `OlapScan -> [Project->] Shuffle Exchange -> Global Agg`

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
