### PR TITLE
[BugFix] Fix the Parquet metadata reading error in ASan mode

### DIFF
--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -530,7 +530,7 @@ Status FileMetaDataParser::_parse_footer(FileMetaDataPtr* file_metadata_ptr, int
         RETURN_IF_ERROR(file_metadata->init(t_metadata, _scanner_ctx->case_sensitive));
         *file_metadata_size = CurrentThread::current().get_consumed_bytes() - before_bytes;
     }
-#ifdef BE_TEST
+#if defined(BE_TEST) || defined(__SANITIZE_ADDRESS__) || defined(ADDRESS_SANITIZER)
     *file_metadata_size = sizeof(FileMetaData);
 #endif
     return Status::OK();


### PR DESCRIPTION
## Why I'm doing:

```
Parsing unexpected parquet file metadata size 0: file =
```

## What I'm doing:

The `FileMetaDataParser` uses memory hook to calculate the memory size of the footer, but in ASan mode, the memory hook is disabled, so the returned footer size is zero.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extend the conditional that overrides `file_metadata_size` to apply in ASan builds, preventing zero-size metadata when memory hooks are disabled.
> 
> - **Parquet backend**:
>   - In `be/src/formats/parquet/metadata.cpp` within `_parse_footer`, broaden preprocessor guard from `#ifdef BE_TEST` to `#if defined(BE_TEST) || defined(__SANITIZE_ADDRESS__) || defined(ADDRESS_SANITIZER)` so `file_metadata_size` is set to `sizeof(FileMetaData)` under ASan.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a404c17e7dd056dc0f0a0c5768dd726ae08325f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->