### PR TITLE
[Enhancement] Add some compatible codes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -79,6 +79,9 @@ public final class GlobalVariable {
     public static final String ENABLE_TDE = "enable_tde";
 
     // cngroup
+    public static final String CNGROUP_RESOURCE_USAGE_FRESH_RATIO = "cngroup_resource_usage_fresh_ratio";
+    public static final String CNGROUP_LOW_WATERMARK_RUNNING_QUERY_COUNT  = "cngroup_low_watermark_running_query_count";
+    public static final String CNGROUP_LOW_WATERMARK_CPU_USED_PERMILLE = "cngroup_low_watermark_cpu_used_permille";
     public static final String CNGROUP_SCHEDULE_MODE = "cngroup_schedule_mode";
 
     public static final String ENABLE_QUERY_HISTORY = "enable_query_history";
@@ -218,6 +221,15 @@ public final class GlobalVariable {
 
     @VariableMgr.VarAttr(name = ENABLE_TDE, flag = VariableMgr.GLOBAL | VariableMgr.READ_ONLY)
     public static boolean enableTde = KeyMgr.isEncrypted();
+
+    @VariableMgr.VarAttr(name = CNGROUP_RESOURCE_USAGE_FRESH_RATIO)
+    private static double cngroupResourceUsageFreshRatio = 0.5;
+
+    @VariableMgr.VarAttr(name = CNGROUP_LOW_WATERMARK_RUNNING_QUERY_COUNT)
+    private static long cngroupLowWatermarkRunningQueryCount = 8;
+
+    @VariableMgr.VarAttr(name = CNGROUP_LOW_WATERMARK_CPU_USED_PERMILLE)
+    private static long cngroupLowWatermarkCPUUsedPermille = 600;
 
     @VariableMgr.VarAttr(name = CNGROUP_SCHEDULE_MODE)
     private static String cngroupScheduleMode = "standard";
@@ -376,6 +388,30 @@ public final class GlobalVariable {
 
     public static void setActivateAllRolesOnLogin(boolean activateAllRolesOnLogin) {
         GlobalVariable.activateAllRolesOnLogin = activateAllRolesOnLogin;
+    }
+
+    public static void setCngroupResourceUsageFreshRatio(double value) {
+        cngroupResourceUsageFreshRatio = value;
+    }
+
+    public static double getCngroupResourceUsageFreshRatio() {
+        return cngroupResourceUsageFreshRatio;
+    }
+
+    public static void setCngroupLowWatermarkRunningQueryCount(long value) {
+        cngroupLowWatermarkRunningQueryCount = value;
+    }
+
+    public static long getCngroupLowWatermarkRunningQueryCount() {
+        return cngroupLowWatermarkRunningQueryCount;
+    }
+
+    public static void setCngroupLowWatermarkCPUUsedPermille(long value) {
+        cngroupLowWatermarkCPUUsedPermille = value;
+    }
+
+    public static long getCngroupLowWatermarkCPUUsedPermille() {
+        return cngroupLowWatermarkCPUUsedPermille;
     }
 
     public static void setCngroupScheduleMode(String mode) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce new CN group variables with defaults and accessors for resource freshness ratio and low-watermark thresholds in GlobalVariable.
> 
> - **Config/QE (`GlobalVariable.java`)**:
>   - Add CN group variables with `VarAttr` annotations and defaults:
>     - `cngroup_resource_usage_fresh_ratio` (default `0.5`)
>     - `cngroup_low_watermark_running_query_count` (default `8`)
>     - `cngroup_low_watermark_cpu_used_permille` (default `600`)
>   - Expose corresponding getters/setters for the above variables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c50f65e2c20b3a7773251a478c55b448465b030e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->