### PR TITLE
[Tool] revert perl module again due to build break

### DIFF
--- a/docker/dockerfiles/toolchains/toolchains-centos7.Dockerfile
+++ b/docker/dockerfiles/toolchains/toolchains-centos7.Dockerfile
@@ -76,7 +76,6 @@ LABEL com.starrocks.commit=${COMMIT_ID}
 RUN yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && yum install -y gh && \
         yum install -y ${EPEL_RPM_URL} && yum install -y wget unzip bzip2 patch bison byacc flex autoconf automake make \
         libtool which git ccache binutils-devel python3 file less psmisc \
-        perl-IPC-Cmd perl-Time-Piece && \
         localedef --no-archive -i en_US -f UTF-8 en_US.UTF-8 && \
         yum clean all && rm -rf /var/cache/yum
 


### PR DESCRIPTION
* introduced additional `*-devel` packages which pollutes the build env.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
