### PR TITLE
[Enhancement] reading predicate column by late materialization and sort predicate column according to predicate selectivity

### DIFF
--- a/be/src/column/CMakeLists.txt
+++ b/be/src/column/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(Column STATIC
         column.cpp
         column_access_path.cpp
         column_helper.cpp
+        append_with_mask.cpp
         column_viewer.cpp
         const_column.cpp
         datum.cpp

--- a/be/src/column/append_with_mask.cpp
+++ b/be/src/column/append_with_mask.cpp
@@ -58,7 +58,8 @@ Status AppendWithMaskVisitor<PositiveSelect>::do_visit(NullableColumn* column) {
             size_t appended = nullable_column->null_column()->size() - orig_size;
             if (appended != 0) {
                 const auto null_data = nullable_column->null_column()->immutable_data();
-                bool has_new_null = SIMD::contain_nonzero(null_data, orig_size, appended);
+                bool has_new_null =
+                        SIMD::contain_nonzero(null_data, orig_size, appended) || nullable_column->has_null();
                 nullable_column->set_has_null(has_new_null);
             }
         }

--- a/be/src/column/append_with_mask.cpp
+++ b/be/src/column/append_with_mask.cpp
@@ -50,11 +50,11 @@ Status AppendWithMaskVisitor<PositiveSelect>::do_visit(NullableColumn* column) {
         const auto* src_column = down_cast<const NullableColumn*>(&_src);
         if (!src_column->has_null()) {
             size_t selected = count_selected();
-            nullable_column->null_column()->resize(orig_size + selected);
-            RETURN_IF_ERROR(apply(nullable_column->mutable_data_column(), src_column->data_column().get()));
+            nullable_column->null_column_raw_ptr()->resize(orig_size + selected);
+            RETURN_IF_ERROR(apply(nullable_column->data_column_raw_ptr(), src_column->data_column().get()));
         } else {
-            RETURN_IF_ERROR(apply(nullable_column->mutable_data_column(), src_column->data_column().get()));
-            RETURN_IF_ERROR(apply(nullable_column->null_column().get(), src_column->null_column().get()));
+            RETURN_IF_ERROR(apply(nullable_column->data_column_raw_ptr(), src_column->data_column().get()));
+            RETURN_IF_ERROR(apply(nullable_column->null_column_raw_ptr(), src_column->null_column().get()));
             size_t appended = nullable_column->null_column()->size() - orig_size;
             if (appended != 0) {
                 const auto null_data = nullable_column->null_column()->immutable_data();
@@ -64,8 +64,8 @@ Status AppendWithMaskVisitor<PositiveSelect>::do_visit(NullableColumn* column) {
         }
     } else {
         size_t selected = count_selected();
-        nullable_column->null_column()->resize(orig_size + selected);
-        RETURN_IF_ERROR(apply(nullable_column->mutable_data_column(), &_src));
+        nullable_column->null_column_raw_ptr()->resize(orig_size + selected);
+        RETURN_IF_ERROR(apply(nullable_column->data_column_raw_ptr(), &_src));
     }
 
     DCHECK_EQ(nullable_column->null_column()->size(), nullable_column->data_column()->size());

--- a/be/src/column/append_with_mask.cpp
+++ b/be/src/column/append_with_mask.cpp
@@ -1,0 +1,243 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "column/append_with_mask.h"
+
+#include "column/array_column.h"
+#include "column/column.h"
+#include "column/const_column.h"
+#include "column/decimalv3_column.h"
+#include "column/json_column.h"
+#include "column/map_column.h"
+#include "column/object_column.h"
+#include "column/struct_column.h"
+#include "column/variant_column.h"
+#include "simd/simd.h"
+
+namespace starrocks {
+
+template <bool PositiveSelect>
+AppendWithMaskVisitor<PositiveSelect>::AppendWithMaskVisitor(const Column& src, const uint8_t* mask, size_t count)
+        : Base(this), _src(src), _mask(mask), _count(count) {}
+
+template <bool PositiveSelect>
+Status AppendWithMaskVisitor<PositiveSelect>::do_visit(NullableColumn* column) {
+    if (_mask == nullptr || _count == 0) {
+        return Status::OK();
+    }
+
+    auto* nullable_column = down_cast<NullableColumn*>(column);
+    size_t orig_size = nullable_column->null_column()->size();
+
+    if (_src.only_null()) {
+        size_t selected = count_selected();
+        nullable_column->append_nulls(selected);
+        return Status::OK();
+    }
+
+    if (_src.is_nullable()) {
+        const auto* src_column = down_cast<const NullableColumn*>(&_src);
+        if (!src_column->has_null()) {
+            size_t selected = count_selected();
+            nullable_column->null_column()->resize(orig_size + selected);
+            RETURN_IF_ERROR(apply(nullable_column->mutable_data_column(), src_column->data_column().get()));
+        } else {
+            RETURN_IF_ERROR(apply(nullable_column->mutable_data_column(), src_column->data_column().get()));
+            RETURN_IF_ERROR(apply(nullable_column->null_column().get(), src_column->null_column().get()));
+            size_t appended = nullable_column->null_column()->size() - orig_size;
+            if (appended != 0) {
+                const auto null_data = nullable_column->null_column()->immutable_data();
+                bool has_new_null = SIMD::contain_nonzero(null_data, orig_size, appended);
+                nullable_column->set_has_null(has_new_null);
+            }
+        }
+    } else {
+        size_t selected = count_selected();
+        nullable_column->null_column()->resize(orig_size + selected);
+        RETURN_IF_ERROR(apply(nullable_column->mutable_data_column(), &_src));
+    }
+
+    DCHECK_EQ(nullable_column->null_column()->size(), nullable_column->data_column()->size());
+    return Status::OK();
+}
+
+template <bool PositiveSelect>
+Status AppendWithMaskVisitor<PositiveSelect>::do_visit(BinaryColumn* column) {
+    return append_binary(column);
+}
+
+template <bool PositiveSelect>
+Status AppendWithMaskVisitor<PositiveSelect>::do_visit(LargeBinaryColumn* column) {
+    return append_binary(column);
+}
+
+template <bool PositiveSelect>
+bool AppendWithMaskVisitor<PositiveSelect>::is_selected(uint8_t value) const {
+    if constexpr (PositiveSelect) {
+        return value != 0;
+    } else {
+        return value == 0;
+    }
+}
+
+template <bool PositiveSelect>
+size_t AppendWithMaskVisitor<PositiveSelect>::count_selected() const {
+    if (_mask == nullptr) {
+        return 0;
+    }
+
+    size_t selected = SIMD::count_nonzero(_mask, _count);
+    if constexpr (PositiveSelect) {
+        return selected;
+    } else {
+        return _count - selected;
+    }
+}
+
+template <bool PositiveSelect>
+template <typename T>
+Status AppendWithMaskVisitor<PositiveSelect>::append_fixed_length(FixedLengthColumnBase<T>* column) {
+    if (_mask == nullptr || _count == 0) {
+        return Status::OK();
+    }
+    if (_src.is_view()) {
+        append_fallback(column);
+        return Status::OK();
+    }
+
+    auto* src_column = dynamic_cast<const FixedLengthColumnBase<T>*>(&_src);
+    if (src_column == nullptr) {
+        append_fallback(column);
+        return Status::OK();
+    }
+
+    size_t selected = count_selected();
+    if (selected == 0) {
+        return Status::OK();
+    }
+
+    auto& data = column->get_data();
+    size_t orig_size = data.size();
+    raw::stl_vector_resize_uninitialized(&data, orig_size + selected);
+    auto* __restrict dest = data.data() + orig_size;
+    const T* __restrict src_data = reinterpret_cast<const T*>(src_column->raw_data());
+
+    for (size_t i = 0; i < _count; ++i) {
+        if (is_selected(_mask[i])) {
+            *dest++ = src_data[i];
+        }
+    }
+    return Status::OK();
+}
+
+template <bool PositiveSelect>
+template <typename T>
+Status AppendWithMaskVisitor<PositiveSelect>::append_binary_impl(BinaryColumnBase<T>* column) {
+    if (_mask == nullptr || _count == 0) {
+        return Status::OK();
+    }
+    if (_src.is_binary_view()) {
+        append_fallback(column);
+        return Status::OK();
+    }
+
+    auto* src_column = dynamic_cast<const BinaryColumnBase<T>*>(&_src);
+    if (src_column == nullptr) {
+        append_fallback(column);
+        return Status::OK();
+    }
+
+    size_t selected = count_selected();
+    if (selected == 0) {
+        return Status::OK();
+    }
+
+    const auto* src_offsets = src_column->get_offset().data();
+    const auto* src_bytes = src_column->continuous_data();
+
+    size_t total_bytes = 0;
+    for (size_t i = 0; i < _count; ++i) {
+        if (is_selected(_mask[i])) {
+            total_bytes += src_offsets[i + 1] - src_offsets[i];
+        }
+    }
+
+    auto& offsets = column->get_offset();
+    auto& bytes = column->get_bytes();
+    size_t old_rows = offsets.size() - 1;
+    size_t old_bytes = bytes.size();
+    offsets.resize(old_rows + selected + 1);
+    bytes.resize(old_bytes + total_bytes);
+
+    auto* dest_offsets = offsets.data() + old_rows + 1;
+    auto* dest_bytes = bytes.data() + old_bytes;
+
+    T current_offset = offsets[old_rows];
+    if (current_offset != static_cast<T>(old_bytes)) {
+        current_offset = static_cast<T>(old_bytes);
+        offsets[old_rows] = current_offset;
+    }
+    size_t copied = 0;
+    for (size_t i = 0; i < _count; ++i) {
+        if (is_selected(_mask[i])) {
+            const T start = src_offsets[i];
+            const T end = src_offsets[i + 1];
+            const T len = end - start;
+            strings::memcpy_inlined(dest_bytes + copied, src_bytes + start, len);
+            copied += len;
+            current_offset += len;
+            *dest_offsets++ = current_offset;
+        }
+    }
+
+    column->invalidate_slice_cache();
+    return Status::OK();
+}
+
+template <bool PositiveSelect>
+Status AppendWithMaskVisitor<PositiveSelect>::apply(Column* dst, const Column* src) {
+    return append_with_mask<PositiveSelect>(dst, *src, _mask, _count);
+}
+
+template <bool PositiveSelect>
+template <typename ColumnType>
+void AppendWithMaskVisitor<PositiveSelect>::append_fallback(ColumnType* column) {
+    if (_mask == nullptr || _count == 0) {
+        return;
+    }
+    for (size_t i = 0; i < _count; ++i) {
+        if (is_selected(_mask[i])) {
+            column->append(_src, i, 1);
+        }
+    }
+}
+
+template <bool PositiveSelect>
+Status append_with_mask(Column* dst, const Column& src, const uint8_t* mask, size_t count) {
+    if (dst == nullptr || count == 0) {
+        return Status::OK();
+    }
+    AppendWithMaskVisitor<PositiveSelect> visitor(src, mask, count);
+    return dst->accept_mutable(&visitor);
+}
+
+// Explicit instantiations
+
+template class AppendWithMaskVisitor<true>;
+template class AppendWithMaskVisitor<false>;
+
+template Status append_with_mask<true>(Column*, const Column&, const uint8_t*, size_t);
+template Status append_with_mask<false>(Column*, const Column&, const uint8_t*, size_t);
+
+} // namespace starrocks

--- a/be/src/column/append_with_mask.h
+++ b/be/src/column/append_with_mask.h
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "column/column_visitor_adapter.h"
+#include "column/vectorized_fwd.h"
+#include "common/status.h"
+
+namespace starrocks {
+
+template <bool PositiveSelect>
+Status append_with_mask(Column* dst, const Column& src, const uint8_t* mask, size_t count);
+
+extern template Status append_with_mask<true>(Column*, const Column&, const uint8_t*, size_t);
+extern template Status append_with_mask<false>(Column*, const Column&, const uint8_t*, size_t);
+
+template <bool PositiveSelect>
+class AppendWithMaskVisitor : public ColumnVisitorMutableAdapter<AppendWithMaskVisitor<PositiveSelect>> {
+    using Base = ColumnVisitorMutableAdapter<AppendWithMaskVisitor<PositiveSelect>>;
+
+public:
+    AppendWithMaskVisitor(const Column& src, const uint8_t* mask, size_t count);
+
+    Status do_visit(NullableColumn* column);
+    Status do_visit(BinaryColumn* column);
+    Status do_visit(LargeBinaryColumn* column);
+
+    template <typename T>
+    Status do_visit(FixedLengthColumnBase<T>* column) {
+        return append_fixed_length(column);
+    }
+
+    template <typename ColumnType>
+    Status do_visit(ColumnType* column) {
+        append_fallback(column);
+        return Status::OK();
+    }
+
+private:
+    bool is_selected(uint8_t value) const;
+    size_t count_selected() const;
+
+    template <typename T>
+    Status append_fixed_length(FixedLengthColumnBase<T>* column);
+
+    template <typename T>
+    Status append_binary_impl(BinaryColumnBase<T>* column);
+
+    Status append_binary(BinaryColumn* column) { return append_binary_impl(column); }
+    Status append_binary(LargeBinaryColumn* column) { return append_binary_impl(column); }
+
+    Status apply(Column* dst, const Column* src);
+
+    template <typename ColumnType>
+    void append_fallback(ColumnType* column);
+
+    const Column& _src;
+    const uint8_t* _mask;
+    size_t _count;
+};
+
+} // namespace starrocks

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -562,7 +562,7 @@ void BinaryColumnBase<T>::remove_first_n_values(size_t count) {
     DCHECK_LE(count, _offsets.size() - 1);
     size_t remain_size = _offsets.size() - 1 - count;
 
-    ColumnPtr column = cut(count, remain_size);
+    MutableColumnPtr column = cut(count, remain_size);
     auto* binary_column = down_cast<BinaryColumnBase<T>*>(column.get());
     _offsets = std::move(binary_column->_offsets);
     _bytes = std::move(binary_column->get_bytes());
@@ -571,7 +571,7 @@ void BinaryColumnBase<T>::remove_first_n_values(size_t count) {
 }
 
 template <typename T>
-ColumnPtr BinaryColumnBase<T>::cut(size_t start, size_t length) const {
+MutableColumnPtr BinaryColumnBase<T>::cut(size_t start, size_t length) const {
     auto result = this->create();
 
     if (start >= size() || length == 0) {

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -466,7 +466,7 @@ void BinaryColumnBase<T>::_build_german_strings() const {
 }
 
 template <typename T>
-void BinaryColumnBase<T>::_materialize_view_if_needed() {
+void BinaryColumnBase<T>::_ensure_materialized() {
     if (_resource.empty()) {
         return;
     }

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -14,8 +14,11 @@
 
 #pragma once
 
+#include <memory>
+
 #include "column/bytes.h"
 #include "column/column.h"
+#include "column/container_resource.h"
 #include "column/datum.h"
 #include "column/german_string.h"
 #include "column/vectorized_fwd.h"
@@ -64,12 +67,26 @@ public:
         }
     }
 
+    explicit BinaryColumnBase(ContainerResource resource, Offsets offsets)
+            : _bytes(), _offsets(std::move(offsets)), _resource(std::move(resource)), _immuable_container(*this) {
+        if (_offsets.empty()) {
+            _offsets.emplace_back(0);
+        }
+        if (!config::enable_zero_copy_from_page_cache) {
+            _materialize_view_if_needed();
+        }
+    }
+
     // NOTE: do *NOT* copy |_slices|
-    BinaryColumnBase(const BinaryColumnBase<T>& rhs) : _bytes(rhs._bytes), _offsets(rhs._offsets) {}
+    BinaryColumnBase(const BinaryColumnBase<T>& rhs)
+            : _bytes(rhs._bytes), _offsets(rhs._offsets), _resource(rhs._resource), _immuable_container(*this) {}
 
     // NOTE: do *NOT* copy |_slices|
     BinaryColumnBase(BinaryColumnBase<T>&& rhs) noexcept
-            : _bytes(std::move(rhs._bytes)), _offsets(std::move(rhs._offsets)) {}
+            : _bytes(std::move(rhs._bytes)),
+              _offsets(std::move(rhs._offsets)),
+              _resource(std::move(rhs._resource)),
+              _immuable_container(*this) {}
 
     BinaryColumnBase<T>& operator=(const BinaryColumnBase<T>& rhs) {
         BinaryColumnBase<T> tmp(rhs);
@@ -98,10 +115,14 @@ public:
             return;
         }
 #endif
-        if (!_offsets.empty()) {
-            DCHECK_EQ(_bytes.size(), _offsets.back());
-        } else {
-            DCHECK_EQ(_bytes.size(), 0);
+        // When we hold a view via _resource, _bytes is empty and data comes from external memory,
+        // so we should not check the consistency between _bytes and _offsets
+        if (_resource.empty()) {
+            if (!_offsets.empty()) {
+                DCHECK_EQ(_bytes.size(), _offsets.back());
+            } else {
+                DCHECK_EQ(_bytes.size(), 0);
+            }
         }
     }
 
@@ -128,7 +149,10 @@ public:
 
     size_t type_size() const override { return sizeof(Slice); }
 
-    size_t byte_size() const override { return _bytes.size() * sizeof(uint8_t) + _offsets.size() * sizeof(Offset); }
+    size_t byte_size() const override {
+        size_t data_size = _resource.empty() ? _bytes.size() : _offsets.back();
+        return data_size * sizeof(uint8_t) + _offsets.size() * sizeof(Offset);
+    }
 
     size_t byte_size(size_t from, size_t size) const override {
         DCHECK_LE(from + size, this->size()) << "Range error";
@@ -138,8 +162,13 @@ public:
     size_t byte_size(size_t idx) const override { return _offsets[idx + 1] - _offsets[idx] + sizeof(uint32_t); }
 
     Slice get_slice(size_t idx) const {
-        return Slice(_bytes.data() + _offsets[idx], _offsets[idx + 1] - _offsets[idx]);
+        const uint8_t* base = _data_base();
+        return Slice(base + _offsets[idx], _offsets[idx + 1] - _offsets[idx]);
     }
+
+    const char* get_string_begin() const { return reinterpret_cast<const char*>(_data_base()); }
+
+    const char* get_string_end() const { return reinterpret_cast<const char*>(_data_base() + _total_bytes()); }
 
     void check_or_die() const override;
 
@@ -235,9 +264,10 @@ public:
         // max size of one string is 2^32, so use uint32_t not T
         auto binary_size = static_cast<uint32_t>(_offsets[idx + 1] - _offsets[idx]);
         T offset = _offsets[idx];
+        const uint8_t* base = _data_base();
 
         strings::memcpy_inlined(pos, &binary_size, sizeof(uint32_t));
-        strings::memcpy_inlined(pos + sizeof(uint32_t), &_bytes[offset], binary_size);
+        strings::memcpy_inlined(pos + sizeof(uint32_t), base + offset, binary_size);
 
         return sizeof(uint32_t) + binary_size;
     }
@@ -318,11 +348,19 @@ public:
 
     const BinaryDataProxyContainer& get_proxy_data() const { return _immuable_container; }
 
-    Bytes& get_bytes() { return _bytes; }
+    Bytes& get_bytes() {
+        _materialize_view_if_needed();
+        return _bytes;
+    }
 
-    const Bytes& get_bytes() const { return _bytes; }
+    ImmBytes get_immutable_bytes() const {
+        if (!_resource.empty()) {
+            return _resource.span<uint8_t>();
+        }
+        return ImmBytes(_bytes.data(), _bytes.size());
+    }
 
-    const uint8_t* continuous_data() const override { return reinterpret_cast<const uint8_t*>(_bytes.data()); }
+    const uint8_t* continuous_data() const override { return _data_base(); }
 
     Offsets& get_offset() { return _offsets; }
     const Offsets& get_offset() const { return _offsets; }
@@ -330,7 +368,8 @@ public:
     Datum get(size_t n) const override { return Datum(get_slice(n)); }
 
     size_t container_memory_usage() const override {
-        return _bytes.capacity() + _offsets.capacity() * sizeof(_offsets[0]) + _slices.capacity() * sizeof(_slices[0]);
+        size_t bytes_memory = _resource.empty() ? _bytes.capacity() : 0;
+        return bytes_memory + _offsets.capacity() * sizeof(_offsets[0]) + _slices.capacity() * sizeof(_slices[0]);
     }
 
     size_t reference_memory_usage(size_t from, size_t size) const override { return 0; }
@@ -343,6 +382,7 @@ public:
         swap(_offsets, r._offsets);
         swap(_slices, r._slices);
         swap(_slices_cache, r._slices_cache);
+        swap(_resource, r._resource);
     }
 
     void reset_column() override {
@@ -352,6 +392,7 @@ public:
         _offsets.resize(1, 0);
         _slices.clear();
         _slices_cache = false;
+        _resource.reset();
     }
 
     void invalidate_slice_cache() {
@@ -382,9 +423,15 @@ public:
 private:
     void _build_slices() const;
     void _build_german_strings() const;
+    void _materialize_view_if_needed();
+    ALWAYS_INLINE const uint8_t* _data_base() const {
+        return _resource.empty() ? _bytes.data() : reinterpret_cast<const uint8_t*>(_resource.data());
+    }
+    size_t _total_bytes() const { return _offsets.empty() ? 0 : _offsets.back(); }
 
     Bytes _bytes;
     Offsets _offsets;
+    ContainerResource _resource;
 
     mutable Container _slices;
     mutable bool _slices_cache = false;

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -301,7 +301,7 @@ public:
 
     MutableColumnPtr clone_empty() const override { return BinaryColumnBase<T>::create(); }
 
-    ColumnPtr cut(size_t start, size_t length) const;
+    MutableColumnPtr cut(size_t start, size_t length) const;
     size_t filter_range(const Filter& filter, size_t start, size_t to) override;
 
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -73,7 +73,7 @@ public:
             _offsets.emplace_back(0);
         }
         if (!config::enable_zero_copy_from_page_cache) {
-            _materialize_view_if_needed();
+            _ensure_materialized();
         }
     }
 
@@ -349,7 +349,7 @@ public:
     const BinaryDataProxyContainer& get_proxy_data() const { return _immuable_container; }
 
     Bytes& get_bytes() {
-        _materialize_view_if_needed();
+        _ensure_materialized();
         return _bytes;
     }
 
@@ -423,7 +423,7 @@ public:
 private:
     void _build_slices() const;
     void _build_german_strings() const;
-    void _materialize_view_if_needed();
+    void _ensure_materialized();
     ALWAYS_INLINE const uint8_t* _data_base() const {
         return _resource.empty() ? _bytes.data() : reinterpret_cast<const uint8_t*>(_resource.data());
     }

--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -162,10 +162,11 @@ void Chunk::append_column(ColumnPtr&& column, const FieldPtr& field) {
     check_or_die();
 }
 
-void Chunk::append_column(ColumnPtr&& column, ColumnId column_id) {
+void Chunk::append_column(const ColumnPtr& column, ColumnId column_id, [[maybe_unused]] bool is_column_id) {
+    DCHECK(is_column_id);
     DCHECK(!_cid_to_index.contains(column_id));
     _cid_to_index[column_id] = _columns.size();
-    _append_column_checked(_columns.size(), std::move(column));
+    _append_column_checked(_columns.size(), column);
     check_or_die();
 }
 

--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -162,6 +162,13 @@ void Chunk::append_column(ColumnPtr&& column, const FieldPtr& field) {
     check_or_die();
 }
 
+void Chunk::append_column(ColumnPtr&& column, ColumnId column_id) {
+    DCHECK(!_cid_to_index.contains(column_id));
+    _cid_to_index[column_id] = _columns.size();
+    _append_column_checked(_columns.size(), std::move(column));
+    check_or_die();
+}
+
 void Chunk::append_column(const ColumnPtr& column, const FieldPtr& field) {
     DCHECK(!_cid_to_index.contains(field->id()));
     _cid_to_index[field->id()] = _columns.size();

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -127,7 +127,6 @@ public:
     // - When those method are called, the column will be moved into the chunk, and the original column will be reset.
     // - If the column is shared with others, it will be cloned and moved into the chunk.
     void append_column(ColumnPtr&& column, const FieldPtr& field);
-    void append_column(ColumnPtr&& column, ColumnId column_id);
     void append_column(ColumnPtr&& column, SlotId slot_id);
     void update_column(ColumnPtr&& column, SlotId slot_id);
     // - When those method are called, ensure the column is not shared with other columns in the chunk;
@@ -135,6 +134,7 @@ public:
     void append_column(const ColumnPtr& column, const FieldPtr& field);
     void append_column(const ColumnPtr& column, SlotId slot_id);
     void update_column(ColumnPtr& column, SlotId slot_id);
+    void append_column(const ColumnPtr& column, ColumnId column_id, [[maybe_unused]] bool is_column_id);
 
     void append_vector_column(ColumnPtr&& column, const FieldPtr& field, SlotId slot_id);
     void update_column_by_index(ColumnPtr&& column, size_t idx);

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -127,6 +127,7 @@ public:
     // - When those method are called, the column will be moved into the chunk, and the original column will be reset.
     // - If the column is shared with others, it will be cloned and moved into the chunk.
     void append_column(ColumnPtr&& column, const FieldPtr& field);
+    void append_column(ColumnPtr&& column, ColumnId column_id);
     void append_column(ColumnPtr&& column, SlotId slot_id);
     void update_column(ColumnPtr&& column, SlotId slot_id);
     // - When those method are called, ensure the column is not shared with other columns in the chunk;

--- a/be/src/column/column_hash/column_hash.cpp
+++ b/be/src/column/column_hash/column_hash.cpp
@@ -37,7 +37,8 @@ namespace starrocks {
 // Concept hash function
 template <typename HashFunction>
 concept HashFunctionConcept = requires(HashFunction h, const void* data, int32_t bytes, uint32_t seed) {
-    { h.hash(data, bytes, seed) } -> std::same_as<uint32_t>;
+    { h.hash(data, bytes, seed) }
+    ->std::same_as<uint32_t>;
 };
 
 // Hash function type tags
@@ -71,7 +72,8 @@ struct XXHash3 {
 // Concept definition for Selector
 template <typename Selector>
 concept SelectorConcept = requires(Selector s, std::function<void(uint32_t)> fn) {
-    { s.for_each(fn) } -> std::same_as<void>;
+    { s.for_each(fn) }
+    ->std::same_as<void>;
 };
 
 // [idx]

--- a/be/src/column/column_hash/column_hash.cpp
+++ b/be/src/column/column_hash/column_hash.cpp
@@ -37,8 +37,7 @@ namespace starrocks {
 // Concept hash function
 template <typename HashFunction>
 concept HashFunctionConcept = requires(HashFunction h, const void* data, int32_t bytes, uint32_t seed) {
-    { h.hash(data, bytes, seed) }
-    ->std::same_as<uint32_t>;
+    { h.hash(data, bytes, seed) } -> std::same_as<uint32_t>;
 };
 
 // Hash function type tags
@@ -72,8 +71,7 @@ struct XXHash3 {
 // Concept definition for Selector
 template <typename Selector>
 concept SelectorConcept = requires(Selector s, std::function<void(uint32_t)> fn) {
-    { s.for_each(fn) }
-    ->std::same_as<void>;
+    { s.for_each(fn) } -> std::same_as<void>;
 };
 
 // [idx]
@@ -233,7 +231,7 @@ public:
     template <typename SizeT>
     Status do_visit(const BinaryColumnBase<SizeT>& column) {
         const auto& offsets = column.get_offset();
-        const auto& bytes = column.get_bytes();
+        const auto& bytes = column.get_immutable_bytes();
         const auto column_size = column.size();
         _selector.for_each([&](uint32_t idx) {
             // Skip out-of-bounds indices (preserve hash seed)

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -514,9 +514,9 @@ size_t ColumnHelper::compute_bytes_size(ColumnsConstIterator const& begin, Colum
         }
         auto binary = ColumnHelper::get_binary_column(col.get());
         if (col->is_constant()) {
-            n += binary->get_bytes().size() * row_num;
+            n += binary->get_immutable_bytes().size() * row_num;
         } else {
-            n += binary->get_bytes().size();
+            n += binary->get_immutable_bytes().size();
         }
     }
     return n;

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -118,7 +118,6 @@ void NullableColumn::append_selective(const Column& src, const uint32_t* indexes
 
     DCHECK_EQ(_null_column->size(), _data_column->size());
 }
-
 void NullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
     DCHECK_EQ(_null_column->size(), _data_column->size());
     size_t orig_size = _null_column->size();

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -259,7 +259,6 @@ public:
 
     size_t null_count() const;
     size_t null_count(size_t offset, size_t count) const;
-
     Datum get(size_t n) const override {
         if (_has_null && (immutable_null_column_data()[n])) {
             return {};

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -879,7 +879,7 @@ CONF_Int32(vector_chunk_size, "4096");
 // Valid range: [0-1000].
 // `0` will disable late materialization.
 // `1000` will enable late materialization always.
-CONF_Int32(late_materialization_ratio, "10");
+CONF_mInt32(late_materialization_ratio, "10");
 
 // Valid range: [0-1000].
 // `0` will disable late materialization select metric type.
@@ -1880,4 +1880,7 @@ CONF_mBool(enable_cow_optimization, "true");
 // The diagnose level for cow optimization, 0 means no diagnose, 1 means diagnose when use_count > 1, 2 means diagnose when use_count > 2.
 CONF_Int32(cow_optimization_diagnose_level, "0");
 
+// if the first predicate column's selectivity bigger than this, trigger sample,
+// which means if the selectivity is very good already, we don't need to sample
+CONF_mDouble(tigger_sample_selectivity, "0.2");
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1880,7 +1880,8 @@ CONF_mBool(enable_cow_optimization, "true");
 // The diagnose level for cow optimization, 0 means no diagnose, 1 means diagnose when use_count > 1, 2 means diagnose when use_count > 2.
 CONF_Int32(cow_optimization_diagnose_level, "0");
 
-// if the first predicate column's selectivity bigger than this, trigger sample,
-// which means if the selectivity is very good already, we don't need to sample
-CONF_mDouble(tigger_sample_selectivity, "0.2");
+// If the first predicate column's selectivity is higher than this threshold, trigger sampling
+// to potentially find a better predicate order. When selectivity is already good (low), sampling
+// is unlikely to help and will be skipped.
+CONF_mDouble(predicate_sampling_trigger_selectivity_threshold, "0.2");
 } // namespace starrocks::config

--- a/be/src/exec/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/chunks_sorter_full_sort.cpp
@@ -74,7 +74,7 @@ static void reserve_memory(Column* dst_col, const std::vector<ChunkPtr>& src_chu
     for (const auto& src_chk : src_chunks) {
         const auto* src_data_col = ColumnHelper::get_data_column(src_chk->get_column_by_index(col_idx).get());
         const auto* src_binary_col = down_cast<const BinaryColumnType*>(src_data_col);
-        total_num_bytes += src_binary_col->get_bytes().size();
+        total_num_bytes += src_binary_col->get_immutable_bytes().size();
     }
     binary_dst_col->get_bytes().reserve(total_num_bytes);
 }

--- a/be/src/exec/join/join_hash_table.cpp
+++ b/be/src/exec/join/join_hash_table.cpp
@@ -135,7 +135,7 @@ size_t JoinHashMapSelector::_get_binary_column_max_size(RuntimeState* state, con
     }
 
     const auto& offsets = binary_column->get_offset();
-    const auto& bytes = binary_column->get_bytes();
+    auto bytes = binary_column->get_immutable_bytes();
 
     bool has_tail_zero = false;
     for (size_t i = offsets.size() - 1; i > 0 && offsets[i] > 0; i--) {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -241,6 +241,8 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
     _params.profile = _runtime_profile;
     _params.runtime_state = _runtime_state;
     _params.use_page_cache = _runtime_state->use_page_cache();
+    _params.enable_predicate_col_late_materialize =
+            _runtime_state->query_options().enable_predicate_col_late_materialize;
     _params.use_pk_index = thrift_olap_scan_node.use_pk_index;
     _params.sample_options = thrift_olap_scan_node.sample_options;
     if (thrift_olap_scan_node.__isset.enable_prune_column_after_index_filter) {

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -50,15 +50,11 @@ const std::vector<ColumnAccessPathPtr>* OlapScanContext::column_access_paths() c
 
 void OlapScanContext::attach_shared_input(int32_t operator_seq, int32_t source_index) {
     auto key = std::make_pair(operator_seq, source_index);
-    VLOG_ROW << fmt::format("attach_shared_input ({}, {}), active {}", operator_seq, source_index,
-                            _active_inputs.size());
     _num_active_inputs += _active_inputs.emplace(key).second;
 }
 
 void OlapScanContext::detach_shared_input(int32_t operator_seq, int32_t source_index) {
     auto key = std::make_pair(operator_seq, source_index);
-    VLOG_ROW << fmt::format("detach_shared_input ({}, {}), remain {}", operator_seq, source_index,
-                            _active_inputs.size());
     int erased = _active_inputs.erase(key);
     if (erased && _num_active_inputs.fetch_sub(1) == 1) {
         _active_inputs_empty = true;

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.h
@@ -83,6 +83,8 @@ public:
                               std::vector<bool> is_null_first, std::string sort_keys, int64_t offset,
                               int64_t partition_limit, const TTopNType::type topn_type);
 
+    ~LocalPartitionTopnContext() = default;
+
     Status prepare(RuntimeState* state, RuntimeProfile* runtime_profile);
 
     // Add one chunk to partitioner

--- a/be/src/exec/sorted_streaming_aggregator.cpp
+++ b/be/src/exec/sorted_streaming_aggregator.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 
+#include "column/append_with_mask.h"
 #include "column/array_column.h"
 #include "column/column_visitor_adapter.h"
 #include "column/nullable_column.h"
@@ -185,111 +186,6 @@ private:
     const NullMasks _null_masks;
 };
 
-// append the result by selector
-// selector[i] == 0 means selected
-//
-class AppendWithMask : public ColumnVisitorMutableAdapter<AppendWithMask> {
-public:
-    using SelMask = Filter;
-
-    AppendWithMask(Column* column, SelMask sel_mask, size_t selected_size)
-            : ColumnVisitorMutableAdapter(this),
-              _column(column),
-              _sel_mask(std::move(sel_mask)),
-              _selected_size(selected_size) {}
-
-    Status do_visit(NullableColumn* column) {
-        auto col = down_cast<NullableColumn*>(_column);
-        AppendWithMask data_appender(col->data_column_raw_ptr(), _sel_mask, _selected_size);
-        RETURN_IF_ERROR(column->data_column_raw_ptr()->accept_mutable(&data_appender));
-        AppendWithMask null_appender(col->null_column_raw_ptr(), _sel_mask, _selected_size);
-        RETURN_IF_ERROR(column->null_column_raw_ptr()->accept_mutable(&null_appender));
-        column->update_has_null();
-        return Status::OK();
-    }
-
-    Status do_visit(ConstColumn* column) {
-        return Status::NotSupported("Unsupported const column in column wise comparator");
-    }
-
-    Status do_visit(ArrayColumn* column) {
-        auto col = down_cast<ArrayColumn*>(_column);
-
-        for (size_t i = 0; i < _sel_mask.size(); ++i) {
-            if (_sel_mask[i] == 0) {
-                column->append(*col, i, 1);
-            }
-        }
-
-        return Status::OK();
-    }
-
-    Status do_visit(LargeBinaryColumn* column) {
-        return Status::NotSupported("Unsupported large binary column in column wise comparator");
-    }
-
-    Status do_visit(BinaryColumn* column) {
-        auto col = down_cast<BinaryColumn*>(_column);
-        auto& slices = col->get_proxy_data();
-        std::vector<Slice> datas(_sel_mask.size());
-        size_t offsets = 0;
-
-        for (size_t i = 0; i < _sel_mask.size(); ++i) {
-            datas[offsets] = slices[i];
-            offsets += !_sel_mask[i];
-        }
-        DCHECK_EQ(_selected_size, offsets);
-        datas.resize(_selected_size);
-        column->append_strings(datas.data(), datas.size());
-        return Status::OK();
-    }
-
-    template <typename T>
-    Status do_visit(FixedLengthColumnBase<T>* column) {
-        auto col = down_cast<FixedLengthColumnBase<T>*>(_column);
-        const auto& container = col->get_data();
-        std::vector<T> datas(_sel_mask.size());
-        size_t offsets = 0;
-
-        for (size_t i = 0; i < _sel_mask.size(); ++i) {
-            datas[offsets] = container[i];
-            offsets += !_sel_mask[i];
-        }
-
-        DCHECK_EQ(_selected_size, offsets);
-        datas.resize(_selected_size);
-        column->append_numbers(datas.data(), sizeof(T) * _selected_size);
-
-        return Status::OK();
-    }
-
-    template <typename T>
-    Status do_visit(ObjectColumn<T>* column) {
-        return Status::NotSupported("Unsupported object column in column wise comparator");
-    }
-
-    Status do_visit(MapColumn* column) {
-        return Status::NotSupported("Unsupported map column in column wise comparator");
-    }
-
-    Status do_visit(StructColumn* column) {
-        auto col = down_cast<StructColumn*>(_column);
-
-        for (size_t i = 0; i < _sel_mask.size(); ++i) {
-            if (_sel_mask[i] == 0) {
-                column->append(*col, i, 1);
-            }
-        }
-
-        return Status::OK();
-    }
-
-private:
-    Column* _column;
-    const SelMask _sel_mask;
-    size_t _selected_size;
-};
-
 // batch allocate states
 // For streaming aggregates, the maximum number of aggregate states we can hold is chunk_size + 1
 // (the states for processing a batch of chunks and the last remaining state).
@@ -361,7 +257,7 @@ StatusOr<ChunkPtr> SortedStreamingAggregator::streaming_compute_agg_state(size_t
 
     // selector[i] == 0 means selected
     Filter selector(chunk_size);
-    size_t selected_size = _init_selector(selector, chunk_size);
+    _init_selector(selector, chunk_size);
 
     // finalize state
     // group[i] != group[i - 1] means we have add a new state for group[i], then we need call finalize for group[i - 1]
@@ -376,7 +272,7 @@ StatusOr<ChunkPtr> SortedStreamingAggregator::streaming_compute_agg_state(size_t
 
     // combine group by keys
     auto res_group_by_columns = _create_group_by_columns(chunk_size);
-    RETURN_IF_ERROR(_build_group_by_columns(chunk_size, selected_size, selector, res_group_by_columns));
+    RETURN_IF_ERROR(_build_group_by_columns(chunk_size, selector, res_group_by_columns));
     auto result_chunk =
             _build_output_chunk(std::move(res_group_by_columns), std::move(agg_result_columns), use_intermediate);
 
@@ -409,9 +305,9 @@ StatusOr<ChunkPtr> SortedStreamingAggregator::streaming_compute_distinct(size_t 
     RETURN_IF_ERROR(_compute_group_by(chunk_size));
     // selector[i] == 0 means selected
     Filter selector(chunk_size);
-    size_t selected_size = _init_selector(selector, chunk_size);
+    _init_selector(selector, chunk_size);
     auto res_group_by_columns = _create_group_by_columns(chunk_size);
-    RETURN_IF_ERROR(_build_group_by_columns(chunk_size, selected_size, selector, res_group_by_columns));
+    RETURN_IF_ERROR(_build_group_by_columns(chunk_size, selector, res_group_by_columns));
     auto result_chunk = _build_output_chunk(std::move(res_group_by_columns), {}, false);
 
     // prepare for next
@@ -425,18 +321,13 @@ StatusOr<ChunkPtr> SortedStreamingAggregator::streaming_compute_distinct(size_t 
     return result_chunk;
 }
 
-size_t SortedStreamingAggregator::_init_selector(Filter& selector, size_t chunk_size) {
-    size_t selected_size = 0;
-    {
-        SCOPED_TIMER(_agg_stat->agg_compute_timer);
-        for (size_t i = 1; i < _cmp_vector.size(); ++i) {
-            selector[i - 1] = _cmp_vector[i] == 0;
-            selected_size += !selector[i - 1];
-        }
-        // we will never select the last rows
-        selector[chunk_size - 1] = 1;
+void SortedStreamingAggregator::_init_selector(Filter& selector, size_t chunk_size) {
+    SCOPED_TIMER(_agg_stat->agg_compute_timer);
+    for (size_t i = 1; i < _cmp_vector.size(); ++i) {
+        selector[i - 1] = _cmp_vector[i] == 0;
     }
-    return selected_size;
+    // we will never select the last rows
+    selector[chunk_size - 1] = 1;
 }
 
 Status SortedStreamingAggregator::_compute_group_by(size_t chunk_size) {
@@ -548,8 +439,7 @@ void SortedStreamingAggregator::_close_group_by(size_t chunk_size, const Filter&
     }
 }
 
-Status SortedStreamingAggregator::_build_group_by_columns(size_t chunk_size, size_t selected_size,
-                                                          const Filter& selector,
+Status SortedStreamingAggregator::_build_group_by_columns(size_t chunk_size, const Filter& selector,
                                                           MutableColumns& agg_group_by_columns) {
     SCOPED_TIMER(_agg_stat->agg_append_timer);
     if (_cmp_vector[0] != 0 && !_last_columns.empty() && !_last_columns.back()->empty()) {
@@ -559,8 +449,8 @@ Status SortedStreamingAggregator::_build_group_by_columns(size_t chunk_size, siz
     }
 
     for (size_t i = 0; i < agg_group_by_columns.size(); ++i) {
-        AppendWithMask appender(_group_by_columns[i]->as_mutable_raw_ptr(), selector, selected_size);
-        RETURN_IF_ERROR(agg_group_by_columns[i]->accept_mutable(&appender));
+        RETURN_IF_ERROR(append_with_mask</*PositiveSelect=*/false>(agg_group_by_columns[i]->as_mutable_raw_ptr(), *_group_by_columns[i],
+                                                                   selector.data(), selector.size()));
     }
     return Status::OK();
 }

--- a/be/src/exec/sorted_streaming_aggregator.cpp
+++ b/be/src/exec/sorted_streaming_aggregator.cpp
@@ -449,8 +449,9 @@ Status SortedStreamingAggregator::_build_group_by_columns(size_t chunk_size, con
     }
 
     for (size_t i = 0; i < agg_group_by_columns.size(); ++i) {
-        RETURN_IF_ERROR(append_with_mask</*PositiveSelect=*/false>(agg_group_by_columns[i]->as_mutable_raw_ptr(), *_group_by_columns[i],
-                                                                   selector.data(), selector.size()));
+        RETURN_IF_ERROR(append_with_mask</*PositiveSelect=*/false>(agg_group_by_columns[i]->as_mutable_raw_ptr(),
+                                                                   *_group_by_columns[i], selector.data(),
+                                                                   selector.size()));
     }
     return Status::OK();
 }

--- a/be/src/exec/sorted_streaming_aggregator.h
+++ b/be/src/exec/sorted_streaming_aggregator.h
@@ -42,13 +42,12 @@ private:
     Status _update_states(size_t chunk_size, bool is_update_phase);
     // init selector by _cmp_vector
     // return selected_size (distinct num_rows)
-    size_t _init_selector(Filter& selector, size_t chunk_size);
+    void _init_selector(Filter& selector, size_t chunk_size);
 
     Status _get_agg_result_columns(size_t chunk_size, const Filter& selector, MutableColumns& agg_result_columns);
     void _close_group_by(size_t chunk_size, const Filter& selector);
 
-    Status _build_group_by_columns(size_t chunk_size, size_t selected_size, const Filter& selector,
-                                   MutableColumns& agg_group_by_columns);
+    Status _build_group_by_columns(size_t chunk_size, const Filter& selector, MutableColumns& agg_group_by_columns);
 
     AggDataPtr _last_state = nullptr;
     Columns _last_columns;

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -146,6 +146,8 @@ Status TabletScanner::_init_reader_params(const std::vector<OlapScanRange*>* key
     // to avoid the unnecessary SerDe and improve query performance
     _params.need_agg_finalize = _need_agg_finalize;
     _params.use_page_cache = _runtime_state->use_page_cache();
+    _params.enable_predicate_col_late_materialize =
+            _runtime_state->query_options().enable_predicate_col_late_materialize;
     auto parser = _pool.add(new OlapPredicateParser(_tablet_schema));
 
     ASSIGN_OR_RETURN(auto pred_tree, _parent->_conjuncts_manager->get_predicate_tree(parser, _predicate_free_pool));

--- a/be/src/exprs/agg/group_concat.h
+++ b/be/src/exprs/agg/group_concat.h
@@ -123,17 +123,17 @@ public:
             const auto* column_val = down_cast<const InputColumnType*>(columns[0]);
             if (!ctx->is_notnull_constant_column(1)) {
                 const auto* column_sep = down_cast<const InputColumnType*>(columns[1]);
-                this->data(state).intermediate_string.reserve(column_val->get_bytes().size() +
-                                                              column_sep->get_bytes().size());
+                this->data(state).intermediate_string.reserve(column_val->get_immutable_bytes().size() +
+                                                              column_sep->get_immutable_bytes().size());
             } else {
                 auto const_column_sep = ctx->get_constant_column(1);
                 Slice sep = ColumnHelper::get_const_value<TYPE_VARCHAR>(const_column_sep);
-                this->data(state).intermediate_string.reserve(column_val->get_bytes().size() +
+                this->data(state).intermediate_string.reserve(column_val->get_immutable_bytes().size() +
                                                               sep.get_size() * chunk_size);
             }
         } else {
             const auto* column_val = down_cast<const InputColumnType*>(columns[0]);
-            this->data(state).intermediate_string.reserve(column_val->get_bytes().size() + 2 * chunk_size);
+            this->data(state).intermediate_string.reserve(column_val->get_immutable_bytes().size() + 2 * chunk_size);
         }
 
         for (size_t i = 0; i < chunk_size; ++i) {
@@ -213,8 +213,8 @@ public:
                 if (chunk_size > 0) {
                     size_t old_size = bytes.size();
                     CHECK_EQ(old_size, 0);
-                    size_t new_size = 2 * chunk_size * sizeof(uint32_t) + column_value->get_bytes().size() +
-                                      column_sep->get_bytes().size();
+                    size_t new_size = 2 * chunk_size * sizeof(uint32_t) + column_value->get_immutable_bytes().size() +
+                                      column_sep->get_immutable_bytes().size();
                     bytes.resize(new_size);
                     dst_column->get_offset().resize(chunk_size + 1);
 
@@ -235,7 +235,7 @@ public:
                 if (chunk_size > 0) {
                     size_t old_size = bytes.size();
                     CHECK_EQ(old_size, 0);
-                    size_t new_size = 2 * chunk_size * sizeof(uint32_t) + column_value->get_bytes().size() +
+                    size_t new_size = 2 * chunk_size * sizeof(uint32_t) + column_value->get_immutable_bytes().size() +
                                       chunk_size * sep.size;
                     bytes.resize(new_size);
                     dst_column->get_offset().resize(chunk_size + 1);
@@ -263,8 +263,8 @@ public:
 
                 size_t old_size = bytes.size();
                 CHECK_EQ(old_size, 0);
-                size_t new_size =
-                        2 * chunk_size * sizeof(uint32_t) + column_value->get_bytes().size() + size_sep * chunk_size;
+                size_t new_size = 2 * chunk_size * sizeof(uint32_t) + column_value->get_immutable_bytes().size() +
+                                  size_sep * chunk_size;
                 bytes.resize(new_size);
                 dst_column->get_offset().resize(chunk_size + 1);
 

--- a/be/src/exprs/like_predicate.cpp
+++ b/be/src/exprs/like_predicate.cpp
@@ -354,9 +354,9 @@ StatusOr<ColumnPtr> LikePredicate::constant_substring_fn(FunctionContext* contex
         const Buffer<uint32_t>& offsets = haystack->get_offset();
         res->resize(haystack->size());
 
-        const char* begin = haystack->get_slice(0).data;
+        const char* begin = haystack->get_string_begin();
         const char* pos = begin;
-        const char* end = pos + haystack->get_bytes().size();
+        const char* end = haystack->get_string_end();
 
         /// Current index in the array of strings.
         size_t i = 0;

--- a/be/src/exprs/locate.cpp
+++ b/be/src/exprs/locate.cpp
@@ -111,7 +111,7 @@ ColumnPtr haystack_vector_and_needle_const(const ColumnPtr& haystack_ptr, const 
 
     const char* begin = haystack->get_slice(0).data;
     const char* pos = begin;
-    const char* end = pos + haystack->get_bytes().size();
+    const char* end = pos + haystack->get_immutable_bytes().size();
 
     /// Current index in the array of strings.
     size_t i = 0;

--- a/be/src/exprs/split.cpp
+++ b/be/src/exprs/split.cpp
@@ -114,7 +114,7 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
     auto state = reinterpret_cast<SplitState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
     if (context->is_notnull_constant_column(0) && context->is_notnull_constant_column(1)) {
         std::vector<std::string> split_string = state->const_split_strings;
-        array_binary_column->reserve(row_nums * split_string.size(), haystack_columns->get_bytes().size());
+        array_binary_column->reserve(row_nums * split_string.size(), haystack_columns->get_immutable_bytes().size());
 
         for (int row = 0; row < row_nums; ++row) {
             array_offsets->append(offset);
@@ -134,7 +134,7 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
         if (delimiter.size == 0) { // split each character
             std::vector<Slice> v;
             v.reserve(haystack_columns->byte_size());
-            array_binary_column->reserve(haystack_columns->byte_size(), haystack_columns->get_bytes().size());
+            array_binary_column->reserve(haystack_columns->byte_size(), haystack_columns->get_immutable_bytes().size());
 
             for (int row = 0; row < row_nums; ++row) {
                 array_offsets->append(offset);
@@ -152,7 +152,7 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
             array_binary_column->append_continuous_strings(v.data(), v.size());
         } else {
             //row_nums * 5 is an estimated value, because the true value cannot be obtained for the time being here
-            array_binary_column->reserve(row_nums * 5, haystack_columns->get_bytes().size());
+            array_binary_column->reserve(row_nums * 5, haystack_columns->get_immutable_bytes().size());
             for (int row = 0; row < row_nums; ++row) {
                 array_offsets->append(offset);
                 if (string_viewer.is_null(row)) {
@@ -193,7 +193,7 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
                     NullColumn::create(*ColumnHelper::as_raw_column<NullableColumn>(columns[0])->null_column()));
         }
     } else {
-        array_binary_column->reserve(row_nums * 5, haystack_columns->get_bytes().size() * sizeof(uint8_t));
+        array_binary_column->reserve(row_nums * 5, haystack_columns->get_immutable_bytes().size() * sizeof(uint8_t));
 
         auto result_array = ArrayColumn::create(NullableColumn::create(BinaryColumn::create(), NullColumn::create()),
                                                 UInt32Column::create());

--- a/be/src/formats/csv/string_converter.cpp
+++ b/be/src/formats/csv/string_converter.cpp
@@ -25,7 +25,7 @@ namespace starrocks::csv {
 Status StringConverter::write_string(OutputStream* os, const Column& column, size_t row_num,
                                      const Options& options) const {
     auto* binary = down_cast<const BinaryColumn*>(&column);
-    const auto& bytes = binary->get_bytes();
+    auto bytes = binary->get_immutable_bytes();
     const auto& offsets = binary->get_offset();
 
     Slice s(&bytes[offsets[row_num]], offsets[row_num + 1] - offsets[row_num]);
@@ -36,7 +36,7 @@ Status StringConverter::write_string(OutputStream* os, const Column& column, siz
 Status StringConverter::write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                             const Options& options) const {
     auto* binary = down_cast<const BinaryColumn*>(&column);
-    const auto& bytes = binary->get_bytes();
+    auto bytes = binary->get_immutable_bytes();
     const auto& offsets = binary->get_offset();
 
     Slice s(&bytes[offsets[row_num]], offsets[row_num + 1] - offsets[row_num]);

--- a/be/src/formats/csv/varbinary_converter.cpp
+++ b/be/src/formats/csv/varbinary_converter.cpp
@@ -30,7 +30,7 @@ namespace starrocks::csv {
 Status VarBinaryConverter::write_string(OutputStream* os, const Column& column, size_t row_num,
                                         const Options& options) const {
     auto* binary = down_cast<const BinaryColumn*>(&column);
-    auto& bytes = binary->get_bytes();
+    auto& bytes = binary->get_immutable_bytes();
     auto& offsets = binary->get_offset();
     // TODO: support binary type config later
 

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -287,7 +287,7 @@ public:
         auto* src_column = ColumnHelper::as_raw_column<BinaryColumn>(src_nullable_column->data_column());
         auto* dst_column = ColumnHelper::as_raw_column<ColumnType>(dst_nullable_column->data_column_raw_ptr());
 
-        const BinaryColumn::Bytes& src_data = src_column->get_bytes();
+        auto src_data = src_column->get_immutable_bytes();
         auto& dst_data = dst_column->get_data();
         auto& src_null_data = src_nullable_column->null_column()->get_data();
         auto& dst_null_data = dst_nullable_column->null_column_raw_ptr()->get_data();

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -392,7 +392,7 @@ Status LevelBuilder::_write_byte_array_column_chunk(const LevelBuilderContext& c
     const auto* data_col = down_cast<const RunTimeColumnType<lt>*>(ColumnHelper::get_data_column(col.get()));
     const auto* null_col = get_raw_null_column(col);
     const auto& vo = data_col->get_offset();
-    const auto& vb = data_col->get_bytes();
+    auto vb = data_col->get_immutable_bytes();
 
     // Use the rep_levels in the context from caller since node is primitive.
     auto& rep_levels = ctx._rep_levels;

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -204,7 +204,7 @@ class BinaryColumnSerde {
 public:
     template <typename T>
     static int64_t max_serialized_size(const BinaryColumnBase<T>& column, const int encode_level) {
-        const auto& bytes = column.get_bytes();
+        auto bytes = column.get_immutable_bytes();
         const auto& offsets = column.get_offset();
         int64_t res = sizeof(T) * 2;
         int64_t offsets_size = offsets.size() * sizeof(typename BinaryColumnBase<T>::Offset);
@@ -224,7 +224,7 @@ public:
 
     template <typename T>
     static uint8_t* serialize(const BinaryColumnBase<T>& column, uint8_t* buff, const int encode_level) {
-        const auto& bytes = column.get_bytes();
+        auto bytes = column.get_immutable_bytes();
         const auto& offsets = column.get_offset();
 
         T bytes_size = bytes.size() * sizeof(uint8_t);

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -785,11 +785,11 @@ public:
 
         // input
         auto columns = _segment_column->columns();
-        std::vector<const Bytes*> input_bytes;
+        std::vector<const Byte*> input_bytes;
         std::vector<const Offsets*> input_offsets;
         for (auto& seg_column : columns) {
             auto col_ptr = ColumnHelper::as_column<ColumnT>(seg_column);
-            input_bytes.push_back(&col_ptr->get_bytes());
+            input_bytes.push_back(col_ptr->continuous_data());
             input_offsets.push_back(&col_ptr->get_offset());
         }
 
@@ -822,10 +822,10 @@ public:
         for (size_t i = 0; i < _size; i++) {
             size_t idx = _indexes[from + i];
             auto [segment_id, segment_offset] = _segment_address(idx, segment_size);
-            const Bytes& src_bytes = *input_bytes[segment_id];
+            const Byte* src_bytes = input_bytes[segment_id];
             const Offsets& src_offsets = *input_offsets[segment_id];
             Offset str_size = src_offsets[segment_offset + 1] - src_offsets[segment_offset];
-            const Byte* str_data = src_bytes.data() + src_offsets[segment_offset];
+            const Byte* str_data = src_bytes + src_offsets[segment_offset];
 
             strings::memcpy_inlined(dest_bytes + output_offsets[i], str_data, str_size);
         }

--- a/be/src/storage/column_not_in_predicate.cpp
+++ b/be/src/storage/column_not_in_predicate.cpp
@@ -18,6 +18,7 @@
 #include "column/nullable_column.h"
 #include "gutil/casts.h"
 #include "olap_type_infra.h"
+#include "simd/simd.h"
 #include "storage/column_predicate.h"
 #include "storage/in_predicate_utils.h"
 #include "storage/rowset/bitmap_index_reader.h"
@@ -437,6 +438,75 @@ ColumnPredicate* new_column_not_in_predicate_from_datum(const TypeInfoPtr& type_
                     return new ColumnNotInPredicate<LT>(type_info, id, std::move(value_set));
                 }
             });
+}
+
+Status compound_and_predicates_evaluate(const std::vector<const ColumnPredicate*>& predicates, const Column* col,
+                                        uint8_t* selection, uint16_t* selected_idx, uint16_t from, uint16_t to) {
+    const auto num_rows = to - from;
+    if (predicates.empty()) {
+        memset(selection + from, 1, num_rows);
+        return Status::OK();
+    }
+
+    std::vector<const ColumnPredicate*> vectorized_preds;
+    std::vector<const ColumnPredicate*> non_vectorized_preds;
+    vectorized_preds.reserve(predicates.size());
+    non_vectorized_preds.reserve(predicates.size());
+    for (const auto& pred : predicates) {
+        if (pred->can_vectorized()) {
+            vectorized_preds.emplace_back(pred);
+        } else {
+            non_vectorized_preds.emplace_back(pred);
+        }
+    }
+
+    // Evaluate vectorized predicates first.
+    bool first = true;
+    bool contains_true = true;
+
+    for (const auto& pred : vectorized_preds) {
+        if (first) {
+            first = false;
+            RETURN_IF_ERROR(pred->evaluate(col, selection, from, to));
+        } else {
+            RETURN_IF_ERROR(pred->evaluate_and(col, selection, from, to));
+        }
+
+        contains_true = SIMD::count_nonzero(selection + from, num_rows);
+        if (!contains_true) {
+            break;
+        }
+    }
+
+    if (contains_true && !non_vectorized_preds.empty()) {
+        uint16_t selected_size = 0;
+        if (first) {
+            // When there is no any vectorized predicate, should initialize selected_idx in a vectorized way.
+            selected_size = to - from;
+            for (uint16_t i = from, j = 0; i < to; ++i, ++j) {
+                selected_idx[j] = i;
+            }
+        } else {
+            for (uint16_t i = from; i < to; ++i) {
+                selected_idx[selected_size] = i;
+                selected_size += selection[i];
+            }
+        }
+
+        for (const auto& pred : non_vectorized_preds) {
+            ASSIGN_OR_RETURN(selected_size, pred->evaluate_branchless(col, selected_idx, selected_size));
+            if (selected_size == 0) {
+                break;
+            }
+        }
+
+        memset(&selection[from], 0, to - from);
+        for (uint16_t i = 0; i < selected_size; ++i) {
+            selection[selected_idx[i]] = 1;
+        }
+    }
+
+    return Status::OK();
 }
 
 } //namespace starrocks

--- a/be/src/storage/column_predicate.h
+++ b/be/src/storage/column_predicate.h
@@ -271,6 +271,9 @@ ColumnPredicate* new_column_in_predicate_from_datum(const TypeInfoPtr& type, Col
 ColumnPredicate* new_column_not_in_predicate_from_datum(const TypeInfoPtr& type, ColumnId id,
                                                         const std::vector<Datum>& operands);
 
+Status compound_and_predicates_evaluate(const std::vector<const ColumnPredicate*>& predicates, const Column* col,
+                                        uint8_t* selection, uint16_t* selected_idx, uint16_t from, uint16_t to);
+
 template <LogicalType LT>
 class Bitset;
 template <LogicalType LT>

--- a/be/src/storage/column_predicate_cmp.cpp
+++ b/be/src/storage/column_predicate_cmp.cpp
@@ -960,7 +960,7 @@ public:
     using Base = BinaryColumnPredicateCmpBase<field_type, std::not_equal_to<ValueType>>;
 
     BinaryColumnNePredicate(const TypeInfoPtr& type_info, ColumnId id, ValueType value)
-            : Base(PredicateType::kNE, type_info, id, value) {}
+            : Base(PredicateType::kNE, type_info, id, value), _is_empty_string(value.empty()) {}
 
     bool zone_map_filter(const ZoneMapDetail& detail) const override { return true; }
 
@@ -983,6 +983,51 @@ public:
         return Status::OK();
 #endif
     }
+
+    // Optimized evaluate_branchless for empty string comparison
+    StatusOr<uint16_t> evaluate_branchless(const Column* column, uint16_t* sel, uint16_t sel_size) const override {
+        if (!_is_empty_string) {
+            // For non-empty string, use base class implementation
+            return Base::evaluate_branchless(column, sel, sel_size);
+        }
+
+        // Fast path for col != ''
+        // Only need to check if length > 0, no need to compare actual data
+        const BinaryColumn* binary_column;
+        if (column->is_nullable()) {
+            binary_column =
+                    down_cast<const BinaryColumn*>(down_cast<const NullableColumn*>(column)->data_column().get());
+        } else {
+            binary_column = down_cast<const BinaryColumn*>(column);
+        }
+
+        const auto& offsets = binary_column->get_offset();
+        const uint32_t* offset_data = offsets.data();
+        uint16_t new_size = 0;
+
+        if (!column->has_null()) {
+            // Non-nullable column: just check length != 0
+            for (uint16_t i = 0; i < sel_size; ++i) {
+                uint16_t data_idx = sel[i];
+                uint32_t len = offset_data[data_idx + 1] - offset_data[data_idx];
+                sel[new_size] = data_idx;
+                new_size += (len != 0); // Branchless: increment only if len > 0
+            }
+        } else {
+            // Nullable column: check not null AND length != 0
+            const uint8_t* is_null = down_cast<const NullableColumn*>(column)->immutable_null_column_data().data();
+            for (uint16_t i = 0; i < sel_size; ++i) {
+                uint16_t data_idx = sel[i];
+                uint32_t len = offset_data[data_idx + 1] - offset_data[data_idx];
+                sel[new_size] = data_idx;
+                new_size += (!is_null[data_idx]) & (len != 0); // Branchless
+            }
+        }
+        return new_size;
+    }
+
+private:
+    const bool _is_empty_string;
 };
 
 ColumnPredicate* new_column_ne_predicate(const TypeInfoPtr& type_info, ColumnId id, const Slice& operand) {

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -214,6 +214,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     seg_options.asc_hint = options.asc_hint;
     seg_options.column_access_paths = options.column_access_paths;
     seg_options.has_preaggregation = options.has_preaggregation;
+    seg_options.enable_predicate_col_late_materialize = options.enable_predicate_col_late_materialize;
     if (options.is_primary_keys) {
         seg_options.is_primary_keys = true;
         seg_options.delvec_loader = std::make_shared<LakeDelvecLoader>(

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -345,6 +345,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.enable_join_runtime_filter_pushdown = params.enable_join_runtime_filter_pushdown;
     rs_opts.prune_column_after_index_filter = params.prune_column_after_index_filter;
     rs_opts.enable_gin_filter = params.enable_gin_filter;
+    rs_opts.enable_predicate_col_late_materialize = params.enable_predicate_col_late_materialize;
 
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;

--- a/be/src/storage/predicate_tree/predicate_tree.cpp
+++ b/be/src/storage/predicate_tree/predicate_tree.cpp
@@ -472,6 +472,11 @@ bool PredicateTree::empty() const {
     return is_empty(_root);
 }
 
+bool PredicateTree::has_or_predicate() const {
+    // if only has AND predicates, there is only one compound And predicate node
+    return _compound_node_contexts.size() > 1;
+}
+
 PredicateAndNode PredicateTree::release_root() {
     return std::move(_root);
 }

--- a/be/src/storage/predicate_tree/predicate_tree.h
+++ b/be/src/storage/predicate_tree/predicate_tree.h
@@ -330,6 +330,8 @@ public:
     /// Whether there is no ColumnPredicates in the tree.
     bool empty() const;
 
+    bool has_or_predicate() const;
+
     const PredicateAndNode& root() const { return _root; }
     /// Release the ownership of all the nodes.
     PredicateAndNode release_root();

--- a/be/src/storage/push_utils.cpp
+++ b/be/src/storage/push_utils.cpp
@@ -149,7 +149,7 @@ ColumnPtr PushBrokerReader::_padding_char_column(const ColumnPtr& column, const 
     new_bytes.assign(num_rows * len, 0); // padding 0
 
     uint32_t from = 0;
-    const auto bytes = binary->get_bytes();
+    auto bytes = binary->get_immutable_bytes();
     for (size_t i = 0; i < num_rows; ++i) {
         uint32_t copy_data_len = std::min(len, offsets[i + 1] - offsets[i]);
         strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offsets[i], copy_data_len);

--- a/be/src/storage/rowset/binary_dict_page.cpp
+++ b/be/src/storage/rowset/binary_dict_page.cpp
@@ -36,10 +36,16 @@
 
 #include <memory>
 
+#include "column/append_with_mask.h"
+#include "column/binary_column.h"
+#include "column/column_helper.h"
+#include "column/nullable_column.h"
 #include "common/logging.h"
 #include "gutil/casts.h"
 #include "gutil/strings/substitute.h" // for Substitute
+#include "simd/simd.h"
 #include "storage/chunk_helper.h"
+#include "storage/column_predicate.h"
 #include "storage/range.h"
 #include "storage/rowset/bitshuffle_page.h"
 #include "types/logical_type.h"
@@ -215,7 +221,7 @@ Status BinaryDictPageDecoder<Type>::seek_to_position_in_page(uint32_t pos) {
 template <LogicalType Type>
 void BinaryDictPageDecoder<Type>::set_dict_decoder(PageDecoder* dict_decoder) {
     _dict_decoder = down_cast<BinaryPlainPageDecoder<Type>*>(dict_decoder);
-    _max_value_legth = _dict_decoder->max_value_length();
+    _max_value_length = _dict_decoder->max_value_length();
 }
 
 template <LogicalType Type>
@@ -262,23 +268,179 @@ Status BinaryDictPageDecoder<Type>::next_batch(const SparseRange<>& range, Colum
         _dict_decoder->batch_string_at_index(slices, codewords, nread);
     }
 
-    class SliceContainerAdaptor {
-    public:
-        using value_type = Slice;
-        SliceContainerAdaptor(Slice* slices, size_t size) : _slices(slices), _size(size) {}
-
-        Slice* data() const { return _slices; }
-        size_t size() const { return _size; }
-
-    private:
-        Slice* _slices;
-        size_t _size;
-    };
-
     SliceContainerAdaptor adaptor(slices, nread);
-    bool ok = dst->append_strings_overflow(adaptor, _max_value_legth);
+    bool ok = dst->append_strings_overflow(adaptor, _max_value_length);
     DCHECK(ok) << "append_strings_overflow failed";
     RETURN_IF(!ok, Status::InternalError("BinaryDictPageDecoder::next_batch failed"));
+    return Status::OK();
+}
+
+template <LogicalType Type>
+Status BinaryDictPageDecoder<Type>::next_batch_with_filter(
+        Column* column, const SparseRange<>& range, const std::vector<const ColumnPredicate*>& compound_and_predicates,
+        const uint8_t* null_data, uint8_t* selection, uint16_t* selected_idx) {
+    DCHECK(Type != TYPE_CHAR);
+    if (_encoding_type == PLAIN_ENCODING) {
+        return _data_page_decoder->next_batch_with_filter(column, range, compound_and_predicates, null_data, selection,
+                                                          selected_idx);
+    }
+
+    DCHECK(_parsed);
+    DCHECK(_dict_decoder != nullptr) << "dict decoder pointer is nullptr";
+    DCHECK(null_data == nullptr || column->is_nullable());
+
+    // caller must make sure SparseRange's ranges are all in the same page
+    size_t num_rows = range.span_size();
+    if (null_data != nullptr) {
+        // Create temporary nullable column for predicate evaluation
+        auto temp_column = column->clone_empty();
+        auto temp_nullable_column = down_cast<NullableColumn*>(temp_column.get());
+        auto temp_data_column = temp_nullable_column->data_column_raw_ptr();
+        auto& temp_null_column = temp_nullable_column->null_column_ref();
+
+        // Read data column and null column
+        ContainerResource container(_page_handle, null_data, num_rows);
+        int n = temp_null_column.append_numbers(container);
+        DCHECK_EQ(n, num_rows);
+        RETURN_IF_ERROR(next_batch(range, temp_data_column));
+        DCHECK(temp_null_column.size() == num_rows);
+        DCHECK(temp_data_column->size() == num_rows);
+        temp_nullable_column->update_has_null();
+
+        // Evaluate predicates on the temporary column
+        RETURN_IF_ERROR(compound_and_predicates_evaluate(compound_and_predicates, temp_column.get(), selection,
+                                                         selected_idx, 0, num_rows));
+
+        uint32_t selected_count = SIMD::count_nonzero(selection, num_rows);
+        if (selected_count == 0) {
+            return Status::OK();
+        }
+
+        auto nullable_column = down_cast<NullableColumn*>(column);
+        RETURN_IF_ERROR(
+                append_with_mask</*PositiveSelect=*/true>(nullable_column, *temp_nullable_column, selection, num_rows));
+
+        return Status::OK();
+    }
+
+    if (PREDICT_FALSE(_data_page_decoder->current_index() >= _data_page_decoder->count())) {
+        return Status::OK();
+    }
+
+    // Step 1: Create dictionary column and apply predicates to dictionary
+    uint32_t dict_size = _dict_decoder->count();
+    if (dict_size == 0) {
+        return Status::OK();
+    }
+
+    // For other types, use true zero-copy construction directly from decoder data
+    const void* data_ptr = _dict_decoder->get_raw_data();
+    size_t data_length = _dict_decoder->get_data_length();
+
+    BinaryColumn::Offsets temp_offsets;
+    _dict_decoder->get_offsets_for_zero_copy(temp_offsets);
+
+    // Create zero-copy BinaryColumn directly from decoder's data
+    ContainerResource container(_page_handle, data_ptr, data_length);
+    auto dict_column = BinaryColumn::create(std::move(container), std::move(temp_offsets));
+
+    // Apply predicates to dictionary
+    std::vector<uint8_t> dict_selection(dict_size, 0);
+    std::vector<uint16_t> dict_selected_idx(dict_size);
+    RETURN_IF_ERROR(compound_and_predicates_evaluate(compound_and_predicates, dict_column.get(), dict_selection.data(),
+                                                     dict_selected_idx.data(), 0, dict_size));
+    // Count selected dictionary entries
+    uint32_t dict_selected_count = SIMD::count_nonzero(dict_selection.data(), dict_size);
+    if (dict_selected_count == 0) {
+        memset(selection, 0, num_rows);
+        return Status::OK();
+    }
+
+    // Step 2: Read dictionary codes for the range (we must do this regardless of dict selection)
+    if (_vec_code_buf == nullptr) {
+        _vec_code_buf = ChunkHelper::column_from_field_type(TYPE_INT, false);
+    }
+    _vec_code_buf->resize(0);
+    _vec_code_buf->reserve(num_rows);
+
+    RETURN_IF_ERROR(_data_page_decoder->next_batch(range, _vec_code_buf.get()));
+    size_t nread = _vec_code_buf->size();
+
+    if (nread == 0) {
+        return Status::OK();
+    }
+
+    using cast_type = CppTypeTraits<TYPE_INT>::CppType;
+    const auto* codewords = reinterpret_cast<const cast_type*>(_vec_code_buf->raw_data());
+
+    // Step 3: Update selection based on dictionary selection and collect matching slices
+    std::vector<Slice> selected_slices;
+    selected_slices.reserve(nread);
+
+    for (size_t i = 0; i < nread; ++i) {
+        uint32_t code = codewords[i];
+        if (code < dict_size && dict_selection[code]) {
+            selection[i] = 1;
+            Slice element = _dict_decoder->string_at_index(code);
+            selected_slices.emplace_back(element);
+        } else {
+            selection[i] = 0;
+        }
+    }
+
+    // Step 4: Append selected strings to column using append_strings_overflow
+    if (!selected_slices.empty()) {
+        SliceContainerAdaptor adaptor(selected_slices);
+        bool ok = column->append_strings_overflow(adaptor, _max_value_length);
+        RETURN_IF(!ok, Status::InternalError("BinaryDictPageDecoder::next_batch_with_filter failed"));
+    }
+
+    return Status::OK();
+}
+
+template <LogicalType Type>
+Status BinaryDictPageDecoder<Type>::read_by_rowids(const ordinal_t first_ordinal_in_page, const rowid_t* rowids,
+                                                   size_t* count, Column* column) {
+    if (_encoding_type == PLAIN_ENCODING) {
+        return _data_page_decoder->read_by_rowids(first_ordinal_in_page, rowids, count, column);
+    }
+    DCHECK(_parsed);
+    DCHECK(_dict_decoder != nullptr) << "dict decoder pointer is nullptr";
+    if (PREDICT_FALSE(*count == 0)) {
+        return Status::OK();
+    }
+    if (_vec_code_buf == nullptr) {
+        _vec_code_buf = ChunkHelper::column_from_field_type(TYPE_INT, false);
+    }
+    _vec_code_buf->resize(0);
+    _vec_code_buf->reserve(*count);
+    size_t read_count = *count;
+    RETURN_IF_ERROR(
+            _data_page_decoder->read_by_rowids(first_ordinal_in_page, rowids, &read_count, _vec_code_buf.get()));
+    DCHECK_EQ(_vec_code_buf->size(), read_count);
+
+    if (PREDICT_FALSE(read_count == 0)) {
+        *count = 0;
+        return Status::OK();
+    }
+    using cast_type = CppTypeTraits<TYPE_INT>::CppType;
+    const auto* codewords = reinterpret_cast<const cast_type*>(_vec_code_buf->raw_data());
+    auto slices_data = std::make_unique_for_overwrite<uint8_t[]>(read_count * sizeof(Slice));
+    Slice* slices = reinterpret_cast<Slice*>(slices_data.get());
+    if constexpr (Type == TYPE_CHAR) {
+        for (size_t i = 0; i < read_count; i++) {
+            Slice element = _dict_decoder->string_at_index(codewords[i]);
+            element.size = strnlen(element.data, element.size);
+            slices[i] = element;
+        }
+    } else {
+        _dict_decoder->batch_string_at_index(slices, codewords, read_count);
+    }
+
+    SliceContainerAdaptor adaptor(slices, read_count);
+    bool ok = column->append_strings_overflow(adaptor, _max_value_length);
+    RETURN_IF(!ok, Status::InternalError("BinaryDictPageDecoder::read_by_rowids failed"));
+    *count = read_count;
     return Status::OK();
 }
 
@@ -290,10 +452,45 @@ Status BinaryDictPageDecoder<Type>::next_dict_codes(size_t* n, Column* dst) {
 }
 
 template <LogicalType Type>
+Status BinaryDictPageDecoder<Type>::read_dict_codes_by_rowids(const ordinal_t first_ordinal_in_page,
+                                                              const rowid_t* rowids, size_t* count, Column* dst) {
+    DCHECK(_encoding_type == DICT_ENCODING);
+    DCHECK(_parsed);
+    return _data_page_decoder->read_by_rowids(first_ordinal_in_page, rowids, count, dst);
+}
+
+template <LogicalType Type>
 Status BinaryDictPageDecoder<Type>::next_dict_codes(const SparseRange<>& range, Column* dst) {
     DCHECK(_encoding_type == DICT_ENCODING);
     DCHECK(_parsed);
     return _data_page_decoder->next_batch(range, dst);
+}
+
+template <LogicalType Type>
+void BinaryDictPageDecoder<Type>::reserve_col(size_t n, Column* column) {
+    if (_encoding_type == PLAIN_ENCODING) {
+        return _data_page_decoder->reserve_col(n, column);
+    }
+
+    if (_dict_decoder == nullptr) {
+        column->reserve(n);
+        return;
+    }
+
+    size_t estimated_row_size = _dict_decoder->estimate_row_size();
+    Column* data_col;
+    if (column->is_nullable()) {
+        // This is NullableColumn, get its data_column
+        auto* nullable_col = down_cast<NullableColumn*>(column);
+        data_col = nullable_col->data_column_raw_ptr();
+    } else {
+        data_col = column;
+    }
+
+    if (data_col->is_binary()) {
+        BinaryColumn* binary_col = down_cast<BinaryColumn*>(data_col);
+        binary_col->reserve(n, estimated_row_size * n);
+    }
 }
 
 template class BinaryDictPageDecoder<TYPE_CHAR>;

--- a/be/src/storage/rowset/binary_dict_page.h
+++ b/be/src/storage/rowset/binary_dict_page.h
@@ -133,6 +133,16 @@ public:
 
     Status next_batch(const SparseRange<>& range, Column* dst) override;
 
+    Status next_batch_with_filter(Column* column, const SparseRange<>& range,
+                                  const std::vector<const ColumnPredicate*>& compound_and_predicates,
+                                  const uint8_t* null_data, uint8_t* selection, uint16_t* selected_idx) override;
+
+    Status read_by_rowids(const ordinal_t first_ordinal_in_page, const rowid_t* rowids, size_t* count,
+                          Column* column) override;
+
+    Status read_dict_codes_by_rowids(const ordinal_t first_ordinal_in_page, const rowid_t* rowids, size_t* count,
+                                     Column* dst);
+
     uint32_t count() const override { return _data_page_decoder->count(); }
 
     uint32_t current_index() const override { return _data_page_decoder->current_index(); }
@@ -145,6 +155,12 @@ public:
 
     Status next_dict_codes(const SparseRange<>& range, Column* dst) override;
 
+    void reserve_col(size_t n, Column* column) override;
+
+    bool support_push_down_predicate() const override { return Type != TYPE_CHAR; }
+
+    bool supports_read_by_rowids() const override { return true; }
+
 private:
     Slice _data;
     std::unique_ptr<PageDecoder> _data_page_decoder;
@@ -153,7 +169,7 @@ private:
     EncodingTypePB _encoding_type;
     MutableColumnPtr _vec_code_buf;
 
-    uint32_t _max_value_legth = 0;
+    uint32_t _max_value_length = 0;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/binary_dict_page.h
+++ b/be/src/storage/rowset/binary_dict_page.h
@@ -156,9 +156,6 @@ public:
     Status next_dict_codes(const SparseRange<>& range, Column* dst) override;
 
     void reserve_col(size_t n, Column* column) override;
-
-    bool support_push_down_predicate() const override { return Type == TYPE_VARCHAR; }
-
     bool supports_read_by_rowids() const override { return true; }
 
 private:

--- a/be/src/storage/rowset/binary_dict_page.h
+++ b/be/src/storage/rowset/binary_dict_page.h
@@ -157,7 +157,7 @@ public:
 
     void reserve_col(size_t n, Column* column) override;
 
-    bool support_push_down_predicate() const override { return Type != TYPE_CHAR; }
+    bool support_push_down_predicate() const override { return Type == TYPE_VARCHAR; }
 
     bool supports_read_by_rowids() const override { return true; }
 

--- a/be/src/storage/rowset/binary_plain_page.cpp
+++ b/be/src/storage/rowset/binary_plain_page.cpp
@@ -288,7 +288,7 @@ Status BinaryPlainPageDecoder<Type>::next_range_with_filter(
         // Append null flags for selected rows if null_data is provided
         if (null != nullptr) {
             auto* nullable_column = down_cast<NullableColumn*>(dst);
-            auto* temp_nullable = down_cast<NullableColumn*>(temp_eval_column.get());
+            auto* temp_nullable = down_cast<NullableColumn*>(temp_eval_column->as_mutable_raw_ptr());
             RETURN_IF_ERROR(append_with_mask</*PositiveSelect=*/true>(
                     nullable_column->null_column_raw_ptr(), *temp_nullable->null_column(), selection, num_rows));
             nullable_column->update_has_null();

--- a/be/src/storage/rowset/binary_plain_page.cpp
+++ b/be/src/storage/rowset/binary_plain_page.cpp
@@ -274,8 +274,8 @@ Status BinaryPlainPageDecoder<Type>::next_range_with_filter(
         }
 
         // Evaluate predicates on the temporary column
-        Status predicate_result = compound_and_predicates_evaluate(compound_and_predicates, temp_eval_column.get(),
-                                                                   selection, selected_idx, 0, num_rows);
+        RETURN_IF_ERROR(compound_and_predicates_evaluate(compound_and_predicates, temp_eval_column.get(), selection,
+                                                         selected_idx, 0, num_rows));
 
         uint32_t selected_count = SIMD::count_nonzero(selection, num_rows);
         if (selected_count == 0) {

--- a/be/src/storage/rowset/binary_plain_page.h
+++ b/be/src/storage/rowset/binary_plain_page.h
@@ -276,8 +276,8 @@ public:
         return -1;
     }
 
-    bool support_push_down_predicate() const override { return Type != TYPE_CHAR; }
-    bool supports_read_by_rowids() const override { return true; }
+    bool support_push_down_predicate() const override { return Type == TYPE_VARCHAR; }
+    bool supports_read_by_rowids() const override { return Type == TYPE_VARCHAR; }
 
     uint32_t max_value_length() const {
         uint32_t max_length = 0;

--- a/be/src/storage/rowset/binary_plain_page.h
+++ b/be/src/storage/rowset/binary_plain_page.h
@@ -276,7 +276,6 @@ public:
         return -1;
     }
 
-    bool support_push_down_predicate() const override { return Type == TYPE_VARCHAR; }
     bool supports_read_by_rowids() const override { return Type == TYPE_VARCHAR; }
 
     uint32_t max_value_length() const {

--- a/be/src/storage/rowset/binary_plain_page.h
+++ b/be/src/storage/rowset/binary_plain_page.h
@@ -61,7 +61,7 @@
 
 namespace starrocks {
 class Column;
-}
+} // namespace starrocks
 
 namespace starrocks {
 
@@ -216,6 +216,9 @@ public:
 
         _parsed = true;
 
+        uint32_t total_bytes = _offsets_pos;
+        _estimated_row_size = _num_elems == 0 ? 0 : total_bytes / _num_elems;
+
         return Status::OK();
     }
 
@@ -231,6 +234,13 @@ public:
 
     bool append_range(uint32_t idx, uint32_t end, Column* dst) const;
 
+    Status read_by_rowids(const ordinal_t first_ordinal_in_page, const rowid_t* rowids, size_t* count,
+                          Column* column) override;
+
+    Status next_batch_with_filter(Column* column, const SparseRange<>& range,
+                                  const std::vector<const ColumnPredicate*>& compound_and_predicates,
+                                  const uint8_t* null_data, uint8_t* selection, uint16_t* selected_idx) override;
+
     uint32_t count() const override {
         DCHECK(_parsed);
         return _num_elems;
@@ -242,6 +252,8 @@ public:
     }
 
     EncodingTypePB encoding_type() const override { return PLAIN_ENCODING; }
+
+    size_t estimate_row_size() const { return _estimated_row_size; }
 
     Slice string_at_index(uint32_t idx) const {
         const uint32_t start_offset = offset(idx);
@@ -264,6 +276,9 @@ public:
         return -1;
     }
 
+    bool support_push_down_predicate() const override { return Type != TYPE_CHAR; }
+    bool supports_read_by_rowids() const override { return true; }
+
     uint32_t max_value_length() const {
         uint32_t max_length = 0;
         for (int i = 0; i < _num_elems; ++i) {
@@ -276,6 +291,43 @@ public:
     }
 
     uint32_t dict_size() { return _num_elems; }
+
+    // Zero-copy access methods for dictionary usage
+    const void* get_raw_data() const {
+        const uint32_t start_offset = offset_uncheck(0);
+        return &_data[start_offset];
+    }
+
+    size_t get_data_length() const { return _num_elems > 0 ? offset(_num_elems) - offset_uncheck(0) : 0; }
+
+    // Get offsets for zero-copy construction
+    void get_offsets_for_zero_copy(BinaryColumn::Offsets& offsets) const {
+        offsets.clear();
+        offsets.resize(_num_elems + 1);
+        offsets[0] = 0; // Start from 0
+        if (_num_elems == 0) {
+            return;
+        }
+
+        uint32_t base_offset = offset_uncheck(0); // Get the base offset
+        for (uint32_t i = 0; i < _num_elems - 1; ++i) {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+            auto offset = _offsets_ptr[i + 1];
+#else
+            // direct call offset_uncheck() will break auto-vectorized
+            // maybe we can remove this condition compile after we upgrade the toolchain
+            auto offset = offset_uncheck(i + 1);
+#endif
+            // Convert absolute offset to relative offset from base
+            uint32_t current_offset = offset - base_offset;
+            offsets[i + 1] = current_offset;
+        }
+
+        for (uint32_t i = _num_elems - 1; i < _num_elems; i++) {
+            uint32_t current_offset = offset(i + 1) - base_offset;
+            offsets[i + 1] = current_offset;
+        }
+    }
 
 private:
     // Return the offset within '_data' where the string value with index 'idx' can be found.
@@ -291,6 +343,26 @@ private:
 #endif
     }
 
+    Status next_range_with_filter(uint32_t idx, uint32_t end, Column* dst,
+                                  const std::vector<const ColumnPredicate*>& compound_and_predicates,
+                                  const uint8_t* null, uint8_t* selection, uint16_t* selected_idx);
+
+    void reserve_col(size_t n, Column* column) override {
+        Column* data_col;
+        if (column->is_nullable()) {
+            // This is NullableColumn, get its data_column
+            auto* nullable_col = down_cast<NullableColumn*>(column);
+            data_col = nullable_col->data_column().get();
+        } else {
+            data_col = column;
+        }
+
+        if (data_col->is_binary() && data_col->capacity() == 0) {
+            BinaryColumn* binary_col = down_cast<BinaryColumn*>(data_col);
+            binary_col->reserve(n, n * _estimated_row_size);
+        }
+    }
+
     Slice _data;
     bool _parsed;
 
@@ -300,6 +372,8 @@ private:
 
     // Index of the currently seeked element in the page.
     uint32_t _cur_idx;
+
+    size_t _estimated_row_size;
 
     std::optional<std::vector<Slice>> _parsed_datas;
 };

--- a/be/src/storage/rowset/binary_plain_page.h
+++ b/be/src/storage/rowset/binary_plain_page.h
@@ -352,7 +352,7 @@ private:
         if (column->is_nullable()) {
             // This is NullableColumn, get its data_column
             auto* nullable_col = down_cast<NullableColumn*>(column);
-            data_col = nullable_col->data_column().get();
+            data_col = nullable_col->data_column_raw_ptr();
         } else {
             data_col = column;
         }

--- a/be/src/storage/rowset/binary_prefix_page.cpp
+++ b/be/src/storage/rowset/binary_prefix_page.cpp
@@ -329,7 +329,6 @@ Status BinaryPrefixPageDecoder<Type>::next_batch(const SparseRange<>& range, Col
     }
     return Status::OK();
 }
-
 template class BinaryPrefixPageDecoder<TYPE_CHAR>;
 template class BinaryPrefixPageDecoder<TYPE_VARCHAR>;
 

--- a/be/src/storage/rowset/binary_prefix_page.h
+++ b/be/src/storage/rowset/binary_prefix_page.h
@@ -130,7 +130,6 @@ public:
     Status next_batch(size_t* n, Column* dst) override;
 
     Status next_batch(const SparseRange<>& range, Column* dst) override;
-
     uint32_t count() const override {
         DCHECK(_parsed);
         return _num_values;

--- a/be/src/storage/rowset/bitshuffle_page.h
+++ b/be/src/storage/rowset/bitshuffle_page.h
@@ -359,11 +359,16 @@ public:
 
     Status next_batch(const SparseRange<>& range, Column* dst) override;
 
+    Status read_by_rowids(const ordinal_t first_ordinal_in_page, const rowid_t* rowids, size_t* count,
+                          Column* column) override;
+
     uint32_t count() const override { return _num_elements; }
 
     uint32_t current_index() const override { return _cur_index; }
 
     EncodingTypePB encoding_type() const override { return BIT_SHUFFLE; }
+
+    bool supports_read_by_rowids() const override { return true; }
 
 private:
     void _copy_next_values(size_t n, void* data) {
@@ -410,6 +415,35 @@ inline Status BitShufflePageDecoder<Type>::next_batch(const SparseRange<>& range
         _cur_index += r.span_size();
         to_read -= r.span_size();
     }
+    return Status::OK();
+}
+
+template <LogicalType Type>
+inline Status BitShufflePageDecoder<Type>::read_by_rowids(const ordinal_t first_ordinal_in_page, const rowid_t* rowids,
+                                                          size_t* count, Column* column) {
+    DCHECK(_parsed);
+    if (PREDICT_FALSE(*count == 0)) {
+        return Status::OK();
+    }
+    size_t total = *count;
+    size_t read_count = 0;
+    [[maybe_unused]] CppType data[total];
+    for (size_t i = 0; i < total; i++) {
+        ordinal_t ord = rowids[i] - first_ordinal_in_page;
+        if (UNLIKELY(ord >= _num_elements)) {
+            break;
+        }
+        data[read_count++] = *reinterpret_cast<const CppType*>(get_data(ord * SIZE_OF_TYPE));
+    }
+
+    if (read_count > 0) {
+        size_t nappend = column->append_numbers(data, SIZE_OF_TYPE * read_count);
+        if (UNLIKELY(nappend != read_count)) {
+            return Status::InternalError(
+                    fmt::format("append_numbers failed, expected rows[{}], actual rows[{}]", read_count, nappend));
+        }
+    }
+    *count = read_count;
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/column_decoder.h
+++ b/be/src/storage/rowset/column_decoder.h
@@ -57,6 +57,8 @@ public:
 
     int32_t dict_convert_size() const { return _code_convert_map.has_value() ? _code_convert_map->size() - 1 : 0; }
 
+    void reserve_col(size_t n, Column* column) { _iter->reserve_col(n, column); }
+
 private:
     Status _encode_string_to_global_id(Column* datas, Column* codes);
 

--- a/be/src/storage/rowset/column_iterator.cpp
+++ b/be/src/storage/rowset/column_iterator.cpp
@@ -64,6 +64,10 @@ Status ColumnIterator::fetch_dict_codes_by_rowid(const Column& rowids, Column* v
     return fetch_dict_codes_by_rowid(p, rowids.size(), values);
 }
 
+Status ColumnIterator::fetch_values_by_rowid_for_predicate_evaluate(const Column& rowids, Column* values) {
+    return fetch_values_by_rowid(rowids, values);
+}
+
 Status ColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
     auto iter = range.new_iterator();
     auto to_read = range.span_size();

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -224,13 +224,19 @@ public:
     // and return glocal dict value if is global dictionary column
     Status fetch_values_by_rowid(const Column& rowids, Column* values);
 
-    // this interface will return dict value with given rowids without any translate
+    // this interface will return local dict value with given rowids without any translate
     // just like next_dict_codes but with given rowids
     virtual Status fetch_dict_codes_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
         return Status::NotSupported("");
     }
 
     Status fetch_dict_codes_by_rowid(const Column& rowids, Column* values);
+
+    // used for predicate late-materialization
+    // for low dictionary column, predicate will be rewritten by local dictionary,
+    // so predicate evaluation needs to read local dictionary values if this is a low dictionary column,
+    // This method will return local dictionary value if this is a low dictionary column
+    virtual Status fetch_values_by_rowid_for_predicate_evaluate(const Column& rowids, Column* values);
 
     // for Struct type (Struct)
     virtual Status next_batch(size_t* n, Column* dst, ColumnAccessPath* path) { return next_batch(n, dst); }

--- a/be/src/storage/rowset/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/dictcode_column_iterator.h
@@ -46,6 +46,9 @@ public:
 
     Status next_batch(const SparseRange<>& range, Column* dst) override { return _parent->next_dict_codes(range, dst); }
 
+    Status fetch_values_by_rowid_for_predicate_evaluate(const Column& rowids, Column* values) override {
+        return _parent->fetch_dict_codes_by_rowid(rowids, values);
+    }
     std::string name() const override { return "DictCodeColumnIterator"; }
 
 private:
@@ -81,6 +84,10 @@ public:
         _swap_null_columns(_local_dict_code_col.get(), values);
         values->set_delete_state(_local_dict_code_col->delete_state());
         return Status::OK();
+    }
+
+    Status fetch_values_by_rowid_for_predicate_evaluate(const Column& rowids, Column* values) override {
+        return _parent->fetch_dict_codes_by_rowid(rowids, values);
     }
 
     Status next_dict_codes(size_t* n, Column* dst) override {

--- a/be/src/storage/rowset/page_decoder.h
+++ b/be/src/storage/rowset/page_decoder.h
@@ -147,10 +147,6 @@ public:
 
     virtual void reserve_col(size_t n, Column* column) { column->reserve(n); }
 
-    // Check if this page decoder supports push down predicate for late materialization
-    // Returns true if this decoder can efficiently handle predicates in next_batch_with_filter
-    virtual bool support_push_down_predicate() const { return false; }
-
     virtual bool supports_read_by_rowids() const { return false; }
 
 protected:

--- a/be/src/storage/rowset/page_decoder.h
+++ b/be/src/storage/rowset/page_decoder.h
@@ -34,14 +34,16 @@
 
 #pragma once
 
-#include "common/status.h"
+#include "column/nullable_column.h"
+#include "common/status.h" // for Status
 #include "gen_cpp/segment.pb.h"
 #include "storage/range.h"
 #include "storage/rowset/page_handle_fwd.h"
 
 namespace starrocks {
+class ColumnPredicate;
 class Column;
-}
+} // namespace starrocks
 
 namespace starrocks {
 
@@ -90,6 +92,31 @@ public:
         return Status::NotSupported("PageDecoder Not Support");
     }
 
+    // given a set of ranges in page, apply compound and predicates on it, and only return filtered data
+    // since null data is separate from actually data page, we need pass the null data by caller if this is a nullable column
+    // null_data is a uint8_t array where null_data[i] indicates whether the i-th row is null (1 for null, 0 for not null)
+    // callee is responsible to handle null column and append null data into dst column if selected
+    virtual Status next_batch_with_filter(Column* column, const SparseRange<>& range,
+                                          const std::vector<const ColumnPredicate*>& compound_and_predicates,
+                                          const uint8_t* null_data, uint8_t* selection, uint16_t* selected_idx) {
+        return Status::NotSupported("PageDecoder Not Support next_batch_with_filter");
+    }
+
+    /**
+     * rowids and count represent a rowId vector
+     * read_by_rowids read selected rows in rowId vector
+     *  and return row numbers it read by 'count'
+     */
+    virtual Status read_by_rowids(const ordinal_t first_ordinal_in_page, const rowid_t* rowids, size_t* count,
+                                  Column* column) {
+        return Status::NotSupported("PageDecoder Not Support");
+    }
+
+    virtual Status read_dict_codes_by_rowids(const ordinal_t first_ordinal_in_page, const rowid_t* rowids,
+                                             size_t* count, Column* dst) {
+        return Status::NotSupported("PageDecoder Doesn't Support read_dict_codes_by_rowids");
+    }
+
     // Return the number of elements in this page.
     virtual uint32_t count() const = 0;
 
@@ -117,6 +144,14 @@ public:
     const PageDecoder& operator=(const PageDecoder&) = delete;
 
     void set_page_handle(const std::shared_ptr<PageHandle>& page_handle) { _page_handle = page_handle; }
+
+    virtual void reserve_col(size_t n, Column* column) { column->reserve(n); }
+
+    // Check if this page decoder supports push down predicate for late materialization
+    // Returns true if this decoder can efficiently handle predicates in next_batch_with_filter
+    virtual bool support_push_down_predicate() const { return false; }
+
+    virtual bool supports_read_by_rowids() const { return false; }
 
 protected:
     std::shared_ptr<PageHandle> _page_handle;

--- a/be/src/storage/rowset/parsed_page.cpp
+++ b/be/src/storage/rowset/parsed_page.cpp
@@ -235,7 +235,7 @@ public:
         return count;
     }
 
-    Status read_by_rowds(Column* column, const rowid_t* rowids, size_t* count) override {
+    Status read_by_rowids(Column* column, const rowid_t* rowids, size_t* count) override {
         return Status::NotSupported("V1 version don't support read_by_rowds");
     }
 
@@ -370,7 +370,7 @@ public:
         return Status::OK();
     }
 
-    Status read_by_rowds(Column* column, const rowid_t* rowids, size_t* count) override {
+    Status read_by_rowids(Column* column, const rowid_t* rowids, size_t* count) override {
         if (_null_flags.size() == 0) {
             RETURN_IF_ERROR(_data_decoder->read_by_rowids(_first_ordinal, rowids, count, column));
         } else {

--- a/be/src/storage/rowset/parsed_page.cpp
+++ b/be/src/storage/rowset/parsed_page.cpp
@@ -375,14 +375,14 @@ public:
             RETURN_IF_ERROR(_data_decoder->read_by_rowids(_first_ordinal, rowids, count, column));
         } else {
             auto nc = down_cast<NullableColumn*>(column);
-            RETURN_IF_ERROR(_data_decoder->read_by_rowids(_first_ordinal, rowids, count, nc->data_column().get()));
+            RETURN_IF_ERROR(_data_decoder->read_by_rowids(_first_ordinal, rowids, count, nc->data_column_raw_ptr()));
             std::vector<uint8_t> null_flags;
             for (size_t i = 0; i < *count; i++) {
                 ordinal_t ord = rowids[i] - _first_ordinal;
                 DCHECK_LT(ord, _num_rows);
                 null_flags.emplace_back(_null_flags[ord]);
             }
-            nc->null_column()->append_numbers(null_flags.data(), null_flags.size());
+            nc->null_column_raw_ptr()->append_numbers(null_flags.data(), null_flags.size());
             nc->update_has_null();
         }
         return Status::OK();
@@ -407,14 +407,14 @@ public:
         } else {
             auto nc = down_cast<NullableColumn*>(column);
             RETURN_IF_ERROR(
-                    _data_decoder->read_dict_codes_by_rowids(_first_ordinal, rowids, count, nc->data_column().get()));
+                    _data_decoder->read_dict_codes_by_rowids(_first_ordinal, rowids, count, nc->data_column_raw_ptr()));
             std::vector<uint8_t> null_flags;
             for (size_t i = 0; i < *count; i++) {
                 ordinal_t ord = rowids[i] - _first_ordinal;
                 DCHECK_LT(ord, _num_rows);
                 null_flags.emplace_back(_null_flags[ord]);
             }
-            nc->null_column()->append_numbers(null_flags.data(), null_flags.size());
+            nc->null_column_raw_ptr()->append_numbers(null_flags.data(), null_flags.size());
             nc->update_has_null();
         }
         return Status::OK();

--- a/be/src/storage/rowset/parsed_page.cpp
+++ b/be/src/storage/rowset/parsed_page.cpp
@@ -39,10 +39,12 @@
 #include <cstddef>
 #include <memory>
 
+#include "column/append_with_mask.h"
 #include "column/nullable_column.h"
 #include "common/status.h"
 #include "gutil/strings/substitute.h"
 #include "simd/simd.h"
+#include "storage/column_predicate.h"
 #include "storage/rowset/binary_dict_page.h"
 #include "storage/rowset/bitshuffle_page.h"
 #include "storage/rowset/encoding_info.h"
@@ -233,6 +235,50 @@ public:
         return count;
     }
 
+    Status read_by_rowds(Column* column, const rowid_t* rowids, size_t* count) override {
+        return Status::NotSupported("V1 version don't support read_by_rowds");
+    }
+
+    Status read_dict_codes_by_rowids(Column* column, const rowid_t* rowids, size_t* count) override {
+        return Status::NotSupported("V1 version don't support read_dict_codes_by_rowids");
+    }
+
+    // v1 can't support read_with_filter efficiently, so we read first and then filter
+    // since at least 80% rows is null, so it won't hurt performance much
+    Status read_with_filter(Column* column, const SparseRange<>& range,
+                            const std::vector<const ColumnPredicate*>& compound_and_predicates, uint8_t* selection,
+                            uint16_t* selected_idx) override {
+        DCHECK_LE(range.span_size(), remaining());
+
+        size_t original_col_size = column->size();
+        size_t num_rows = range.span_size();
+
+        // Clone a new column for reading data
+        auto temp_column = column->clone_empty();
+
+        // Read data to temp column (read will handle null flags automatically)
+        RETURN_IF_ERROR(read(temp_column.get(), range));
+
+        // Evaluate predicates on the temporary column
+        RETURN_IF_ERROR(compound_and_predicates_evaluate(compound_and_predicates, temp_column.get(), selection,
+                                                         selected_idx, 0, num_rows));
+
+        uint32_t selected_count = SIMD::count_nonzero(selection, num_rows);
+        if (selected_count == 0) {
+            return Status::OK();
+        }
+
+        RETURN_IF_ERROR(append_with_mask</*PositiveSelect=*/true>(column, *temp_column, selection, num_rows));
+
+        size_t added_col_size = column->size() - original_col_size;
+        if (selected_count != added_col_size) {
+            return Status::InternalError(
+                    fmt::format("Selected size:{}, does not match added col size:{}", selected_count, added_col_size));
+        }
+
+        return Status::OK();
+    }
+
 private:
     friend Status parse_page_v1(std::unique_ptr<ParsedPage>* result, PageHandle handle, const Slice& body,
                                 const DataPageFooterPB& footer, const EncodingInfo* encoding,
@@ -290,6 +336,58 @@ public:
         return Status::OK();
     }
 
+    Status read_with_filter(Column* column, const SparseRange<>& range,
+                            const std::vector<const ColumnPredicate*>& compound_and_predicates, uint8_t* selection,
+                            uint16_t* selected_idx) override {
+        DCHECK_EQ(_offset_in_page, range.begin());
+        DCHECK_EQ(_offset_in_page, _data_decoder->current_index());
+
+        size_t original_col_size = column->size();
+
+        if (_null_flags.size() == 0) {
+            RETURN_IF_ERROR(_data_decoder->next_batch_with_filter(column, range, compound_and_predicates, nullptr,
+                                                                  selection, selected_idx));
+        } else {
+            // For ParsedPageV2 with nulls: pass null flags to data_decoder
+            // The data_decoder will handle null predicates
+            auto nc = down_cast<NullableColumn*>(column);
+
+            // Pass the null flags starting from current offset
+            // The data_decoder will handle appending null flags to the column
+            const uint8_t* null_data = _null_flags.data() + _offset_in_page;
+            RETURN_IF_ERROR(_data_decoder->next_batch_with_filter(nc, range, compound_and_predicates, null_data,
+                                                                  selection, selected_idx));
+        }
+
+        size_t selected_size = SIMD::count_nonzero(selection, range.span_size());
+        size_t added_col_size = column->size() - original_col_size;
+        if (selected_size != added_col_size) {
+            return Status::InternalError(
+                    fmt::format("Selected size:{}, does not match added col size:{}", selected_size, added_col_size));
+        }
+        _offset_in_page = range.end();
+
+        return Status::OK();
+    }
+
+    Status read_by_rowds(Column* column, const rowid_t* rowids, size_t* count) override {
+        if (_null_flags.size() == 0) {
+            RETURN_IF_ERROR(_data_decoder->read_by_rowids(_first_ordinal, rowids, count, column));
+        } else {
+            auto nc = down_cast<NullableColumn*>(column);
+            RETURN_IF_ERROR(_data_decoder->read_by_rowids(_first_ordinal, rowids, count, nc->data_column().get()));
+            std::vector<uint8_t> null_flags;
+            for (size_t i = 0; i < *count; i++) {
+                ordinal_t ord = rowids[i] - _first_ordinal;
+                DCHECK_LT(ord, _num_rows);
+                null_flags.emplace_back(_null_flags[ord]);
+            }
+            nc->null_column()->append_numbers(null_flags.data(), null_flags.size());
+            nc->update_has_null();
+        }
+        return Status::OK();
+    }
+
     Status read_dict_codes(Column* column, size_t* count) override {
         if (_null_flags.size() == 0) {
             RETURN_IF_ERROR(_data_decoder->next_dict_codes(count, column));
@@ -300,6 +398,25 @@ public:
             nc->update_has_null();
         }
         _offset_in_page += *count;
+        return Status::OK();
+    }
+
+    Status read_dict_codes_by_rowids(Column* column, const rowid_t* rowids, size_t* count) override {
+        if (_null_flags.size() == 0) {
+            RETURN_IF_ERROR(_data_decoder->read_dict_codes_by_rowids(_first_ordinal, rowids, count, column));
+        } else {
+            auto nc = down_cast<NullableColumn*>(column);
+            RETURN_IF_ERROR(
+                    _data_decoder->read_dict_codes_by_rowids(_first_ordinal, rowids, count, nc->data_column().get()));
+            std::vector<uint8_t> null_flags;
+            for (size_t i = 0; i < *count; i++) {
+                ordinal_t ord = rowids[i] - _first_ordinal;
+                DCHECK_LT(ord, _num_rows);
+                null_flags.emplace_back(_null_flags[ord]);
+            }
+            nc->null_column()->append_numbers(null_flags.data(), null_flags.size());
+            nc->update_has_null();
+        }
         return Status::OK();
     }
 
@@ -351,6 +468,7 @@ Status parse_page_v1(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
                      uint32_t page_index) {
     auto page = std::make_unique<ParsedPageV1>();
     page->_page_handle = std::move(handle);
+    page->_version = 1;
 
     auto null_size = footer.nullmap_size();
     page->_has_null = null_size > 0;
@@ -380,6 +498,7 @@ Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
                      uint32_t page_index) {
     auto page = std::make_unique<ParsedPageV2>();
     page->_page_handle = std::make_shared<PageHandle>(std::move(handle));
+    page->_version = 2;
 
     // TODO: port the nulls decode to null pages
     auto null_size = footer.nullmap_size();

--- a/be/src/storage/rowset/parsed_page.h
+++ b/be/src/storage/rowset/parsed_page.h
@@ -98,7 +98,7 @@ public:
         return Status::NotSupported("Read by range Not Support");
     }
 
-    virtual Status read_by_rowds(Column* column, const rowid_t* rowids, size_t* count) {
+    virtual Status read_by_rowids(Column* column, const rowid_t* rowids, size_t* count) {
         return Status::NotSupported("Read by rowids Not Support");
     }
 

--- a/be/src/storage/rowset/parsed_page.h
+++ b/be/src/storage/rowset/parsed_page.h
@@ -98,6 +98,10 @@ public:
         return Status::NotSupported("Read by range Not Support");
     }
 
+    virtual Status read_by_rowds(Column* column, const rowid_t* rowids, size_t* count) {
+        return Status::NotSupported("Read by rowids Not Support");
+    }
+
     // prerequisite: encoding_type() is `DICT_ENCODING`.
     // Attempts to read up to |*count| dictionary codes from this page into the |column|.
     // On success, `Status::OK` is returned, and the number of codes read will be updated to
@@ -114,6 +118,29 @@ public:
 
     virtual size_t read_null_count() { return 0; }
 
+    virtual Status read_dict_codes_by_rowids(Column* column, const rowid_t* rowids, size_t* count) = 0;
+
+    // Check if this page supports read_by_rowds efficiently.
+    // V1 format returns false due to null/non-null interleaving complexity.
+    // V2 format returns true if _data_decoder supports read_by_rowids.
+    bool supports_read_by_rowids() {
+        if (_version == 1) {
+            return false;
+        }
+        return _data_decoder->supports_read_by_rowids();
+    }
+
+    virtual Status read_with_filter(Column* column, const SparseRange<>& range,
+                                    const std::vector<const ColumnPredicate*>& compound_and_predicates,
+                                    uint8_t* selection, uint16_t* selected_idx) = 0;
+    void reserve_col(size_t n, Column* column) {
+        if (_data_decoder != nullptr) {
+            _data_decoder->reserve_col(n, column);
+        } else {
+            column->reserve(n);
+        }
+    }
+
 protected:
     uint32_t _page_index{0};
     uint64_t _num_rows{0};
@@ -126,6 +153,7 @@ protected:
     ordinal_t _corresponding_element_ordinal = 0;
     std::unique_ptr<PageDecoder> _data_decoder;
     PagePointer _page_pointer;
+    uint32_t _version;
 };
 
 Status parse_page(std::unique_ptr<ParsedPage>* result, PageHandle handle, const Slice& body,

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -773,6 +773,7 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
     seg_options.vector_search_option = options.vector_search_option;
     seg_options.sample_options = options.sample_options;
     seg_options.enable_join_runtime_filter_pushdown = options.enable_join_runtime_filter_pushdown;
+    seg_options.enable_predicate_col_late_materialize = options.enable_predicate_col_late_materialize;
 
     if (options.delete_predicates != nullptr) {
         seg_options.delete_predicates = options.delete_predicates->get_predicates(end_version());

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -99,6 +99,7 @@ public:
 
     TTableSampleOptions sample_options;
     bool enable_join_runtime_filter_pushdown = false;
+    bool enable_predicate_col_late_materialize = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -792,14 +792,14 @@ bool ScalarColumnIterator::support_push_down_predicate(
         }
     }
 
-    // Check if the decoder supports push down predicate
-    // First check dict decoder, then check current page decoder
-    if (_dict_decoder != nullptr) {
-        return _dict_decoder->support_push_down_predicate();
+    // if this column is low cardinality column, do not push down filter
+    if (_reader->has_all_dict_encoded() && _reader->all_dict_encoded()) {
+        return false;
     }
 
-    // No decoder available yet, conservatively return false
-    return false;
+    // push down filter is this is varchar, since varchar doesn't support zero copy
+    // and copy varchar is a heavy operation
+    return _reader->column_type() == TYPE_VARCHAR;
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -269,6 +269,14 @@ Status ScalarColumnIterator::null_count(size_t* count) {
 }
 
 Status ScalarColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
+    auto read_func = [](ParsedPage* page, Column* column, const SparseRange<>& read_range) -> Status {
+        return page->read(column, read_range);
+    };
+    return _next_batch_template(range, dst, read_func);
+}
+
+template <typename ReadFunc>
+Status ScalarColumnIterator::_next_batch_template(const SparseRange<>& range, Column* dst, ReadFunc&& read_func) {
     size_t prev_bytes = dst->byte_size();
     SparseRangeIterator<> iter = range.new_iterator();
     size_t end_ord = _page->first_ordinal() + _page->num_rows();
@@ -320,7 +328,7 @@ Status ScalarColumnIterator::next_batch(const SparseRange<>& range, Column* dst)
             // current page have been added in read range
             // read current page data first
             contain_deleted_row = contain_deleted_row || _contains_deleted_row(_page->page_index());
-            RETURN_IF_ERROR(_page->read(dst, read_range));
+            RETURN_IF_ERROR(read_func(_page.get(), dst, read_range));
             read_range.clear();
         }
     }
@@ -328,13 +336,33 @@ Status ScalarColumnIterator::next_batch(const SparseRange<>& range, Column* dst)
     if (!read_range.empty()) {
         // read data left if read range is not empty
         contain_deleted_row = contain_deleted_row || _contains_deleted_row(_page->page_index());
-        RETURN_IF_ERROR(_page->read(dst, read_range));
+        RETURN_IF_ERROR(read_func(_page.get(), dst, read_range));
         read_range.clear();
     }
     dst->set_delete_state(contain_deleted_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
     _opts.stats->bytes_read += (dst->byte_size() - prev_bytes);
 
     return Status::OK();
+}
+
+Status ScalarColumnIterator::next_batch_with_filter(const SparseRange<>& range, Column* dst,
+                                                    const std::vector<const ColumnPredicate*>& compound_and_predicates,
+                                                    Buffer<uint8_t>* selection, Buffer<uint16_t>* selected_idx,
+                                                    size_t* processed_rows) {
+    size_t cur_col_size = dst->size();
+    uint8_t* cur_sel = selection->data() + cur_col_size;
+    uint16_t* cur_idx = selected_idx->data() + cur_col_size;
+    auto read_func = [&](ParsedPage* page, Column* column, const SparseRange<>& read_range) -> Status {
+        RETURN_IF_ERROR(page->read_with_filter(column, read_range, compound_and_predicates, cur_sel, cur_idx));
+        // Update selection and selected_idx pointers to point to the next position
+        // after processing this page's data
+        size_t total_rows = read_range.span_size();
+        cur_sel += total_rows;
+        cur_idx += total_rows;
+        *processed_rows += total_rows;
+        return Status::OK();
+    };
+    return _next_batch_template(range, dst, read_func);
 }
 
 Status ScalarColumnIterator::_load_next_page(bool* eos) {
@@ -622,49 +650,63 @@ Status ScalarColumnIterator::_do_decode_dict_codes(const int32_t* codes, size_t 
     return Status::OK();
 }
 
-template <typename PageParseFunc>
-Status ScalarColumnIterator::_fetch_by_rowid(const rowid_t* rowids, size_t size, Column* values,
-                                             PageParseFunc&& page_parse) {
+template <typename RowidReaderFunc, typename RangeReaderFunc>
+Status ScalarColumnIterator::_fetch_by_rowid_helper(const rowid_t* rowids, size_t size, Column* values,
+                                                    RowidReaderFunc&& rowid_reader, RangeReaderFunc&& range_reader) {
     DCHECK(std::is_sorted(rowids, rowids + size));
     RETURN_IF(size == 0, Status::OK());
     size_t prev_bytes = values->byte_size();
-    const rowid_t* const end = rowids + size;
     bool contain_deleted_row = (values->delete_state() != DEL_NOT_SATISFIED);
-    do {
-        RETURN_IF_ERROR(seek_to_ordinal(*rowids));
+    const rowid_t* cursor = rowids;
+    const rowid_t* const end = rowids + size;
+    while (cursor != end) {
+        RETURN_IF_ERROR(seek_to_ordinal(*cursor));
         contain_deleted_row = contain_deleted_row || _contains_deleted_row(_page->page_index());
         auto last_rowid = implicit_cast<rowid_t>(_page->first_ordinal() + _page->num_rows());
-        const rowid_t* next_page_rowid = std::lower_bound(rowids, end, last_rowid);
-        while (rowids != next_page_rowid) {
-            DCHECK_EQ(_current_ordinal, _page->first_ordinal() + _page->offset());
-            rowid_t curr = *rowids;
-            _current_ordinal = implicit_cast<ordinal_t>(curr);
-            RETURN_IF_ERROR(_page->seek(curr - _page->first_ordinal()));
-            const rowid_t* p = rowids + 1;
-            while ((next_page_rowid != p) && (*p == curr + 1)) {
-                curr = *p++;
+        const rowid_t* next_page_rowid = std::lower_bound(cursor, end, last_rowid);
+        if (_page->supports_read_by_rowids()) {
+            size_t nread = next_page_rowid - cursor;
+            RETURN_IF_ERROR(rowid_reader(_page.get(), values, cursor, &nread));
+            cursor += nread;
+        } else {
+            while (cursor != next_page_rowid) {
+                DCHECK_EQ(_current_ordinal, _page->first_ordinal() + _page->offset());
+                rowid_t curr = *cursor;
+                _current_ordinal = implicit_cast<ordinal_t>(curr);
+                RETURN_IF_ERROR(_page->seek(curr - _page->first_ordinal()));
+                const rowid_t* contiguous = cursor + 1;
+                while ((contiguous != next_page_rowid) && (*contiguous == curr + 1)) {
+                    curr = *contiguous++;
+                }
+                size_t run = contiguous - cursor;
+                RETURN_IF_ERROR(range_reader(_page.get(), values, &run));
+                _current_ordinal += run;
+                cursor = contiguous;
             }
-            size_t nread = p - rowids;
-            RETURN_IF_ERROR(page_parse(values, &nread));
-            _current_ordinal += nread;
-            rowids = p;
+            DCHECK_EQ(_current_ordinal, _page->first_ordinal() + _page->offset());
         }
-        DCHECK_EQ(_current_ordinal, _page->first_ordinal() + _page->offset());
-    } while (rowids != end);
+    }
     values->set_delete_state(contain_deleted_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
     _opts.stats->bytes_read += static_cast<int64_t>(values->byte_size() - prev_bytes);
-    DCHECK_EQ(_current_ordinal, _page->first_ordinal() + _page->offset());
     return Status::OK();
 }
 
 Status ScalarColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
-    auto page_parse = [&](Column* column, size_t* count) { return _page->read(column, count); };
-    return _fetch_by_rowid(rowids, size, values, page_parse);
+    auto rowid_reader = [&](ParsedPage* page, Column* column, const rowid_t* rowid_batch, size_t* count) {
+        return page->read_by_rowds(column, rowid_batch, count);
+    };
+    auto range_reader = [&](ParsedPage* page, Column* column, size_t* count) { return page->read(column, count); };
+    return _fetch_by_rowid_helper(rowids, size, values, rowid_reader, range_reader);
 }
 
 Status ScalarColumnIterator::fetch_dict_codes_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
-    auto page_parse = [&](Column* column, size_t* count) { return _page->read_dict_codes(column, count); };
-    return _fetch_by_rowid(rowids, size, values, page_parse);
+    auto rowid_reader = [&](ParsedPage* page, Column* column, const rowid_t* rowid_batch, size_t* count) {
+        return page->read_dict_codes_by_rowids(column, rowid_batch, count);
+    };
+    auto range_reader = [&](ParsedPage* page, Column* column, size_t* count) {
+        return page->read_dict_codes(column, count);
+    };
+    return _fetch_by_rowid_helper(rowids, size, values, rowid_reader, range_reader);
 }
 
 int ScalarColumnIterator::dict_size() {
@@ -731,6 +773,33 @@ StatusOr<std::vector<std::pair<int64_t, int64_t>>> ScalarColumnIterator::get_io_
     }
 
     return res;
+}
+
+bool ScalarColumnIterator::support_push_down_predicate(
+        const std::vector<const ColumnPredicate*>& compound_and_predicates) {
+    // Check if there's a binary column != '' predicate
+    // This predicate cannot be efficiently pushed down
+    for (const auto* pred : compound_and_predicates) {
+        if (pred->type() == PredicateType::kNE && pred->type_info()->type() == TYPE_VARCHAR) {
+            const Datum& value = pred->value();
+            if (!value.is_null()) {
+                const Slice& value_slice = value.get_slice();
+                if (value_slice.empty()) {
+                    // Found binary col <> '' predicate, cannot support push down
+                    return false;
+                }
+            }
+        }
+    }
+
+    // Check if the decoder supports push down predicate
+    // First check dict decoder, then check current page decoder
+    if (_dict_decoder != nullptr) {
+        return _dict_decoder->support_push_down_predicate();
+    }
+
+    // No decoder available yet, conservatively return false
+    return false;
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -693,7 +693,7 @@ Status ScalarColumnIterator::_fetch_by_rowid_helper(const rowid_t* rowids, size_
 
 Status ScalarColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
     auto rowid_reader = [&](ParsedPage* page, Column* column, const rowid_t* rowid_batch, size_t* count) {
-        return page->read_by_rowds(column, rowid_batch, count);
+        return page->read_by_rowids(column, rowid_batch, count);
     };
     auto range_reader = [&](ParsedPage* page, Column* column, size_t* count) { return page->read(column, count); };
     return _fetch_by_rowid_helper(rowids, size, values, rowid_reader, range_reader);

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -61,6 +61,11 @@ public:
 
     Status next_batch(const SparseRange<>& range, Column* dst) override;
 
+    Status next_batch_with_filter(const SparseRange<>& range, Column* dst,
+                                  const std::vector<const ColumnPredicate*>& compound_and_predicates,
+                                  Buffer<uint8_t>* selection, Buffer<uint16_t>* selected_idx,
+                                  size_t* processed_rows) override;
+
     ordinal_t get_current_ordinal() const override { return _current_ordinal; }
 
     ordinal_t num_rows() const override { return _reader->num_rows(); }
@@ -111,6 +116,16 @@ public:
 
     std::string name() const override { return "ScalarColumnIterator"; }
 
+    void reserve_col(size_t n, Column* column) override {
+        if (_page != nullptr) {
+            _page->reserve_col(n, column);
+        } else {
+            column->reserve(n);
+        }
+    }
+
+    bool support_push_down_predicate(const std::vector<const ColumnPredicate*>& compound_and_predicates) override;
+
 private:
     static Status _seek_to_pos_in_page(ParsedPage* page, ordinal_t offset_in_page);
     Status _load_next_page(bool* eos);
@@ -134,13 +149,17 @@ private:
     template <LogicalType Type>
     Status _fetch_all_dict_words(std::vector<Slice>* words) const;
 
-    template <typename ParseFunc>
-    Status _fetch_by_rowid(const rowid_t* rowids, size_t size, Column* values, ParseFunc&& page_parse);
+    template <typename RowidReaderFunc, typename RangeReaderFunc>
+    Status _fetch_by_rowid_helper(const rowid_t* rowids, size_t size, Column* values, RowidReaderFunc&& rowid_reader,
+                                  RangeReaderFunc&& range_reader);
 
     template <LogicalType Type>
     Status _load_dict_page();
 
     bool _contains_deleted_row(uint32_t page_index) const;
+
+    template <typename ReadFunc>
+    Status _next_batch_template(const SparseRange<>& range, Column* dst, ReadFunc&& read_func);
 
     ColumnReader* _reader;
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2373,7 +2373,7 @@ Status SegmentIterator::_evaluate_col_runtime_filters(ColumnId column_id, Column
     Chunk chunk;
     // `column` is owned by storage layer, we don't have ownership
     ColumnPtr bits = col->as_mutable_ptr();
-    chunk.append_column(bits, column_id);
+    chunk.append_column(bits, column_id, true);
 
     RETURN_IF_ERROR(iter->second.evaluate(&chunk, selection, from, to));
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2373,7 +2373,7 @@ Status SegmentIterator::_evaluate_col_runtime_filters(ColumnId column_id, Column
     Chunk chunk;
     // `column` is owned by storage layer, we don't have ownership
     ColumnPtr bits = col->as_mutable_ptr();
-    chunk.append_column(bits, column_id, true);
+    chunk.append_column(bits, column_id);
 
     RETURN_IF_ERROR(iter->second.evaluate(&chunk, selection, from, to));
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -33,7 +33,6 @@
 #include "simd/simd.h"
 #include "storage/chunk_helper.h"
 #include "storage/chunk_iterator.h"
-#include "storage/column_expr_predicate.h"
 #include "storage/column_or_predicate.h"
 #include "storage/column_predicate.h"
 #include "storage/column_predicate_rewriter.h"
@@ -42,7 +41,6 @@
 #include "storage/index/vector/tenann/del_id_filter.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/vector_index_reader.h"
-#include "storage/index/vector/vector_index_reader_factory.h"
 #include "storage/index/vector/vector_search_option.h"
 #include "storage/lake/update_manager.h"
 #include "storage/projection_iterator.h"
@@ -108,7 +106,7 @@ static int compare(const Slice& lhs_index_key, const Chunk& rhs_chunk, const Sch
 
 class SegmentIterator final : public ChunkIterator {
 public:
-    SegmentIterator(std::shared_ptr<Segment> segment, Schema _schema, SegmentReadOptions options);
+    SegmentIterator(std::shared_ptr<Segment> segment, Schema _schema, const SegmentReadOptions& options);
 
     ~SegmentIterator() override = default;
 
@@ -132,10 +130,11 @@ private:
         // Release all chunk resources to free memory
         void close();
         // Seek all column iterators to the specified ordinal position
-        Status seek_columns(ordinal_t pos);
+        Status seek_columns(ordinal_t pos, bool predicate_col_late_materialize_read);
         // Read column data from the specified range into the chunk
         // Handles column pruning and delete state tracking
-        Status read_columns(Chunk* chunk, const SparseRange<>& range);
+        Status read_columns(Chunk* chunk, const SparseRange<>& range, bool predicate_col_late_materialize_read,
+                            Buffer<uint8_t>* selection, Buffer<uint16_t>* selected_idx);
         // Calculate total memory usage of all chunks in this context
         int64_t memory_usage() const;
         // Get the number of column iterators in this context
@@ -151,6 +150,12 @@ private:
         std::vector<ColumnIterator*> _column_iterators;
         std::vector<ColumnId> _subfield_columns;
         std::vector<ColumnIterator*> _subfield_iterators;
+        std::vector<ColumnIterator*> _column_iterators_for_predicate_late_materialize;
+        std::vector<ColumnId> _column_id_for_predicate_late_materialize;
+        std::map<ColumnId, ColumnIterator*> _column_ids_to_column_iterators;
+        std::map<ColumnId, size_t> _column_ids_to_index;
+        ColumnId _row_id_column_id;
+
         ScanContext* _next{nullptr};
 
         // index the column which only be used for filter
@@ -177,9 +182,29 @@ private:
 
         // If the column is pruneable, it means that we can skip the page read for it.
         // Currently, it only can be happend if the column is a pure pushdown predicate
-        // for inverted index.
-        std::unordered_set<size_t> _prune_cols;
+        // for inverted index. Store ColumnId instead of column index so checks remain
+        // valid even when iterator ordering changes.
+        std::unordered_set<ColumnId> _prune_cols;
         bool _prune_column_after_index_filter = false;
+        bool _enable_predicate_col_late_materialize = false;
+        bool _only_output_one_predicate_col_with_filter_push_down = false;
+        bool _support_push_down_predicate = false;
+        std::vector<ColumnId> _predicate_order;
+        ColumnPredicateMap _column_predicate_map;
+        bool _is_filtered = false; // true if push down predicate into page level
+
+        // Selectivity tracking for predicate column late materialization
+        // Maps (score) to column_id, where score = read_time_ns * selectivity
+        // Lower score = better (fast to read, high filtering rate)
+        // Using multimap to allow multiple columns with same selectivity
+        std::multimap<double, ColumnId> _predicate_selectivity_map;
+        // Track evaluated chunk count for periodic selectivity updates (every 32 chunks)
+        size_t _evaluated_chunk_nums = 0;
+
+        // Continuous tracking of first column selectivity for sampling trigger
+        // Accumulated since last reset (either initialization or predicate order change)
+        size_t _first_column_total_rows_read = 0;   // Total rows read for first column
+        size_t _first_column_total_rows_passed = 0; // Total rows passed first column filter
     };
 
     // Vector index related context, only created when needed
@@ -259,9 +284,30 @@ private:
     StatusOr<uint16_t> _filter_by_non_expr_predicates(Chunk* chunk, vector<rowid_t>* rowid, uint16_t from, uint16_t to);
     StatusOr<uint16_t> _filter_by_expr_predicates(Chunk* chunk, vector<rowid_t>* rowid);
     StatusOr<uint16_t> _filter_by_record_predicate(Chunk* chunk, vector<rowid_t>* rowid);
+
+    StatusOr<uint16_t> _filter_by_compound_and_predicates(Chunk* chunk, vector<rowid_t>* rowid, uint16_t from,
+                                                          uint16_t to, ColumnId column_id,
+                                                          const std::vector<const ColumnPredicate*>& and_predicates,
+                                                          std::vector<Column*>& current_cols,
+                                                          bool apply_runtime_filter = true);
+
+    Status _evaluate_col_runtime_filters(ColumnId column_id, Column* col, uint8_t* selection, uint16_t from,
+                                         uint16_t to);
+
     uint16_t _filter_chunk_by_selection(Chunk* chunk, vector<rowid_t>* rowid, uint16_t from, uint16_t to);
 
+    uint16_t _filter_columns_by_selection(std::vector<Column*>& columns, vector<rowid_t>* rowid, uint16_t from,
+                                          uint16_t to);
+
     void _init_column_predicates();
+
+    StatusOr<size_t> trigger_sample_if_necessary(vector<rowid_t>* rowid);
+
+    // Sample and measure all predicate columns to update selectivity and read time
+    // Reads all predicate columns (like _predicate_evaluate_without_late_materialize)
+    // and measures actual read time and filtering effectiveness for each column
+    // Returns the sampled chunk size if successful
+    StatusOr<size_t> _sample_predicate_columns(vector<rowid_t>* rowid);
 
     Status _init_context();
 
@@ -306,7 +352,7 @@ private:
 
     Status _apply_inverted_index();
 
-    Status _read(Chunk* chunk, vector<rowid_t>* rowid, size_t n);
+    Status _read(Chunk* chunk, vector<rowid_t>* rowid, size_t n, bool predicate_col_late_materialize_read);
 
     void _init_column_access_paths();
 
@@ -337,6 +383,13 @@ private:
 
     Status _init_reader_from_file(const std::string& index_path, const std::shared_ptr<TabletIndex>& tablet_index_meta,
                                   const std::map<std::string, std::string>& query_params);
+    StatusOr<size_t> _predicate_evaluate(vector<rowid_t>* rowid);
+
+    StatusOr<size_t> _predicate_evaluate_without_late_materialize(vector<rowid_t>* rowid);
+
+    StatusOr<size_t> _predicate_evaluate_late_materialize(vector<rowid_t>* rowid);
+
+    void _build_context_for_predicate(ScanContext* ctx);
 
 private:
     using RawColumnIterators = std::vector<std::unique_ptr<ColumnIterator>>;
@@ -366,6 +419,8 @@ private:
     PredicateTree _non_expr_pred_tree;
     PredicateTree _expr_pred_tree;
     RuntimeFilterPredicates _runtime_filter_preds;
+    // Runtime filter predicates organized by column id for late materialization
+    std::unordered_map<ColumnId, RuntimeFilterPredicates> _column_to_runtime_filters_map;
 
     // _selection is used to accelerate
     Buffer<uint8_t> _selection;
@@ -404,6 +459,8 @@ private:
 
     // Inverted index context - only created when needed
     std::unique_ptr<InvertedIndexContext> _inverted_index_ctx;
+
+    bool _enable_predicate_col_late_materialize;
 };
 
 // ScanContext method implementations
@@ -415,34 +472,88 @@ void SegmentIterator::ScanContext::close() {
     _adapt_global_dict_chunk.reset();
 }
 
-Status SegmentIterator::ScanContext::seek_columns(ordinal_t pos) {
-    for (auto iter : _column_iterators) {
+Status SegmentIterator::ScanContext::seek_columns(ordinal_t pos, bool predicate_col_late_materialize_read) {
+    std::vector<ColumnIterator*>& column_iterators =
+            predicate_col_late_materialize_read ? _column_iterators_for_predicate_late_materialize : _column_iterators;
+    for (auto iter : column_iterators) {
         RETURN_IF_ERROR(iter->seek_to_ordinal(pos));
     }
     return Status::OK();
 }
 
-Status SegmentIterator::ScanContext::read_columns(Chunk* chunk, const SparseRange<>& range) {
+Status SegmentIterator::ScanContext::read_columns(Chunk* chunk, const SparseRange<>& range,
+                                                  bool predicate_col_late_materialize_read, Buffer<uint8_t>* selection,
+                                                  Buffer<uint16_t>* selected_idx) {
+    std::vector<ColumnIterator*>& column_iterators =
+            predicate_col_late_materialize_read ? _column_iterators_for_predicate_late_materialize : _column_iterators;
+
+    bool first_col_supports_pushdown =
+            predicate_col_late_materialize_read
+                    ? column_iterators[0]->support_push_down_predicate(_column_predicate_map[_predicate_order[0]])
+                    : false;
+    // reset _is_filtered every time
+    _is_filtered = false;
+
     bool may_has_del_row = chunk->delete_state() != DEL_NOT_SATISFIED;
-    std::vector<size_t> pruned_cols;
+    std::vector<ColumnId> pruned_cols;
     size_t pruned_col_size = 0;
     size_t num_rows = chunk->num_rows();
-    for (size_t i = 0; i < _column_iterators.size(); i++) {
-        auto* col = chunk->get_column_raw_ptr_by_index(i);
-        if (_prune_column_after_index_filter && _prune_cols.count(i)) {
-            pruned_cols.push_back(i);
+    for (size_t i = 0; i < column_iterators.size(); i++) {
+        ColumnId column_id = predicate_col_late_materialize_read ? _column_id_for_predicate_late_materialize[i]
+                                                                 : _read_schema.field(i)->id();
+        if (_prune_column_after_index_filter && _prune_cols.count(column_id)) {
+            pruned_cols.push_back(column_id);
             continue;
         }
-        RETURN_IF_ERROR(_column_iterators[i]->next_batch(range, col));
+        auto* col = chunk->get_column_raw_ptr_by_id(column_id);
+
+        // for binary column, we must reserve enough memory to avoid extra memcpy
+        // but if segment is small and there are lots of segments, we can't reserve too much unnecessary memory
+        if (col->capacity() == 0) {
+            column_iterators[i]->reserve_col(range.span_size(), col);
+        }
+
+        if (!predicate_col_late_materialize_read || !first_col_supports_pushdown) {
+            RETURN_IF_ERROR(column_iterators[i]->next_batch(range, col));
+        } else {
+            size_t processed_rows = 0;
+            if (i == 0) {
+                size_t original_row_num = col->size();
+
+                // for first predicate column, if can filter data in page level
+                // _is_filtered is set to true
+                // and selection is record for filter rowId column
+                // and only append filtered data in col
+                RETURN_IF_ERROR(column_iterators[i]->next_batch_with_filter(range, col,
+                                                                            _column_predicate_map[_predicate_order[0]],
+                                                                            selection, selected_idx, &processed_rows));
+                size_t appended_rows = col->size() - original_row_num;
+                if (processed_rows >= appended_rows && stats != nullptr) {
+                    stats->rows_vec_cond_filtered += (processed_rows - appended_rows);
+                }
+                _first_column_total_rows_read += processed_rows;
+                _first_column_total_rows_passed += appended_rows;
+                _is_filtered = true;
+            } else {
+                // for rowId column iterator, apply selection if _is_filtered is true
+                DCHECK(i == 1);
+                RETURN_IF_ERROR(column_iterators[i]->next_batch_with_filter(range, col, ColumnPredicates(), selection,
+                                                                            selected_idx, &processed_rows));
+            }
+        }
+
         if (pruned_col_size == 0) {
             pruned_col_size = col->size();
         }
+        if (pruned_col_size != col->size()) {
+            return Status::InternalError(
+                    fmt::format("pruned_col_size {} != column size:{}", pruned_col_size, col->size()));
+        }
         DCHECK_EQ(pruned_col_size, col->size());
-        DCHECK_EQ(num_rows + range.span_size(), col->size());
         may_has_del_row |= (col->delete_state() != DEL_NOT_SATISFIED);
     }
-    for (size_t i : pruned_cols) {
-        auto* col = chunk->get_column_raw_ptr_by_index(i);
+    for (ColumnId cid : pruned_cols) {
+        auto* col = chunk->get_column_raw_ptr_by_id(cid);
         // make sure each pruned column has the same size as the unpruneable one.
         col->resize(pruned_col_size);
     }
@@ -499,9 +610,9 @@ std::string SegmentIterator::ScanContext::to_string() const {
     oss << "\"_has_force_dict_encode\": " << (_has_force_dict_encode ? "true" : "false") << ",";
     oss << "\"_prune_cols\": [";
     size_t prune_count = 0;
-    for (auto idx : _prune_cols) {
+    for (auto cid : _prune_cols) {
         if (prune_count++ > 0) oss << ", ";
-        oss << idx;
+        oss << cid;
     }
     oss << "],";
     oss << "\"_prune_column_after_index_filter\": " << (_prune_column_after_index_filter ? "true" : "false");
@@ -509,12 +620,13 @@ std::string SegmentIterator::ScanContext::to_string() const {
     return oss.str();
 }
 
-SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, Schema schema, SegmentReadOptions options)
+SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, Schema schema, const SegmentReadOptions& options)
         : ChunkIterator(std::move(schema), options.chunk_size),
           _segment(std::move(segment)),
           _opts(std::move(options)),
           _bitmap_index_evaluator(_schema, _opts.pred_tree),
-          _predicate_columns(_opts.pred_tree.num_columns()) {
+          _predicate_columns(_opts.pred_tree.num_columns()),
+          _enable_predicate_col_late_materialize(_opts.enable_predicate_col_late_materialize) {
     // Initialize vector index context only when needed
     if (_opts.use_vector_index) {
         _vector_index_ctx = std::make_unique<VectorIndexContext>();
@@ -642,8 +754,8 @@ Status SegmentIterator::_init() {
     // rewrite stage
     // Rewriting predicates using segment dictionary codes
     RETURN_IF_ERROR(_rewrite_predicates());
-    RETURN_IF_ERROR(_init_context());
     _init_column_predicates();
+    RETURN_IF_ERROR(_init_context());
 
     // reverse scan_range
     if (!_opts.asc_hint) {
@@ -1072,7 +1184,6 @@ void SegmentIterator::_init_column_predicates() {
     PredicateAndNode used_pred_root;
     _opts.pred_tree.root().partition_copy([](const auto& node) { return node.visit(IndexOnlyPredicateChecker()); },
                                           &useless_pred_root, &used_pred_root);
-
     PredicateAndNode expr_pred_root;
     PredicateAndNode non_expr_pred_root;
     used_pred_root.partition_move([](auto& node) { return node.visit(ExprPredicateChecker()); }, &expr_pred_root,
@@ -1080,6 +1191,158 @@ void SegmentIterator::_init_column_predicates() {
     _expr_pred_tree = PredicateTree::create(std::move(expr_pred_root));
     _non_expr_pred_tree = PredicateTree::create(std::move(non_expr_pred_root));
     _runtime_filter_preds = _opts.runtime_filter_preds;
+}
+
+StatusOr<size_t> SegmentIterator::trigger_sample_if_necessary(vector<rowid_t>* rowid) {
+    // Check every 16 chunks if we should trigger sampling based on selectivity
+    // if only have one predicate column, do not sample
+    const bool should_check_selectivity = (_context->_evaluated_chunk_nums++ % 16) == 0 &&
+                                          (!_context->_only_output_one_predicate_col_with_filter_push_down);
+    if (should_check_selectivity && _context->_enable_predicate_col_late_materialize) {
+        // Calculate accumulated selectivity.
+        // If selectivity > tigger_sample_selectivity or this is the first time, trigger sampling
+        // to potentially find an even better predicate order
+        double first_column_selectivity = _context->_first_column_total_rows_read == 0
+                                                  ? 1
+                                                  : static_cast<double>(_context->_first_column_total_rows_passed) /
+                                                            _context->_first_column_total_rows_read;
+        if (first_column_selectivity > config::tigger_sample_selectivity) {
+            ColumnId old_first_column_id = _context->_predicate_order[0];
+
+            // Sample and update predicate selectivity
+            ASSIGN_OR_RETURN(size_t sampled_chunk_size, _sample_predicate_columns(rowid));
+
+            // Check if the first column changed after sampling
+            ColumnId new_first_column_id = _context->_predicate_order.front();
+            if (new_first_column_id != old_first_column_id) {
+                // First column changed, reset selectivity statistics
+                _context->_first_column_total_rows_read = 0;
+                _context->_first_column_total_rows_passed = 0;
+            }
+            return sampled_chunk_size;
+        }
+    }
+    return 0;
+}
+
+StatusOr<size_t> SegmentIterator::_sample_predicate_columns(vector<rowid_t>* rowid) {
+    // Clear previous measurements
+    _context->_predicate_selectivity_map.clear();
+
+    // Read a sample chunk with predicate_col_late_materialize_read = false
+    // This reads ALL predicate columns at once (not using late materialization)
+    const uint32_t sample_size = _reserve_chunk_size;
+
+    Chunk* chunk = _context->_read_chunk.get();
+
+    if (!_range_iter.has_more()) {
+        return 0;
+    }
+
+    // Call _read with predicate_col_late_materialize_read = false to read all columns
+    RETURN_IF_ERROR(_read(chunk, rowid, sample_size, false));
+
+    const size_t chunk_size = chunk->num_rows();
+    if (chunk_size == 0) {
+        return 0;
+    }
+
+    // Similar to RuntimeFilterProbeCollector::update_selectivity
+    // Use two selections:
+    // 1. _selection: for merged result of all predicates (merged_selection)
+    // 2. current_selection: for current predicate result
+    Buffer<uint8_t> current_selection;
+    current_selection.resize(chunk_size);
+
+    bool use_merged_selection = true; // Similar to RuntimeFilter's use_merged_selection flag
+
+    // Evaluate each predicate column and measure its selectivity
+    for (const auto& column_id : _context->_predicate_order) {
+        auto* col = chunk->get_column_raw_ptr_by_id(column_id);
+
+        const auto& predicates = _context->_column_predicate_map.at(column_id);
+        bool has_compound_predicates = !predicates.empty();
+        bool has_runtime_filters =
+                _opts.enable_join_runtime_filter_pushdown && _column_to_runtime_filters_map.contains(column_id);
+
+        if (!has_compound_predicates && !has_runtime_filters) {
+            // Column may have been added for read-only; no predicates or runtime filters to evaluate.
+            _context->_predicate_selectivity_map.emplace(1.0, column_id);
+            continue;
+        }
+
+        // First predicate uses _selection (merged), subsequent use current_selection
+        auto& selection = use_merged_selection ? _selection : current_selection;
+
+        if (has_compound_predicates) {
+            // Use compound_and_predicates_evaluate to evaluate predicates
+            // Similar to RuntimeFilter::evaluate
+            RETURN_IF_ERROR(compound_and_predicates_evaluate(predicates, col, selection.data(), _selected_idx.data(), 0,
+                                                             chunk_size));
+        } else {
+            DCHECK(has_runtime_filters);
+            // No predicates but runtime filters exist, start with all rows selected.
+            std::fill(selection.data(), selection.data() + chunk_size, 1);
+        }
+
+        if (has_runtime_filters) {
+            RETURN_IF_ERROR(_evaluate_col_runtime_filters(column_id, col, selection.data(), 0, chunk_size));
+        }
+
+        // Count rows that passed predicates
+        size_t true_count = SIMD::count_nonzero(selection.data(), chunk_size);
+        double selectivity = static_cast<double>(true_count) / chunk_size;
+
+        // Store selectivity directly as the sorting key (like RuntimeFilter)
+        _context->_predicate_selectivity_map.emplace(selectivity, column_id);
+
+        // Merge selections (similar to RuntimeFilter's logic)
+        if (use_merged_selection) {
+            // First predicate: result is already in _selection (merged_selection)
+            use_merged_selection = false;
+        } else {
+            // Subsequent predicates: AND current selection with merged selection
+            uint8_t* dest = _selection.data();             // merged_selection
+            const uint8_t* src = current_selection.data(); // current result
+            for (size_t j = 0; j < chunk_size; ++j) {
+                dest[j] = src[j] & dest[j];
+            }
+        }
+    }
+
+    // Filter the entire chunk (including all columns and rowid) based on merged selection
+    // _selection already contains the merged result, use it directly
+    // This removes rows that don't pass all predicates
+    size_t filtered_chunk_size = _filter_chunk_by_selection(chunk, rowid, 0, chunk_size);
+
+    // Update predicate order based on selectivity (lower selectivity = higher filtering = better)
+    std::vector<ColumnId> new_order;
+    new_order.reserve(_context->_predicate_order.size());
+
+    for (const auto& kv : _context->_predicate_selectivity_map) {
+        new_order.push_back(kv.second);
+    }
+
+    DCHECK(new_order.size() == _context->_predicate_order.size());
+    if (new_order.size() != _context->_predicate_order.size()) {
+        return Status::InternalError("scan predicate late materializationo error!");
+    }
+
+    const ColumnId old_first_column_id = _context->_predicate_order.front();
+
+    // Update the predicate order
+    _context->_predicate_order = std::move(new_order);
+
+    // Update the first column iterator if it changed
+    const ColumnId new_first_column_id = _context->_predicate_order.front();
+    if (new_first_column_id != old_first_column_id) {
+        _context->_column_iterators_for_predicate_late_materialize[0] =
+                _context->_column_ids_to_column_iterators[new_first_column_id];
+        _context->_column_id_for_predicate_late_materialize[0] = new_first_column_id;
+    }
+
+    // Return the filtered chunk size (after applying all predicates)
+    return filtered_chunk_size;
 }
 
 Status SegmentIterator::_get_row_ranges_by_keys() {
@@ -1458,15 +1721,20 @@ Status SegmentIterator::_read_columns(const Schema& schema, Chunk* chunk, size_t
     return Status::OK();
 }
 
-inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowids, size_t n) {
+inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowids, size_t n,
+                                     bool predicate_col_late_materialize_read) {
     size_t read_num = 0;
     SparseRange<> range;
 
-    if (_cur_rowid != _range_iter.begin() || _cur_rowid == 0) {
+    // Always seek columns if switching between late materialization modes or position changed
+    // This ensures all column iterators (_column_iterators vs _column_iterators_for_predicate_late_materialize)
+    // are synchronized at the same position
+    if (_cur_rowid != _range_iter.begin() || _cur_rowid == 0 ||
+        (_context->_enable_predicate_col_late_materialize && !predicate_col_late_materialize_read)) {
         _cur_rowid = _range_iter.begin();
         _opts.stats->block_seek_num += 1;
         SCOPED_RAW_TIMER(&_opts.stats->block_seek_ns);
-        RETURN_IF_ERROR(_context->seek_columns(_cur_rowid));
+        RETURN_IF_ERROR(_context->seek_columns(_cur_rowid, predicate_col_late_materialize_read));
     }
 
     _range_iter.next_range(n, &range);
@@ -1474,8 +1742,11 @@ inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowids, size
     {
         _opts.stats->blocks_load += 1;
         SCOPED_RAW_TIMER(&_opts.stats->block_fetch_ns);
-        RETURN_IF_ERROR(_context->read_columns(chunk, range));
-        chunk->check_or_die();
+        RETURN_IF_ERROR(
+                _context->read_columns(chunk, range, predicate_col_late_materialize_read, &_selection, &_selected_idx));
+        if (!predicate_col_late_materialize_read) {
+            chunk->check_or_die();
+        }
     }
 
     if (rowids != nullptr) {
@@ -1491,7 +1762,6 @@ inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowids, size
 
     _cur_rowid = range.end();
     _opts.stats->raw_rows_read += read_num;
-    chunk->check_or_die();
     return Status::OK();
 }
 
@@ -1603,10 +1873,6 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
     }
 #endif // USE_STAROS
 
-    const uint32_t chunk_capacity = _reserve_chunk_size;
-    const uint32_t return_chunk_threshold = std::max<uint32_t>(chunk_capacity - chunk_capacity / 4, 1);
-    const bool has_non_expr_predicate = !_non_expr_pred_tree.empty();
-    const bool scan_range_normalized = _scan_range.is_sorted();
     const int64_t prev_raw_rows_read = _opts.stats->raw_rows_read;
 
     _context->_read_chunk->reset();
@@ -1615,40 +1881,18 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
     _context->_adapt_global_dict_chunk->reset();
 
     Chunk* chunk = _context->_read_chunk.get();
-    uint16_t chunk_start = chunk->num_rows();
 
-    // TODO: use accumulator refactor here
-    while ((chunk_start < return_chunk_threshold) & _range_iter.has_more()) {
-        RETURN_IF_ERROR(_read(chunk, rowid, chunk_capacity - chunk_start));
-        chunk->check_or_die();
-        size_t next_start = chunk->num_rows();
-
-        if (has_non_expr_predicate) {
-            ASSIGN_OR_RETURN(next_start, _filter_by_non_expr_predicates(chunk, rowid, chunk_start, next_start));
-            chunk->check_or_die();
-        }
-        chunk_start = next_start;
-        DCHECK_EQ(chunk_start, chunk->num_rows());
-
-        if (chunk_start && !scan_range_normalized) {
-            break;
-        }
-    }
-
-    size_t raw_chunk_size = chunk->num_rows();
-
-    ASSIGN_OR_RETURN(size_t chunk_size, _filter_by_expr_predicates(chunk, rowid));
+    StatusOr<size_t> predicte_result = _predicate_evaluate(rowid);
 
     _opts.stats->block_load_ns += sw.elapsed_time();
 
     int64_t total_read = _opts.stats->raw_rows_read - prev_raw_rows_read;
 
-    if (UNLIKELY(raw_chunk_size == 0)) {
-        // Return directly if chunk_start is zero, i.e, chunk is empty.
-        // Otherwise, chunk will be swapped with result, which is incorrect
-        // because the chunk is a pointer to _read_chunk instead of _final_chunk.
-        return Status::EndOfFile("no more data in segment");
+    if (UNLIKELY(predicte_result.status().is_end_of_file() || !predicte_result.status().ok())) {
+        return predicte_result.status();
     }
+
+    size_t chunk_size = predicte_result.value();
 
     if (_context->_has_dict_column) {
         chunk = _context->_dict_chunk.get();
@@ -1739,6 +1983,180 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
     return Status::OK();
 }
 
+StatusOr<size_t> SegmentIterator::_predicate_evaluate(vector<rowid_t>* rowid) {
+    if (_context->_enable_predicate_col_late_materialize ||
+        _context->_only_output_one_predicate_col_with_filter_push_down) {
+        return _predicate_evaluate_late_materialize(rowid);
+    } else {
+        return _predicate_evaluate_without_late_materialize(rowid);
+    }
+}
+
+StatusOr<size_t> SegmentIterator::_predicate_evaluate_late_materialize(vector<rowid_t>* rowid) {
+    ASSIGN_OR_RETURN(size_t sampled_chunk_size, trigger_sample_if_necessary(rowid));
+    if (sampled_chunk_size > 0) {
+        // Sampling was triggered, return the sampled chunk size without further processing
+        return sampled_chunk_size;
+    }
+
+    const uint32_t chunk_capacity = _reserve_chunk_size;
+    const uint32_t return_chunk_threshold = std::max<uint32_t>(chunk_capacity - chunk_capacity / 4, 1);
+    const bool has_non_expr_predicate = !_non_expr_pred_tree.empty();
+    const bool scan_range_normalized = _scan_range.is_sorted();
+    Chunk* chunk = _context->_read_chunk.get();
+    std::vector<Column*> current_columns;
+    current_columns.reserve(_context->_column_id_for_predicate_late_materialize.size());
+
+    const ColumnId first_column_id = _context->_predicate_order.front();
+    auto* first_col = chunk->get_column_raw_ptr_by_id(first_column_id);
+
+    const ColumnPredicateMap& non_expr_column_predicate_map = _non_expr_pred_tree.get_immediate_column_predicate_map();
+    const ColumnPredicateMap& expr_column_predicate_map = _expr_pred_tree.get_immediate_column_predicate_map();
+
+    current_columns.emplace_back(first_col);
+    if (_context->_enable_predicate_col_late_materialize) {
+        DCHECK(!_context->_only_output_one_predicate_col_with_filter_push_down);
+        auto* rowid_column = chunk->get_column_raw_ptr_by_id(_context->_row_id_column_id);
+        current_columns.emplace_back(rowid_column);
+    }
+    uint16_t chunk_start = first_col->size();
+
+    size_t original_chunk_size = chunk_start;
+    while ((chunk_start < return_chunk_threshold) && _range_iter.has_more()) {
+        RETURN_IF_ERROR(_read(chunk, rowid, chunk_capacity - chunk_start, true));
+        // chunk->check_or_die();
+        size_t next_start = first_col->size();
+
+        // Count how many rowids were read by this _read() call
+        if (!_context->_is_filtered) {
+            size_t rows_read_this_iter = next_start - chunk_start;
+            _context->_first_column_total_rows_read += rows_read_this_iter;
+        }
+
+        if (has_non_expr_predicate && !_context->_is_filtered &&
+            non_expr_column_predicate_map.contains(first_column_id)) {
+            // use first column's non-expr predicate to filter data
+            // This will filter rowid_column, removing rows that don't match the predicate
+            // column-expr-predicate doesn't support [begin, end] interface
+            ASSIGN_OR_RETURN(next_start, _filter_by_compound_and_predicates(
+                                                 chunk, rowid, chunk_start, next_start, first_column_id,
+                                                 non_expr_column_predicate_map.at(first_column_id), current_columns));
+        }
+
+        chunk_start = next_start;
+        // DCHECK_EQ(chunk_start, chunk->num_rows());
+
+        if (chunk_start && !scan_range_normalized) {
+            break;
+        }
+    }
+
+    size_t chunk_size = first_col->size();
+
+    if (expr_column_predicate_map.contains(first_column_id) && !_context->_is_filtered) {
+        // Don't apply runtime filter here because it was already applied in non_expr predicate filtering
+        ASSIGN_OR_RETURN(chunk_size, _filter_by_compound_and_predicates(chunk, rowid, 0, chunk_size, first_column_id,
+                                                                        expr_column_predicate_map.at(first_column_id),
+                                                                        current_columns, false));
+    }
+
+    if (!_context->_is_filtered) {
+        _context->_first_column_total_rows_passed += (chunk_size - original_chunk_size);
+    }
+
+    bool may_has_del_row = chunk->delete_state() != DEL_NOT_SATISFIED;
+    for (int i = 1; i < _context->_predicate_order.size(); i++) {
+        const ColumnId current_column_id = _context->_predicate_order[i];
+        ColumnPtr rowid_column = chunk->get_column_by_id(_context->_row_id_column_id);
+        // read column by row id if not read yet
+        const auto* ordinals = down_cast<FixedLengthColumn<rowid_t>*>(rowid_column.get());
+        auto* col = chunk->get_column_raw_ptr_by_id(current_column_id);
+        current_columns.emplace_back(col);
+
+        col->resize(0);
+        {
+            SCOPED_RAW_TIMER(&_opts.stats->late_materialize_ns);
+            // for dict column, no matter it's global or local
+            // we should get its local dict values in predicate evaluation
+            // _decode_dict_codes will translate dict value into string if this is local dict
+            // otherwise will translate local dict value into global dict value
+            DCHECK(_context->_column_ids_to_index[current_column_id] < _context->_is_dict_column.size());
+            if (_context->_is_dict_column[_context->_column_ids_to_index[current_column_id]]) {
+                ColumnIterator* cur_iter = _context->_column_ids_to_column_iterators[current_column_id];
+                cur_iter->reserve_col(chunk_size, col);
+                RETURN_IF_ERROR(cur_iter->fetch_dict_codes_by_rowid(*ordinals, col));
+            } else {
+                _column_decoders[current_column_id].reserve_col(chunk_size, col);
+                RETURN_IF_ERROR(_column_decoders[current_column_id].decode_values_by_rowid(*ordinals, col));
+            }
+        }
+        // DCHECK_EQ(ordinals->size(), col->size());
+        if (ordinals->size() != col->size()) {
+            return Status::Corruption("_predicate_evaluate_late_materialize col size not equal to ordinal col size");
+        }
+        may_has_del_row |= (col->delete_state() != DEL_NOT_SATISFIED);
+
+        // evaluate predicate on this column, including expr and non-expr predicates
+        ASSIGN_OR_RETURN(chunk_size, _filter_by_compound_and_predicates(
+                                             chunk, rowid, 0, chunk_size, current_column_id,
+                                             _context->_column_predicate_map.at(current_column_id), current_columns));
+    }
+
+    DCHECK(current_columns.size() == chunk->num_columns())
+            << "current column size:" << current_columns.size() << ", chunk column size:" << chunk->num_columns();
+
+    // check chunk until every predicate column is read
+    chunk->check_or_die();
+
+    chunk->set_delete_state(may_has_del_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
+
+    if (UNLIKELY(chunk_size == 0 && !_range_iter.has_more())) {
+        // Return directly if chunk_start is zero, i.e, chunk is empty.
+        // Otherwise, chunk will be swapped with result, which is incorrect
+        // because the chunk is a pointer to _read_chunk instead of _final_chunk.
+        return Status::EndOfFile("no more data in segment");
+    }
+    return chunk_size;
+}
+
+StatusOr<size_t> SegmentIterator::_predicate_evaluate_without_late_materialize(vector<rowid_t>* rowid) {
+    const uint32_t chunk_capacity = _reserve_chunk_size;
+    const uint32_t return_chunk_threshold = std::max<uint32_t>(chunk_capacity - chunk_capacity / 4, 1);
+    const bool has_non_expr_predicate = !_non_expr_pred_tree.empty();
+    const bool scan_range_normalized = _scan_range.is_sorted();
+
+    Chunk* chunk = _context->_read_chunk.get();
+    uint16_t chunk_start = chunk->num_rows();
+    while ((chunk_start < return_chunk_threshold) & _range_iter.has_more()) {
+        RETURN_IF_ERROR(_read(chunk, rowid, chunk_capacity - chunk_start, false));
+        chunk->check_or_die();
+        size_t next_start = chunk->num_rows();
+
+        if (has_non_expr_predicate) {
+            ASSIGN_OR_RETURN(next_start, _filter_by_non_expr_predicates(chunk, rowid, chunk_start, next_start));
+            chunk->check_or_die();
+        }
+        chunk_start = next_start;
+        DCHECK_EQ(chunk_start, chunk->num_rows());
+
+        if (chunk_start && !scan_range_normalized) {
+            break;
+        }
+    }
+
+    size_t raw_chunk_size = chunk->num_rows();
+    if (UNLIKELY(raw_chunk_size == 0)) {
+        // Return directly if chunk_start is zero, i.e, chunk is empty.
+        // Otherwise, chunk will be swapped with result, which is incorrect
+        // because the chunk is a pointer to _read_chunk instead of _final_chunk.
+        return Status::EndOfFile("no more data in segment");
+    }
+
+    ASSIGN_OR_RETURN(size_t chunk_size, _filter_by_expr_predicates(chunk, rowid));
+
+    return chunk_size;
+}
+
 FieldPtr SegmentIterator::_make_field(size_t i) {
     DCHECK(_vector_index_ctx != nullptr);
     return std::make_shared<Field>(i, _vector_index_ctx->vector_distance_column_name, get_type_info(TYPE_FLOAT), false);
@@ -1808,6 +2226,77 @@ Status SegmentIterator::_switch_context(ScanContext* to) {
 
     _context = to;
     return Status::OK();
+}
+
+Status SegmentIterator::_evaluate_col_runtime_filters(ColumnId column_id, Column* col, uint8_t* selection,
+                                                      uint16_t from, uint16_t to) {
+    if (!_opts.enable_join_runtime_filter_pushdown) {
+        return Status::OK();
+    }
+
+    auto iter = _column_to_runtime_filters_map.find(column_id);
+    if (iter == _column_to_runtime_filters_map.end()) {
+        return Status::OK();
+    }
+
+    SCOPED_RAW_TIMER(&_opts.stats->rf_cond_evaluate_ns);
+    size_t input_count = SIMD::count_nonzero(&selection[from], to - from);
+
+    Chunk chunk;
+    // `column` is owned by storage layer, we don't have ownership
+    ColumnPtr bits = col->as_mutable_ptr();
+    chunk.append_column(bits, column_id, true);
+
+    RETURN_IF_ERROR(iter->second.evaluate(&chunk, selection, from, to));
+
+    size_t output_count = SIMD::count_nonzero(&selection[from], to - from);
+    _opts.stats->rf_cond_input_rows += input_count;
+    _opts.stats->rf_cond_output_rows += output_count;
+    return Status::OK();
+}
+
+StatusOr<uint16_t> SegmentIterator::_filter_by_compound_and_predicates(
+        Chunk* chunk, vector<rowid_t>* rowid, uint16_t from, uint16_t to, ColumnId column_id,
+        const std::vector<const ColumnPredicate*>& and_predicates, std::vector<Column*>& current_cols,
+        bool apply_runtime_filter) {
+    if (from == to) {
+        return to;
+    }
+
+    // Check if we need to process this column at all
+    bool has_compound_predicates = and_predicates.size() > 0;
+    bool has_runtime_filters = apply_runtime_filter && _opts.enable_join_runtime_filter_pushdown &&
+                               _column_to_runtime_filters_map.contains(column_id);
+
+    if (!has_compound_predicates && !has_runtime_filters) {
+        return to;
+    }
+
+    SCOPED_RAW_TIMER(&_opts.stats->vec_cond_ns);
+    Column* col = chunk->get_column_raw_ptr_by_id(column_id);
+    // Evaluate compound predicates
+    if (has_compound_predicates) {
+        SCOPED_RAW_TIMER(&_opts.stats->vec_cond_evaluate_ns);
+        if (col->empty()) {
+            DCHECK(from == to);
+            return to;
+        }
+        RETURN_IF_ERROR(compound_and_predicates_evaluate(and_predicates, col, _selection.data(), _selected_idx.data(),
+                                                         from, to));
+    } else {
+        // If no compound predicates but have runtime filters, initialize selection to all true
+        std::fill(&_selection[from], &_selection[to], 1);
+    }
+
+    // Evaluate runtime filters for this column
+    if (has_runtime_filters) {
+        RETURN_IF_ERROR(_evaluate_col_runtime_filters(column_id, col, _selection.data(), from, to));
+    }
+
+    SCOPED_RAW_TIMER(&_opts.stats->vec_cond_chunk_copy_ns);
+    uint16_t chunk_size = _filter_columns_by_selection(current_cols, rowid, from, to);
+    _opts.stats->rows_vec_cond_filtered += (to - chunk_size);
+    return chunk_size;
 }
 
 StatusOr<uint16_t> SegmentIterator::_filter_by_non_expr_predicates(Chunk* chunk, vector<rowid_t>* rowid, uint16_t from,
@@ -1883,6 +2372,32 @@ uint16_t SegmentIterator::_filter_chunk_by_selection(Chunk* chunk, vector<rowid_
     return chunk_size;
 }
 
+uint16_t SegmentIterator::_filter_columns_by_selection(std::vector<Column*>& columns, vector<rowid_t>* rowid,
+                                                       uint16_t from, uint16_t to) {
+    auto hit_count = SIMD::count_nonzero(&_selection[from], to - from);
+    uint16_t chunk_size = to;
+    if (hit_count == 0) {
+        chunk_size = from;
+        for (auto& column : columns) {
+            column->resize(chunk_size);
+        }
+        if (rowid != nullptr) {
+            rowid->resize(chunk_size);
+        }
+    } else if (hit_count != to - from) {
+        for (auto& column : columns) {
+            column->filter_range(_selection, from, to);
+        }
+        chunk_size = columns[0]->size();
+        if (rowid != nullptr) {
+            auto size = ColumnHelper::filter_range<uint32_t>(_selection, rowid->data(), from, to);
+            rowid->resize(size);
+        }
+    }
+
+    return chunk_size;
+}
+
 inline bool SegmentIterator::_can_using_dict_code(const FieldPtr& field) const {
     if (field->type()->type() == TYPE_ARRAY) {
         return false;
@@ -1950,7 +2465,7 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
                 // 3. column is not one of the delete predicate columns
                 // 4. column must not be dict decoded when the read is finished
                 // 5. column not in record predicate
-                ctx->_prune_cols.insert(i);
+                ctx->_prune_cols.insert(cid);
             }
         }
 
@@ -1983,6 +2498,8 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
 
             if (ctx->_skip_dict_decode_indexes[i]) {
                 ctx->_dict_decode_schema.append(f2);
+                ctx->_column_ids_to_column_iterators.emplace(cid, ctx->_column_iterators.back());
+                ctx->_column_ids_to_index.emplace(cid, i);
                 continue;
             }
 
@@ -2011,6 +2528,8 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
             ctx->_is_dict_column.emplace_back(false);
             ctx->_dict_decode_schema.append(f);
         }
+        ctx->_column_ids_to_column_iterators.emplace(cid, ctx->_column_iterators.back());
+        ctx->_column_ids_to_index.emplace(cid, i);
     }
 
     size_t build_read_index_size = ctx->_read_schema.num_fields();
@@ -2031,6 +2550,7 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
         ctx->_is_dict_column.emplace_back(false);
         ctx->_late_materialize = true;
         ctx->_skip_dict_decode_indexes.push_back(false);
+        ctx->_row_id_column_id = cid;
     }
 
     for (size_t i = 0; i < num_fields; ++i) {
@@ -2070,6 +2590,8 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
     VLOG(2) << "SegmentIterator::_build_context late_materialization=" << late_materialization << " "
             << ctx->to_string();
 
+    _build_context_for_predicate(ctx);
+
     return Status::OK();
 }
 
@@ -2078,7 +2600,8 @@ Status SegmentIterator::_init_context() {
     RETURN_IF_ERROR(_init_global_dict_decoder());
 
     if (_predicate_columns == 0 || _opts.pred_tree.empty() ||
-        (_predicate_columns >= _schema.num_fields() && _predicate_column_access_paths.empty())) {
+        (_predicate_columns >= _schema.num_fields() && _predicate_column_access_paths.empty() &&
+         !_enable_predicate_col_late_materialize)) {
         // non or all field has predicate, disable late materialization.
         RETURN_IF_ERROR(_build_context<false>(&_context_list[0]));
     } else {
@@ -2109,6 +2632,113 @@ Status SegmentIterator::_init_context() {
         }
     }
     return _switch_context(&_context_list[0]);
+}
+
+void SegmentIterator::_build_context_for_predicate(ScanContext* ctx) {
+    bool has_or_predicates = _non_expr_pred_tree.has_or_predicate() || _expr_pred_tree.has_or_predicate();
+    // `_context` is not initialized while building ScanContext instances (e.g. during `_init_context`).
+    // Using the argument `ctx` ensures the enablement decision is evaluated for the context under construction
+    // instead of dereferencing the yet-to-be-initialized `_context`, which caused crashes on empty tablets.
+    ctx->_enable_predicate_col_late_materialize =
+            !has_or_predicates && ctx->_late_materialize && _opts.enable_predicate_col_late_materialize;
+
+    const ColumnPredicateMap& column_predicate_map = _opts.pred_tree.get_immediate_column_predicate_map();
+    if (column_predicate_map.empty()) {
+        ctx->_only_output_one_predicate_col_with_filter_push_down = false;
+        ctx->_enable_predicate_col_late_materialize = false;
+        return;
+    }
+
+    // For case like : select col from table where col like "%jerry%"
+    // we only need output one predicate column, so context's _late_materialize is always false
+    // but we still can push down predicate into page level
+    ctx->_only_output_one_predicate_col_with_filter_push_down =
+            !has_or_predicates && (_predicate_columns == 1 && _schema.num_fields() == 1) &&
+            ctx->_column_iterators[0]->support_push_down_predicate(column_predicate_map.begin()->second);
+
+    if (!ctx->_enable_predicate_col_late_materialize && !ctx->_only_output_one_predicate_col_with_filter_push_down) {
+        return;
+    }
+
+    ctx->_column_predicate_map.reserve(column_predicate_map.size());
+    ctx->_predicate_order.reserve(column_predicate_map.size());
+
+    for (const auto& pair : column_predicate_map) {
+        ctx->_predicate_order.emplace_back(pair.first);
+        ctx->_column_predicate_map.emplace(pair.first, pair.second);
+    }
+
+    // if column predicate is always true for string column or already used by bitmap index
+    // it will be removed from predicate tree
+    // but we still need to read it
+    // so we add the columnId into column_predicate_map with empty ColumnPredicates, so it will only read without filter
+    if (ctx->_predicate_order.size() + 1 < ctx->_column_iterators.size()) {
+        DCHECK(ctx->_column_ids_to_column_iterators.size() + 1 == ctx->_column_iterators.size());
+        for (auto pair : ctx->_column_ids_to_column_iterators) {
+            if (!ctx->_column_predicate_map.contains(pair.first)) {
+                ctx->_predicate_order.emplace_back(pair.first);
+                ctx->_column_predicate_map.emplace(pair.first, std::vector<const ColumnPredicate*>());
+            }
+        }
+    }
+
+    // Build column-specific RuntimeFilterPredicates for late materialization
+    // Group runtime filter predicates by ColumnId
+    if (!_runtime_filter_preds.empty() && _opts.enable_join_runtime_filter_pushdown &&
+        _column_to_runtime_filters_map.empty()) {
+        // First, collect predicates by column id
+        std::unordered_map<ColumnId, std::vector<RuntimeFilterPredicate*>> column_rf_map;
+        for (auto* rf_pred : _runtime_filter_preds.rf_predicates()) {
+            ColumnId cid = rf_pred->get_column_id();
+            column_rf_map[cid].push_back(rf_pred);
+        }
+
+        // Create a RuntimeFilterPredicates object for each column
+        for (const auto& [cid, rf_pred_list] : column_rf_map) {
+            RuntimeFilterPredicates rf_preds(_runtime_filter_preds.driver_sequence());
+            for (auto* rf_pred : rf_pred_list) {
+                rf_preds.add_predicate(rf_pred);
+            }
+            _column_to_runtime_filters_map.emplace(cid, std::move(rf_preds));
+        }
+    }
+
+    // Ensure columns with only runtime filters are also added to predicate_order and _column_predicate_map
+    // These columns may not have regular predicates but have runtime filters
+    if (_opts.enable_join_runtime_filter_pushdown) {
+        for (const auto& [cid, rf_preds] : _column_to_runtime_filters_map) {
+            // If this column is not in column_predicate_map, add it with empty predicates
+            if (!ctx->_column_predicate_map.contains(cid)) {
+                // Check if the column has a column iterator
+                DCHECK(ctx->_column_ids_to_column_iterators.contains(cid));
+                if (ctx->_column_ids_to_column_iterators.contains(cid)) {
+                    ctx->_predicate_order.emplace_back(cid);
+                    ctx->_column_predicate_map.emplace(cid, std::vector<const ColumnPredicate*>());
+                }
+            }
+        }
+    }
+
+    // all predicate columns + rowId column == _column_iterators size
+    DCHECK(ctx->_predicate_order.size() + 1 == ctx->_column_iterators.size() ||
+           ctx->_only_output_one_predicate_col_with_filter_push_down);
+
+    DCHECK(!ctx->_predicate_order.empty());
+
+    const ColumnId first_column_id = ctx->_predicate_order.front();
+    ctx->_column_iterators_for_predicate_late_materialize.clear();
+
+    ctx->_column_iterators_for_predicate_late_materialize.emplace_back(
+            ctx->_column_ids_to_column_iterators[first_column_id]);
+    ctx->_column_id_for_predicate_late_materialize.emplace_back(first_column_id);
+
+    // if only one predicate, and only need read this column, we do not need to use rowid Column
+    if (ctx->_only_output_one_predicate_col_with_filter_push_down) {
+        return;
+    }
+    // add row id iterator
+    ctx->_column_iterators_for_predicate_late_materialize.emplace_back(ctx->_column_iterators.back());
+    ctx->_column_id_for_predicate_late_materialize.emplace_back(ctx->_row_id_column_id);
 }
 
 Status SegmentIterator::_init_global_dict_decoder() {

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1322,7 +1322,7 @@ StatusOr<size_t> SegmentIterator::trigger_sample_if_necessary(vector<rowid_t>* r
                                                   ? 1
                                                   : static_cast<double>(_context->_first_column_total_rows_passed) /
                                                             _context->_first_column_total_rows_read;
-        if (first_column_selectivity > config::tigger_sample_selectivity) {
+        if (first_column_selectivity > config::predicate_sampling_trigger_selectivity_threshold) {
             ColumnId old_first_column_id = _context->_predicate_order[0];
 
             // Sample and update predicate selectivity
@@ -2170,7 +2170,7 @@ StatusOr<size_t> SegmentIterator::_predicate_evaluate_late_materialize_read_firs
     size_t chunk_size = first_col->size();
 
     if (expr_column_predicate_map.contains(first_column_id) && !_context->_is_filtered) {
-        // Don't apply runtime filter here because it was already applied in non_expr predicate filtering
+        // column-expr-predicate doesn't support [begin, end] interface
         ASSIGN_OR_RETURN(chunk_size, _filter_by_compound_and_predicates(chunk, rowid, 0, chunk_size, first_column_id,
                                                                         expr_column_predicate_map.at(first_column_id),
                                                                         current_columns, false));

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -123,6 +123,7 @@ public:
     TTableSampleOptions sample_options;
 
     bool enable_join_runtime_filter_pushdown = false;
+    bool enable_predicate_col_late_materialize = false;
 
     bool read_by_generated_column_adding = false;
 

--- a/be/src/storage/runtime_filter_predicate.h
+++ b/be/src/storage/runtime_filter_predicate.h
@@ -81,6 +81,8 @@ public:
     bool empty() const { return _rf_predicates.empty(); }
 
     Status evaluate(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to);
+    std::vector<RuntimeFilterPredicate*> rf_predicates() const { return _rf_predicates; }
+    int32_t driver_sequence() const { return _driver_sequence; }
 
 private:
     template <bool is_sample>

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -368,6 +368,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.vector_search_option = params.vector_search_option;
     rs_opts.sample_options = params.sample_options;
     rs_opts.enable_join_runtime_filter_pushdown = params.enable_join_runtime_filter_pushdown;
+    rs_opts.enable_predicate_col_late_materialize = params.enable_predicate_col_late_materialize;
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;
         rs_opts.version = _version.second;

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -107,6 +107,7 @@ struct TabletReaderParams {
 
     TTableSampleOptions sample_options;
     bool enable_join_runtime_filter_pushdown = false;
+    bool enable_predicate_col_late_materialize = false;
 
 public:
     std::string to_string() const;

--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -116,7 +116,7 @@ private:
 
 Status JavaArrayConverter::do_visit(const BinaryColumn& column) {
     size_t num_rows = column.size();
-    auto bytes = byte_buffer(column.get_bytes());
+    auto bytes = byte_buffer(column.get_immutable_bytes());
     auto offsets = byte_buffer(column.get_offset());
     const auto& method_map = _helper.method_map();
     if (auto iter = method_map.find(JNIPrimTypeId<Slice>::id); iter != method_map.end()) {

--- a/be/src/udf/java/java_native_method.cpp
+++ b/be/src/udf/java/java_native_method.cpp
@@ -41,7 +41,7 @@ public:
 
     Status do_visit(const BinaryColumn& column) {
         _jarr[_idx++] = reinterpret_cast<int64_t>(column.get_offset().data());
-        _jarr[_idx++] = reinterpret_cast<int64_t>(column.get_bytes().data());
+        _jarr[_idx++] = reinterpret_cast<int64_t>(column.get_immutable_bytes().data());
         return Status::OK();
     }
 

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -239,6 +239,25 @@ public:
     }
 };
 
+class SliceContainerAdaptor {
+public:
+    using value_type = Slice;
+
+    SliceContainerAdaptor(const Slice* slices, size_t size) : _slices(slices), _size(size) {}
+
+    SliceContainerAdaptor(Slice* slices, size_t size) : _slices(slices), _size(size) {}
+
+    explicit SliceContainerAdaptor(const std::vector<Slice>& slices) : _slices(slices.data()), _size(slices.size()) {}
+
+    const Slice* data() const { return _slices; }
+
+    size_t size() const { return _size; }
+
+private:
+    const Slice* _slices;
+    size_t _size;
+};
+
 inline std::ostream& operator<<(std::ostream& os, const Slice& slice) {
     os << slice.to_string();
     return os;

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -1137,7 +1137,7 @@ TEST_F(OrcChunkReaderTest, TestReadBinaryColumn) {
         auto* c = starrocks::ColumnHelper::as_raw_column<starrocks::NullableColumn>(col);
         auto* nulls = c->null_column()->get_data().data();
         auto* values = ColumnHelper::cast_to_raw<TYPE_VARBINARY>(c->data_column());
-        auto& vb = values->get_bytes();
+        auto& vb = values->get_immutable_bytes();
         auto& vo = values->get_offset();
 
         EXPECT_FALSE(nulls[0]);

--- a/be/test/storage/rowset/binary_dict_page_test.cpp
+++ b/be/test/storage/rowset/binary_dict_page_test.cpp
@@ -44,6 +44,7 @@
 #include "gen_cpp/segment.pb.h"
 #include "runtime/mem_pool.h"
 #include "storage/chunk_helper.h"
+#include "storage/column_predicate.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/binary_plain_page.h"
 #include "storage/rowset/page_decoder.h"
@@ -297,6 +298,185 @@ TEST_F(BinaryDictPageTest, TestEncodingRatio) {
 
     LOG(INFO) << "source line number:" << slices.size();
     test_with_large_data_size(slices);
+}
+
+TEST_F(BinaryDictPageTest, TestNextBatchWithFilter) {
+    std::vector<Slice> slices;
+    slices.emplace_back("a_100");
+    slices.emplace_back("b_200");
+    slices.emplace_back("c_300");
+    slices.emplace_back("d_400");
+    slices.emplace_back("e_500");
+
+    // encode
+    PageBuilderOptions options;
+    options.data_page_size = 256 * 1024;
+    options.dict_page_size = 256 * 1024;
+    BinaryDictPageBuilder page_builder(options);
+    size_t count = slices.size();
+
+    const Slice* ptr = &slices[0];
+    count = page_builder.add(reinterpret_cast<const uint8_t*>(ptr), count);
+    auto s = page_builder.finish()->build();
+
+    // construct dict page
+    OwnedSlice dict_slice = page_builder.get_dictionary_page()->build();
+    auto dict_page_decoder = std::make_unique<BinaryPlainPageDecoder<TYPE_VARCHAR>>(dict_slice.slice());
+    ASSERT_TRUE(dict_page_decoder->init().ok());
+
+    // decode
+    Slice encoded_data = s.slice();
+    PageFooterPB footer;
+    footer.set_type(DATA_PAGE);
+    DataPageFooterPB* data_page_footer = footer.mutable_data_page_footer();
+    data_page_footer->set_nullmap_size(0);
+    std::unique_ptr<std::vector<uint8_t>> page = nullptr;
+
+    Status st = StoragePageDecoder::decode_page(&footer, 0, starrocks::DICT_ENCODING, &page, &encoded_data);
+    ASSERT_TRUE(st.ok());
+
+    BinaryDictPageDecoder<TYPE_VARCHAR> page_decoder(encoded_data);
+    page_decoder.set_dict_decoder(dict_page_decoder.get());
+    ASSERT_TRUE(page_decoder.init().ok());
+
+    // Case 1: Without NULLs (nullptr passed for null_data)
+    {
+        auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+
+        // Prepare filter: >= "c_300"
+        std::unique_ptr<ColumnPredicate> predicate(new_column_ge_predicate(get_type_info(TYPE_VARCHAR), 0, "c_300"));
+        std::vector<const ColumnPredicate*> predicates;
+        predicates.push_back(predicate.get());
+
+        SparseRange<> range(0, 5);
+        std::vector<uint8_t> selection(5);
+        std::vector<uint16_t> selected_idx(5);
+
+        // reset selection
+        for (int i = 0; i < 5; ++i) selection[i] = 1;
+
+        st = page_decoder.next_batch_with_filter(column.get(), range, predicates, nullptr, selection.data(),
+                                                 selected_idx.data());
+        ASSERT_TRUE(st.ok()) << st.to_string();
+
+        // Check selection
+        ASSERT_EQ(0, selection[0]);
+        ASSERT_EQ(0, selection[1]);
+        ASSERT_EQ(1, selection[2]);
+        ASSERT_EQ(1, selection[3]);
+        ASSERT_EQ(1, selection[4]);
+
+        ASSERT_EQ(3, column->size());
+        ASSERT_EQ("c_300", column->get(0).get_slice().to_string());
+        ASSERT_EQ("d_400", column->get(1).get_slice().to_string());
+        ASSERT_EQ("e_500", column->get(2).get_slice().to_string());
+    }
+
+    // Reset decoder state
+    ASSERT_TRUE(page_decoder.seek_to_position_in_page(0).ok());
+
+    // Case 2: With NULLs (null_data passed)
+    {
+        // Use NullableColumn
+        auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, true);
+
+        // Prepare filter: >= "c_300"
+        std::unique_ptr<ColumnPredicate> predicate(new_column_ge_predicate(get_type_info(TYPE_VARCHAR), 0, "c_300"));
+        std::vector<const ColumnPredicate*> predicates;
+        predicates.push_back(predicate.get());
+
+        SparseRange<> range(0, 5);
+        std::vector<uint8_t> selection(5);
+        std::vector<uint16_t> selected_idx(5);
+
+        // reset selection
+        for (int i = 0; i < 5; ++i) selection[i] = 1;
+
+        // null_data: 0->not null, 1->null
+        // Mark "c_300" (idx 2) as NULL. "e_500" (idx 4) as NULL.
+        // "b_200" (idx 1) is not null but filtered out (< "c_300")
+        // "a_100" (idx 0) is not null but filtered out
+        // "d_400" (idx 3) is not null and kept (>= "c_300")
+        uint8_t null_data[] = {0, 0, 1, 0, 1};
+
+        st = page_decoder.next_batch_with_filter(column.get(), range, predicates, null_data, selection.data(),
+                                                 selected_idx.data());
+        ASSERT_TRUE(st.ok()) << st.to_string();
+
+        // Check selection
+        // 0: "a_100" < "c_300" -> 0
+        // 1: "b_200" < "c_300" -> 0
+        // 2: NULL < "c_300" (unknown/false) -> 0
+        // 3: "d_400" >= "c_300" -> 1
+        // 4: NULL < "c_300" -> 0
+
+        ASSERT_EQ(0, selection[0]);
+        ASSERT_EQ(0, selection[1]);
+        ASSERT_EQ(0, selection[2]);
+        ASSERT_EQ(1, selection[3]);
+        ASSERT_EQ(0, selection[4]);
+
+        // Check column data
+        // Should contain 1 row: "d_400"
+        ASSERT_EQ(1, column->size());
+        ASSERT_EQ("d_400", column->get(0).get_slice().to_string());
+    }
+}
+
+TEST_F(BinaryDictPageTest, TestReadByRowids) {
+    std::vector<std::string> strings;
+    std::vector<Slice> slices;
+    strings.reserve(10);
+    for (int i = 0; i < 10; ++i) {
+        strings.emplace_back("val_" + std::to_string(i));
+        slices.emplace_back(strings.back());
+    }
+
+    // encode
+    PageBuilderOptions options;
+    options.data_page_size = 256 * 1024;
+    options.dict_page_size = 256 * 1024;
+    BinaryDictPageBuilder page_builder(options);
+    size_t count = slices.size();
+
+    const Slice* ptr = &slices[0];
+    page_builder.add(reinterpret_cast<const uint8_t*>(ptr), count);
+    auto s = page_builder.finish()->build();
+
+    // construct dict page
+    OwnedSlice dict_slice = page_builder.get_dictionary_page()->build();
+    auto dict_page_decoder = std::make_unique<BinaryPlainPageDecoder<TYPE_VARCHAR>>(dict_slice.slice());
+    ASSERT_TRUE(dict_page_decoder->init().ok());
+
+    // decode
+    Slice encoded_data = s.slice();
+    PageFooterPB footer;
+    footer.set_type(DATA_PAGE);
+    DataPageFooterPB* data_page_footer = footer.mutable_data_page_footer();
+    data_page_footer->set_nullmap_size(0);
+    std::unique_ptr<std::vector<uint8_t>> page = nullptr;
+
+    Status st = StoragePageDecoder::decode_page(&footer, 0, starrocks::DICT_ENCODING, &page, &encoded_data);
+    ASSERT_TRUE(st.ok());
+
+    BinaryDictPageDecoder<TYPE_VARCHAR> page_decoder(encoded_data);
+    page_decoder.set_dict_decoder(dict_page_decoder.get());
+    ASSERT_TRUE(page_decoder.init().ok());
+
+    auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+
+    rowid_t rowids[] = {1, 3, 5, 8};
+    size_t num_read = 4;
+
+    st = page_decoder.read_by_rowids(0, rowids, &num_read, column.get());
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(4, num_read);
+    ASSERT_EQ(4, column->size());
+
+    ASSERT_EQ("val_1", column->get(0).get_slice().to_string());
+    ASSERT_EQ("val_3", column->get(1).get_slice().to_string());
+    ASSERT_EQ("val_5", column->get(2).get_slice().to_string());
+    ASSERT_EQ("val_8", column->get(3).get_slice().to_string());
 }
 
 } // namespace starrocks

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -21,6 +21,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "column/column_helper.h"
+#include "common/config.h"
 #include "common/object_pool.h"
 #include "fs/fs_memory.h"
 #include "gen_cpp/tablet_schema.pb.h"
@@ -30,17 +32,15 @@
 #include "storage/chunk_helper.h"
 #include "storage/column_predicate_rewriter.h"
 #include "storage/olap_common.h"
-#include "common/config.h"
 #include "storage/record_predicate/record_predicate_helper.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/segment.h"
 #include "storage/rowset/segment_options.h"
 #include "storage/rowset/segment_writer.h"
+#include "storage/runtime_filter_predicate.h"
 #include "storage/tablet_schema_helper.h"
 #include "testutil/assert.h"
 #include "types/logical_type.h"
-#include "storage/runtime_filter_predicate.h"
-#include "column/column_helper.h"
 
 namespace starrocks {
 
@@ -161,38 +161,6 @@ struct VecSchemaBuilder {
 private:
     Schema vec_schema;
 };
-
-// A lightweight runtime filter predicate used only for UT.
-// It filters INT column values equal to _match_value.
-class FakeRuntimeFilterPredicate : public RuntimeFilterPredicate {
-public:
-    FakeRuntimeFilterPredicate(ColumnId cid, int match_value)
-            : RuntimeFilterPredicate(nullptr, cid), _match_value(match_value) {}
-
-    Status evaluate(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) override {
-        auto* col = ColumnHelper::cast_to_raw<TYPE_INT>(chunk->get_column_by_id(_column_id));
-        for (uint16_t i = from; i < to; i++) {
-            selection[i] = selection[i] && (col->get_data()[i] == _match_value);
-        }
-        return Status::OK();
-    }
-
-    StatusOr<uint16_t> evaluate(Chunk* chunk, uint16_t* sel, uint16_t sel_size, uint16_t* target_sel) override {
-        auto* col = ColumnHelper::cast_to_raw<TYPE_INT>(chunk->get_column_by_id(_column_id));
-        uint16_t out = 0;
-        for (uint16_t i = 0; i < sel_size; i++) {
-            uint16_t idx = sel[i];
-            if (col->get_data()[idx] == _match_value) {
-                target_sel[out++] = idx;
-            }
-        }
-        return out;
-    }
-
-private:
-    int _match_value;
-};
-
 } // namespace test
 
 // This case is only triggered by dictionary inconsistencies.
@@ -531,88 +499,6 @@ TEST_F(SegmentIteratorTest, TestPredicateLateMaterializationSingleColumnPushdown
     }
     ASSERT_EQ(total, 50);
     ASSERT_GE(stats.rows_vec_cond_filtered, 50);
-}
-
-// Runtime filter + late materialization: runtime filter column should be read late and still filter correctly.
-TEST_F(SegmentIteratorTest, TestPredicateLateMaterializationWithRuntimeFilter) {
-    using namespace starrocks::test;
-
-    // Force late materialization to be always on.
-    auto prev_ratio = config::late_materialization_ratio;
-    config::late_materialization_ratio = 1000;
-    DeferOp reset_ratio([&]() { config::late_materialization_ratio = prev_ratio; });
-
-    std::string file_name = kSegmentDir + "/predicate_late_materialize_runtime_filter";
-    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
-
-    TabletSchemaBuilder builder;
-    std::shared_ptr<TabletSchema> tablet_schema = builder.create(0, false, TYPE_INT, true)  // c0 key
-                                                          .create(1, false, TYPE_INT, false) // c1 filter by RF
-                                                          .create(2, false, TYPE_INT, false) // c2 late read
-                                                          .build();
-
-    SegmentWriterOptions opts;
-    opts.num_rows_per_block = 32;
-    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
-
-    const int32_t chunk_size = 64;
-    const size_t num_rows = 50;
-
-    auto c0_provider = [](int32_t i) { return i; };
-    auto c1_provider = [](int32_t i) { return i % 10; }; // 0..9 repeat
-    auto c2_provider = [](int32_t i) { return 2000 + i; };
-
-    TabletDataBuilder data_builder(writer, tablet_schema, chunk_size, num_rows);
-    ASSERT_OK(data_builder.append(0, c0_provider));
-    ASSERT_OK(data_builder.append(1, c1_provider));
-    ASSERT_OK(data_builder.append(2, c2_provider));
-    ASSERT_OK(data_builder.finalize_footer());
-
-    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
-    ASSERT_EQ(segment->num_rows(), num_rows);
-
-    VecSchemaBuilder schema_builder;
-    schema_builder.add(0, "c0", TYPE_INT).add(1, "c1", TYPE_INT).add(2, "c2", TYPE_INT);
-    auto vec_schema = schema_builder.build();
-
-    // Light predicate on c0 to enable predicate tree; keeps all rows.
-    std::unique_ptr<ColumnPredicate> predicate(new_column_ge_predicate(get_type_info(TYPE_INT), 0, "0"));
-    PredicateAndNode pred_root;
-    pred_root.add_child(PredicateColumnNode{predicate.get()});
-
-    SegmentReadOptions seg_opts;
-    OlapReaderStatistics stats;
-    seg_opts.fs = _fs;
-    seg_opts.stats = &stats;
-    seg_opts.tablet_schema = tablet_schema;
-    seg_opts.enable_predicate_col_late_materialize = true;
-    seg_opts.enable_join_runtime_filter_pushdown = true;
-    seg_opts.pred_tree = PredicateTree::create(std::move(pred_root));
-
-    // Add a runtime filter: c1 == 5
-    ObjectPool pool;
-    auto* rf_pred = pool.add(new FakeRuntimeFilterPredicate(/*cid=*/1, /*match_value=*/5));
-    seg_opts.runtime_filter_preds = RuntimeFilterPredicates(/*driver_sequence=*/0);
-    seg_opts.runtime_filter_preds.add_predicate(rf_pred);
-
-    auto chunk_iter = new_segment_iterator(segment, vec_schema, seg_opts);
-    ASSERT_OK(chunk_iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
-    ASSERT_OK(chunk_iter->init_output_schema(std::unordered_set<uint32_t>()));
-
-    auto res_chunk = ChunkHelper::new_chunk(chunk_iter->output_schema(), config::vector_chunk_size);
-    ASSERT_OK(chunk_iter->get_next(res_chunk.get()));
-
-    // Only rows where c1 == 5 should remain (5 rows among 0..49).
-    ASSERT_EQ(res_chunk->num_rows(), 5);
-    auto c0_col = ColumnHelper::cast_to_raw<TYPE_INT>(res_chunk->get_column_by_index(0));
-    auto c1_col = ColumnHelper::cast_to_raw<TYPE_INT>(res_chunk->get_column_by_index(1));
-    auto c2_col = ColumnHelper::cast_to_raw<TYPE_INT>(res_chunk->get_column_by_index(2));
-    for (size_t i = 0; i < res_chunk->num_rows(); ++i) {
-        ASSERT_EQ(c1_col->get_data()[i], 5);
-        ASSERT_EQ(c2_col->get_data()[i] - c0_col->get_data()[i], 2000);
-    }
-    res_chunk->reset();
-    ASSERT_TRUE(chunk_iter->get_next(res_chunk.get()).is_end_of_file());
 }
 
 // NOLINTNEXTLINE

--- a/be/test/udf/java/java_native_method_test.cpp
+++ b/be/test/udf/java/java_native_method_test.cpp
@@ -67,7 +67,7 @@ TEST_F(JavaNativeMethodTest, get_addrs_int) {
         const auto* binary_column = down_cast<const BinaryColumn*>(data_column);
         ASSERT_EQ(results[0], (jlong)nullable_column->null_column_data().data());
         ASSERT_EQ(results[1], (jlong)binary_column->get_offset().data());
-        ASSERT_EQ(results[2], (jlong)binary_column->get_bytes().data());
+        ASSERT_EQ(results[2], (jlong)binary_column->get_immutable_bytes().data());
         env->DeleteLocalRef(arr);
     }
     // test array/map

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1029,6 +1029,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_FULL_SORT_USE_GERMAN_STRING = "enable_full_sort_use_german_string";
 
     public static final String ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH = "enable_insert_select_external_auto_refresh";
+    public static final String ENABLE_PREDICATE_COL_LATE_MATERIALIZE = "enable_predicate_col_late_materialize";
 
     public static final String PUSH_DOWN_HEAVY_EXPRS = "push_down_heavy_exprs";
 
@@ -2147,6 +2148,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH)
     private boolean enableInsertSelectExternalAutoRefresh = true;
+    
+    @VarAttr(name = ENABLE_PREDICATE_COL_LATE_MATERIALIZE)
+    private boolean enablePredicateColLateMaterialize = true;
 
     @VarAttr(name = PUSH_DOWN_HEAVY_EXPRS)
     private boolean pushDownHeavyExprs = true;
@@ -5692,6 +5696,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public void setEnableInsertSelectExternalAutoRefresh(boolean enableInsertSelectExternalAutoRefresh) {
         this.enableInsertSelectExternalAutoRefresh = enableInsertSelectExternalAutoRefresh;
     }
+    
+    public void setEnablePredicateColLateMaterialize(boolean enablePredicateColLateMaterialize) {
+        this.enablePredicateColLateMaterialize = enablePredicateColLateMaterialize;
+    }
+
+    public boolean isEnablePredicateColLateMaterialize() {
+        return enablePredicateColLateMaterialize;
+    }
 
     public void setPushDownHeavyExprs(boolean flag) {
         this.pushDownHeavyExprs = flag;
@@ -5817,6 +5829,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setGroup_concat_max_len(groupConcatMaxLen);
         tResult.setRpc_http_min_size(rpcHttpMinSize);
         tResult.setInterleaving_group_size(interleavingGroupSize);
+        tResult.setEnable_predicate_col_late_materialize(enablePredicateColLateMaterialize);
 
         TCompressionType loadCompressionType =
                 CompressionUtils.findTCompressionByName(loadTransmissionCompressionType);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddIndexOnlyPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddIndexOnlyPredicateRule.java
@@ -71,6 +71,7 @@ public class AddIndexOnlyPredicateRule implements TreeRewriteRule {
                         BinaryPredicateOperator newIndexPredicate =
                                 BinaryPredicateOperator.ge(call, ConstantOperator.createDouble(0));
                         scan.setPredicate(CompoundPredicateOperator.and(scan.getPredicate(), newIndexPredicate));
+                        context.getOptimizerContext().getSessionVariable().setEnablePredicateColLateMaterialize(false);
                         return null;
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -135,6 +135,7 @@ public class StatisticUtils {
         context.getSessionVariable().setConnectorIoTasksPerScanOperator(Config.collect_stats_io_tasks_per_connector_operator);
         context.getSessionVariable().setEnableSPMRewrite(false);
         context.getSessionVariable().setSingleNodeExecPlan(false);
+        context.getSessionVariable().setEnablePredicateColLateMaterialize(false);
 
         WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         Warehouse warehouse = manager.getBackgroundWarehouse();

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -360,6 +360,8 @@ struct TQueryOptions {
   // 0: fnv_hash (default, for backward compatibility)
   // 1: xxh3_hash (faster)
   201: optional i32 exchange_hash_function_version = 0;
+   // whether enable predicate column late materialization
+  202: optional bool enable_predicate_col_late_materialize;
   
   210: optional bool enable_global_late_materialization;
   211: optional bool enable_schedule_log;

--- a/test/sql/test_scan/R/test_scan_predicate_late_materialization
+++ b/test/sql/test_scan/R/test_scan_predicate_late_materialization
@@ -1,0 +1,294 @@
+-- name: test_predicate_late_materialization 
+drop table if exists predicate_lm_v1_sparse;
+-- result:
+-- !result
+drop table if exists predicate_lm_v2_low_full;
+-- result:
+-- !result
+drop table if exists predicate_lm_v2_low_half_null;
+-- result:
+-- !result
+drop table if exists predicate_lm_v2_high_half_null;
+-- result:
+-- !result
+drop table if exists predicate_lm_v2_high_full;
+-- result:
+-- !result
+create table predicate_lm_v1_sparse (
+    id int,
+    col_string string,
+    col_int int
+)
+duplicate key(id)
+distributed by hash(id)
+properties(
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+create table predicate_lm_v2_low_full (
+    id int,
+    col_string string not null,
+    col_int int
+)
+duplicate key(id)
+distributed by hash(id)
+properties(
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+create table predicate_lm_v2_low_half_null (
+    id int,
+    col_string string,
+    col_int int
+)
+duplicate key(id)
+distributed by hash(id)
+properties(
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+create table predicate_lm_v2_high_half_null (
+    id int,
+    col_string string,
+    col_int int
+)
+duplicate key(id)
+distributed by hash(id)
+properties(
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+create table predicate_lm_v2_high_full (
+    id int,
+    col_string string not null,
+    col_int int
+)
+duplicate key(id)
+distributed by hash(id)
+properties(
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into predicate_lm_v1_sparse
+select id,
+       if(id <= 5900, NULL, if(id % 2 = 0, 'xxx', 'abc')),
+       id
+from table(generate_series(1, 6000)) gen(id);
+-- result:
+-- !result
+insert into predicate_lm_v2_low_full
+select id,
+       if(id % 4 = 0, 'abc', 'xxx'),
+       id
+from table(generate_series(1, 8000)) gen(id);
+-- result:
+-- !result
+insert into predicate_lm_v2_low_half_null
+select id,
+       case
+           when id % 2 then NULL
+           when id % 5 = 0 then 'abc'
+           else 'xxx'
+       end,
+       id
+from table(generate_series(1, 8000)) gen(id);
+-- result:
+-- !result
+insert into predicate_lm_v2_high_half_null
+select id,
+       case
+           when id % 2  then NULL
+           when id % 177 then 'xxx'
+           else concat('value_', id)
+       end,
+       id
+from table(generate_series(1, 12000)) gen(id);
+-- result:
+-- !result
+insert into predicate_lm_v2_high_full
+select id,
+       case
+           when id % 177 then 'xxx'
+           else concat('value_', id)
+       end,
+       id
+from table(generate_series(1, 9000)) gen(id);
+-- result:
+-- !result
+sync;
+-- result:
+-- !result
+set enable_predicate_col_late_materialize = true;
+-- result:
+-- !result
+select count(*) from predicate_lm_v1_sparse where col_string like 'xxx';
+-- result:
+50
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+-- result:
+4475
+-- !result
+set enable_predicate_col_late_materialize = false;
+-- result:
+-- !result
+select count(*) from predicate_lm_v1_sparse where col_string like 'xxx';
+-- result:
+50
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+-- result:
+4475
+-- !result
+set enable_predicate_col_late_materialize = true;
+-- result:
+-- !result
+select count(*) from predicate_lm_v2_low_full where col_string like 'xxx';
+-- result:
+6000
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+-- result:
+4475
+-- !result
+set enable_predicate_col_late_materialize = false;
+-- result:
+-- !result
+select count(*) from predicate_lm_v2_low_full where col_string like 'xxx';
+-- result:
+6000
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+-- result:
+4475
+-- !result
+set enable_predicate_col_late_materialize = true;
+-- result:
+-- !result
+select count(*) from predicate_lm_v2_low_half_null where col_string like 'xxx';
+-- result:
+3200
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+-- result:
+4475
+-- !result
+set enable_predicate_col_late_materialize = false;
+-- result:
+-- !result
+select count(*) from predicate_lm_v2_low_half_null where col_string like 'xxx';
+-- result:
+3200
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+-- result:
+4475
+-- !result
+set cbo_enable_low_cardinality_optimize = false;
+-- result:
+-- !result
+set enable_predicate_col_late_materialize = true;
+-- result:
+-- !result
+select count(*) from predicate_lm_v2_low_half_null where col_string like 'xxx';
+-- result:
+3200
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+-- result:
+4475
+-- !result
+set enable_predicate_col_late_materialize = false;
+-- result:
+-- !result
+select count(*) from predicate_lm_v2_low_half_null where col_string like 'xxx';
+-- result:
+3200
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+-- result:
+4475
+-- !result
+set enable_predicate_col_late_materialize = true;
+-- result:
+-- !result
+select count(*) from predicate_lm_v2_high_half_null where col_string like 'xxx';
+-- result:
+5967
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+-- result:
+4475
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string != '' and col_int % 2 = 0;
+-- result:
+4500
+-- !result
+set enable_predicate_col_late_materialize = false;
+-- result:
+-- !result
+select count(*) from predicate_lm_v2_high_half_null where col_string like 'xxx';
+-- result:
+5967
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+-- result:
+4475
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string != '' and col_int % 2 = 0;
+-- result:
+4500
+-- !result
+set enable_predicate_col_late_materialize = true;
+-- result:
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx';
+-- result:
+8950
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+-- result:
+4475
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string != '' and col_int % 2 = 0;
+-- result:
+4500
+-- !result
+set enable_predicate_col_late_materialize = false;
+-- result:
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx';
+-- result:
+8950
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+-- result:
+4475
+-- !result
+select count(*) from predicate_lm_v2_high_full where col_string != '' and col_int % 2 = 0;
+-- result:
+4500
+-- !result
+set enable_predicate_col_late_materialize = true;
+-- result:
+-- !result
+drop table if exists predicate_lm_v1_sparse;
+-- result:
+-- !result
+drop table if exists predicate_lm_v2_low_full;
+-- result:
+-- !result
+drop table if exists predicate_lm_v2_low_half_null;
+-- result:
+-- !result
+drop table if exists predicate_lm_v2_high_half_null;
+-- result:
+-- !result
+drop table if exists predicate_lm_v2_high_full;
+-- result:
+-- !result

--- a/test/sql/test_scan/R/test_scan_predicate_late_materialization
+++ b/test/sql/test_scan/R/test_scan_predicate_late_materialization
@@ -277,6 +277,34 @@ select count(*) from predicate_lm_v2_high_full where col_string != '' and col_in
 set enable_predicate_col_late_materialize = true;
 -- result:
 -- !result
+set enable_predicate_col_late_materialize = true;
+-- result:
+-- !result
+select count(*) from predicate_lm_v2_low_full where col_int > 0 and col_string = 'abc';
+-- result:
+2000
+-- !result
+select count(*) 
+from predicate_lm_v2_low_full t1 
+join predicate_lm_v2_low_full t2 on t1.col_int = t2.col_int and t1.col_string = t2.col_string 
+where t1.col_int > 0 and t1.col_string = 'abc';
+-- result:
+2000
+-- !result
+set enable_predicate_col_late_materialize = false;
+-- result:
+-- !result
+select count(*) from predicate_lm_v2_low_full where col_int > 0 and col_string = 'abc';
+-- result:
+2000
+-- !result
+select count(*) 
+from predicate_lm_v2_low_full t1 
+join predicate_lm_v2_low_full t2 on t1.col_int = t2.col_int and t1.col_string = t2.col_string 
+where t1.col_int > 0 and t1.col_string = 'abc';
+-- result:
+2000
+-- !result
 drop table if exists predicate_lm_v1_sparse;
 -- result:
 -- !result

--- a/test/sql/test_scan/T/test_scan_predicate_late_materialization
+++ b/test/sql/test_scan/T/test_scan_predicate_late_materialization
@@ -172,6 +172,23 @@ select count(*) from predicate_lm_v2_high_full where col_string != '' and col_in
 
 
 set enable_predicate_col_late_materialize = true;
+-- Scenario 7: low cardinality column, predicate order col_int then col_string
+set enable_predicate_col_late_materialize = true;
+select count(*) from predicate_lm_v2_low_full where col_int > 0 and col_string = 'abc';
+
+-- Scenario 8: join, col_string and col_int in ON clause, predicate order col_int then col_string
+select count(*) 
+from predicate_lm_v2_low_full t1 
+join predicate_lm_v2_low_full t2 on t1.col_int = t2.col_int and t1.col_string = t2.col_string 
+where t1.col_int > 0 and t1.col_string = 'abc';
+
+set enable_predicate_col_late_materialize = false;
+select count(*) from predicate_lm_v2_low_full where col_int > 0 and col_string = 'abc';
+select count(*) 
+from predicate_lm_v2_low_full t1 
+join predicate_lm_v2_low_full t2 on t1.col_int = t2.col_int and t1.col_string = t2.col_string 
+where t1.col_int > 0 and t1.col_string = 'abc';
+
 
 drop table if exists predicate_lm_v1_sparse;
 drop table if exists predicate_lm_v2_low_full;

--- a/test/sql/test_scan/T/test_scan_predicate_late_materialization
+++ b/test/sql/test_scan/T/test_scan_predicate_late_materialization
@@ -1,0 +1,180 @@
+-- name: test_predicate_late_materialization 
+drop table if exists predicate_lm_v1_sparse;
+drop table if exists predicate_lm_v2_low_full;
+drop table if exists predicate_lm_v2_low_half_null;
+drop table if exists predicate_lm_v2_high_half_null;
+drop table if exists predicate_lm_v2_high_full;
+
+-- Build deterministic tables to cover parsed-page v1/v2 plus various cardinality/null distributions.
+create table predicate_lm_v1_sparse (
+    id int,
+    col_string string,
+    col_int int
+)
+duplicate key(id)
+distributed by hash(id)
+properties(
+    "replication_num" = "1"
+);
+
+create table predicate_lm_v2_low_full (
+    id int,
+    col_string string not null,
+    col_int int
+)
+duplicate key(id)
+distributed by hash(id)
+properties(
+    "replication_num" = "1"
+);
+
+create table predicate_lm_v2_low_half_null (
+    id int,
+    col_string string,
+    col_int int
+)
+duplicate key(id)
+distributed by hash(id)
+properties(
+    "replication_num" = "1"
+);
+
+create table predicate_lm_v2_high_half_null (
+    id int,
+    col_string string,
+    col_int int
+)
+duplicate key(id)
+distributed by hash(id)
+properties(
+    "replication_num" = "1"
+);
+
+create table predicate_lm_v2_high_full (
+    id int,
+    col_string string not null,
+    col_int int
+)
+duplicate key(id)
+distributed by hash(id)
+properties(
+    "replication_num" = "1"
+);
+
+-- More than 80% NULL rows to emulate parsed page v1.
+insert into predicate_lm_v1_sparse
+select id,
+       if(id <= 5900, NULL, if(id % 2 = 0, 'xxx', 'abc')),
+       id
+from table(generate_series(1, 6000)) gen(id);
+
+-- Low cardinality string column without NULL values.
+insert into predicate_lm_v2_low_full
+select id,
+       if(id % 4 = 0, 'abc', 'xxx'),
+       id
+from table(generate_series(1, 8000)) gen(id);
+
+-- Half NULL, low cardinality strings.
+insert into predicate_lm_v2_low_half_null
+select id,
+       case
+           when id % 2 then NULL
+           when id % 5 = 0 then 'abc'
+           else 'xxx'
+       end,
+       id
+from table(generate_series(1, 8000)) gen(id);
+
+-- High cardinality strings with 50% NULL coverage.
+insert into predicate_lm_v2_high_half_null
+select id,
+       case
+           when id % 2  then NULL
+           when id % 177 then 'xxx'
+           else concat('value_', id)
+       end,
+       id
+from table(generate_series(1, 12000)) gen(id);
+
+-- High cardinality strings without NULL values.
+insert into predicate_lm_v2_high_full
+select id,
+       case
+           when id % 177 then 'xxx'
+           else concat('value_', id)
+       end,
+       id
+from table(generate_series(1, 9000)) gen(id);
+
+sync;
+
+-- Scenario 1: parse v1 format, >80% NULL, low cardinality column
+set enable_predicate_col_late_materialize = true;
+select count(*) from predicate_lm_v1_sparse where col_string like 'xxx';
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+set enable_predicate_col_late_materialize = false;
+select count(*) from predicate_lm_v1_sparse where col_string like 'xxx';
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+
+-- Scenario 2: parse v2 format, low cardinality column, no NULL values
+set enable_predicate_col_late_materialize = true;
+select count(*) from predicate_lm_v2_low_full where col_string like 'xxx';
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+set enable_predicate_col_late_materialize = false;
+select count(*) from predicate_lm_v2_low_full where col_string like 'xxx';
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+
+
+-- Scenario 3: parse v2 format, low cardinality column, half NULL values
+set enable_predicate_col_late_materialize = true;
+select count(*) from predicate_lm_v2_low_half_null where col_string like 'xxx';
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+
+set enable_predicate_col_late_materialize = false;
+select count(*) from predicate_lm_v2_low_half_null where col_string like 'xxx';
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+
+
+-- Scenario 4: parse v2 format, disable low cardinality optimization manually
+set cbo_enable_low_cardinality_optimize = false;
+set enable_predicate_col_late_materialize = true;
+select count(*) from predicate_lm_v2_low_half_null where col_string like 'xxx';
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+
+set enable_predicate_col_late_materialize = false;
+select count(*) from predicate_lm_v2_low_half_null where col_string like 'xxx';
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+
+-- Scenario 5: parse v2 format, high cardinality column, half NULL values
+set enable_predicate_col_late_materialize = true;
+select count(*) from predicate_lm_v2_high_half_null where col_string like 'xxx';
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+select count(*) from predicate_lm_v2_high_full where col_string != '' and col_int % 2 = 0;
+
+set enable_predicate_col_late_materialize = false;
+select count(*) from predicate_lm_v2_high_half_null where col_string like 'xxx';
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+select count(*) from predicate_lm_v2_high_full where col_string != '' and col_int % 2 = 0;
+
+
+-- Scenario 6: parse v2 format, high cardinality column, no NULL values
+set enable_predicate_col_late_materialize = true;
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx';
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+select count(*) from predicate_lm_v2_high_full where col_string != '' and col_int % 2 = 0;
+
+
+set enable_predicate_col_late_materialize = false;
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx';
+select count(*) from predicate_lm_v2_high_full where col_string like 'xxx' and col_int % 2 = 0;
+select count(*) from predicate_lm_v2_high_full where col_string != '' and col_int % 2 = 0;
+
+
+set enable_predicate_col_late_materialize = true;
+
+drop table if exists predicate_lm_v1_sparse;
+drop table if exists predicate_lm_v2_low_full;
+drop table if exists predicate_lm_v2_low_half_null;
+drop table if exists predicate_lm_v2_high_half_null;
+drop table if exists predicate_lm_v2_high_full;


### PR DESCRIPTION
## Why I'm doing:
1. optimize our internal table scan'late materialization's implementation, so selected rows in the same page can be handled in one function call
2. support reading predicate column by late materialization, if predicate columns' number is huge, and the  predicates  in front can filter lots of data, this can reduce io and memory copy
3. since we don't need reading predicate columns all at once, we can reorder the predicate columns so the predicate with lower selectivity can execute first. This is done by sample data and check the selectivity of every predicate
4. if the first predicate column is string, push down the string predicate into page level, so we don't need to read big string into column then filter it if not satisfied predicate. This is one implementation of zero-copy, since our current zero-copy doesn't support string type.
5. optimize predicate evaluation speed for: string_col != "", only check the offset column.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces late materialization for predicate columns and page-level filtering, plus zero-copy binary string handling, to reduce IO and copying.
> 
> - Adds `append_with_mask` utility and uses it in aggregation to build group-by columns efficiently
> - Refactors `BinaryColumn` to support zero-copy via `ContainerResource` and `get_immutable_bytes()`, updating call sites to avoid unnecessary copies
> - Extends page decoders (`binary_plain`, `binary_dict`, `bitshuffle`) and `ParsedPage` with `next_batch_with_filter`, `read_by_rowids`, and reservation helpers; `ScalarColumnIterator`/`RowIdColumnIterator` now push down predicates, filter in-page, and fetch by rowids
> - Adds fast path for string `<> ''` in predicates and a compound predicate evaluator that vectorizes AND evaluation
> - Enables predicate-column late materialization across scan paths (OLAP, Lake, Rowset) via new reader option; exposes `PredicateTree::has_or_predicate`
> - API tweaks: `Chunk::append_column(..., ColumnId, ...)`, binary hash/selectivity callers now use immutable bytes
> - Config: add `predicate_sampling_trigger_selectivity_threshold`, change `late_materialization_ratio` to mutable (`CONF_mInt32`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddb3939ffd92eb69f1e90f26831c69ad9f4266a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->