### PR TITLE
[UT] fix flaky test test_predicate_columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
@@ -124,7 +124,7 @@ public class AnalyzeStatusSystemTable extends SystemTable {
             } catch (Throwable e) {
                 // TODO: change the exception into an checked exception in MetadataMgr.getTable
                 // The underlying SDK might throw an deep exception with this message
-                if (!e.getMessage().contains("table not found")) {
+                if (!(e.getMessage() != null && e.getMessage().contains("table not found"))) {
                     LOG.warn("failed to get table meta", e);
                 }
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
@@ -36,6 +36,8 @@ import com.starrocks.thrift.TAnalyzeStatusReq;
 import com.starrocks.thrift.TAnalyzeStatusRes;
 import com.starrocks.thrift.TSchemaTableType;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 import java.util.List;
@@ -46,6 +48,7 @@ import java.util.Optional;
  */
 public class AnalyzeStatusSystemTable extends SystemTable {
 
+    private static final Logger LOG = LogManager.getLogger(AnalyzeStatusSystemTable.class);
     private static final String NAME = "analyze_status";
     private static final List<Column> COLUMNS;
 
@@ -117,6 +120,13 @@ public class AnalyzeStatusSystemTable extends SystemTable {
                     continue;
                 }
             } catch (MetaNotFoundException ignored) {
+                continue;
+            } catch (Throwable e) {
+                // TODO: change the exception into an checked exception in MetadataMgr.getTable
+                // The underlying SDK might throw an deep exception with this message
+                if (!e.getMessage().contains("table not found")) {
+                    LOG.warn("failed to get table meta", e);
+                }
                 continue;
             }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fix `sql/test_analyze_statistics/R/test_predicate_columns@test_predicate_columns` 

The direct issue is that querying `information_schema.analyze_status` throws an exception, and the table causing the exception is not generated by this case but is a table used for Hive statistics, which was likely dropped after execution. However, since `information_schema.analyze_status` is global, it somehow triggered the issue.

Current fix is to ignore all exceptions when iterate all jobs in `analyze_status`. In the future, the `MetadataMgr.getTable` should throw an checked exception if the table is not found, so that all callers don't have to check specific error messages.

```
2025-10-26 09:59:07.890+08:00 ERROR (thrift-server-pool-7|170) [ProcessFunction.process():49] Internal error processing getAnalyzeStatus
 com.starrocks.connector.exception.StarRocksConnectorException: Failed to get table [hive_db_daff680fa9b148aaacf098a0c3bde24d.t1], msg: NoSuchObjectException: hive.hive_db_daff680fa9b148aaacf098a0c3bde24d.t1 table not found
        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:178)
        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:163)
        at com.starrocks.connector.hive.HiveMetaClient.getTable(HiveMetaClient.java:272)
        at com.starrocks.connector.hive.HiveMetastore.getTable(HiveMetastore.java:116)
        at com.starrocks.connector.hive.CachingHiveMetastore.loadTable(CachingHiveMetastore.java:311)
        at com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:169)
        at com.google.common.cache.CacheLoader$1.load(CacheLoader.java:192)
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3570)
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2312)
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2189)
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2079)
        at com.google.common.cache.LocalCache.get(LocalCache.java:4011)
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4034)
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5010)
        at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:5017)
        at com.starrocks.connector.metastore.CachingMetastore.get(CachingMetastore.java:88)
        at com.starrocks.connector.hive.CachingHiveMetastore.getTable(CachingHiveMetastore.java:303)
        at com.starrocks.connector.hive.CachingHiveMetastore.loadTable(CachingHiveMetastore.java:311)
        at com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:169)
        at com.google.common.cache.CacheLoader$1.load(CacheLoader.java:192)
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3570)
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2312)
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2189)
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2079)
        at com.google.common.cache.LocalCache.get(LocalCache.java:4011)
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4034)
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5010)
        at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:5017)
        at com.starrocks.connector.metastore.CachingMetastore.get(CachingMetastore.java:88)
        at com.starrocks.connector.hive.CachingHiveMetastore.getTable(CachingHiveMetastore.java:303)
        at com.starrocks.connector.hive.HiveMetastoreOperations.getTable(HiveMetastoreOperations.java:250)
        at com.starrocks.connector.hive.HiveMetadata.getTable(HiveMetadata.java:207)
        at com.starrocks.connector.CatalogConnectorMetadata.getTable(CatalogConnectorMetadata.java:151)
        at com.starrocks.server.MetadataMgr.lambda$getTable$5(MetadataMgr.java:508)
        at java.base/java.util.Optional.map(Optional.java:260)
        at com.starrocks.server.MetadataMgr.getTable(MetadataMgr.java:508)
        at com.starrocks.catalog.system.information.AnalyzeStatusSystemTable.query(AnalyzeStatusSystemTable.java:114)
        at com.starrocks.service.FrontendServiceImpl.getAnalyzeStatus(FrontendServiceImpl.java:678)
        at com.starrocks.thrift.FrontendService$Processor$getAnalyzeStatus.getResult(FrontendService.java:6941)
        at com.starrocks.thrift.FrontendService$Processor$getAnalyzeStatus.getResult(FrontendService.java:6918)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40)
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:174)
        ... 45 more
Caused by: NoSuchObjectException(message:hive.hive_db_daff680fa9b148aaacf098a0c3bde24d.t1 table not found)
        at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$get_table_result$get_table_resultStandardScheme.read(ThriftHiveMetastore.java)
        at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$get_table_result$get_table_resultStandardScheme.read(ThriftHiveMetastore.java)
        at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$get_table_result.read(ThriftHiveMetastore.java)
        at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:93)
        at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.recv_get_table(ThriftHiveMetastore.java:2042)
        at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.get_table(ThriftHiveMetastore.java:2028)
        at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.getTable(HiveMetaStoreClient.java:657)
        at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.getTable(HiveMetaStoreClient.java:637)
        at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.getTable(HiveMetaStoreClient.java:649)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.invoke(RetryingMetaStoreClient.java:208)
        at jdk.proxy2/jdk.proxy2.$Proxy43.getTable(Unknown Source)
        ... 50 more
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
