### PR TITLE
[BugFix] Fix the bug in reading Parquet files when parquet_late_materialization_enable is false

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1033,7 +1033,7 @@ CONF_mInt32(orc_writer_version, "-1");
 
 // parquet reader
 CONF_mBool(parquet_coalesce_read_enable, "true");
-CONF_Bool(parquet_late_materialization_enable, "true");
+CONF_mBool(parquet_late_materialization_enable, "true");
 CONF_Bool(parquet_page_index_enable, "true");
 CONF_mBool(parquet_reader_bloom_filter_enable, "true");
 CONF_mBool(parquet_statistics_process_more_filter_enable, "true");

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -446,10 +446,10 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
         } else {
             if (config::parquet_late_materialization_enable) {
                 _lazy_column_indices.emplace_back(read_col_idx);
+                _column_readers[slot_id]->set_can_lazy_decode(true);
             } else {
                 _active_column_indices.emplace_back(read_col_idx);
             }
-            _column_readers[slot_id]->set_can_lazy_decode(true);
         }
         ++read_col_idx;
     }

--- a/test/sql/test_external_file/R/test_parquet_late_materialization
+++ b/test/sql/test_external_file/R/test_parquet_late_materialization
@@ -1,0 +1,82 @@
+-- name: test_parquet_late_materialization @sequential
+update default_catalog.information_schema.be_configs set value = "false" where name = "parquet_late_materialization_enable";
+-- result:
+-- !result
+create external catalog parquet_late_materialization_${uuid0} PROPERTIES (
+    "type"="hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+set catalog parquet_late_materialization_${uuid0};
+-- result:
+-- !result
+create database hive_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/hive_db_${uuid0}/test_parquet_late_materialization/${uuid0}"
+);
+-- result:
+-- !result
+use hive_db_${uuid0};
+-- result:
+-- !result
+create table t1 (c1 string, c2 int, c3 string, c4 int, c5 string, c6 string, c7 string, c8 string, c9 string, c10 string, c11 string, c12 string);
+-- result:
+-- !result
+insert into t1 select c1,c1,c1,c1,c1,c1,c1,c1,c1,c1,c1,c1 from table(generate_series(1, 12000)) as t(c1);
+-- result:
+-- !result
+select * from t1 where c3>"4080" and c3 <"4120" and c2 >4100 and c2<4108;
+-- result:
+4101	4101	4101	4101	4101	4101	4101	4101	4101	4101	4101	4101
+4102	4102	4102	4102	4102	4102	4102	4102	4102	4102	4102	4102
+4103	4103	4103	4103	4103	4103	4103	4103	4103	4103	4103	4103
+4104	4104	4104	4104	4104	4104	4104	4104	4104	4104	4104	4104
+4105	4105	4105	4105	4105	4105	4105	4105	4105	4105	4105	4105
+4106	4106	4106	4106	4106	4106	4106	4106	4106	4106	4106	4106
+4107	4107	4107	4107	4107	4107	4107	4107	4107	4107	4107	4107
+-- !result
+select * from t1 where c3>"4080" and c3 <"4120" and c2 >4100 and c2<4108;
+-- result:
+4101	4101	4101	4101	4101	4101	4101	4101	4101	4101	4101	4101
+4102	4102	4102	4102	4102	4102	4102	4102	4102	4102	4102	4102
+4103	4103	4103	4103	4103	4103	4103	4103	4103	4103	4103	4103
+4104	4104	4104	4104	4104	4104	4104	4104	4104	4104	4104	4104
+4105	4105	4105	4105	4105	4105	4105	4105	4105	4105	4105	4105
+4106	4106	4106	4106	4106	4106	4106	4106	4106	4106	4106	4106
+4107	4107	4107	4107	4107	4107	4107	4107	4107	4107	4107	4107
+-- !result
+select * from t1 where c3>"4080" and c3 <"4120" and c2 >4100 and c2<4108;
+-- result:
+4101	4101	4101	4101	4101	4101	4101	4101	4101	4101	4101	4101
+4102	4102	4102	4102	4102	4102	4102	4102	4102	4102	4102	4102
+4103	4103	4103	4103	4103	4103	4103	4103	4103	4103	4103	4103
+4104	4104	4104	4104	4104	4104	4104	4104	4104	4104	4104	4104
+4105	4105	4105	4105	4105	4105	4105	4105	4105	4105	4105	4105
+4106	4106	4106	4106	4106	4106	4106	4106	4106	4106	4106	4106
+4107	4107	4107	4107	4107	4107	4107	4107	4107	4107	4107	4107
+-- !result
+select * from t1 where c3>"4080" and c3 <"4120" and c2 >4100 and c2<4108;
+-- result:
+4101	4101	4101	4101	4101	4101	4101	4101	4101	4101	4101	4101
+4102	4102	4102	4102	4102	4102	4102	4102	4102	4102	4102	4102
+4103	4103	4103	4103	4103	4103	4103	4103	4103	4103	4103	4103
+4104	4104	4104	4104	4104	4104	4104	4104	4104	4104	4104	4104
+4105	4105	4105	4105	4105	4105	4105	4105	4105	4105	4105	4105
+4106	4106	4106	4106	4106	4106	4106	4106	4106	4106	4106	4106
+4107	4107	4107	4107	4107	4107	4107	4107	4107	4107	4107	4107
+-- !result
+update default_catalog.information_schema.be_configs set value = "true" where name = "parquet_late_materialization_enable";
+-- result:
+-- !result
+drop table t1 force;
+-- result:
+-- !result
+drop database hive_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result

--- a/test/sql/test_external_file/T/test_parquet_late_materialization
+++ b/test/sql/test_external_file/T/test_parquet_late_materialization
@@ -1,0 +1,29 @@
+-- name: test_parquet_late_materialization @sequential
+
+update default_catalog.information_schema.be_configs set value = "false" where name = "parquet_late_materialization_enable";
+
+create external catalog parquet_late_materialization_${uuid0} PROPERTIES (
+    "type"="hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+set catalog parquet_late_materialization_${uuid0};
+create database hive_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/hive_db_${uuid0}/test_parquet_late_materialization/${uuid0}"
+);
+use hive_db_${uuid0};
+create table t1 (c1 string, c2 int, c3 string, c4 int, c5 string, c6 string, c7 string, c8 string, c9 string, c10 string, c11 string, c12 string);
+insert into t1 select c1,c1,c1,c1,c1,c1,c1,c1,c1,c1,c1,c1 from table(generate_series(1, 12000)) as t(c1);
+
+-- query multi times
+select * from t1 where c3>"4080" and c3 <"4120" and c2 >4100 and c2<4108;
+select * from t1 where c3>"4080" and c3 <"4120" and c2 >4100 and c2<4108;
+select * from t1 where c3>"4080" and c3 <"4120" and c2 >4100 and c2<4108;
+select * from t1 where c3>"4080" and c3 <"4120" and c2 >4100 and c2<4108;
+
+update default_catalog.information_schema.be_configs set value = "true" where name = "parquet_late_materialization_enable";
+drop table t1 force;
+drop database hive_db_${uuid0};
+set catalog default_catalog;


### PR DESCRIPTION
## Why I'm doing:

```
W20251015 17:12:21.615027 139839203739200 file_reader.cpp:380] FileReader::get_next failed. reason = Internal error: DictDecoder append strings to column failed 3: 0
be/src/formats/parquet/encoding.cpp:48 this->next_batch(run, content_type, dst, forward_filter)
be/src/formats/parquet/stored_column_reader.cpp:347 _read_values_on_levels(num_values, content_type, dst, false, value_filter)
```

## What I'm doing:

If `config::parquet_late_materialization_enable` is false, we should set the lazy decoding of the column reader to false.

```
        if (!_dict_column_indices.empty() || !_left_no_dict_filter_conjuncts_by_slot.empty()) {
            has_filter = true;
            ASSIGN_OR_RETURN(size_t hit_count, _read_range_round_by_round(r, &chunk_filter, &active_chunk));
            if (hit_count == 0) {
                _param.stats->late_materialize_skip_rows += count;
                continue;
            }
            active_chunk->filter_range(chunk_filter, 0, count);
        } 
```

If not, in the first round, the column of active_chunk will be replaced with the dict column. When hit_count == 0, we will use the dict column to read the column, and the column type will be mismatched.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
