### PR TITLE
[Enhancement] Support cloud native tablets in be_tablets system table

### DIFF
--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -176,6 +176,17 @@ std::vector<staros::starlet::ShardInfo> StarOSWorker::shards() const {
     return vec;
 }
 
+std::vector<staros::starlet::ShardId> StarOSWorker::shard_ids() const {
+    std::vector<staros::starlet::ShardId> vec;
+    vec.reserve(_shards.size());
+
+    std::shared_lock l(_mtx);
+    for (const auto& shard : _shards) {
+        vec.emplace_back(shard.first);
+    }
+    return vec;
+}
+
 absl::StatusOr<staros::starlet::WorkerInfo> StarOSWorker::worker_info() const {
     staros::starlet::WorkerInfo worker_info;
 

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -68,6 +68,8 @@ public:
 
     std::vector<ShardInfo> shards() const override;
 
+    std::vector<ShardId> shard_ids() const;
+
     // `conf`: a k-v map, provides additional information about the filesystem configuration
     absl::StatusOr<std::shared_ptr<FileSystem>> get_shard_filesystem(ShardId id, const Configuration& conf);
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -23,6 +23,7 @@
 #include "agent/master_info.h"
 #include "common/compiler_util.h"
 #include "common/config.h"
+#include "exec/schema_scanner/schema_be_tablets_scanner.h"
 #include "fmt/format.h"
 #include "fs/fs.h"
 #include "fs/fs_util.h"
@@ -85,6 +86,11 @@ TabletManager::~TabletManager() = default;
 
 std::string TabletManager::tablet_root_location(int64_t tablet_id) const {
     return _location_provider->root_location(tablet_id);
+}
+
+std::string TabletManager::real_tablet_root_location(int64_t tablet_id) const {
+    auto location_or = _location_provider->real_location(tablet_root_location(tablet_id));
+    return location_or.ok() ? location_or.value() : "";
 }
 
 std::string TabletManager::tablet_metadata_root_location(int64_t tablet_id) const {
@@ -1208,6 +1214,102 @@ StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, i
     size_t footer_size_hint = 16 * 1024;
     return load_segment(segment_info, segment_id, &footer_size_hint, lake_io_opts, fill_metadata_cache,
                         std::move(tablet_schema));
+}
+
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
+static std::pair<int64_t, int64_t> get_table_partition_id(const staros::starlet::ShardInfo& shard_info) {
+    const auto& properties = shard_info.properties;
+
+    int64_t table_id = -1;
+    auto table_id_iter = properties.find("tableId");
+    if (table_id_iter != properties.end()) {
+        table_id = std::atol(table_id_iter->second.data());
+    }
+
+    int64_t partition_id = -1;
+    auto partition_id_iter = properties.find("partitionId");
+    if (partition_id_iter != properties.end()) {
+        partition_id = std::atol(partition_id_iter->second.data());
+    }
+
+    return std::make_pair(table_id, partition_id);
+}
+
+void TabletManager::get_tablet_basic_info(const staros::starlet::ShardInfo* shard_info, int64_t table_id,
+                                          int64_t partition_id, const std::set<int64_t>& authorized_table_ids,
+                                          const std::unordered_map<int64_t, int64_t>& partition_versions,
+                                          std::vector<TabletBasicInfo>& tablet_infos) {
+    const auto& id_pair = get_table_partition_id(*shard_info);
+    auto shard_table_id = id_pair.first;
+    auto shard_partition_id = id_pair.second;
+
+    if ((partition_id != -1 && partition_id != shard_partition_id) || (table_id != -1 && table_id != shard_table_id) ||
+        authorized_table_ids.find(shard_table_id) == authorized_table_ids.end()) {
+        return;
+    }
+
+    int64_t tablet_id = shard_info->id;
+    auto search = partition_versions.find(shard_partition_id);
+    if (search == partition_versions.end()) {
+        LOG(WARNING) << "partition: " << shard_partition_id << " not found, tablet: " << tablet_id;
+        return;
+    }
+
+    int version = search->second;
+    auto tablet_or = get_tablet(tablet_id, version);
+    if (!tablet_or.ok()) {
+        LOG(WARNING) << "fail to get tablet: " << tablet_id << ", version: " << version
+                     << ", err: " << tablet_or.status();
+        return;
+    }
+
+    auto& info = tablet_infos.emplace_back();
+    info.table_id = shard_table_id;
+    info.partition_id = shard_partition_id;
+    tablet_or.value().get_basic_info(info);
+}
+#endif // USE_STAROS
+
+void TabletManager::get_tablets_basic_info(int64_t table_id, int64_t partition_id, int64_t tablet_id,
+                                           const std::set<int64_t>& authorized_table_ids,
+                                           const std::unordered_map<int64_t, int64_t>& partition_versions,
+                                           std::vector<TabletBasicInfo>& tablet_infos) {
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
+    if (g_worker == nullptr) {
+        return;
+    }
+
+    // process the tablet with the given tablet_id
+    if (tablet_id != -1) {
+        auto shard_info_or = g_worker->retrieve_shard_info(tablet_id);
+        if (shard_info_or.ok()) {
+            const auto& shard_info = shard_info_or.value();
+            get_tablet_basic_info(&shard_info, table_id, partition_id, authorized_table_ids, partition_versions,
+                                  tablet_infos);
+        } else {
+            LOG(WARNING) << "fail to get shard info of tablet: " << tablet_id << ", err: " << shard_info_or.status();
+        }
+        return;
+    }
+
+    // iterate all shards and get the tablets belong to the given table_id and partition_id
+    const auto& shards = g_worker->shards();
+    for (const auto& shard_info : shards) {
+        get_tablet_basic_info(&shard_info, table_id, partition_id, authorized_table_ids, partition_versions,
+                              tablet_infos);
+    }
+
+    // order by table_id, partition_id, tablet_id by default
+    std::sort(tablet_infos.begin(), tablet_infos.end(), [](const TabletBasicInfo& a, const TabletBasicInfo& b) {
+        if (a.partition_id == b.partition_id) {
+            return a.tablet_id < b.tablet_id;
+        }
+        if (a.table_id == b.table_id) {
+            return a.partition_id < b.partition_id;
+        }
+        return a.table_id < b.table_id;
+    });
+#endif // USE_STAROS
 }
 
 void TabletManager::stop() {

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -31,12 +31,6 @@
 #include "storage/rowset/base_rowset.h"
 #include "util/bthreads/single_flight.h"
 
-#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
-namespace staros::starlet {
-class ShardInfo;
-} // namespace staros::starlet
-#endif // USE_STAROS
-
 namespace starrocks {
 struct FileInfo;
 struct TabletBasicInfo;
@@ -80,7 +74,7 @@ public:
 
     StatusOr<Tablet> get_tablet(int64_t tablet_id);
 
-    StatusOr<VersionedTablet> get_tablet(int64_t tablet_id, int64_t version);
+    StatusOr<VersionedTablet> get_tablet(int64_t tablet_id, int64_t version, bool fill_cache = true);
 
     StatusOr<CompactionTaskPtr> compact(CompactionTaskContext* context);
 
@@ -265,10 +259,9 @@ private:
     Status corrupted_tablet_meta_handler(const Status& s, const std::string& metadata_location);
 
 #if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
-    void get_tablet_basic_info(const staros::starlet::ShardInfo* shard_info, int64_t table_id, int64_t partition_id,
-                               const std::set<int64_t>& authorized_table_ids,
-                               const std::unordered_map<int64_t, int64_t>& partition_versions,
-                               std::vector<TabletBasicInfo>& tablet_infos);
+    StatusOr<TabletBasicInfo> get_tablet_basic_info(int64_t tablet_id, int64_t table_id, int64_t partition_id,
+                                                    const std::set<int64_t>& authorized_table_ids,
+                                                    const std::unordered_map<int64_t, int64_t>& partition_versions);
 #endif // USE_STAROS
 
 private:

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1607,4 +1607,15 @@ bool UpdateManager::TEST_primary_index_refcnt(int64_t tablet_id, uint32_t expect
     return index_entry->get_ref() == expected_cnt;
 }
 
+int64_t UpdateManager::get_index_memory_size(int64_t tablet_id) const {
+    int64_t index_memory_size = 0;
+    auto& index_cache = _tablet_mgr->update_mgr()->index_cache();
+    auto index_entry = index_cache.get(tablet_id);
+    if (index_entry != nullptr) {
+        index_memory_size = index_entry->size();
+        index_cache.release(index_entry);
+    }
+    return index_memory_size;
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -227,6 +227,8 @@ public:
 
     bool TEST_primary_index_refcnt(int64_t tablet_id, uint32_t expected_cnt);
 
+    int64_t get_index_memory_size(int64_t tablet_id) const;
+
 private:
     // print memory tracker state
     void _print_memory_stats();

--- a/be/src/storage/lake/versioned_tablet.cpp
+++ b/be/src/storage/lake/versioned_tablet.cpp
@@ -104,7 +104,7 @@ std::vector<RowsetPtr> VersionedTablet::get_rowsets() const {
     return Rowset::get_rowsets(_tablet_mgr, _metadata);
 }
 
-void VersionedTablet::get_basic_info(TabletBasicInfo& info) const {
+TabletBasicInfo VersionedTablet::get_basic_info() const {
     int64_t num_rowset = _metadata->rowsets_size();
     int64_t num_segment = 0;
     int64_t num_row = 0;
@@ -117,6 +117,7 @@ void VersionedTablet::get_basic_info(TabletBasicInfo& info) const {
 
     auto keys_type = _metadata->schema().keys_type();
 
+    TabletBasicInfo info;
     // set table_id and partition_id outside
     info.tablet_id = id();
     info.num_version = num_rowset;
@@ -148,6 +149,8 @@ void VersionedTablet::get_basic_info(TabletBasicInfo& info) const {
             info.data_size += index_disk_usage;
         }
     }
+
+    return info;
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/versioned_tablet.cpp
+++ b/be/src/storage/lake/versioned_tablet.cpp
@@ -14,10 +14,12 @@
 
 #include "storage/lake/versioned_tablet.h"
 
+#include "exec/schema_scanner/schema_be_tablets_scanner.h"
 #include "storage/lake/pk_tablet_writer.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet_reader.h"
 #include "storage/lake/tablet_writer.h"
+#include "storage/lake/update_manager.h"
 #include "storage/tablet_schema_map.h"
 
 namespace starrocks::lake {
@@ -100,6 +102,52 @@ bool VersionedTablet::has_delete_predicates() const {
 
 std::vector<RowsetPtr> VersionedTablet::get_rowsets() const {
     return Rowset::get_rowsets(_tablet_mgr, _metadata);
+}
+
+void VersionedTablet::get_basic_info(TabletBasicInfo& info) const {
+    int64_t num_rowset = _metadata->rowsets_size();
+    int64_t num_segment = 0;
+    int64_t num_row = 0;
+    int64_t data_size = 0;
+    for (const auto& rowset : _metadata->rowsets()) {
+        num_segment += rowset.segments_size();
+        num_row += rowset.num_rows();
+        data_size += rowset.data_size();
+    }
+
+    auto keys_type = _metadata->schema().keys_type();
+
+    // set table_id and partition_id outside
+    info.tablet_id = id();
+    info.num_version = num_rowset;
+    info.max_version = version();
+    info.min_version = 0;
+    info.num_rowset = num_rowset;
+    info.num_segment = num_segment;
+    info.num_row = num_row;
+    info.data_size = data_size;
+    info.create_time = 0;
+    info.state = 1; // running
+    info.type = keys_type;
+    info.data_dir = _tablet_mgr->real_tablet_root_location(id());
+    info.shard_id = id();
+    info.schema_hash = 0;
+    info.medium_type = TStorageMedium::HDD;
+
+    // set pk tablet index_mem and index_disk_usage
+    if (keys_type == KeysType::PRIMARY_KEYS) {
+        info.index_mem = _tablet_mgr->update_mgr()->get_index_memory_size(id());
+
+        // only support cloud native pk index
+        if (_metadata->has_sstable_meta()) {
+            int64_t index_disk_usage = 0;
+            for (const auto& sst : _metadata->sstable_meta().sstables()) {
+                index_disk_usage += sst.filesize();
+            }
+            info.index_disk_usage = index_disk_usage;
+            info.data_size += index_disk_usage;
+        }
+    }
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/versioned_tablet.h
+++ b/be/src/storage/lake/versioned_tablet.h
@@ -21,6 +21,7 @@
 #include "storage/rowset/base_rowset.h"
 
 namespace starrocks {
+struct TabletBasicInfo;
 class TabletSchema;
 class TabletMetadataPB;
 class Schema;
@@ -86,6 +87,8 @@ public:
     TabletManager* tablet_manager() const { return _tablet_mgr; }
 
     bool has_delete_predicates() const;
+
+    void get_basic_info(TabletBasicInfo& info) const;
 
 private:
     TabletManager* _tablet_mgr;

--- a/be/src/storage/lake/versioned_tablet.h
+++ b/be/src/storage/lake/versioned_tablet.h
@@ -88,7 +88,7 @@ public:
 
     bool has_delete_predicates() const;
 
-    void get_basic_info(TabletBasicInfo& info) const;
+    TabletBasicInfo get_basic_info() const;
 
 private:
     TabletManager* _tablet_mgr;

--- a/be/test/service/staros_worker_test.cpp
+++ b/be/test/service/staros_worker_test.cpp
@@ -58,6 +58,7 @@ TEST_F(StarOSWorkerTest, test_add_listener) {
 
     info.id = 1;
     EXPECT_TRUE(worker->add_shard(info).ok());
+    EXPECT_EQ(1, worker->shard_ids().size());
 
     // no shard registered, counter and ids will not be modified
     EXPECT_EQ(0, counter);
@@ -68,6 +69,7 @@ TEST_F(StarOSWorkerTest, test_add_listener) {
 
     info.id = 2;
     EXPECT_TRUE(worker->add_shard(info).ok());
+    EXPECT_EQ(2, worker->shard_ids().size());
 
     // shard:2 added
     EXPECT_EQ(1, counter);

--- a/test/sql/test_information_schema/R/test_be_tablets
+++ b/test/sql/test_information_schema/R/test_be_tablets
@@ -1,0 +1,42 @@
+-- name: test_lake_be_tablets @cloud
+
+CREATE TABLE test_lake_be_tablets (
+  k1 date,
+  k2 int,
+  v1 int
+)
+PRIMARY KEY (k1, k2)
+PARTITION BY RANGE(k1) (
+  PARTITION p1 VALUES LESS THAN ('2025-10-01'),
+  PARTITION p2 VALUES LESS THAN ('2025-11-01')
+)
+DISTRIBUTED BY HASH(k2) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+
+select count(*) from information_schema.be_tablets t, information_schema.tables_config c where t.table_id = c.table_id and c.table_name = "test_lake_be_tablets";
+-- result:
+6
+-- !result
+select distinct max_version from information_schema.be_tablets t, information_schema.tables_config c where t.table_id = c.table_id and c.table_name = "test_lake_be_tablets" order by max_version;
+-- result:
+1
+-- !result
+
+insert into test_lake_be_tablets values ("2025-09-01",4,100), ("2025-10-01",5,100), ("2025-10-02",4,100);
+-- result:
+-- !result
+select distinct max_version from information_schema.be_tablets t, information_schema.tables_config c where t.table_id = c.table_id and c.table_name = "test_lake_be_tablets" order by max_version;
+-- result:
+2
+-- !result
+
+insert into test_lake_be_tablets values ("2025-10-03",5,100);
+-- result:
+-- !result
+select distinct max_version from information_schema.be_tablets t, information_schema.tables_config c where t.table_id = c.table_id and c.table_name = "test_lake_be_tablets" order by max_version;
+-- result:
+2
+3
+-- !result

--- a/test/sql/test_information_schema/T/test_be_tablets
+++ b/test/sql/test_information_schema/T/test_be_tablets
@@ -1,0 +1,23 @@
+-- name: test_lake_be_tablets @cloud
+
+CREATE TABLE test_lake_be_tablets (
+  k1 date,
+  k2 int,
+  v1 int
+)
+PRIMARY KEY (k1, k2)
+PARTITION BY RANGE(k1) (
+  PARTITION p1 VALUES LESS THAN ('2025-10-01'),
+  PARTITION p2 VALUES LESS THAN ('2025-11-01')
+)
+DISTRIBUTED BY HASH(k2) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+select count(*) from information_schema.be_tablets t, information_schema.tables_config c where t.table_id = c.table_id and c.table_name = "test_lake_be_tablets";
+select distinct max_version from information_schema.be_tablets t, information_schema.tables_config c where t.table_id = c.table_id and c.table_name = "test_lake_be_tablets" order by max_version;
+
+insert into test_lake_be_tablets values ("2025-09-01",4,100), ("2025-10-01",5,100), ("2025-10-02",4,100);
+select distinct max_version from information_schema.be_tablets t, information_schema.tables_config c where t.table_id = c.table_id and c.table_name = "test_lake_be_tablets" order by max_version;
+
+insert into test_lake_be_tablets values ("2025-10-03",5,100);
+select distinct max_version from information_schema.be_tablets t, information_schema.tables_config c where t.table_id = c.table_id and c.table_name = "test_lake_be_tablets" order by max_version;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
mysql> select * from information_schema.be_tablets where table_id = 54116;
+-------+----------+--------------+-----------+-------------+-------------+-------------+------------+---------+-----------+-----------+-------------+---------+---------+-------------------------------+----------+-------------+------------+-------------+-------------+
| BE_ID | TABLE_ID | PARTITION_ID | TABLET_ID | NUM_VERSION | MAX_VERSION | MIN_VERSION | NUM_ROWSET | NUM_ROW | DATA_SIZE | INDEX_MEM | CREATE_TIME | STATE   | TYPE    | DATA_DIR                      | SHARD_ID | SCHEMA_HASH | INDEX_DISK | MEDIUM_TYPE | NUM_SEGMENT |
+-------+----------+--------------+-----------+-------------+-------------+-------------+------------+---------+-----------+-----------+-------------+---------+---------+-------------------------------+----------+-------------+------------+-------------+-------------+
| 10001 |    54116 |        54118 |     54119 |           1 |           2 |           0 |          1 |  249478 |   9296682 |         0 |           0 | RUNNING | PRIMARY | s3://xxx/db10003/54116/54118/ |    54119 |           0 |    2332474 | HDD         |           1 |
| 10001 |    54116 |        54118 |     54120 |           1 |           2 |           0 |          1 |  251009 |   9357491 |         0 |           0 | RUNNING | PRIMARY | s3://xxx/db10003/54116/54118/ |    54120 |           0 |    2348041 | HDD         |           1 |
| 10001 |    54116 |        54118 |     54121 |           1 |           2 |           0 |          1 |  250284 |   9327522 |         0 |           0 | RUNNING | PRIMARY | s3://xxx/db10003/54116/54118/ |    54121 |           0 |    2340917 | HDD         |           1 |
| 10001 |    54116 |        54118 |     54122 |           1 |           2 |           0 |          1 |  249529 |   9299342 |         0 |           0 | RUNNING | PRIMARY | s3://xxx/db10003/54116/54118/ |    54122 |           0 |    2332751 | HDD         |           1 |
| 10001 |    54116 |        54118 |     54123 |           1 |           2 |           0 |          1 |  250237 |   9331945 |         0 |           0 | RUNNING | PRIMARY | s3://xxx/db10003/54116/54118/ |    54123 |           0 |    2341501 | HDD         |           1 |
| 10001 |    54116 |        54118 |     54124 |           1 |           2 |           0 |          1 |  249463 |   9296463 |         0 |           0 | RUNNING | PRIMARY | s3://xxx/db10003/54116/54118/ |    54124 |           0 |    2332177 | HDD         |           1 |
+-------+----------+--------------+-----------+-------------+-------------+-------------+------------+---------+-----------+-----------+-------------+---------+---------+-------------------------------+----------+-------------+------------+-------------+-------------+
6 rows in set (0.05 sec)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends `be_tablets` to report shared-data lake tablets with basic stats and PK index metrics, sourcing shards via StarOS and tablet metadata via Lake TabletManager.
> 
> - **Information Schema**:
>   - Extend `schema_be_tablets_scanner` to aggregate lake tablets via `ExecEnv::lake_tablet_manager()` in addition to shared-nothing tablets.
>   - Fetch partition visible versions (`get_partitions_meta`) and pass auth-checked table/partition filters to lake manager.
> - **Lake Storage**:
>   - `TabletManager`:
>     - Add `get_tablet(..., bool fill_cache)`, `real_tablet_root_location`, and `get_tablets_basic_info` to enumerate tablets from StarOS shards with auth and version gating.
>     - Internal helper `get_tablet_basic_info` and ordering of results.
>   - `VersionedTablet`: new `get_basic_info()` assembling `TabletBasicInfo` (rows/segments/versions, data size, dir, medium, shard_id, plus PK index mem/disk if applicable).
>   - `UpdateManager`: expose `get_index_memory_size(tablet_id)` for PK index memory usage.
> - **StarOS**:
>   - `StarOSWorker`: add `shard_ids()` to list local shard IDs.
> - **Tests**:
>   - Add SQL tests for cloud: `information_schema.be_tablets` count and `max_version` evolution.
>   - Unit tests: `versioned_tablet` basic info; `staros_worker` validates `shard_ids()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24a55563183240b666c57be07a4b3c437fcc65cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->