### PR TITLE
[Enhancement] set the constant json_path JsonExtractIterator

### DIFF
--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -677,6 +677,7 @@ public:
         TypeDescriptor return_type(_type);
         std::vector<TypeDescriptor> arg_types = {TypeDescriptor::create_json_type(), TypeDescriptor(TYPE_VARCHAR)};
         _fn_context.reset(FunctionContext::create_context(&_state, &_mem_pool, return_type, arg_types));
+        _fn_context->set_constant_columns(Columns{nullptr, path_column->clone()});
     }
 
     ~JsonExtractIterator() override {

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -677,7 +677,8 @@ public:
         TypeDescriptor return_type(_type);
         std::vector<TypeDescriptor> arg_types = {TypeDescriptor::create_json_type(), TypeDescriptor(TYPE_VARCHAR)};
         _fn_context.reset(FunctionContext::create_context(&_state, &_mem_pool, return_type, arg_types));
-        _fn_context->set_constant_columns(Columns{nullptr, path_column->clone()});
+        auto const_path = ColumnHelper::create_const_column<TYPE_VARCHAR>(_path.to_string(), 1);
+        _fn_context->set_constant_columns(Columns{nullptr, const_path});
     }
 
     ~JsonExtractIterator() override {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


If the json_path is not found within a flattened segment, it will default to the `JsonExtractIterator`, which introduces a performance bottleneck due to repeatedly parsing the JSON path.


```
-   34.84%     0.03%  pip_scan_com     starrocks_be       [.] starrocks::SegmentIterator::_read(starrocks::Chunk*, std::vector<unsigned int, std::allocator<unsigned int> >*, unsigned long)                                                 ▒
   - 34.81% starrocks::SegmentIterator::_read(starrocks::Chunk*, std::vector<unsigned int, std::allocator<unsigned int> >*, unsigned long)                                                                                                   ▒
      - 34.67% starrocks::SegmentIterator::ScanContext::read_columns(starrocks::Chunk*, starrocks::SparseRange<unsigned int> const&)                                                                                                         ▒
         - 31.30% starrocks::JsonExtractIterator::next_batch(starrocks::SparseRange<unsigned int> const&, starrocks::Column*)                                                                                                                ▒
            - 22.45% starrocks::JsonExtractIterator::do_extract(starrocks::Column*)                                                                                                                                                          ▒
               - 22.41% starrocks::JsonFunctions::get_native_json_string(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<▒
                  - 22.36% starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > starrocks::JsonFunctions::_full_json_query_impl<(starrocks::LogicalType)17>(starrocks::FunctionContext*, std::vector<starrock▒
                     - 21.06% starrocks::get_prepared_or_parse(starrocks::FunctionContext*, starrocks::Slice, starrocks::JsonPath*)                                                                                                          ▒
                        + 19.16% starrocks::JsonPath::parse(starrocks::Slice)                                                                                                                                                                ▒
                          0.59% starrocks::JsonPath::reset(starrocks::JsonPath&&)                                                                                                                                                            ▒
                          0.51% jefree                                                                                                                                                                                                       ▒
            + 8.51% starrocks::JsonMergeIterator::next_batch(starrocks::SparseRange<unsigned int> const&, starrocks::Column*)                                                                                                                ▒
         + 3.31% starrocks::GlobalDictCodeColumnIterator::next_batch(starrocks::SparseRange<unsigned int> const&, starrocks::Column*)                                                                                                        ▒

```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Provide a constant `json_path` column to `FunctionContext` in `JsonExtractIterator` to treat the path as a constant during extraction.
> 
> - **Storage / JSON extraction**:
>   - In `be/src/storage/rowset/json_column_iterator.cpp`, `JsonExtractIterator` now sets `FunctionContext` constant columns with the JSON path (`_fn_context->set_constant_columns(Columns{nullptr, const_path})`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b004e32651eed75040a539e52eefd1b9a345fb9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->