### PR TITLE
[BugFix] Ensure be not crashed even if agg_func is null

### DIFF
--- a/be/src/storage/aggregate_iterator.cpp
+++ b/be/src/storage/aggregate_iterator.cpp
@@ -62,8 +62,9 @@ public:
         RETURN_IF_ERROR(ChunkIterator::init_encoded_schema(dict_maps));
         RETURN_IF_ERROR(_child->init_encoded_schema(dict_maps));
         _curr_chunk = ChunkHelper::new_chunk(encoded_schema(), _chunk_size);
-        _aggregator = std::make_unique<ChunkAggregator>(&encoded_schema(), _chunk_size, _pre_aggregate_factor / 100,
-                                                        _is_vertical_merge, _is_key);
+        ASSIGN_OR_RETURN(_aggregator,
+                         ChunkAggregator::create(&encoded_schema(), _chunk_size, _pre_aggregate_factor / 100,
+                                                 _is_vertical_merge, _is_key));
         return Status::OK();
     }
 
@@ -71,8 +72,9 @@ public:
         RETURN_IF_ERROR(ChunkIterator::init_output_schema(unused_output_column_ids));
         RETURN_IF_ERROR(_child->init_output_schema(unused_output_column_ids));
         _curr_chunk = ChunkHelper::new_chunk(output_schema(), _chunk_size);
-        _aggregator = std::make_unique<ChunkAggregator>(&output_schema(), _chunk_size, _pre_aggregate_factor / 100,
-                                                        _is_vertical_merge, _is_key);
+        ASSIGN_OR_RETURN(_aggregator,
+                         ChunkAggregator::create(&output_schema(), _chunk_size, _pre_aggregate_factor / 100,
+                                                 _is_vertical_merge, _is_key));
         return Status::OK();
     }
 

--- a/be/src/storage/chunk_aggregator.cpp
+++ b/be/src/storage/chunk_aggregator.cpp
@@ -70,6 +70,7 @@ Status ChunkAggregator::prepare() {
         ASSIGN_OR_RETURN(auto aggregator, ColumnAggregatorFactory::create_value_column_aggregator(_schema->field(i)));
         _column_aggregator.emplace_back(std::move(aggregator));
     }
+    aggregate_reset();
     return Status::OK();
 }
 

--- a/be/src/storage/chunk_aggregator.h
+++ b/be/src/storage/chunk_aggregator.h
@@ -32,12 +32,24 @@ private:
                     bool is_vertical_merge, bool is_key);
 
 public:
-    ChunkAggregator(const Schema* schema, uint32_t reserve_rows, uint32_t max_aggregate_rows, double factor);
+    explicit ChunkAggregator(const Schema* schema, uint32_t reserve_rows, uint32_t max_aggregate_rows, double factor);
 
-    ChunkAggregator(const Schema* schema, uint32_t max_aggregate_rows, double factor);
+    explicit ChunkAggregator(const Schema* schema, uint32_t max_aggregate_rows, double factor);
 
-    ChunkAggregator(const Schema* schema, uint32_t max_aggregate_rows, double factor, bool is_vertical_merge,
-                    bool is_key);
+    explicit ChunkAggregator(const Schema* schema, uint32_t max_aggregate_rows, double factor, bool is_vertical_merge,
+                             bool is_key);
+
+    Status prepare();
+
+    static StatusOr<std::unique_ptr<ChunkAggregator>> create(const Schema* schema, uint32_t reserve_rows,
+                                                             uint32_t max_aggregate_rows, double factor);
+    static StatusOr<std::unique_ptr<ChunkAggregator>> create(const Schema* schema, uint32_t reserve_rows,
+                                                             uint32_t max_aggregate_rows, double factor,
+                                                             bool is_vertical_merge, bool is_key);
+    static StatusOr<std::unique_ptr<ChunkAggregator>> create(const Schema* schema, uint32_t max_aggregate_rows,
+                                                             double factor);
+    static StatusOr<std::unique_ptr<ChunkAggregator>> create(const Schema* schema, uint32_t max_aggregate_rows,
+                                                             double factor, bool is_vertical_merge, bool is_key);
 
     void update_source(ChunkPtr& chunk) { update_source(chunk, nullptr); }
     // |source_masks| is used if |_is_vertical_merge| is true.

--- a/be/src/storage/column_aggregate_func.cpp
+++ b/be/src/storage/column_aggregate_func.cpp
@@ -14,10 +14,14 @@
 
 #include "storage/column_aggregate_func.h"
 
+#include <fmt/format.h>
+
 #include "column/array_column.h"
 #include "column/map_column.h"
 #include "column/struct_column.h"
 #include "column/vectorized_fwd.h"
+#include "common/status.h"
+#include "common/statusor.h"
 #include "exprs/agg/aggregate.h"
 #include "exprs/agg/aggregate_state_allocator.h"
 #include "exprs/agg/combinator/agg_state_union.h"
@@ -424,12 +428,12 @@ ColumnAggregatorPtr ColumnAggregatorFactory::create_key_column_aggregator(const 
     }
 }
 
-ColumnAggregatorPtr ColumnAggregatorFactory::create_value_column_aggregator(const starrocks::FieldPtr& field) {
+StatusOr<ColumnAggregatorPtr> ColumnAggregatorFactory::create_value_column_aggregator(
+        const starrocks::FieldPtr& field) {
     LogicalType type = field->type()->type();
     starrocks::StorageAggregateType method = field->aggregate_method();
     if (method == STORAGE_AGGREGATE_NONE) {
-        CHECK(false) << "bad agg method NONE for column: " << field->name();
-        return nullptr;
+        return Status::InternalError(fmt::format("Bad agg method NONE for column: {}", field->name()));
     } else if (method == STORAGE_AGGREGATE_REPLACE) {
         auto p = create_value_aggregator(type, method);
         if (field->is_nullable()) {
@@ -446,17 +450,21 @@ ColumnAggregatorPtr ColumnAggregatorFactory::create_value_column_aggregator(cons
         }
     } else if (method == STORAGE_AGGREGATE_AGG_STATE_UNION) {
         if (field->get_agg_state_desc() == nullptr) {
-            CHECK(false) << "Bad agg state union method for column: " << field->name()
-                         << " for its agg state type is null";
-            return nullptr;
+            return Status::InternalError(
+                    fmt::format("Bad agg state union method for column: {} "
+                                "for its agg state type is null",
+                                field->name()));
         }
         auto* agg_state_desc = field->get_agg_state_desc();
         auto func_name = agg_state_desc->get_func_name();
         DCHECK_EQ(field->is_nullable(), agg_state_desc->is_result_nullable());
         auto* agg_func = AggStateDesc::get_agg_state_func(agg_state_desc);
-        CHECK(agg_func != nullptr) << "Unknown aggregate function, name=" << func_name << ", type=" << type
-                                   << ", is_nullable=" << field->is_nullable()
-                                   << ", agg_state_desc=" << agg_state_desc->debug_string();
+        if (agg_func == nullptr) {
+            return Status::InternalError(
+                    fmt::format("Unknown aggregate function, name={}, type={}, "
+                                "is_nullable={}, agg_state_desc={}",
+                                func_name, type, field->is_nullable(), agg_state_desc->debug_string()));
+        }
         auto agg_state_union = std::make_unique<AggStateUnion>(*agg_state_desc, agg_func);
         return std::make_unique<AggFuncBasedValueAggregator>(agg_state_desc, std::move(agg_state_union));
     } else {
@@ -480,8 +488,10 @@ ColumnAggregatorPtr ColumnAggregatorFactory::create_value_column_aggregator(cons
 
         auto agg_func = AggregateFuncResolver::instance()->get_aggregate_info(func_name, normalized_tpe, normalized_tpe,
                                                                               false, field->is_nullable());
-        CHECK(agg_func != nullptr) << "Unknown aggregate function, name=" << func_name << ", type=" << type
-                                   << ", is_nullable=" << field->is_nullable();
+        if (agg_func == nullptr) {
+            return Status::InternalError(fmt::format("Unknown aggregate function, name={}, type={}, is_nullable={}",
+                                                     func_name, type, field->is_nullable()));
+        }
         return std::make_unique<AggFuncBasedValueAggregator>(agg_func);
     }
 }

--- a/be/src/storage/column_aggregate_func.h
+++ b/be/src/storage/column_aggregate_func.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "column/field.h"
+#include "common/statusor.h"
 #include "runtime/memory/mem_hook_allocator.h"
 #include "storage/column_aggregator.h"
 
@@ -24,7 +25,7 @@ static MemHookAllocator kDefaultColumnAggregatorAllocator = MemHookAllocator{};
 class ColumnAggregatorFactory {
 public:
     static ColumnAggregatorPtr create_key_column_aggregator(const FieldPtr& field);
-    static ColumnAggregatorPtr create_value_column_aggregator(const FieldPtr& field);
+    static StatusOr<ColumnAggregatorPtr> create_value_column_aggregator(const FieldPtr& field);
 };
 
 } // namespace starrocks

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -467,17 +467,18 @@ Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t 
     if (_mem_tracker->limit_exceeded()) {
         VLOG(2) << "Flushing memory table due to memory limit exceeded";
         st = _flush_memtable();
+        RETURN_IF_ERROR(_reset_mem_table());
     } else if (_mem_tracker->parent() && _mem_tracker->parent()->limit_exceeded()) {
         VLOG(2) << "Flushing memory table due to parent memory limit exceeded";
         st = _flush_memtable();
+        RETURN_IF_ERROR(_reset_mem_table());
     } else if (full) {
         st = flush_memtable_async();
         ADD_COUNTER_RELAXED(_stats.memtable_full_count, 1);
+        RETURN_IF_ERROR(_reset_mem_table());
     }
     if (!st.ok()) {
         _set_state(kAborted, st);
-    } else {
-        st = _reset_mem_table();
     }
     return st;
 }

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -439,7 +439,7 @@ Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t 
                     "memory limit exceeded, please reduce load frequency or increase config "
                     "`load_process_max_memory_hard_limit_ratio` or add more BE nodes");
         }
-        _reset_mem_table();
+        RETURN_IF_ERROR(_reset_mem_table());
     }
     auto state = get_state();
     if (state != kWriting) {
@@ -467,18 +467,17 @@ Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t 
     if (_mem_tracker->limit_exceeded()) {
         VLOG(2) << "Flushing memory table due to memory limit exceeded";
         st = _flush_memtable();
-        _reset_mem_table();
     } else if (_mem_tracker->parent() && _mem_tracker->parent()->limit_exceeded()) {
         VLOG(2) << "Flushing memory table due to parent memory limit exceeded";
         st = _flush_memtable();
-        _reset_mem_table();
     } else if (full) {
         st = flush_memtable_async();
-        _reset_mem_table();
         ADD_COUNTER_RELAXED(_stats.memtable_full_count, 1);
     }
     if (!st.ok()) {
         _set_state(kAborted, st);
+    } else {
+        st = _reset_mem_table();
     }
     return st;
 }
@@ -685,7 +684,7 @@ Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTa
     return Status::OK();
 }
 
-void DeltaWriter::_reset_mem_table() {
+Status DeltaWriter::_reset_mem_table() {
     if (!_schema_initialized) {
         _vectorized_schema = MemTable::convert_schema(_tablet_schema, _opt.slots);
         _schema_initialized = true;
@@ -697,8 +696,10 @@ void DeltaWriter::_reset_mem_table() {
         _mem_table = std::make_unique<MemTable>(_tablet->tablet_id(), &_vectorized_schema, _opt.slots,
                                                 _mem_table_sink.get(), "", _mem_tracker);
     }
+    RETURN_IF_ERROR(_mem_table->prepare());
     _mem_table->set_write_buffer_row(_memtable_buffer_row);
     _write_buffer_size = _mem_table->write_buffer_size();
+    return Status::OK();
 }
 
 Status DeltaWriter::commit() {

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -249,7 +249,7 @@ private:
 
     void _garbage_collection();
 
-    void _reset_mem_table();
+    Status _reset_mem_table();
 
     void _set_state(State state, const Status& st);
 

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -359,6 +359,7 @@ inline Status DeltaWriterImpl::reset_memtable() {
         _mem_table = std::make_unique<MemTable>(_tablet_id, &_write_schema_for_mem_table, _mem_table_sink.get(),
                                                 _max_buffer_size, _mem_tracker);
     }
+    RETURN_IF_ERROR(_mem_table->prepare());
     _mem_table->set_write_buffer_row(_max_buffer_rows);
     return Status::OK();
 }

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -69,13 +69,14 @@ Schema MemTable::convert_schema(const TabletSchemaCSPtr& tablet_schema,
     }
 }
 
-void MemTable::_init_aggregator_if_needed() {
+Status MemTable::prepare() {
     if (_keys_type != KeysType::DUP_KEYS) {
         // The ChunkAggregator used by MemTable may be used to aggregate into a large Chunk,
         // which is not suitable for obtaining Chunk from ColumnPool,
         // otherwise it will take up a lot of memory and may not be released.
-        _aggregator = std::make_unique<ChunkAggregator>(_vectorized_schema, 0, INT_MAX, 0);
+        ASSIGN_OR_RETURN(_aggregator, ChunkAggregator::create(_vectorized_schema, 0, INT_MAX, 0));
     }
+    return Status::OK();
 }
 
 MemTable::MemTable(int64_t tablet_id, const Schema* schema, const std::vector<SlotDescriptor*>* slot_descs,
@@ -92,7 +93,6 @@ MemTable::MemTable(int64_t tablet_id, const Schema* schema, const std::vector<Sl
         _slot_descs->back()->col_name() == LOAD_OP_COLUMN) {
         _has_op_slot = true;
     }
-    _init_aggregator_if_needed();
 }
 
 MemTable::MemTable(int64_t tablet_id, const Schema* schema, const std::vector<SlotDescriptor*>* slot_descs,
@@ -108,7 +108,6 @@ MemTable::MemTable(int64_t tablet_id, const Schema* schema, const std::vector<Sl
         _slot_descs->back()->col_name() == LOAD_OP_COLUMN) {
         _has_op_slot = true;
     }
-    _init_aggregator_if_needed();
 }
 
 MemTable::MemTable(int64_t tablet_id, const Schema* schema, MemTableSink* sink, int64_t max_buffer_size,
@@ -120,9 +119,7 @@ MemTable::MemTable(int64_t tablet_id, const Schema* schema, MemTableSink* sink, 
           _sink(sink),
           _aggregator(nullptr),
           _max_buffer_size(max_buffer_size),
-          _mem_tracker(mem_tracker) {
-    _init_aggregator_if_needed();
-}
+          _mem_tracker(mem_tracker) {}
 
 MemTable::~MemTable() = default;
 

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -84,6 +84,9 @@ public:
 
     ~MemTable();
 
+    // prepare the memtable for writing which must be called before writing any data
+    Status prepare();
+
     int64_t tablet_id() const { return _tablet_id; }
 
     // the total memory used (contain tmp chunk and aggregator chunk)
@@ -121,7 +124,6 @@ private:
     Status _sort_column_inc(bool by_sort_key = false);
     void _append_to_sorted_chunk(Chunk* src, Chunk* dest, bool is_final);
 
-    void _init_aggregator_if_needed();
     void _aggregate(bool is_final);
 
     Status _split_upserts_deletes(ChunkPtr& src, ChunkPtr* upserts, MutableColumnPtr* deletes);

--- a/be/test/storage/chunk_aggregator_test.cpp
+++ b/be/test/storage/chunk_aggregator_test.cpp
@@ -21,6 +21,7 @@
 
 #include "column/column_helper.h"
 #include "storage/column_aggregate_func.h"
+#include "testutil/assert.h"
 
 namespace starrocks {
 
@@ -40,6 +41,7 @@ TEST(ChunkAggregatorTest, testNoneAggregator) {
     SchemaPtr schema = std::make_shared<Schema>(fields);
 
     ChunkAggregator aggregator(schema.get(), 1024, 0.9);
+    ASSERT_OK(aggregator.prepare());
 
     ASSERT_EQ(true, aggregator.source_exhausted());
 
@@ -89,7 +91,7 @@ TEST(ChunkAggregatorTest, testNonKeyColumnsByMask) {
     SchemaPtr schema = std::make_shared<Schema>(fields);
 
     ChunkAggregator aggregator(schema.get(), 1024, 0, true, false);
-
+    ASSERT_OK(aggregator.prepare());
     ASSERT_EQ(true, aggregator.source_exhausted());
 
     auto v_col = Int32Column::create();

--- a/be/test/storage/column_aggregator_test.cpp
+++ b/be/test/storage/column_aggregator_test.cpp
@@ -29,7 +29,7 @@ TEST(ColumnAggregator, testIntSum) {
     FieldPtr field = std::make_shared<Field>(1, "test", LogicalType::TYPE_INT, false);
     field->set_aggregate_method(StorageAggregateType::STORAGE_AGGREGATE_SUM);
 
-    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field).value();
 
     Int32Column::Ptr src1 = Int32Column::create();
     Int32Column::Ptr src2 = Int32Column::create();
@@ -92,7 +92,7 @@ TEST(ColumnAggregator, testNullIntSum) {
     FieldPtr field = std::make_shared<Field>(1, "test", LogicalType::TYPE_INT, true);
     field->set_aggregate_method(StorageAggregateType::STORAGE_AGGREGATE_SUM);
 
-    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field).value();
 
     Int32Column::Ptr src1 = Int32Column::create();
     auto null1 = NullColumn ::create();
@@ -198,7 +198,7 @@ TEST(ColumnAggregator, testIntMax) {
     FieldPtr field = std::make_shared<Field>(1, "test", LogicalType::TYPE_INT, false);
     field->set_aggregate_method(StorageAggregateType::STORAGE_AGGREGATE_MAX);
 
-    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field).value();
 
     Int32Column::Ptr src1 = Int32Column::create();
     Int32Column::Ptr src2 = Int32Column::create();
@@ -261,7 +261,7 @@ TEST(ColumnAggregator, testStringMin) {
     FieldPtr field = std::make_shared<Field>(1, "test", LogicalType::TYPE_VARCHAR, false);
     field->set_aggregate_method(StorageAggregateType::STORAGE_AGGREGATE_MIN);
 
-    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field).value();
 
     BinaryColumn::Ptr src1 = BinaryColumn::create();
     BinaryColumn::Ptr src2 = BinaryColumn::create();
@@ -325,7 +325,7 @@ TEST(ColumnAggregator, testNullBooleanMin) {
     field->set_aggregate_method(StorageAggregateType::STORAGE_AGGREGATE_MIN);
 
     NullableColumn::Ptr agg = NullableColumn::create(BooleanColumn::create(), NullColumn::create());
-    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field).value();
     aggregator->update_aggregate(agg.get());
     std::vector<uint32_t> loops;
 
@@ -387,7 +387,7 @@ TEST(ColumnAggregator, testNullIntReplaceIfNotNull) {
     FieldPtr field = std::make_shared<Field>(1, "test", LogicalType::TYPE_INT, true);
     field->set_aggregate_method(StorageAggregateType::STORAGE_AGGREGATE_REPLACE_IF_NOT_NULL);
 
-    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field).value();
 
     Int32Column::Ptr src1 = Int32Column::create();
     auto null1 = NullColumn ::create();
@@ -494,7 +494,7 @@ TEST(ColumnAggregator, testNullIntReplace) {
     FieldPtr field = std::make_shared<Field>(1, "test", LogicalType::TYPE_INT, true);
     field->set_aggregate_method(StorageAggregateType::STORAGE_AGGREGATE_REPLACE);
 
-    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field).value();
 
     Int32Column::Ptr src1 = Int32Column::create();
     auto null1 = NullColumn ::create();
@@ -609,7 +609,7 @@ TEST(ColumnAggregator, testArrayReplace) {
     UInt32Column::Ptr agg_offsets = UInt32Column::create();
     ArrayColumn::Ptr agg = ArrayColumn::create(std::move(agg_elements), std::move(agg_offsets));
 
-    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field).value();
     aggregator->update_aggregate(agg.get());
     std::vector<uint32_t> loops;
 
@@ -689,7 +689,7 @@ TEST(ColumnAggregator, testNullArrayReplaceIfNotNull2) {
             ArrayColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
                                 UInt32Column::create()),
             NullColumn::create());
-    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field).value();
     aggregator->update_aggregate(agg.get());
 
     // first chunk column
@@ -767,7 +767,7 @@ TEST(ColumnAggregator, testNullArrayReplaceIfNotNull) {
             ArrayColumn::create(NullableColumn::create(BinaryColumn::create(), NullColumn::create()),
                                 UInt32Column::create()),
             NullColumn::create());
-    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field).value();
     aggregator->update_aggregate(agg.get());
     std::vector<uint32_t> loops;
 

--- a/be/test/storage/memtable_flush_executor_test.cpp
+++ b/be/test/storage/memtable_flush_executor_test.cpp
@@ -274,6 +274,7 @@ TEST_F(MemTableFlushExecutorTest, testMemtableFlush) {
     const string path = "./MemTableFlushExecutorTest_testDupKeysInsertFlushRead";
     MySetUp("pk int,name varchar,pv int", "pk int,name varchar,pv int", 1, KeysType::DUP_KEYS, path);
     auto mem_table = make_unique<MemTable>(1, &_vectorized_schema, _slots, _mem_table_sink.get(), _mem_tracker.get());
+    ASSERT_TRUE(mem_table->prepare().ok());
     auto mem_table_flush_executor = make_unique<MemTableFlushExecutor>();
 
     std::vector<DataDir*> data_dirs = {nullptr, nullptr};
@@ -304,6 +305,7 @@ TEST_F(MemTableFlushExecutorTest, testMemtableFlushWithSeg) {
     const string path = "./MemTableFlushExecutorTest_testMemtableFlushWithSeg";
     MySetUp("pk int,name varchar,pv int", "pk int,name varchar,pv int", 1, KeysType::DUP_KEYS, path);
     auto mem_table = make_unique<MemTable>(1, &_vectorized_schema, _slots, _mem_table_sink.get(), _mem_tracker.get());
+    ASSERT_TRUE(mem_table->prepare().ok());
     auto mem_table_flush_executor = make_unique<MemTableFlushExecutor>();
 
     std::vector<DataDir*> data_dirs = {nullptr, nullptr};

--- a/be/test/storage/memtable_test.cpp
+++ b/be/test/storage/memtable_test.cpp
@@ -227,6 +227,7 @@ public:
         _vectorized_schema = MemTable::convert_schema(_schema, _slots);
         _mem_table =
                 std::make_unique<MemTable>(1, &_vectorized_schema, _slots, _mem_table_sink.get(), _mem_tracker.get());
+        ASSERT_TRUE(_mem_table->prepare().ok());
     }
 
     void TearDown() override {


### PR DESCRIPTION
## Why I'm doing:
```
F20251027 04:50:28.633571 48009975011072 column_aggregate_func.cpp:483] Check failed: agg_func != nullptr Unknown aggregate function, name=sum, type=51, is_nullable=1
main RELEASE (build 95e7862 distro centos arch x86_64)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000
F20251027 04:50:28.633596 48013710276352 column_aggregate_func.cpp:483] Check failed: agg_func != nullptr Unknown aggregate function, name=sum, type=51, is_nullable=1F20251027 04:50:28.633679 48013714478848 column_aggregate_func.cpp:483] Check failed: agg_func != nullptr Unknown aggregate function, name=sum, type=51, is_nullable=1
F00000000 00:00:00.000000 48013714478848 logging.cc:1962] RAW: Check data_->num_chars_to_log_ > 0 && data_->message_text_[data_->num_chars_to_log_ - 1] == '\n' failed:
[1761511828.633][thread: 48009975011072] je_mallctl execute purge success
[1761511828.633][thread: 48013710276352] je_mallctl execute purge success
[1761511828.633][thread: 48013714478848] je_mallctl execute purge success
[1761511828.633][thread: 48009975011072] je_mallctl execute dontdump success
*** Aborted at 1761511828 (unix time) try "date -d @1761511828" if you are using GNU date ***
PC: @     0x2baa22d4d387 __GI_raise
*** SIGABRT (@0x3e800000c94) received by PID 3220 (TID 0x2baa31819700) LWP(3337) from PID 3220; stack trace: ***
    @     0x2baa2094320b __pthread_once_slow
[1761511828.633][thread: 48013710276352] je_mallctl execute dontdump success
[1761511828.633][thread: 48013714478848] je_mallctl execute dontdump success
    @          0xdff1714 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x2baa2094c630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @     0x2baa22d4d387 __GI_raise
    @     0x2baa22d4ea78 __GI_abort
    @          0x8ab4783 starrocks::failure_function()
    @          0xdfe650a google::LogMessage::Fail()
    @          0xdfe7f44 google::LogMessageFatal::~LogMessageFatal()
    @          0x7e1ee14 starrocks::ColumnAggregatorFactory::create_value_column_aggregator(std::shared_ptr<starrocks::Field> const&)
    @          0x7490886 starrocks::ChunkAggregator::ChunkAggregator(starrocks::Schema const*, unsigned int, unsigned int, double, bool, bool)
    @          0x7491ac4 starrocks::MemTable::_init_aggregator_if_needed() [clone .part.0]
    @          0x7492918 starrocks::MemTable::MemTable(long, starrocks::Schema const*, std::vector<starrocks::SlotDescriptor*, std::allocator<starrocks::SlotDescriptor*> > const*, starrocks::MemTableSink*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<cha@
    @          0x7e38c27 starrocks::DeltaWriter::_reset_mem_table()
    @          0x7e3bb8c starrocks::DeltaWriter::write(starrocks::Chunk const&, unsigned int const*, unsigned int, unsigned int)
    @          0xa99423a starrocks::AsyncDeltaWriter::_execute(void*, bthread::TaskIterator<starrocks::AsyncDeltaWriter::Task>&)
    @          0xe1c0bec bthread::ExecutionQueueBase::_execute(bthread::TaskNode*, bool, int*)
    @          0xe1c1c07 bthread::ExecutionQueueBase::_execute_tasks(void*)
    @          0x82eb248 starrocks::ThreadPool::dispatch_thread()
    @          0x82e1cf0 starrocks::Thread::supervise_thread(void*)
    @     0x2baa20944ea5 start_thread
    @     0x2baa22e15b0d __clone

```
## What I'm doing:
- Ensure be not crashed even if agg_func is null.

Fixes https://github.com/StarRocks/StarRocksTest/issues/10488

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
