### PR TITLE
[Enhancement] Update tenann to v0.5.0 and support arm64 build

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -101,11 +101,8 @@ option(WITH_TENANN "Build with TENANN" OFF)
 
 option(WITH_RELATIVE_SRC_PATH "Build source file with relative path" ON)
 
-# Only support tenann on x86
-if (${WITH_TENANN} STREQUAL "ON" AND NOT "${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "aarch64")
+if (${WITH_TENANN} STREQUAL "ON")
     add_definitions(-DWITH_TENANN)
-else()
-    set(WITH_TENANN "OFF")
 endif()
 
 message(STATUS "WITH TENANN is: ${WITH_TENANN}")

--- a/build.sh
+++ b/build.sh
@@ -412,7 +412,6 @@ cd ${STARROCKS_HOME}
 
 if [[ "${MACHINE_TYPE}" == "aarch64" ]]; then
     export LIBRARY_PATH=${JAVA_HOME}/jre/lib/aarch64/server/
-    WITH_TENANN=OFF
 else
     export LIBRARY_PATH=${JAVA_HOME}/jre/lib/amd64/server/
 fi

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1539,11 +1539,9 @@ build_simdutf() {
 build_tenann() {
     check_if_source_exist $TENANN_SOURCE
     rm -rf $TP_INSTALL_DIR/include/tenann
-    rm -rf $TP_INSTALL_DIR/lib/libtenann-bundle.a
-    rm -rf $TP_INSTALL_DIR/lib/libtenann-bundle-avx2.a
-    cp -r $TP_SOURCE_DIR/$TENANN_SOURCE/include/tenann $TP_INSTALL_DIR/include/tenann
-    cp -r $TP_SOURCE_DIR/$TENANN_SOURCE/lib/libtenann-bundle.a $TP_INSTALL_DIR/lib/
-    cp -r $TP_SOURCE_DIR/$TENANN_SOURCE/lib/libtenann-bundle-avx2.a $TP_INSTALL_DIR/lib/
+    rm -rf $TP_INSTALL_DIR/lib/libtenann-bundl*.a
+    cp -r $TP_SOURCE_DIR/$TENANN_SOURCE/include/tenann $TP_INSTALL_DIR/include/
+    cp -r $TP_SOURCE_DIR/$TENANN_SOURCE/lib/libtenann-bundl*.a $TP_INSTALL_DIR/lib/
 }
 
 build_icu() {
@@ -1750,11 +1748,12 @@ declare -a all_packages=(
     azure
     libdivide
     flamegraph
+    tenann
 )
 
 # Machine specific packages
 if [[ "${MACHINE_TYPE}" != "aarch64" ]]; then
-    all_packages+=(breakpad libdeflate tenann pprof)
+    all_packages+=(breakpad libdeflate pprof)
 fi
 
 # Initialize packages array - if none specified, build all

--- a/thirdparty/vars-aarch64.sh
+++ b/thirdparty/vars-aarch64.sh
@@ -51,6 +51,12 @@ JINDOSDK_NAME="jindosdk-4.6.8-linux-el7-aarch64.tar.gz"
 JINDOSDK_SOURCE="jindosdk-4.6.8-linux-el7-aarch64"
 JINDOSDK_MD5SUM="27a4e2cd9a403c6e21079a866287d88b"
 
+# tenann
+TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.0-RELEASE/tenann-v0.5.0-RELEASE-arm64.tar.gz"
+TENANN_NAME="tenann-v0.5.0-RELEASE-arm64.tar.gz"
+TENANN_SOURCE="tenann-v0.5.0-RELEASE"
+TENANN_MD5SUM="397632c3b81a25e636177c8f80291cc3"
+
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v3.5-rc4/starcache-centos7_arm64.tar.gz"
 STARCACHE_NAME="starcache.tar.gz"

--- a/thirdparty/vars-x86_64.sh
+++ b/thirdparty/vars-x86_64.sh
@@ -51,6 +51,12 @@ JINDOSDK_NAME="jindosdk-4.6.8-linux.tar.gz"
 JINDOSDK_SOURCE="jindosdk-4.6.8-linux"
 JINDOSDK_MD5SUM="5436e4fe39c4dfdc942e41821f1dd8a9"
 
+# tenann
+TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.0-RELEASE/tenann-v0.5.0-RELEASE-x86_64.tar.gz"
+TENANN_NAME="tenann-v0.5.0-RELEASE-x86_64.tar.gz"
+TENANN_SOURCE="tenann-v0.5.0-RELEASE"
+TENANN_MD5SUM="192ef22c00cf39315a91f54dab120855"
+
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v3.5-rc4/starcache-centos7_amd64.tar.gz"
 STARCACHE_NAME="starcache.tar.gz"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -440,12 +440,6 @@ SIMDUTF_NAME="simdutf-5.2.8.tar.gz"
 SIMDUTF_SOURCE="simdutf-5.2.8"
 SIMDUTF_MD5SUM="731c78ab5a10c6073942dc93d5c4b04c"
 
-# tenann
-TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.4.2-RELEASE/tenann-v0.4.2-RELEASE.tar.gz"
-TENANN_NAME="tenann-v0.4.2-RELEASE.tar.gz"
-TENANN_SOURCE="tenann-v0.4.2-RELEASE"
-TENANN_MD5SUM="40a00643d953982845901ae60766aad4"
-
 # icu
 ICU_DOWNLOAD="https://github.com/unicode-org/icu/releases/download/release-76-1/icu4c-76_1-src.zip"
 ICU_NAME="icu4c-76_1-src.zip"


### PR DESCRIPTION
## Why I'm doing:

currently arm64 platform does not support vector index 

## What I'm doing:

I've add arm64 support to tenann, this PR add arm64 support for starrocks by using new tenann version, and modify build scripts to support arm64 tenann

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades tenann to v0.5.0 and enables building/packaging on arm64 by removing x86-only gating and updating third-party scripts.
> 
> - **Build system**:
>   - Enable `WITH_TENANN` unconditionally (remove x86-only restriction) and keep AVX2/non-AVX2 selection for `tenann` libs.
>   - Include `tenann` in default third-party build list; remove it from the x86-only package list.
>   - Adjust `build_tenann` to install headers and `libtenann-bundl*.a` via glob.
>   - Stop forcing `WITH_TENANN=OFF` on `aarch64` in `build.sh`.
> - **Third-party vars**:
>   - Add arch-specific `tenann` v0.5.0 sources to `vars-aarch64.sh` and `vars-x86_64.sh`.
>   - Remove legacy `tenann` v0.4.2 entries from `vars.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbd56874eb690d9698b736330594fd226278c292. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->