### PR TITLE
[BugFix] fix the profile page copy&download

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/action/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/QueryProfileAction.java
@@ -161,62 +161,27 @@ public class QueryProfileAction extends WebBaseAction {
     }
 
     private void appendButtons(StringBuilder buffer) {
-        // Add external CSS and JavaScript files for collapsible profile viewer
+        // Add external CSS and JavaScript files
         buffer.append("<link rel=\"stylesheet\" href=\"/static?res=collapsible-profile.css\">");
         buffer.append("<script type=\"text/javascript\" src=\"/static?res=collapsible-profile.js\"></script>");
+        buffer.append("<script type=\"text/javascript\" src=\"/static?res=profile-buttons.js\"></script>");
 
-        // Original button functions
+        // Define global variable for original content
         buffer.append("<script type=\"text/javascript\">\n" +
-                "function viewProfile() {\n" +
-                "  const params = new URLSearchParams(window.location.search);\n" +
-                "  const query_id = params.get('query_id');\n" +
-                "  window.location.href = '/query_profile?query_id=' + query_id + '&content_type=profile';\n" +
-                "}" + "</script>");
-        buffer.append("<script type=\"text/javascript\">\n" +
-                "function formattedSql() {\n" +
-                "  const params = new URLSearchParams(window.location.search);\n" +
-                "  const query_id = params.get('query_id');\n" +
-                "  window.location.href = '/query_profile?query_id=' + query_id + '&content_type=sql';\n" +
-                "}" + "</script>");
-        buffer.append("<script type=\"text/javascript\">\n" +
-                "function analyzeProfile() {\n" +
-                "  const params = new URLSearchParams(window.location.search);\n" +
-                "  const query_id = params.get('query_id');\n" +
-                "  window.location.href = '/query_profile?query_id=' + query_id + '&content_type=analyze';\n" +
-                "}" + "</script>");
-        buffer.append("<script type=\"text/javascript\">\n" +
-                "function copy(){\n" +
-                "  v = $('#profile').html()\n" +
-                "  const t = document.createElement('textarea')\n" +
-                "  t.style.cssText = 'position: absolute;top:0;left:0;opacity:0'\n" +
-                "  document.body.appendChild(t)\n" +
-                "  t.value = v\n" +
-                "  t.select()\n" +
-                "  document.execCommand('copy')\n" +
-                "  document.body.removeChild(t)\n" +
-                "}\n" +
+                "// Global variable to store original profile content\n" +
+                "var originalProfileContent = '';\n" +
                 "</script>");
-        buffer.append("<script type=\"text/javascript\">\n" +
-                "function download() {\n" +
-                "  content = $('#profile').html()\n" +
-                "  const file = new Blob([content], { type: \"text/plain\" });\n" +
-                "  const params = new URLSearchParams(window.location.search);\n" +
-                "  const query_id = params.get('query_id');\n" +
-                "  const a = document.createElement('a');\n" +
-                "  a.href = URL.createObjectURL(file);\n" +
-                "  a.download = query_id + \"profile.txt\";\n" +
-                "  a.click();\n" +
-                "\n" +
-                "  URL.revokeObjectURL(a.href);\n" +
-                "}" + "</script>");
         
-        // Add new buttons for collapsible functionality
-        buffer.append("<input type=\"button\" onclick=\"viewProfile();\" value=\"View Profile\"></input>");
-        buffer.append("<input type=\"button\" onclick=\"formattedSql();\" value=\"Formatted SQL\"></input>");
-        buffer.append("<input type=\"button\" onclick=\"analyzeProfile();\" value=\"Analyze Profile\"></input>");
-        buffer.append("<input type=\"button\" onclick=\"expandAll();\" value=\"Expand All\"></input>");
-        buffer.append("<input type=\"button\" onclick=\"collapseAll();\" value=\"Collapse All\"></input>");
-        buffer.append("<input type=\"button\" onclick=\"copy();\" value=\"Copy\"></input>");
-        buffer.append("<input type=\"button\" onclick=\"download();\" value=\"Download\"></input>");
+        // Load button HTML template
+        buffer.append("<div id=\"profile-buttons-container\"></div>");
+        buffer.append("<script type=\"text/javascript\">\n" +
+                "// Load button HTML template\n" +
+                "fetch('/static?res=profile-buttons.html')\n" +
+                "  .then(response => response.text())\n" +
+                "  .then(html => {\n" +
+                "    document.getElementById('profile-buttons-container').innerHTML = html;\n" +
+                "  })\n" +
+                "  .catch(error => console.error('Error loading buttons:', error));\n" +
+                "</script>");
     }
 }

--- a/webroot/static/collapsible-profile.css
+++ b/webroot/static/collapsible-profile.css
@@ -37,3 +37,16 @@
 .profile-line.hidden {
   display: none;
 }
+
+/* Button Layout Styles */
+.button-group-left {
+  float: left;
+}
+
+.button-group-right {
+  float: right;
+}
+
+.button-group-left input, .button-group-right input {
+  margin-right: 5px;
+}

--- a/webroot/static/collapsible-profile.js
+++ b/webroot/static/collapsible-profile.js
@@ -19,8 +19,27 @@ function initCollapsibleProfile() {
   const profileElement = document.getElementById('profile');
   if (!profileElement) return;
   
-  const originalContent = profileElement.textContent;
-  const lines = originalContent.split('\n');
+  // Get original HTML content and convert to text while preserving newlines
+  const originalHTML = profileElement.innerHTML;
+  
+  // Convert HTML to text while preserving newlines
+  // Replace <br> tags with newlines, then strip other HTML tags
+  let originalText = originalHTML
+    .replace(/<br\s*\/?>/gi, '\n')  // Convert <br> to newlines
+    .replace(/<[^>]*>/g, '')        // Remove all other HTML tags
+    .replace(/&lt;/g, '<')          // Decode HTML entities
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+  
+  // Store original content globally for copy/download functions
+  if (typeof originalProfileContent !== 'undefined') {
+    originalProfileContent = originalText;
+  }
+  
+  // Parse lines for collapsible view
+  const lines = originalText.split('\n');
   
   // Parse lines and build structure
   const parsedLines = [];

--- a/webroot/static/profile-buttons.html
+++ b/webroot/static/profile-buttons.html
@@ -1,0 +1,31 @@
+<!--
+  Copyright 2021-present StarRocks, Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!-- Profile Action Buttons Template -->
+<div class="button-group-left">
+  <input type="button" onclick="viewProfile();" value="View Profile"></input>
+  <input type="button" onclick="formattedSql();" value="Formatted SQL"></input>
+  <input type="button" onclick="analyzeProfile();" value="Analyze Profile"></input>
+</div>
+
+<div class="button-group-right">
+  <input type="button" onclick="expandAll();" value="Expand All"></input>
+  <input type="button" onclick="collapseAll();" value="Collapse All"></input>
+  <input type="button" onclick="copy();" value="Copy"></input>
+  <input type="button" onclick="download();" value="Download"></input>
+</div>
+
+<div style="clear: both;"></div>

--- a/webroot/static/profile-buttons.js
+++ b/webroot/static/profile-buttons.js
@@ -1,0 +1,61 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Profile Action Button Functions
+
+function viewProfile() {
+  const params = new URLSearchParams(window.location.search);
+  const query_id = params.get('query_id');
+  window.location.href = '/query_profile?query_id=' + query_id + '&content_type=profile';
+}
+
+function formattedSql() {
+  const params = new URLSearchParams(window.location.search);
+  const query_id = params.get('query_id');
+  window.location.href = '/query_profile?query_id=' + query_id + '&content_type=sql';
+}
+
+function analyzeProfile() {
+  const params = new URLSearchParams(window.location.search);
+  const query_id = params.get('query_id');
+  window.location.href = '/query_profile?query_id=' + query_id + '&content_type=analyze';
+}
+
+function copy() {
+  // Use original content if available, otherwise get current visible text
+  v = originalProfileContent || document.getElementById('profile').textContent
+  
+  const t = document.createElement('textarea')
+  t.style.cssText = 'position: absolute;top:0;left:0;opacity:0'
+  document.body.appendChild(t)
+  t.value = v
+  t.select()
+  document.execCommand('copy')
+  document.body.removeChild(t)
+}
+
+function download() {
+  // Use original content if available, otherwise get current visible text
+  content = originalProfileContent || document.getElementById('profile').textContent
+  
+  const file = new Blob([content], { type: "text/plain" });
+  const params = new URLSearchParams(window.location.search);
+  const query_id = params.get('query_id');
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(file);
+  a.download = query_id + "profile.txt";
+  a.click();
+
+  URL.revokeObjectURL(a.href);
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Follow #64455
1. Fix the copy/download button, making sure it will not contains HTML tags
2. Refactor the code, removing js/css from java

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes profile page copy/download to use raw text (no HTML), moves button UI/logic to external assets, and improves collapsible profile parsing and button layout.
> 
> - **Profile Page Rendering (`QueryProfileAction.java`)**:
>   - Replace inline JS with external assets: include `collapsible-profile.css`, `collapsible-profile.js`, and new `profile-buttons.js`.
>   - Load button markup from `profile-buttons.html` into a container via `fetch`.
>   - Define global `originalProfileContent` for copy/download.
> - **Collapsible Viewer (`webroot/static/collapsible-profile.js`)**:
>   - Parse text from `innerHTML` by stripping tags/decoding entities; store in `originalProfileContent`.
>   - Use parsed lines to render collapsible tree as before.
> - **Buttons**:
>   - Add `webroot/static/profile-buttons.html` (button template) and `profile-buttons.js` (navigation, expand/collapse, copy, download).
>   - `copy()`/`download()` use raw profile text (avoid HTML tags).
> - **Styles (`collapsible-profile.css`)**:
>   - Add left/right button group layout with spacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ef8fbb801e13512bf259ccce54b70e235664bb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->