### PR TITLE
[BugFix] Consider minRetainVersion when full vacuum for partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
@@ -206,6 +206,9 @@ public class FullVacuumDaemon extends FrontendDaemon implements Writable {
         }
         long minCheckVersion = 0;
         long maxCheckVersion = visibleVersion; // always should be inited by current visibleVersion
+        if (partition.getMinRetainVersion() > 0) {
+            maxCheckVersion = Math.min(maxCheckVersion, partition.getMinRetainVersion());
+        }
         vacuumFullRequest.setMinCheckVersion(minCheckVersion);
         vacuumFullRequest.setMaxCheckVersion(maxCheckVersion);
         vacuumFullRequest.setRetainVersions(retainVersions);


### PR DESCRIPTION
## What I'm doing:
In current full vacuum implementation, the vacuumable version range is [minCheckVersion, maxCheckVersion), and maxCheckVersion is always the visible version and does not consider the minRetainVersion. In this pr, we will consider the minRetainVersion when full vacuum for partition by modifying the maxCheckVersion to the min of visible version and partition's minRetainVersion.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
