### PR TITLE
[UT] Fix error of write test case result to db

### DIFF
--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -644,15 +644,21 @@ class StarrocksSQLApiLib(object):
     def use_database(self, db_name):
         return self.execute_sql("use %s" % db_name)
 
-    def create_database_and_table(self, database_name, table_name, table_sql_path=None, tolerate_exist=False):
+    def create_database_and_table(self, catalog_name, database_name, table_name, table_sql_path=None,
+                                  tolerate_exist=False):
         """
         create database, use database and create table
         Args:
+            catalog_name:     catalog
             database_name:    db
             table_name:       table
             table_sql_path:   sql dir
             tolerate_exist:   tolerate if not exists
         """
+        if catalog_name is not None:
+            set_catalog_res = self.execute_sql("set catalog %s" % catalog_name)
+            tools.assert_true(set_catalog_res["status"], "set catalog failed")
+
         # create database
         create_db_res = self.create_database(database_name, tolerate_exist=tolerate_exist)
         tools.assert_true(create_db_res["status"], "create database failed")
@@ -1564,7 +1570,7 @@ class StarrocksSQLApiLib(object):
 
         # create record table
         try:
-            self.create_database_and_table(T_R_DB, T_R_TABLE, "sql_framework", True)
+            self.create_database_and_table("default_catalog", T_R_DB, T_R_TABLE, "sql_framework", True)
         except AssertionError:
             self_print(f"Failed to create DB/Table to save the results, please check the env!", ColorEnum.RED)
             sys.exit(1)


### PR DESCRIPTION
## Why I'm doing:

When run single external table case, save result to db failed.

```
python3 run.py -a sequential -r --config conf/sr.conf --file_filter=.*test_parquet_late.* --skip_reruns

======================================================================
ERROR: 0    : sql/test_external_file/T/test_parquet_late_materialization:test_parquet_late_materialization
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/disk6/lxh/.local/lib/python3.10/site-packages/nose/case.py", line 385, in tearDown
    try_run(self.inst, ('teardown', 'tearDown'))
  File "/home/disk6/lxh/.local/lib/python3.10/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/home/disk6/lxh/starrocks/test/lib/sql_annotation.py", line 68, in wrapper
    res = func(*args, **kwargs)
  File "/home/disk6/lxh/starrocks/test/test_sql_cases.py", line 153, in tearDown
    res = self.save_r_into_db(self.case_info.file, self.case_info.name, self.res_log, self.version)
  File "/home/disk6/lxh/starrocks/test/lib/sr_sql_lib.py", line 1573, in save_r_into_db
    sys.exit(1)
SystemExit: 1

----------------------------------------------------------------------
Ran 1 test in 12.228s

FAILED (errors=1)
Traceback (most recent call last):
  File "/home/disk6/lxh/starrocks/test/run.py", line 261, in <module>
    sr_sql_lib.StarrocksSQLApiLib().save_r_into_file(part)
  File "/home/disk6/lxh/starrocks/test/lib/sr_sql_lib.py", line 1613, in save_r_into_file
    tools.assert_true(use_res["status"], "use db: [%s] error" % T_R_DB)
  File "/usr/lib/python3.10/unittest/case.py", line 687, in assertTrue
    raise self.failureException(msg)
AssertionError: False is not true : use db: [t_r_db] error
```

## What I'm doing:

Fix error of write result to db

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add optional `catalog_name` to `create_database_and_table` (sets catalog when provided) and call it with `default_catalog` when saving R results to DB.
> 
> - **Test SQL lib (`test/lib/sr_sql_lib.py`)**:
>   - Extend `create_database_and_table` to accept `catalog_name` and execute `set catalog <name>` when provided.
>   - Update `save_r_into_db` to create/use record DB/table under `default_catalog`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f1c077ca3fdfbc90b3c1be5381c7e3d249e3e8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->