### PR TITLE
[BugFix] Fix create mv with iceberg table bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ custom_env.sh
 ut_dir
 log/
 fe_plugins/*/target
+fe/fe-core/pseudo_cluster_*
 fe_plugins/output
 fe/mocked
 fe/ut_ports

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -1856,6 +1856,7 @@ public class MaterializedViewAnalyzer {
                                                     Map<TableName, Table> refTableNameTableMap,
                                                     Map<Integer, Expr> changedPartitionByExprs,
                                                     Map<Expr, Expr> partitionByExprToAdjustExprMap) {
+        // what if partitionByExpr is not slot ref, eg: date_trunc('day', dt)
         List<SlotRef> slotRefs = partitionByExpr.collectAllSlotRefs();
         if (slotRefs.size() != 1) {
             throw new SemanticException("Partition expr only can ref one slot refs:",
@@ -1926,7 +1927,7 @@ public class MaterializedViewAnalyzer {
                     originalPartitionByExpr.toSql());
         }
         SlotRef slotRef = slotRefs.get(0);
-        resolveRefToMVColumns(mvColumns, slotRef, mvTableName);
+        tryToResolveRefToMVColumns(mvColumns, slotRef, mvTableName);
         partitionByExprToAdjustExprMap.put(originalPartitionByExpr, adjustedPartitionByExpr);
     }
 
@@ -1934,7 +1935,7 @@ public class MaterializedViewAnalyzer {
      * For generated column, change its referred slot ref from original ref-base-table's output columns to
      * MV's output columns.
      */
-    public static void resolveRefToMVColumns(List<Column> columns, SlotRef slotRef, TableName mvTableName) {
+    public static void tryToResolveRefToMVColumns(List<Column> columns, SlotRef slotRef, TableName mvTableName) {
         Column mvPartitionColumn = null;
         int columnId = 0;
         for (Column column : columns) {
@@ -1945,8 +1946,8 @@ public class MaterializedViewAnalyzer {
             columnId++;
         }
         if (mvPartitionColumn == null) {
-            throw new SemanticException("Materialized view partition exp column:"
-                    + slotRef.getColumnName() + " is not found in query statement");
+            LOG.warn("Materialized view partition exp column:" + slotRef.getColumnName() + " is not found in query statement");
+            return;
         }
         SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(columnId), slotRef.getColumnName(),
                 mvPartitionColumn.getType(), mvPartitionColumn.isAllowNull());
@@ -2094,10 +2095,12 @@ public class MaterializedViewAnalyzer {
         if (!MvUtils.isFuncCallExpr(partitionByExpr, FunctionSet.DATE_TRUNC)) {
             return null;
         }
+
         // why resolve slot ref to mv columns?
         // generated column should refer mv's defined column, but partitionByExpr is ref to base table's column,
         // so resolve slot ref to mv columns.
-        resolveRefToMVColumns(mvColumns, slotRef, mvTableName);
+        tryToResolveRefToMVColumns(mvColumns, slotRef, mvTableName);
+
         int zoneHourOffset = getIcebergPartitionColumnTimeZoneOffset(icebergTable, slotRef);
         return getIcebergAdjustPartitionExpr(partitionByExpr, slotRef, zoneHourOffset);
     }
@@ -2115,7 +2118,7 @@ public class MaterializedViewAnalyzer {
             // why resolve slot ref to mv columns?
             // generated column should refer mv's defined column, but partitionByExpr is ref to base table's column,
             // so resolve slot ref to mv columns.
-            resolveRefToMVColumns(mvColumns, slotRef, mvTableName);
+            tryToResolveRefToMVColumns(mvColumns, slotRef, mvTableName);
             return partitionByExpr;
         }
         return null;

--- a/test/sql/test_materialized_view/R/test_create_mv_with_iceberg_transfoms
+++ b/test/sql/test_materialized_view/R/test_create_mv_with_iceberg_transfoms
@@ -1,0 +1,177 @@
+-- name: test_create_mv_with_iceberg_transfoms
+set new_planner_optimize_timeout=10000;
+-- result:
+-- !result
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database sql_test_db_${uuid0};
+-- result:
+-- !result
+use sql_test_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+                  l_orderkey    BIGINT,
+                  l_partkey     INT,
+                  l_suppkey     INT,
+                  l_linenumber  INT,
+                  l_quantity    DECIMAL(15, 2),
+                  l_extendedprice  DECIMAL(15, 2),
+                  l_discount    DECIMAL(15, 2),
+                  l_tax         DECIMAL(15, 2),
+                  l_returnflag  VARCHAR(1),
+                  l_linestatus  VARCHAR(1),
+                  l_shipdate    STRING,
+                  l_commitdate  STRING,
+                  l_receiptdate STRING,
+                  l_shipinstruct VARCHAR(25),
+                  l_shipmode     VARCHAR(10),
+                  l_comment      VARCHAR(44)
+);
+-- result:
+-- !result
+INSERT INTO t1  VALUES( 1, 1001, 5001, 1, 10.00, 1000.00, 0.05, 0.08, 'N', 'O', '2024-11-12', '2024-11-15', '2024-11-20', 'DELIVER IN PERSON', 'AIR', 'Quick delivery required');
+-- result:
+-- !result
+INSERT INTO t1  VALUES (2, 1002, 5002, 2, 20.00, 2000.00, 0.10, 0.15, 'R', 'F', '2024-11-13', '2024-11-16', '2024-11-21', 'TAKE BACK RETURN', 'RAIL', 'Handle with care');
+-- result:
+-- !result
+INSERT INTO t1  VALUES (3, 1003, 5003, 3, 30.00, 3000.00, 0.15, 0.20, 'A', 'P', '2024-11-14', '2024-11-17', '2024-11-22', 'NONE', 'SHIP', 'Fragile item');
+-- result:
+-- !result
+CREATE TABLE lineitem_date (
+                          l_orderkey    BIGINT,
+                          l_partkey     INT,
+                          l_suppkey     INT,
+                          l_linenumber  INT,
+                          l_quantity    DECIMAL(15, 2),
+                          l_extendedprice  DECIMAL(15, 2),
+                          l_discount    DECIMAL(15, 2),
+                          l_tax         DECIMAL(15, 2),
+                          l_commitdate  DATE,
+                          l_receiptdate DATE,
+                          l_shipinstruct VARCHAR(25),
+                          l_shipmode     VARCHAR(10),
+                          l_comment      VARCHAR(44),
+                          l_returnflag  VARCHAR(1),
+                          l_linestatus  VARCHAR(1),
+                          l_shipdate    DATE
+) PARTITION BY (l_returnflag, l_linestatus, l_shipdate);
+-- result:
+-- !result
+INSERT INTO lineitem_date SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, to_date(l_commitdate), to_date(l_receiptdate), l_shipinstruct, l_shipmode, l_comment, l_returnflag, l_linestatus, to_date(l_shipdate) FROM t1;
+-- result:
+-- !result
+CREATE TABLE lineitem_hours (
+                          l_orderkey    BIGINT,
+                          l_partkey     INT,
+                          l_suppkey     INT,
+                          l_linenumber  INT,
+                          l_quantity    DECIMAL(15, 2),
+                          l_extendedprice  DECIMAL(15, 2),
+                          l_discount    DECIMAL(15, 2),
+                          l_tax         DECIMAL(15, 2),
+                          l_commitdate  DATETIME,
+                          l_receiptdate DATETIME,
+                          l_shipinstruct VARCHAR(25),
+                          l_shipmode     VARCHAR(10),
+                          l_comment      VARCHAR(44),
+                          l_shipdate    DATETIME,
+                          l_returnflag  VARCHAR(1),
+                          l_linestatus  VARCHAR(1)
+) PARTITION BY  hour(l_shipdate), l_returnflag, l_linestatus;
+-- result:
+-- !result
+INSERT INTO lineitem_hours SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, to_date(l_commitdate), to_date(l_receiptdate), l_shipinstruct, l_shipmode, l_comment, l_shipdate, l_returnflag, l_linestatus FROM t1;
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_hours
+PARTITION BY (l_returnflag, l_linestatus, dt_hour)
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+  SELECT l_returnflag, l_linestatus, date_trunc('hour', l_shipdate) as dt_hour, count(*) FROM mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_hours group by l_returnflag, l_linestatus, date_trunc('hour', l_shipdate);
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_hours WITH SYNC MODE;
+function: print_hit_materialized_views("SELECT l_returnflag, l_linestatus, date_trunc('hour', l_shipdate) as dt_hour, count(*) FROM mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_hours group by l_returnflag, l_linestatus, date_trunc('hour', l_shipdate);")
+-- result:
+test_hours
+-- !result
+SELECT l_returnflag, l_linestatus, date_trunc('hour', l_shipdate) as dt_hour, count(*) FROM mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_hours group by l_returnflag, l_linestatus, date_trunc('hour', l_shipdate) ORDER BY l_returnflag, l_linestatus, date_trunc('hour', l_shipdate);
+-- result:
+A	P	2024-11-14 00:00:00	1
+N	O	2024-11-12 00:00:00	1
+R	F	2024-11-13 00:00:00	1
+-- !result
+SELECT * FROM test_hours order by l_returnflag, l_linestatus, dt_hour;
+-- result:
+A	P	2024-11-14 00:00:00	1
+N	O	2024-11-12 00:00:00	1
+R	F	2024-11-13 00:00:00	1
+-- !result
+DROP MATERIALIZED VIEW test_hours;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_date
+PARTITION BY (l_returnflag, l_linestatus, dt_date)
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+  SELECT l_returnflag, l_linestatus, l_shipdate as dt_date, count(*) FROM mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_date group by l_returnflag, l_linestatus, l_shipdate;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_date WITH SYNC MODE;
+function: print_hit_materialized_views("SELECT l_returnflag, l_linestatus, l_shipdate as dt_date, count(*) FROM mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_date group by l_returnflag, l_linestatus, l_shipdate;")
+-- result:
+test_date
+-- !result
+SELECT l_returnflag, l_linestatus, l_shipdate as dt_date, count(*) FROM mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_date group by l_returnflag, l_linestatus, l_shipdate ORDER BY l_returnflag, l_linestatus, l_shipdate;
+-- result:
+A	P	2024-11-14	1
+N	O	2024-11-12	1
+R	F	2024-11-13	1
+-- !result
+SELECT * FROM test_date order by l_returnflag, l_linestatus, dt_date;
+-- result:
+A	P	2024-11-14	1
+N	O	2024-11-12	1
+R	F	2024-11-13	1
+-- !result
+DROP MATERIALIZED VIEW test_date;
+-- result:
+-- !result
+DROP DATABASE db_${uuid0};
+-- result:
+-- !result
+DROP TABLE mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_hours;
+-- result:
+-- !result
+DROP TABLE mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_date;
+-- result:
+-- !result
+DROP TABLE mv_iceberg_${uuid0}.sql_test_db_${uuid0}.t1;
+-- result:
+-- !result
+DROP DATABASE mv_iceberg_${uuid0}.sql_test_db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_create_mv_with_iceberg_transfoms
+++ b/test/sql/test_materialized_view/T/test_create_mv_with_iceberg_transfoms
@@ -1,0 +1,121 @@
+-- name: test_create_mv_with_iceberg_transfoms
+
+set new_planner_optimize_timeout=10000;
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database sql_test_db_${uuid0};
+use sql_test_db_${uuid0};
+
+
+CREATE TABLE t1 (
+                  l_orderkey    BIGINT,
+                  l_partkey     INT,
+                  l_suppkey     INT,
+                  l_linenumber  INT,
+                  l_quantity    DECIMAL(15, 2),
+                  l_extendedprice  DECIMAL(15, 2),
+                  l_discount    DECIMAL(15, 2),
+                  l_tax         DECIMAL(15, 2),
+                  l_returnflag  VARCHAR(1),
+                  l_linestatus  VARCHAR(1),
+                  l_shipdate    STRING,
+                  l_commitdate  STRING,
+                  l_receiptdate STRING,
+                  l_shipinstruct VARCHAR(25),
+                  l_shipmode     VARCHAR(10),
+                  l_comment      VARCHAR(44)
+);
+
+INSERT INTO t1  VALUES( 1, 1001, 5001, 1, 10.00, 1000.00, 0.05, 0.08, 'N', 'O', '2024-11-12', '2024-11-15', '2024-11-20', 'DELIVER IN PERSON', 'AIR', 'Quick delivery required');
+INSERT INTO t1  VALUES (2, 1002, 5002, 2, 20.00, 2000.00, 0.10, 0.15, 'R', 'F', '2024-11-13', '2024-11-16', '2024-11-21', 'TAKE BACK RETURN', 'RAIL', 'Handle with care');
+INSERT INTO t1  VALUES (3, 1003, 5003, 3, 30.00, 3000.00, 0.15, 0.20, 'A', 'P', '2024-11-14', '2024-11-17', '2024-11-22', 'NONE', 'SHIP', 'Fragile item');
+
+CREATE TABLE lineitem_date (
+                          l_orderkey    BIGINT,
+                          l_partkey     INT,
+                          l_suppkey     INT,
+                          l_linenumber  INT,
+                          l_quantity    DECIMAL(15, 2),
+                          l_extendedprice  DECIMAL(15, 2),
+                          l_discount    DECIMAL(15, 2),
+                          l_tax         DECIMAL(15, 2),
+                          l_commitdate  DATE,
+                          l_receiptdate DATE,
+                          l_shipinstruct VARCHAR(25),
+                          l_shipmode     VARCHAR(10),
+                          l_comment      VARCHAR(44),
+                          l_returnflag  VARCHAR(1),
+                          l_linestatus  VARCHAR(1),
+                          l_shipdate    DATE
+) PARTITION BY (l_returnflag, l_linestatus, l_shipdate);
+INSERT INTO lineitem_date SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, to_date(l_commitdate), to_date(l_receiptdate), l_shipinstruct, l_shipmode, l_comment, l_returnflag, l_linestatus, to_date(l_shipdate) FROM t1;
+
+CREATE TABLE lineitem_hours (
+                          l_orderkey    BIGINT,
+                          l_partkey     INT,
+                          l_suppkey     INT,
+                          l_linenumber  INT,
+                          l_quantity    DECIMAL(15, 2),
+                          l_extendedprice  DECIMAL(15, 2),
+                          l_discount    DECIMAL(15, 2),
+                          l_tax         DECIMAL(15, 2),
+                          l_commitdate  DATETIME,
+                          l_receiptdate DATETIME,
+                          l_shipinstruct VARCHAR(25),
+                          l_shipmode     VARCHAR(10),
+                          l_comment      VARCHAR(44),
+                          l_shipdate    DATETIME,
+                          l_returnflag  VARCHAR(1),
+                          l_linestatus  VARCHAR(1)
+) PARTITION BY  hour(l_shipdate), l_returnflag, l_linestatus;
+
+INSERT INTO lineitem_hours SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, to_date(l_commitdate), to_date(l_receiptdate), l_shipinstruct, l_shipmode, l_comment, l_shipdate, l_returnflag, l_linestatus FROM t1;
+
+set catalog default_catalog;
+-- create mv
+create database db_${uuid0};
+use db_${uuid0};
+
+-------------------------------- HOURS --------------------------------
+CREATE MATERIALIZED VIEW test_hours
+PARTITION BY (l_returnflag, l_linestatus, dt_hour)
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+  SELECT l_returnflag, l_linestatus, date_trunc('hour', l_shipdate) as dt_hour, count(*) FROM mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_hours group by l_returnflag, l_linestatus, date_trunc('hour', l_shipdate);
+
+REFRESH MATERIALIZED VIEW test_hours WITH SYNC MODE;
+function: print_hit_materialized_views("SELECT l_returnflag, l_linestatus, date_trunc('hour', l_shipdate) as dt_hour, count(*) FROM mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_hours group by l_returnflag, l_linestatus, date_trunc('hour', l_shipdate);")
+SELECT l_returnflag, l_linestatus, date_trunc('hour', l_shipdate) as dt_hour, count(*) FROM mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_hours group by l_returnflag, l_linestatus, date_trunc('hour', l_shipdate) ORDER BY l_returnflag, l_linestatus, date_trunc('hour', l_shipdate);
+SELECT * FROM test_hours order by l_returnflag, l_linestatus, dt_hour;
+
+DROP MATERIALIZED VIEW test_hours;
+
+-------------------------------- DATE --------------------------------
+CREATE MATERIALIZED VIEW test_date
+PARTITION BY (l_returnflag, l_linestatus, dt_date)
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+  SELECT l_returnflag, l_linestatus, l_shipdate as dt_date, count(*) FROM mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_date group by l_returnflag, l_linestatus, l_shipdate;
+
+REFRESH MATERIALIZED VIEW test_date WITH SYNC MODE;
+function: print_hit_materialized_views("SELECT l_returnflag, l_linestatus, l_shipdate as dt_date, count(*) FROM mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_date group by l_returnflag, l_linestatus, l_shipdate;")
+SELECT l_returnflag, l_linestatus, l_shipdate as dt_date, count(*) FROM mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_date group by l_returnflag, l_linestatus, l_shipdate ORDER BY l_returnflag, l_linestatus, l_shipdate;
+SELECT * FROM test_date order by l_returnflag, l_linestatus, dt_date;
+
+DROP MATERIALIZED VIEW test_date;
+
+DROP DATABASE db_${uuid0};
+
+DROP TABLE mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_hours;
+DROP TABLE mv_iceberg_${uuid0}.sql_test_db_${uuid0}.lineitem_date;
+DROP TABLE mv_iceberg_${uuid0}.sql_test_db_${uuid0}.t1;
+DROP DATABASE mv_iceberg_${uuid0}.sql_test_db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

Caused by: com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: Materialized view partition exp column:ts is not found in query statement.
```
    @Test
    public void testRefBaseTablePartitionWithTransform2() throws Exception {
        final String sql = "CREATE MATERIALIZED VIEW test_mv1\n" +
                "PARTITION BY ds\n" +
                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
                "REFRESH DEFERRED MANUAL\n" +
                "PROPERTIES (\n" +
                "\"replication_num\" = \"1\"\n" +
                ")\n" +
                "AS SELECT id, data, date_trunc('month', ts) as ds  FROM `iceberg0`.`partitioned_transforms_db`.`t0_month` as a;";
        CreateMaterializedViewStatement stmt =
                (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql,
                        connectContext);
        MaterializedViewAnalyzer.analyze(stmt, starRocksAssert.getCtx());
        Assertions.assertTrue(stmt.isRefBaseTablePartitionWithTransform());
    }
```
## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/64361

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make MV partition expr-to-MV column resolution non-fatal and add tests for Iceberg MV with transform/alias partitions; update .gitignore.
> 
> - **FE/Core (Analyzer)**:
>   - Make `resolveRefToMVColumns` tolerant (renamed to `tryToResolveRefToMVColumns`): log warning and return when MV column not found instead of throwing, and update all call sites (`recordPartitionByExprToAdjustExprMap`, `getAdjustedIcebergPartitionExpr`, `getAdjustedOlapTablePartitionExpr`).
> - **Tests**:
>   - Add SQL integration tests for creating/refreshing MVs over Iceberg tables with transforms (`date_trunc`) and direct date partitions in `test/sql/test_materialized_view/{R,T}/test_create_mv_with_iceberg_transfoms`.
>   - Add unit tests to support alias-based partition columns and verify list partition and transform detection in `MvRefreshAndRewriteIcebergTest`.
> - **Misc**:
>   - Update `.gitignore` to exclude `fe/fe-core/pseudo_cluster_*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a15d8d1ffa859dfc54141c9bab525be2a8812d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->