### PR TITLE
[Enhancement] Optimize performance for zone-map index filter with or-predicates

### DIFF
--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -137,8 +137,12 @@ public:
     /// |pred_relation| is the relation among |predicates|, it can be AND or OR.
     virtual Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                               const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                              CompoundNodeType pred_relation) {
-        row_ranges->add({0, static_cast<rowid_t>(num_rows())});
+                                              CompoundNodeType pred_relation, const Range<>* src_range = nullptr) {
+        if (src_range == nullptr) {
+            row_ranges->add({0, static_cast<rowid_t>(num_rows())});
+        } else {
+            row_ranges->add(*src_range);
+        }
         return Status::OK();
     }
 

--- a/be/src/storage/rowset/column_iterator_decorator.h
+++ b/be/src/storage/rowset/column_iterator_decorator.h
@@ -47,8 +47,8 @@ public:
 
     Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                       const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                      CompoundNodeType pred_relation) override {
-        return _parent->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation);
+                                      CompoundNodeType pred_relation, const Range<>* src_range = nullptr) override {
+        return _parent->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation, src_range);
     }
 
     bool has_original_bloom_filter_index() const override { return _parent->has_original_bloom_filter_index(); }

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -676,7 +676,7 @@ Status ColumnReader::_zone_map_filter(const std::vector<const ColumnPredicate*>&
 
     int32_t i = 0;
     int32_t end_page = num_pages;
-    if (src_range != nullptr) {
+    if (src_range != nullptr && src_range->end() != 0) {
         i = _ordinal_index->seek_at_or_before(src_range->begin()).page_index();
         end_page = _ordinal_index->seek_at_or_before(src_range->end() - 1).page_index();
         if (end_page + 1 <= num_pages) {
@@ -684,7 +684,7 @@ Status ColumnReader::_zone_map_filter(const std::vector<const ColumnPredicate*>&
         }
     }
 
-    for (i = 0; i < end_page; ++i) {
+    for (; i < end_page; ++i) {
         const ZoneMapPB& zm = zone_maps[i];
         ZoneMapDetail detail;
         RETURN_IF_ERROR(_parse_zone_map(type_info, zm, &detail));

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -159,7 +159,8 @@ public:
     Status zone_map_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p,
                            const ::starrocks::ColumnPredicate* del_predicate,
                            std::unordered_set<uint32_t>* del_partial_filtered_pages, SparseRange<>* row_ranges,
-                           const IndexReadOptions& opts, CompoundNodeType pred_relation);
+                           const IndexReadOptions& opts, CompoundNodeType pred_relation,
+                           const Range<>* src_range = nullptr);
 
     // NOTE: RAW interface should be used carefully
     // Return all page-level zonemap
@@ -231,12 +232,14 @@ private:
     // handling type mismatches between column and predicate types after fast schema evolution
     LogicalType _get_zone_map_parse_type(const ColumnPredicate* predicate) const;
     Status _parse_zone_map(LogicalType type, const ZoneMapPB& zm, ZoneMapDetail* detail) const;
+    Status _parse_zone_map(const TypeInfoPtr& type_info, const ZoneMapPB& zm, ZoneMapDetail* detail) const;
 
     Status _calculate_row_ranges(const std::vector<uint32_t>& page_indexes, SparseRange<>* row_ranges);
 
     template <CompoundNodeType PredRelation>
     Status _zone_map_filter(const std::vector<const ColumnPredicate*>& predicates, const ColumnPredicate* del_predicate,
-                            std::unordered_set<uint32_t>* del_partial_filtered_pages, std::vector<uint32_t>* pages);
+                            std::unordered_set<uint32_t>* del_partial_filtered_pages, std::vector<uint32_t>* pages,
+                            const Range<>* src_range);
 
     Status _load_inverted_index(const std::shared_ptr<TabletIndex>& index_meta, const SegmentReadOptions& opts);
 

--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -160,11 +160,15 @@ Status DefaultValueColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, 
 
 Status DefaultValueColumnIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                               const ColumnPredicate* del_predicate,
-                                                              SparseRange<>* row_ranges,
-                                                              CompoundNodeType pred_relation) {
+                                                              SparseRange<>* row_ranges, CompoundNodeType pred_relation,
+                                                              const Range<>* src_range) {
     DCHECK(row_ranges->empty());
     // TODO
-    row_ranges->add({0, static_cast<rowid_t>(_num_rows)});
+    if (src_range == nullptr) {
+        row_ranges->add({0, static_cast<rowid_t>(_num_rows)});
+    } else {
+        row_ranges->add(*src_range);
+    }
     // TODO: Setting `_may_contained_deleted_row` to true is a temporary fix,
     // which will affect performance in some scenarios.
     // It is best to filter according to DefaultValue,

--- a/be/src/storage/rowset/default_value_column_iterator.h
+++ b/be/src/storage/rowset/default_value_column_iterator.h
@@ -78,7 +78,7 @@ public:
 
     Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                       const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                      CompoundNodeType pred_relation) override;
+                                      CompoundNodeType pred_relation, const Range<>* src_range = nullptr) override;
 
     bool all_page_dict_encoded() const override { return false; }
 

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -299,11 +299,7 @@ Status JsonFlatColumnIterator::get_row_ranges_by_zone_map(const std::vector<cons
                                                           const ColumnPredicate* del_predicate,
                                                           SparseRange<>* row_ranges, CompoundNodeType pred_relation,
                                                           const Range<>* src_range) {
-    if (src_range == nullptr) {
-        row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
-    } else {
-        row_ranges->add(*src_range);
-    }
+    row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
     return Status::OK();
 }
 
@@ -646,11 +642,7 @@ Status JsonMergeIterator::seek_to_ordinal(ordinal_t ord) {
 Status JsonMergeIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                      const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
                                                      CompoundNodeType pred_relation, const Range<>* src_range) {
-    if (src_range == nullptr) {
-        row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
-    } else {
-        row_ranges->add(*src_range);
-    }
+    row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -83,7 +83,7 @@ public:
 
     Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                       const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                      CompoundNodeType pred_relation) override;
+                                      CompoundNodeType pred_relation, const Range<>* src_range = nullptr) override;
 
     std::string name() const override { return "JsonFlatColumnIterator"; }
 
@@ -297,8 +297,13 @@ Status JsonFlatColumnIterator::seek_to_ordinal(ordinal_t ord) {
 
 Status JsonFlatColumnIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                           const ColumnPredicate* del_predicate,
-                                                          SparseRange<>* row_ranges, CompoundNodeType pred_relation) {
-    row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
+                                                          SparseRange<>* row_ranges, CompoundNodeType pred_relation,
+                                                          const Range<>* src_range) {
+    if (src_range == nullptr) {
+        row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
+    } else {
+        row_ranges->add(*src_range);
+    }
     return Status::OK();
 }
 
@@ -332,7 +337,7 @@ public:
     /// for vectorized engine
     Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                       const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                      CompoundNodeType pred_relation) override;
+                                      CompoundNodeType pred_relation, const Range<>* src_range = nullptr) override;
 
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
@@ -433,8 +438,9 @@ Status JsonDynamicFlatIterator::seek_to_ordinal(ordinal_t ord) {
 
 Status JsonDynamicFlatIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                            const ColumnPredicate* del_predicate,
-                                                           SparseRange<>* row_ranges, CompoundNodeType pred_relation) {
-    return _json_iter->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation);
+                                                           SparseRange<>* row_ranges, CompoundNodeType pred_relation,
+                                                           const Range<>* src_range) {
+    return _json_iter->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation, src_range);
 }
 
 class JsonMergeIterator final : public ColumnIterator {
@@ -467,7 +473,8 @@ public:
     /// for vectorized engine
     [[nodiscard]] Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                     const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                                    CompoundNodeType pred_relation) override;
+                                                    CompoundNodeType pred_relation,
+                                                    const Range<>* src_range = nullptr) override;
 
     [[nodiscard]] Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
@@ -638,8 +645,12 @@ Status JsonMergeIterator::seek_to_ordinal(ordinal_t ord) {
 
 Status JsonMergeIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                      const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                                     CompoundNodeType pred_relation) {
-    row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
+                                                     CompoundNodeType pred_relation, const Range<>* src_range) {
+    if (src_range == nullptr) {
+        row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
+    } else {
+        row_ranges->add(*src_range);
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -413,7 +413,7 @@ Status ScalarColumnIterator::_read_data_page(const OrdinalPageIndexIterator& ite
 
 Status ScalarColumnIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                         const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
-                                                        CompoundNodeType pred_relation) {
+                                                        CompoundNodeType pred_relation, const Range<>* src_range) {
     DCHECK(row_ranges->empty());
     if (_reader->has_zone_map()) {
         if (!_delete_partial_satisfied_pages.has_value()) {
@@ -427,7 +427,7 @@ Status ScalarColumnIterator::get_row_ranges_by_zone_map(const std::vector<const 
         opts.read_file = _opts.read_file;
         opts.stats = _opts.stats;
         RETURN_IF_ERROR(_reader->zone_map_filter(predicates, del_predicate, &_delete_partial_satisfied_pages.value(),
-                                                 row_ranges, opts, pred_relation));
+                                                 row_ranges, opts, pred_relation, src_range));
     } else {
         row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
     }

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -69,7 +69,7 @@ public:
 
     Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicate,
                                       const ColumnPredicate* del_predicate, SparseRange<>* range,
-                                      CompoundNodeType pred_relationn) override;
+                                      CompoundNodeType pred_relation, const Range<>* src_range = nullptr) override;
 
     bool has_original_bloom_filter_index() const override;
     bool has_ngram_bloom_filter_index() const override;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1211,8 +1211,8 @@ struct ZoneMapFilterEvaluator {
             const ColumnPredicate* del_pred = iter != del_preds.end() ? &(iter->second) : nullptr;
 
             SparseRange<> cur_row_ranges;
-            RETURN_IF_ERROR(
-                    column_iterators[cid]->get_row_ranges_by_zone_map(col_preds, del_pred, &cur_row_ranges, Type));
+            RETURN_IF_ERROR(column_iterators[cid]->get_row_ranges_by_zone_map(col_preds, del_pred, &cur_row_ranges,
+                                                                              Type, &src_range));
             _merge_row_ranges<Type>(row_ranges, cur_row_ranges);
         }
 
@@ -1232,8 +1232,8 @@ struct ZoneMapFilterEvaluator {
                     const ColumnPredicate* del_pred = &(iter->second);
 
                     SparseRange<> cur_row_ranges;
-                    RETURN_IF_ERROR(
-                            column_iterators[cid]->get_row_ranges_by_zone_map({}, del_pred, &cur_row_ranges, Type));
+                    RETURN_IF_ERROR(column_iterators[cid]->get_row_ranges_by_zone_map({}, del_pred, &cur_row_ranges,
+                                                                                      Type, &src_range));
                     _merge_row_ranges<Type>(row_ranges, cur_row_ranges);
                 }
             }
@@ -1267,6 +1267,7 @@ struct ZoneMapFilterEvaluator {
 
     const std::map<ColumnId, ColumnOrPredicate>& del_preds;
     const std::set<ColumnId>& del_columns;
+    const Range<> src_range;
     bool has_apply_only_del_columns = false;
 };
 
@@ -1299,9 +1300,9 @@ Status SegmentIterator::_get_row_ranges_by_zone_map() {
     // prune data pages by zone map index.
     // -------------------------------------------------------------
 
-    ASSIGN_OR_RETURN(auto hit_row_ranges,
-                     _opts.pred_tree_for_zone_map.visit(ZoneMapFilterEvaluator{
-                             _opts.pred_tree_for_zone_map, _column_iterators, _del_predicates, del_columns}));
+    ASSIGN_OR_RETURN(auto hit_row_ranges, _opts.pred_tree_for_zone_map.visit(ZoneMapFilterEvaluator{
+                                                  _opts.pred_tree_for_zone_map, _column_iterators, _del_predicates,
+                                                  del_columns, Range<>{_scan_range.begin(), _scan_range.end()}}));
     if (hit_row_ranges.has_value()) {
         zm_range &= hit_row_ranges.value();
     }


### PR DESCRIPTION
## Why I'm doing:

- Reduce unnecessary `get_type_info` calls.  
   - Currently, `get_type_info(lt)` is called once per page, which is expensive because it involves copying `TypeInfo`.  
   - Change: Call `get_type_info(lt)` only once for all pages.  

- Avoid repeatedly calling `zone_map_filter()` on the same Tablet during tablet internal parallel reads.  
   Tablet internal parallel splits a Tablet into multiple sub-ranges (splits), each reading data within a given Tablet and rowid range.  
   - Previous behavior: `zone_map_filter()` ignored the rowid range and was applied to all pages in the Tablet.  
     As a result, for large Tablets, each page could be filtered multiple times, causing significant performance degradation.  
   - Change: Pass the rowid range to `zone_map_filter()` to ensure it is applied only once per relevant range.

## What I'm doing:


Fixes #issue

### Test

**Prepare Data**

```sql


CREATE TABLE __row_util_base (
  k1 bigint NULL
) ENGINE=OLAP
DUPLICATE KEY(`k1`)
DISTRIBUTED BY HASH(`k1`) BUCKETS 32
PROPERTIES (
    "replication_num" = "1"
);
insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
insert into __row_util_base select * from __row_util_base; -- 20000
insert into __row_util_base select * from __row_util_base; -- 40000
insert into __row_util_base select * from __row_util_base; -- 80000
insert into __row_util_base select * from __row_util_base; -- 160000
insert into __row_util_base select * from __row_util_base; -- 320000
insert into __row_util_base select * from __row_util_base; -- 640000
insert into __row_util_base select * from __row_util_base; -- 1280000
insert into __row_util_base select * from __row_util_base; -- 640000
insert into __row_util_base select * from __row_util_base; -- 1280000
insert into __row_util_base select * from __row_util_base; -- 640000
insert into __row_util_base select * from __row_util_base; -- 1280000
insert into __row_util_base select * from __row_util_base; -- 640000
insert into __row_util_base select * from __row_util_base; -- 1280000
insert into __row_util_base select * from __row_util_base; -- 640000
insert into __row_util_base select * from __row_util_base; -- 1280000
insert into __row_util_base select * from __row_util_base; -- 640000
insert into __row_util_base select * from __row_util_base; -- 1280000
insert into __row_util_base select * from __row_util_base; -- 640000
insert into __row_util_base select * from __row_util_base; -- 1280000
insert into __row_util_base select * from __row_util_base; -- 640000
insert into __row_util_base select * from __row_util_base; -- 1280000


CREATE TABLE __row_util (
  idx bigint NULL
) ENGINE=OLAP
DUPLICATE KEY(`idx`)
DISTRIBUTED BY HASH(`idx`) BUCKETS 640
PROPERTIES (
    "replication_num" = "1"
);
insert into __row_util select row_number() over() as idx from __row_util_base;

CREATE TABLE t1 (
    s1 string NULL,
    k1 bigint NULL,
    s2 string NULL,
    int1 bigint NULL
) ENGINE=OLAP
DUPLICATE KEY(`s1`)
DISTRIBUTED BY HASH(`k1`) BUCKETS 6
PROPERTIES (
    "replication_num" = "1"
);

insert into t1
select 

lpad(cast(idx % 2157 as string), 10, '0') as s1,
idx,
lpad(cast(idx % 29737 as string), 32, '0') as s2,

idx
from __row_util where idx <= 163840000;
```

Query
```sql
-- Q1
SELECT COUNT(1) FROM t1 WHERE 
(s1 = "0000001422" AND s2 = "00000000000000000000000000015533" AND int1 <= 163840000) OR (s1 = "0000001422" AND s2 = "00000000000000000000000000001185" AND int1 <= 163840000) 
OR (s1 = "0000000897" AND s2 = "00000000000000000000000000019936" AND int1 <= 163840000) OR (s1 = "0000000897" AND s2 = "00000000000000000000000000027375" AND int1 <= 163840000) 
OR (s1 = "0000001422" AND s2 = "00000000000000000000000000004524" AND int1 <= 163840000) OR (s1 = "0000001422" AND s2 = "00000000000000000000000000012087" AND int1 <= 163840000) 
.... -- 21 ORs

-- Q2
-- 1000 ORs
```

Latency
- Q1
    - Before: 780ms
    - After: 250ms
- Q2
    - Before: 18.9s
    - After: 2s

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds row-range-aware zone map filtering and caches type info per scan to cut redundant work and avoid re-filtering pages across splits.
> 
> - **Zone Map filtering (row-range aware)**
>   - Add `src_range` parameter to `get_row_ranges_by_zone_map(...)` across iterators (`ColumnIterator`, `ScalarColumnIterator`, `DefaultValueColumnIterator`, JSON iterators) and `ColumnReader::zone_map_filter(...)`.
>   - Use `_scan_range` in `SegmentIterator` to pass `Range<>` into filtering and prune only relevant pages.
>   - Map `src_range` to page index bounds via `_ordinal_index` to limit scanned pages.
> - **Type info reuse in zone map parsing**
>   - Refactor `_parse_zone_map` with `TypeInfoPtr` overload; compute `type_info` once per filter pass instead of per page.
> - **Plumbing and consistency**
>   - Update `ColumnIteratorDecorator` and call sites to forward new param.
>   - Minor cleanups: replace per-loop `num_pages` usage, compute `end_page`, and small renames.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 974e71ae3e94ab69475326fce6f0e1f551d9e0fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->