### PR TITLE
[Enhancement] change the default value of json_flat_sparsity_factor

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1576,7 +1576,7 @@ CONF_mDouble(json_flat_complex_type_factor, "0.3");
 CONF_mDouble(json_flat_null_factor, "0.3");
 
 // extract flat json column when row_num * sparsity_factor < hit_row_num
-CONF_mDouble(json_flat_sparsity_factor, "0.9");
+CONF_mDouble(json_flat_sparsity_factor, "0.3");
 
 // the maximum number of extracted JSON sub-field
 CONF_mInt32(json_flat_column_max, "100");

--- a/be/src/storage/flat_json_config.h
+++ b/be/src/storage/flat_json_config.h
@@ -18,6 +18,7 @@
 
 #include <sstream>
 
+#include "common/config.h"
 #include "gen_cpp/AgentService_types.h"
 
 namespace starrocks {
@@ -101,8 +102,8 @@ public:
 
 private:
     bool _flat_json_enable = false;
-    double _flat_json_null_factor = 0.3;
-    double _flat_json_sparsity_factor = 0.9;
-    int _flat_json_max_column_max = 100;
+    double _flat_json_null_factor = config::json_flat_null_factor;
+    double _flat_json_sparsity_factor = config::json_flat_sparsity_factor;
+    int _flat_json_max_column_max = config::json_flat_column_max;
 };
 } // namespace starrocks

--- a/be/test/exprs/flat_json_functions_test.cpp
+++ b/be/test/exprs/flat_json_functions_test.cpp
@@ -45,7 +45,10 @@ namespace starrocks {
 class FlatJsonQueryTestFixture2
         : public ::testing::TestWithParam<std::tuple<std::string, std::vector<std::string>, std::vector<LogicalType>,
                                                      std::string, std::string>> {
-    void SetUp() override { config::enable_json_flat_complex_type = true; }
+    void SetUp() override {
+        config::enable_json_flat_complex_type = true;
+        config::json_flat_sparsity_factor = 0.9;
+    }
     void TearDown() override { config::enable_json_flat_complex_type = false; }
 };
 
@@ -599,7 +602,10 @@ class FlatJsonDeriverPaths
         : public ::testing::TestWithParam<
                   std::tuple<std::string, std::string, std::vector<std::string>, std::vector<LogicalType>>> {
 public:
-    void SetUp() override { config::enable_json_flat_complex_type = true; }
+    void SetUp() override {
+        config::enable_json_flat_complex_type = true;
+        config::json_flat_sparsity_factor = 0.9;
+    }
     void TearDown() override { config::enable_json_flat_complex_type = false; }
 };
 

--- a/be/test/storage/rowset/flat_json_column_compact_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_compact_test.cpp
@@ -56,13 +56,10 @@ protected:
     void SetUp() override {
         config::enable_json_flat_complex_type = true;
         _meta.reset(new ColumnMetaPB());
-    }
-
-    void TearDown() override {
-        config::enable_json_flat_complex_type = false;
-        config::json_flat_null_factor = 0.3;
         config::json_flat_sparsity_factor = 0.9;
     }
+
+    void TearDown() override { config::enable_json_flat_complex_type = false; }
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
         return std::make_shared<Segment>(fs, FileInfo{fname}, 1, _dummy_segment_schema, nullptr);

--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -65,11 +65,11 @@ protected:
     void SetUp() override {
         config::enable_json_flat_complex_type = true;
         _meta = std::make_shared<ColumnMetaPB>();
+        config::json_flat_sparsity_factor = 0.9;
     }
 
     void TearDown() override {
         config::enable_json_flat_complex_type = false;
-        config::json_flat_sparsity_factor = 0.9;
         config::json_flat_null_factor = 0.3;
     }
 

--- a/be/test/util/json_flattener_test.cpp
+++ b/be/test/util/json_flattener_test.cpp
@@ -54,8 +54,14 @@ class JsonPathDeriverTest
         : public ::testing::TestWithParam<
                   std::tuple<std::string, std::string, bool, std::vector<std::string>, std::vector<LogicalType>>> {
 public:
-    void SetUp() override { config::enable_json_flat_complex_type = true; }
-    void TearDown() override { config::enable_json_flat_complex_type = false; }
+    void SetUp() override {
+        config::enable_json_flat_complex_type = true;
+        config::json_flat_sparsity_factor = 0.9; // Set to 0.9 to extract only paths that exist in all rows
+    }
+    void TearDown() override {
+        config::enable_json_flat_complex_type = false;
+        config::json_flat_sparsity_factor = 0.3; // Reset to default
+    }
 };
 
 TEST_P(JsonPathDeriverTest, json_path_deriver_test) {

--- a/be/test/util/json_flattener_test.cpp
+++ b/be/test/util/json_flattener_test.cpp
@@ -121,7 +121,7 @@ protected:
 
     void TearDown() override {
         config::enable_json_flat_complex_type = false;
-        config::json_flat_sparsity_factor = 0.9;
+        config::json_flat_sparsity_factor = 0.3;
         config::json_flat_null_factor = 0.3;
         config::json_flat_complex_type_factor = 0.3;
     }

--- a/be/test/util/json_flattener_test.cpp
+++ b/be/test/util/json_flattener_test.cpp
@@ -123,7 +123,10 @@ public:
     ~JsonFlattenerTest() override = default;
 
 protected:
-    void SetUp() override { config::enable_json_flat_complex_type = true; }
+    void SetUp() override {
+        config::enable_json_flat_complex_type = true;
+        config::json_flat_sparsity_factor = 0.9; // Set to 0.9 to extract only paths that exist in all rows
+    }
 
     void TearDown() override {
         config::enable_json_flat_complex_type = false;

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -3322,7 +3322,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 
 ##### json_flat_sparsity_factor
 
-- Default: 0.9
+- Default: 0.3
 - Type: Double
 - Unit:
 - Is mutable: Yes

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -804,7 +804,7 @@ PROPERTIES (
 
 - `flat_json.enable` (Optional): Whether to enable the Flat JSON feature. After this feature is enabled, newly loaded JSON data will be automatically flattened, improving JSON query performance.
 - `flat_json.null.factor` (Optional): The proportion threshold of NULL values in the column. A column will not be extracted by Flat JSON if its proportion of NULL values is higher than this threshold. This parameter takes effect only when `flat_json.enable` is set to `true`. Default value: `0.3`.
-- `flat_json.sparsity.factor` (Optional): The proportion threshold of columns with the same name. A column will not be extracted by Flat JSON if the proportion of columns with the same name is lower than this value. This parameter takes effect only when `flat_json.enable` is set to `true`. Default value: `0.9`.
+- `flat_json.sparsity.factor` (Optional): The proportion threshold of columns with the same name. A column will not be extracted by Flat JSON if the proportion of columns with the same name is lower than this value. This parameter takes effect only when `flat_json.enable` is set to `true`. Default value: `0.3`.
 - `flat_json.column.max` (Optional): The maximum number of sub-fields that can be extracted by Flat JSON. This parameter takes effect only when `flat_json.enable` is set to `true`. Default value: `100`.
 
 ## Examples

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -1761,7 +1761,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### json_flat_sparsity_factor
 
-- デフォルト: 0.9
+- デフォルト: 0.3
 - タイプ: Double
 - 単位: 
 - 可変: はい

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -801,7 +801,7 @@ PROPERTIES (
 
 - `flat_json.enable` (オプション): Flat JSON 機能を有効にするかどうか。この機能を有効にすると、新たに読み込まれた JSON データが自動的にフラット化され、JSON クエリのパフォーマンスが向上します。
 - `flat_json.null.factor` (オプション): 列内の NULL 値の割合の閾値。この閾値を超えるNULL値の割合を持つ列は、Flat JSON によって抽出されません。このパラメーターは、`flat_json.enable` が `true` に設定されている場合のみ有効になります。 デフォルト値: `0.3`。
-- `flat_json.sparsity.factor` (オプション): 同じ名前を持つ列の割合の閾値。同じ名前を持つ列の割合がこの値未満の場合、Flat JSON ではその列が抽出されません。このパラメーターは、`flat_json.enable` が `true` に設定されている場合のみ有効になります。デフォルト値: `0.9`。
+- `flat_json.sparsity.factor` (オプション): 同じ名前を持つ列の割合の閾値。同じ名前を持つ列の割合がこの値未満の場合、Flat JSON ではその列が抽出されません。このパラメーターは、`flat_json.enable` が `true` に設定されている場合のみ有効になります。デフォルト値: `0.3`。
 - `flat_json.column.max` (オプション): Flat JSON で抽出可能なサブフィールドの最大数。このパラメーターは、`flat_json.enable` が `true` に設定されている場合のみ有効になります。 デフォルト値: `100`。
 
 ## 例

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -802,7 +802,7 @@ PROPERTIES (
 
 - `flat_json.enable`（可选）：是否启用 Flat JSON 功能。启用此功能后，新导入的 JSON 数据将自动进行扁平化处理，从而提升 JSON 查询性能。
 - `flat_json.null.factor`（可选）：列中 NULL 值的比例阈值。如果某列的 NULL 值比例高于此阈值，则该列不会被 Flat JSON 提取。此参数仅在 `flat_json.enable` 设置为 `true` 时生效。默认值：`0.3`。
-- `flat_json.sparsity.factor`（可选）：具有相同名称的列的比例阈值。如果具有相同名称的列的比例低于此值，则 Flat JSON 不会提取该列。此参数仅在 `flat_json.enable` 设置为 `true` 时生效。默认值：`0.9`。
+- `flat_json.sparsity.factor`（可选）：具有相同名称的列的比例阈值。如果具有相同名称的列的比例低于此值，则 Flat JSON 不会提取该列。此参数仅在 `flat_json.enable` 设置为 `true` 时生效。默认值：`0.3`。
 - `flat_json.column.max`（可选）：Flat JSON 可提取的子字段最大数量。此参数仅在 `flat_json.enable` 设置为 `true` 时生效。默认值：`100`。
 
 ## 示例

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3274,8 +3274,7 @@ public class Config extends ConfigBase {
     @ConfField
     public static double flat_json_null_factor = 0.3;
 
-    @ConfField
-    public static double flat_json_sparsity_factory = 0.9;
+    @ConfField public static double flat_json_sparsity_factory = 0.3;
 
     @ConfField
     public static int flat_json_column_max = 100;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


Update the default value of json_flat_sparsity_factor from 0.9 to 0.3 to provide a more lenient JSON flattening strategy. This change allows more sparse JSON fields to be extracted, improving field coverage while maintaining reasonable data quality standards.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3