### PR TITLE
[Enhancement] Avoid OOM causing operating system freezes

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1756,7 +1756,7 @@ CONF_mInt64(rf_branchless_ratio, "8");
 CONF_mInt32(big_query_sec, "1");
 
 // modules that need to be mlocked, separated by commas
-CONF_Strings(sys_mlock_modules, "main,libc.so.6,libm.so.6");
+CONF_Strings(sys_mlock_modules, "main,linux-vdso.so.1,libjemalloc.so.2,libc.so.6,libm.so.6,ld-linux-x86-64.so.2");
 
 CONF_mInt64(split_exchanger_buffer_chunk_num, "1000");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1755,7 +1755,8 @@ CONF_mInt64(rf_branchless_ratio, "8");
 
 CONF_mInt32(big_query_sec, "1");
 
-// modules that need to be mlocked, separated by commas
+// modules that code segments need to be mlocked, separated by commas
+// locked pages will not be swapped out
 CONF_Strings(sys_mlock_modules, "main,linux-vdso.so.1,libjemalloc.so.2,libc.so.6,libm.so.6,ld-linux-x86-64.so.2");
 
 CONF_mInt64(split_exchanger_buffer_chunk_num, "1000");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1755,6 +1755,9 @@ CONF_mInt64(rf_branchless_ratio, "8");
 
 CONF_mInt32(big_query_sec, "1");
 
+// modules that need to be mlocked, separated by commas
+CONF_Strings(sys_mlock_modules, "main,libc.so.6,libm.so.6");
+
 CONF_mInt64(split_exchanger_buffer_chunk_num, "1000");
 
 // when to split hashmap/hashset into two level hashmap/hashset, negative number means use default value

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -65,6 +65,7 @@
 #include "util/disk_info.h"
 #include "util/logging.h"
 #include "util/mem_info.h"
+#include "util/memory_lock.h"
 #include "util/misc.h"
 #include "util/monotime.h"
 #include "util/network_util.h"
@@ -300,6 +301,8 @@ void Daemon::init(bool as_cn, const std::vector<StorePath>& paths) {
     }
 
     LOG(INFO) << get_version_string(false);
+
+    starrocks::mlock_modules();
 
     init_thrift_logging();
     CpuInfo::init();

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -302,7 +302,9 @@ void Daemon::init(bool as_cn, const std::vector<StorePath>& paths) {
 
     LOG(INFO) << get_version_string(false);
 
+#ifndef BE_TEST
     starrocks::mlock_modules();
+#endif
 
     init_thrift_logging();
     CpuInfo::init();

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -111,6 +111,7 @@ set(UTIL_FILES
   bthreads/future_impl.cpp
   hash_util.cpp
   debug_action.cpp
+  memory_lock.cpp
   internal_service_recoverable_stub.cpp
   lake_service_recoverable_stub.cpp
   byte_buffer.cpp

--- a/be/src/util/memory_lock.cpp
+++ b/be/src/util/memory_lock.cpp
@@ -1,0 +1,99 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/memory_lock.h"
+
+#include <link.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "common/config.h"
+#include "common/logging.h"
+#include "util/starrocks_metrics.h"
+
+static inline uintptr_t page_align_down(uintptr_t addr, size_t page) {
+    return addr & ~(page - 1);
+}
+static inline uintptr_t page_align_up(uintptr_t addr, size_t page) {
+    return (addr + page - 1) & ~(page - 1);
+}
+
+static void lock_segment(const char* module_name, void* start, void* end) {
+    size_t page_size = sysconf(_SC_PAGESIZE);
+    uintptr_t seg_start = page_align_down((uintptr_t)start, page_size);
+    uintptr_t seg_end = page_align_up((uintptr_t)end, page_size);
+    size_t seg_len = seg_end - seg_start;
+
+    if (mlock((void*)seg_start, seg_len) != 0) {
+        LOG(WARNING) << "mlock failed for " << module_name << " " << seg_start << "-" << seg_end << " (" << seg_len
+                     << " bytes): " << strerror(errno);
+    } else {
+        VLOG_FILE << "mlock success for " << module_name << " " << seg_start << "-" << seg_end << " (" << seg_len
+                  << " bytes)";
+        starrocks::StarRocksMetrics::instance()->exec_runtime_memory_size.increment(seg_len);
+    }
+}
+
+static int module_name_matches(const char* dlpi_name, const std::vector<std::string>& module_list) {
+    if (module_list.empty()) return 0;
+
+    VLOG_FILE << "find module name: " << dlpi_name;
+
+    if (!dlpi_name || dlpi_name[0] == '\0') {
+        for (const auto& module_name : module_list) {
+            if (module_name == "main") return 1;
+        }
+        return 0;
+    }
+    for (const auto& module_name : module_list) {
+        if (strstr(dlpi_name, module_name.c_str()) != nullptr) return 1;
+    }
+
+    return 0;
+}
+
+static int phdr_callback(struct dl_phdr_info* info, size_t size, void* data) {
+    const std::vector<std::string>* module_list = (const std::vector<std::string>*)data;
+
+    if (!module_name_matches(info->dlpi_name, *module_list)) return 0;
+
+    for (int i = 0; i < info->dlpi_phnum; i++) {
+        const ElfW(Phdr)* ph = &info->dlpi_phdr[i];
+        if (ph->p_type == PT_LOAD && (ph->p_flags & PF_X)) {
+            void* seg_start = (void*)(info->dlpi_addr + ph->p_vaddr);
+            void* seg_end = (void*)(info->dlpi_addr + ph->p_vaddr + ph->p_memsz);
+            lock_segment(info->dlpi_name, seg_start, seg_end);
+        }
+    }
+    return 0;
+}
+
+namespace starrocks {
+void mlock_modules(const std::vector<std::string>& module_list) {
+    dl_iterate_phdr(phdr_callback, (void*)&module_list);
+}
+
+void mlock_modules() {
+    std::vector<std::string> module_list = config::sys_mlock_modules;
+    mlock_modules(module_list);
+}
+
+} // namespace starrocks

--- a/be/src/util/memory_lock.cpp
+++ b/be/src/util/memory_lock.cpp
@@ -42,7 +42,7 @@ static void lock_segment(const char* module_name, void* start, void* end) {
     uintptr_t seg_end = page_align_up((uintptr_t)end, page_size);
     size_t seg_len = seg_end - seg_start;
 
-    if (mlock((void*)seg_start, seg_len) != 0) {
+    if (mlock((void*)seg_start, seg_len) != 0) { // NOLINT
         LOG(WARNING) << "mlock failed for " << module_name << " " << seg_start << "-" << seg_end << " (" << seg_len
                      << " bytes): " << strerror(errno);
     } else {
@@ -78,8 +78,8 @@ static int phdr_callback(struct dl_phdr_info* info, size_t size, void* data) {
     for (int i = 0; i < info->dlpi_phnum; i++) {
         const ElfW(Phdr)* ph = &info->dlpi_phdr[i];
         if (ph->p_type == PT_LOAD && (ph->p_flags & PF_X)) {
-            void* seg_start = (void*)(info->dlpi_addr + ph->p_vaddr);
-            void* seg_end = (void*)(info->dlpi_addr + ph->p_vaddr + ph->p_memsz);
+            void* seg_start = (void*)(info->dlpi_addr + ph->p_vaddr);             // NOLINT
+            void* seg_end = (void*)(info->dlpi_addr + ph->p_vaddr + ph->p_memsz); // NOLINT
             lock_segment(info->dlpi_name, seg_start, seg_end);
         }
     }

--- a/be/src/util/memory_lock.h
+++ b/be/src/util/memory_lock.h
@@ -1,0 +1,19 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace starrocks {
+void mlock_modules();
+} // namespace starrocks

--- a/be/src/util/memory_lock.h
+++ b/be/src/util/memory_lock.h
@@ -15,5 +15,15 @@
 #pragma once
 
 namespace starrocks {
+// This function is used to lock the memory of specified modules.
+// When memory is locked, it will not be swapped out to disk.
+// Therefore, when available memory is low, these executable pages are not frequently swapped out.
+// This can prevent the operating system from freezing.
+//
+// The modules to be locked can be configured through the configuration item "config::sys_mlock_modules".
+// These code segments of the modules will be locked in memory.
+//
+// Under Release mode, they will lock approximately 170MB of memory,
+// with no significant memory consumption.
 void mlock_modules();
 } // namespace starrocks

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -254,6 +254,8 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
     REGISTER_STARROCKS_METRIC(blocks_open_reading);
     REGISTER_STARROCKS_METRIC(blocks_open_writing);
 
+    REGISTER_STARROCKS_METRIC(exec_runtime_memory_size);
+
     REGISTER_STARROCKS_METRIC(short_circuit_request_total);
     REGISTER_STARROCKS_METRIC(short_circuit_request_duration_us);
 }

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -395,6 +395,8 @@ public:
     METRICS_DEFINE_THREAD_POOL(remote_snapshot);
     METRICS_DEFINE_THREAD_POOL(replicate_snapshot);
 
+    METRIC_DEFINE_INT_COUNTER(exec_runtime_memory_size, MetricUnit::BYTES);
+
     // short circuit executor
     METRIC_DEFINE_INT_COUNTER(short_circuit_request_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(short_circuit_request_duration_us, MetricUnit::MICROSECONDS);


### PR DESCRIPTION


## Why I'm doing:

StarRocks has a large binary. When the operating system runs low on memory, it attempts to free up some memory. If the freed memory consists of executable pages that are subsequently executed shortly after, the operating system may appear to freeze. In this patch, we use the mlock system call to lock the code segments of executable files in memory. This can significantly reduce the chances of the operating system freezing

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Locks selected modules’ executable segments via mlock at BE startup (configurable by `sys_mlock_modules`) and exposes locked size via `exec_runtime_memory_size` metric.
> 
> - **Startup/Runtime**:
>   - Call `mlock_modules()` during `Daemon::init()` to lock executable segments of selected modules.
> - **Config**:
>   - Add `config::sys_mlock_modules` (comma-separated module names) to control which modules are mlocked.
> - **Util**:
>   - New `util/memory_lock.{h,cpp}` implementing `mlock_modules()` using `dl_iterate_phdr` and `mlock`.
>   - Build integration: add `memory_lock.cpp` to `be/src/util/CMakeLists.txt`.
> - **Metrics**:
>   - Add `exec_runtime_memory_size` counter; increment with bytes locked; register metric in `StarRocksMetrics`.
> - **Includes**:
>   - Include `util/memory_lock.h` in `daemon.cpp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fb05b91322d356b3d8d3bb118ed066f5b075513. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->