### PR TITLE
[BugFix] fix the extractPath of asyncProfiler

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
@@ -67,6 +67,10 @@ public class ProcProfileCollector extends FrontendDaemon {
         deleteExpiredFiles();
     }
 
+    public String getProfileLogDir() {
+        return profileLogDir;
+    }
+
     // AsyncProfiler depends on the native library libasyncProfiler.so, which is bundled inside the JAR.
     // By default, it extracts this library to the /tmp directory in order to load it.
     // However, if /tmp is mounted with the "noexec" option, loading the library will fail.
@@ -77,9 +81,11 @@ public class ProcProfileCollector extends FrontendDaemon {
         final String libPathProperty = "one.profiler.extractPath";
         String value = System.getProperty(libPathProperty);
         if (StringUtils.isEmpty(value)) {
-            String path = Config.STARROCKS_HOME_DIR + "/bin/";
-            System.setProperty(libPathProperty, path);
-            LOG.info("change the system property {} to {}", libPathProperty, path);
+            String dir = Config.STARROCKS_HOME_DIR + "/bin/";
+            if (StringUtils.isNotEmpty(Config.STARROCKS_HOME_DIR) && new File(dir).exists()) {
+                System.setProperty(libPathProperty, dir);
+                LOG.info("change the system property {} to {}", libPathProperty, dir);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
@@ -79,6 +79,7 @@ public class ProcProfileCollector extends FrontendDaemon {
         if (StringUtils.isEmpty(value)) {
             String path = Config.STARROCKS_HOME_DIR + "/bin/";
             System.setProperty(libPathProperty, path);
+            LOG.info("change the system property {} to {}", libPathProperty, path);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
@@ -20,6 +20,7 @@ import one.profiler.AsyncProfiler;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -53,6 +54,7 @@ public class ProcProfileCollector extends FrontendDaemon {
     protected void runAfterCatalogReady() {
         File file = new File(profileLogDir);
         file.mkdirs();
+        prepareLibrary();
 
         if (Config.proc_profile_cpu_enable) {
             collectCPUProfile();
@@ -63,6 +65,21 @@ public class ProcProfileCollector extends FrontendDaemon {
         }
 
         deleteExpiredFiles();
+    }
+
+    // AsyncProfiler depends on the native library libasyncProfiler.so, which is bundled inside the JAR.
+    // By default, it extracts this library to the /tmp directory in order to load it.
+    // However, if /tmp is mounted with the "noexec" option, loading the library will fail.
+    // To avoid this issue, we explicitly set 'one.profiler.extractPath' to a directory with execute permissions.
+    // See prepareLibrary() for how the extraction path is set to a safer default under STARROCKS_HOME.
+    // See https://github.com/StarRocks/starrocks/issues/64502
+    private void prepareLibrary() {
+        final String libPathProperty = "one.profiler.extractPath";
+        String value = System.getProperty(libPathProperty);
+        if (StringUtils.isEmpty(value)) {
+            String path = Config.STARROCKS_HOME_DIR + "/bin/";
+            System.setProperty(libPathProperty, path);
+        }
     }
 
     private void collectMemProfile() {

--- a/fe/fe-core/src/test/java/com/starrocks/memory/ProcProfileCollectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/memory/ProcProfileCollectorTest.java
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.memory;
+
+import com.starrocks.common.Config;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProcProfileCollectorTest {
+
+    @Test
+    public void runAfterCatalogReady() throws IOException, InterruptedException {
+        Config.proc_profile_collect_time_s = 1;
+        ProcProfileCollector collector = new ProcProfileCollector();
+        String dir = collector.getProfileLogDir();
+        File profileDir = new File(dir);
+
+        // count the number of files in the directory
+        Function<Void, Integer> countFiles = (x) -> {
+            int count = 0;
+            String[] files = profileDir.list();
+            for (String filename : files) {
+                if (filename.startsWith("cpu-profile-") && filename.endsWith(".tar.gz")) {
+                    count++;
+                }
+            }
+            return count;
+        };
+
+        int prevCount = countFiles.apply(null);
+
+        collector.runAfterCatalogReady();
+        assertTrue(profileDir.exists(), "Profile log directory should exist");
+        assertTrue(profileDir.isDirectory(), "Profile log directory should be a directory");
+
+        collector.runAfterCatalogReady();
+        int afterCount = countFiles.apply(null);
+        assertTrue(afterCount > prevCount);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #64502

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set AsyncProfiler extract path to a safe location and add a unit test for ProcProfileCollector profiling output.
> 
> - **Profiling setup**:
>   - Set `one.profiler.extractPath` to `Config.STARROCKS_HOME_DIR + "/bin/"` in `prepareLibrary()` when unset, avoiding failures on noexec `/tmp`.
>   - Invoke `prepareLibrary()` in `runAfterCatalogReady()`.
> - **API**:
>   - Add `getProfileLogDir()` to expose the profile output directory.
> - **Tests**:
>   - Add `ProcProfileCollectorTest` to verify profile directory creation and that CPU profile `.tar.gz` files increase after runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfc6daf35cc07df165eb99f6d477f97dba60a4c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->