### PR TITLE
[BugFix] Fix full vacuum failed if tablet metadata is bundle file with InitVersion

### DIFF
--- a/be/src/storage/lake/vacuum_full.cpp
+++ b/be/src/storage/lake/vacuum_full.cpp
@@ -64,10 +64,18 @@ static Status vacuum_expired_tablet_metadata(TabletManager* tablet_mgr, std::str
             continue;
         }
         const string path = join_path(metadata_root_location, name);
-        ASSIGN_OR_RETURN(auto metadata, tablet_mgr->get_tablet_metadata(tablet_id, version, false));
-        if ((metadata->has_commit_time() && metadata->commit_time() < grace_timestamp) ||
-            /* init version does not has commit time, delete it if there is any meta has been expired. */
-            (has_expired && !metadata->has_commit_time())) {
+        bool need_clear = false;
+        if (has_expired && tablet_id == 0 && version == kInitialVersion) {
+            // No need to get metadata for this case, just delete it if has_expired = true.
+            need_clear = true;
+        } else if (tablet_id != 0) {
+            ASSIGN_OR_RETURN(auto metadata, tablet_mgr->get_tablet_metadata(tablet_id, version, false));
+            if (metadata->has_commit_time() && metadata->commit_time() < grace_timestamp) {
+                need_clear = true;
+            }
+        }
+
+        if (need_clear) {
             LOG(INFO) << "Try delete for full vacuum: " << path;
             RETURN_IF_ERROR(metafile_deleter.delete_file(path));
             expired_metas.push_back(name);

--- a/be/src/storage/lake/vacuum_full.cpp
+++ b/be/src/storage/lake/vacuum_full.cpp
@@ -70,7 +70,8 @@ static Status vacuum_expired_tablet_metadata(TabletManager* tablet_mgr, std::str
             need_clear = true;
         } else if (tablet_id != 0) {
             ASSIGN_OR_RETURN(auto metadata, tablet_mgr->get_tablet_metadata(tablet_id, version, false));
-            if (metadata->has_commit_time() && metadata->commit_time() < grace_timestamp) {
+            if ((metadata->has_commit_time() && metadata->commit_time() < grace_timestamp) ||
+                (has_expired && !metadata->has_commit_time())) {
                 need_clear = true;
             }
         }

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -266,7 +266,8 @@ TEST_P(LakeVacuumTest, test_vacuum_full_with_initial_meta_no_failure) {
     // This ensures pre-fix implementation (which reads 0_1.meta) will fail, while the fixed
     // implementation will skip reading it and succeed.
     {
-        auto initial_meta_path = join_path(join_path(kTestDir, kMetadataDirectoryName), tablet_initial_metadata_filename());
+        auto initial_meta_path =
+                join_path(join_path(kTestDir, kMetadataDirectoryName), tablet_initial_metadata_filename());
         ASSIGN_OR_ABORT(auto f, FileSystem::Default()->new_writable_file(initial_meta_path));
         ASSERT_OK(f->append("not-a-valid-protobuf"));
         ASSERT_OK(f->close());


### PR DESCRIPTION
## Why I'm doing:
In current implementation, tablet metadata with version 1 will be treated as a normal tablet metadata file even it is a bundle file. In this case, full vacuum in BE/CN side will try to call tablet_mgr->get_tablet_metadata to get the tablet metadata. But in this case, tablet id = 0 which cause that this function call will return NotFound error for sure and full vacuum will failed.

## What I'm doing:
When we deal with bundle tablet metadata file with version 1, we need not to call tablet_mgr->get_tablet_metadata because t has not commit_timestamp and get_tablet_metadata basiclly is used to check this timestamp. So we need to handle this case specially that if tablet id = 0 and version = 1 and some tabletmeta has been expired before, we can just delete it without calling get_tablet_metadata

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
