### PR TITLE
[Enhancement] Support collect statistics for iceberg table with partition evolution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -342,7 +342,7 @@ public interface IcebergCatalog extends MemoryTrackable {
                         PartitionSpec spec = nativeTable.specs().get(specId);
 
                         String partitionName =
-                                PartitionUtil.convertIcebergPartitionToPartitionName(spec, partitionData);
+                                PartitionUtil.convertIcebergPartitionToPartitionName(nativeTable, spec, partitionData);
 
                         long lastUpdated = -1;
                         try {
@@ -351,7 +351,7 @@ public interface IcebergCatalog extends MemoryTrackable {
                             logger.error("The table [{}.{}] snapshot [{}] has been expired", nativeTable.name(), partitionName,
                                     snapshotId, e);
                         }
-                        Partition partition = new Partition(lastUpdated);
+                        Partition partition = new Partition(lastUpdated, specId);
                         partitionMap.put(partitionName, partition);
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/Partition.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 public class Partition implements PartitionInfo {
     private final long modifiedTime;
+    private int specId;
 
     @Override
     public long getModifiedTime() {
@@ -31,7 +32,17 @@ public class Partition implements PartitionInfo {
         return TimeUnit.MICROSECONDS;
     }
 
+    public int getSpecId() {
+        return specId;
+    }
+
     public Partition(long modifiedTime) {
         this.modifiedTime = modifiedTime;
+        this.specId = -1;
+    }
+
+    public Partition(long modifiedTime, int specId) {
+        this.modifiedTime = modifiedTime;
+        this.specId = specId;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -36,13 +36,18 @@ import com.starrocks.sql.ast.expression.Expr;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.StructProjection;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -61,6 +66,8 @@ import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class IcebergApiConverterTest {
 
@@ -161,7 +168,7 @@ public class IcebergApiConverterTest {
     }
 
     @Test
-    public void testIdentityPartitionNames() {
+    public void testIdentityPartitionNames() throws Exception {
         List<Types.NestedField> fields = Lists.newArrayList();
         fields.add(Types.NestedField.optional(1, "id", new Types.IntegerType()));
         fields.add(Types.NestedField.optional(2, "dt", new Types.DateType()));
@@ -170,19 +177,36 @@ public class IcebergApiConverterTest {
         Schema schema = new Schema(fields);
         PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
         PartitionSpec partitionSpec = builder.identity("dt").build();
-        String partitionName = convertIcebergPartitionToPartitionName(partitionSpec, DataFiles.data(partitionSpec,
-                "dt=2022-08-01"));
-        assertEquals("dt=2022-08-01", partitionName);
+        org.apache.iceberg.Table table = mock(org.apache.iceberg.Table.class);
+        when(table.spec()).thenReturn(partitionSpec);
+        when(table.schema()).thenReturn(schema);
+        try (MockedStatic<Partitioning> mockedStatic = Mockito.mockStatic(Partitioning.class)) {
+            mockedStatic.when(() -> Partitioning.partitionType(table)).thenReturn(partitionSpec.partitionType());
 
+            StructLike partitionData = DataFiles.data(partitionSpec, "dt=2022-08-01");
+            StructProjection partition = StructProjection.create(schema, schema);
+            partition.wrap(partitionData);
+            String partitionName = convertIcebergPartitionToPartitionName(table, partitionSpec, partition);
+            assertEquals("dt=2022-08-01", partitionName);
+        }
+
+        // Second test case
         builder = PartitionSpec.builderFor(schema);
         partitionSpec = builder.identity("id").identity("dt").build();
-        partitionName = convertIcebergPartitionToPartitionName(partitionSpec, DataFiles.data(partitionSpec,
-                "id=1/dt=2022-08-01"));
-        assertEquals("id=1/dt=2022-08-01", partitionName);
+        when(table.spec()).thenReturn(partitionSpec);
+        try (MockedStatic<Partitioning> mockedStatic = Mockito.mockStatic(Partitioning.class)) {
+            mockedStatic.when(() -> Partitioning.partitionType(table)).thenReturn(partitionSpec.partitionType());
+
+            StructLike partitionData = DataFiles.data(partitionSpec, "id=1/dt=2022-08-01");
+            StructProjection partition = StructProjection.create(schema, schema);
+            partition.wrap(partitionData);
+            String partitionName = convertIcebergPartitionToPartitionName(table, partitionSpec, partition);
+            assertEquals("id=1/dt=2022-08-01", partitionName);
+        }
     }
 
     @Test
-    public void testNonIdentityPartitionNames() {
+    public void testNonIdentityPartitionNames() throws Exception {
         List<Types.NestedField> fields = Lists.newArrayList();
         fields.add(Types.NestedField.optional(1, "id", new Types.IntegerType()));
         fields.add(Types.NestedField.optional(2, "ts", Types.TimestampType.withoutZone()));
@@ -191,15 +215,34 @@ public class IcebergApiConverterTest {
         Schema schema = new Schema(fields);
         PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
         PartitionSpec partitionSpec = builder.hour("ts").build();
-        String partitionName = convertIcebergPartitionToPartitionName(partitionSpec, DataFiles.data(partitionSpec,
-                "ts_hour=62255"));
-        assertEquals("ts_hour=1977-02-06-23", partitionName);
+        org.apache.iceberg.Table table = mock(org.apache.iceberg.Table.class);
+        when(table.spec()).thenReturn(partitionSpec);
+        when(table.schema()).thenReturn(schema);
 
+        try (MockedStatic<Partitioning> mockedStatic = Mockito.mockStatic(Partitioning.class)) {
+            mockedStatic.when(() -> Partitioning.partitionType(table)).thenReturn(partitionSpec.partitionType());
+
+            StructLike partitionData = DataFiles.data(partitionSpec, "ts_hour=62255");
+            StructProjection partition = StructProjection.create(schema, schema);
+            partition.wrap(partitionData);
+            String partitionName = convertIcebergPartitionToPartitionName(table, partitionSpec, partition);
+            assertEquals("ts_hour=1977-02-06-23", partitionName);
+        }
+
+        // Second test case
         builder = PartitionSpec.builderFor(schema);
         partitionSpec = builder.hour("ts").truncate("data", 2).build();
-        partitionName = convertIcebergPartitionToPartitionName(partitionSpec, DataFiles.data(partitionSpec,
-                "ts_hour=365/data_trunc=xy"));
-        assertEquals("ts_hour=1970-01-16-05/data_trunc=xy", partitionName);
+        when(table.spec()).thenReturn(partitionSpec);
+
+        try (MockedStatic<Partitioning> mockedStatic = Mockito.mockStatic(Partitioning.class)) {
+            mockedStatic.when(() -> Partitioning.partitionType(table)).thenReturn(partitionSpec.partitionType());
+
+            StructLike partitionData = DataFiles.data(partitionSpec, "ts_hour=365/data_trunc=xy");
+            StructProjection partition = StructProjection.create(schema, schema);
+            partition.wrap(partitionData);
+            String partitionName = convertIcebergPartitionToPartitionName(table, partitionSpec, partition);
+            assertEquals("ts_hour=1970-01-16-05/data_trunc=xy", partitionName);
+        }
     }
 
     @Test

--- a/test/sql/test_iceberg/R/test_iceberg_collect_stats
+++ b/test/sql/test_iceberg/R/test_iceberg_collect_stats
@@ -120,25 +120,6 @@ None
 drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5 force;
 -- result:
 -- !result
-create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6 (
-    c1 decimal(10,3)
-) partition by truncate(c1, 50);
--- result:
--- !result
-insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6 values(1.23), (2.34), (3.45);
--- result:
--- !result
-[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6;
--- result:
-iceberg_collect_stats_2b0cc3e04eb5425f8ed5624f15534ba8.iceberg_collect_stats_db_2b0cc3e04eb5425f8ed5624f15534ba8.t6	analyze	status	OK
--- !result
-function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6', 'cardinality: 3')
--- result:
-None
--- !result
-drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6 force;
--- result:
--- !result
 drop database iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_iceberg/R/test_iceberg_collect_stats
+++ b/test/sql/test_iceberg/R/test_iceberg_collect_stats
@@ -120,6 +120,25 @@ None
 drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5 force;
 -- result:
 -- !result
+create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6 (
+    c1 decimal(10,3)
+) partition by truncate(c1, 50);
+-- result:
+-- !result
+insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6 values(1.23), (2.34), (3.45);
+-- result:
+-- !result
+[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6;
+-- result:
+iceberg_collect_stats_2b0cc3e04eb5425f8ed5624f15534ba8.iceberg_collect_stats_db_2b0cc3e04eb5425f8ed5624f15534ba8.t6	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6', 'cardinality: 3')
+-- result:
+None
+-- !result
+drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6 force;
+-- result:
+-- !result
 drop database iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_iceberg/R/test_iceberg_transformed_partition
+++ b/test/sql/test_iceberg/R/test_iceberg_transformed_partition
@@ -2,11 +2,203 @@
 create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
 -- result:
 -- !result
-function: assert_explain_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_identity_to_bucket_partition;","cardinality=1")
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_identity_to_bucket_partition;
+-- result:
+1	aa
+-- !result
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_identity_to_bucket_partition;
+-- result:
+iceberg_sql_test_9b5179fb8fe44ee0a352473d2bd47108.iceberg_ci_db.test_identity_to_bucket_partition	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_identity_to_bucket_partition;","cardinality=1", "ESTIMATE")
 -- result:
 None
 -- !result
-function: assert_explain_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.day_partition;","cardinality=1")
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.day_partition;
+-- result:
+1	2024-08-08 15:32:51.751000
+-- !result
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.day_partition;
+-- result:
+iceberg_sql_test_9b5179fb8fe44ee0a352473d2bd47108.iceberg_ci_db.day_partition	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.day_partition;","cardinality=1", "ESTIMATE")
+-- result:
+None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_date_add_bucket order by k1;
+-- result:
+1	sr	2025-01-01
+2	sr	2025-01-02
+3	sr	2025-01-03
+4	lake	2025-01-04
+5	lake	2025-01-05
+-- !result
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_date_add_bucket;
+-- result:
+iceberg_sql_test_9b5179fb8fe44ee0a352473d2bd47108.iceberg_ci_db.test_partition_date_add_bucket	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_date_add_bucket order by k1;","cardinality=5", "ESTIMATE")
+-- result:
+None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_ts_to_day order by k1;
+-- result:
+1	sr	2025-01-01 00:00:00
+2	sr	2025-01-01 02:00:00
+3	sr	2025-01-02 02:00:00
+-- !result
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_ts_to_day;
+-- result:
+iceberg_sql_test_9b5179fb8fe44ee0a352473d2bd47108.iceberg_ci_db.test_partition_ts_to_day	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_ts_to_day order by k1;","cardinality=3", "ESTIMATE")
+-- result:
+None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_month order by k1;
+-- result:
+1	sr	2025-01-01 00:00:00
+2	sr	2025-01-02 00:00:00
+3	sr	2025-01-03 00:00:00
+4	sr	2025-01-04 00:00:00
+5	sr	2025-01-05 00:00:00
+-- !result
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_month;
+-- result:
+iceberg_sql_test_9b5179fb8fe44ee0a352473d2bd47108.iceberg_ci_db.test_partition_day_to_month	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_month order by k1;","cardinality=7", "ESTIMATE")
+-- result:
+None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_month_to_year order by k1;
+-- result:
+1	sr	2025-01-01
+2	sr	2025-02-01
+3	sr	2025-03-01
+4	sr	2025-10-01
+5	sr	2026-08-01
+-- !result
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_month_to_year;
+-- result:
+iceberg_sql_test_9b5179fb8fe44ee0a352473d2bd47108.iceberg_ci_db.test_partition_month_to_year	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_month_to_year order by k1;","cardinality=7", "ESTIMATE")
+-- result:
+None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_bucket_drop_bucket order by k1;
+-- result:
+1	sr	2025-01-02 00:00:00
+2	sr	2025-01-03 00:00:00
+3	sr	2025-01-03 00:00:00
+4	sr	2025-01-04 00:00:00
+5	sr	2025-01-05 00:00:00
+6	sr	2025-01-02 00:00:00
+-- !result
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_bucket_drop_bucket;
+-- result:
+iceberg_sql_test_9b5179fb8fe44ee0a352473d2bd47108.iceberg_ci_db.test_partition_day_bucket_drop_bucket	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_bucket_drop_bucket order by k1;","cardinality=7", "ESTIMATE")
+-- result:
+None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_bucket order by k1;
+-- result:
+1	sr	2025-01-02 00:00:00
+2	sr	2025-01-03 00:00:00
+2	sr	2025-01-05 00:00:00
+3	sr	2025-01-05 00:00:00
+4	sr	2025-01-06 00:00:00
+-- !result
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_bucket;
+-- result:
+iceberg_sql_test_9b5179fb8fe44ee0a352473d2bd47108.iceberg_ci_db.test_partition_day_to_bucket	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_bucket order by k1;","cardinality=6", "ESTIMATE")
+-- result:
+None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_truncate order by k1;
+-- result:
+1	sr	2025-01-01 00:00:00
+2	sr	2025-01-02 00:00:00
+3	sr	2025-01-02 00:00:00
+4	lake	2025-01-02 00:00:00
+-- !result
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_truncate;
+-- result:
+iceberg_sql_test_9b5179fb8fe44ee0a352473d2bd47108.iceberg_ci_db.test_partition_day_to_truncate	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_truncate order by k1;","cardinality=8", "ESTIMATE")
+-- result:
+None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_drop_day order by k1;
+-- result:
+1	sr	2025-01-01 00:00:00
+2	sr	2025-01-02 00:00:00
+3	sr	2025-01-03 00:00:00
+4	sr	2025-01-04 00:00:00
+-- !result
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_drop_day;
+-- result:
+iceberg_sql_test_9b5179fb8fe44ee0a352473d2bd47108.iceberg_ci_db.test_partition_day_drop_day	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_drop_day order by k1;","cardinality=4", "ESTIMATE")
+-- result:
+None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_day_add_month order by k1;
+-- result:
+1	sr	2025-01-01 00:00:00
+2	sr	2025-01-02 00:00:00
+3	sr	2025-01-03 00:00:00
+4	sr	2025-01-04 00:00:00
+-- !result
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_day_add_month;
+-- result:
+iceberg_sql_test_9b5179fb8fe44ee0a352473d2bd47108.iceberg_ci_db.test_partition_drop_day_add_month	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_day_add_month order by k1;","cardinality=5", "ESTIMATE")
+-- result:
+None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_month_add_bucket order by k1;
+-- result:
+1	sr	2025-01-01
+2	sr	2025-01-02
+3	sr	2025-01-03
+4	sr	2025-01-04
+5	sr	2025-01-05
+-- !result
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_month_add_bucket;
+-- result:
+iceberg_sql_test_9b5179fb8fe44ee0a352473d2bd47108.iceberg_ci_db.test_partition_drop_month_add_bucket	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_month_add_bucket order by k1;","cardinality=7", "ESTIMATE")
+-- result:
+None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_bucket_add_truncate order by k1;
+-- result:
+1	sr	2025-01-01
+2	sr	2025-01-02
+3	sr	2025-01-03
+4	sr	2025-02-03
+5	sr	2025-02-05
+6	sr	2025-03-05
+7	sr	2025-03-07
+8	lake	2025-03-08
+9	lake	2025-05-08
+-- !result
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_bucket_add_truncate;
+-- result:
+iceberg_sql_test_9b5179fb8fe44ee0a352473d2bd47108.iceberg_ci_db.test_partition_drop_bucket_add_truncate	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_bucket_add_truncate order by k1;","cardinality=8", "ESTIMATE")
 -- result:
 None
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_collect_stats
+++ b/test/sql/test_iceberg/T/test_iceberg_collect_stats
@@ -64,6 +64,13 @@ insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5 
 function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5', 'cardinality: 2')
 drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5 force;
 
+create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6 (
+    c1 decimal(10,3)
+) partition by truncate(c1, 50);
+insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6 values(1.23), (2.34), (3.45);
+[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6;
+function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6', 'cardinality: 3')
+drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6 force;
 
 drop database iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0};
 drop catalog iceberg_collect_stats_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_collect_stats
+++ b/test/sql/test_iceberg/T/test_iceberg_collect_stats
@@ -64,14 +64,6 @@ insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5 
 function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5', 'cardinality: 2')
 drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t5 force;
 
-create table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6 (
-    c1 decimal(10,3)
-) partition by truncate(c1, 50);
-insert into iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6 values(1.23), (2.34), (3.45);
-[UC] analyze table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6;
-function: assert_explain_costs_contains('select * from iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6', 'cardinality: 3')
-drop table iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0}.t6 force;
-
 drop database iceberg_collect_stats_${uuid0}.iceberg_collect_stats_db_${uuid0};
 drop catalog iceberg_collect_stats_${uuid0};
 

--- a/test/sql/test_iceberg/T/test_iceberg_transformed_partition
+++ b/test/sql/test_iceberg/T/test_iceberg_transformed_partition
@@ -2,7 +2,57 @@
 
 create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
 
-function: assert_explain_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_identity_to_bucket_partition;","cardinality=1")
-function: assert_explain_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.day_partition;","cardinality=1")
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_identity_to_bucket_partition;
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_identity_to_bucket_partition;
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_identity_to_bucket_partition;","cardinality=1", "ESTIMATE")
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.day_partition;
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.day_partition;
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.day_partition;","cardinality=1", "ESTIMATE")
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_date_add_bucket order by k1;
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_date_add_bucket;
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_date_add_bucket order by k1;","cardinality=5", "ESTIMATE")
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_ts_to_day order by k1;
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_ts_to_day;
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_ts_to_day order by k1;","cardinality=3", "ESTIMATE")
+
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_month order by k1;
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_month;
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_month order by k1;","cardinality=7", "ESTIMATE")
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_month_to_year order by k1;
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_month_to_year;
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_month_to_year order by k1;","cardinality=7", "ESTIMATE")
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_bucket_drop_bucket order by k1;
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_bucket_drop_bucket;
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_bucket_drop_bucket order by k1;","cardinality=7", "ESTIMATE")
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_bucket order by k1;
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_bucket;
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_bucket order by k1;","cardinality=6", "ESTIMATE")
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_truncate order by k1;
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_truncate;
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_to_truncate order by k1;","cardinality=8", "ESTIMATE")
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_drop_day order by k1;
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_drop_day;
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_day_drop_day order by k1;","cardinality=4", "ESTIMATE")
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_day_add_month order by k1;
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_day_add_month;
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_day_add_month order by k1;","cardinality=5", "ESTIMATE")
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_month_add_bucket order by k1;
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_month_add_bucket;
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_month_add_bucket order by k1;","cardinality=7", "ESTIMATE")
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_bucket_add_truncate order by k1;
+[UC] analyze table iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_bucket_add_truncate;
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_partition_drop_bucket_add_truncate order by k1;","cardinality=8", "ESTIMATE")
 
 drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request introduces several enhancements and refactors around Iceberg table partition handling, particularly improving how partition names and predicates are generated and utilized for statistics collection. The main focus is on supporting partition evolution, ensuring correct predicate generation for statistics queries, and skipping unsupported default partitions.

Partition handling and evolution:

* Refactored `convertIcebergPartitionToPartitionName` to use the full active partition type from the Iceberg table, supporting partition evolution and ensuring correct partition name generation. 

Statistics collection improvements:

* Statistics collection jobs now skip the default Iceberg partition (`ICEBERG_DEFAULT_PARTITION`), as predicates cannot be generated for it.

Partition predicate and transform support:

* Improved transform support checks to operate on `PartitionField` rather than column name, simplifying logic and error handling.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable stats collection on Iceberg tables with partition evolution by generating correct partition names/predicates, carrying specId, and skipping default partitions.
> 
> - **Iceberg partition handling**:
>   - Refactor `PartitionUtil.convertIcebergPartitionToPartitionName` to take `Table`, `PartitionSpec`, and `StructProjection`, using `Partitioning.partitionType(...)` to build names compatible with partition evolution.
>   - Update call site in `IcebergCatalog`.
> - **Partition metadata**:
>   - Add `specId` to `connector.iceberg.Partition` with getter and new constructor; `IcebergCatalog` now records `specId` from metadata rows.
> - **Stats collection (ExternalFullStatisticsCollectJob)**:
>   - Skip `ICEBERG_DEFAULT_PARTITION` for Iceberg.
>   - Generate predicates per-partition using `IcebergPartitionTraits`, `PartitionSpec`, and `PartitionField`; support identity/year/month/day/hour/bucket/truncate; avoid normalizing Iceberg partition names.
> - **API adjustments in utils**:
>   - Change `IcebergPartitionUtils.toPartitionRange` and `convertPartitionTransformToPredicate` to accept `PartitionField`; update all callers (including predicate expr builder).
> - **Tests**:
>   - Adapt unit tests to new partition-name API using `StructProjection` and mocked `Partitioning`.
>   - Add/expand SQL tests for transformed partitions and stats collection (including decimal truncate).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ef6d528928e2bd84aae8922d74e73e7cb3c533c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->